### PR TITLE
feat: add Resources page for classroom wiki (#196)

### DIFF
--- a/src/app/api/student/classrooms/[id]/resources/route.ts
+++ b/src/app/api/student/classrooms/[id]/resources/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/student/classrooms/[id]/resources - Get resources for an enrolled classroom
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: classroomId } = await params
+
+    const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+    if (!access.ok) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: resources, error } = await supabase
+      .from('classroom_resources')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .single()
+
+    if (error && error.code !== 'PGRST116') {
+      // PGRST116 = no rows returned
+      console.error('Error fetching resources:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch resources' },
+        { status: 500 }
+      )
+    }
+
+    // Return resources or null (no resources yet)
+    return NextResponse.json({ resources: resources || null })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get resources error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/teacher/classrooms/[id]/resources/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/resources/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import {
+  assertTeacherOwnsClassroom,
+  assertTeacherCanMutateClassroom,
+} from '@/lib/server/classrooms'
+import type { TiptapContent } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/teacher/classrooms/[id]/resources - Get resources for a classroom
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId } = await params
+
+    const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: resources, error } = await supabase
+      .from('classroom_resources')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .single()
+
+    if (error && error.code !== 'PGRST116') {
+      // PGRST116 = no rows returned
+      console.error('Error fetching resources:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch resources' },
+        { status: 500 }
+      )
+    }
+
+    // Return resources or null (no resources yet)
+    return NextResponse.json({ resources: resources || null })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get resources error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// PUT /api/teacher/classrooms/[id]/resources - Upsert resources for a classroom
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId } = await params
+    const body = await request.json()
+    const { content } = body as { content: TiptapContent }
+
+    if (!content || content.type !== 'doc') {
+      return NextResponse.json(
+        { error: 'Invalid content format' },
+        { status: 400 }
+      )
+    }
+
+    const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Upsert: insert or update based on classroom_id unique constraint
+    const { data: resources, error } = await supabase
+      .from('classroom_resources')
+      .upsert(
+        {
+          classroom_id: classroomId,
+          content,
+          updated_at: new Date().toISOString(),
+          updated_by: user.id,
+        },
+        {
+          onConflict: 'classroom_id',
+        }
+      )
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error upserting resources:', error)
+      return NextResponse.json(
+        { error: 'Failed to save resources' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ resources })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Upsert resources error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -12,6 +12,8 @@ import { TeacherRosterTab } from './TeacherRosterTab'
 import { TeacherSettingsTab } from './TeacherSettingsTab'
 import { TeacherLessonCalendarTab, TeacherLessonCalendarSidebar, CalendarSidebarState } from './TeacherLessonCalendarTab'
 import { StudentLessonCalendarTab } from './StudentLessonCalendarTab'
