### PR TITLE
Join link redirects to login

### DIFF
--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -31,6 +31,11 @@ export default function JoinClassroomPage() {
           }),
         })
 
+        if (response.status === 401) {
+          router.push(`/login?next=${encodeURIComponent(`/join/${trimmedCode}`)}`)
+          return
+        }
+
         const data = await response.json()
 
         if (!response.ok) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,19 @@
 'use client'
 
 import { useState, FormEvent } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Input } from '@/components/Input'
 import { Button } from '@/components/Button'
 
+function isSafeNextPath(next: string): boolean {
+  if (!next.startsWith('/')) return false
+  if (next.startsWith('//')) return false
+  return true
+}
+
 export default function LoginPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -30,7 +37,12 @@ export default function LoginPage() {
         throw new Error(data.error || 'Login failed')
       }
 
-      // Redirect based on user role
+      const next = searchParams.get('next')
+      if (next && isSafeNextPath(next)) {
+        router.push(next)
+        return
+      }
+
       router.push(data.redirectUrl)
     } catch (err: any) {
       setError(err.message || 'An error occurred')


### PR DESCRIPTION
When a student opens a join link while logged out, redirect them to `/login?next=/join/<code>` and continue after login.

Changes:
- `src/app/join/[code]/page.tsx`: if join API returns 401, redirect to login with next.
- `src/app/login/page.tsx`: support `?next=` (relative-only) for post-login redirect.

Tests: `npm test`.
