### PR TITLE
fix: sync right sidebar state on tab switch (#222)

### DIFF
--- a/src/components/layout/ThreePanelProvider.tsx
+++ b/src/components/layout/ThreePanelProvider.tsx
@@ -100,11 +100,7 @@ export function ThreePanelProvider({
 
   // Sync right sidebar state when routeKey (tab) changes
   useEffect(() => {
-    if (config.rightSidebar.enabled && config.rightSidebar.defaultOpen) {
-      setRightOpenState(true)
-    } else if (!config.rightSidebar.enabled) {
-      setRightOpenState(false)
-    }
+    setRightOpenState(config.rightSidebar.enabled && config.rightSidebar.defaultOpen)
     setRightWidthState(config.rightSidebar.defaultWidth)
   }, [routeKey, config])
 

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -21,6 +21,7 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
       <button onClick={() => setRouteKey('today')}>go-today</button>
       <button onClick={() => setRouteKey('assignments-student')}>go-assignments</button>
       <button onClick={() => setRouteKey('quizzes-teacher')}>go-quizzes</button>
+      <button onClick={() => setRouteKey('roster')}>go-roster</button>
       <ThreePanelProvider
         routeKey={routeKey}
         initialLeftExpanded={false}
@@ -106,5 +107,20 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
     expect(screen.getByTestId('enabled').textContent).toBe('true')
     expect(screen.getByTestId('open').textContent).toBe('true')
+  })
+
+  it('closes sidebar when switching from today to an enabled tab with defaultOpen: false', () => {
+    render(<TestHarness initialRouteKey="today" />)
+
+    // today: enabled=true, defaultOpen=true
+    expect(screen.getByTestId('open').textContent).toBe('true')
+
+    // Switch to roster: enabled=true, defaultOpen=false
+    act(() => {
+      screen.getByText('go-roster').click()
+    })
+
+    expect(screen.getByTestId('enabled').textContent).toBe('true')
+    expect(screen.getByTestId('open').textContent).toBe('false')
   })
 })


### PR DESCRIPTION
## Summary
- Right sidebar (Today's Plan) disappeared when switching away from the Today tab and back
- Root cause: `ThreePanelProvider` only set sidebar open/closed state on initial render, never re-synced when `routeKey` changed
- Added a `useEffect` that syncs `rightOpen` and `rightWidth` state whenever `routeKey` changes
- Simplified sync logic to always reset sidebar to `defaultOpen`, fixing a gap where navigating to an enabled tab with `defaultOpen: false` left the sidebar stuck open

## Test plan
- [x] Added 5 component tests covering tab-switch scenarios (including enabled + defaultOpen: false case)
- [x] All existing tests pass with no regressions
- [ ] Manual verification: switch from Today → Assignments → Today and confirm Today's Plan sidebar remains visible
- [ ] Manual verification: switch from Today → Roster and confirm sidebar closes

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)