### PR TITLE
fix: show pending status for today/future attendance instead of absent

### DIFF
--- a/src/app/api/teacher/attendance/route.ts
+++ b/src/app/api/teacher/attendance/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { computeAttendanceRecords } from '@/lib/attendance'
+import { getTodayInToronto } from '@/lib/timezone'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -123,10 +124,12 @@ export async function GET(request: NextRequest) {
     }
 
     // Compute attendance records
+    const today = getTodayInToronto()
     const attendanceRecords = computeAttendanceRecords(
       students,
       classDays || [],
-      entries || []
+      entries || [],
+      today
     )
 
     // Get sorted list of class day dates

--- a/src/app/api/teacher/export-csv/route.ts
+++ b/src/app/api/teacher/export-csv/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { computeAttendanceRecords } from '@/lib/attendance'
+import { getTodayInToronto } from '@/lib/timezone'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -131,10 +132,12 @@ export async function GET(request: NextRequest) {
     }
 
     // Compute attendance
+    const today = getTodayInToronto()
     const attendanceRecords = computeAttendanceRecords(
       students || [],
       classDays || [],
-      entries || []
+      entries || [],
+      today
     )
 
     // Get sorted dates (only class days)

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -8,6 +8,7 @@ import { getTodayInToronto } from '@/lib/timezone'
 import { addDaysToDateString } from '@/lib/date-string'
 import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
 import { getAttendanceDotClass, getAttendanceLabel } from '@/lib/attendance'
+import type { AttendanceStatus } from '@/types'
 import {
   DataTable,
   DataTableBody,
@@ -120,6 +121,8 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
     if (!selectedDate) return true
     return isClassDayOnDate(classDays, selectedDate)
   }, [classDays, selectedDate])
+
+  const today = useMemo(() => getTodayInToronto(), [])
 
   const rows = useMemo(() => {
     return [...logs].sort((a, b) => {
@@ -245,7 +248,11 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
             <DataTableBody>
               {rows.map((row) => {
                 const isSelected = selectedStudentId === row.student_id
-                const status = row.entry ? 'present' : 'absent'
+                const status: AttendanceStatus = row.entry
+                  ? 'present'
+                  : selectedDate >= today
+                    ? 'pending'
+                    : 'absent'
                 const logText = getLogText(row)
 
                 return (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import type { Operation } from 'fast-json-patch'
 
 export type UserRole = 'student' | 'teacher'
 
-export type AttendanceStatus = 'present' | 'absent'
+export type AttendanceStatus = 'present' | 'absent' | 'pending'
 
 export type MoodEmoji = '😊' | '🙂' | '😐' | '😟' | '😢'
 


### PR DESCRIPTION
## Summary
- Adds a third attendance state: **pending** (gray) for today and future class days without entries
- Previously these showed as **absent** (red), which was misleading since students still have time to submit
- Green = present (entry exists), Red = absent (past day, no entry), Gray = pending (today/future, no entry yet)

## Changes
- Added `'pending'` to `AttendanceStatus` type
- Updated `computeAttendanceStatusForStudent` to accept `today` param and return pending for today/future dates
- Updated helper functions (`getAttendanceIcon`, `getAttendanceDotClass`, `getAttendanceLabel`) to handle pending
- Updated `TeacherAttendanceTab` to calculate status correctly based on selected date vs today
- Updated API routes to pass today's date to attendance computation
- Pending days are excluded from summary counts (present/absent totals)

## Test plan
- [x] Unit tests updated and passing (14 tests)
- [ ] Manual test: View attendance for today - students without entries show gray "Pending"
- [ ] Manual test: View attendance for past date - students without entries show red "Absent"
- [ ] Manual test: View attendance for future date - all students without entries show gray "Pending"
- [ ] Manual test: Student submits entry today - status changes to green immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)