### PR TITLE
feat: extend session duration to 6 months and improve root URL handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,14 @@
 import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
-export default function HomePage() {
+export default async function HomePage() {
+  const user = await getCurrentUser()
+
+  if (user) {
+    redirect('/classrooms')
+  }
+
   redirect('/login')
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,7 +36,7 @@ function getSessionOptions() {
       secure: process.env.NODE_ENV === 'production',
       httpOnly: true,
       sameSite: 'lax' as const,
-      maxAge: 14 * 24 * 60 * 60, // 14 days
+      maxAge: 180 * 24 * 60 * 60, // 6 months
     },
   }
 }


### PR DESCRIPTION
## Summary
- Extends session cookie duration from 14 days to **6 months** (180 days) so users don't need to re-authenticate during the semester
- Root URL (`/`) now redirects logged-in users to `/classrooms` instead of always redirecting to `/login`

Closes #166

## Test plan
- [ ] Start dev server (`pnpm dev`)
- [ ] Login with test credentials
- [ ] Close browser tab
- [ ] Navigate back to `localhost:3000` - should redirect to `/classrooms` (not `/login`)
- [ ] Check DevTools → Application → Cookies → verify `pika_session` has expiry ~6 months out

🤖 Generated with [Claude Code](https://claude.ai/code)