### PR TITLE
fix: teacher roster auth error handling

### DIFF
--- a/src/app/api/teacher/classrooms/[id]/roster/[rosterId]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/[rosterId]/route.ts
@@ -140,10 +140,9 @@ export async function DELETE(
 
     return NextResponse.json({ success: true })
   } catch (error: any) {
+    if (error.name === 'AuthenticationError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (error.name === 'AuthorizationError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     console.error('Remove student error:', error)
-    return NextResponse.json(
-      { error: error.message || 'Unauthorized' },
-      { status: 401 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/app/api/teacher/classrooms/[id]/roster/add/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/add/route.ts
@@ -93,10 +93,9 @@ export async function POST(
       errors: errors.length > 0 ? errors : undefined,
     })
   } catch (error: any) {
+    if (error.name === 'AuthenticationError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (error.name === 'AuthorizationError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     console.error('Add students error:', error)
-    return NextResponse.json(
-      { error: error.message || 'Unauthorized' },
-      { status: 401 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/app/api/teacher/classrooms/[id]/roster/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/route.ts
@@ -96,10 +96,9 @@ export async function GET(
 
     return NextResponse.json({ roster })
   } catch (error: any) {
+    if (error.name === 'AuthenticationError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (error.name === 'AuthorizationError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     console.error('Get roster error:', error)
-    return NextResponse.json(
-      { error: error.message || 'Unauthorized' },
-      { status: 401 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/app/api/teacher/classrooms/[id]/roster/upload-csv/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/upload-csv/route.ts
@@ -111,10 +111,9 @@ export async function POST(
       upsertedCount: upserted?.length ?? 0,
     })
   } catch (error: any) {
+    if (error.name === 'AuthenticationError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (error.name === 'AuthorizationError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     console.error('Upload CSV error:', error)
-    return NextResponse.json(
-      { error: error.message || 'Unauthorized' },
-      { status: 401 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }


### PR DESCRIPTION
Fixes confusing roster auth failures:

- Teacher roster API routes now return proper 401/403/500 instead of always 401 and leaking the error message.
- Roster tab shows a clearer message when the session has been replaced (common when you log in as a student in another tab).

Tests: pnpm test