### PR TITLE
fix: make daily log summaries cron-only

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -337,10 +337,10 @@
 
 ## 2025-12-14 06:59 [AI - GPT-5.2]
 **Goal:** Implement `epic-daily-log-summaries` (teacher 1-line summaries)
-**Completed:** Added cached 1-line AI summaries for teacher Logs view (generated with OpenAI `gpt-5-nano` by default, stored per-entry, recomputed only when entry text changes). Logs API now returns `summary` per student row; UI shows the summary when collapsed and full text when expanded. Added migration for `entry_summaries` table and tests for caching/generation behavior.
+**Completed:** Added cached 1-line AI summaries for teacher Logs view (generated with OpenAI `gpt-5-nano` by default and stored per-entry). Summaries are generated **only** by the nightly cron job (no on-demand generation; no regeneration). Logs API now returns `summary` per student row; UI shows the summary when collapsed and full text when expanded. Added migration for `entry_summaries` table and tests for cron generation + cached reads.
 **Status:** completed
 **Artifacts:**
-- Files: `supabase/migrations/010_entry_summaries.sql`, `src/lib/daily-log-summaries.ts`, `src/app/api/teacher/logs/route.ts`, `src/app/classrooms/[classroomId]/TeacherLogsTab.tsx`, `tests/api/teacher/logs.test.ts`, `tests/unit/daily-log-summaries.test.ts`, `.env.example`, `.ai/features.json`
-**Next:** Apply migration `010_entry_summaries.sql` to staging/prod; set `OPENAI_API_KEY` (and optionally `OPENAI_DAILY_LOG_SUMMARY_MODEL`) in Vercel; smoke test teacher Logs tab.
+- Files: `supabase/migrations/010_entry_summaries.sql`, `src/lib/daily-log-summaries.ts`, `src/app/api/cron/nightly-assignment-summaries/route.ts`, `src/app/api/teacher/logs/route.ts`, `src/app/classrooms/[classroomId]/TeacherLogsTab.tsx`, `tests/api/teacher/logs.test.ts`, `tests/api/cron/nightly-assignment-summaries.test.ts`, `tests/unit/daily-log-summaries.test.ts`, `.env.example`, `.ai/features.json`
+**Next:** Apply migration `010_entry_summaries.sql` to staging/prod; set `OPENAI_API_KEY` (and optionally `OPENAI_DAILY_LOG_SUMMARY_MODEL`) in Vercel; verify cron runs nightly and then smoke test teacher Logs tab (summaries appear the next day).
 **Blockers:** None
 ---

--- a/src/app/api/cron/nightly-assignment-summaries/route.ts
+++ b/src/app/api/cron/nightly-assignment-summaries/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { formatInTimeZone } from 'date-fns-tz'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { generateDailyLogSummary, hashDailyLogText } from '@/lib/daily-log-summaries'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 const TIMEZONE = 'America/Toronto'
+const DEFAULT_MAX_ENTRIES = 200
 
 function getCronAuthHeader(request: NextRequest): string | null {
   return request.headers.get('authorization') ?? request.headers.get('Authorization')
@@ -21,6 +24,37 @@ function isWithinNightlyWindowToronto(date: Date): boolean {
   const hour = Number(formatInTimeZone(date, TIMEZONE, 'H'))
   const minute = Number(formatInTimeZone(date, TIMEZONE, 'm'))
   return (hour === 1 || hour === 2) && minute < 10
+}
+
+function getYesterdayTorontoDateString(now: Date): string {
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+  return formatInTimeZone(yesterday, TIMEZONE, 'yyyy-MM-dd')
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let nextIndex = 0
+
+  async function worker() {
+    while (true) {
+      const current = nextIndex
+      nextIndex++
+      if (current >= items.length) return
+      results[current] = await fn(items[current])
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, Math.max(1, items.length)) },
+    () => worker()
+  )
+  await Promise.all(workers)
+  return results
 }
 
 async function handle(request: NextRequest) {
@@ -57,10 +91,90 @@ async function handle(request: NextRequest) {
     )
   }
 
