### PR TITLE
Fix assignments end-to-end (auto-create docs)

### DIFF
--- a/docs/core/assignments-smoke.md
+++ b/docs/core/assignments-smoke.md
@@ -1,0 +1,33 @@
+# Assignments Smoke Test (Manual)
+
+Goal: confirm the end-to-end assignments flow works for teachers and students.
+
+## Preconditions
+- Teacher and student accounts exist.
+- Student is enrolled in the classroom.
+- (If roster allow-list is enabled) student email is on roster and enrollment is enabled.
+
+## Teacher flow
+1) Log in as teacher.
+2) Go to `Classrooms` → open the classroom.
+3) Open `Assignments` tab.
+4) Click `+ New Assignment`, fill:
+   - Title
+   - Optional description
+   - Due date/time
+5) Confirm assignment appears in the list and open it.
+6) Confirm `Student Submissions` list loads.
+
+## Student flow
+1) Log in as student.
+2) Ensure you are in the classroom (join via code/link if needed).
+3) Open `Assignments` tab.
+4) Open the new assignment.
+5) Type some text; confirm autosave shows `Saving…` then `Saved`.
+6) Click `Submit`; confirm status changes to submitted and timestamp appears.
+7) Click `Unsubmit`; confirm status returns to in-progress.
+
+## Teacher review
+1) In the assignment detail page, confirm the student status changes to submitted.
+2) Click the student row; confirm the teacher can view the student’s work.
+

--- a/src/app/api/assignment-docs/[id]/unsubmit/route.ts
+++ b/src/app/api/assignment-docs/[id]/unsubmit/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 // POST /api/assignment-docs/[id]/unsubmit - Unsubmit assignment
 export async function POST(
   request: NextRequest,
@@ -46,6 +49,7 @@ export async function POST(
       .from('assignment_docs')
       .select('id, student_id')
       .eq('assignment_id', assignmentId)
+      .eq('student_id', user.id)
       .single()
 
     if (docError && docError.code === 'PGRST116') {
@@ -60,13 +64,6 @@ export async function POST(
       return NextResponse.json(
         { error: 'Failed to fetch assignment doc' },
         { status: 500 }
-      )
-    }
-
-    if (!existingDoc || existingDoc.student_id !== user.id) {
-      return NextResponse.json(
-        { error: 'Not authorized to unsubmit this document' },
-        { status: 403 }
       )
     }
 

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -14,38 +14,9 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('POST /api/assignment-docs/[id]/submit', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
-  it('should return 404 when doc does not exist', async () => {
-    const mockFrom = vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
-        })),
-      })),
-    }))
-    ;(mockSupabaseClient.from as any) = mockFrom
-
-    const request = new NextRequest('http://localhost:3000/api/assignment-docs/doc-999/submit', {
-      method: 'POST',
-    })
-
-    const response = await POST(request, { params: { id: 'doc-999' } })
-    expect(response.status).toBe(404)
-  })
-
-  it('should return 403 when not student owner', async () => {
+  it('should return 400 when doc does not exist', async () => {
     const mockFrom = vi.fn((table: string) => {
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'doc-1', student_id: 'other-student', assignment_id: 'assign-1' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      } else if (table === 'assignments') {
+      if (table === 'assignments') {
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
@@ -56,7 +27,8 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
             })),
           })),
         }
-      } else if (table === 'classroom_enrollments') {
+      }
+      if (table === 'classroom_enrollments') {
         return {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnThis(),
@@ -67,14 +39,69 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
           })),
         }
       }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+          })),
+        }
+      }
     })
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/assignment-docs/doc-1/submit', {
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
     })
 
-    const response = await POST(request, { params: { id: 'doc-1' } })
-    expect(response.status).toBe(403)
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(400)
+  })
+
+  it('should return 400 when doc content is empty', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'enroll-1' },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'doc-1', student_id: 'student-1', assignment_id: 'assign-1', content: '   ' },
+              error: null,
+            }),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(400)
   })
 })

--- a/tests/api/assignment-docs/unsubmit.test.ts
+++ b/tests/api/assignment-docs/unsubmit.test.ts
@@ -15,37 +15,8 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
   it('should return 404 when doc does not exist', async () => {
-    const mockFrom = vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
-        })),
-      })),
-    }))
-    ;(mockSupabaseClient.from as any) = mockFrom
-
-    const request = new NextRequest('http://localhost:3000/api/assignment-docs/doc-999/unsubmit', {
-      method: 'POST',
-    })
-
-    const response = await POST(request, { params: { id: 'doc-999' } })
-    expect(response.status).toBe(404)
-  })
-
-  it('should return 403 when not student owner', async () => {
     const mockFrom = vi.fn((table: string) => {
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'doc-1', student_id: 'other-student', assignment_id: 'assign-1' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      } else if (table === 'assignments') {
+      if (table === 'assignments') {
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
@@ -56,7 +27,8 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
             })),
           })),
         }
-      } else if (table === 'classroom_enrollments') {
+      }
+      if (table === 'classroom_enrollments') {
         return {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnThis(),
@@ -67,14 +39,79 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
           })),
         }
       }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+          })),
+        }
+      }
     })
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/assignment-docs/doc-1/unsubmit', {
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/unsubmit', {
       method: 'POST',
     })
 
-    const response = await POST(request, { params: { id: 'doc-1' } })
-    expect(response.status).toBe(403)
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(404)
+  })
+
+  it('unsubmits when doc exists', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'enroll-1' },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'doc-1', student_id: 'student-1', assignment_id: 'assign-1' },
+              error: null,
+            }),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'doc-1', is_submitted: false },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/unsubmit', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    expect(response.status).toBe(200)
   })
 })


### PR DESCRIPTION
Fixes the student assignment workflow so it works end-to-end.

Key fixes:
- `/api/assignment-docs/[assignmentId]` now correctly scopes docs by `(assignment_id, student_id)` and auto-creates a draft doc when missing.
- Submit/unsubmit routes now scope by student and enforce non-empty content on submit.
- Updates API tests to match the intended contract.
- Adds manual smoke checklist: `docs/core/assignments-smoke.md`.

Tests: `npm test`.
