### PR TITLE
chore: drop unused profiles view

### DIFF
--- a/supabase/migrations/027_drop_profiles_view.sql
+++ b/supabase/migrations/027_drop_profiles_view.sql
@@ -1,0 +1,4 @@
+-- Migration: Drop unused profiles view
+-- Purpose: Remove convenience alias that was never adopted and shows as unrestricted
+
+DROP VIEW IF EXISTS profiles;


### PR DESCRIPTION
## Summary
- Drops the `profiles` view created in migration 007
- View was a convenience alias for `users` table but was never used
- Removes "unrestricted" warning in Supabase dashboard

## Context
Views don't directly support RLS and show as unrestricted. Since this view is unused, dropping it is cleaner than adding SECURITY INVOKER.

## Test plan
- [ ] Run migration: `supabase db reset`
- [ ] Verify view is gone: `SELECT * FROM profiles` should error
- [ ] Verify app still works (view was never used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)