### PR TITLE
feat: UI gallery + Playwright snapshot runner

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -234,3 +234,13 @@
 **Next:** Merge and validate teacher flow: login → `/classrooms` list → open/switch classrooms
 **Blockers:** None
 ---
+
+## 2025-12-13 17:10 [AI - GPT-5.2]
+**Goal:** Add UI review tools (gallery + snapshots)
+**Completed:** Added a staging-enabled `/__ui` gallery (gated by `ENABLE_UI_GALLERY=true`) and a Playwright snapshot runner that captures key screens across two laptop viewports into local artifacts
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/__ui/page.tsx`, `src/app/__ui/UiGallery.tsx`, `e2e/ui-snapshots.spec.ts`, `playwright.config.ts`, `README.md`, `docs/core/tests.md`, `.env.example`
+**Next:** Set `ENABLE_UI_GALLERY=true` on staging and run `pnpm run e2e:snapshots` against staging to generate the first snapshot pack
+**Blockers:** None
+---

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ ENABLE_MOCK_EMAIL=true
 # Application
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# UI Gallery (dev/staging)
+ENABLE_UI_GALLERY=false
+
 # Cron (Vercel Cron Jobs)
 # Vercel will send this value as: Authorization: Bearer <CRON_SECRET>
 CRON_SECRET=generate-a-secure-random-secret

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ supabase/.temp/
 
 # Remote Supabase reference (backup)
 .env.remote.local
+
+# Playwright / UI snapshots (generated locally)
+/playwright-report/
+/test-results/
+/artifacts/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,26 @@ npm run test:watch
 npm run test:ui
 ```
 
