### PR TITLE
fix: align due date format and join fallback

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -1329,3 +1329,13 @@
 - Files: `src/app/teacher/calendar/page.tsx`, `src/app/classrooms/[classroomId]/assignments/[assignmentId]/TeacherAssignmentDetail.tsx`, `src/app/classrooms/[classroomId]/assignments/[assignmentId]/students/[studentId]/page.tsx`, `src/app/snapshots-gallery/SnapshotGallery.tsx`
 **Next:** None
 **Blockers:** None
+---
+## 2025-12-20 00:24 [AI - Codex]
+**Goal:** Align due date formatting and join error fallback messaging after PR #76 follow-up.
+**Completed:** Updated assignment due date formatting to match "Tue Dec 16" pattern, adjusted unit tests, and shortened join fallback error to include roster hint while still surfacing server errors. Ran full test suite.
+**Status:** completed
+**Artifacts:**
+- Branch: `76-date-format-join-fallback`
+- Files: `src/lib/assignments.ts`, `tests/unit/assignments.test.ts`, `src/app/join/[code]/page.tsx`
+**Tests:** `pnpm test`
+**Blockers:** None

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -45,7 +45,7 @@ export default function JoinClassroomPage() {
           if (data?.code === 'not_on_roster') {
             throw new Error('Your email is not on the roster. Make sure you are signed in with your board email and ask your teacher to add you.')
           }
-          throw new Error(data.error || 'Make sure you signed in with your school email. Ask your teacher to add you to the roster.')
+          throw new Error(data?.error || 'Unable to join. Check your code and school email, or ask your teacher to add you.')
         }
 
         // Redirect to student dashboard with the new classroom selected

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -80,10 +80,10 @@ export function getAssignmentStatusBadgeClass(status: AssignmentStatus): string 
 
 /**
  * Format a due date for display
- * Example: "Tue Dec 16, 2025"
+ * Example: "Tue Dec 16"
  */
 export function formatDueDate(dueAt: string): string {
-  return formatInTimeZone(new Date(dueAt), 'America/Toronto', 'EEE MMM d, yyyy')
+  return formatInTimeZone(new Date(dueAt), 'America/Toronto', 'EEE MMM d')
 }
 
 /**

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -300,10 +300,10 @@ describe('assignment utilities', () => {
     it('should format date in America/Toronto timezone', () => {
       const formatted = formatDueDate('2024-10-20T23:59:59-04:00')
 
-      // Should include month, day, year
+      // Should include month and day (no year)
       expect(formatted).toMatch(/Oct|October/)
       expect(formatted).toMatch(/20/)
-      expect(formatted).toMatch(/2024/)
+      expect(formatted).not.toMatch(/\b2024\b/)
     })
 
     it('should include day of week in formatted output', () => {
@@ -318,10 +318,10 @@ describe('assignment utilities', () => {
 
       // Should NOT include time
       expect(formatted).not.toMatch(/\d{1,2}:\d{2}/)
-      // Should include month, day, year
+      // Should include month and day (no year)
       expect(formatted).toMatch(/Oct/)
       expect(formatted).toMatch(/21/)
-      expect(formatted).toMatch(/2024/)
+      expect(formatted).not.toMatch(/\b2024\b/)
     })
 
     it('should format consistently for different dates', () => {


### PR DESCRIPTION
## Summary
- align assignment due date display with global "Tue Dec 16" format
- shorten join fallback error while keeping roster hint
- update unit tests for date formatting

## Testing
- pnpm test