+import { TeacherResourcesTab } from './TeacherResourcesTab'
+import { StudentResourcesTab } from './StudentResourcesTab'
 import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
 import { ClassDaysProvider } from '@/hooks/useClassDays'
 import {
@@ -69,8 +71,8 @@ export function ClassroomPageClient({
   const tab = searchParams.get('tab') ?? initialTab
   const defaultTab = isTeacher ? 'attendance' : 'today'
   const validTabs = isTeacher
-    ? (['attendance', 'assignments', 'calendar', 'roster', 'settings'] as const)
-    : (['today', 'assignments', 'calendar'] as const)
+    ? (['attendance', 'assignments', 'calendar', 'resources', 'roster', 'settings'] as const)
+    : (['today', 'assignments', 'calendar', 'resources'] as const)
 
   const activeTab = (validTabs as readonly string[]).includes(tab ?? '') ? (tab as string) : defaultTab
 
@@ -380,6 +382,7 @@ function ClassroomPageContent({
                   onSidebarStateChange={setCalendarSidebarState}
                 />
               )}
+              {activeTab === 'resources' && <TeacherResourcesTab classroom={classroom} />}
               {activeTab === 'roster' && <TeacherRosterTab classroom={classroom} />}
               {activeTab === 'settings' && <TeacherSettingsTab classroom={classroom} />}
             </>
@@ -398,6 +401,7 @@ function ClassroomPageContent({
                 />
               )}
               {activeTab === 'calendar' && <StudentLessonCalendarTab classroom={classroom} />}
+              {activeTab === 'resources' && <StudentResourcesTab classroom={classroom} />}
             </>
           )}
         </MainContent>

--- a/src/app/classrooms/[classroomId]/StudentResourcesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentResourcesTab.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { RichTextViewer } from '@/components/editor'
+import { PageContent, PageLayout } from '@/components/PageLayout'
+import type { Classroom, TiptapContent } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentResourcesTab({ classroom }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [content, setContent] = useState<TiptapContent | null>(null)
+
+  useEffect(() => {
+    async function loadResources() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/student/classrooms/${classroom.id}/resources`)
+        const data = await res.json()
+        setContent(data.resources?.content || null)
+      } catch (err) {
+        console.error('Error loading resources:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadResources()
+  }, [classroom.id])
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <PageContent>
+          <div className="flex items-center justify-center h-64">
+            <Spinner />
+          </div>
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  const hasContent = content && content.content && content.content.length > 0
+
+  return (
+    <PageLayout>
+      <PageContent>
+        <div className="bg-surface rounded-lg shadow-sm p-6">
+          {hasContent ? (
+            <RichTextViewer content={content} />
+          ) : (
+            <div className="text-center py-12">
+              <p className="text-text-muted">No resources have been added yet.</p>
+            </div>
+          )}
+        </div>
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/src/app/classrooms/[classroomId]/TeacherResourcesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherResourcesTab.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { RichTextEditor } from '@/components/editor'
+import { PageContent, PageLayout } from '@/components/PageLayout'
+import type { Classroom, TiptapContent } from '@/types'
+
+const EMPTY_DOC: TiptapContent = { type: 'doc', content: [] }
+const AUTOSAVE_DEBOUNCE_MS = 2000
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherResourcesTab({ classroom }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [content, setContent] = useState<TiptapContent>(EMPTY_DOC)
+  const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
+  const [lastSavedTime, setLastSavedTime] = useState<Date | null>(null)
+
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const pendingContentRef = useRef<TiptapContent | null>(null)
+  const lastSavedContentRef = useRef<string>('')
+  const isArchived = !!classroom.archived_at
+
+  // Load resources on mount
+  useEffect(() => {
+    async function loadResources() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/resources`)
+        const data = await res.json()
+        const loadedContent = data.resources?.content || EMPTY_DOC
+        setContent(loadedContent)
+        lastSavedContentRef.current = JSON.stringify(loadedContent)
+        setSaveStatus('saved')
+      } catch (err) {
+        console.error('Error loading resources:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadResources()
+  }, [classroom.id])
+
+  // Save content to server
+  const saveContent = useCallback(async (newContent: TiptapContent) => {
+    const newContentStr = JSON.stringify(newContent)
+    if (newContentStr === lastSavedContentRef.current) {
+      setSaveStatus('saved')
+      return
+    }
+
+    setSaveStatus('saving')
+
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/resources`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: newContent }),
+      })
+
+      if (!res.ok) {
+        throw new Error('Failed to save')
+      }
+
+      lastSavedContentRef.current = newContentStr
+      setSaveStatus('saved')
+      setLastSavedTime(new Date())
+    } catch (err) {
+      console.error('Error saving resources:', err)
+      setSaveStatus('unsaved')
+    }
+  }, [classroom.id])
+
+  // Handle content change with debounced autosave
+  const handleContentChange = useCallback((newContent: TiptapContent) => {
+    setContent(newContent)
+    setSaveStatus('unsaved')
+    pendingContentRef.current = newContent
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+    }
+
+    saveTimeoutRef.current = setTimeout(() => {
+      saveContent(newContent)
+    }, AUTOSAVE_DEBOUNCE_MS)
+  }, [saveContent])
+
+  // Flush pending save on blur
+  const handleBlur = useCallback(() => {
+    if (saveStatus === 'unsaved' && pendingContentRef.current) {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+      saveContent(pendingContentRef.current)
+    }
+  }, [saveStatus, saveContent])
+
+  // Handle beforeunload - save pending changes with sendBeacon
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (pendingContentRef.current) {
+        const contentStr = JSON.stringify(pendingContentRef.current)
+        if (contentStr !== lastSavedContentRef.current) {
+          navigator.sendBeacon(
+            `/api/teacher/classrooms/${classroom.id}/resources`,
+            new Blob([JSON.stringify({ content: pendingContentRef.current })], { type: 'application/json' })
+          )
+        }
+      }
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+    }
+  }, [classroom.id])
+
+  if (loading) {
+    return (
+      <PageLayout>
+        <PageContent>
+          <div className="flex items-center justify-center h-64">
+            <Spinner />
+          </div>
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  const hasContent = content.content && content.content.length > 0
+  const formattedTime = lastSavedTime
+    ? lastSavedTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : null
+
+  return (
+    <PageLayout>
+      <PageContent>
+        <div className="bg-surface rounded-lg shadow-sm">
+          <div className="flex items-center justify-between px-6 py-3 border-b border-border">
+            <h2 className="text-lg font-semibold text-text-default">Resources</h2>
+            <span
+              className={
+                'text-sm ' +
+                (saveStatus === 'saved'
+                  ? 'text-text-muted'
+                  : saveStatus === 'saving'
+                    ? 'text-text-muted'
+                    : 'text-warning')
+              }
+            >
+              {saveStatus === 'saving' && 'Saving...'}
+              {saveStatus === 'saved' && formattedTime && `Last saved ${formattedTime}`}
+              {saveStatus === 'saved' && !formattedTime && ''}
+              {saveStatus === 'unsaved' && 'Unsaved changes'}
+            </span>
+          </div>
+
+          <div className="p-6">
+            {isArchived && (
+              <div className="mb-4 rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+                This classroom is archived. Resources are read-only.
+              </div>
+            )}
+
+            {!hasContent && !isArchived && (
+              <div className="mb-4 rounded-lg border border-border bg-surface-2 p-4">
+                <p className="text-sm text-text-muted mb-2">
+                  Use this page to share static resources with your students:
+                </p>
+                <ul className="text-sm text-text-muted list-disc list-inside space-y-1">
+                  <li>Contact information and office hours</li>
+                  <li>Links to external resources</li>
+                  <li>Rubrics and grading policies</li>
+                  <li>Class expectations and rules</li>
+                </ul>
+              </div>
+            )}
+
+            <RichTextEditor
+              content={content}
+              onChange={handleContentChange}
+              onBlur={handleBlur}
+              placeholder="Add resources for your students..."
+              editable={!isArchived}
+              showToolbar={!isArchived}
+              className="min-h-[400px]"
+            />
+          </div>
+        </div>
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardList,
   Settings,
   PenSquare,
+  StickyNote,
   Users,
   ChevronDown,
   type LucideIcon,
@@ -30,6 +31,7 @@ export type ClassroomNavItemId =
   | 'attendance'
   | 'assignments'
   | 'calendar'
+  | 'resources'
   | 'roster'
   | 'settings'
   | 'today'
@@ -54,6 +56,7 @@ const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
+  { id: 'resources', label: 'Resources', icon: StickyNote },
   { id: 'roster', label: 'Roster', icon: Users },
   { id: 'settings', label: 'Settings', icon: Settings },
 ]
@@ -62,6 +65,7 @@ const studentItems: NavItem[] = [
   { id: 'today', label: 'Today', icon: PenSquare },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
+  { id: 'resources', label: 'Resources', icon: StickyNote },
 ]
 
 // ============================================================================

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -45,6 +45,8 @@ export type RouteKey =
   | 'assignments-teacher-viewing'
   | 'calendar-teacher'
   | 'calendar-student'
+  | 'resources-teacher'
+  | 'resources-student'
 
 // ============================================================================
 // Constants
@@ -115,6 +117,14 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
     mainContent: { maxWidth: 'full' },
   },
+  'resources-teacher': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'full' },
+  },
+  'resources-student': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'reading' },
+  },
 }
 
 // ============================================================================
@@ -184,6 +194,10 @@ export function getRouteKeyFromTab(
 
   if (tab === 'calendar') {
     return role === 'teacher' ? 'calendar-teacher' : 'calendar-student'
+  }
+
+  if (tab === 'resources') {
+    return role === 'teacher' ? 'resources-teacher' : 'resources-student'
   }
 
   if (tab === 'assignments') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -229,3 +229,11 @@ export interface SelectedStudentInfo {
   onGoPrev: () => void
   onGoNext: () => void
 }
+
+export interface ClassroomResources {
+  id: string
+  classroom_id: string
+  content: TiptapContent
+  updated_at: string
+  updated_by: string | null
+}

--- a/supabase/migrations/024_classroom_materials.sql
+++ b/supabase/migrations/024_classroom_materials.sql
@@ -1,0 +1,13 @@
+-- Migration: classroom_materials table
+-- Purpose: Wiki-style static content per classroom
+
+CREATE TABLE classroom_materials (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  classroom_id UUID NOT NULL REFERENCES classrooms(id) ON DELETE CASCADE,
+  content JSONB NOT NULL DEFAULT '{"type":"doc","content":[]}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  UNIQUE(classroom_id)
+);
+
+CREATE INDEX classroom_materials_classroom_id_idx ON classroom_materials(classroom_id);

--- a/supabase/migrations/025_rename_materials_to_resources.sql
+++ b/supabase/migrations/025_rename_materials_to_resources.sql
@@ -1,0 +1,5 @@
+-- Migration: Rename classroom_materials to classroom_resources
+-- Purpose: Better naming - "Resources" is clearer than "Materials"
+
+ALTER TABLE classroom_materials RENAME TO classroom_resources;
+ALTER INDEX classroom_materials_classroom_id_idx RENAME TO classroom_resources_classroom_id_idx;

--- a/tests/api/student/resources.test.ts
+++ b/tests/api/student/resources.test.ts
@@ -1,0 +1,134 @@
+/**
+ * API tests for GET /api/student/classrooms/[id]/resources
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '@/app/api/student/classrooms/[id]/resources/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1' })) }))
+vi.mock('@/lib/server/classrooms', () => ({
+  assertStudentCanAccessClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/student/classrooms/[id]/resources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return null when no resources exist', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.resources).toBeNull()
+  })
+
+  it('should return existing resources', async () => {
+    const mockResources = {
+      id: 'm-1',
+      classroom_id: 'c-1',
+      content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Test' }] }] },
+      updated_at: '2025-01-15T12:00:00Z',
+      updated_by: 'teacher-1',
+    }
+
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: mockResources, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.resources.id).toBe('m-1')
+    expect(data.resources.content.content[0].content[0].text).toBe('Test')
+  })
+
+  it('should return 403 when student is not enrolled', async () => {
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Not enrolled in this classroom',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+    const data = await response.json()
+    expect(data.error).toBe('Not enrolled in this classroom')
+  })
+
+  it('should return 403 when classroom is archived', async () => {
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+    const data = await response.json()
+    expect(data.error).toBe('Classroom is archived')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})

--- a/tests/api/teacher/resources.test.ts
+++ b/tests/api/teacher/resources.test.ts
@@ -1,0 +1,260 @@
+/**
+ * API tests for GET/PUT /api/teacher/classrooms/[id]/resources
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET, PUT } from '@/app/api/teacher/classrooms/[id]/resources/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherOwnsClassroom: vi.fn(async () => ({ ok: true })),
+  assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/teacher/classrooms/[id]/resources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return null when no resources exist', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.resources).toBeNull()
+  })
+
+  it('should return existing resources', async () => {
+    const mockResources = {
+      id: 'm-1',
+      classroom_id: 'c-1',
+      content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Test' }] }] },
+      updated_at: '2025-01-15T12:00:00Z',
+      updated_by: 'teacher-1',
+    }
+
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: mockResources, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.resources.id).toBe('m-1')
+    expect(data.resources.content.content[0].content[0].text).toBe('Test')
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    const { assertTeacherOwnsClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherOwnsClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})
+
+describe('PUT /api/teacher/classrooms/[id]/resources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 400 for invalid content format', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: { type: 'invalid', content: [] } }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toContain('Invalid content format')
+  })
+
+  it('should return 400 for missing content', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({}),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toContain('Invalid content format')
+  })
+
+  it('should upsert resources successfully', async () => {
+    const mockResources = {
+      id: 'm-1',
+      classroom_id: 'c-1',
+      content: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Test' }] }] },
+      updated_at: '2025-01-15T12:00:00Z',
+      updated_by: 'teacher-1',
+    }
+
+    const mockFrom = vi.fn(() => ({
+      upsert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: mockResources, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: mockResources.content }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.resources.id).toBe('m-1')
+  })
+
+  it('should return 403 when classroom is archived', async () => {
+    const { assertTeacherCanMutateClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherCanMutateClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: { type: 'doc', content: [] } }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+    const data = await response.json()
+    expect(data.error).toBe('Classroom is archived')
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    const { assertTeacherCanMutateClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherCanMutateClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: { type: 'doc', content: [] } }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: { type: 'doc', content: [] } }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      upsert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/resources',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content: { type: 'doc', content: [] } }),
+      }
+    )
+    const response = await PUT(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a "Resources" page to each classroom - a simple wiki where teachers can share static resources with students.

- **Database**: Add `classroom_resources` table with Tiptap JSON content storage
- **Teacher API**: GET/PUT endpoints at `/api/teacher/classrooms/[id]/resources`
- **Student API**: GET endpoint at `/api/student/classrooms/[id]/resources`
- **Teacher UI**: RichTextEditor with 2s debounced autosave + sendBeacon on page close
- **Student UI**: Read-only RichTextViewer with empty state message
- **Navigation**: Resources tab (StickyNote icon) after Calendar for both roles
- **Tests**: 18 new API tests covering auth, permissions, and CRUD operations

## Test plan

- [ ] Teacher can navigate to Resources tab and see empty state suggestions
- [ ] Teacher can add/edit content with rich text formatting
- [ ] Content auto-saves after 2s of inactivity
- [ ] Content persists after page refresh
- [ ] Student can view resources (read-only)
- [ ] Student sees "No resources" message when none added
- [ ] Resources tab appears after Calendar in nav for both roles
- [ ] Archived classroom shows read-only warning for teacher
- [ ] Run `pnpm test` - all tests pass

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)