### PR TITLE
chore: enforce git worktree workflow

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -325,6 +325,21 @@
 **Blockers:** None
 ---
 
+## 2025-12-14 12:55 [AI - GPT-5.2]
+**Goal:** Enforce worktree-based git workflow (prevent multi-terminal confusion)
+**Completed:** Documented a mandatory “hub checkout + one worktree per branch/PR” workflow under `../worktrees/pika/`, clarified “no branch work in `pika/`” and “never switch branches inside a worktree”, and added explicit cleanup instructions after merge.
+**Status:** completed
+**Artifacts:**
+- `docs/workflow/worktrees.md`
+- `.ai/START-HERE.md`
+- `AGENTS.md`
+- `docs/ai-instructions.md`
+- `docs/workflow/handle-issue.md`
+- `docs/core/agents.md`
+**Next:** Use `pika/` only for fetch/PR ops; create and use a dedicated worktree for every branch/task.
+**Blockers:** None
+---
+
 ## 2025-12-14 06:46 [AI - GPT-5.2]
 **Goal:** Remove PR journal bot requirement
 **Completed:** Deleted the PR-event journaling GitHub Action and updated `epic-ai-effectiveness-layer` to remove PR-journal-bot verification; marked the epic passing.

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -4,6 +4,16 @@
 
 ---
 
+## 0) Worktree Workflow (MANDATORY)
+
+Never do branch work inside `pika/` (the hub checkout).
+
+If you need a branch/PR, create and use a dedicated worktree under `../worktrees/pika/`.
+
+See: `docs/workflow/worktrees.md`
+
+---
+
 ## 1) Verify the Environment (1–2 min)
 
 ```bash
@@ -102,6 +112,10 @@ Before writing code:
    node scripts/features.mjs fail <feature-id>
    ```
 3. Commit and push the journal + feature changes.
+4. If the work was merged, remove the worktree:
+   ```bash
+   git worktree remove ../worktrees/pika/<branch-name>
+   ```
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 - Read `.ai/START-HERE.md` at the start of every session.
 - Follow the required reading order in `docs/ai-instructions.md` before modifying code.
 
+## Git Worktrees (MANDATORY)
+- Never do branch work in the main repo directory (`pika/`).
+- Any branch work must happen in a dedicated git worktree under `../worktrees/pika/`.
+- Do not switch branches inside an existing working tree; create a new worktree instead.
+- After a PR is merged, remove its worktree (see `docs/workflow/worktrees.md`).
+
 ## Project Overview
 - Next.js 14+ (App Router) + TypeScript
 - Supabase (PostgreSQL) for data/storage
@@ -34,4 +40,3 @@
 4. `docs/core/design.md` (UI/UX rules)
 5. `docs/core/project-context.md` (setup and commands)
 6. `.ai/JOURNAL.md` + `docs/core/decision-log.md` (history/rationale)
-

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -119,18 +119,19 @@ This TDD approach ensures code quality and prevents regressions.
 
 1. Read ai-instructions.md (this file)
 2. Read all required docs in sequence
-3. Identify which agent role to adopt (see agents.md)
-4. Write tests FIRST for core logic
-5. Implement minimal code to pass tests
-6. Refactor for clarity
-7. Update docs if architecture changes
+3. Create a worktree for your branch (see `docs/workflow/worktrees.md`)
+4. Identify which agent role to adopt (see agents.md)
+5. Write tests FIRST for core logic
+6. Implement minimal code to pass tests
+7. Refactor for clarity
+8. Update docs if architecture changes
 
 ### Workflow 2: Working on an Issue
 
 1. Run: `gh issue view X --json number,title,body,labels`
 2. Follow reading order above
 3. Follow `docs/issue-worker.md` (protocol) and `docs/workflow/handle-issue.md` (quick pointer)
-4. Create branch: `issue/X-slug`
+4. Create a worktree for `issue/X-slug` (see `docs/workflow/worktrees.md`)
 5. Follow TDD workflow
 6. Create PR with "Closes #X"
 
@@ -145,10 +146,11 @@ This TDD approach ensures code quality and prevents regressions.
 ### Workflow 4: Fixing a Bug
 
 1. Read ai-instructions.md and relevant core docs
-2. Write a failing test that reproduces the bug
-3. Fix code to pass the test
-4. Refactor if needed
-5. Verify all tests pass
+2. Create a worktree for your branch (see `docs/workflow/worktrees.md`)
+3. Write a failing test that reproduces the bug
+4. Fix code to pass the test
+5. Refactor if needed
+6. Verify all tests pass
 
 ---
 

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -43,6 +43,17 @@ Choose the appropriate agent based on your task:
 
 ---
 
