### PR TITLE
chore: run Playwright snapshots against local dev by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,28 @@ ENABLE_UI_GALLERY=true
 
 Visit `/__ui` (e.g. `https://your-url/__ui`).
 
-Run Playwright snapshots against staging (generates local screenshots + an HTML report):
+Run Playwright snapshots (generates local screenshots + an HTML report).
+
+**Local dev workflow (recommended)**:
+```bash
+# 1) Seed a dev DB with password-based accounts (teacher + students)
+ENV_FILE=.env.local ALLOW_DB_WIPE=true pnpm run seed:fresh
+
+# 2) Enable the gallery locally (optional)
+export ENABLE_UI_GALLERY=true
+
+# 3) Start the dev server
+pnpm dev
+
+# 4) In another terminal, install browsers once and run snapshots
+pnpm run e2e:install
+E2E_BASE_URL=http://localhost:3000 pnpm run e2e:snapshots
+
+# 5) View the report
+pnpm exec playwright show-report playwright-report
+```
+
+**Staging workflow**:
 ```bash
 E2E_BASE_URL=https://your-staging-url \
 E2E_TEACHER_EMAIL=teacher@yrdsb.ca \

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from '@playwright/test'
 
-const baseURL = process.env.E2E_BASE_URL
-if (!baseURL) {
-  throw new Error('E2E_BASE_URL is required (set it to your staging URL)')
-}
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000'
 
 export default defineConfig({
   testDir: './e2e',
@@ -23,4 +20,3 @@ export default defineConfig({
     },
   ],
 })
-


### PR DESCRIPTION
Makes the snapshot runner default to local dev.

- `playwright.config.ts` defaults `baseURL` to `http://localhost:3000` when `E2E_BASE_URL` is not set.
- `README.md` now documents the recommended local workflow: `seed:fresh` → `pnpm dev` → `pnpm run e2e:snapshots` → view report.
