### PR TITLE
feat: add Quiz feature for classroom polls and surveys

### DIFF
--- a/src/app/api/student/quizzes/[id]/respond/route.ts
+++ b/src/app/api/student/quizzes/[id]/respond/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// POST /api/student/quizzes/[id]/respond - Submit all responses
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: quizId } = await params
+    const body = await request.json()
+    const { responses } = body
+
+    // responses should be: { [question_id]: selected_option_index }
+    if (!responses || typeof responses !== 'object') {
+      return NextResponse.json({ error: 'Responses are required' }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Verify student is enrolled
+    const { data: enrollment, error: enrollError } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', quiz.classroom_id)
+      .eq('student_id', user.id)
+      .single()
+
+    if (enrollError || !enrollment) {
+      return NextResponse.json({ error: 'Not enrolled in this classroom' }, { status: 403 })
+    }
+
+    // Quiz must be active
+    if (quiz.status !== 'active') {
+      return NextResponse.json({ error: 'Quiz is not active' }, { status: 400 })
+    }
+
+    // Check if student has already responded
+    const { data: existingResponses } = await supabase
+      .from('quiz_responses')
+      .select('id')
+      .eq('quiz_id', quizId)
+      .eq('student_id', user.id)
+      .limit(1)
+
+    if ((existingResponses?.length || 0) > 0) {
+      return NextResponse.json({ error: 'You have already responded to this quiz' }, { status: 400 })
+    }
+
+    // Fetch all questions for this quiz
+    const { data: questions, error: questionsError } = await supabase
+      .from('quiz_questions')
+      .select('id, options')
+      .eq('quiz_id', quizId)
+
+    if (questionsError || !questions) {
+      console.error('Error fetching questions:', questionsError)
+      return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+    }
+
+    // Validate that all questions are answered
+    const questionIds = questions.map((q) => q.id)
+    const responseQuestionIds = Object.keys(responses)
+
+    const missingQuestions = questionIds.filter((qid) => !responseQuestionIds.includes(qid))
+    if (missingQuestions.length > 0) {
+      return NextResponse.json({ error: 'All questions must be answered' }, { status: 400 })
+    }
+
+    // Validate that response values are valid option indices
+    const questionsMap = new Map(questions.map((q) => [q.id, q.options]))
+    for (const [questionId, selectedOption] of Object.entries(responses)) {
+      const options = questionsMap.get(questionId)
+      if (!options) {
+        return NextResponse.json({ error: `Invalid question ID: ${questionId}` }, { status: 400 })
+      }
+      if (typeof selectedOption !== 'number' || selectedOption < 0 || selectedOption >= options.length) {
+        return NextResponse.json(
+          { error: `Invalid option for question ${questionId}` },
+          { status: 400 }
+        )
+      }
+    }
+
+    // Insert all responses
+    const responsesToInsert = Object.entries(responses).map(([questionId, selectedOption]) => ({
+      quiz_id: quizId,
+      question_id: questionId,
+      student_id: user.id,
+      selected_option: selectedOption as number,
+    }))
+
+    const { error: insertError } = await supabase
+      .from('quiz_responses')
+      .insert(responsesToInsert)
+
+    if (insertError) {
+      console.error('Error inserting responses:', insertError)
+      return NextResponse.json({ error: 'Failed to submit responses' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Submit quiz response error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/student/quizzes/[id]/results/route.ts
+++ b/src/app/api/student/quizzes/[id]/results/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { aggregateResults, canStudentViewResults } from '@/lib/quizzes'
+import type { QuizQuestion, QuizResponse } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/student/quizzes/[id]/results - Get aggregated results (if allowed)
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: quizId } = await params
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    // Verify student is enrolled
+    const { data: enrollment, error: enrollError } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', quiz.classroom_id)
+      .eq('student_id', user.id)
+      .single()
+
+    if (enrollError || !enrollment) {
+      return NextResponse.json({ error: 'Not enrolled in this classroom' }, { status: 403 })
+    }
+
+    // Check if student has responded
+    const { data: studentResponses } = await supabase
+      .from('quiz_responses')
+      .select('id')
+      .eq('quiz_id', quizId)
+      .eq('student_id', user.id)
+      .limit(1)
+
+    const hasResponded = (studentResponses?.length || 0) > 0
+
+    // Check if student can view results
+    if (!canStudentViewResults(quiz, hasResponded)) {
+      return NextResponse.json(
+        { error: 'Results are not available for this quiz' },
+        { status: 403 }
+      )
+    }
+
+    // Fetch questions
+    const { data: questions, error: questionsError } = await supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('quiz_id', quizId)
+      .order('position', { ascending: true })
+
+    if (questionsError) {
+      console.error('Error fetching questions:', questionsError)
+      return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+    }
+
+    // Fetch all responses
+    const { data: responses, error: responsesError } = await supabase
+      .from('quiz_responses')
+      .select('*')
+      .eq('quiz_id', quizId)
+
+    if (responsesError) {
+      console.error('Error fetching responses:', responsesError)
+      return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+    }
+
+    // Aggregate results
+    const aggregated = aggregateResults(
+      (questions || []) as QuizQuestion[],
+      (responses || []) as QuizResponse[]
+    )
+
+    // Get student's own responses
+    const myResponses: Record<string, number> = {}
+    const { data: myResponsesData } = await supabase
+      .from('quiz_responses')
+      .select('question_id, selected_option')
+      .eq('quiz_id', quizId)
+      .eq('student_id', user.id)
+
+    for (const r of myResponsesData || []) {
+      myResponses[r.question_id] = r.selected_option
+    }
+
+    return NextResponse.json({
+      quiz: {
+        id: quiz.id,
+        title: quiz.title,
+        status: quiz.status,
+      },
+      results: aggregated,
+      my_responses: myResponses,
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get student quiz results error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/student/quizzes/[id]/route.ts
+++ b/src/app/api/student/quizzes/[id]/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { getStudentQuizStatus } from '@/lib/quizzes'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/student/quizzes/[id] - Get quiz with questions
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: quizId } = await params
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Verify student is enrolled
+    const { data: enrollment, error: enrollError } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', quiz.classroom_id)
+      .eq('student_id', user.id)
+      .single()
+
+    if (enrollError || !enrollment) {
+      return NextResponse.json({ error: 'Not enrolled in this classroom' }, { status: 403 })
+    }
+
+    // Check if student has responded
+    const { data: responses } = await supabase
+      .from('quiz_responses')
+      .select('id')
+      .eq('quiz_id', quizId)
+      .eq('student_id', user.id)
+      .limit(1)
+
+    const hasResponded = (responses?.length || 0) > 0
+
+    // Students can only see active quizzes or closed quizzes they responded to
+    if (quiz.status === 'draft') {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+    if (quiz.status === 'closed' && !hasResponded) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    const studentStatus = getStudentQuizStatus(quiz, hasResponded)
+
+    // Fetch questions
+    const { data: questions, error: questionsError } = await supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('quiz_id', quizId)
+      .order('position', { ascending: true })
+
+    if (questionsError) {
+      console.error('Error fetching questions:', questionsError)
+      return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+    }
+
+    // Get student's responses if they've responded
+    let studentResponses: Record<string, number> = {}
+    if (hasResponded) {
+      const { data: allResponses } = await supabase
+        .from('quiz_responses')
+        .select('question_id, selected_option')
+        .eq('quiz_id', quizId)
+        .eq('student_id', user.id)
+
+      studentResponses = Object.fromEntries(
+        (allResponses || []).map((r) => [r.question_id, r.selected_option])
+      )
+    }
+
+    return NextResponse.json({
+      quiz: {
+        id: quiz.id,
+        classroom_id: quiz.classroom_id,
+        title: quiz.title,
+        status: quiz.status,
+        show_results: quiz.show_results,
+        position: quiz.position,
+        created_at: quiz.created_at,
+        updated_at: quiz.updated_at,
+      },
+      questions: questions || [],
+      student_status: studentStatus,
+      student_responses: studentResponses,
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get student quiz error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/student/quizzes/route.ts
+++ b/src/app/api/student/quizzes/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+import { getStudentQuizStatus } from '@/lib/quizzes'
+import type { Quiz } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/student/quizzes?classroom_id=xxx - List quizzes for student
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole('student')
+    const { searchParams } = new URL(request.url)
+    const classroomId = searchParams.get('classroom_id')
+
+    if (!classroomId) {
+      return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status })
+    }
+
+    // Fetch active quizzes
+    const { data: activeQuizzes, error: activeError } = await supabase
+      .from('quizzes')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .eq('status', 'active')
+      .order('position', { ascending: true })
+
+    if (activeError) {
+      console.error('Error fetching active quizzes:', activeError)
+      return NextResponse.json({ error: 'Failed to fetch quizzes' }, { status: 500 })
+    }
+
+    // Get student's responses for all quizzes in this classroom
+    const { data: allResponses } = await supabase
+      .from('quiz_responses')
+      .select('quiz_id')
+      .eq('student_id', user.id)
+
+    const respondedQuizIds = new Set(allResponses?.map((r) => r.quiz_id) || [])
+
+    // Also fetch closed quizzes the student has responded to
+    const { data: closedQuizzes, error: closedError } = await supabase
+      .from('quizzes')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .eq('status', 'closed')
+      .order('position', { ascending: true })
+
+    if (closedError) {
+      console.error('Error fetching closed quizzes:', closedError)
+      // Continue without closed quizzes
+    }
+
+    // Filter closed quizzes to only those the student has responded to
+    const respondedClosedQuizzes = (closedQuizzes || []).filter((q) =>
+      respondedQuizIds.has(q.id)
+    )
+
+    // Combine and add student status
+    const allQuizzes = [...(activeQuizzes || []), ...respondedClosedQuizzes]
+
+    const quizzesWithStatus = allQuizzes.map((quiz: Quiz) => {
+      const hasResponded = respondedQuizIds.has(quiz.id)
+      const studentStatus = getStudentQuizStatus(quiz, hasResponded)
+
+      return {
+        ...quiz,
+        student_status: studentStatus,
+      }
+    })
+
+    return NextResponse.json({ quizzes: quizzesWithStatus })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get student quizzes error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/quizzes/[id]/questions/[qid]/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/questions/[qid]/route.ts
@@ -1,0 +1,192 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { validateQuizOptions } from '@/lib/quizzes'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// PATCH /api/teacher/quizzes/[id]/questions/[qid] - Update a question
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; qid: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: quizId, qid: questionId } = await params
+    const body = await request.json()
+    const { question_text, options } = body
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          teacher_id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    if (quiz.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Cannot modify questions on non-draft quizzes
+    if (quiz.status !== 'draft') {
+      return NextResponse.json(
+        { error: 'Cannot modify questions on a quiz that is not in draft status' },
+        { status: 400 }
+      )
+    }
+
+    // Verify question belongs to this quiz
+    const { data: existingQuestion, error: qError } = await supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('id', questionId)
+      .eq('quiz_id', quizId)
+      .single()
+
+    if (qError || !existingQuestion) {
+      return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+    }
+
+    // Build update object
+    const updates: Record<string, any> = {}
+    if (question_text !== undefined) {
+      if (!question_text.trim()) {
+        return NextResponse.json({ error: 'Question text cannot be empty' }, { status: 400 })
+      }
+      updates.question_text = question_text.trim()
+    }
+    if (options !== undefined) {
+      if (!Array.isArray(options)) {
+        return NextResponse.json({ error: 'Options must be an array' }, { status: 400 })
+      }
+      const validation = validateQuizOptions(options)
+      if (!validation.valid) {
+        return NextResponse.json({ error: validation.error }, { status: 400 })
+      }
+      updates.options = options
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No updates provided' }, { status: 400 })
+    }
+
+    const { data: question, error } = await supabase
+      .from('quiz_questions')
+      .update(updates)
+      .eq('id', questionId)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error updating question:', error)
+      return NextResponse.json({ error: 'Failed to update question' }, { status: 500 })
+    }
+
+    return NextResponse.json({ question })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Update question error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// DELETE /api/teacher/quizzes/[id]/questions/[qid] - Delete a question
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; qid: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: quizId, qid: questionId } = await params
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          teacher_id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    if (quiz.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Cannot delete questions from non-draft quizzes
+    if (quiz.status !== 'draft') {
+      return NextResponse.json(
+        { error: 'Cannot delete questions from a quiz that is not in draft status' },
+        { status: 400 }
+      )
+    }
+
+    // Verify question belongs to this quiz
+    const { data: existingQuestion, error: qError } = await supabase
+      .from('quiz_questions')
+      .select('id')
+      .eq('id', questionId)
+      .eq('quiz_id', quizId)
+      .single()
+
+    if (qError || !existingQuestion) {
+      return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+    }
+
+    const { error } = await supabase
+      .from('quiz_questions')
+      .delete()
+      .eq('id', questionId)
+
+    if (error) {
+      console.error('Error deleting question:', error)
+      return NextResponse.json({ error: 'Failed to delete question' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Delete question error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/quizzes/[id]/questions/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/questions/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { validateQuizOptions } from '@/lib/quizzes'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// POST /api/teacher/quizzes/[id]/questions - Add a question
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: quizId } = await params
+    const body = await request.json()
+    const { question_text, options } = body
+
+    if (!question_text || !question_text.trim()) {
+      return NextResponse.json({ error: 'Question text is required' }, { status: 400 })
+    }
+
+    if (!options || !Array.isArray(options)) {
+      return NextResponse.json({ error: 'Options must be an array' }, { status: 400 })
+    }
+
+    const validation = validateQuizOptions(options)
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          teacher_id,
+          archived_at
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    if (quiz.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Cannot add questions to non-draft quizzes
+    if (quiz.status !== 'draft') {
+      return NextResponse.json(
+        { error: 'Cannot add questions to a quiz that is not in draft status' },
+        { status: 400 }
+      )
+    }
+
+    // Get next position
+    const { data: lastQuestion } = await supabase
+      .from('quiz_questions')
+      .select('position')
+      .eq('quiz_id', quizId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const nextPosition = typeof lastQuestion?.position === 'number' ? lastQuestion.position + 1 : 0
+
+    const { data: question, error } = await supabase
+      .from('quiz_questions')
+      .insert({
+        quiz_id: quizId,
+        question_text: question_text.trim(),
+        options,
+        position: nextPosition,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error creating question:', error)
+      return NextResponse.json({ error: 'Failed to create question' }, { status: 500 })
+    }
+
+    return NextResponse.json({ question }, { status: 201 })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Create question error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/quizzes/[id]/results/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/results/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { aggregateResults } from '@/lib/quizzes'
+import type { QuizQuestion, QuizResponse } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/teacher/quizzes/[id]/results - Get aggregated results
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: quizId } = await params
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          id,
+          teacher_id
+        )
+      `)
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    // Fetch questions
+    const { data: questions, error: questionsError } = await supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('quiz_id', quizId)
+      .order('position', { ascending: true })
+
+    if (questionsError) {
+      console.error('Error fetching questions:', questionsError)
+      return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+    }
+
+    // Fetch all responses
+    const { data: responses, error: responsesError } = await supabase
+      .from('quiz_responses')
+      .select('*')
+      .eq('quiz_id', quizId)
+
+    if (responsesError) {
+      console.error('Error fetching responses:', responsesError)
+      return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+    }
+
+    // Get unique responder IDs
+    const responderIds = [...new Set(responses?.map((r) => r.student_id) || [])]
+
+    // Get responder details (names)
+    let responders: { student_id: string; name: string | null; email: string }[] = []
+    if (responderIds.length > 0) {
+      const { data: users } = await supabase
+        .from('users')
+        .select('id, email')
+        .in('id', responderIds)
+
+      const { data: profiles } = await supabase
+        .from('student_profiles')
+        .select('user_id, first_name, last_name')
+        .in('user_id', responderIds)
+
+      const profileMap = new Map(
+        profiles?.map((p) => [
+          p.user_id,
+          `${p.first_name} ${p.last_name}`.trim(),
+        ]) || []
+      )
+
+      responders = (users || []).map((u) => ({
+        student_id: u.id,
+        name: profileMap.get(u.id) || null,
+        email: u.email,
+      }))
+
+      // Sort by name (with email fallback)
+      responders.sort((a, b) => {
+        const nameA = a.name || a.email
+        const nameB = b.name || b.email
+        return nameA.localeCompare(nameB)
+      })
+    }
+
+    // Aggregate results
+    const aggregated = aggregateResults(
+      (questions || []) as QuizQuestion[],
+      (responses || []) as QuizResponse[]
+    )
+
+    // Count total students in classroom
+    const { count: totalStudents } = await supabase
+      .from('classroom_enrollments')
+      .select('*', { count: 'exact', head: true })
+      .eq('classroom_id', quiz.classroom_id)
+
+    return NextResponse.json({
+      quiz: {
+        id: quiz.id,
+        title: quiz.title,
+        status: quiz.status,
+        show_results: quiz.show_results,
+      },
+      results: aggregated,
+      responders,
+      stats: {
+        total_students: totalStudents || 0,
+        responded: responderIds.length,
+      },
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get quiz results error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/quizzes/[id]/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/route.ts
@@ -1,0 +1,229 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { canActivateQuiz } from '@/lib/quizzes'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/teacher/quizzes/[id] - Get quiz with questions
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id } = await params
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          id,
+          teacher_id,
+          title,
+          archived_at
+        )
+      `)
+      .eq('id', id)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    // Fetch questions
+    const { data: questions, error: questionsError } = await supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('quiz_id', id)
+      .order('position', { ascending: true })
+
+    if (questionsError) {
+      console.error('Error fetching questions:', questionsError)
+      return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      quiz: {
+        id: quiz.id,
+        classroom_id: quiz.classroom_id,
+        title: quiz.title,
+        status: quiz.status,
+        show_results: quiz.show_results,
+        position: quiz.position,
+        created_by: quiz.created_by,
+        created_at: quiz.created_at,
+        updated_at: quiz.updated_at,
+      },
+      questions: questions || [],
+      classroom: quiz.classrooms,
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get quiz error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// PATCH /api/teacher/quizzes/[id] - Update quiz title/status/show_results
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id } = await params
+    const body = await request.json()
+    const { title, status, show_results } = body
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: existing, error: existingError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          teacher_id,
+          archived_at
+        )
+      `)
+      .eq('id', id)
+      .single()
+
+    if (existingError || !existing) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (existing.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    if (existing.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // If activating quiz, validate it has questions
+    if (status === 'active' && existing.status === 'draft') {
+      const { count: questionsCount } = await supabase
+        .from('quiz_questions')
+        .select('*', { count: 'exact', head: true })
+        .eq('quiz_id', id)
+
+      const activation = canActivateQuiz(existing, questionsCount || 0)
+      if (!activation.valid) {
+        return NextResponse.json({ error: activation.error }, { status: 400 })
+      }
+    }
+
+    // Build update object
+    const updates: Record<string, any> = {}
+    if (title !== undefined) updates.title = title.trim()
+    if (status !== undefined) updates.status = status
+    if (show_results !== undefined) updates.show_results = show_results
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No updates provided' }, { status: 400 })
+    }
+
+    const { data: quiz, error } = await supabase
+      .from('quizzes')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error updating quiz:', error)
+      return NextResponse.json({ error: 'Failed to update quiz' }, { status: 500 })
+    }
+
+    return NextResponse.json({ quiz })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Update quiz error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// DELETE /api/teacher/quizzes/[id] - Delete quiz
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id } = await params
+    const supabase = getServiceRoleClient()
+
+    // Fetch quiz and verify ownership
+    const { data: existing, error: existingError } = await supabase
+      .from('quizzes')
+      .select(`
+        *,
+        classrooms!inner (
+          teacher_id,
+          archived_at
+        )
+      `)
+      .eq('id', id)
+      .single()
+
+    if (existingError || !existing) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (existing.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    if (existing.classrooms.archived_at) {
+      return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
+    }
+
+    // Count responses for confirmation warning
+    const { count: responsesCount } = await supabase
+      .from('quiz_responses')
+      .select('*', { count: 'exact', head: true })
+      .eq('quiz_id', id)
+
+    const { error } = await supabase
+      .from('quizzes')
+      .delete()
+      .eq('id', id)
+
+    if (error) {
+      console.error('Error deleting quiz:', error)
+      return NextResponse.json({ error: 'Failed to delete quiz' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, responses_count: responsesCount || 0 })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Delete quiz error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/quizzes/route.ts
+++ b/src/app/api/teacher/quizzes/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/teacher/quizzes?classroom_id=xxx - List quizzes for a classroom
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const { searchParams } = new URL(request.url)
+    const classroomId = searchParams.get('classroom_id')
+
+    if (!classroomId) {
+      return NextResponse.json(
+        { error: 'classroom_id is required' },
+        { status: 400 }
+      )
+    }
+
+    const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Fetch quizzes with questions count
+    const { data: quizzes, error: quizzesError } = await supabase
+      .from('quizzes')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: true })
+      .order('created_at', { ascending: true })
+
+    if (quizzesError) {
+      console.error('Error fetching quizzes:', quizzesError)
+      return NextResponse.json({ error: 'Failed to fetch quizzes' }, { status: 500 })
+    }
+
+    // Count total students in classroom
+    const { count: totalStudents } = await supabase
+      .from('classroom_enrollments')
+      .select('*', { count: 'exact', head: true })
+      .eq('classroom_id', classroomId)
+
+    // Get stats for each quiz
+    const quizzesWithStats = await Promise.all(
+      (quizzes || []).map(async (quiz) => {
+        // Count questions
+        const { count: questionsCount } = await supabase
+          .from('quiz_questions')
+          .select('*', { count: 'exact', head: true })
+          .eq('quiz_id', quiz.id)
+
+        // Count unique students who responded
+        const { data: responses } = await supabase
+          .from('quiz_responses')
+          .select('student_id')
+          .eq('quiz_id', quiz.id)
+
+        const uniqueStudentIds = new Set(responses?.map((r) => r.student_id) || [])
+
+        return {
+          ...quiz,
+          stats: {
+            total_students: totalStudents || 0,
+            responded: uniqueStudentIds.size,
+            questions_count: questionsCount || 0,
+          },
+        }
+      })
+    )
+
+    return NextResponse.json({ quizzes: quizzesWithStats })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get quizzes error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// POST /api/teacher/quizzes - Create a new quiz
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const body = await request.json()
+    const { classroom_id, title } = body
+
+    if (!classroom_id) {
+      return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+    }
+    if (!title || !title.trim()) {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 })
+    }
+
+    const ownership = await assertTeacherCanMutateClassroom(user.id, classroom_id)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Get next position
+    const { data: lastQuiz } = await supabase
+      .from('quizzes')
+      .select('position')
+      .eq('classroom_id', classroom_id)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const nextPosition = typeof lastQuiz?.position === 'number' ? lastQuiz.position + 1 : 0
+
+    const { data: quiz, error } = await supabase
+      .from('quizzes')
+      .insert({
+        classroom_id,
+        title: title.trim(),
+        created_by: user.id,
+        position: nextPosition,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error creating quiz:', error)
+      return NextResponse.json({ error: 'Failed to create quiz' }, { status: 500 })
+    }
+
+    return NextResponse.json({ quiz }, { status: 201 })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Create quiz error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -14,6 +14,8 @@ import { TeacherLessonCalendarTab, TeacherLessonCalendarSidebar, CalendarSidebar
 import { StudentLessonCalendarTab } from './StudentLessonCalendarTab'
 import { TeacherResourcesTab } from './TeacherResourcesTab'
 import { StudentResourcesTab } from './StudentResourcesTab'
+import { TeacherQuizzesTab } from './TeacherQuizzesTab'
+import { StudentQuizzesTab } from './StudentQuizzesTab'
 import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
 import { ClassDaysProvider } from '@/hooks/useClassDays'
 import {
@@ -71,8 +73,8 @@ export function ClassroomPageClient({
   const tab = searchParams.get('tab') ?? initialTab
   const defaultTab = isTeacher ? 'attendance' : 'today'
   const validTabs = isTeacher
-    ? (['attendance', 'assignments', 'calendar', 'resources', 'roster', 'settings'] as const)
-    : (['today', 'assignments', 'calendar', 'resources'] as const)
+    ? (['attendance', 'assignments', 'quizzes', 'calendar', 'resources', 'roster', 'settings'] as const)
+    : (['today', 'assignments', 'quizzes', 'calendar', 'resources'] as const)
 
   const activeTab = (validTabs as readonly string[]).includes(tab ?? '') ? (tab as string) : defaultTab
 
@@ -376,6 +378,7 @@ function ClassroomPageContent({
                   onViewModeChange={handleViewModeChange}
                 />
               )}
+              {activeTab === 'quizzes' && <TeacherQuizzesTab classroom={classroom} />}
               {activeTab === 'calendar' && (
                 <TeacherLessonCalendarTab
                   classroom={classroom}
@@ -400,6 +403,7 @@ function ClassroomPageContent({
                   onSelectAssignment={handleSelectAssignment}
                 />
               )}
+              {activeTab === 'quizzes' && <StudentQuizzesTab classroom={classroom} />}
               {activeTab === 'calendar' && <StudentLessonCalendarTab classroom={classroom} />}
               {activeTab === 'resources' && <StudentResourcesTab classroom={classroom} />}
             </>

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { ChevronLeft } from 'lucide-react'
+import { Spinner } from '@/components/Spinner'
+import { PageContent, PageLayout } from '@/components/PageLayout'
+import { Button } from '@/ui'
+import { getQuizStatusBadgeClass } from '@/lib/quizzes'
+import { StudentQuizForm } from '@/components/StudentQuizForm'
+import { StudentQuizResults } from '@/components/StudentQuizResults'
+import type { Classroom, StudentQuizView, QuizQuestion } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentQuizzesTab({ classroom }: Props) {
+  const [quizzes, setQuizzes] = useState<StudentQuizView[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedQuizId, setSelectedQuizId] = useState<string | null>(null)
+  const [selectedQuiz, setSelectedQuiz] = useState<{
+    quiz: StudentQuizView
+    questions: QuizQuestion[]
+    studentResponses: Record<string, number>
+  } | null>(null)
+  const [loadingQuiz, setLoadingQuiz] = useState(false)
+
+  const loadQuizzes = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/student/quizzes?classroom_id=${classroom.id}`)
+      const data = await res.json()
+      setQuizzes(data.quizzes || [])
+    } catch (err) {
+      console.error('Error loading quizzes:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [classroom.id])
+
+  useEffect(() => {
+    loadQuizzes()
+  }, [loadQuizzes])
+
+  async function handleSelectQuiz(quizId: string) {
+    setSelectedQuizId(quizId)
+    setLoadingQuiz(true)
+
+    try {
+      const res = await fetch(`/api/student/quizzes/${quizId}`)
+      const data = await res.json()
+      setSelectedQuiz({
+        quiz: data.quiz,
+        questions: data.questions || [],
+        studentResponses: data.student_responses || {},
+      })
+    } catch (err) {
+      console.error('Error loading quiz:', err)
+    } finally {
+      setLoadingQuiz(false)
+    }
+  }
+
+  function handleBack() {
+    setSelectedQuizId(null)
+    setSelectedQuiz(null)
+    loadQuizzes() // Refresh list to get updated status
+  }
+
+  function handleQuizSubmitted() {
+    // Reload the quiz to get updated status
+    if (selectedQuizId) {
+      handleSelectQuiz(selectedQuizId)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  // Quiz Detail View
+  if (selectedQuizId && selectedQuiz) {
+    const hasResponded = Object.keys(selectedQuiz.studentResponses).length > 0
+
+    return (
+      <PageLayout>
+        <PageContent>
+          <div className="max-w-2xl mx-auto">
+            <button
+              type="button"
+              onClick={handleBack}
+              className="flex items-center gap-1 text-sm text-text-muted hover:text-text-default mb-4"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back to quizzes
+            </button>
+
+            <h2 className="text-xl font-bold text-text-default mb-1">{selectedQuiz.quiz.title}</h2>
+
+            {hasResponded && selectedQuiz.quiz.show_results ? (
+              <StudentQuizResults
+                quizId={selectedQuizId}
+                myResponses={selectedQuiz.studentResponses}
+              />
+            ) : hasResponded ? (
+              <div className="mt-6 p-4 bg-success-bg rounded-lg text-center">
+                <p className="text-success font-medium">You have submitted your response.</p>
+                {!selectedQuiz.quiz.show_results && (
+                  <p className="text-sm text-text-muted mt-1">
+                    Results are not available for this quiz.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <StudentQuizForm
+                quizId={selectedQuizId}
+                questions={selectedQuiz.questions}
+                onSubmitted={handleQuizSubmitted}
+              />
+            )}
+          </div>
+        </PageContent>
+      </PageLayout>
+    )
+  }
+
+  // Loading quiz details
+  if (selectedQuizId && loadingQuiz) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  // Quiz List View
+  return (
+    <PageLayout>
+      <PageContent>
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-xl font-bold text-text-default mb-4">Quizzes</h2>
+
+          {quizzes.length === 0 ? (
+            <p className="text-text-muted text-center py-8">No quizzes available.</p>
+          ) : (
+            <div className="space-y-3">
+              {quizzes.map((quiz) => (
+                <button
+                  key={quiz.id}
+                  type="button"
+                  onClick={() => handleSelectQuiz(quiz.id)}
+                  className="w-full text-left p-4 rounded-lg border border-border bg-surface hover:bg-surface-hover transition-colors"
+                >
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium text-text-default">{quiz.title}</h3>
+                    {quiz.student_status === 'not_started' && (
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
+                        New
+                      </span>
+                    )}
+                    {quiz.student_status === 'responded' && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                        Submitted
+                      </span>
+                    )}
+                    {quiz.student_status === 'can_view_results' && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
+                        View Results
+                      </span>
+                    )}
+                  </div>
+                  {quiz.status === 'closed' && (
+                    <p className="text-xs text-text-muted mt-1">This quiz is closed</p>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Plus } from 'lucide-react'
+import { Spinner } from '@/components/Spinner'
+import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import { Button, ConfirmDialog } from '@/ui'
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCell,
+  DataTableHead,
+  DataTableHeaderCell,
+  DataTableRow,
+  EmptyStateRow,
+  KeyboardNavigableTable,
+  SortableHeaderCell,
+  TableCard,
+} from '@/components/DataTable'
+import { RightSidebarToggle, useRightSidebar } from '@/components/layout'
+import { applyDirection, toggleSort } from '@/lib/table-sort'
+import { getQuizStatusLabel, getQuizStatusBadgeClass } from '@/lib/quizzes'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { QuizModal } from '@/components/QuizModal'
+import { QuizDetailPanel } from '@/components/QuizDetailPanel'
+import type { Classroom, QuizWithStats, Quiz } from '@/types'
+
+type SortColumn = 'title' | 'status' | 'responded'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function TeacherQuizzesTab({ classroom }: Props) {
+  const [quizzes, setQuizzes] = useState<QuizWithStats[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selectedQuizId, setSelectedQuizId] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [editingQuiz, setEditingQuiz] = useState<Quiz | null>(null)
+  const [deleteQuiz, setDeleteQuiz] = useState<{ quiz: QuizWithStats; responsesCount: number } | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
+    column: SortColumn
+    direction: 'asc' | 'desc'
+  }>({ column: 'title', direction: 'asc' })
+
+  const { setOpen: setRightSidebarOpen } = useRightSidebar()
+
+  const loadQuizzes = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/teacher/quizzes?classroom_id=${classroom.id}`)
+      const data = await res.json()
+      setQuizzes(data.quizzes || [])
+    } catch (err) {
+      console.error('Error loading quizzes:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [classroom.id])
+
+  useEffect(() => {
+    loadQuizzes()
+  }, [loadQuizzes])
+
+  // Listen for quiz updates
+  useEffect(() => {
+    function handleQuizzesUpdated(event: Event) {
+      const detail = (event as CustomEvent<{ classroomId?: string }>).detail
+      if (!detail || detail.classroomId !== classroom.id) return
+      loadQuizzes()
+    }
+    window.addEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleQuizzesUpdated)
+    return () => window.removeEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleQuizzesUpdated)
+  }, [classroom.id, loadQuizzes])
+
+  const rows = useMemo(() => {
+    return [...quizzes].sort((a, b) => {
+      if (sortColumn === 'title') {
+        return applyDirection(a.title.localeCompare(b.title), sortDirection)
+      }
+      if (sortColumn === 'status') {
+        return applyDirection(a.status.localeCompare(b.status), sortDirection)
+      }
+      if (sortColumn === 'responded') {
+        return applyDirection(a.stats.responded - b.stats.responded, sortDirection)
+      }
+      return 0
+    })
+  }, [quizzes, sortColumn, sortDirection])
+
+  const rowKeys = useMemo(() => rows.map((q) => q.id), [rows])
+
+  function handleSort(column: SortColumn) {
+    setSortState((prev) => toggleSort(prev, column))
+  }
+
+  function handleRowClick(quiz: QuizWithStats) {
+    const newSelectedId = selectedQuizId === quiz.id ? null : quiz.id
+    setSelectedQuizId(newSelectedId)
+    if (newSelectedId) {
+      setRightSidebarOpen(true)
+    }
+  }
+
+  function handleKeyboardSelect(quizId: string) {
+    setSelectedQuizId(quizId)
+    setRightSidebarOpen(true)
+  }
+
+  function handleNewQuiz() {
+    setEditingQuiz(null)
+    setShowModal(true)
+  }
+
+  function handleQuizCreated() {
+    setShowModal(false)
+    loadQuizzes()
+    window.dispatchEvent(
+      new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
+    )
+  }
+
+  async function handleDeleteConfirm() {
+    if (!deleteQuiz) return
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${deleteQuiz.quiz.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to delete quiz')
+      }
+      if (selectedQuizId === deleteQuiz.quiz.id) {
+        setSelectedQuizId(null)
+      }
+      loadQuizzes()
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
+      )
+    } catch (err) {
+      console.error('Error deleting quiz:', err)
+    } finally {
+      setDeleting(false)
+      setDeleteQuiz(null)
+    }
+  }
+
+  async function handleRequestDelete(quiz: QuizWithStats) {
+    // Get response count for confirmation message
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quiz.id}/results`)
+      const data = await res.json()
+      setDeleteQuiz({ quiz, responsesCount: data.stats?.responded || 0 })
+    } catch {
+      setDeleteQuiz({ quiz, responsesCount: quiz.stats.responded })
+    }
+  }
+
+  const selectedQuiz = rows.find((q) => q.id === selectedQuizId)
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <PageLayout>
+      <PageActionBar
+        primary={
+          <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            New Quiz
+          </Button>
+        }
+        trailing={<RightSidebarToggle />}
+      />
+
+      <PageContent className="flex gap-4">
+        <div className="flex-1 min-w-0">
+          <KeyboardNavigableTable
+            rowKeys={rowKeys}
+            selectedKey={selectedQuizId}
+            onSelectKey={handleKeyboardSelect}
+          >
+            <TableCard>
+              <DataTable>
+                <DataTableHead>
+                  <DataTableRow>
+                    <SortableHeaderCell
+                      label="Title"
+                      isActive={sortColumn === 'title'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('title')}
+                    />
+                    <SortableHeaderCell
+                      label="Status"
+                      isActive={sortColumn === 'status'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('status')}
+                    />
+                    <DataTableHeaderCell align="center">Questions</DataTableHeaderCell>
+                    <SortableHeaderCell
+                      label="Responses"
+                      isActive={sortColumn === 'responded'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('responded')}
+                      align="center"
+                    />
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {rows.map((quiz) => {
+                    const isSelected = selectedQuizId === quiz.id
+
+                    return (
+                      <DataTableRow
+                        key={quiz.id}
+                        className={[
+                          'cursor-pointer transition-colors',
+                          isSelected
+                            ? 'bg-info-bg hover:bg-info-bg-hover'
+                            : 'hover:bg-surface-hover',
+                        ].join(' ')}
+                        onClick={() => handleRowClick(quiz)}
+                      >
+                        <DataTableCell className="font-medium">{quiz.title}</DataTableCell>
+                        <DataTableCell>
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getQuizStatusBadgeClass(quiz.status)}`}
+                          >
+                            {getQuizStatusLabel(quiz.status)}
+                          </span>
+                        </DataTableCell>
+                        <DataTableCell align="center" className="text-text-muted">
+                          {quiz.stats.questions_count}
+                        </DataTableCell>
+                        <DataTableCell align="center" className="text-text-muted">
+                          {quiz.stats.responded}/{quiz.stats.total_students}
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
+                  {rows.length === 0 && (
+                    <EmptyStateRow colSpan={4} message="No quizzes yet. Create one to get started." />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </TableCard>
+          </KeyboardNavigableTable>
+        </div>
+      </PageContent>
+
+      <QuizModal
+        isOpen={showModal}
+        classroomId={classroom.id}
+        quiz={editingQuiz}
+        onClose={() => setShowModal(false)}
+        onSuccess={handleQuizCreated}
+      />
+
+      {selectedQuiz && (
+        <QuizDetailPanel
+          quiz={selectedQuiz}
+          classroomId={classroom.id}
+          onQuizUpdate={loadQuizzes}
+          onDelete={() => handleRequestDelete(selectedQuiz)}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteQuiz}
+        title="Delete quiz?"
+        description={
+          deleteQuiz && deleteQuiz.responsesCount > 0
+            ? `This quiz has ${deleteQuiz.responsesCount} response${deleteQuiz.responsesCount === 1 ? '' : 's'}. Deleting it will permanently remove all student responses.`
+            : 'This action cannot be undone.'
+        }
+        confirmLabel={deleting ? 'Deleting...' : 'Delete'}
+        cancelLabel="Cancel"
+        confirmVariant="danger"
+        isConfirmDisabled={deleting}
+        isCancelDisabled={deleting}
+        onCancel={() => setDeleteQuiz(null)}
+        onConfirm={handleDeleteConfirm}
+      />
+    </PageLayout>
+  )
+}

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { Plus, Trash2, Play, Square, Eye, EyeOff } from 'lucide-react'
+import { Button, ConfirmDialog } from '@/ui'
+import { Spinner } from '@/components/Spinner'
+import { getQuizStatusLabel, getQuizStatusBadgeClass, canActivateQuiz } from '@/lib/quizzes'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
+import { QuizResultsView } from '@/components/QuizResultsView'
+import type { Quiz, QuizQuestion, QuizWithStats, QuizResultsAggregate } from '@/types'
+
+interface Props {
+  quiz: QuizWithStats
+  classroomId: string
+  onQuizUpdate: () => void
+  onDelete: () => void
+}
+
+export function QuizDetailPanel({ quiz, classroomId, onQuizUpdate, onDelete }: Props) {
+  const [questions, setQuestions] = useState<QuizQuestion[]>([])
+  const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
+  const [responders, setResponders] = useState<{ student_id: string; name: string | null; email: string }[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showActivateConfirm, setShowActivateConfirm] = useState(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+  const [updating, setUpdating] = useState(false)
+  const [viewMode, setViewMode] = useState<'questions' | 'results'>('questions')
+  const [error, setError] = useState('')
+
+  const loadQuizDetails = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quiz.id}`)
+      const data = await res.json()
+      setQuestions(data.questions || [])
+
+      // Also load results if quiz has responses
+      if (quiz.stats.responded > 0) {
+        const resultsRes = await fetch(`/api/teacher/quizzes/${quiz.id}/results`)
+        const resultsData = await resultsRes.json()
+        setResults(resultsData.results || [])
+        setResponders(resultsData.responders || [])
+      } else {
+        setResults(null)
+        setResponders([])
+      }
+    } catch (err) {
+      console.error('Error loading quiz details:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [quiz.id, quiz.stats.responded])
+
+  useEffect(() => {
+    loadQuizDetails()
+  }, [loadQuizDetails])
+
+  async function handleStatusChange(newStatus: 'active' | 'closed') {
+    setUpdating(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quiz.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update quiz')
+      }
+      onQuizUpdate()
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId } })
+      )
+    } catch (err: any) {
+      setError(err.message || 'Failed to update quiz')
+    } finally {
+      setUpdating(false)
+      setShowActivateConfirm(false)
+      setShowCloseConfirm(false)
+    }
+  }
+
+  async function handleToggleShowResults() {
+    setUpdating(true)
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quiz.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ show_results: !quiz.show_results }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to update quiz')
+      }
+      onQuizUpdate()
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId } })
+      )
+    } catch (err: any) {
+      setError(err.message || 'Failed to update quiz')
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  async function handleAddQuestion() {
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quiz.id}/questions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question_text: 'New question',
+          options: ['Option 1', 'Option 2'],
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to add question')
+      }
+      loadQuizDetails()
+      onQuizUpdate()
+    } catch (err: any) {
+      setError(err.message || 'Failed to add question')
+    }
+  }
+
+  function handleQuestionUpdated() {
+    loadQuizDetails()
+    onQuizUpdate()
+  }
+
+  const activation = canActivateQuiz(quiz, questions.length)
+
+  if (loading) {
+    return (
+      <div className="p-4 flex justify-center">
+        <Spinner />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      {/* Header */}
+      <div>
+        <h3 className="text-lg font-semibold text-text-default">{quiz.title}</h3>
+        <div className="mt-1 flex items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getQuizStatusBadgeClass(quiz.status)}`}
+          >
+            {getQuizStatusLabel(quiz.status)}
+          </span>
+          <span className="text-sm text-text-muted">
+            {quiz.stats.responded}/{quiz.stats.total_students} responded
+          </span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-2 bg-danger-bg text-danger text-sm rounded">{error}</div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-2">
+        {quiz.status === 'draft' && (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setShowActivateConfirm(true)}
+            disabled={!activation.valid || updating}
+            className="gap-1.5"
+          >
+            <Play className="h-4 w-4" />
+            Activate
+          </Button>
+        )}
+        {quiz.status === 'active' && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setShowCloseConfirm(true)}
+            disabled={updating}
+            className="gap-1.5"
+          >
+            <Square className="h-4 w-4" />
+            Close
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleToggleShowResults}
+          disabled={updating}
+          className="gap-1.5"
+        >
+          {quiz.show_results ? (
+            <>
+              <EyeOff className="h-4 w-4" />
+              Hide Results
+            </>
+          ) : (
+            <>
+              <Eye className="h-4 w-4" />
+              Show Results
+            </>
+          )}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDelete}
+          disabled={updating}
+          className="gap-1.5 text-danger hover:bg-danger-bg"
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
+      </div>
+
+      {/* View Toggle */}
+      {quiz.stats.responded > 0 && (
+        <div className="flex border-b border-border">
+          <button
+            type="button"
+            onClick={() => setViewMode('questions')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              viewMode === 'questions'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:text-text-default'
+            }`}
+          >
+            Questions ({questions.length})
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode('results')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              viewMode === 'results'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:text-text-default'
+            }`}
+          >
+            Results ({quiz.stats.responded})
+          </button>
+        </div>
+      )}
+
+      {/* Content */}
+      {viewMode === 'questions' ? (
+        <div className="space-y-3">
+          {questions.map((question, index) => (
+            <QuizQuestionEditor
+              key={question.id}
+              quizId={quiz.id}
+              question={question}
+              questionNumber={index + 1}
+              isEditable={quiz.status === 'draft'}
+              onUpdated={handleQuestionUpdated}
+            />
+          ))}
+
+          {questions.length === 0 && (
+            <p className="text-sm text-text-muted py-4 text-center">
+              No questions yet. Add one to get started.
+            </p>
+          )}
+
+          {quiz.status === 'draft' && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleAddQuestion}
+              className="w-full gap-1.5"
+            >
+              <Plus className="h-4 w-4" />
+              Add Question
+            </Button>
+          )}
+
+          {quiz.status === 'draft' && !activation.valid && (
+            <p className="text-sm text-warning">{activation.error}</p>
+          )}
+        </div>
+      ) : (
+        <QuizResultsView results={results} responders={responders} />
+      )}
+
+      {/* Confirmation Dialogs */}
+      <ConfirmDialog
+        isOpen={showActivateConfirm}
+        title="Activate quiz?"
+        description="Once activated, students will be able to respond. You won't be able to add or modify questions."
+        confirmLabel={updating ? 'Activating...' : 'Activate'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={updating}
+        isCancelDisabled={updating}
+        onCancel={() => setShowActivateConfirm(false)}
+        onConfirm={() => handleStatusChange('active')}
+      />
+
+      <ConfirmDialog
+        isOpen={showCloseConfirm}
+        title="Close quiz?"
+        description="Students will no longer be able to respond. Students who haven't responded won't be able to see this quiz."
+        confirmLabel={updating ? 'Closing...' : 'Close'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={updating}
+        isCancelDisabled={updating}
+        onCancel={() => setShowCloseConfirm(false)}
+        onConfirm={() => handleStatusChange('closed')}
+      />
+    </div>
+  )
+}

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { Button, FormField, Input } from '@/ui'
+import type { Quiz } from '@/types'
+
+interface QuizModalProps {
+  isOpen: boolean
+  classroomId: string
+  quiz?: Quiz | null
+  onClose: () => void
+  onSuccess: (quiz: Quiz) => void
+}
+
+export function QuizModal({ isOpen, classroomId, quiz, onClose, onSuccess }: QuizModalProps) {
+  const titleInputRef = useRef<HTMLInputElement>(null)
+  const [title, setTitle] = useState('')
+  const [showResults, setShowResults] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const isEditMode = !!quiz
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    if (quiz) {
+      setTitle(quiz.title)
+      setShowResults(quiz.show_results)
+    } else {
+      setTitle('')
+      setShowResults(false)
+    }
+    setError('')
+
+    setTimeout(() => {
+      titleInputRef.current?.focus()
+      if (quiz) {
+        titleInputRef.current?.select()
+      }
+    }, 100)
+  }, [isOpen, quiz])
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!title.trim()) {
+      setError('Title is required')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+
+    try {
+      if (isEditMode) {
+        const response = await fetch(`/api/teacher/quizzes/${quiz.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: title.trim(), show_results: showResults }),
+        })
+        const data = await response.json()
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to update quiz')
+        }
+        onSuccess(data.quiz)
+      } else {
+        const response = await fetch('/api/teacher/quizzes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ classroom_id: classroomId, title: title.trim() }),
+        })
+        const data = await response.json()
+        if (!response.ok) {
+          throw new Error(data.error || 'Failed to create quiz')
+        }
+        onSuccess(data.quiz)
+      }
+      onClose()
+    } catch (err: any) {
+      setError(err.message || 'An error occurred')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (e.target === e.currentTarget) {
+      onClose()
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') {
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className="bg-surface rounded-lg shadow-xl border border-border w-[min(90vw,28rem)] p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quiz-modal-title"
+      >
+        <h2 id="quiz-modal-title" className="text-xl font-bold text-text-default mb-4">
+          {isEditMode ? 'Edit Quiz' : 'New Quiz'}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <FormField label="Title" error={error}>
+            <Input
+              ref={titleInputRef}
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Enter quiz title"
+              disabled={saving}
+            />
+          </FormField>
+
+          {isEditMode && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showResults}
+                onChange={(e) => setShowResults(e.target.checked)}
+                disabled={saving}
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-text-default">Show results to students after responding</span>
+            </label>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              className="flex-1"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" className="flex-1" disabled={saving}>
+              {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/QuizQuestionEditor.tsx
+++ b/src/components/QuizQuestionEditor.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus, Trash2, GripVertical } from 'lucide-react'
+import { Button, ConfirmDialog, Input } from '@/ui'
+import type { QuizQuestion } from '@/types'
+
+interface Props {
+  quizId: string
+  question: QuizQuestion
+  questionNumber: number
+  isEditable: boolean
+  onUpdated: () => void
+}
+
+export function QuizQuestionEditor({ quizId, question, questionNumber, isEditable, onUpdated }: Props) {
+  const [text, setText] = useState(question.question_text)
+  const [options, setOptions] = useState<string[]>(question.options)
+  const [isEditing, setIsEditing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSave() {
+    if (!text.trim()) {
+      setError('Question text is required')
+      return
+    }
+    if (options.length < 2) {
+      setError('At least 2 options required')
+      return
+    }
+    if (options.some((o) => !o.trim())) {
+      setError('Options cannot be empty')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quizId}/questions/${question.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question_text: text.trim(), options }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to update question')
+      }
+      setIsEditing(false)
+      onUpdated()
+    } catch (err: any) {
+      setError(err.message || 'Failed to update question')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/teacher/quizzes/${quizId}/questions/${question.id}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to delete question')
+      }
+      onUpdated()
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete question')
+    } finally {
+      setDeleting(false)
+      setShowDeleteConfirm(false)
+    }
+  }
+
+  function handleAddOption() {
+    setOptions([...options, ''])
+  }
+
+  function handleRemoveOption(index: number) {
+    if (options.length <= 2) return
+    setOptions(options.filter((_, i) => i !== index))
+  }
+
+  function handleOptionChange(index: number, value: string) {
+    const newOptions = [...options]
+    newOptions[index] = value
+    setOptions(newOptions)
+  }
+
+  function handleCancel() {
+    setText(question.question_text)
+    setOptions(question.options)
+    setIsEditing(false)
+    setError('')
+  }
+
+  if (isEditing && isEditable) {
+    return (
+      <div className="border border-border rounded-lg p-3 space-y-3 bg-surface-2">
+        <div className="flex items-start gap-2">
+          <span className="text-sm font-medium text-text-muted mt-2">Q{questionNumber}.</span>
+          <div className="flex-1">
+            <Input
+              type="text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Enter question"
+              disabled={saving}
+              className="text-sm"
+            />
+          </div>
+        </div>
+
+        <div className="pl-7 space-y-2">
+          {options.map((option, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <span className="w-5 h-5 rounded-full border border-border flex items-center justify-center text-xs text-text-muted">
+                {String.fromCharCode(65 + index)}
+              </span>
+              <Input
+                type="text"
+                value={option}
+                onChange={(e) => handleOptionChange(index, e.target.value)}
+                placeholder={`Option ${String.fromCharCode(65 + index)}`}
+                disabled={saving}
+                className="flex-1 text-sm"
+              />
+              {options.length > 2 && (
+                <button
+                  type="button"
+                  onClick={() => handleRemoveOption(index)}
+                  disabled={saving}
+                  className="p-1 text-text-muted hover:text-danger"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          ))}
+
+          {options.length < 6 && (
+            <button
+              type="button"
+              onClick={handleAddOption}
+              disabled={saving}
+              className="flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              <Plus className="h-4 w-4" />
+              Add option
+            </button>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-danger pl-7">{error}</p>}
+
+        <div className="flex gap-2 pl-7">
+          <Button variant="secondary" size="sm" onClick={handleCancel} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-border rounded-lg p-3 bg-surface">
+      <div className="flex items-start gap-2">
+        {isEditable && (
+          <GripVertical className="h-4 w-4 text-text-muted mt-0.5 cursor-grab" />
+        )}
+        <span className="text-sm font-medium text-text-muted">Q{questionNumber}.</span>
+        <div className="flex-1">
+          <p className="text-sm text-text-default">{question.question_text}</p>
+          <ul className="mt-2 space-y-1">
+            {question.options.map((option, index) => (
+              <li key={index} className="flex items-center gap-2 text-sm text-text-muted">
+                <span className="w-5 h-5 rounded-full border border-border flex items-center justify-center text-xs">
+                  {String.fromCharCode(65 + index)}
+                </span>
+                {option}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {isEditable && (
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className="p-1 text-text-muted hover:text-text-default"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="p-1 text-text-muted hover:text-danger"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={showDeleteConfirm}
+        title="Delete question?"
+        description="This action cannot be undone."
+        confirmLabel={deleting ? 'Deleting...' : 'Delete'}
+        cancelLabel="Cancel"
+        confirmVariant="danger"
+        isConfirmDisabled={deleting}
+        isCancelDisabled={deleting}
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={handleDelete}
+      />
+    </div>
+  )
+}

--- a/src/components/QuizResultsView.tsx
+++ b/src/components/QuizResultsView.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import type { QuizResultsAggregate } from '@/types'
+
+interface Props {
+  results: QuizResultsAggregate[] | null
+  responders?: { student_id: string; name: string | null; email: string }[]
+}
+
+export function QuizResultsView({ results, responders }: Props) {
+  if (!results || results.length === 0) {
+    return (
+      <div className="text-sm text-text-muted py-4 text-center">
+        No responses yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Results by Question */}
+      {results.map((result, index) => (
+        <div key={result.question_id} className="space-y-2">
+          <p className="text-sm font-medium text-text-default">
+            Q{index + 1}. {result.question_text}
+          </p>
+          <div className="space-y-1.5">
+            {result.options.map((option, optionIndex) => {
+              const count = result.counts[optionIndex]
+              const percent = result.total_responses > 0
+                ? (count / result.total_responses) * 100
+                : 0
+
+              return (
+                <div key={optionIndex} className="space-y-0.5">
+                  <div className="flex justify-between text-sm">
+                    <span className="text-text-default">{option}</span>
+                    <span className="text-text-muted">
+                      {count} ({percent.toFixed(0)}%)
+                    </span>
+                  </div>
+                  <div className="h-4 bg-surface-2 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-primary rounded-full transition-all duration-300"
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <p className="text-xs text-text-muted">
+            {result.total_responses} response{result.total_responses !== 1 ? 's' : ''}
+          </p>
+        </div>
+      ))}
+
+      {/* Responders List */}
+      {responders && responders.length > 0 && (
+        <div className="pt-4 border-t border-border">
+          <h4 className="text-sm font-medium text-text-default mb-2">
+            Responded ({responders.length})
+          </h4>
+          <ul className="space-y-1">
+            {responders.map((responder) => (
+              <li key={responder.student_id} className="text-sm text-text-muted">
+                {responder.name || responder.email.split('@')[0]}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState } from 'react'
+import { Button, ConfirmDialog } from '@/ui'
+import type { QuizQuestion } from '@/types'
+
+interface Props {
+  quizId: string
+  questions: QuizQuestion[]
+  onSubmitted: () => void
+}
+
+export function StudentQuizForm({ quizId, questions, onSubmitted }: Props) {
+  const [responses, setResponses] = useState<Record<string, number>>({})
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const allAnswered = questions.every((q) => responses[q.id] !== undefined)
+
+  function handleOptionSelect(questionId: string, optionIndex: number) {
+    setResponses((prev) => ({ ...prev, [questionId]: optionIndex }))
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true)
+    setError('')
+
+    try {
+      const res = await fetch(`/api/student/quizzes/${quizId}/respond`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ responses }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to submit response')
+      }
+      onSubmitted()
+    } catch (err: any) {
+      setError(err.message || 'Failed to submit response')
+    } finally {
+      setSubmitting(false)
+      setShowConfirm(false)
+    }
+  }
+
+  return (
+    <div className="mt-4 space-y-6">
+      {questions.map((question, index) => (
+        <div key={question.id} className="space-y-2">
+          <p className="font-medium text-text-default">
+            {index + 1}. {question.question_text}
+          </p>
+          <div className="space-y-2">
+            {question.options.map((option, optionIndex) => {
+              const isSelected = responses[question.id] === optionIndex
+
+              return (
+                <label
+                  key={optionIndex}
+                  className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                    isSelected
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:bg-surface-hover'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name={`question-${question.id}`}
+                    checked={isSelected}
+                    onChange={() => handleOptionSelect(question.id, optionIndex)}
+                    className="sr-only"
+                  />
+                  <span
+                    className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                      isSelected ? 'border-primary' : 'border-border'
+                    }`}
+                  >
+                    {isSelected && (
+                      <span className="w-2.5 h-2.5 rounded-full bg-primary" />
+                    )}
+                  </span>
+                  <span className="text-text-default">{option}</span>
+                </label>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+
+      {error && (
+        <div className="p-3 bg-danger-bg text-danger text-sm rounded-lg">{error}</div>
+      )}
+
+      <div className="pt-4">
+        <Button
+          onClick={() => setShowConfirm(true)}
+          disabled={!allAnswered || submitting}
+          className="w-full"
+        >
+          Submit
+        </Button>
+        {!allAnswered && (
+          <p className="text-sm text-text-muted text-center mt-2">
+            Answer all questions to submit
+          </p>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        title="Submit your answers?"
+        description="You cannot change your answers after submitting."
+        confirmLabel={submitting ? 'Submitting...' : 'Submit'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={submitting}
+        isCancelDisabled={submitting}
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={handleSubmit}
+      />
+    </div>
+  )
+}

--- a/src/components/StudentQuizResults.tsx
+++ b/src/components/StudentQuizResults.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import type { QuizResultsAggregate } from '@/types'
+
+interface Props {
+  quizId: string
+  myResponses: Record<string, number>
+}
+
+export function StudentQuizResults({ quizId, myResponses }: Props) {
+  const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    async function loadResults() {
+      try {
+        const res = await fetch(`/api/student/quizzes/${quizId}/results`)
+        const data = await res.json()
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to load results')
+        }
+        setResults(data.results || [])
+      } catch (err: any) {
+        setError(err.message || 'Failed to load results')
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadResults()
+  }, [quizId])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 bg-danger-bg text-danger rounded-lg mt-4">
+        {error}
+      </div>
+    )
+  }
+
+  if (!results || results.length === 0) {
+    return (
+      <div className="text-center py-8 text-text-muted">
+        No results available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      <div className="p-4 bg-success-bg rounded-lg">
+        <p className="text-success font-medium">Your response has been submitted.</p>
+      </div>
+
+      <h3 className="font-semibold text-text-default">Results</h3>
+
+      {results.map((result, index) => {
+        const myAnswer = myResponses[result.question_id]
+
+        return (
+          <div key={result.question_id} className="space-y-2">
+            <p className="font-medium text-text-default">
+              {index + 1}. {result.question_text}
+            </p>
+            <div className="space-y-1.5">
+              {result.options.map((option, optionIndex) => {
+                const count = result.counts[optionIndex]
+                const percent = result.total_responses > 0
+                  ? (count / result.total_responses) * 100
+                  : 0
+                const isMyAnswer = myAnswer === optionIndex
+
+                return (
+                  <div key={optionIndex} className="space-y-0.5">
+                    <div className="flex justify-between text-sm">
+                      <span className={isMyAnswer ? 'text-primary font-medium' : 'text-text-default'}>
+                        {option}
+                        {isMyAnswer && ' (your answer)'}
+                      </span>
+                      <span className="text-text-muted">
+                        {count} ({percent.toFixed(0)}%)
+                      </span>
+                    </div>
+                    <div className="h-4 bg-surface-2 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all duration-300 ${
+                          isMyAnswer ? 'bg-primary' : 'bg-text-muted/30'
+                        }`}
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            <p className="text-xs text-text-muted">
+              {result.total_responses} response{result.total_responses !== 1 ? 's' : ''}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
   Calendar,
+  CircleHelp,
   ClipboardCheck,
   ClipboardList,
   Settings,
@@ -30,6 +31,7 @@ import {
 export type ClassroomNavItemId =
   | 'attendance'
   | 'assignments'
+  | 'quizzes'
   | 'calendar'
   | 'resources'
   | 'roster'
@@ -55,6 +57,7 @@ type SidebarAssignment = {
 const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
+  { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: StickyNote },
   { id: 'roster', label: 'Roster', icon: Users },
@@ -64,6 +67,7 @@ const teacherItems: NavItem[] = [
 const studentItems: NavItem[] = [
   { id: 'today', label: 'Today', icon: PenSquare },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
+  { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: StickyNote },
 ]

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -11,3 +11,9 @@ export const TEACHER_ASSIGNMENTS_SELECTION_EVENT = 'pika:teacherAssignmentsSelec
 
 /** Dispatched when assignments are created, updated, or deleted */
 export const TEACHER_ASSIGNMENTS_UPDATED_EVENT = 'pika:teacherAssignmentsUpdated'
+
+/** Dispatched when teacher quiz selection changes */
+export const TEACHER_QUIZZES_SELECTION_EVENT = 'pika:teacherQuizzesSelection'
+
+/** Dispatched when quizzes are created, updated, or deleted */
+export const TEACHER_QUIZZES_UPDATED_EVENT = 'pika:teacherQuizzesUpdated'

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -43,6 +43,8 @@ export type RouteKey =
   | 'assignments-student'
   | 'assignments-teacher-list'
   | 'assignments-teacher-viewing'
+  | 'quizzes-teacher'
+  | 'quizzes-student'
   | 'calendar-teacher'
   | 'calendar-student'
   | 'resources-teacher'
@@ -108,6 +110,14 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
   'assignments-teacher-viewing': {
     rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '40%' },
     mainContent: { maxWidth: 'full' },
+  },
+  'quizzes-teacher': {
+    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '40%' },
+    mainContent: { maxWidth: 'full' },
+  },
+  'quizzes-student': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'reading' },
   },
   'calendar-teacher': {
     rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '50%' },
@@ -204,6 +214,10 @@ export function getRouteKeyFromTab(
     if (role === 'student') return 'assignments-student'
     if (isViewingWork) return 'assignments-teacher-viewing'
     return 'assignments-teacher-list'
+  }
+
+  if (tab === 'quizzes') {
+    return role === 'teacher' ? 'quizzes-teacher' : 'quizzes-student'
   }
 
   // Default fallback

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -1,0 +1,106 @@
+/**
+ * Quiz utilities for status calculation, validation, and result aggregation
+ */
+
+import type {
+  Quiz,
+  QuizQuestion,
+  QuizResponse,
+  QuizStatus,
+  StudentQuizStatus,
+  QuizResultsAggregate,
+} from '@/types'
+
+/**
+ * Get human-readable label for quiz status
+ */
+export function getQuizStatusLabel(status: QuizStatus): string {
+  const labels: Record<QuizStatus, string> = {
+    draft: 'Draft',
+    active: 'Active',
+    closed: 'Closed',
+  }
+  return labels[status]
+}
+
+/**
+ * Get badge CSS classes for quiz status
+ */
+export function getQuizStatusBadgeClass(status: QuizStatus): string {
+  const classes: Record<QuizStatus, string> = {
+    draft: 'bg-surface-2 text-text-muted',
+    active: 'bg-success-bg text-success',
+    closed: 'bg-danger-bg text-danger',
+  }
+  return classes[status]
+}
+
+/**
+ * Check if a student can respond to a quiz
+ */
+export function canStudentRespond(quiz: Quiz, hasResponded: boolean): boolean {
+  return quiz.status === 'active' && !hasResponded
+}
+
+/**
+ * Check if a student can view quiz results
+ */
+export function canStudentViewResults(quiz: Quiz, hasResponded: boolean): boolean {
+  return quiz.show_results && hasResponded
+}
+
+/**
+ * Get the student's status for a quiz
+ */
+export function getStudentQuizStatus(quiz: Quiz, hasResponded: boolean): StudentQuizStatus {
+  if (!hasResponded) return 'not_started'
+  if (quiz.show_results) return 'can_view_results'
+  return 'responded'
+}
+
+/**
+ * Aggregate quiz responses into per-question results
+ */
+export function aggregateResults(
+  questions: QuizQuestion[],
+  responses: QuizResponse[]
+): QuizResultsAggregate[] {
+  return questions.map((q) => {
+    const questionResponses = responses.filter((r) => r.question_id === q.id)
+    const counts = q.options.map((_, idx) =>
+      questionResponses.filter((r) => r.selected_option === idx).length
+    )
+    return {
+      question_id: q.id,
+      question_text: q.question_text,
+      options: q.options,
+      counts,
+      total_responses: questionResponses.length,
+    }
+  })
+}
+
+/**
+ * Validate quiz question options
+ */
+export function validateQuizOptions(options: string[]): { valid: boolean; error?: string } {
+  if (options.length < 2) return { valid: false, error: 'At least 2 options required' }
+  if (options.some((o) => !o.trim())) return { valid: false, error: 'Options cannot be empty' }
+  return { valid: true }
+}
+
+/**
+ * Check if a quiz can be activated (draft → active)
+ */
+export function canActivateQuiz(
+  quiz: Quiz,
+  questionsCount: number
+): { valid: boolean; error?: string } {
+  if (quiz.status !== 'draft') {
+    return { valid: false, error: 'Only draft quizzes can be activated' }
+  }
+  if (questionsCount < 1) {
+    return { valid: false, error: 'Quiz must have at least 1 question' }
+  }
+  return { valid: true }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,3 +237,65 @@ export interface ClassroomResources {
   updated_at: string
   updated_by: string | null
 }
+
+// Quiz types
+export type QuizStatus = 'draft' | 'active' | 'closed'
+
+export interface Quiz {
+  id: string
+  classroom_id: string
+  title: string
+  status: QuizStatus
+  show_results: boolean
+  position: number
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+export interface QuizQuestion {
+  id: string
+  quiz_id: string
+  question_text: string
+  options: string[]
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface QuizResponse {
+  id: string
+  quiz_id: string
+  question_id: string
+  student_id: string
+  selected_option: number
+  submitted_at: string
+}
+
+// Extended quiz types for UI
+export interface QuizWithQuestions extends Quiz {
+  questions: QuizQuestion[]
+}
+
+export interface QuizWithStats extends Quiz {
+  stats: {
+    total_students: number
+    responded: number
+    questions_count: number
+  }
+}
+
+export type StudentQuizStatus = 'not_started' | 'responded' | 'can_view_results'
+
+export interface StudentQuizView extends Quiz {
+  student_status: StudentQuizStatus
+  questions?: QuizQuestion[]
+}
+
+export interface QuizResultsAggregate {
+  question_id: string
+  question_text: string
+  options: string[]
+  counts: number[] // count per option, same index
+  total_responses: number
+}

--- a/supabase/migrations/026_quizzes.sql
+++ b/supabase/migrations/026_quizzes.sql
@@ -1,0 +1,267 @@
+-- Migration: Add quizzes feature for Pika
+-- Creates tables for quizzes, quiz_questions, and quiz_responses
+
+-- ============================================================================
+-- 1. Create quizzes table (container)
+-- ============================================================================
+create table if not exists public.quizzes (
+  id uuid primary key default gen_random_uuid(),
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  title text not null,
+  status text not null default 'draft' check (status in ('draft', 'active', 'closed')),
+  show_results boolean not null default false,
+  position integer not null default 0,
+  created_by uuid not null references public.users (id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Indexes for quizzes
+create index if not exists idx_quizzes_classroom_id on public.quizzes (classroom_id);
+create index if not exists idx_quizzes_classroom_status on public.quizzes (classroom_id, status);
+
+-- Updated_at trigger for quizzes
+create or replace function public.update_quizzes_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_quizzes_updated_at on public.quizzes;
+create trigger update_quizzes_updated_at
+  before update on public.quizzes
+  for each row
+  execute function public.update_quizzes_updated_at();
+
+-- ============================================================================
+-- 2. Create quiz_questions table
+-- ============================================================================
+create table if not exists public.quiz_questions (
+  id uuid primary key default gen_random_uuid(),
+  quiz_id uuid not null references public.quizzes (id) on delete cascade,
+  question_text text not null,
+  options jsonb not null, -- ["Option A", "Option B", ...]
+  position integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Index for quiz_questions
+create index if not exists idx_quiz_questions_quiz_id on public.quiz_questions (quiz_id);
+
+-- Updated_at trigger for quiz_questions
+create or replace function public.update_quiz_questions_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_quiz_questions_updated_at on public.quiz_questions;
+create trigger update_quiz_questions_updated_at
+  before update on public.quiz_questions
+  for each row
+  execute function public.update_quiz_questions_updated_at();
+
+-- ============================================================================
+-- 3. Create quiz_responses table
+-- ============================================================================
+create table if not exists public.quiz_responses (
+  id uuid primary key default gen_random_uuid(),
+  quiz_id uuid not null references public.quizzes (id) on delete cascade,
+  question_id uuid not null references public.quiz_questions (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  selected_option integer not null check (selected_option >= 0),
+  submitted_at timestamptz not null default now(),
+  unique (question_id, student_id)
+);
+
+-- Indexes for quiz_responses
+create index if not exists idx_quiz_responses_quiz_id on public.quiz_responses (quiz_id);
+create index if not exists idx_quiz_responses_student_id on public.quiz_responses (student_id);
+
+-- ============================================================================
+-- 4. RLS Policies for quizzes table
+-- ============================================================================
+alter table public.quizzes enable row level security;
+
+-- Teachers can view quizzes for their classrooms
+create policy "Teachers can view their classroom quizzes"
+  on public.quizzes for select
+  using (
+    exists (
+      select 1 from public.classrooms
+      where classrooms.id = quizzes.classroom_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can create quizzes for their classrooms
+create policy "Teachers can create quizzes for their classrooms"
+  on public.quizzes for insert
+  with check (
+    exists (
+      select 1 from public.classrooms
+      where classrooms.id = classroom_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can update quizzes for their classrooms
+create policy "Teachers can update their classroom quizzes"
+  on public.quizzes for update
+  using (
+    exists (
+      select 1 from public.classrooms
+      where classrooms.id = quizzes.classroom_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can delete quizzes for their classrooms
+create policy "Teachers can delete their classroom quizzes"
+  on public.quizzes for delete
+  using (
+    exists (
+      select 1 from public.classrooms
+      where classrooms.id = quizzes.classroom_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Students can view active quizzes OR closed quizzes they responded to
+create policy "Students can view quizzes"
+  on public.quizzes for select
+  using (
+    exists (
+      select 1 from public.classroom_enrollments
+      where classroom_enrollments.classroom_id = quizzes.classroom_id
+      and classroom_enrollments.student_id = auth.uid()
+    )
+    and (
+      status = 'active'
+      or (status = 'closed' and exists (
+        select 1 from public.quiz_responses
+        where quiz_responses.quiz_id = quizzes.id
+        and quiz_responses.student_id = auth.uid()
+      ))
+    )
+  );
+
+-- ============================================================================
+-- 5. RLS Policies for quiz_questions table
+-- ============================================================================
+alter table public.quiz_questions enable row level security;
+
+-- Teachers can view questions for their classroom quizzes
+create policy "Teachers can view quiz questions"
+  on public.quiz_questions for select
+  using (
+    exists (
+      select 1 from public.quizzes
+      join public.classrooms on classrooms.id = quizzes.classroom_id
+      where quizzes.id = quiz_questions.quiz_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can create questions for their classroom quizzes
+create policy "Teachers can create quiz questions"
+  on public.quiz_questions for insert
+  with check (
+    exists (
+      select 1 from public.quizzes
+      join public.classrooms on classrooms.id = quizzes.classroom_id
+      where quizzes.id = quiz_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can update questions for their classroom quizzes
+create policy "Teachers can update quiz questions"
+  on public.quiz_questions for update
+  using (
+    exists (
+      select 1 from public.quizzes
+      join public.classrooms on classrooms.id = quizzes.classroom_id
+      where quizzes.id = quiz_questions.quiz_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Teachers can delete questions for their classroom quizzes
+create policy "Teachers can delete quiz questions"
+  on public.quiz_questions for delete
+  using (
+    exists (
+      select 1 from public.quizzes
+      join public.classrooms on classrooms.id = quizzes.classroom_id
+      where quizzes.id = quiz_questions.quiz_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Students can view questions for quizzes they can see
+create policy "Students can view quiz questions"
+  on public.quiz_questions for select
+  using (
+    exists (
+      select 1 from public.quizzes
+      join public.classroom_enrollments on classroom_enrollments.classroom_id = quizzes.classroom_id
+      where quizzes.id = quiz_questions.quiz_id
+      and classroom_enrollments.student_id = auth.uid()
+      and (
+        quizzes.status = 'active'
+        or (quizzes.status = 'closed' and exists (
+          select 1 from public.quiz_responses
+          where quiz_responses.quiz_id = quizzes.id
+          and quiz_responses.student_id = auth.uid()
+        ))
+      )
+    )
+  );
+
+-- ============================================================================
+-- 6. RLS Policies for quiz_responses table
+-- ============================================================================
+alter table public.quiz_responses enable row level security;
+
+-- Teachers can view all responses for their classroom quizzes
+create policy "Teachers can view quiz responses"
+  on public.quiz_responses for select
+  using (
+    exists (
+      select 1 from public.quizzes
+      join public.classrooms on classrooms.id = quizzes.classroom_id
+      where quizzes.id = quiz_responses.quiz_id
+      and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+-- Students can view their own responses
+create policy "Students can view their own quiz responses"
+  on public.quiz_responses for select
+  using (student_id = auth.uid());
+
+-- Students can create their own responses (to active quizzes only)
+create policy "Students can create quiz responses"
+  on public.quiz_responses for insert
+  with check (
+    student_id = auth.uid()
+    and exists (
+      select 1 from public.quizzes
+      join public.classroom_enrollments on classroom_enrollments.classroom_id = quizzes.classroom_id
+      where quizzes.id = quiz_id
+      and classroom_enrollments.student_id = auth.uid()
+      and quizzes.status = 'active'
+    )
+  );
+
+-- ============================================================================
+-- Note: The app uses service role client for most operations, so these RLS
+-- policies are primarily for security defense-in-depth. The API routes handle
+-- authorization checks before database operations.
+-- ============================================================================

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -3,7 +3,18 @@
  * Provides reusable mock objects for testing throughout the application
  */
 
-import type { Entry, Assignment, AssignmentDoc, Classroom, Student, Teacher, TiptapContent } from '@/types'
+import type {
+  Entry,
+  Assignment,
+  AssignmentDoc,
+  Classroom,
+  Student,
+  Teacher,
+  TiptapContent,
+  Quiz,
+  QuizQuestion,
+  QuizResponse,
+} from '@/types'
 
 // ============================================================================
 // Mock Data Factories
@@ -181,3 +192,50 @@ export const torontoMidnight = (dateString: string): string => {
  */
 export const DST_SPRING_FORWARD_2024 = '2024-03-10T02:00:00-05:00' // 2 AM → 3 AM
 export const DST_FALL_BACK_2024 = '2024-11-03T02:00:00-04:00' // 2 AM → 1 AM
+
+// ============================================================================
+// Quiz Mock Factories
+// ============================================================================
+
+/**
+ * Create a mock quiz with default or custom values
+ */
+export const createMockQuiz = (overrides: Partial<Quiz> = {}): Quiz => ({
+  id: 'quiz-1',
+  classroom_id: 'classroom-1',
+  title: 'Test Quiz',
+  status: 'draft',
+  show_results: false,
+  position: 0,
+  created_by: 'teacher-1',
+  created_at: '2024-10-10T10:00:00Z',
+  updated_at: '2024-10-10T10:00:00Z',
+  ...overrides,
+})
+
+/**
+ * Create a mock quiz question with default or custom values
+ */
+export const createMockQuizQuestion = (overrides: Partial<QuizQuestion> = {}): QuizQuestion => ({
+  id: 'question-1',
+  quiz_id: 'quiz-1',
+  question_text: 'What is your favorite color?',
+  options: ['Red', 'Blue', 'Green', 'Yellow'],
+  position: 0,
+  created_at: '2024-10-10T10:00:00Z',
+  updated_at: '2024-10-10T10:00:00Z',
+  ...overrides,
+})
+
+/**
+ * Create a mock quiz response with default or custom values
+ */
+export const createMockQuizResponse = (overrides: Partial<QuizResponse> = {}): QuizResponse => ({
+  id: 'response-1',
+  quiz_id: 'quiz-1',
+  question_id: 'question-1',
+  student_id: 'student-1',
+  selected_option: 0,
+  submitted_at: '2024-10-15T14:30:00Z',
+  ...overrides,
+})

--- a/tests/unit/quizzes.test.ts
+++ b/tests/unit/quizzes.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for quiz utilities (src/lib/quizzes.ts)
+ * Tests quiz status calculation, validation, and aggregation functions
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getQuizStatusLabel,
+  getQuizStatusBadgeClass,
+  canStudentRespond,
+  canStudentViewResults,
+  getStudentQuizStatus,
+  aggregateResults,
+  validateQuizOptions,
+  canActivateQuiz,
+} from '@/lib/quizzes'
+import { createMockQuiz, createMockQuizQuestion, createMockQuizResponse } from '../helpers/mocks'
+
+describe('quiz utilities', () => {
+  // ==========================================================================
+  // getQuizStatusLabel()
+  // ==========================================================================
+
+  describe('getQuizStatusLabel', () => {
+    it('should return "Draft" for draft status', () => {
+      expect(getQuizStatusLabel('draft')).toBe('Draft')
+    })
+
+    it('should return "Active" for active status', () => {
+      expect(getQuizStatusLabel('active')).toBe('Active')
+    })
+
+    it('should return "Closed" for closed status', () => {
+      expect(getQuizStatusLabel('closed')).toBe('Closed')
+    })
+  })
+
+  // ==========================================================================
+  // getQuizStatusBadgeClass()
+  // ==========================================================================
+
+  describe('getQuizStatusBadgeClass', () => {
+    it('should return muted classes for draft status', () => {
+      const classes = getQuizStatusBadgeClass('draft')
+      expect(classes).toContain('bg-surface-2')
+      expect(classes).toContain('text-text-muted')
+    })
+
+    it('should return success classes for active status', () => {
+      const classes = getQuizStatusBadgeClass('active')
+      expect(classes).toContain('bg-success-bg')
+      expect(classes).toContain('text-success')
+    })
+
+    it('should return danger classes for closed status', () => {
+      const classes = getQuizStatusBadgeClass('closed')
+      expect(classes).toContain('bg-danger-bg')
+      expect(classes).toContain('text-danger')
+    })
+  })
+
+  // ==========================================================================
+  // canStudentRespond()
+  // ==========================================================================
+
+  describe('canStudentRespond', () => {
+    it('should return true when quiz is active and student has not responded', () => {
+      const quiz = createMockQuiz({ status: 'active' })
+      expect(canStudentRespond(quiz, false)).toBe(true)
+    })
+
+    it('should return false when quiz is active but student has already responded', () => {
+      const quiz = createMockQuiz({ status: 'active' })
+      expect(canStudentRespond(quiz, true)).toBe(false)
+    })
+
+    it('should return false when quiz is draft', () => {
+      const quiz = createMockQuiz({ status: 'draft' })
+      expect(canStudentRespond(quiz, false)).toBe(false)
+    })
+
+    it('should return false when quiz is closed', () => {
+      const quiz = createMockQuiz({ status: 'closed' })
+      expect(canStudentRespond(quiz, false)).toBe(false)
+    })
+  })
+
+  // ==========================================================================
+  // canStudentViewResults()
+  // ==========================================================================
+
+  describe('canStudentViewResults', () => {
+    it('should return true when show_results is true and student has responded', () => {
+      const quiz = createMockQuiz({ show_results: true })
+      expect(canStudentViewResults(quiz, true)).toBe(true)
+    })
+
+    it('should return false when show_results is true but student has not responded', () => {
+      const quiz = createMockQuiz({ show_results: true })
+      expect(canStudentViewResults(quiz, false)).toBe(false)
+    })
+
+    it('should return false when show_results is false even if student has responded', () => {
+      const quiz = createMockQuiz({ show_results: false })
+      expect(canStudentViewResults(quiz, true)).toBe(false)
+    })
+
+    it('should return false when both show_results is false and student has not responded', () => {
+      const quiz = createMockQuiz({ show_results: false })
+      expect(canStudentViewResults(quiz, false)).toBe(false)
+    })
+  })
+
+  // ==========================================================================
+  // getStudentQuizStatus()
+  // ==========================================================================
+
+  describe('getStudentQuizStatus', () => {
+    it('should return "not_started" when student has not responded', () => {
+      const quiz = createMockQuiz({ status: 'active', show_results: true })
+      expect(getStudentQuizStatus(quiz, false)).toBe('not_started')
+    })
+
+    it('should return "can_view_results" when student has responded and results are enabled', () => {
+      const quiz = createMockQuiz({ status: 'active', show_results: true })
+      expect(getStudentQuizStatus(quiz, true)).toBe('can_view_results')
+    })
+
+    it('should return "responded" when student has responded but results are disabled', () => {
+      const quiz = createMockQuiz({ status: 'active', show_results: false })
+      expect(getStudentQuizStatus(quiz, true)).toBe('responded')
+    })
+  })
+
+  // ==========================================================================
+  // aggregateResults()
+  // ==========================================================================
+
+  describe('aggregateResults', () => {
+    it('should aggregate responses correctly for a single question', () => {
+      const questions = [
+        createMockQuizQuestion({
+          id: 'q1',
+          question_text: 'Favorite color?',
+          options: ['Red', 'Blue', 'Green'],
+        }),
+      ]
+      const responses = [
+        createMockQuizResponse({ question_id: 'q1', selected_option: 0 }),
+        createMockQuizResponse({ question_id: 'q1', selected_option: 1, student_id: 's2' }),
+        createMockQuizResponse({ question_id: 'q1', selected_option: 1, student_id: 's3' }),
+      ]
+
+      const result = aggregateResults(questions, responses)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].question_id).toBe('q1')
+      expect(result[0].question_text).toBe('Favorite color?')
+      expect(result[0].options).toEqual(['Red', 'Blue', 'Green'])
+      expect(result[0].counts).toEqual([1, 2, 0])
+      expect(result[0].total_responses).toBe(3)
+    })
+
+    it('should aggregate responses for multiple questions', () => {
+      const questions = [
+        createMockQuizQuestion({ id: 'q1', options: ['A', 'B'] }),
+        createMockQuizQuestion({ id: 'q2', options: ['X', 'Y', 'Z'] }),
+      ]
+      const responses = [
+        createMockQuizResponse({ question_id: 'q1', selected_option: 0, student_id: 's1' }),
+        createMockQuizResponse({ question_id: 'q1', selected_option: 1, student_id: 's2' }),
+        createMockQuizResponse({ question_id: 'q2', selected_option: 2, student_id: 's1' }),
+        createMockQuizResponse({ question_id: 'q2', selected_option: 2, student_id: 's2' }),
+      ]
+
+      const result = aggregateResults(questions, responses)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].counts).toEqual([1, 1])
+      expect(result[0].total_responses).toBe(2)
+      expect(result[1].counts).toEqual([0, 0, 2])
+      expect(result[1].total_responses).toBe(2)
+    })
+
+    it('should handle questions with no responses', () => {
+      const questions = [
+        createMockQuizQuestion({ id: 'q1', options: ['A', 'B', 'C'] }),
+      ]
+      const responses: any[] = []
+
+      const result = aggregateResults(questions, responses)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].counts).toEqual([0, 0, 0])
+      expect(result[0].total_responses).toBe(0)
+    })
+
+    it('should handle empty questions array', () => {
+      const result = aggregateResults([], [])
+      expect(result).toEqual([])
+    })
+  })
+
+  // ==========================================================================
+  // validateQuizOptions()
+  // ==========================================================================
+
+  describe('validateQuizOptions', () => {
+    it('should return valid for 2 or more non-empty options', () => {
+      expect(validateQuizOptions(['A', 'B'])).toEqual({ valid: true })
+      expect(validateQuizOptions(['A', 'B', 'C'])).toEqual({ valid: true })
+      expect(validateQuizOptions(['A', 'B', 'C', 'D'])).toEqual({ valid: true })
+    })
+
+    it('should return invalid for less than 2 options', () => {
+      const result1 = validateQuizOptions(['A'])
+      expect(result1.valid).toBe(false)
+      expect(result1.error).toBe('At least 2 options required')
+
+      const result2 = validateQuizOptions([])
+      expect(result2.valid).toBe(false)
+      expect(result2.error).toBe('At least 2 options required')
+    })
+
+    it('should return invalid for empty option strings', () => {
+      const result1 = validateQuizOptions(['A', ''])
+      expect(result1.valid).toBe(false)
+      expect(result1.error).toBe('Options cannot be empty')
+
+      const result2 = validateQuizOptions(['A', '   '])
+      expect(result2.valid).toBe(false)
+      expect(result2.error).toBe('Options cannot be empty')
+    })
+
+    it('should trim whitespace when checking for empty options', () => {
+      const result = validateQuizOptions(['  A  ', '  B  '])
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  // ==========================================================================
+  // canActivateQuiz()
+  // ==========================================================================
+
+  describe('canActivateQuiz', () => {
+    it('should return valid when quiz is draft with at least 1 question', () => {
+      const quiz = createMockQuiz({ status: 'draft' })
+      expect(canActivateQuiz(quiz, 1)).toEqual({ valid: true })
+      expect(canActivateQuiz(quiz, 5)).toEqual({ valid: true })
+    })
+
+    it('should return invalid when quiz is not draft', () => {
+      const activeQuiz = createMockQuiz({ status: 'active' })
+      const result1 = canActivateQuiz(activeQuiz, 5)
+      expect(result1.valid).toBe(false)
+      expect(result1.error).toBe('Only draft quizzes can be activated')
+
+      const closedQuiz = createMockQuiz({ status: 'closed' })
+      const result2 = canActivateQuiz(closedQuiz, 5)
+      expect(result2.valid).toBe(false)
+      expect(result2.error).toBe('Only draft quizzes can be activated')
+    })
+
+    it('should return invalid when quiz has no questions', () => {
+      const quiz = createMockQuiz({ status: 'draft' })
+      const result = canActivateQuiz(quiz, 0)
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Quiz must have at least 1 question')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add a new **Quiz** tab to classrooms for teachers to create multiple-choice polls/surveys
- Students can respond once and optionally view aggregated results
- Teachers can manage quiz lifecycle: draft → active → closed

## Changes

### Database
- New `quizzes`, `quiz_questions`, `quiz_responses` tables with RLS policies

### API Routes
- **Teacher**: CRUD for quizzes and questions, view aggregated results
- **Student**: list quizzes, view/respond, view results (if allowed)

### UI Components
- Teacher: quiz list table, detail panel, question editor, results view with CSS bar charts
- Student: quiz list, response form, results view

### Navigation
- Added "Quizzes" tab with `CircleHelp` icon (after Assignments, before Calendar)

## Test plan

- [x] Unit tests for quiz utilities (28 tests passing)
- [x] All existing tests pass (766 total)
- [ ] Manual testing: Teacher flow (create quiz → add questions → activate → view results)
- [ ] Manual testing: Student flow (view quiz → respond → view results)
- [ ] Visual verification with Playwright screenshots

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)