-  // NOTE: Summary generation is implemented in a later phase.
-  // This endpoint intentionally no-ops until the assignments AI summary feature is ready.
+  if (!process.env.OPENAI_API_KEY?.trim()) {
+    return NextResponse.json(
+      { status: 'ok', ran: false, message: 'OPENAI_API_KEY_not_configured' },
+      { status: 200 }
+    )
+  }
+
+  const supabase = getServiceRoleClient()
+  const targetDate = getYesterdayTorontoDateString(new Date())
+
+  const { data: entries, error: entriesError } = await supabase
+    .from('entries')
+    .select('id, text')
+    .eq('date', targetDate)
+    .limit(DEFAULT_MAX_ENTRIES)
+
+  if (entriesError) {
+    console.error('Error fetching entries for summaries:', entriesError)
+    return NextResponse.json({ error: 'Failed to fetch entries' }, { status: 500 })
+  }
+
+  const entryIds = (entries || []).map((e: any) => e.id)
+  if (entryIds.length === 0) {
+    return NextResponse.json(
+      { status: 'ok', ran: true, date: targetDate, processed: 0, created: 0 },
+      { status: 200 }
+    )
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('entry_summaries')
+    .select('entry_id')
+    .in('entry_id', entryIds)
+
+  if (existingError) {
+    console.error('Error fetching existing entry summaries:', existingError)
+    return NextResponse.json({ error: 'Failed to fetch existing summaries' }, { status: 500 })
+  }
+
+  const existingIds = new Set((existing || []).map((r: any) => r.entry_id))
+  const missing = (entries || []).filter((e: any) => !existingIds.has(e.id))
+
+  if (missing.length === 0) {
+    return NextResponse.json(
+      { status: 'ok', ran: true, date: targetDate, processed: entryIds.length, created: 0 },
+      { status: 200 }
+    )
+  }
+
+  const generated = await mapWithConcurrency(
+    missing,
+    5,
+    async (entry: any) => {
+      const { summary, model } = await generateDailyLogSummary(entry.text)
+      return {
+        entry_id: entry.id,
+        model,
+        text_hash: hashDailyLogText(entry.text),
+        summary,
+      }
+    }
+  )
+
+  const { error: insertError } = await supabase
+    .from('entry_summaries')
+    .upsert(generated, { onConflict: 'entry_id' })
+
+  if (insertError) {
+    // We intentionally never regenerate; if another run already inserted, treat as success.
+    const message = String((insertError as any)?.message ?? '')
+    if (!message.toLowerCase().includes('duplicate')) {
+      console.error('Error inserting entry summaries:', insertError)
+      return NextResponse.json({ error: 'Failed to store summaries' }, { status: 500 })
+    }
+  }
+
   return NextResponse.json(
-    { status: 'ok', ran: false, message: 'not_implemented' },
+    {
+      status: 'ok',
+      ran: true,
+      date: targetDate,
+      processed: entryIds.length,
+      created: generated.length,
+    },
     { status: 200 }
   )
 }

--- a/tests/api/cron/nightly-assignment-summaries.test.ts
+++ b/tests/api/cron/nightly-assignment-summaries.test.ts
@@ -6,16 +6,25 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { GET, POST } from '@/app/api/cron/nightly-assignment-summaries/route'
 
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
 describe('/api/cron/nightly-assignment-summaries', () => {
   const originalCronSecret = process.env.CRON_SECRET
   const originalNodeEnv = process.env.NODE_ENV
   const originalVercelEnv = process.env.VERCEL_ENV
+  const originalOpenAiKey = process.env.OPENAI_API_KEY
 
   beforeEach(() => {
     vi.useFakeTimers()
     process.env.CRON_SECRET = 'test-cron-secret'
     process.env.NODE_ENV = 'test'
     delete process.env.VERCEL_ENV
+    delete process.env.OPENAI_API_KEY
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -36,6 +45,12 @@ describe('/api/cron/nightly-assignment-summaries', () => {
       delete process.env.VERCEL_ENV
     } else {
       process.env.VERCEL_ENV = originalVercelEnv
+    }
+
+    if (originalOpenAiKey === undefined) {
+      delete process.env.OPENAI_API_KEY
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAiKey
     }
   })
 
@@ -102,6 +117,85 @@ describe('/api/cron/nightly-assignment-summaries', () => {
 
     const body = await response.json()
     expect(body.status).toBe('ok')
+  })
+
+  it('returns ok but does not run when OPENAI_API_KEY is not configured', async () => {
+    vi.setSystemTime(new Date('2025-01-01T06:00:00Z'))
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/cron/nightly-assignment-summaries',
+      { headers: { authorization: 'Bearer test-cron-secret' } }
+    )
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+    expect(body.ran).toBe(false)
+    expect(body.message).toBe('OPENAI_API_KEY_not_configured')
+  })
+
+  it('generates summaries for yesterday entries that are missing summaries', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+    // 06:00Z is 1am Toronto during standard time (UTC-5). Yesterday Toronto date is 2024-12-31.
+    vi.setSystemTime(new Date('2025-01-01T06:00:00Z'))
+
+    const upsertSpy = vi.fn().mockResolvedValue({ error: null })
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'e1', text: 'hello' },
+                  { id: 'e2', text: 'world' },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'entry_summaries') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ entry_id: 'e1' }], // e1 already has a summary
+              error: null,
+            }),
+          })),
+          upsert: upsertSpy,
+        }
+      }
+      return {}
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ output_text: 'Summary' }),
+      } as any)
+    )
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/cron/nightly-assignment-summaries',
+      { headers: { authorization: 'Bearer test-cron-secret' } }
+    )
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.status).toBe('ok')
+    expect(body.ran).toBe(true)
+    expect(body.date).toBe('2024-12-31')
+    expect(body.created).toBe(1)
+    expect(upsertSpy).toHaveBeenCalledWith(
+      [expect.objectContaining({ entry_id: 'e2', summary: 'Summary' })],
+      { onConflict: 'entry_id' }
+    )
   })
 
   it('rejects force=1 in production', async () => {


### PR DESCRIPTION
Make daily log summaries as cheap as possible:

- `GET /api/teacher/logs` only reads cached `entry_summaries` (no OpenAI calls).
- Nightly cron (`/api/cron/nightly-assignment-summaries`) generates summaries once for *yesterday’s* entries that don’t have a summary yet.
- Existing summaries are never regenerated/overwritten.

Notes:
- Requires `OPENAI_API_KEY` and migration `010_entry_summaries.sql`.
- Summaries will appear the day after the cron runs.
