### PR TITLE
Fix entries rich_content migration numbering

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2208,3 +2208,14 @@
 **Tests:** Not run (vitest missing in worktree).
 **Next:** Re-run CI or local tests after installing deps.
 **Blockers:** None
+---
+## 2026-01-09 14:22 [AI - Codex]
+**Goal:** Resolve duplicate migration version for entries rich content.
+**Completed:** Renamed entries rich_content migration to 018 and made the column add idempotent.
+**Status:** completed
+**Artifacts:**
+- Branch: fix-entries-rich-content-migration
+- Files: supabase/migrations/018_entries_rich_content.sql
+**Tests:** Not run (migration-only change).
+**Next:** Open PR and apply migration on staging with `supabase db push --include-all`.
+**Blockers:** None

--- a/supabase/migrations/018_entries_rich_content.sql
+++ b/supabase/migrations/018_entries_rich_content.sql
@@ -3,7 +3,7 @@
 
 -- STEP 1: Add new JSONB column
 ALTER TABLE public.entries
-  ADD COLUMN rich_content JSONB;
+  ADD COLUMN IF NOT EXISTS rich_content JSONB;
 
 -- STEP 2: Set default for new entries
 ALTER TABLE public.entries


### PR DESCRIPTION
## Summary\n- renumber entries rich_content migration to 018 to avoid duplicate 016\n- make rich_content column add idempotent with IF NOT EXISTS\n\n## Testing\n- Not run (migration-only change)