### PR TITLE
feat: classroom shell with tabs + daily teacher logs/attendance

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -195,5 +195,12 @@
 **Artifacts:**
 - Files: `README.md`, `docs/core/pilot-mvp.md`, `docs/core/project-context.md`, `src/app/api/cron/nightly-assignment-summaries/route.ts`
 **Next:** Configure the single cron schedule in Vercel dashboard; keep staging enabled only while validating, then disable to free cron quota
+## 2025-12-13 14:27 [AI - GPT-5.2]
+**Goal:** Start classroom shell UX
+**Completed:** Added `/classrooms/[id]` role-based tabs, a reusable date navigator, and new teacher daily Attendance + Logs views (with inline expand and expand-all); added `/api/teacher/logs` to power the Logs tab
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/page.tsx`, `src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx`, `src/app/classrooms/[classroomId]/TeacherLogsTab.tsx`, `src/app/classrooms/[classroomId]/StudentTodayTab.tsx`, `src/app/classrooms/[classroomId]/StudentHistoryTab.tsx`, `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`, `src/components/DateNavigator.tsx`, `src/app/api/teacher/logs/route.ts`, `src/lib/class-days.ts`, `src/lib/date-string.ts`
+**Next:** Move teacher roster/calendar/settings into their tabs and update navigation to prefer the classroom shell over legacy `/teacher/*` and `/student/*` pages
 **Blockers:** None
 ---

--- a/src/app/api/teacher/logs/route.ts
+++ b/src/app/api/teacher/logs/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+/**
+ * GET /api/teacher/logs?classroom_id=xxx&date=YYYY-MM-DD
+ * Returns roster students with an optional entry for the selected date.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const { searchParams } = new URL(request.url)
+    const classroomId = searchParams.get('classroom_id')
+    const date = searchParams.get('date')
+
+    if (!classroomId) {
+      return NextResponse.json(
+        { error: 'classroom_id is required' },
+        { status: 400 }
+      )
+    }
+
+    if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return NextResponse.json(
+        { error: 'Invalid date format (use YYYY-MM-DD)' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: classroom, error: classroomError } = await supabase
+      .from('classrooms')
+      .select('teacher_id')
+      .eq('id', classroomId)
+      .single()
+
+    if (classroomError || !classroom) {
+      return NextResponse.json(
+        { error: 'Classroom not found' },
+        { status: 404 }
+      )
+    }
+
+    if (classroom.teacher_id !== user.id) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403 }
+      )
+    }
+
+    const { data: enrollments, error: enrollmentsError } = await supabase
+      .from('classroom_enrollments')
+      .select(`
+        student_id,
+        users!classroom_enrollments_student_id_fkey(
+          id,
+          email
+        )
+      `)
+      .eq('classroom_id', classroomId)
+
+    if (enrollmentsError) {
+      console.error('Error fetching enrollments:', enrollmentsError)
+      return NextResponse.json(
+        { error: 'Failed to fetch students' },
+        { status: 500 }
+      )
+    }
+
+    const students = (enrollments || [])
+      .map(e => {
+        const u = e.users as unknown as { id: string; email: string }
+        return { id: u.id, email: u.email }
+      })
+      .sort((a, b) => a.email.localeCompare(b.email))
+
+    let entriesQuery = supabase
+      .from('entries')
+      .select('*')
+      .eq('classroom_id', classroomId)
+
+    if (date) {
+      entriesQuery = entriesQuery.eq('date', date)
+    }
+
+    const { data: entries, error: entriesError } = await entriesQuery
+
+    if (entriesError) {
+      console.error('Error fetching entries:', entriesError)
+      return NextResponse.json(
+        { error: 'Failed to fetch entries' },
+        { status: 500 }
+      )
+    }
+
+    const entryByStudentId = new Map(
+      (entries || []).map(entry => [entry.student_id, entry])
+    )
+
+    const logs = students.map(student => ({
+      student_id: student.id,
+      student_email: student.email,
+      entry: entryByStudentId.get(student.id) || null,
+    }))
+
+    return NextResponse.json({
+      classroom_id: classroomId,
+      date: date || null,
+      logs,
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    console.error('Get teacher logs error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Spinner } from '@/components/Spinner'
+import {
+  formatDueDate,
+  formatRelativeDueDate,
+  getAssignmentStatusLabel,
+  getAssignmentStatusBadgeClass,
+} from '@/lib/assignments'
+import type { AssignmentWithStatus, Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentAssignmentsTab({ classroom }: Props) {
+  const [assignments, setAssignments] = useState<AssignmentWithStatus[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/student/assignments?classroom_id=${classroom.id}`)
+        const data = await res.json()
+        setAssignments(data.assignments || [])
+      } catch (err) {
+        console.error('Error loading assignments:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [classroom.id])
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm">
+      <div className="p-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">Assignments</h2>
+      </div>
+
+      <div className="p-4">
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Spinner />
+          </div>
+        ) : assignments.length === 0 ? (
+          <div className="text-center py-8 text-gray-500">No assignments yet</div>
+        ) : (
+          <div className="space-y-3">
+            {assignments.map((assignment) => (
+              <Link
+                key={assignment.id}
+                href={`/classrooms/${classroom.id}/assignments/${assignment.id}`}
+                className="block p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="font-medium text-gray-900 truncate">
+                      {assignment.title}
+                    </h3>
+                    <p className="text-sm text-gray-600 mt-1">
+                      {formatDueDate(assignment.due_at)}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      {formatRelativeDueDate(assignment.due_at)}
+                    </p>
+                  </div>
+                  <span className={`px-2 py-1 rounded text-xs font-medium ${getAssignmentStatusBadgeClass(assignment.status)}`}>
+                    {getAssignmentStatusLabel(assignment.status)}
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/StudentHistoryTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentHistoryTab.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { getAttendanceIcon } from '@/lib/attendance'
+import type { AttendanceStatus, ClassDay, Classroom, Entry } from '@/types'
+
+interface HistoryRow {
+  date: string
+  status: AttendanceStatus
+  entry: Entry | null
+}
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentHistoryTab({ classroom }: Props) {
+  const [rows, setRows] = useState<HistoryRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const classDaysRes = await fetch(`/api/teacher/class-days?classroom_id=${classroom.id}`)
+        const classDaysData = await classDaysRes.json()
+        const classDays: ClassDay[] = (classDaysData.class_days || []).filter((d: ClassDay) => d.is_class_day)
+
+        const entriesRes = await fetch(`/api/student/entries?classroom_id=${classroom.id}`)
+        const entriesData = await entriesRes.json()
+        const entries: Entry[] = entriesData.entries || []
+
+        const entryMap = new Map(entries.map(e => [e.date, e]))
+
+        const nextRows = classDays
+          .map(day => {
+            const entry = entryMap.get(day.date) || null
+            return { date: day.date, entry, status: entry ? 'present' : 'absent' as AttendanceStatus }
+          })
+          .sort((a, b) => b.date.localeCompare(a.date))
+
+        setRows(nextRows)
+      } catch (err) {
+        console.error('Error loading history:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [classroom.id])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm">
+      <div className="p-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">History</h2>
+      </div>
+      <div className="divide-y divide-gray-100">
+        {rows.slice(0, 60).map((row) => (
+          <div key={row.date} className="p-4 flex items-center justify-between">
+            <div className="text-sm text-gray-700">{row.date}</div>
+            <div className="text-xl" aria-label={row.status}>
+              {getAttendanceIcon(row.status)}
+            </div>
+          </div>
+        ))}
+        {rows.length === 0 && (
+          <div className="p-6 text-center text-gray-500">No class days yet</div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useEffect, useState, FormEvent } from 'react'
+import { Button } from '@/components/Button'
+import { Spinner } from '@/components/Spinner'
+import { getTodayInToronto } from '@/lib/timezone'
+import { isClassDayOnDate } from '@/lib/class-days'
+import type { Classroom, ClassDay, Entry, MoodEmoji } from '@/types'
+
+const MOOD_OPTIONS: MoodEmoji[] = ['😊', '🙂', '😐']
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentTodayTab({ classroom }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [today, setToday] = useState('')
+  const [classDays, setClassDays] = useState<ClassDay[]>([])
+  const [existingEntry, setExistingEntry] = useState<Entry | null>(null)
+  const [text, setText] = useState('')
+  const [mood, setMood] = useState<MoodEmoji | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const todayDate = getTodayInToronto()
+        setToday(todayDate)
+
+        const classDayRes = await fetch(`/api/teacher/class-days?classroom_id=${classroom.id}`)
+        const classDayData = await classDayRes.json()
+        setClassDays(classDayData.class_days || [])
+
+        const entriesRes = await fetch(`/api/student/entries?classroom_id=${classroom.id}`)
+        const entriesData = await entriesRes.json()
+        const todayEntry = (entriesData.entries || []).find((e: Entry) => e.date === todayDate) || null
+
+        setExistingEntry(todayEntry)
+        setText(todayEntry?.text || '')
+        setMood(todayEntry?.mood || null)
+      } catch (err) {
+        console.error('Error loading today tab:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [classroom.id])
+
+  const isClassDay = today ? isClassDayOnDate(classDays, today) : true
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError('')
+    setSuccess('')
+    setSubmitting(true)
+
+    try {
+      const response = await fetch('/api/student/entries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classroom_id: classroom.id,
+          date: today,
+          text,
+          mood,
+        }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save entry')
+      }
+
+      setExistingEntry(data.entry)
+      setSuccess('Entry saved!')
+      setTimeout(() => setSuccess(''), 2000)
+    } catch (err: any) {
+      setError(err.message || 'An error occurred')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Today</h2>
+        <div className="text-sm text-gray-600">{today}</div>
+      </div>
+
+      {!isClassDay ? (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-center">
+          <p className="text-gray-600">No class today</p>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              What did you do today?
+            </label>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={4}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Write a short update..."
+              required
+              disabled={submitting}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Mood (optional)
+            </label>
+            <div className="flex gap-3">
+              {MOOD_OPTIONS.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMood(m)}
+                  className={`text-3xl p-2 rounded-lg transition ${
+                    mood === m
+                      ? 'bg-blue-50 border-2 border-blue-500'
+                      : 'hover:bg-gray-50 border-2 border-transparent'
+                  }`}
+                  disabled={submitting}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {success && <p className="text-sm text-green-600">{success}</p>}
+
+          <Button type="submit" disabled={submitting || !text}>
+            {submitting ? 'Saving...' : existingEntry ? 'Update' : 'Save'}
+          </Button>
+        </form>
+      )}
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { DateNavigator } from '@/components/DateNavigator'
+import { getTodayInToronto } from '@/lib/timezone'
+import { addDaysToDateString } from '@/lib/date-string'
+import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
+import { getAttendanceIcon } from '@/lib/attendance'
+import type { AttendanceRecord, ClassDay, Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherAttendanceTab({ classroom }: Props) {
+  const [classDays, setClassDays] = useState<ClassDay[]>([])
+  const [attendance, setAttendance] = useState<AttendanceRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedDate, setSelectedDate] = useState<string>('')
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      try {
+        const classDaysRes = await fetch(`/api/teacher/class-days?classroom_id=${classroom.id}`)
+        const classDaysData = await classDaysRes.json()
+        const nextClassDays: ClassDay[] = classDaysData.class_days || []
+        setClassDays(nextClassDays)
+
+        const today = getTodayInToronto()
+        const previousClassDay = getMostRecentClassDayBefore(nextClassDays, today)
+        setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
+
+        const attendanceRes = await fetch(`/api/teacher/attendance?classroom_id=${classroom.id}`)
+        const attendanceData = await attendanceRes.json()
+        setAttendance(attendanceData.attendance || [])
+      } catch (err) {
+        console.error('Error loading attendance tab:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [classroom.id])
+
+  const isClassDay = useMemo(() => {
+    if (!selectedDate) return true
+    return isClassDayOnDate(classDays, selectedDate)
+  }, [classDays, selectedDate])
+
+  const rows = useMemo(() => {
+    return attendance.map((record) => {
+      const status = record.dates[selectedDate]
+      return {
+        student_id: record.student_id,
+        student_email: record.student_email,
+        status: status || 'absent',
+      }
+    })
+  }, [attendance, selectedDate])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <h2 className="text-lg font-semibold text-gray-900">Attendance</h2>
+          <DateNavigator
+            value={selectedDate}
+            onChange={setSelectedDate}
+            shortcutLabel="Yesterday"
+            onShortcut={() => {
+              const today = getTodayInToronto()
+              const previousClassDay = getMostRecentClassDayBefore(classDays, today)
+              setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
+            }}
+          />
+        </div>
+        {!isClassDay && (
+          <div className="mt-3 text-sm text-gray-600">
+            No class on {selectedDate}.
+          </div>
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm divide-y divide-gray-100">
+        {rows.map((row) => (
+          <div key={row.student_id} className="p-4 flex items-center justify-between">
+            <div className="text-sm text-gray-800">{row.student_email}</div>
+            <div className={`text-xl ${isClassDay ? '' : 'opacity-40'}`}>
+              {isClassDay ? getAttendanceIcon(row.status) : '—'}
+            </div>
+          </div>
+        ))}
+        {rows.length === 0 && (
+          <div className="p-6 text-center text-gray-500">No students enrolled</div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/TeacherLogsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLogsTab.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { DateNavigator } from '@/components/DateNavigator'
+import { getTodayInToronto } from '@/lib/timezone'
+import { addDaysToDateString } from '@/lib/date-string'
+import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
+import type { ClassDay, Classroom, Entry } from '@/types'
+
+interface LogRow {
+  student_id: string
+  student_email: string
+  entry: Entry | null
+}
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherLogsTab({ classroom }: Props) {
+  const [classDays, setClassDays] = useState<ClassDay[]>([])
+  const [selectedDate, setSelectedDate] = useState<string>('')
+  const [logs, setLogs] = useState<LogRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    async function loadBase() {
+      setLoading(true)
+      try {
+        const classDaysRes = await fetch(`/api/teacher/class-days?classroom_id=${classroom.id}`)
+        const classDaysData = await classDaysRes.json()
+        const nextClassDays: ClassDay[] = classDaysData.class_days || []
+        setClassDays(nextClassDays)
+
+        const today = getTodayInToronto()
+        const previousClassDay = getMostRecentClassDayBefore(nextClassDays, today)
+        setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
+      } catch (err) {
+        console.error('Error loading logs base:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadBase()
+  }, [classroom.id])
+
+  const isClassDay = useMemo(() => {
+    if (!selectedDate) return true
+    return isClassDayOnDate(classDays, selectedDate)
+  }, [classDays, selectedDate])
+
+  useEffect(() => {
+    async function loadLogs() {
+      if (!selectedDate) return
+      if (!isClassDay) {
+        setLogs([])
+        setExpanded(new Set())
+        return
+      }
+
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/teacher/logs?classroom_id=${classroom.id}&date=${selectedDate}`)
+        const data = await res.json()
+        setLogs(data.logs || [])
+        setExpanded(new Set())
+      } catch (err) {
+        console.error('Error loading logs:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadLogs()
+  }, [classroom.id, isClassDay, selectedDate])
+
+  const studentsWithLogs = useMemo(
+    () => logs.filter(l => Boolean(l.entry)).map(l => l.student_id),
+    [logs]
+  )
+
+  function toggle(studentId: string) {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(studentId)) next.delete(studentId)
+      else next.add(studentId)
+      return next
+    })
+  }
+
+  function expandAll() {
+    setExpanded(new Set(studentsWithLogs))
+  }
+
+  function collapseAll() {
+    setExpanded(new Set())
+  }
+
+  if (loading && logs.length === 0) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <h2 className="text-lg font-semibold text-gray-900">Logs</h2>
+          <DateNavigator
+            value={selectedDate}
+            onChange={setSelectedDate}
+            shortcutLabel="Yesterday"
+            onShortcut={() => {
+              const today = getTodayInToronto()
+              const previousClassDay = getMostRecentClassDayBefore(classDays, today)
+              setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
+            }}
+          />
+        </div>
+
+        <div className="mt-3 flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-sm text-gray-600">
+            {isClassDay ? `Showing ${selectedDate}` : `No class on ${selectedDate}`}
+          </div>
+          {isClassDay && (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+                onClick={expandAll}
+                disabled={studentsWithLogs.length === 0}
+              >
+                Expand all
+              </button>
+              <button
+                type="button"
+                className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+                onClick={collapseAll}
+                disabled={expanded.size === 0}
+              >
+                Collapse all
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm divide-y divide-gray-100">
+        {(isClassDay ? logs : []).map((row) => {
+          const hasEntry = Boolean(row.entry)
+          const isExpanded = expanded.has(row.student_id)
+          return (
+            <div key={row.student_id} className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-gray-900">
+                    {row.student_email}
+                  </div>
+                  {!hasEntry ? (
+                    <div className="mt-1 text-sm text-gray-400">
+                      (missing)
+                    </div>
+                  ) : isExpanded ? (
+                    <div className="mt-2 text-sm text-gray-700 whitespace-pre-wrap">
+                      {row.entry!.text}
+                    </div>
+                  ) : (
+                    <div className="mt-1 text-sm text-gray-600 truncate">
+                      {row.entry!.text}
+                    </div>
+                  )}
+                </div>
+                {hasEntry && (
+                  <button
+                    type="button"
+                    className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 flex-shrink-0"
+                    onClick={() => toggle(row.student_id)}
+                  >
+                    {isExpanded ? 'Collapse' : 'Expand'}
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+
+        {isClassDay && logs.length === 0 && (
+          <div className="p-6 text-center text-gray-500">No students enrolled</div>
+        )}
+        {!isClassDay && (
+          <div className="p-6 text-center text-gray-500">No class on this day</div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/DateNavigator.tsx
+++ b/src/components/DateNavigator.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { addDaysToDateString } from '@/lib/date-string'
+
+interface Props {
+  value: string
+  onChange: (next: string) => void
+  onShortcut?: () => void
+  shortcutLabel?: string
+  disabled?: boolean
+  className?: string
+}
+
+export function DateNavigator({
+  value,
+  onChange,
+  onShortcut,
+  shortcutLabel,
+  disabled,
+  className,
+}: Props) {
+  const canUseShortcut = Boolean(onShortcut && shortcutLabel)
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+          onClick={() => onChange(addDaysToDateString(value, -1))}
+          disabled={disabled}
+        >
+          ←
+        </button>
+
+        <input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm disabled:opacity-50"
+          disabled={disabled}
+        />
+
+        <button
+          type="button"
+          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+          onClick={() => onChange(addDaysToDateString(value, 1))}
+          disabled={disabled}
+        >
+          →
+        </button>
+
+        {canUseShortcut && (
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+            onClick={onShortcut}
+            disabled={disabled}
+          >
+            {shortcutLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/lib/class-days.ts
+++ b/src/lib/class-days.ts
@@ -1,0 +1,20 @@
+import type { ClassDay } from '@/types'
+
+export function isClassDayOnDate(classDays: ClassDay[], date: string): boolean {
+  const found = classDays.find(day => day.date === date)
+  return Boolean(found?.is_class_day)
+}
+
+export function getMostRecentClassDayBefore(
+  classDays: ClassDay[],
+  beforeDate: string
+): string | null {
+  const candidates = classDays
+    .filter(day => day.is_class_day)
+    .map(day => day.date)
+    .filter(date => date < beforeDate)
+    .sort()
+
+  return candidates.length ? candidates[candidates.length - 1] : null
+}
+

--- a/src/lib/date-string.ts
+++ b/src/lib/date-string.ts
@@ -1,0 +1,15 @@
+export function addDaysToDateString(dateString: string, deltaDays: number): string {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+  if (!dateRegex.test(dateString)) {
+    throw new Error(`Invalid date string: ${dateString}`)
+  }
+
+  const base = new Date(`${dateString}T00:00:00.000Z`)
+  if (Number.isNaN(base.getTime())) {
+    throw new Error(`Invalid date string: ${dateString}`)
+  }
+
+  base.setUTCDate(base.getUTCDate() + deltaDays)
+  return base.toISOString().slice(0, 10)
+}
+

--- a/tests/api/teacher/logs.test.ts
+++ b/tests/api/teacher/logs.test.ts
@@ -1,0 +1,130 @@
+/**
+ * API tests for GET /api/teacher/logs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '@/app/api/teacher/logs/route'
+import { NextRequest } from 'next/server'
+import { mockAuthenticationError } from '../setup'
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async (role: string) => {
+    if (role === 'teacher') {
+      return { id: 'teacher-1', email: 'test@teacher.com', role: 'teacher' }
+    }
+    throw new Error('Unauthorized')
+  }),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/teacher/logs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    ;(requireRole as any).mockRejectedValueOnce(mockAuthenticationError())
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1')
+    const response = await GET(request)
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 400 when classroom_id is missing', async () => {
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs')
+    const response = await GET(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('should return 400 for invalid date', async () => {
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1&date=2025-1-1')
+    const response = await GET(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'other-teacher' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      return {}
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1')
+    const response = await GET(request)
+    expect(response.status).toBe(403)
+  })
+
+  it('should return 200 with roster and entry (when present)', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
+                { student_id: 's2', users: { id: 's2', email: 'b@student.com' } },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'e1', student_id: 's2', classroom_id: 'classroom-1', date: '2025-01-02', text: 'hello', minutes_reported: null, mood: null, created_at: '', updated_at: '', on_time: true },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      return {}
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1&date=2025-01-02')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.logs).toHaveLength(2)
+    expect(body.logs[0].student_email).toBe('a@student.com')
+    expect(body.logs[0].entry).toBe(null)
+    expect(body.logs[1].student_email).toBe('b@student.com')
+    expect(body.logs[1].entry?.id).toBe('e1')
+  })
+})
+

--- a/tests/unit/class-days.test.ts
+++ b/tests/unit/class-days.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import type { ClassDay } from '@/types'
+import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
+
+describe('class-days helpers', () => {
+  const classDays: ClassDay[] = [
+    { id: '1', classroom_id: 'c', date: '2025-01-01', is_class_day: true, prompt_text: null },
+    { id: '2', classroom_id: 'c', date: '2025-01-02', is_class_day: false, prompt_text: null },
+    { id: '3', classroom_id: 'c', date: '2025-01-03', is_class_day: true, prompt_text: null },
+  ]
+
+  it('detects class day on date', () => {
+    expect(isClassDayOnDate(classDays, '2025-01-01')).toBe(true)
+    expect(isClassDayOnDate(classDays, '2025-01-02')).toBe(false)
+    expect(isClassDayOnDate(classDays, '2025-01-04')).toBe(false)
+  })
+
+  it('finds most recent class day strictly before a date', () => {
+    expect(getMostRecentClassDayBefore(classDays, '2025-01-01')).toBe(null)
+    expect(getMostRecentClassDayBefore(classDays, '2025-01-02')).toBe('2025-01-01')
+    expect(getMostRecentClassDayBefore(classDays, '2025-01-04')).toBe('2025-01-03')
+  })
+})
+

--- a/tests/unit/date-string.test.ts
+++ b/tests/unit/date-string.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { addDaysToDateString } from '@/lib/date-string'
+
+describe('addDaysToDateString', () => {
+  it('adds and subtracts days deterministically', () => {
+    expect(addDaysToDateString('2025-01-01', 1)).toBe('2025-01-02')
+    expect(addDaysToDateString('2025-01-01', -1)).toBe('2024-12-31')
+  })
+
+  it('throws on invalid input', () => {
+    expect(() => addDaysToDateString('2025-1-1', 1)).toThrow()
+    expect(() => addDaysToDateString('not-a-date', 1)).toThrow()
+  })
+})
+


### PR DESCRIPTION
Implements the first pass of the Classroom Home shell at `/classrooms/[classroomId]`.

Teacher:
- Tabs: Attendance, Logs, Assignments (existing), placeholders for Roster/Calendar/Settings
- Attendance + Logs are daily views with a shared date navigator
- Default date is the most recent class day < today (America/Toronto)
- Logs list shows all students with grey missing state; inline expand and Expand all (only students with logs)

Student:
- Tabs: Today, History, Assignments

API/Utilities:
- Adds `GET /api/teacher/logs` for the Logs tab
- Adds date/class-day helpers (`src/lib/class-days.ts`, `src/lib/date-string.ts`) + tests

Verification:
- `npm test`
- `npm run build`
