### PR TITLE
fix: tune calendar top margin from -mt-2 to -mt-2.5 (#219)

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -105,7 +105,7 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
 
   return (
     <PageLayout>
-      <PageContent className="-mt-2">
+      <PageContent className="-mt-2.5">
         <LessonCalendar
           classroom={classroom}
           lessonPlans={lessonPlans}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -411,7 +411,7 @@ export function TeacherLessonCalendarTab({ classroom, onSidebarStateChange }: Pr
 
   return (
     <PageLayout>
-      <PageContent className="-mt-2">
+      <PageContent className="-mt-2.5">
         <LessonCalendar
           classroom={classroom}
           lessonPlans={lessonPlans}


### PR DESCRIPTION
## Summary
- Fine-tune calendar tab top margin from `-mt-2` to `-mt-2.5` for better spacing between header and Week/Month/All controls

## Test plan
- [ ] Open Calendar tab — confirm balanced spacing above Week/Month/All buttons
- [ ] Check both student and teacher calendar views

🤖 Generated with [Claude Code](https://claude.com/claude-code)