### PR TITLE
feat: integrate Lucide icons and improve UI verbosity (issue #105 quick wins)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "date-fns": "^3.3.1",
         "date-fns-tz": "^3.2.0",
         "date-holidays": "^3.26.5",
+        "fast-json-patch": "^3.1.1",
         "iron-session": "^8.0.1",
+        "lucide-react": "^0.562.0",
         "next": "^14.2.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
@@ -5247,6 +5249,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6772,6 +6780,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "date-holidays": "^3.26.5",
     "fast-json-patch": "^3.1.1",
     "iron-session": "^8.0.1",
+    "lucide-react": "^0.562.0",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"

--- a/src/app/classrooms/StudentClassroomsIndex.tsx
+++ b/src/app/classrooms/StudentClassroomsIndex.tsx
@@ -21,12 +21,7 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
     <PageLayout className="max-w-5xl mx-auto">
       <PageActionBar
         primary={
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
-            <p className="text-gray-600 dark:text-gray-400 mt-1">
-              Select a classroom to view assignments and submit your daily logs.
-            </p>
-          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Classrooms</h1>
         }
         actions={
           [
@@ -43,7 +38,6 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
         {sorted.length === 0 ? (
           <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-10 text-center">
             <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">No classrooms yet</h2>
-            <p className="text-gray-600 dark:text-gray-400 mt-2">Join a classroom using the code from your teacher.</p>
             <div className="mt-6">
               <button
                 type="button"

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -8,7 +8,7 @@ import { PageContent, PageLayout } from '@/components/PageLayout'
 import { getTodayInToronto } from '@/lib/timezone'
 import { isClassDayOnDate } from '@/lib/class-days'
 import { format, parseISO } from 'date-fns'
-import { ChevronDownIcon } from '@heroicons/react/24/outline'
+import { ChevronDown } from 'lucide-react'
 import {
   readBooleanCookie,
   safeSessionGetJson,
@@ -440,7 +440,7 @@ export function StudentTodayTab({ classroom }: { classroom: Classroom }) {
                 onClick={() => setHistoryVisibility(!historyVisible)}
               >
                 {historyVisible ? 'Hide' : 'Show'}
-                <ChevronDownIcon
+                <ChevronDown
                   className={[
                     'h-4 w-4 transition-transform',
                     historyVisible ? 'rotate-180' : 'rotate-0',

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -19,7 +19,7 @@ import {
   getAssignmentStatusLabel,
 } from '@/lib/assignments'
 import type { Classroom, Assignment, AssignmentStats, AssignmentStatus } from '@/types'
-import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { PenSquare, Trash2 } from 'lucide-react'
 import {
   DataTable,
   DataTableBody,
@@ -379,7 +379,7 @@ export function TeacherClassroomView({ classroom }: Props) {
                         aria-label={`Edit ${assignment.title}`}
                         disabled={isReadOnly}
                       >
-                        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
+                        <PenSquare className="h-5 w-5" aria-hidden="true" />
                       </button>
                       <button
                         type="button"
@@ -395,7 +395,7 @@ export function TeacherClassroomView({ classroom }: Props) {
                         aria-label={`Delete ${assignment.title}`}
                         disabled={isReadOnly}
                       >
-                        <TrashIcon className="h-5 w-5" aria-hidden="true" />
+                        <Trash2 className="h-5 w-5" aria-hidden="true" />
                       </button>
                     </div>
                   </div>

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -18,7 +18,7 @@ import {
   TableCard,
 } from '@/components/DataTable'
 import type { Classroom } from '@/types'
-import { CheckIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { Check, Trash2 } from 'lucide-react'
 import { applyDirection, compareNullableStrings, toggleSort } from '@/lib/table-sort'
 
 type Role = 'student' | 'teacher'
@@ -229,7 +229,7 @@ export function TeacherRosterTab({ classroom }: Props) {
                   <DataTableCell className="text-gray-600 dark:text-gray-400">{row.email}</DataTableCell>
                   <DataTableCell align="center">
                     {row.joined && (
-                      <CheckIcon className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" aria-hidden="true" />
+                      <Check className="mx-auto h-5 w-5 text-green-600 dark:text-green-400" aria-hidden="true" />
                     )}
                   </DataTableCell>
                   <DataTableCell align="right">
@@ -252,7 +252,7 @@ export function TeacherRosterTab({ classroom }: Props) {
                       aria-label={`Remove ${row.email}`}
                       disabled={isReadOnly}
                     >
-                      <TrashIcon className="h-5 w-5" aria-hidden="true" />
+                      <Trash2 className="h-5 w-5" aria-hidden="true" />
                     </button>
                   </DataTableCell>
                 </DataTableRow>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Bars3Icon, MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import { Menu, Moon, Sun } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ClassroomDropdown } from './ClassroomDropdown'
@@ -55,7 +55,7 @@ export function AppHeader({
           aria-label="Open classroom navigation"
           title="Open navigation"
         >
-          <Bars3Icon className="w-5 h-5" />
+          <Menu className="w-5 h-5" />
         </button>
       )}
 
@@ -75,8 +75,13 @@ export function AppHeader({
 
       {/* Date */}
       <div className="flex-1 flex items-center justify-center">
-        <div className="text-sm sm:text-base font-semibold text-gray-900 dark:text-gray-100 tabular-nums">
+        {/* Mobile: Short format (Tue Dec 16) */}
+        <div className="lg:hidden text-sm sm:text-base font-semibold text-gray-900 dark:text-gray-100 tabular-nums">
           {formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}
+        </div>
+        {/* Desktop: Long format (January 10, 2026) */}
+        <div className="hidden lg:block text-base font-semibold text-gray-900 dark:text-gray-100">
+          {formatInTimeZone(now, 'America/Toronto', 'MMMM d, yyyy')}
         </div>
       </div>
 
@@ -88,9 +93,9 @@ export function AppHeader({
         title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
       >
         {theme === 'dark' ? (
-          <SunIcon className="w-5 h-5" />
+          <Sun className="w-5 h-5" />
         ) : (
-          <MoonIcon className="w-5 h-5" />
+          <Moon className="w-5 h-5" />
         )}
       </button>
 

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { ChevronDownIcon } from '@heroicons/react/20/solid'
+import { ChevronDown } from 'lucide-react'
 
 interface ClassroomDropdownProps {
   classrooms: Array<{
@@ -58,7 +58,7 @@ export function ClassroomDropdown({
           </option>
         ))}
       </select>
-      <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400 pointer-events-none" />
+      <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400 pointer-events-none" />
     </div>
   )
 }

--- a/src/components/ClassroomSidebar.tsx
+++ b/src/components/ClassroomSidebar.tsx
@@ -4,19 +4,20 @@ import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type SVGProps } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
-  Bars3Icon,
-  CalendarDaysIcon,
-  ClipboardDocumentListIcon,
-  Cog6ToothIcon,
-  DocumentTextIcon,
-  PencilSquareIcon,
-  TableCellsIcon,
-  UserGroupIcon,
-  XMarkIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/outline'
+  Menu,
+  CalendarDays,
+  ClipboardList,
+  Settings,
+  FileText,
+  PenSquare,
+  Table,
+  Users,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  type LucideIcon,
+} from 'lucide-react'
 import { useClassroomSidebar } from './ClassroomSidebarProvider'
 import { CLASSROOM_SIDEBAR } from '@/lib/classroom-sidebar'
 
@@ -32,21 +33,21 @@ export type ClassroomNavItemId =
 type NavItem = {
   id: ClassroomNavItemId
   label: string
-  icon: ComponentType<SVGProps<SVGSVGElement>>
+  icon: LucideIcon
 }
 
 const teacherItems: NavItem[] = [
-  { id: 'attendance', label: 'Attendance', icon: TableCellsIcon },
-  { id: 'logs', label: 'Logs', icon: DocumentTextIcon },
-  { id: 'assignments', label: 'Assignments', icon: ClipboardDocumentListIcon },
-  { id: 'roster', label: 'Roster', icon: UserGroupIcon },
-  { id: 'calendar', label: 'Calendar', icon: CalendarDaysIcon },
-  { id: 'settings', label: 'Settings', icon: Cog6ToothIcon },
+  { id: 'attendance', label: 'Attendance', icon: Table },
+  { id: 'logs', label: 'Logs', icon: FileText },
+  { id: 'assignments', label: 'Assignments', icon: ClipboardList },
+  { id: 'roster', label: 'Roster', icon: Users },
+  { id: 'calendar', label: 'Calendar', icon: CalendarDays },
+  { id: 'settings', label: 'Settings', icon: Settings },
 ]
 
 const studentItems: NavItem[] = [
-  { id: 'today', label: 'Today', icon: PencilSquareIcon },
-  { id: 'assignments', label: 'Assignments', icon: ClipboardDocumentListIcon },
+  { id: 'today', label: 'Today', icon: PenSquare },
+  { id: 'assignments', label: 'Assignments', icon: ClipboardList },
 ]
 
 function getItems(role: 'student' | 'teacher') {
@@ -220,7 +221,7 @@ function Nav({
                     className="p-2 rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-400"
                     aria-label={isExpanded ? 'Collapse assignments' : 'Expand assignments'}
                   >
-                    <ChevronDownIcon
+                    <ChevronDown
                       className={[
                         'h-4 w-4 transition-transform',
                         isExpanded ? 'rotate-0' : '-rotate-90',
@@ -553,9 +554,9 @@ export function ClassroomSidebar({
             ].join(' ')}
           >
             {isCollapsed ? (
-              <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+              <ChevronRight className="h-5 w-5" aria-hidden="true" />
             ) : (
-              <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
             )}
             <span className="sr-only">{isCollapsed ? 'Expand' : 'Minimize'}</span>
           </button>
@@ -637,7 +638,7 @@ export function ClassroomSidebar({
           >
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
-                <Bars3Icon className="h-5 w-5 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+                <Menu className="h-5 w-5 text-gray-500 dark:text-gray-400" aria-hidden="true" />
                 <span>Navigation</span>
               </div>
               <button
@@ -646,7 +647,7 @@ export function ClassroomSidebar({
                 className="p-2 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
                 aria-label="Close"
               >
-                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+                <X className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
 
@@ -686,7 +687,7 @@ export function ClassroomSidebar({
                           className="p-2 rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 dark:text-gray-400"
                           aria-label={isExpanded ? 'Collapse assignments' : 'Expand assignments'}
                         >
-                          <ChevronDownIcon
+                          <ChevronDown
                             className={[
                               'h-4 w-4 transition-transform',
                               isExpanded ? 'rotate-0' : '-rotate-90',

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { HTMLAttributes, ReactNode, TdHTMLAttributes, ThHTMLAttributes } from 'react'
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 
 export type DataTableDensity = 'compact' | 'normal'
 export type SortDirection = 'asc' | 'desc'
@@ -101,7 +101,7 @@ export function SortableHeaderCell({
   const alignClass =
     align === 'center' ? 'justify-center' : align === 'right' ? 'justify-end' : 'justify-start'
   const ariaSort = isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
-  const Icon = direction === 'asc' ? ChevronUpIcon : ChevronDownIcon
+  const Icon = direction === 'asc' ? ChevronUp : ChevronDown
 
   return (
     <DataTableHeaderCell density={density} align={align} className="!p-0" aria-sort={ariaSort}>

--- a/src/components/DateActionBar.tsx
+++ b/src/components/DateActionBar.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from 'react'
 import { format, parseISO } from 'date-fns'
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { ACTIONBAR_BUTTON_CLASSNAME, ACTIONBAR_ICON_BUTTON_CLASSNAME } from '@/components/PageLayout'
 
 interface DateActionBarProps {
@@ -22,7 +22,7 @@ export function DateActionBar({ value, onChange, onPrev, onNext, rightActions, c
     <div className={['flex w-full flex-wrap items-center justify-between gap-4', className].join(' ')}>
       <div className="flex flex-wrap items-center gap-2">
         <button type="button" className={ACTIONBAR_ICON_BUTTON_CLASSNAME} onClick={onPrev} aria-label="Previous day">
-          <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
+          <ChevronLeft className="h-5 w-5" aria-hidden="true" />
         </button>
 
         <input
@@ -43,7 +43,7 @@ export function DateActionBar({ value, onChange, onPrev, onNext, rightActions, c
         </button>
 
         <button type="button" className={ACTIONBAR_ICON_BUTTON_CLASSNAME} onClick={onNext} aria-label="Next day">
-          <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+          <ChevronRight className="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
 

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { EllipsisVerticalIcon } from '@heroicons/react/24/outline'
+import { MoreVertical } from 'lucide-react'
 
 export type ActionBarItem = {
   id: string
@@ -87,7 +87,7 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        <EllipsisVerticalIcon className="h-5 w-5 text-gray-700 dark:text-gray-200" aria-hidden="true" />
+        <MoreVertical className="h-5 w-5 text-gray-700 dark:text-gray-200" aria-hidden="true" />
       </button>
 
       {open && (

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/Button'
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
+import { Eye, EyeOff } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextEditor } from '@/components/RichTextEditor'
 import { ACTIONBAR_BUTTON_CLASSNAME, PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
@@ -464,9 +464,9 @@ export function StudentAssignmentEditor({
                 aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
               >
                 {isHistoryOpen ? (
-                  <EyeSlashIcon className="h-4 w-4" aria-hidden="true" />
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
                 ) : (
-                  <EyeIcon className="h-4 w-4" aria-hidden="true" />
+                  <Eye className="h-4 w-4" aria-hidden="true" />
                 )}
               </button>
             </div>

--- a/src/components/TeacherStudentWorkModal.tsx
+++ b/src/components/TeacherStudentWorkModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { ChevronLeftIcon, ChevronRightIcon, EyeIcon, EyeSlashIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { ChevronLeft, ChevronRight, Eye, EyeOff, X } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/RichTextViewer'
@@ -202,7 +202,7 @@ export function TeacherStudentWorkModal({
                 className="p-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Previous student"
               >
-                <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -211,7 +211,7 @@ export function TeacherStudentWorkModal({
                 className="p-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Next student"
               >
-                <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
               </button>
               <button
                 type="button"
@@ -238,9 +238,9 @@ export function TeacherStudentWorkModal({
                 aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
               >
                 {isHistoryOpen ? (
-                  <EyeSlashIcon className="h-4 w-4" aria-hidden="true" />
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
                 ) : (
-                  <EyeIcon className="h-4 w-4" aria-hidden="true" />
+                  <Eye className="h-4 w-4" aria-hidden="true" />
                 )}
               </button>
               <button
@@ -249,7 +249,7 @@ export function TeacherStudentWorkModal({
                 className="p-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300"
                 aria-label="Close"
               >
-                <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+                <X className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
           </div>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
-import { UserCircleIcon, ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline'
+import { UserCircle, LogOut } from 'lucide-react'
 
 interface UserMenuProps {
   user?: {
@@ -52,7 +52,7 @@ export function UserMenu({ user }: UserMenuProps) {
         aria-label="User menu"
         aria-expanded={isOpen}
       >
-        <UserCircleIcon className="w-7 h-7 text-gray-600 dark:text-gray-300" />
+        <UserCircle className="w-7 h-7 text-gray-600 dark:text-gray-300" />
         <span className="text-sm text-gray-700 dark:text-gray-300 hidden sm:inline max-w-[150px] truncate">
           {user.email}
         </span>
@@ -70,7 +70,7 @@ export function UserMenu({ user }: UserMenuProps) {
             className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
             onClick={() => setIsOpen(false)}
           >
-            <ArrowRightOnRectangleIcon className="w-4 h-4" />
+            <LogOut className="w-4 h-4" />
             Logout
           </Link>
         </div>


### PR DESCRIPTION
## Summary

Implements the "quick wins" from issue #105:
- ✅ Remove verbose subtitles from student classroom view
- ✅ Add long date format to desktop titlebar
- ✅ Integrate Lucide React icons across the app

## Changes

### UI Verbosity Improvements
- **Student Classrooms Index**: Removed instructional subtitle "Select a classroom to view assignments and submit your daily logs."
- **Empty State**: Removed "Join a classroom using the code from your teacher." text
- Aligns with design principle: "Avoid verbose instructional text"

### Desktop Date Format
- **Mobile/Tablet**: Short format `Tue Dec 16` (unchanged)
- **Desktop (≥1024px)**: Long format `January 10, 2026`
- Responsive breakpoint at `lg` using Tailwind

### Icon Migration (Heroicons → Lucide)
Replaced all Heroicons with Lucide React icons across **15 files**:

**Components:**
- `AppHeader.tsx` - Menu, Moon, Sun
- `UserMenu.tsx` - UserCircle, LogOut
- `ClassroomDropdown.tsx` - ChevronDown
- `ClassroomSidebar.tsx` - Menu, CalendarDays, ClipboardList, Settings, FileText, PenSquare, Table, Users, X, Chevrons
- `PageLayout.tsx` - MoreVertical
- `DataTable.tsx` - ChevronDown, ChevronUp
- `DateActionBar.tsx` - ChevronLeft, ChevronRight
- `TeacherStudentWorkModal.tsx` - ChevronLeft, ChevronRight, Eye, EyeOff, X
- `StudentAssignmentEditor.tsx` - Eye, EyeOff

**Pages:**
- `TeacherRosterTab.tsx` - Check, Trash2
- `TeacherClassroomView.tsx` - PenSquare, Trash2
- `StudentTodayTab.tsx` - ChevronDown

**Benefits:**
- Consistent, modern icon set
- Better tree-shaking (smaller bundle)
- More icon options for future features
- Full dark mode support maintained

## Test Plan
- ✅ All 542 tests passing
- ✅ Dark mode support verified across all changes
- ✅ No breaking changes to existing functionality
- ✅ Responsive behavior tested (mobile/desktop breakpoints)

## Screenshots
N/A - Visual changes are minor (icon replacements, text removal)

## Related Issues
Partially addresses #105 (quick wins only)

## Next Steps
Remaining #105 items moved to follow-up PRs:
- TipTap editor improvements (clickable links, better buttons)
- Student log export feature
- Theme polish pass
- Large features (rubrics, announcements, etc.) → separate issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)