+### UI Review (Gallery + Snapshots)
+
+Enable the UI gallery (recommended on staging):
+```env
+ENABLE_UI_GALLERY=true
+```
+
+Visit `/__ui` (e.g. `https://your-url/__ui`).
+
+Run Playwright snapshots against staging (generates local screenshots + an HTML report):
+```bash
+E2E_BASE_URL=https://your-staging-url \
+E2E_TEACHER_EMAIL=teacher@yrdsb.ca \
+E2E_STUDENT_EMAIL=student1@student.yrdsb.ca \
+E2E_PASSWORD=test1234 \
+pnpm run e2e:snapshots
+
+pnpm exec playwright show-report playwright-report
+```
+
 ### Build
 ```bash
 npm run build

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -139,6 +139,13 @@ Focus on **critical user flows**:
 
 **Tools**: Consider Playwright for 1-2 E2E tests (optional).
 
+### UI Snapshot Runs (Playwright)
+
+For visual review (spacing/aesthetics), we also support a **manual** Playwright snapshot run against staging:
+- Spec: `e2e/ui-snapshots.spec.ts`
+- Output (local): `artifacts/ui-snapshots/` (screenshots) and `playwright-report/` (HTML report)
+- Gallery (web): `/__ui` (gated by `ENABLE_UI_GALLERY=true`)
+
 ---
 
 ## 6. Component Tests (Optional)

--- a/e2e/ui-snapshots.spec.ts
+++ b/e2e/ui-snapshots.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const TEACHER_EMAIL = process.env.E2E_TEACHER_EMAIL || 'teacher@yrdsb.ca'
+const STUDENT_EMAIL = process.env.E2E_STUDENT_EMAIL || 'student1@student.yrdsb.ca'
+const PASSWORD = process.env.E2E_PASSWORD || 'test1234'
+const SNAPSHOT_DIR = process.env.E2E_SNAPSHOT_DIR || 'artifacts/ui-snapshots'
+
+async function login(page: Page, email: string) {
+  await page.goto('/login')
+  await page.getByLabel('School Email').fill(email)
+  await page.getByLabel('Password').fill(PASSWORD)
+  await page.getByRole('button', { name: 'Login' }).click()
+  await page.waitForURL('**/classrooms**', { timeout: 30_000 })
+}
+
+async function snap(page: Page, name: string) {
+  await page.waitForLoadState('networkidle')
+  const path = `${SNAPSHOT_DIR}/${name}.png`
+  mkdirSync(dirname(path), { recursive: true })
+  await page.screenshot({ path, fullPage: true })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('logged-out screens', async ({ page }) => {
+  await page.goto('/login')
+  await snap(page, 'auth/login')
+
+  await page.goto('/signup')
+  await snap(page, 'auth/signup')
+
+  await page.goto('/forgot-password')
+  await snap(page, 'auth/forgot-password')
+})
+
+test('teacher screens', async ({ page }) => {
+  await login(page, TEACHER_EMAIL)
+
+  await page.goto('/__ui')
+  await snap(page, 'teacher/ui-gallery')
+
+  await page.goto('/classrooms')
+  await snap(page, 'teacher/classrooms-index')
+
+  const openLink = page.getByRole('link', { name: 'Open' }).first()
+  await expect(openLink).toBeVisible({ timeout: 15_000 })
+  await openLink.click()
+  await page.waitForURL('**/classrooms/**', { timeout: 15_000 })
+  await snap(page, 'teacher/classroom/attendance')
+
+  await page.getByRole('button', { name: 'Logs' }).click()
+  await snap(page, 'teacher/classroom/logs-collapsed')
+
+  const expandAll = page.getByRole('button', { name: 'Expand all' })
+  if (await expandAll.isVisible()) {
+    await expandAll.click()
+  }
+  await snap(page, 'teacher/classroom/logs-expanded')
+
+  await page.getByRole('button', { name: 'Roster' }).click()
+  await snap(page, 'teacher/classroom/roster')
+
+  await page.getByRole('button', { name: 'Calendar' }).click()
+  await snap(page, 'teacher/classroom/calendar')
+
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await snap(page, 'teacher/classroom/settings')
+
+  await page.getByRole('button', { name: 'Assignments' }).click()
+  await snap(page, 'teacher/classroom/assignments')
+
+  const assignmentLink = page.locator('a[href*="/assignments/"]').first()
+  if ((await assignmentLink.count()) > 0) {
+    await assignmentLink.click()
+    await page.waitForURL('**/assignments/**', { timeout: 15_000 })
+    await snap(page, 'teacher/assignment/detail')
+  }
+})
+
+test('student screens', async ({ page }) => {
+  await login(page, STUDENT_EMAIL)
+
+  await page.goto('/__ui')
+  await snap(page, 'student/ui-gallery')
+
+  // Student is auto-routed into their most recent classroom from /classrooms
+  await page.goto('/classrooms')
+  await page.waitForURL('**/classrooms/**', { timeout: 15_000 })
+  await snap(page, 'student/classroom/today')
+
+  await page.getByRole('button', { name: 'History' }).click()
+  await snap(page, 'student/classroom/history')
+
+  await page.getByRole('button', { name: 'Assignments' }).click()
+  await snap(page, 'student/classroom/assignments')
+
+  const assignmentLink = page.locator('a[href*="/assignments/"]').first()
+  if ((await assignmentLink.count()) > 0) {
+    await assignmentLink.click()
+    await page.waitForURL('**/assignments/**', { timeout: 15_000 })
+    await snap(page, 'student/assignment/editor')
+  }
+
+  await page.goto('/join')
+  await snap(page, 'student/join')
+})
+

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "e2e:install": "playwright install",
+    "e2e:snapshots": "playwright test e2e/ui-snapshots.spec.ts",
     "seed": "tsx scripts/seed.ts",
     "seed:fresh": "tsx scripts/clear-and-seed.ts",
     "generate:secret": "node scripts/generate-env.js"
@@ -30,6 +32,7 @@
     "react-dom": "^18.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@types/bcryptjs": "^2.4.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test'
+
+const baseURL = process.env.E2E_BASE_URL
+if (!baseURL) {
+  throw new Error('E2E_BASE_URL is required (set it to your staging URL)')
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  reporter: [['list'], ['html', { open: 'never' }]],
+  retries: 0,
+  use: {
+    baseURL,
+  },
+  projects: [
+    {
+      name: 'desktop-1440x900',
+      use: { viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'desktop-1280x720',
+      use: { viewport: { width: 1280, height: 720 } },
+    },
+  ],
+})
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 8.0.4
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -36,6 +36,9 @@ importers:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@testing-library/jest-dom':
         specifier: ^6.2.0
         version: 6.9.1
@@ -615,6 +618,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -1198,6 +1206,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1598,6 +1611,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2412,6 +2435,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/rollup-android-arm-eabi@4.53.3':
@@ -3062,6 +3089,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3380,7 +3410,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@14.2.35(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -3401,6 +3431,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.57.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -3454,6 +3485,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/app/__ui/UiGallery.tsx
+++ b/src/app/__ui/UiGallery.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import type { Classroom } from '@/types'
+
+type Role = 'teacher' | 'student'
+
+interface Props {
+  role: Role
+}
+
+export function UiGallery({ role }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string>('')
+  const [classrooms, setClassrooms] = useState<Classroom[]>([])
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError('')
+      try {
+        const url = role === 'teacher'
+          ? '/api/teacher/classrooms'
+          : '/api/student/classrooms'
+        const res = await fetch(url)
+        const data = await res.json()
+
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to load classrooms')
+        }
+
+        const next = role === 'teacher'
+          ? (data.classrooms || [])
+          : (data.classrooms || [])
+        setClassrooms(next)
+      } catch (err: any) {
+        setError(err.message || 'Failed to load')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [role])
+
+  const teacherLinks = useMemo(() => {
+    return classrooms.map((c) => ({
+      id: c.id,
+      title: c.title,
+      links: [
+        { label: 'Attendance', href: `/classrooms/${c.id}?tab=attendance` },
+        { label: 'Logs', href: `/classrooms/${c.id}?tab=logs` },
+        { label: 'Assignments', href: `/classrooms/${c.id}?tab=assignments` },
+        { label: 'Roster', href: `/classrooms/${c.id}?tab=roster` },
+        { label: 'Calendar', href: `/classrooms/${c.id}?tab=calendar` },
+        { label: 'Settings', href: `/classrooms/${c.id}?tab=settings` },
+      ],
+    }))
+  }, [classrooms])
+
+  const studentLinks = useMemo(() => {
+    return classrooms.map((c) => ({
+      id: c.id,
+      title: c.title,
+      links: [
+        { label: 'Today', href: `/classrooms/${c.id}?tab=today` },
+        { label: 'History', href: `/classrooms/${c.id}?tab=history` },
+        { label: 'Assignments', href: `/classrooms/${c.id}?tab=assignments` },
+      ],
+    }))
+  }, [classrooms])
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">UI Gallery</h1>
+        <p className="text-gray-600 mt-1">
+          Quick links to key views for visual review (spacing, layout, UI flow).
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <h2 className="text-lg font-semibold text-gray-900">Common</h2>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/classrooms">
+            Classrooms
+          </Link>
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/join">
+            Join (student)
+          </Link>
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/logout">
+            Logout
+          </Link>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <h2 className="text-lg font-semibold text-gray-900">Logged-out (open in a private window)</h2>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/login">
+            Login
+          </Link>
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/signup">
+            Signup
+          </Link>
+          <Link className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50" href="/forgot-password">
+            Forgot password
+          </Link>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <h2 className="text-lg font-semibold text-gray-900">
+          {role === 'teacher' ? 'Teacher' : 'Student'} Views
+        </h2>
+
+        {loading ? (
+          <div className="mt-3 text-sm text-gray-600">Loading…</div>
+        ) : error ? (
+          <div className="mt-3 text-sm text-red-600">{error}</div>
+        ) : classrooms.length === 0 ? (
+          <div className="mt-3 text-sm text-gray-600">No classrooms found.</div>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {(role === 'teacher' ? teacherLinks : studentLinks).map((group) => (
+              <div key={group.id} className="border border-gray-100 rounded-lg p-4">
+                <div className="text-sm font-semibold text-gray-900">{group.title}</div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {group.links.map((l) => (
+                    <Link
+                      key={l.href}
+                      className="px-3 py-2 rounded-md border border-gray-200 text-sm hover:bg-gray-50"
+                      href={l.href}
+                    >
+                      {l.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/__ui/page.tsx
+++ b/src/app/__ui/page.tsx
@@ -1,0 +1,20 @@
+import { notFound, redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/auth'
+import { UiGallery } from './UiGallery'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default async function UiGalleryPage() {
+  if (process.env.ENABLE_UI_GALLERY !== 'true') {
+    notFound()
+  }
+
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect('/login')
+  }
+
+  return <UiGallery role={user.role} />
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
+    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Adds two UI review tools:

1) **Web UI Gallery** (for quickly navigating views)
- Route: `/__ui`
- Gated by `ENABLE_UI_GALLERY=true` (intended for staging/dev)
- Uses existing APIs to list classroom links by role

2) **Playwright snapshot runner** (for visual snapshots)
- Spec: `e2e/ui-snapshots.spec.ts`
- Config: `playwright.config.ts` (runs two laptop viewports)
- Outputs (local): `artifacts/ui-snapshots/` (pngs) + `playwright-report/` (HTML)

Usage:
- Set staging env: `ENABLE_UI_GALLERY=true`
- Run locally:
  ```bash
  pnpm run e2e:install
  E2E_BASE_URL=https://<your-staging-url> \
  E2E_TEACHER_EMAIL=teacher@yrdsb.ca \
  E2E_STUDENT_EMAIL=student1@student.yrdsb.ca \
  E2E_PASSWORD=test1234 \
  pnpm run e2e:snapshots

  pnpm exec playwright show-report playwright-report
  ```

Notes:
- Vitest is constrained to `tests/**` so it won’t try to run Playwright specs.
