### PR TITLE
feat: show student log history in attendance right panel (#235)

### DIFF
--- a/src/app/api/teacher/student-history/route.ts
+++ b/src/app/api/teacher/student-history/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+/**
+ * GET /api/teacher/student-history?classroom_id=xxx&student_id=xxx&before_date=YYYY-MM-DD&limit=10
+ * Returns past entries for a student in reverse chronological order.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const { searchParams } = new URL(request.url)
+    const classroomId = searchParams.get('classroom_id')
+    const studentId = searchParams.get('student_id')
+    const beforeDate = searchParams.get('before_date')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '10', 10) || 10, 50)
+
+    if (!classroomId || !studentId) {
+      return NextResponse.json(
+        { error: 'classroom_id and student_id are required' },
+        { status: 400 }
+      )
+    }
+
+    if (beforeDate && !/^\d{4}-\d{2}-\d{2}$/.test(beforeDate)) {
+      return NextResponse.json(
+        { error: 'Invalid before_date format (use YYYY-MM-DD)' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: classroom, error: classroomError } = await supabase
+      .from('classrooms')
+      .select('teacher_id')
+      .eq('id', classroomId)
+      .single()
+
+    if (classroomError || !classroom) {
+      return NextResponse.json(
+        { error: 'Classroom not found' },
+        { status: 404 }
+      )
+    }
+
+    if (classroom.teacher_id !== user.id) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403 }
+      )
+    }
+
+    // Verify student is enrolled in the classroom
+    const { data: enrollment, error: enrollmentError } = await supabase
+      .from('classroom_enrollments')
+      .select('student_id')
+      .eq('classroom_id', classroomId)
+      .eq('student_id', studentId)
+      .single()
+
+    if (enrollmentError || !enrollment) {
+      return NextResponse.json(
+        { error: 'Student not found in classroom' },
+        { status: 404 }
+      )
+    }
+
+    let query = supabase
+      .from('entries')
+      .select('*')
+      .eq('student_id', studentId)
+      .eq('classroom_id', classroomId)
+      .order('date', { ascending: false })
+      .limit(limit)
+
+    if (beforeDate) {
+      query = query.lt('date', beforeDate)
+    }
+
+    const { data: entries, error: entriesError } = await query
+
+    if (entriesError) {
+      console.error('Error fetching student history:', entriesError)
+      return NextResponse.json(
+        { error: 'Failed to fetch entries' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ entries: entries || [] })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    console.error('Get student history error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -36,6 +36,7 @@ import { Spinner } from '@/components/Spinner'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { TEACHER_ASSIGNMENTS_UPDATED_EVENT, TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
+import { StudentLogHistory } from '@/components/StudentLogHistory'
 import type { Classroom, Entry, LessonPlan, TiptapContent, SelectedStudentInfo, Assignment, QuizWithStats } from '@/types'
 
 interface UserInfo {
@@ -119,8 +120,8 @@ function ClassroomPageContent({
   const isTeacher = user.role === 'teacher'
 
   // State for selected student log (teacher attendance tab)
-  const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null)
   const [selectedStudentName, setSelectedStudentName] = useState<string>('')
+  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
 
   // State for selected assignment instructions (assignments tab)
   const [selectedAssignment, setSelectedAssignment] = useState<SelectedAssignmentInstructions | null>(null)
@@ -164,9 +165,9 @@ function ClassroomPageContent({
   const prevViewModeRef = useRef<AssignmentViewMode>('summary')
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const handleSelectEntry = useCallback((entry: Entry | null, studentName: string) => {
-    setSelectedEntry(entry)
+  const handleSelectEntry = useCallback((_entry: Entry | null, studentName: string, studentId: string | null) => {
     setSelectedStudentName(studentName)
+    setSelectedStudentId(studentId)
   }, [])
 
   const handleSelectAssignment = useCallback((assignment: SelectedAssignmentInstructions | null) => {
@@ -533,17 +534,16 @@ function ClassroomPageContent({
                 Select a quiz to view details.
               </p>
             </div>
+          ) : isTeacher && activeTab === 'attendance' && selectedStudentId ? (
+            <StudentLogHistory
+              studentId={selectedStudentId}
+              classroomId={classroom.id}
+            />
           ) : isTeacher && activeTab === 'attendance' ? (
             <div className="p-4">
-              {selectedEntry ? (
-                <p className="text-sm text-text-default whitespace-pre-wrap">
-                  {selectedEntry.text}
-                </p>
-              ) : (
-                <p className="text-sm text-text-muted">
-                  Select a student to view their log.
-                </p>
-              )}
+              <p className="text-sm text-text-muted">
+                Select a student to view their log.
+              </p>
             </div>
           ) : isTeacher && activeTab === 'assignments' && selectedStudent ? (
             <TeacherStudentWorkPanel

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -23,7 +23,6 @@ import {
   TableCard,
 } from '@/components/DataTable'
 import { applyDirection, compareNullableStrings, toggleSort } from '@/lib/table-sort'
-import { useLeftSidebar, RightSidebarToggle } from '@/components/layout'
 import type { ClassDay, Classroom, Entry } from '@/types'
 
 type SortColumn = 'first_name' | 'last_name' | 'id'
@@ -40,7 +39,7 @@ interface LogRow {
 
 interface Props {
   classroom: Classroom
-  onSelectEntry?: (entry: Entry | null, studentName: string) => void
+  onSelectEntry?: (entry: Entry | null, studentName: string, studentId: string | null) => void
 }
 
 export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
@@ -53,8 +52,6 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
     column: SortColumn
     direction: 'asc' | 'desc'
   }>({ column: 'last_name', direction: 'asc' })
-
-  const { isExpanded: isLeftExpanded } = useLeftSidebar()
 
   useEffect(() => {
     async function load() {
@@ -84,7 +81,7 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
       if (!isClassDayOnDate(classDays, selectedDate)) {
         setLogs([])
         setSelectedStudentId(null)
-        onSelectEntry?.(null, '')
+        onSelectEntry?.(null, '', null)
         return
       }
 
@@ -104,10 +101,10 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
           const firstLog = mappedLogs[0]
           setSelectedStudentId(firstLog.student_id)
           const studentName = [firstLog.student_first_name, firstLog.student_last_name].filter(Boolean).join(' ') || firstLog.email_username
-          onSelectEntry?.(firstLog.entry, studentName)
+          onSelectEntry?.(firstLog.entry, studentName, firstLog.student_id)
         } else {
           setSelectedStudentId(null)
-          onSelectEntry?.(null, '')
+          onSelectEntry?.(null, '', null)
         }
       } catch (err) {
         console.error('Error loading logs:', err)
@@ -155,16 +152,10 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
 
     if (newSelectedId) {
       const studentName = [row.student_first_name, row.student_last_name].filter(Boolean).join(' ') || row.email_username
-      onSelectEntry?.(row.entry, studentName)
+      onSelectEntry?.(row.entry, studentName, row.student_id)
     } else {
-      onSelectEntry?.(null, '')
+      onSelectEntry?.(null, '', null)
     }
-  }
-
-  function getLogText(row: LogRow): string {
-    if (row.summary) return row.summary
-    if (row.entry?.text) return row.entry.text
-    return '—'
   }
 
   // Keyboard navigation handler
@@ -177,7 +168,7 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
       const studentName =
         [row.student_first_name, row.student_last_name].filter(Boolean).join(' ') ||
         row.email_username
-      onSelectEntry?.(row.entry, studentName)
+      onSelectEntry?.(row.entry, studentName, row.student_id)
     },
     [rows, onSelectEntry]
   )
@@ -204,7 +195,7 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
             onNext={() => moveDateBy(1)}
           />
         }
-        trailing={<RightSidebarToggle />}
+        trailing={null}
       />
 
       <PageContent>
@@ -241,9 +232,6 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
                 <DataTableHeaderCell density="tight" align="center">
                   Status
                 </DataTableHeaderCell>
-                <DataTableHeaderCell density="tight">
-                  Log
-                </DataTableHeaderCell>
               </DataTableRow>
             </DataTableHead>
             <DataTableBody>
@@ -254,8 +242,6 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
                   : selectedDate >= today
                     ? 'pending'
                     : 'absent'
-                const logText = getLogText(row)
-
                 return (
                   <DataTableRow
                     key={row.student_id}
@@ -283,23 +269,12 @@ export function TeacherAttendanceTab({ classroom, onSelectEntry }: Props) {
                         <span className="text-text-muted">—</span>
                       )}
                     </DataTableCell>
-                    <DataTableCell density="tight" className={isLeftExpanded ? 'max-w-xs' : 'max-w-md'}>
-                      {logText !== '—' ? (
-                        <Tooltip content={logText}>
-                          <div className="truncate text-text-muted">
-                            {logText}
-                          </div>
-                        </Tooltip>
-                      ) : (
-                        <div className="text-text-muted">—</div>
-                      )}
-                    </DataTableCell>
                   </DataTableRow>
                 )
               })}
               {rows.length === 0 && (
                 <EmptyStateRow
-                  colSpan={5}
+                  colSpan={4}
                   message={isClassDay ? 'No students enrolled' : 'Not a class day'}
                   density="tight"
                 />

--- a/src/components/StudentLogHistory.tsx
+++ b/src/components/StudentLogHistory.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import type { Entry } from '@/types'
+
+interface Props {
+  studentId: string
+  classroomId: string
+}
+
+export function StudentLogHistory({ studentId, classroomId }: Props) {
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setEntries([])
+    setHasMore(false)
+    setLoading(true)
+
+    const params = new URLSearchParams({
+      classroom_id: classroomId,
+      student_id: studentId,
+      limit: '10',
+    })
+
+    fetch(`/api/teacher/student-history?${params}`, { signal: controller.signal })
+      .then(res => res.json())
+      .then(data => {
+        if (controller.signal.aborted) return
+        const fetched: Entry[] = data.entries || []
+        setEntries(fetched)
+        setHasMore(fetched.length === 10)
+      })
+      .catch(err => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        console.error('Error loading student history:', err)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [studentId, classroomId])
+
+  function loadMore() {
+    if (entries.length === 0) return
+    const oldestDate = entries[entries.length - 1].date
+    setLoading(true)
+
+    const controller = new AbortController()
+
+    const params = new URLSearchParams({
+      classroom_id: classroomId,
+      student_id: studentId,
+      before_date: oldestDate,
+      limit: '10',
+    })
+
+    fetch(`/api/teacher/student-history?${params}`, { signal: controller.signal })
+      .then(res => res.json())
+      .then(data => {
+        const fetched: Entry[] = data.entries || []
+        setEntries(prev => [...prev, ...fetched])
+        setHasMore(fetched.length === 10)
+      })
+      .catch(err => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        console.error('Error loading more history:', err)
+      })
+      .finally(() => setLoading(false))
+  }
+
+  return (
+    <div className="p-4 space-y-3">
+      {entries.length === 0 && !loading && (
+        <p className="text-sm text-text-muted">No entries.</p>
+      )}
+
+      {entries.map(entry => (
+        <div key={entry.id}>
+          <p className="text-xs text-text-muted mb-1">
+            {formatDate(entry.date)}
+          </p>
+          <p className="text-sm text-text-default whitespace-pre-wrap">
+            {entry.text}
+          </p>
+        </div>
+      ))}
+
+      {loading && (
+        <div className="flex justify-center py-2">
+          <Spinner size="sm" />
+        </div>
+      )}
+
+      {hasMore && !loading && (
+        <button
+          type="button"
+          onClick={loadMore}
+          className="text-xs text-primary hover:text-primary-hover"
+        >
+          Load more
+        </button>
+      )}
+    </div>
+  )
+}
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -88,7 +88,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   attendance: {
-    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '50%' },
+    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   roster: {


### PR DESCRIPTION
## Summary
- Adds `GET /api/teacher/student-history` endpoint with cursor-based pagination, teacher auth, and student enrollment verification
- Adds `StudentLogHistory` component showing all entries (date + full text) in reverse chronological order with "Load more"
- Removes the Log column from the attendance table (redundant now that entries are in the sidebar)
- Right sidebar defaults open on the attendance tab with no toggle (always visible)
- Passes `studentId` through the `onSelectEntry` callback; removes unused `selectedEntry` state

Closes #235

## Test plan
- [ ] Click a student in attendance tab → right panel shows their entries with dates
- [ ] Click "Load more" → additional entries appear
- [ ] Switch students → history resets to new student's entries
- [ ] Student with no entries → "No entries." shown
- [ ] Navigate to attendance tab → sidebar is open by default
- [ ] No Log column in attendance table
- [ ] No sidebar toggle button on attendance tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)