### PR TITLE
feat: make classroom shell the primary entry

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -214,3 +214,13 @@
 **Next:** Merge PR #18 (classroom shell) then merge stacked tabs PR; validate UX on staging with seeded accounts
 **Blockers:** PR #18 required checks
 ---
+
+## 2025-12-13 16:35 [AI - GPT-5.2]
+**Goal:** Make classroom shell the primary app
+**Completed:** Added `/classrooms` landing that routes users into their most recent classroom (teacher: most recently updated; student: most recently joined); added `/join` entry page; updated auth redirects and nav links to point at `/classrooms`; added teacher classroom switcher + create flow in the shell
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/page.tsx`, `src/app/classrooms/teacher-no-classrooms.tsx`, `src/app/join/page.tsx`, `src/app/join/[code]/page.tsx`, `src/app/classrooms/[classroomId]/page.tsx`, `src/app/api/auth/login/route.ts`, `src/app/api/auth/create-password/route.ts`, `src/app/api/auth/reset-password/confirm/route.ts`, `src/app/classrooms/layout.tsx`, `src/app/teacher/layout.tsx`, `src/app/student/layout.tsx`, `src/components/CreateClassroomModal.tsx`, `tests/api/auth/login.test.ts`, `tests/api/auth/create-password.test.ts`
+**Next:** Merge and validate on staging (login → `/classrooms` → classroom shell) for both teacher and student
+**Blockers:** None
+---

--- a/src/app/api/auth/create-password/route.ts
+++ b/src/app/api/auth/create-password/route.ts
@@ -85,10 +85,7 @@ export async function POST(request: NextRequest) {
     // Create session
     await createSession(user.id, user.email, user.role)
 
-    // Return redirect URL based on role
-    const redirectUrl = user.role === 'teacher'
-      ? '/teacher/dashboard'
-      : '/student/today'
+    const redirectUrl = '/classrooms'
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -74,10 +74,7 @@ export async function POST(request: NextRequest) {
     // Create session
     await createSession(user.id, user.email, user.role)
 
-    // Return redirect URL based on role
-    const redirectUrl = user.role === 'teacher'
-      ? '/teacher/dashboard'
-      : '/student/today'
+    const redirectUrl = '/classrooms'
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/auth/reset-password/confirm/route.ts
+++ b/src/app/api/auth/reset-password/confirm/route.ts
@@ -93,10 +93,7 @@ export async function POST(request: NextRequest) {
     // Create new session
     await createSession(user.id, user.email, user.role)
 
-    // Return redirect URL based on role
-    const redirectUrl = user.role === 'teacher'
-      ? '/teacher/dashboard'
-      : '/student/today'
+    const redirectUrl = '/classrooms'
 
     return NextResponse.json({
       success: true,

--- a/src/app/classrooms/layout.tsx
+++ b/src/app/classrooms/layout.tsx
@@ -15,7 +15,7 @@ export default async function ClassroomsLayout({
   }
 
   const isTeacher = user.role === 'teacher'
-  const homeLink = isTeacher ? '/teacher/dashboard' : '/student/today'
+  const homeLink = '/classrooms'
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -27,10 +27,10 @@ export default async function ClassroomsLayout({
               {isTeacher ? (
                 <>
                   <Link
-                    href="/teacher/dashboard"
+                    href={homeLink}
                     className="text-gray-700 hover:text-gray-900"
                   >
-                    Dashboard
+                    Classrooms
                   </Link>
                   <Link
                     href="/teacher/calendar"
@@ -42,10 +42,10 @@ export default async function ClassroomsLayout({
               ) : (
                 <>
                   <Link
-                    href="/student/today"
+                    href={homeLink}
                     className="text-gray-700 hover:text-gray-900"
                   >
-                    Today
+                    Classrooms
                   </Link>
                   <Link
                     href="/student/history"

--- a/src/app/classrooms/page.tsx
+++ b/src/app/classrooms/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/auth'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { TeacherNoClassrooms } from './teacher-no-classrooms'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default async function ClassroomsIndexPage() {
+  const user = await getCurrentUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const supabase = getServiceRoleClient()
+
+  if (user.role === 'teacher') {
+    const { data: classrooms } = await supabase
+      .from('classrooms')
+      .select('id, updated_at')
+      .eq('teacher_id', user.id)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+
+    const mostRecent = classrooms?.[0]
+    if (!mostRecent) {
+      return <TeacherNoClassrooms />
+    }
+
+    redirect(`/classrooms/${mostRecent.id}?tab=attendance`)
+  }
+
+  const { data: enrollments } = await supabase
+    .from('classroom_enrollments')
+    .select('classroom_id, created_at')
+    .eq('student_id', user.id)
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  const mostRecentEnrollment = enrollments?.[0]
+  if (!mostRecentEnrollment) {
+    redirect('/join')
+  }
+
+  redirect(`/classrooms/${mostRecentEnrollment.classroom_id}?tab=today`)
+}
+

--- a/src/app/classrooms/teacher-no-classrooms.tsx
+++ b/src/app/classrooms/teacher-no-classrooms.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CreateClassroomModal } from '@/components/CreateClassroomModal'
+import type { Classroom } from '@/types'
+
+export function TeacherNoClassrooms() {
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(true)
+
+  function onSuccess(classroom: Classroom) {
+    setIsOpen(false)
+    router.push(`/classrooms/${classroom.id}?tab=attendance`)
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-12">
+      <div className="bg-white rounded-lg shadow-sm p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-900">Create your first classroom</h1>
+        <p className="text-gray-600 mt-2">
+          Once you create a classroom, you’ll manage attendance, logs, roster, and assignments from the classroom shell.
+        </p>
+        <div className="mt-6">
+          <button
+            type="button"
+            className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700"
+            onClick={() => setIsOpen(true)}
+          >
+            Create classroom
+          </button>
+        </div>
+      </div>
+
+      <CreateClassroomModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onSuccess={onSuccess}
+      />
+    </div>
+  )
+}
+

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -32,7 +32,7 @@ export default function JoinClassroomPage() {
         }
 
         // Redirect to student dashboard with the new classroom selected
-        router.push(`/student/today?classroomId=${data.classroom.id}`)
+        router.push(`/classrooms/${data.classroom.id}?tab=today`)
       } catch (err: any) {
         console.error('Join error:', err)
         setError(err.message || 'An error occurred')

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function JoinPage() {
+  const router = useRouter()
+  const [code, setCode] = useState('')
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = code.trim()
+    if (!trimmed) return
+    router.push(`/join/${encodeURIComponent(trimmed)}`)
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gray-50">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-sm p-8">
+        <h1 className="text-2xl font-bold text-gray-900">Join a classroom</h1>
+        <p className="text-gray-600 mt-2">
+          Enter the join code your teacher gave you.
+        </p>
+
+        <form className="mt-6 space-y-3" onSubmit={submit}>
+          <label className="block text-sm font-medium text-gray-700">
+            Join code
+            <input
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="ABC123"
+              autoCapitalize="characters"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="w-full px-4 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50"
+            disabled={!code.trim()}
+          >
+            Join
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -26,10 +26,10 @@ export default async function StudentLayout({
             <div className="flex items-center space-x-6">
               <Image src="/pika_silhouette.png" alt="Pika" width={40} height={40} className="object-contain" />
               <Link
-                href="/student/today"
+                href="/classrooms"
                 className="text-gray-700 hover:text-gray-900"
               >
-                Today
+                Classrooms
               </Link>
               <Link
                 href="/student/history"

--- a/src/app/teacher/layout.tsx
+++ b/src/app/teacher/layout.tsx
@@ -26,10 +26,10 @@ export default async function TeacherLayout({
             <div className="flex items-center space-x-6">
               <Image src="/pika_silhouette.png" alt="Pika" width={40} height={40} className="object-contain" />
               <Link
-                href="/teacher/dashboard"
+                href="/classrooms"
                 className="text-gray-700 hover:text-gray-900"
               >
-                Dashboard
+                Classrooms
               </Link>
               <Link
                 href="/teacher/calendar"

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -90,14 +90,16 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
 
       // Step 2: Upload roster if provided
       if (rosterFile) {
-        const formData = new FormData()
-        formData.append('file', rosterFile)
-
-        await fetch(`/api/teacher/classrooms/${classroom.id}/roster/upload-csv`, {
-          method: 'POST',
-          body: formData,
-        })
-        // Ignoring errors on roster upload - classroom is already created
+        try {
+          const csvData = await rosterFile.text()
+          await fetch(`/api/teacher/classrooms/${classroom.id}/roster/upload-csv`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ csvData }),
+          })
+        } catch {
+          // Ignoring errors on roster upload - classroom is already created
+        }
       }
 
       // Step 3: Create calendar

--- a/tests/api/auth/create-password.test.ts
+++ b/tests/api/auth/create-password.test.ts
@@ -138,6 +138,6 @@ describe('POST /api/auth/create-password', () => {
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
-    expect(data.redirectUrl).toBe('/student/today')
+    expect(data.redirectUrl).toBe('/classrooms')
   })
 })

--- a/tests/api/auth/login.test.ts
+++ b/tests/api/auth/login.test.ts
@@ -330,7 +330,7 @@ describe('POST /api/auth/login', () => {
       expect(data).toEqual({
         success: true,
         message: 'Login successful',
-        redirectUrl: '/student/today',
+        redirectUrl: '/classrooms',
         user: {
           id: 'user-1',
           email: 'test@example.com',
@@ -370,7 +370,7 @@ describe('POST /api/auth/login', () => {
       expect(data).toEqual({
         success: true,
         message: 'Login successful',
-        redirectUrl: '/teacher/dashboard',
+        redirectUrl: '/classrooms',
         user: {
           id: 'user-teacher-1',
           email: 'teacher@gapps.yrdsb.ca',


### PR DESCRIPTION
Makes the classroom shell the primary entry point.

Changes:
- Add `/classrooms` landing:
  - Teacher → most recently updated classroom → `/classrooms/:id?tab=attendance`
  - Student → most recently joined classroom → `/classrooms/:id?tab=today`
  - Student with no classrooms → `/join`
  - Teacher with no classrooms → create-first-classroom UI
- Add `/join` page (enter join code) and update `/join/[code]` redirect into the shell.
- Update auth endpoints to return `redirectUrl: /classrooms`.
- Update nav links to point at `/classrooms`.
- Add teacher classroom switcher + “+ New” create flow in `src/app/classrooms/[classroomId]/page.tsx`.
- Fix `CreateClassroomModal` roster upload to send JSON `{ csvData }` (matches the API).

Tests:
- Update auth API tests to expect `/classrooms` redirectUrl.
