### PR TITLE
feat: classroom shell tabs (roster/calendar/settings)

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -204,3 +204,13 @@
 **Next:** Move teacher roster/calendar/settings into their tabs and update navigation to prefer the classroom shell over legacy `/teacher/*` and `/student/*` pages
 **Blockers:** None
 ---
+
+## 2025-12-13 15:30 [AI - GPT-5.2]
+**Goal:** Fill remaining classroom shell tabs
+**Completed:** Implemented teacher `Roster`, `Calendar`, and `Settings` tabs in the classroom shell; updated roster removal to delete classroom-specific student data
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/TeacherRosterTab.tsx`, `src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx`, `src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx`, `src/app/classrooms/[classroomId]/page.tsx`, `src/app/api/teacher/classrooms/[id]/roster/[studentId]/route.ts`, `tests/api/teacher/roster-studentId.test.ts`
+**Next:** Merge PR #18 (classroom shell) then merge stacked tabs PR; validate UX on staging with seeded accounts
+**Blockers:** PR #18 required checks
+---

--- a/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import type { ClassDay, Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherCalendarTab({ classroom }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [classDays, setClassDays] = useState<ClassDay[]>([])
+  const [error, setError] = useState<string>('')
+  const [success, setSuccess] = useState<string>('')
+  const [startDate, setStartDate] = useState<string>('')
+  const [endDate, setEndDate] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/class-days?classroom_id=${classroom.id}`)
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to load class days')
+      }
+      setClassDays(data.class_days || [])
+    } catch (err: any) {
+      setError(err.message || 'Failed to load class days')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classroom.id])
+
+  const sorted = useMemo(() => {
+    return [...classDays].sort((a, b) => a.date.localeCompare(b.date))
+  }, [classDays])
+
+  async function generateFromRange() {
+    setSaving(true)
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch('/api/teacher/class-days', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classroom_id: classroom.id,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to generate class days')
+      }
+      setSuccess(`Generated ${data.count ?? 0} class days.`)
+      await load()
+    } catch (err: any) {
+      setError(err.message || 'Failed to generate class days')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function toggleDay(date: string, isClassDay: boolean) {
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch('/api/teacher/class-days', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classroom_id: classroom.id,
+          date,
+          is_class_day: isClassDay,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update day')
+      }
+      setClassDays(prev => {
+        const existingIndex = prev.findIndex(d => d.date === date)
+        if (existingIndex === -1) return [...prev, data.class_day]
+        const next = [...prev]
+        next[existingIndex] = data.class_day
+        return next
+      })
+    } catch (err: any) {
+      setError(err.message || 'Failed to update day')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-4 space-y-3">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h2 className="text-lg font-semibold text-gray-900">Calendar</h2>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+            onClick={load}
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="text-sm text-gray-600">
+          Define which dates are class days. Students can only log on class days.
+        </div>
+
+        <div className="flex flex-wrap items-end gap-2">
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">Start</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm"
+              disabled={saving}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">End</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm"
+              disabled={saving}
+            />
+          </div>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50"
+            onClick={generateFromRange}
+            disabled={saving || !startDate || !endDate}
+          >
+            {saving ? 'Generating…' : 'Generate'}
+          </button>
+        </div>
+
+        {error && <div className="text-sm text-red-600">{error}</div>}
+        {success && <div className="text-sm text-green-700">{success}</div>}
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm divide-y divide-gray-100">
+        {sorted.map((day) => (
+          <div key={day.date} className="p-4 flex items-center justify-between">
+            <div className="text-sm text-gray-800">{day.date}</div>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={day.is_class_day}
+                onChange={(e) => toggleDay(day.date, e.target.checked)}
+              />
+              Class day
+            </label>
+          </div>
+        ))}
+
+        {sorted.length === 0 && (
+          <div className="p-6 text-center text-gray-500">
+            No class days defined yet. Generate a range above.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import type { Classroom } from '@/types'
+
+interface RosterRow {
+  student_id: string
+  email: string
+  first_name: string | null
+  last_name: string | null
+  student_number: string | null
+  created_at: string
+}
+
+interface Props {
+  classroom: Classroom
+}
+
+function normalizeRosterRows(raw: any[]): RosterRow[] {
+  return (raw || []).map((row) => {
+    const profile = row.student_profiles || {}
+    const user = row.users || {}
+    return {
+      student_id: row.student_id,
+      email: user.email,
+      first_name: profile.first_name ?? null,
+      last_name: profile.last_name ?? null,
+      student_number: profile.student_number ?? null,
+      created_at: row.created_at,
+    } satisfies RosterRow
+  })
+}
+
+export function TeacherRosterTab({ classroom }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [roster, setRoster] = useState<RosterRow[]>([])
+  const [error, setError] = useState<string>('')
+  const [success, setSuccess] = useState<string>('')
+
+  const [uploading, setUploading] = useState(false)
+  const [csvText, setCsvText] = useState('')
+
+  const sortedRoster = useMemo(() => {
+    return [...roster].sort((a, b) => a.email.localeCompare(b.email))
+  }, [roster])
+
+  async function loadRoster() {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster`)
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to load roster')
+      }
+      setRoster(normalizeRosterRows(data.roster || []))
+    } catch (err: any) {
+      setError(err.message || 'Failed to load roster')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadRoster()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classroom.id])
+
+  async function onPickFile(file: File | null) {
+    if (!file) return
+    setError('')
+    setSuccess('')
+    try {
+      const text = await file.text()
+      setCsvText(text)
+    } catch {
+      setError('Failed to read file')
+    }
+  }
+
+  async function uploadCsv() {
+    setUploading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/upload-csv`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csvData: csvText }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to upload CSV')
+      }
+      setSuccess(`Uploaded. Added ${data.addedCount ?? 0} students.`)
+      await loadRoster()
+    } catch (err: any) {
+      setError(err.message || 'Failed to upload CSV')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function removeStudent(studentId: string, email: string) {
+    setError('')
+    setSuccess('')
+    const ok = window.confirm(
+      `Remove ${email} from this classroom?\n\nThis will delete their classroom data (logs and assignment docs).`
+    )
+    if (!ok) return
+
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${studentId}`, {
+        method: 'DELETE',
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to remove student')
+      }
+      setSuccess(`Removed ${email}.`)
+      await loadRoster()
+    } catch (err: any) {
+      setError(err.message || 'Failed to remove student')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-4 space-y-3">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h2 className="text-lg font-semibold text-gray-900">Roster</h2>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+            onClick={loadRoster}
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="text-sm text-gray-600">
+          Upload CSV with columns: Student Number, First Name, Last Name, Email
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
+            className="text-sm"
+            disabled={uploading}
+          />
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50"
+            onClick={uploadCsv}
+            disabled={uploading || csvText.trim().length === 0}
+          >
+            {uploading ? 'Uploading…' : 'Upload'}
+          </button>
+        </div>
+
+        {error && <div className="text-sm text-red-600">{error}</div>}
+        {success && <div className="text-sm text-green-700">{success}</div>}
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm divide-y divide-gray-100">
+        {sortedRoster.map((row) => (
+          <div key={row.student_id} className="p-4 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-gray-900">{row.email}</div>
+              <div className="mt-1 text-sm text-gray-600">
+                {row.first_name || row.last_name
+                  ? `${row.last_name ?? ''}${row.last_name ? ', ' : ''}${row.first_name ?? ''}`.trim()
+                  : '(no name)'}
+                {row.student_number ? ` • ${row.student_number}` : ''}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="px-3 py-2 rounded-md border border-red-200 bg-white text-sm text-red-700 hover:bg-red-50 flex-shrink-0"
+              onClick={() => removeStudent(row.student_id, row.email)}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+
+        {sortedRoster.length === 0 && (
+          <div className="p-6 text-center text-gray-500">No students enrolled</div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import type { Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherSettingsTab({ classroom }: Props) {
+  const joinLink = `${typeof window !== 'undefined' ? window.location.origin : ''}/join/${classroom.class_code}`
+
+  async function copy(text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-6 space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
+        <p className="text-sm text-gray-600 mt-1">
+          Classroom configuration and invite info.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-sm text-gray-600">Join code</div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="px-3 py-2 rounded-md border border-gray-200 bg-gray-50 text-sm">
+            {classroom.class_code}
+          </code>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+            onClick={() => copy(classroom.class_code)}
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-sm text-gray-600">Join link</div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="px-3 py-2 rounded-md border border-gray-200 bg-gray-50 text-sm break-all">
+            {joinLink}
+          </code>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+            onClick={() => copy(joinLink)}
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+
+      <div className="text-sm text-gray-600">
+        Enrollment enable/disable toggle will be added in a later phase.
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/classrooms/[classroomId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/page.tsx
@@ -9,6 +9,9 @@ import { StudentHistoryTab } from './StudentHistoryTab'
 import { StudentAssignmentsTab } from './StudentAssignmentsTab'
 import { TeacherAttendanceTab } from './TeacherAttendanceTab'
 import { TeacherLogsTab } from './TeacherLogsTab'
+import { TeacherRosterTab } from './TeacherRosterTab'
+import { TeacherCalendarTab } from './TeacherCalendarTab'
+import { TeacherSettingsTab } from './TeacherSettingsTab'
 import type { Classroom } from '@/types'
 
 interface UserInfo {
@@ -170,19 +173,13 @@ export default function ClassroomPage() {
             <TeacherClassroomView classroom={classroom} />
           )}
           {activeTab === 'roster' && (
-            <div className="bg-white rounded-lg shadow-sm p-6 text-gray-600">
-              Roster management will live here next (CSV upload + remove).
-            </div>
+            <TeacherRosterTab classroom={classroom} />
           )}
           {activeTab === 'calendar' && (
-            <div className="bg-white rounded-lg shadow-sm p-6 text-gray-600">
-              Calendar (class days) will live here next.
-            </div>
+            <TeacherCalendarTab classroom={classroom} />
           )}
           {activeTab === 'settings' && (
-            <div className="bg-white rounded-lg shadow-sm p-6 text-gray-600">
-              Classroom settings will live here next.
-            </div>
+            <TeacherSettingsTab classroom={classroom} />
           )}
         </>
       ) : (


### PR DESCRIPTION
Stacked on #18.

Implements the remaining teacher classroom shell tabs:
- **Roster**: CSV upload (4 columns) + roster list + remove student.
- **Calendar**: generate class days from a date range + toggle class-day per date.
- **Settings**: show/copy join code + join link.

Behavior change:
- Removing a student now deletes their classroom-specific data (entries/logs + assignment docs for assignments in that classroom), then removes the enrollment. User account/profile are kept.

Tests:
- Expanded `tests/api/teacher/roster-studentId.test.ts` to cover the new delete behavior.
