### PR TITLE
Student UI/UX polish: classrooms layout + assignments sidebar/editor

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -24,6 +24,96 @@
 **Blockers:** None
 ---
 ---
+## 2025-12-18 12:47 [AI - Codex]
+**Goal:** Apply `PageLayout` to the classrooms index page.
+**Completed:** Wrapped `/classrooms` index content in `AppShell` (header hidden) for consistent padding/background and refactored both teacher/student index views to use `PageLayout` + `PageActionBar` + `PageContent`.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/page.tsx`, `src/app/classrooms/TeacherClassroomsIndex.tsx`, `src/app/classrooms/StudentClassroomsIndex.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-18 12:49 [AI - Codex]
+**Goal:** Keep classrooms action labels consistent.
+**Completed:** Restored the leading “+” in the `/classrooms` action-bar buttons (`+ New classroom`, `+ Join classroom`).
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/TeacherClassroomsIndex.tsx`, `src/app/classrooms/StudentClassroomsIndex.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-18 13:09 [AI - Codex]
+**Goal:** Add the global title bar to `/classrooms`.
+**Completed:** Enabled the `AppShell` header on the classrooms index and passed `user` + available `classrooms` so the logo/theme toggle/user menu (and dropdown when applicable) appear.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/page.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-18 13:33 [AI - Codex]
+**Goal:** Avoid showing a selected classroom on the index title bar.
+**Completed:** Stopped passing `classrooms` into `AppShell` on `/classrooms` so the header doesn’t render the classroom dropdown/name when no classroom is selected.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/page.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-19 08:18 [AI - Codex]
+**Goal:** Make the student assignments tab match the teacher layout.
+**Completed:** Reworked the student assignments tab into a master-detail layout (desktop sidebar list of assignments + main content), added an action bar toggle for `View details` vs `Edit`, and redirected the standalone student assignment route into the in-tab view so the editor renders inside the classroom content area.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`, `src/app/classrooms/[classroomId]/assignments/[assignmentId]/StudentAssignmentEditor.tsx`, `src/app/classrooms/[classroomId]/assignments/[assignmentId]/page.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-19 08:28 [AI - Codex]
+**Goal:** Show student assignments in the left classroom sidebar.
+**Completed:** Added a nested assignments list under the student “Assignments” nav item in `ClassroomSidebar` (driven by `/api/student/assignments` + `assignmentId` query param) and removed the in-tab sidebar list while keeping the mobile dropdown selector.
+**Status:** completed
+**Artifacts:**
+- Files: `src/components/ClassroomSidebar.tsx`, `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-19 08:36 [AI - Codex]
+**Goal:** Simplify student assignments action bar.
+**Completed:** Removed the selected assignment title from the action bar and left-aligned the `View details` / `Edit` actions via an optional `actionsAlign="start"` on `PageActionBar`.
+**Status:** completed
+**Artifacts:**
+- Files: `src/components/PageLayout.tsx`, `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-19 09:25 [AI - Codex]
+**Goal:** Surface today’s date in the main title bar.
+**Completed:** Added a Toronto-local date display to `AppHeader` and removed the date from the student “Today” tab action bar to avoid duplication.
+**Status:** completed
+**Artifacts:**
+- Files: `src/components/AppHeader.tsx`, `src/app/classrooms/[classroomId]/StudentTodayTab.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
+## 2025-12-19 09:31 [AI - Codex]
+**Goal:** Make the main title bar date/classroom more prominent.
+**Completed:** Increased typography/weight for the classroom title selector and the Toronto date in the main header, and removed the student Today action bar entirely.
+**Status:** completed
+**Artifacts:**
+- Files: `src/components/AppHeader.tsx`, `src/components/ClassroomDropdown.tsx`, `src/app/classrooms/[classroomId]/StudentTodayTab.tsx`
+**Next:** None
+**Blockers:** None
+---
+---
 ## 2025-12-18 08:42 [AI - Codex]
 **Goal:** Add a compact History section beneath Student Today without changing the core Today form
 **Completed:** Added a rounded History card under the Today card with a chevron text-toggle (cookie-persisted), session-cached fetching of the latest 10 entries (no extra requests on toggle), and entry rows with `Tue Dec 16` date badges + 🟢/🔴 status and ~150-char previews; extended `/api/student/entries` to support an optional `limit` param and added unit + component tests for cookie/session caching and toggle behavior

--- a/src/app/classrooms/StudentClassroomsIndex.tsx
+++ b/src/app/classrooms/StudentClassroomsIndex.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { PageActionBar, PageContent, PageLayout, type ActionBarItem } from '@/components/PageLayout'
 import type { Classroom } from '@/types'
 
 interface Props {
@@ -17,52 +18,60 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
   }, [classrooms])
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
-      <div className="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">Select a classroom to view assignments and submit your daily logs.</p>
-        </div>
-        <button
-          type="button"
-          className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
-          onClick={() => router.push('/join')}
-        >
-          + Join classroom
-        </button>
-      </div>
-
-      {sorted.length === 0 ? (
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
-          <p className="text-gray-600 dark:text-gray-400 mt-2">Join a classroom using the code from your teacher.</p>
-          <div className="mt-6">
-            <button
-              type="button"
-              className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
-              onClick={() => router.push('/join')}
-            >
-              Join classroom
-            </button>
+    <PageLayout className="max-w-5xl mx-auto">
+      <PageActionBar
+        primary={
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-1">
+              Select a classroom to view assignments and submit your daily logs.
+            </p>
           </div>
-        </div>
-      ) : (
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
-          {sorted.map((c) => (
-            <button
-              key={c.id}
-              onClick={() => router.push(`/classrooms/${c.id}?tab=today`)}
-              className="w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
-            >
-              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{c.title}</div>
-              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                Code: <span className="font-mono">{c.class_code}</span>
-                {c.term_label ? ` • ${c.term_label}` : ''}
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+        }
+        actions={
+          [
+            {
+              id: 'join-classroom',
+              label: '+ Join classroom',
+              onSelect: () => router.push('/join'),
+            },
+          ] satisfies ActionBarItem[]
+        }
+      />
+
+      <PageContent>
+        {sorted.length === 0 ? (
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">Join a classroom using the code from your teacher.</p>
+            <div className="mt-6">
+              <button
+                type="button"
+                className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
+                onClick={() => router.push('/join')}
+              >
+                Join classroom
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
+            {sorted.map((c) => (
+              <button
+                key={c.id}
+                onClick={() => router.push(`/classrooms/${c.id}?tab=today`)}
+                className="w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+              >
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{c.title}</div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Code: <span className="font-mono">{c.class_code}</span>
+                  {c.term_label ? ` • ${c.term_label}` : ''}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </PageContent>
+    </PageLayout>
   )
 }

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
+import { PageActionBar, PageContent, PageLayout, type ActionBarItem } from '@/components/PageLayout'
 import type { Classroom } from '@/types'
 
 interface Props {
@@ -19,51 +20,53 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   }, [classrooms])
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
-      <div className="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
-        </div>
-        <button
-          type="button"
-          className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
-          onClick={() => setShowCreate(true)}
-        >
-          + New classroom
-        </button>
-      </div>
+    <PageLayout className="max-w-5xl mx-auto">
+      <PageActionBar
+        primary={<h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>}
+        actions={
+          [
+            {
+              id: 'new-classroom',
+              label: '+ New classroom',
+              onSelect: () => setShowCreate(true),
+            },
+          ] satisfies ActionBarItem[]
+        }
+      />
 
-      {sorted.length === 0 ? (
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
-          <p className="text-gray-600 dark:text-gray-400 mt-2">Create your first classroom to get started.</p>
-          <div className="mt-6">
-            <button
-              type="button"
-              className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
-              onClick={() => setShowCreate(true)}
-            >
-              Create classroom
-            </button>
+      <PageContent>
+        {sorted.length === 0 ? (
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">Create your first classroom to get started.</p>
+            <div className="mt-6">
+              <button
+                type="button"
+                className="px-4 py-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white text-sm hover:bg-blue-700 dark:hover:bg-blue-600"
+                onClick={() => setShowCreate(true)}
+              >
+                Create classroom
+              </button>
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
-          {sorted.map((c) => (
-            <button
-              key={c.id}
-              onClick={() => router.push(`/classrooms/${c.id}?tab=attendance`)}
-              className="w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
-            >
-              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{c.title}</div>
-              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                Code: <span className="font-mono">{c.class_code}</span>
-                {c.term_label ? ` • ${c.term_label}` : ''}
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
+            {sorted.map((c) => (
+              <button
+                key={c.id}
+                onClick={() => router.push(`/classrooms/${c.id}?tab=attendance`)}
+                className="w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+              >
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{c.title}</div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Code: <span className="font-mono">{c.class_code}</span>
+                  {c.term_label ? ` • ${c.term_label}` : ''}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </PageContent>
 
       <CreateClassroomModal
         isOpen={showCreate}
@@ -74,6 +77,6 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
           router.push(`/classrooms/${created.id}?tab=attendance`)
         }}
       />
-    </div>
+    </PageLayout>
   )
 }

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -1,9 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { ChevronDownIcon } from '@heroicons/react/24/outline'
 import { Spinner } from '@/components/Spinner'
-import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import {
+  ACTIONBAR_BUTTON_CLASSNAME,
+  PageActionBar,
+  PageContent,
+  PageLayout,
+  type ActionBarItem,
+} from '@/components/PageLayout'
 import {
   formatDueDate,
   formatRelativeDueDate,
@@ -11,14 +18,24 @@ import {
   getAssignmentStatusBadgeClass,
 } from '@/lib/assignments'
 import type { AssignmentWithStatus, Classroom } from '@/types'
+import { StudentAssignmentEditor } from './assignments/[assignmentId]/StudentAssignmentEditor'
 
 interface Props {
   classroom: Classroom
 }
 
+type StudentAssignmentsView = 'summary' | 'details' | 'edit'
+
 export function StudentAssignmentsTab({ classroom }: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const search = searchParams.toString()
+
   const [assignments, setAssignments] = useState<AssignmentWithStatus[]>([])
   const [loading, setLoading] = useState(true)
+
+  const [isMobileSelectorOpen, setIsMobileSelectorOpen] = useState(false)
+  const mobileSelectorRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     async function load() {
@@ -36,49 +53,236 @@ export function StudentAssignmentsTab({ classroom }: Props) {
     load()
   }, [classroom.id])
 
+  useEffect(() => {
+    if (!isMobileSelectorOpen) return
+
+    function onMouseDown(e: MouseEvent) {
+      if (!mobileSelectorRef.current) return
+      if (e.target instanceof Node && !mobileSelectorRef.current.contains(e.target)) {
+        setIsMobileSelectorOpen(false)
+      }
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setIsMobileSelectorOpen(false)
+    }
+
+    document.addEventListener('mousedown', onMouseDown)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [isMobileSelectorOpen])
+
+  const selectedAssignmentId = searchParams.get('assignmentId')
+  const selectedAssignment = useMemo(() => {
+    if (!selectedAssignmentId) return null
+    return assignments.find((a) => a.id === selectedAssignmentId) ?? null
+  }, [assignments, selectedAssignmentId])
+
+  const view: StudentAssignmentsView = useMemo(() => {
+    if (!selectedAssignmentId) return 'summary'
+    if (!selectedAssignment) return 'summary'
+
+    const raw = searchParams.get('view')
+    if (raw === 'details') return 'details'
+    return 'edit'
+  }, [searchParams, selectedAssignment, selectedAssignmentId])
+
+  const navigate = useCallback(
+    (next: { assignmentId?: string | null; view?: Exclude<StudentAssignmentsView, 'summary'> | null }) => {
+      const params = new URLSearchParams(search)
+      params.set('tab', 'assignments')
+
+      if (next.assignmentId) {
+        params.set('assignmentId', next.assignmentId)
+      } else {
+        params.delete('assignmentId')
+      }
+
+      if (next.assignmentId && next.view) {
+        params.set('view', next.view)
+      } else {
+        params.delete('view')
+      }
+
+      const query = params.toString()
+      router.push(`/classrooms/${classroom.id}${query ? `?${query}` : ''}`)
+    },
+    [classroom.id, router, search],
+  )
+
+  const actionItems: ActionBarItem[] = useMemo(() => {
+    if (!selectedAssignment) return []
+
+    return [
+      {
+        id: 'view-details',
+        label: view === 'details' ? 'View details ✓' : 'View details',
+        onSelect: () => navigate({ assignmentId: selectedAssignment.id, view: 'details' }),
+      },
+      {
+        id: 'edit',
+        label: view === 'edit' ? 'Edit ✓' : 'Edit',
+        onSelect: () => navigate({ assignmentId: selectedAssignment.id, view: 'edit' }),
+      },
+    ]
+  }, [navigate, selectedAssignment, view])
+
   return (
     <PageLayout>
       <PageActionBar
-        primary={<div className="text-sm font-medium text-gray-900 dark:text-gray-100">Assignments</div>}
+        primary={
+          <>
+            <div className="hidden lg:block text-sm font-medium text-gray-900 dark:text-gray-100">Assignments</div>
+            <div className="lg:hidden relative" ref={mobileSelectorRef}>
+              <button
+                type="button"
+                className={[ACTIONBAR_BUTTON_CLASSNAME, 'inline-flex items-center gap-2 max-w-full'].join(' ')}
+                onClick={() => setIsMobileSelectorOpen((prev) => !prev)}
+                aria-label="Select assignment"
+                aria-haspopup="menu"
+                aria-expanded={isMobileSelectorOpen}
+              >
+                <span className="truncate max-w-[16rem]">Assignments</span>
+                <ChevronDownIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+              </button>
+
+              {isMobileSelectorOpen && (
+                <div
+                  role="menu"
+                  className="absolute z-10 mt-2 w-72 max-w-[calc(100vw-2rem)] rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg overflow-hidden"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-900 dark:text-gray-100"
+                    onClick={() => navigate({ assignmentId: null, view: null })}
+                  >
+                    Assignments
+                  </button>
+                  <div className="max-h-72 overflow-auto">
+                    {assignments.map((a) => (
+                      <button
+                        key={a.id}
+                        type="button"
+                        role="menuitem"
+                        className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-900 dark:text-gray-100"
+                        onClick={() => navigate({ assignmentId: a.id, view: 'edit' })}
+                        title={a.title}
+                      >
+                        {a.title}
+                      </button>
+                    ))}
+                    {!loading && assignments.length === 0 && (
+                      <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No assignments</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        }
+        actions={actionItems}
+        actionsAlign="start"
       />
       <PageContent>
-        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm">
-          <div className="p-4">
-            {loading ? (
-              <div className="flex justify-center py-8">
-                <Spinner />
+        <div className="min-w-0">
+          {loading ? (
+              <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm">
+                <div className="p-4">
+                  <div className="flex justify-center py-8">
+                    <Spinner />
+                  </div>
+                </div>
               </div>
-            ) : assignments.length === 0 ? (
-              <div className="text-center py-8 text-gray-500 dark:text-gray-400">No assignments yet</div>
-            ) : (
-              <div className="space-y-3">
-                {assignments.map((assignment) => (
-                  <Link
-                    key={assignment.id}
-                    href={`/classrooms/${classroom.id}/assignments/${assignment.id}`}
-                    className="block p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-blue-300 dark:hover:border-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <h3 className="font-medium text-gray-900 dark:text-white truncate">
-                          {assignment.title}
-                        </h3>
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                          {formatDueDate(assignment.due_at)}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                          {formatRelativeDueDate(assignment.due_at)}
-                        </p>
-                      </div>
-                      <span className={`px-2 py-1 rounded text-xs font-medium ${getAssignmentStatusBadgeClass(assignment.status)}`}>
-                        {getAssignmentStatusLabel(assignment.status)}
-                      </span>
+            ) : view === 'summary' ? (
+              <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm">
+                <div className="p-4">
+                  {assignments.length === 0 ? (
+                    <div className="text-center py-8 text-gray-500 dark:text-gray-400">No assignments yet</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {assignments.map((assignment) => (
+                        <button
+                          key={assignment.id}
+                          type="button"
+                          onClick={() => navigate({ assignmentId: assignment.id, view: 'edit' })}
+                          className="w-full text-left block p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-blue-300 dark:hover:border-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <h3 className="font-medium text-gray-900 dark:text-white truncate">
+                                {assignment.title}
+                              </h3>
+                              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                                {formatDueDate(assignment.due_at)}
+                              </p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                {formatRelativeDueDate(assignment.due_at)}
+                              </p>
+                            </div>
+                            <span
+                              className={`px-2 py-1 rounded text-xs font-medium ${getAssignmentStatusBadgeClass(assignment.status)}`}
+                            >
+                              {getAssignmentStatusLabel(assignment.status)}
+                            </span>
+                          </div>
+                        </button>
+                      ))}
                     </div>
-                  </Link>
-                ))}
+                  )}
+                </div>
               </div>
+            ) : !selectedAssignment ? (
+              <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm">
+                <div className="p-6 text-sm text-gray-600 dark:text-gray-400">
+                  That assignment is no longer available.
+                </div>
+              </div>
+            ) : view === 'details' ? (
+              <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                        {selectedAssignment.title}
+                      </div>
+                      <div className="text-xs text-gray-600 dark:text-gray-400 truncate">
+                        Due: {formatDueDate(selectedAssignment.due_at)} • {formatRelativeDueDate(selectedAssignment.due_at)}
+                      </div>
+                    </div>
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-medium ${getAssignmentStatusBadgeClass(selectedAssignment.status)}`}
+                    >
+                      {getAssignmentStatusLabel(selectedAssignment.status)}
+                    </span>
+                  </div>
+
+                  <div className="mt-4">
+                    {selectedAssignment.description ? (
+                      <div className="bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+                        <div className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                          {selectedAssignment.description}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="text-sm text-gray-500 dark:text-gray-400">
+                        No assignment details provided.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <StudentAssignmentEditor
+                classroomId={classroom.id}
+                assignmentId={selectedAssignment.id}
+                variant="embedded"
+                onExit={() => navigate({ assignmentId: null, view: null })}
+              />
             )}
