### PR TITLE
Align seed + roster add with allow-list

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -254,3 +254,13 @@
 **Next:** Apply migration `009` to staging/prod and confirm end-to-end: teacher uploads roster → student signs in with roster email → joins by code → teacher sees Joined
 **Blockers:** None
 ---
+
+## 2025-12-14 15:55 [AI - GPT-5.2]
+**Goal:** Align dev seeding and roster add with allow-list
+**Completed:** Updated `scripts/clear-and-seed.ts` to wipe and populate `classroom_roster` + `student_profiles`; updated `/api/teacher/classrooms/[id]/roster/add` to upsert allow-list rows (no auto-enrollment); updated tests
+**Status:** completed
+**Artifacts:**
+- Files: `scripts/clear-and-seed.ts`, `src/app/api/teacher/classrooms/[id]/roster/add/route.ts`, `tests/api/teacher/roster-add.test.ts`
+**Next:** Merge PR and (optional) reseed staging/local to confirm teacher roster shows rows + join indicator
+**Blockers:** None
+---

--- a/scripts/clear-and-seed.ts
+++ b/scripts/clear-and-seed.ts
@@ -48,6 +48,8 @@ async function clearAndSeed() {
   await supabase.from('assignments').delete().neq('id', '00000000-0000-0000-0000-000000000000')
   await supabase.from('entries').delete().neq('id', '00000000-0000-0000-0000-000000000000')
   await supabase.from('classroom_enrollments').delete().neq('id', '00000000-0000-0000-0000-000000000000')
+  await supabase.from('classroom_roster').delete().neq('id', '00000000-0000-0000-0000-000000000000')
+  await supabase.from('student_profiles').delete().neq('id', '00000000-0000-0000-0000-000000000000')
   await supabase.from('class_days').delete().neq('id', '00000000-0000-0000-0000-000000000000')
   await supabase.from('classrooms').delete().neq('id', '00000000-0000-0000-0000-000000000000')
   await supabase.from('verification_codes').delete().neq('id', '00000000-0000-0000-0000-000000000000')
@@ -86,6 +88,20 @@ async function clearAndSeed() {
     students.push(data)
   }
 
+  console.log('Creating student profiles...')
+  for (let i = 0; i < students.length; i++) {
+    const student = students[i]!
+    await supabase
+      .from('student_profiles')
+      .upsert({
+        user_id: student.id,
+        student_number: `100${i + 1}`,
+        first_name: `Student${i + 1}`,
+        last_name: 'Test',
+      }, { onConflict: 'user_id' })
+  }
+  console.log('✓ Created student profiles\n')
+
   console.log(`✓ Created 1 teacher and ${students.length} students\n`)
 
   // 2. Create classroom
@@ -103,6 +119,19 @@ async function clearAndSeed() {
     .single()
 
   console.log(`✓ Created classroom: ${classroom!.title}\n`)
+
+  // 2.5 Add students to classroom roster allow-list
+  console.log('Creating classroom roster allow-list...')
+  await supabase
+    .from('classroom_roster')
+    .insert(students.map((student, index) => ({
+      classroom_id: classroom!.id,
+      email: student!.email.toLowerCase().trim(),
+      student_number: `100${index + 1}`,
+      first_name: `Student${index + 1}`,
+      last_name: 'Test',
+    })))
+  console.log(`✓ Added ${students.length} students to classroom roster\n`)
 
   // 3. Enroll students
   console.log('Enrolling students...')


### PR DESCRIPTION
Updates dev seeding and the manual roster add endpoint to match the roster allow-list model.

Changes:
- `scripts/clear-and-seed.ts`: wipes + populates `classroom_roster` and `student_profiles` so a fresh seeded DB works with roster-restricted enrollment.
- `POST /api/teacher/classrooms/[id]/roster/add`: now upserts `classroom_roster` rows only (no user creation, no auto-enrollment).
- Updates `tests/api/teacher/roster-add.test.ts`.

Tests: `npm test`.
