### PR TITLE
feat: add Vercel ignored build step script

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Vercel Ignored Build Step
+# Only build on main and production branches
+# https://vercel.com/docs/deployments/configure-a-build#ignored-build-step
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main" ]] || [[ "$VERCEL_GIT_COMMIT_REF" == "production" ]] ; then
+  # Proceed with the build
+  echo "✅ Building $VERCEL_GIT_COMMIT_REF"
+  exit 1;
+else
+  # Don't build
+  echo "🛑 Skipping build for branch: $VERCEL_GIT_COMMIT_REF"
+  exit 0;
+fi


### PR DESCRIPTION
## Problem

All branches are deploying to Vercel, even though `vercel.json` has:
```json
{
  "git": {
    "deploymentEnabled": {
      "main": true,
      "production": true,
      "*": false
    }
  }
}
```

The `vercel.json` config alone isn't enough - Vercel also needs an **Ignored Build Step** command configured in the dashboard.

## Solution

Add `scripts/vercel-ignore-build.sh` that:
- ✅ Exits with code `1` (proceed) for `main` and `production` branches
- ✅ Exits with code `0` (skip) for all other branches

## Manual Configuration Required

After merging this PR, configure in **Vercel Dashboard**:

1. Go to: **Project Settings → Git**
2. Scroll to: **Ignored Build Step**
3. Set command to:
   ```bash
   bash scripts/vercel-ignore-build.sh
   ```
4. Save changes

## How It Works

```bash
# Branch: fix/vercel-deployment-restriction
🛑 Skipping build for branch: fix/vercel-deployment-restriction
exit 0 (no build)

# Branch: main
✅ Building main
exit 1 (proceed with build)
```

## Test Plan

- ⏳ This PR should NOT deploy to Vercel (after dashboard config)
- ✅ Future PRs to non-production branches won't deploy
- ✅ Merges to `main` will deploy
- ✅ Merges to `production` will deploy

## References

- [Vercel Docs: Ignored Build Step](https://vercel.com/docs/deployments/configure-a-build#ignored-build-step)
- [Vercel JSON: git.deploymentEnabled](https://vercel.com/docs/projects/project-configuration#git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)