### PR TITLE
Resolve claude binary path

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2076,3 +2076,14 @@
 **Next:** Run `./scripts/pika claude` with and without `CLAUDE_BIN` set.
 **Blockers:** None
 ---
+## 2026-01-08 14:21 [AI - Codex]
+**Goal:** Harden claude binary resolution.
+**Completed:** Validated CLAUDE_BIN and command -v targets are executable before use.
+**Status:** completed
+**Artifacts:**
+- Branch: chore/claude-check
+- Files: scripts/pika
+**Tests:** Not run (manual testing planned).
+**Next:** Run ./scripts/pika claude with an invalid CLAUDE_BIN to confirm fallback.
+**Blockers:** None
+---

--- a/scripts/pika
+++ b/scripts/pika
@@ -77,12 +77,19 @@ ensure_env_symlink() {
 
 resolve_claude_bin() {
     if [[ -n "${CLAUDE_BIN:-}" ]]; then
-        echo "$CLAUDE_BIN"
-        return 0
+        if [[ -x "$CLAUDE_BIN" ]]; then
+            echo "$CLAUDE_BIN"
+            return 0
+        fi
+        echo "warning: CLAUDE_BIN is set but not executable: $CLAUDE_BIN" >&2
     fi
     if command -v claude >/dev/null 2>&1; then
-        command -v claude
-        return 0
+        local resolved=""
+        resolved="$(command -v claude)"
+        if [[ -n "$resolved" && -x "$resolved" ]]; then
+            echo "$resolved"
+            return 0
+        fi
     fi
     local fallback="$HOME/.claude/local/claude"
     if [[ -x "$fallback" ]]; then


### PR DESCRIPTION
## Summary
- resolve claude binary via CLAUDE_BIN or ~/.claude/local/claude fallback
- avoid prompting for worktree when claude is missing

## Testing
- not run (manual testing planned)