-          </div>
         </div>
       </PageContent>
     </PageLayout>

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, FormEvent } from 'react'
 import { Button } from '@/components/Button'
 import { Spinner } from '@/components/Spinner'
-import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import { PageContent, PageLayout } from '@/components/PageLayout'
 import { getTodayInToronto } from '@/lib/timezone'
 import { isClassDayOnDate } from '@/lib/class-days'
 import { format, parseISO } from 'date-fns'
@@ -149,19 +149,10 @@ export function StudentTodayTab({ classroom }: Props) {
     )
   }
 
-  const formattedDate = today ? format(parseISO(today), 'EEE MMM d') : ''
   const historyListId = `student-today-history-${classroom.id}`
 
   return (
     <PageLayout>
-      <PageActionBar
-        primary={
-          <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
-            {formattedDate || 'Today'}
-          </div>
-        }
-      />
-
       <PageContent>
         <div className="space-y-6">
           <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm p-6">

--- a/src/app/classrooms/[classroomId]/assignments/[assignmentId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/assignments/[assignmentId]/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { Spinner } from '@/components/Spinner'
-import { StudentAssignmentEditor } from './StudentAssignmentEditor'
 import { TeacherAssignmentDetail } from './TeacherAssignmentDetail'
 
 interface UserInfo {
@@ -42,6 +41,12 @@ export default function AssignmentPage() {
     loadUser()
   }, [router])
 
+  useEffect(() => {
+    if (!user) return
+    if (user.role !== 'student') return
+    router.replace(`/classrooms/${classroomId}?tab=assignments&assignmentId=${assignmentId}&view=edit`)
+  }, [assignmentId, classroomId, router, user])
+
   if (loading) {
     return (
       <div className="flex justify-center py-12">
@@ -54,19 +59,17 @@ export default function AssignmentPage() {
     return null
   }
 
+  if (user.role === 'student') {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-6">
-      {user.role === 'teacher' ? (
-        <TeacherAssignmentDetail
-          classroomId={classroomId}
-          assignmentId={assignmentId}
-        />
-      ) : (
-        <StudentAssignmentEditor
-          classroomId={classroomId}
-          assignmentId={assignmentId}
-        />
-      )}
+      <TeacherAssignmentDetail classroomId={classroomId} assignmentId={assignmentId} />
     </div>
   )
 }

--- a/src/app/classrooms/page.tsx
+++ b/src/app/classrooms/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { AppShell } from '@/components/AppShell'
 import { TeacherClassroomsIndex } from './TeacherClassroomsIndex'
 import { StudentClassroomsIndex } from './StudentClassroomsIndex'
 
@@ -22,7 +23,12 @@ export default async function ClassroomsIndexPage() {
       .select('*')
       .eq('teacher_id', user.id)
       .order('updated_at', { ascending: false })
-    return <TeacherClassroomsIndex initialClassrooms={classrooms || []} />
+
+    return (
+      <AppShell user={{ email: user.email, role: user.role }}>
+        <TeacherClassroomsIndex initialClassrooms={classrooms || []} />
+      </AppShell>
+    )
   }
 
   // Student: fetch all enrolled classrooms
@@ -35,7 +41,11 @@ export default async function ClassroomsIndexPage() {
 
   if (classroomIds.length === 0) {
     // No enrollments, show empty state
-    return <StudentClassroomsIndex initialClassrooms={[]} />
+    return (
+      <AppShell user={{ email: user.email, role: user.role }}>
+        <StudentClassroomsIndex initialClassrooms={[]} />
+      </AppShell>
+    )
   }
 
   const { data: classrooms } = await supabase
@@ -44,5 +54,9 @@ export default async function ClassroomsIndexPage() {
     .in('id', classroomIds)
     .order('updated_at', { ascending: false })
 
-  return <StudentClassroomsIndex initialClassrooms={classrooms || []} />
+  return (
+    <AppShell user={{ email: user.email, role: user.role }}>
+      <StudentClassroomsIndex initialClassrooms={classrooms || []} />
+    </AppShell>
+  )
 }

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Bars3Icon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import { useEffect, useMemo, useState } from 'react'
 import { ClassroomDropdown } from './ClassroomDropdown'
 import { UserMenu } from './UserMenu'
 import { PikaLogo } from './PikaLogo'
@@ -35,6 +36,22 @@ export function AppHeader({
 }: AppHeaderProps) {
   const { theme, toggleTheme } = useTheme()
 
+  const formatter = useMemo(() => {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Toronto',
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    })
+  }, [])
+
+  const [now, setNow] = useState(() => new Date())
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+
   return (
     <header className="h-12 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center px-4 gap-3">
       {/* Mobile sidebar trigger (classroom pages) */}
@@ -64,8 +81,12 @@ export function AppHeader({
         />
       )}
 
-      {/* Spacer */}
-      <div className="flex-1" />
+      {/* Date */}
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-sm sm:text-base font-semibold text-gray-900 dark:text-gray-100 tabular-nums">
+          {formatter.format(now)}
+        </div>
+      </div>
 
       {/* Dark Mode Toggle */}
       <button

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -39,7 +39,7 @@ export function ClassroomDropdown({
   // If only one classroom, show as text instead of dropdown
   if (classrooms.length === 1) {
     return (
-      <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate max-w-xs">
+      <div className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate max-w-xs">
         {classrooms[0].title}
       </div>
     )
@@ -50,7 +50,7 @@ export function ClassroomDropdown({
       <select
         value={currentClassroomId || classrooms[0].id}
         onChange={handleChange}
-        className="h-9 pl-3 pr-8 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none max-w-xs truncate"
+        className="h-10 pl-3 pr-8 text-sm sm:text-base font-semibold border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none max-w-xs truncate"
       >
         {classrooms.map((classroom) => (
           <option key={classroom.id} value={classroom.id}>

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -135,12 +135,50 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
 export function PageActionBar({
   primary,
   actions = [],
+  actionsAlign = 'end',
   className = '',
 }: {
   primary: ReactNode
   actions?: ActionBarItem[]
+  actionsAlign?: 'start' | 'end'
   className?: string
 }) {
+  if (actionsAlign === 'start') {
+    return (
+      <div className={['w-full flex items-start gap-2', className].join(' ')}>
+        <div className="min-w-0">{primary}</div>
+
+        {actions.length > 0 && (
+          <>
+            <div className="hidden sm:flex flex-wrap items-center justify-start gap-2">
+              {actions.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={[
+                    ACTIONBAR_BUTTON_CLASSNAME,
+                    item.destructive
+                      ? 'border-red-200 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200 dark:hover:bg-red-900/30'
+                      : '',
+                  ].join(' ')}
+                  onClick={item.onSelect}
+                  disabled={item.disabled}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+            <div className="sm:hidden">
+              <ActionBarMenu items={actions} />
+            </div>
+          </>
+        )}
+
+        <div className="flex-1" />
+      </div>
+    )
+  }
+
   return (
     <div className={['w-full flex items-start gap-2', className].join(' ')}>
       <div className="min-w-0 flex-1">{primary}</div>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,3 +6,17 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
 process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test-key'
 process.env.SUPABASE_SECRET_KEY = 'sb_secret_test-key'
 process.env.ENABLE_MOCK_EMAIL = 'true'
+
+// JSDOM doesn't fully implement Range#getClientRects/getBoundingClientRect, but TipTap/ProseMirror uses them.
+if (typeof document !== 'undefined' && typeof Range !== 'undefined') {
+  const el = document.createElement('div')
+  const rangeProto = Range.prototype as any
+
+  if (typeof rangeProto.getClientRects !== 'function') {
+    rangeProto.getClientRects = () => el.getClientRects()
+  }
+
+  if (typeof rangeProto.getBoundingClientRect !== 'function') {
+    rangeProto.getBoundingClientRect = () => el.getBoundingClientRect()
+  }
+}


### PR DESCRIPTION
Summary:
- Apply PageLayout/AppShell to /classrooms index
- Student assignments tab: sidebar-driven selection, in-tab details/editor, student deep-link redirect
- Move Toronto date into AppHeader; remove Student Today action bar
- Add PageActionBar actions alignment option
- Fix TipTap JSDOM tests via Range rects polyfill

Follow-up:
- Created #63 for applying autosave editor to Student Today after #60 lands.