### PR TITLE
fix: remove Refresh button from roster and simplify history toggle

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -419,19 +419,18 @@ export function StudentTodayTab({ classroom }: { classroom: Classroom }) {
           </div>
 
           <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm">
-            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-3">
-              <h3 className="text-sm font-medium text-gray-900 dark:text-white">Past</h3>
+            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-end">
               <button
                 type="button"
-                className="inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-300 hover:underline rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
+                className="inline-flex items-center p-1 text-blue-600 dark:text-blue-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
                 aria-expanded={historyVisible}
                 aria-controls={historyListId}
+                aria-label={historyVisible ? 'Hide history' : 'Show history'}
                 onClick={() => setHistoryVisibility(!historyVisible)}
               >
-                {historyVisible ? 'Hide' : 'Show'}
                 <ChevronDown
                   className={[
-                    'h-4 w-4 transition-transform',
+                    'h-5 w-5 transition-transform',
                     historyVisible ? 'rotate-180' : 'rotate-0',
                   ].join(' ')}
                 />

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -431,13 +431,6 @@ export function TeacherRosterTab({ classroom }: Props) {
             )}
           </div>
         }
-        actions={[
-          {
-            id: 'refresh',
-            label: 'Refresh',
-            onSelect: loadRoster,
-          },
-        ]}
       />
 
       <PageContent>

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -93,7 +93,7 @@ describe('StudentTodayTab history section', () => {
     render(<StudentTodayTab classroom={classroom} />)
 
     await screen.findAllByText('Tue Dec 16')
-    await screen.findByText('Past')
+    await screen.findByRole('button', { name: /history/i })
 
     expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
 
@@ -123,7 +123,7 @@ describe('StudentTodayTab history section', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { unmount } = render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByText('Past')
+    await screen.findByRole('button', { name: /history/i })
 
     fireEvent.click(screen.getByRole('button', { name: /hide/i }))
     expect(document.cookie).toMatch(/pika_student_today_history=0/)
@@ -131,7 +131,7 @@ describe('StudentTodayTab history section', () => {
     unmount()
 
     render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByText('Past')
+    await screen.findByRole('button', { name: /history/i })
 
     expect(screen.getByRole('button', { name: /show/i })).toBeInTheDocument()
     expect(screen.queryByText('Mon Dec 15')).not.toBeInTheDocument()
@@ -154,7 +154,7 @@ describe('StudentTodayTab history section', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByText('Past')
+    await screen.findByRole('button', { name: /history/i })
     expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Remove 'Refresh' action button from TeacherRosterTab (roster view)
- Remove 'Past' header and 'Show/Hide' text from StudentTodayTab history bar
- History toggle now uses only a chevron icon with `aria-label` for accessibility

Closes #162

## Test plan
- [x] All 557 tests passing
- [ ] Verify roster view no longer shows Refresh button in dropdown
- [ ] Verify Today view history section shows only chevron toggle (no "Past" header, no "Show/Hide" text)
- [ ] Verify history toggle still works correctly (expands/collapses)

🤖 Generated with [Claude Code](https://claude.ai/code)