### PR TITLE
Use pika.png for header home icon

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -1179,3 +1179,13 @@
 **Next:** None
 **Blockers:** None
 ---
+---
+## 2025-12-18 13:09 [AI - Codex]
+**Goal:** Use `public/pika.png` for the home button icon.
+**Completed:** Replaced the 🐰 emoji logo in the global header with a Next `Image` pointing at `/pika.png`, keeping it at the same `w-8 h-8` size and adding an accessible Home label.
+**Status:** completed
+**Artifacts:**
+- Files: `src/components/PikaLogo.tsx`, `src/components/AppHeader.tsx`
+**Next:** None
+**Blockers:** None
+---

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -51,7 +51,7 @@ export function AppHeader({
       )}
 
       {/* Logo - click to return to classrooms index */}
-      <Link href="/classrooms" className="flex-shrink-0">
+      <Link href="/classrooms" aria-label="Home" title="Home" className="flex-shrink-0">
         <PikaLogo className="w-8 h-8" />
       </Link>
 

--- a/src/components/PikaLogo.tsx
+++ b/src/components/PikaLogo.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 interface PikaLogoProps {
   className?: string
 }
@@ -7,10 +9,13 @@ interface PikaLogoProps {
  */
 export function PikaLogo({ className = 'w-8 h-8' }: PikaLogoProps) {
   return (
-    <div className={`${className} flex items-center justify-center text-blue-500`}>
-      <span className="text-2xl" role="img" aria-label="Pika">
-        🐰
-      </span>
-    </div>
+    <Image
+      src="/pika.png"
+      alt="Pika"
+      width={32}
+      height={32}
+      priority
+      className={`${className} object-contain`}
+    />
   )
 }


### PR DESCRIPTION
- Replace the header "home" bunny emoji with the existing `public/pika.png` asset (same size as before).\n- Add accessible label/title on the home link.