### PR TITLE
docs: add epic for daily log summaries

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -167,3 +167,13 @@
 **Next:** In Vercel Project Settings → General → Node.js Version, set it explicitly to 22 to match `engines`
 **Blockers:** None
 ---
+
+## 2025-12-13 13:38 [AI - GPT-5.2]
+**Goal:** Capture daily logs AI summary epic
+**Completed:** Added an epic to track teacher-facing 1-line daily log summaries using a cheaper model (OpenAI `gpt-5-nano`), separate from assignment summaries
+**Status:** completed
+**Artifacts:**
+- Files: `.ai/features.json`
+**Next:** Implement the classroom shell + Logs view UX first; then add the daily-log summarization pipeline (on-demand + cached)
+**Blockers:** None
+---

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,13 +1,13 @@
 {
   "meta": {
     "project": "pika",
-    "lastUpdated": "2025-12-12",
+    "lastUpdated": "2025-12-13",
     "phase": "Infrastructure — AI Effectiveness Layer",
     "DO_NOT_DELETE_FEATURES": "This inventory is APPEND-ONLY. Mark features as passing/failing, add new features, but NEVER DELETE FEATURES FROM THIS FILE. Deletion corrupts project history.",
     "deletionPolicy": "PROHIBITED",
-    "totalFeatures": 8,
+    "totalFeatures": 9,
     "passing": 6,
-    "failing": 2
+    "failing": 3
   },
   "features": [
     {
@@ -89,7 +89,16 @@
       "issueRefs": ["#8"],
       "blockedBy": [],
       "addedDate": "2025-12-12"
+    },
+    {
+      "id": "epic-daily-log-summaries",
+      "phase": "Phase 7 — AI (Daily Logs)",
+      "description": "Teacher-facing 1-line daily log summaries per student/day (cheap model; separate from assignment summaries)",
+      "passes": false,
+      "verification": "Manual smoke: teacher opens Logs view for a date and sees 1-line summaries for students with logs; verify model is OpenAI gpt-5-nano and summaries are cached unless entry text changes.",
+      "issueRefs": [],
+      "blockedBy": [],
+      "addedDate": "2025-12-13"
     }
   ]
 }
-


### PR DESCRIPTION
Adds a new append-only epic to `.ai/features.json` for teacher-facing 1-line daily log summaries (separate from assignment summaries).

Decision captured:
- Daily log summaries use a cheaper model: OpenAI `gpt-5-nano`.
- Assignment summaries remain `gpt-5-mini`.