+## Worktree Workflow (MANDATORY)
+
+When doing any branch work, use a dedicated git worktree under `../worktrees/pika/`.
+
+- One worktree = one branch = one agent/task
+- Do not switch branches inside an existing worktree; create a new worktree instead
+
+See: `docs/workflow/worktrees.md`
+
+---
+
 ## Agent Definitions
 
 ### 1. Architect Agent

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -34,7 +34,15 @@ Do not proceed with implementation until the user confirms the plan.
 
 After confirmation:
 
-a. **Create branch**: `issue/X-<slug>`
+a. **Create a worktree (MANDATORY)**:
+
+Use a dedicated worktree for the issue branch (see `docs/workflow/worktrees.md`).
+
+Example (from the hub checkout `pika/`):
+
+git fetch origin
+git worktree add -b issue/X-<slug> ../worktrees/pika/issue-X-<slug> origin/main
+cd ../worktrees/pika/issue-X-<slug>
 
 b. **Follow TDD workflow**:
    - Write tests FIRST for core logic (utilities, business rules)

--- a/docs/workflow/worktrees.md
+++ b/docs/workflow/worktrees.md
@@ -1,0 +1,75 @@
+# Git Worktrees (MANDATORY)
+
+This repo uses **git worktrees** to avoid branch/terminal confusion (especially with multiple terminals and/or multiple AIs).
+
+## Hard Rules
+
+1) Never work directly on a branch in the main working directory (`pika/`).
+
+2) Any branch work must happen inside a dedicated worktree.
+
+3) Each worktree must:
+- live in a **sibling directory** under `../worktrees/pika/`
+- check out **exactly one branch**
+- be used by **only one agent/task**
+
+4) Do not switch branches in an existing working tree. Create a new worktree instead.
+
+5) Cleanup after merge: remove the worktree when the work is complete and merged.
+
+## Directory Convention
+
+- `pika/` = “hub” checkout (stays on `main`, stays clean)
+- `../worktrees/pika/<branch-name>/` = one worktree per branch/PR
+
+Example:
+
+../worktrees/pika/feat-classroom-calendar-editing
+
+## Pre-flight Checks (run often)
+
+pwd
+git rev-parse --abbrev-ref HEAD
+git status --porcelain=v1
+
+If `pwd` or `git rev-parse` is not what you expect, stop and fix it before editing files.
+
+## Create a New Branch Worktree
+
+From the hub checkout (`pika/`):
+
+git fetch origin
+git worktree add -b feat/<slug> ../worktrees/pika/feat-<slug> origin/main
+cd ../worktrees/pika/feat-<slug>
+
+## Work on an Existing Branch
+
+From the hub checkout (`pika/`):
+
+git fetch origin
+git worktree add ../worktrees/pika/<branch-name> <branch-name>
+cd ../worktrees/pika/<branch-name>
+
+## Work on an Existing PR
+
+From the hub checkout (`pika/`):
+
+gh pr checkout <PR_NUMBER> --branch pr/<PR_NUMBER>
+git worktree add ../worktrees/pika/pr-<PR_NUMBER> pr/<PR_NUMBER>
+cd ../worktrees/pika/pr-<PR_NUMBER>
+
+## Cleanup After Merge
+
+From the hub checkout (`pika/`):
+
+git worktree remove ../worktrees/pika/<branch-name>
+
+Optionally delete the local branch:
+
+git branch -D <branch-name>
+
+## Supabase Local Dev Note
+
+Avoid running `supabase start` concurrently from multiple worktrees.
+Pick one “primary” worktree for Supabase commands.
+


### PR DESCRIPTION
Adds a mandatory worktree-based git workflow to prevent branch/terminal confusion when using multiple terminals/agents.

Key rules:
- Never do branch work in the hub checkout (pika/)
- Any branch work must happen in ../worktrees/pika/<branch>
- One worktree = one branch = one agent/task
- Never switch branches inside an existing worktree
- Cleanup after merge with git worktree remove

Docs updated:
- docs/workflow/worktrees.md
- docs/workflow/handle-issue.md
- docs/ai-instructions.md
- docs/core/agents.md
- AGENTS.md
- .ai/START-HERE.md

Journal:
- .ai/JOURNAL.md