### PR TITLE
feat: implement dark mode with theme toggle

### DIFF
--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -23,12 +23,12 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Classrooms</h1>
-          <p className="text-gray-600 mt-1">Open a classroom to manage attendance, logs, roster, and assignments.</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">Open a classroom to manage attendance, logs, roster, and assignments.</p>
         </div>
         <button
           type="button"
-          className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700"
+          className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
           onClick={() => setShowCreate(true)}
         >
           + New classroom
@@ -36,13 +36,13 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
       </div>
 
       {sorted.length === 0 ? (
-        <div className="bg-white rounded-lg shadow-sm p-10 text-center">
-          <h2 className="text-lg font-semibold text-gray-900">No classrooms yet</h2>
-          <p className="text-gray-600 mt-2">Create your first classroom to get started.</p>
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
+          <p className="text-gray-600 dark:text-gray-400 mt-2">Create your first classroom to get started.</p>
           <div className="mt-6">
             <button
               type="button"
-              className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700"
+              className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
               onClick={() => setShowCreate(true)}
             >
               Create classroom
@@ -50,19 +50,19 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
           </div>
         </div>
       ) : (
-        <div className="bg-white rounded-lg shadow-sm divide-y divide-gray-100">
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
           {sorted.map((c) => (
             <div key={c.id} className="p-4 flex items-start justify-between gap-4 flex-wrap">
               <div className="min-w-0">
-                <div className="text-sm font-semibold text-gray-900">{c.title}</div>
-                <div className="mt-1 text-sm text-gray-600">
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{c.title}</div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                   Code: <span className="font-mono">{c.class_code}</span>
                   {c.term_label ? ` • ${c.term_label}` : ''}
                 </div>
               </div>
               <Link
                 href={`/classrooms/${c.id}?tab=attendance`}
-                className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50"
+                className="px-3 py-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700"
               >
                 Open
               </Link>

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -89,7 +89,7 @@ export function TeacherAttendanceTab({ classroom }: Props) {
         }
       />
 
-      <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
         {rows.map((row) => (
           <StudentRow.Minimal
             key={row.student_id}
@@ -102,7 +102,7 @@ export function TeacherAttendanceTab({ classroom }: Props) {
           />
         ))}
         {rows.length === 0 && (
-          <div className="py-8 text-center text-sm text-gray-500">
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
             No students enrolled
           </div>
         )}

--- a/src/app/classrooms/[classroomId]/TeacherLogsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLogsTab.tsx
@@ -119,7 +119,7 @@ export function TeacherLogsTab({ classroom }: Props) {
               <>
                 <button
                   type="button"
-                  className="px-2 py-1 rounded-md border border-gray-300 bg-white text-xs hover:bg-gray-50 font-medium"
+                  className="px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 font-medium"
                   onClick={expandAll}
                   disabled={studentsWithLogs.length === 0}
                 >
@@ -127,7 +127,7 @@ export function TeacherLogsTab({ classroom }: Props) {
                 </button>
                 <button
                   type="button"
-                  className="px-2 py-1 rounded-md border border-gray-300 bg-white text-xs hover:bg-gray-50 font-medium"
+                  className="px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 font-medium"
                   onClick={collapseAll}
                   disabled={expanded.size === 0}
                 >
@@ -149,7 +149,7 @@ export function TeacherLogsTab({ classroom }: Props) {
         }
       />
 
-      <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
         {(isClassDay ? logs : []).map((row) => {
           const hasEntry = Boolean(row.entry)
           const isExpanded = expanded.has(row.student_id)
@@ -158,7 +158,7 @@ export function TeacherLogsTab({ classroom }: Props) {
           let expandedContent = null
 
           if (!hasEntry) {
-            preview = <span className="text-gray-400">(missing)</span>
+            preview = <span className="text-gray-400 dark:text-gray-500">(missing)</span>
           } else if (row.summary && !isExpanded) {
             preview = row.summary
           } else if (!isExpanded) {
@@ -166,7 +166,7 @@ export function TeacherLogsTab({ classroom }: Props) {
               <div>
                 <div className="truncate">{row.entry!.text}</div>
                 {!row.summary && (
-                  <div className="text-xs text-gray-400 mt-0.5">
+                  <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
                     Summary pending (generated nightly)
                   </div>
                 )}
@@ -178,11 +178,11 @@ export function TeacherLogsTab({ classroom }: Props) {
             expandedContent = (
               <div className="space-y-2">
                 {row.summary && (
-                  <div className="text-sm text-gray-700 font-medium">
+                  <div className="text-sm text-gray-700 dark:text-gray-300 font-medium">
                     {row.summary}
                   </div>
                 )}
-                <div className="text-sm text-gray-700 whitespace-pre-wrap">
+                <div className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
                   {row.entry!.text}
                 </div>
               </div>
@@ -202,12 +202,12 @@ export function TeacherLogsTab({ classroom }: Props) {
         })}
 
         {isClassDay && logs.length === 0 && (
-          <div className="py-8 text-center text-sm text-gray-500">
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
             No students enrolled
           </div>
         )}
         {!isClassDay && (
-          <div className="py-8 text-center text-sm text-gray-500">
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
             No class on this day
           </div>
         )}

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -166,7 +166,7 @@ export function TeacherRosterTab({ classroom }: Props) {
         action={
           <button
             type="button"
-            className="px-3 py-2 rounded-md border border-gray-300 bg-white text-sm hover:bg-gray-50 font-medium"
+            className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 font-medium"
             onClick={loadRoster}
           >
             Refresh
@@ -175,18 +175,18 @@ export function TeacherRosterTab({ classroom }: Props) {
       />
 
       {/* Upload Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-3 mb-4">
+      <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-3 mb-4">
         <div className="flex flex-wrap items-center gap-2">
           <input
             type="file"
             accept=".csv,text/csv"
             onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
-            className="text-sm"
+            className="text-sm text-gray-900 dark:text-gray-100"
             disabled={uploading}
           />
           <button
             type="button"
-            className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50 font-medium"
+            className="px-3 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50 font-medium"
             onClick={uploadCsv}
             disabled={uploading || csvText.trim().length === 0}
           >
@@ -194,12 +194,12 @@ export function TeacherRosterTab({ classroom }: Props) {
           </button>
         </div>
 
-        {error && <div className="text-sm text-red-600 mt-2">{error}</div>}
-        {success && <div className="text-sm text-green-700 mt-2">{success}</div>}
+        {error && <div className="text-sm text-red-600 dark:text-red-400 mt-2">{error}</div>}
+        {success && <div className="text-sm text-green-700 dark:text-green-400 mt-2">{success}</div>}
       </div>
 
       {/* Student List */}
-      <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-200">
+      <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
         {sortedRoster.map((row) => {
           const fullName = row.first_name || row.last_name
             ? `${row.last_name ?? ''}${row.last_name ? ', ' : ''}${row.first_name ?? ''}`.trim()
@@ -213,15 +213,15 @@ export function TeacherRosterTab({ classroom }: Props) {
               studentNumber={row.student_number ?? undefined}
               badge={
                 row.joined ? (
-                  <span className="text-xs font-medium text-green-700">Joined</span>
+                  <span className="text-xs font-medium text-green-700 dark:text-green-400">Joined</span>
                 ) : (
-                  <span className="text-xs text-gray-500">Not joined</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">Not joined</span>
                 )
               }
               action={
                 <button
                   type="button"
-                  className="px-2 py-1 rounded-md border border-red-200 bg-white text-xs text-red-700 hover:bg-red-50 font-medium"
+                  className="px-2 py-1 rounded-md border border-red-200 dark:border-red-800 bg-white dark:bg-gray-800 text-xs text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 font-medium"
                   onClick={() => removeStudent(row.id, row.email, row.joined)}
                 >
                   Remove
@@ -232,7 +232,7 @@ export function TeacherRosterTab({ classroom }: Props) {
         })}
 
         {sortedRoster.length === 0 && (
-          <div className="py-8 text-center text-sm text-gray-500">
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
             No students on the roster
           </div>
         )}

--- a/src/app/classrooms/[classroomId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/page.tsx
@@ -93,11 +93,11 @@ export default function ClassroomPage() {
     return (
       <AppShell showHeader={false}>
         <div className="max-w-md mx-auto mt-12">
-          <div className="bg-white rounded-lg shadow-sm p-8 text-center">
-            <p className="text-red-600 mb-4">{error}</p>
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
+            <p className="text-red-600 dark:text-red-400 mb-4">{error}</p>
             <button
               onClick={() => router.back()}
-              className="text-blue-600 hover:text-blue-700"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
             >
               Go back
             </button>
@@ -154,7 +154,7 @@ export default function ClassroomPage() {
       currentClassroomId={classroom.id}
     >
       {/* Compact tab navigation */}
-      <div className="border-b border-gray-200 -mx-4 px-4 mb-4">
+      <div className="border-b border-gray-200 dark:border-gray-700 -mx-4 px-4 mb-4">
         <div className="flex gap-4">
           {(isTeacher ? teacherTabs : studentTabs).map(t => {
             const isActive = activeTab === t.id
@@ -165,8 +165,8 @@ export default function ClassroomPage() {
                 onClick={() => setTab(t.id)}
                 className={`py-2 text-sm font-medium border-b-2 transition ${
                   isActive
-                    ? 'border-blue-600 text-blue-600'
-                    : 'border-transparent text-gray-600 hover:text-gray-900'
+                    ? 'border-blue-600 dark:border-blue-400 text-blue-600 dark:text-blue-400'
+                    : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
                 }`}
               >
                 {t.label}
@@ -181,7 +181,7 @@ export default function ClassroomPage() {
         <div className="flex justify-end mb-3">
           <button
             type="button"
-            className="px-3 py-2 rounded-md bg-blue-600 text-white text-sm hover:bg-blue-700 font-medium"
+            className="px-3 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600 font-medium"
             onClick={() => setShowCreateModal(true)}
           >
             + New classroom

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { ThemeProvider } from '@/contexts/ThemeContext'
 
 export const metadata: Metadata = {
   title: 'Pika - Student Daily Log & Attendance',
@@ -13,8 +14,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50">
-        {children}
+      <body className="min-h-screen bg-gray-50 dark:bg-gray-950">
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,10 +2,11 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { HomeIcon, CalendarIcon } from '@heroicons/react/24/outline'
+import { HomeIcon, CalendarIcon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
 import { ClassroomDropdown } from './ClassroomDropdown'
 import { UserMenu } from './UserMenu'
 import { PikaLogo } from './PikaLogo'
+import { useTheme } from '@/contexts/ThemeContext'
 
 interface AppHeaderProps {
   user?: {
@@ -26,9 +27,10 @@ interface AppHeaderProps {
  */
 export function AppHeader({ user, classrooms, currentClassroomId }: AppHeaderProps) {
   const pathname = usePathname()
+  const { theme, toggleTheme } = useTheme()
 
   return (
-    <header className="h-12 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+    <header className="h-12 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center px-4 gap-3">
       {/* Logo */}
       <Link href="/classrooms" className="flex-shrink-0">
         <PikaLogo className="w-8 h-8" />
@@ -63,6 +65,20 @@ export function AppHeader({ user, classrooms, currentClassroomId }: AppHeaderPro
       {/* Spacer */}
       <div className="flex-1" />
 
+      {/* Dark Mode Toggle */}
+      <button
+        onClick={toggleTheme}
+        className="p-2 rounded-md text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      >
+        {theme === 'dark' ? (
+          <SunIcon className="w-5 h-5" />
+        ) : (
+          <MoonIcon className="w-5 h-5" />
+        )}
+      </button>
+
       {/* User Menu */}
       <UserMenu user={user} />
     </header>
@@ -82,8 +98,8 @@ function IconNavButton({ href, icon: Icon, label, isActive }: IconNavButtonProps
       href={href}
       className={`p-2 rounded-md transition-colors ${
         isActive
-          ? 'text-blue-600 bg-blue-50'
-          : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+          ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
+          : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
       }`}
       aria-label={label}
       title={label}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -28,7 +28,7 @@ export function AppShell({
   currentClassroomId
 }: AppShellProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       {showHeader && (
         <AppHeader
           user={user}

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -34,7 +34,7 @@ export function ClassroomDropdown({
   // If only one classroom, show as text instead of dropdown
   if (classrooms.length === 1) {
     return (
-      <div className="text-sm font-medium text-gray-900 truncate max-w-xs">
+      <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate max-w-xs">
         {classrooms[0].title}
       </div>
     )
@@ -45,7 +45,7 @@ export function ClassroomDropdown({
       <select
         value={currentClassroomId || classrooms[0].id}
         onChange={handleChange}
-        className="h-9 pl-3 pr-8 text-sm border border-gray-300 rounded-md bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none max-w-xs truncate"
+        className="h-9 pl-3 pr-8 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none max-w-xs truncate"
       >
         {classrooms.map((classroom) => (
           <option key={classroom.id} value={classroom.id}>
@@ -53,7 +53,7 @@ export function ClassroomDropdown({
           </option>
         ))}
       </select>
-      <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+      <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400 pointer-events-none" />
     </div>
   )
 }

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -145,15 +145,15 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
   const { semester1Year, semester2Year } = getSemesterYears()
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
-        <h2 className="text-xl font-bold text-gray-900 mb-4">Create Classroom</h2>
+    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-opacity-70 flex items-center justify-center p-4 z-50">
+      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-lg w-full p-6">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Create Classroom</h2>
 
         {/* Progress Indicator */}
         <div className="flex items-center mb-6">
-          <div className={`flex-1 h-1 rounded ${step === 'name' ? 'bg-blue-600' : 'bg-blue-200'}`} />
-          <div className={`flex-1 h-1 rounded ml-2 ${step === 'roster' ? 'bg-blue-600' : step === 'calendar' ? 'bg-blue-200' : 'bg-gray-200'}`} />
-          <div className={`flex-1 h-1 rounded ml-2 ${step === 'calendar' ? 'bg-blue-600' : 'bg-gray-200'}`} />
+          <div className={`flex-1 h-1 rounded ${step === 'name' ? 'bg-blue-600 dark:bg-blue-500' : 'bg-blue-200 dark:bg-blue-800'}`} />
+          <div className={`flex-1 h-1 rounded ml-2 ${step === 'roster' ? 'bg-blue-600 dark:bg-blue-500' : step === 'calendar' ? 'bg-blue-200 dark:bg-blue-800' : 'bg-gray-200 dark:bg-gray-700'}`} />
+          <div className={`flex-1 h-1 rounded ml-2 ${step === 'calendar' ? 'bg-blue-600 dark:bg-blue-500' : 'bg-gray-200 dark:bg-gray-700'}`} />
         </div>
 
         {/* Step 1: Name */}
@@ -175,25 +175,25 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
         {/* Step 2: Roster */}
         {step === 'roster' && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Upload Roster (Optional)
             </label>
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               You can skip this step and upload a roster later from the dashboard.
             </p>
             <input
               type="file"
               accept=".csv"
               onChange={(e) => setRosterFile(e.target.files?.[0] || null)}
-              className="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none"
+              className="block w-full text-sm text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer bg-gray-50 dark:bg-gray-800 focus:outline-none"
               disabled={loading}
             />
             {rosterFile && (
-              <p className="text-sm text-gray-600 mt-2">
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
                 Selected: {rosterFile.name}
               </p>
             )}
-            <p className="text-xs text-gray-500 mt-2">
+            <p className="text-xs text-gray-500 dark:text-gray-500 mt-2">
               Format: Student Number, First Name, Last Name, Email
             </p>
           </div>
@@ -202,7 +202,7 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
         {/* Step 3: Calendar */}
         {step === 'calendar' && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
               Choose Calendar
             </label>
 
@@ -215,12 +215,12 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
                 }}
                 className={`w-full p-4 rounded-lg border-2 transition text-left ${
                   calendarMode === 'preset' && selectedSemester === 'semester1'
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-300 hover:border-gray-400'
+                    ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                 }`}
               >
-                <div className="font-medium">Semester 1</div>
-                <div className="text-sm text-gray-600 mt-1">
+                <div className="font-medium text-gray-900 dark:text-gray-100">Semester 1</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                   Sep {semester1Year} - Jan {semester1Year + 1}
                 </div>
               </button>
@@ -233,12 +233,12 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
                 }}
                 className={`w-full p-4 rounded-lg border-2 transition text-left ${
                   calendarMode === 'preset' && selectedSemester === 'semester2'
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-300 hover:border-gray-400'
+                    ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                 }`}
               >
-                <div className="font-medium">Semester 2</div>
-                <div className="text-sm text-gray-600 mt-1">
+                <div className="font-medium text-gray-900 dark:text-gray-100">Semester 2</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                   Feb {semester2Year} - Jun {semester2Year}
                 </div>
               </button>
@@ -248,24 +248,24 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
                 onClick={() => setCalendarMode('custom')}
                 className={`w-full p-4 rounded-lg border-2 transition ${
                   calendarMode === 'custom'
-                    ? 'border-blue-500 bg-blue-50'
-                    : 'border-gray-300 hover:border-gray-400'
+                    ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
                 }`}
               >
-                <div className="font-medium">Custom Date Range</div>
+                <div className="font-medium text-gray-900 dark:text-gray-100">Custom Date Range</div>
               </button>
             </div>
 
             {calendarMode === 'custom' && (
-              <div className="p-4 bg-gray-50 rounded-lg mb-4">
+              <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg mb-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Start</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Start</label>
                     <div className="flex gap-2">
                       <select
                         value={startMonth}
                         onChange={(e) => setStartMonth(parseInt(e.target.value))}
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                        className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
                       >
                         {Array.from({ length: 12 }, (_, i) => i + 1).map(month => (
                           <option key={month} value={month}>
@@ -279,17 +279,17 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
                         onChange={(e) => setStartYear(parseInt(e.target.value))}
                         min={2020}
                         max={2030}
-                        className="w-20 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                        className="w-20 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
                       />
                     </div>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">End</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">End</label>
                     <div className="flex gap-2">
                       <select
                         value={endMonth}
                         onChange={(e) => setEndMonth(parseInt(e.target.value))}
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                        className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
                       >
                         {Array.from({ length: 12 }, (_, i) => i + 1).map(month => (
                           <option key={month} value={month}>
@@ -303,7 +303,7 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
                         onChange={(e) => setEndYear(parseInt(e.target.value))}
                         min={2020}
                         max={2030}
-                        className="w-20 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                        className="w-20 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
                       />
                     </div>
                   </div>
@@ -314,7 +314,7 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
         )}
 
         {error && (
-          <div className="mt-4 text-sm text-red-600">
+          <div className="mt-4 text-sm text-red-600 dark:text-red-400">
             {error}
           </div>
         )}

--- a/src/components/DateNavigator.tsx
+++ b/src/components/DateNavigator.tsx
@@ -26,7 +26,7 @@ export function DateNavigator({
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
-          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+          className="px-3 py-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
           onClick={() => onChange(addDaysToDateString(value, -1))}
           disabled={disabled}
         >
@@ -37,13 +37,13 @@ export function DateNavigator({
           type="date"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm disabled:opacity-50"
+          className="px-3 py-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50"
           disabled={disabled}
         />
 
         <button
           type="button"
-          className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+          className="px-3 py-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
           onClick={() => onChange(addDaysToDateString(value, 1))}
           disabled={disabled}
         >
@@ -53,7 +53,7 @@ export function DateNavigator({
         {canUseShortcut && (
           <button
             type="button"
-            className="px-3 py-2 rounded-md border border-gray-200 bg-white text-sm hover:bg-gray-50 disabled:opacity-50"
+            className="px-3 py-2 rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
             onClick={onShortcut}
             disabled={disabled}
           >

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -15,8 +15,8 @@ export function PageHeader({ title, subtitle, action }: PageHeaderProps) {
   return (
     <div className="flex items-center justify-between mb-4">
       <div>
-        <h1 className="text-lg font-semibold text-gray-900">{title}</h1>
-        {subtitle && <p className="text-sm text-gray-600 mt-0.5">{subtitle}</p>}
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
+        {subtitle && <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{subtitle}</p>}
       </div>
       {action && <div className="flex gap-2">{action}</div>}
     </div>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -8,7 +8,7 @@ export function Spinner({ size = 'md' }: { size?: 'sm' | 'md' | 'lg' }) {
   return (
     <div className="flex justify-center items-center">
       <div
-        className={`${sizeClasses[size]} border-4 border-gray-200 border-t-blue-600 rounded-full animate-spin`}
+        className={`${sizeClasses[size]} border-4 border-gray-200 dark:border-gray-700 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin`}
       />
     </div>
   )

--- a/src/components/StudentRow.tsx
+++ b/src/components/StudentRow.tsx
@@ -13,9 +13,9 @@ interface StudentRowBaseProps {
 function StudentRowBase({ email, className = '', children }: StudentRowBaseProps) {
   return (
     <div
-      className={`flex items-center justify-between py-2 px-3 border-b border-gray-200 hover:bg-gray-50 transition-colors ${className}`}
+      className={`flex items-center justify-between py-2 px-3 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${className}`}
     >
-      <span className="text-sm text-gray-900 truncate flex-1">{email}</span>
+      <span className="text-sm text-gray-900 dark:text-gray-100 truncate flex-1">{email}</span>
       {children}
     </div>
   )
@@ -58,13 +58,13 @@ export function StudentRowMedium({
   action,
 }: StudentRowMediumProps) {
   return (
-    <div className="flex items-center justify-between py-2 px-3 border-b border-gray-200 hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between py-2 px-3 border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
       <div className="flex-1 min-w-0">
-        <div className="text-sm text-gray-900 truncate">{email}</div>
+        <div className="text-sm text-gray-900 dark:text-gray-100 truncate">{email}</div>
         {(name || studentNumber) && (
-          <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-600">
+          <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-600 dark:text-gray-400">
             {name && <span className="font-medium truncate">{name}</span>}
-            {studentNumber && <span className="text-gray-500">#{studentNumber}</span>}
+            {studentNumber && <span className="text-gray-500 dark:text-gray-500">#{studentNumber}</span>}
           </div>
         )}
       </div>
@@ -96,20 +96,20 @@ export function StudentRowExpandable({
   onToggle,
 }: StudentRowExpandableProps) {
   return (
-    <div className="border-b border-gray-200">
-      <div className="flex items-center justify-between py-2 px-3 hover:bg-gray-50 transition-colors cursor-pointer"
+    <div className="border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between py-2 px-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
            onClick={onToggle}>
         <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium text-gray-900 truncate">{email}</div>
+          <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{email}</div>
           {!expanded && preview && (
-            <div className="text-xs text-gray-600 mt-0.5 truncate">
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-0.5 truncate">
               {preview}
             </div>
           )}
         </div>
         <button
           type="button"
-          className="flex-shrink-0 ml-3 px-2 py-1 text-xs text-blue-600 hover:text-blue-700 font-medium"
+          className="flex-shrink-0 ml-3 px-2 py-1 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"
           onClick={(e) => {
             e.stopPropagation()
             onToggle?.()
@@ -119,7 +119,7 @@ export function StudentRowExpandable({
         </button>
       </div>
       {expanded && expandedContent && (
-        <div className="px-3 pb-3 pt-1 bg-gray-50 border-t border-gray-200">
+        <div className="px-3 pb-3 pt-1 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700">
           {expandedContent}
         </div>
       )}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -37,7 +37,7 @@ export function UserMenu({ user }: UserMenuProps) {
     return (
       <Link
         href="/login"
-        className="text-sm text-gray-700 hover:text-gray-900 font-medium"
+        className="text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white font-medium"
       >
         Login
       </Link>
@@ -48,26 +48,26 @@ export function UserMenu({ user }: UserMenuProps) {
     <div className="relative" ref={menuRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 p-1 rounded-md hover:bg-gray-100 transition-colors"
+        className="flex items-center gap-2 p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
         aria-label="User menu"
         aria-expanded={isOpen}
       >
-        <UserCircleIcon className="w-7 h-7 text-gray-600" />
-        <span className="text-sm text-gray-700 hidden sm:inline max-w-[150px] truncate">
+        <UserCircleIcon className="w-7 h-7 text-gray-600 dark:text-gray-300" />
+        <span className="text-sm text-gray-700 dark:text-gray-300 hidden sm:inline max-w-[150px] truncate">
           {user.email}
         </span>
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-56 bg-white rounded-md shadow-lg border border-gray-200 py-1 z-50">
-          <div className="px-4 py-2 border-b border-gray-100">
-            <p className="text-sm font-medium text-gray-900 truncate">{user.email}</p>
-            <p className="text-xs text-gray-500 capitalize">{user.role}</p>
+        <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+          <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{user.email}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">{user.role}</p>
           </div>
 
           <Link
             href="/logout"
-            className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
             onClick={() => setIsOpen(false)}
           >
             <ArrowRightOnRectangleIcon className="w-4 h-4" />

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+  const [mounted, setMounted] = useState(false)
+
+  // Load theme from localStorage on mount
+  useEffect(() => {
+    setMounted(true)
+    const savedTheme = localStorage.getItem('theme') as Theme | null
+    if (savedTheme) {
+      setTheme(savedTheme)
+      document.documentElement.classList.toggle('dark', savedTheme === 'dark')
+    }
+  }, [])
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light'
+    setTheme(newTheme)
+    localStorage.setItem('theme', newTheme)
+    document.documentElement.classList.toggle('dark', newTheme === 'dark')
+  }
+
+  // Prevent flash of unstyled content
+  if (!mounted) {
+    return <>{children}</>
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: 'class', // Enable class-based dark mode
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
Implements comprehensive dark mode support across the entire application with a toggle button in the app header.

## Changes
- **ThemeContext**: Created React context with localStorage persistence for theme preference
- **Toggle UI**: Added moon/sun icon toggle to AppHeader for easy theme switching
- **Tailwind Config**: Enabled class-based dark mode (`darkMode: 'class'`)
- **Component Updates**: Applied dark mode classes to all core components:
  - Layout: AppShell, AppHeader, PageHeader
  - Student displays: StudentRow (Minimal, Medium, Expandable variants)
  - Navigation: ClassroomDropdown, UserMenu, DateNavigator
  - UI elements: Spinner, CreateClassroomModal
  - Teacher tabs: Attendance, Logs, Roster
  - Pages: Classroom page, Classrooms index

## Design Choices
- **Color Palette**: Neutral gray backgrounds (gray-900/gray-950), gray-700 borders, gray-100/gray-300 text
- **Accent Colors**: Blue accents maintained for consistency with light mode
- **Persistence**: User preference saved to localStorage and applied on page load
- **Toggle Location**: Positioned in app header next to user menu for easy access

## Test Plan
- [ ] Toggle between light and dark modes using the button in the header
- [ ] Verify theme preference persists after page reload
- [ ] Check all teacher tabs (Attendance, Logs, Roster, etc.) render correctly in both modes
- [ ] Test classroom dropdown, user menu, and modals in dark mode
- [ ] Verify text contrast and readability in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)