### PR TITLE
feat: add writing authenticity scoring with paste detection and keystroke tracking (#234)

### DIFF
--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -3,7 +3,8 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { countCharacters, countWords, isEmpty } from '@/lib/tiptap-content'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
-import type { TiptapContent } from '@/types'
+import { analyzeAuthenticity } from '@/lib/authenticity'
+import type { AssignmentDocHistoryEntry, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -35,7 +36,7 @@ export async function POST(
     // Get assignment and verify enrollment
     const { data: assignment, error: assignmentError } = await supabase
       .from('assignments')
-      .select('classroom_id')
+      .select('classroom_id, track_authenticity')
       .eq('id', assignmentId)
       .single()
 
@@ -124,6 +125,37 @@ export async function POST(
       })
     } catch (historyError) {
       console.error('Error saving assignment doc history:', historyError)
+    }
+
+    // Compute authenticity score from history (if tracking is enabled)
+    if (assignment.track_authenticity !== false) {
+      try {
+        const { data: historyEntries } = await supabase
+          .from('assignment_doc_history')
+          .select('id, assignment_doc_id, patch, snapshot, word_count, char_count, paste_word_count, keystroke_count, trigger, created_at')
+          .eq('assignment_doc_id', existingDoc.id)
+          .order('created_at', { ascending: true })
+
+        if (historyEntries && historyEntries.length > 1) {
+          const result = analyzeAuthenticity(historyEntries as AssignmentDocHistoryEntry[])
+          if (result.score !== null) {
+            const { error: authError } = await supabase
+              .from('assignment_docs')
+              .update({
+                authenticity_score: result.score,
+                authenticity_flags: result.flags,
+              })
+              .eq('id', existingDoc.id)
+
+            if (!authError && doc) {
+              doc.authenticity_score = result.score
+              doc.authenticity_flags = result.flags
+            }
+          }
+        }
+      } catch (authError) {
+        console.error('Error computing authenticity score:', authError)
+      }
     }
 
     return NextResponse.json({ doc })

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -130,6 +130,7 @@ export async function GET(
         position: assignment.position ?? 0,
         is_draft: assignment.is_draft ?? false,
         released_at: assignment.released_at ?? null,
+        track_authenticity: assignment.track_authenticity ?? true,
         created_by: assignment.created_by,
         created_at: assignment.created_at,
         updated_at: assignment.updated_at
@@ -166,7 +167,7 @@ export async function PATCH(
     const user = await requireRole('teacher')
     const { id } = await params
     const body = await request.json()
-    const { title, rich_instructions, due_at } = body
+    const { title, rich_instructions, due_at, track_authenticity } = body
 
     const supabase = getServiceRoleClient()
 
@@ -213,6 +214,7 @@ export async function PATCH(
       updates.description = extractPlainText(instructions)  // Keep plain text in sync
     }
     if (due_at !== undefined) updates.due_at = due_at
+    if (track_authenticity !== undefined) updates.track_authenticity = track_authenticity
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json(

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
   try {
     const user = await requireRole('teacher')
     const body = await request.json()
-    const { classroom_id, title, rich_instructions, due_at } = body
+    const { classroom_id, title, rich_instructions, due_at, track_authenticity } = body
 
     // Validate required fields
     if (!classroom_id) {
@@ -170,6 +170,7 @@ export async function POST(request: NextRequest) {
       description: extractPlainText(instructions),  // Keep plain text for backwards compatibility
       due_at,
       created_by: user.id,
+      ...(track_authenticity !== undefined && { track_authenticity }),
     }
 
     // If the position column doesn't exist yet, omit it for backwards compatibility.

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -122,6 +122,8 @@ export function StudentAssignmentsTab({ classroom }: Props) {
                 graded_at: null,
                 graded_by: null,
                 returned_at: null,
+                authenticity_score: null,
+                authenticity_flags: null,
                 created_at: now,
                 updated_at: now,
               }

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -62,9 +62,11 @@ interface AssignmentFormProps {
   instructions: TiptapContent
   dueAt: string
   classDays?: ClassDay[]
+  trackAuthenticity: boolean
   onTitleChange: (next: string) => void
   onInstructionsChange: (next: TiptapContent) => void
   onDueAtChange: (next: string) => void
+  onTrackAuthenticityChange: (next: boolean) => void
   onPrevDate: () => void
   onNextDate: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
@@ -89,9 +91,11 @@ export function AssignmentForm({
   instructions,
   dueAt,
   classDays,
+  trackAuthenticity,
   onTitleChange,
   onInstructionsChange,
   onDueAtChange,
+  onTrackAuthenticityChange,
   onPrevDate,
   onNextDate,
   onSubmit,
@@ -154,6 +158,17 @@ export function AssignmentForm({
         })()}
         <DateActionBar value={dueAt} onChange={onDueAtChange} onPrev={onPrevDate} onNext={onNextDate} />
       </div>
+
+      <label className="flex items-center gap-2 text-sm text-text-muted">
+        <input
+          type="checkbox"
+          checked={trackAuthenticity}
+          onChange={(e) => onTrackAuthenticityChange(e.target.checked)}
+          disabled={disabled}
+          className="rounded border-border"
+        />
+        Track writing authenticity
+      </label>
 
       {error && <p className="text-sm text-warning">{error}</p>}
 

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -76,6 +76,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const pendingContentRef = useRef<TiptapContent | null>(null)
   const draftBeforePreviewRef = useRef<TiptapContent | null>(null)
 
+  // Input tracking for authenticity
+  const pasteWordCountRef = useRef(0)
+  const keystrokeCountRef = useRef(0)
+
   const loadAssignment = useCallback(async () => {
     setLoading(true)
     setError('')
@@ -155,6 +159,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         body: JSON.stringify({
           content: newContent,
           trigger: options?.trigger ?? 'autosave',
+          paste_word_count: pasteWordCountRef.current,
+          keystroke_count: keystrokeCountRef.current,
         })
       })
 
@@ -181,6 +187,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         setPreviewEntry(prev => (prev?.id === historyEntry.id ? historyEntry : prev))
       }
       lastSavedContentRef.current = newContentStr
+      pasteWordCountRef.current = 0
+      keystrokeCountRef.current = 0
       setSaveStatus('saved')
     } catch (err: any) {
       console.error('Error saving:', err)
@@ -523,6 +531,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 disabled={submitting || !!previewEntry}
                 editable={!isSubmitted && !previewEntry}
                 onBlur={flushAutosave}
+                onPaste={(wordCount) => { pasteWordCountRef.current += wordCount }}
+                onKeystroke={() => { keystrokeCountRef.current++ }}
                 className="h-full"
               />
             </div>

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -8,13 +8,42 @@ import { HistoryList } from '@/components/HistoryList'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
 import { formatInTimeZone } from 'date-fns-tz'
-import type { Assignment, AssignmentDoc, AssignmentDocHistoryEntry, AssignmentStatus, TiptapContent } from '@/types'
+import type { Assignment, AssignmentDoc, AssignmentDocHistoryEntry, AssignmentStatus, AuthenticityFlag, TiptapContent } from '@/types'
+
+function AuthenticityGauge({ score, flags }: { score: number | null; flags: AuthenticityFlag[] }) {
+  const hasScore = score !== null
+  const displayScore = score ?? 0
+  const color = !hasScore ? 'bg-gray-300' : displayScore >= 70 ? 'bg-green-500' : displayScore >= 40 ? 'bg-yellow-500' : 'bg-red-500'
+  const textColor = !hasScore ? 'text-text-muted' : displayScore >= 70 ? 'text-green-700' : displayScore >= 40 ? 'text-yellow-700' : 'text-red-700'
+
+  return (
+    <div className="space-y-2">
+      <div className="relative h-5 rounded-full bg-gray-200 overflow-hidden">
+        {hasScore && (
+          <div className={`h-full rounded-full ${color}`} style={{ width: `${displayScore}%` }} />
+        )}
+        <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${hasScore ? textColor : 'text-text-muted'}`}>
+          Authenticity {hasScore ? `${displayScore}%` : '—'}
+        </span>
+      </div>
+      {flags.length > 0 && (
+        <div className="space-y-1">
+          {flags.map((flag, i) => (
+            <div key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-red-50 text-red-700">
+              +{flag.wordDelta} words in {flag.seconds}s ({flag.wps} w/s)
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
 function ScoreInput({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
   const n = Number(value) || 0
   return (
     <div>
-      <label className="block text-xs font-medium text-text-muted mb-1">{label} (0–10)</label>
+      <label className="block text-xs font-medium text-text-muted mb-1">{label}</label>
       <div className="flex items-center gap-1">
         <button
           type="button"
@@ -383,6 +412,11 @@ export function TeacherStudentWorkPanel({
             </>
           ) : (
             <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3">
+              <AuthenticityGauge
+                score={data.doc?.authenticity_score ?? null}
+                flags={data.doc?.authenticity_flags ?? []}
+              />
+
               {gradeError && (
                 <div className="text-xs text-danger">{gradeError}</div>
               )}
@@ -391,18 +425,17 @@ export function TeacherStudentWorkPanel({
               <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
               <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
 
-              <div className="text-sm font-medium text-text-default">
-                Total: {totalScore}/30 ({totalPercent}%)
+              <div className="text-sm font-medium text-text-default text-center">
+                {totalScore}/30 ({totalPercent}%)
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Feedback</label>
                 <textarea
                   value={feedback}
                   onChange={(e) => setFeedback(e.target.value)}
                   rows={8}
                   className="w-full rounded border border-border bg-surface px-2 py-1 text-sm text-text-default resize-none"
-                  placeholder="Write feedback..."
+                  placeholder="Feedback"
                 />
               </div>
 

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -62,6 +62,8 @@ export interface RichTextEditorProps {
   content: TiptapContent
   onChange: (content: TiptapContent) => void
   onBlur?: () => void
+  onPaste?: (wordCount: number) => void
+  onKeystroke?: () => void
   placeholder?: string
   disabled?: boolean
   editable?: boolean
@@ -123,6 +125,8 @@ export function RichTextEditor({
   content,
   onChange,
   onBlur,
+  onPaste,
+  onKeystroke,
   placeholder = 'Write your response here...',
   disabled = false,
   editable = true,
@@ -148,6 +152,21 @@ export function RichTextEditor({
         class: 'simple-editor',
       },
       handleDOMEvents: {
+        paste: (_view, event) => {
+          if (onPaste) {
+            const text = event.clipboardData?.getData('text/plain') ?? ''
+            const words = text.trim().split(/\s+/).filter(Boolean).length
+            if (words > 0) onPaste(words)
+          }
+          return false
+        },
+        keydown: (_view, event) => {
+          // Only count key presses that produce characters (skip modifiers, nav, etc.)
+          if (onKeystroke && event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
+            onKeystroke()
+          }
+          return false
+        },
         click: (view, event) => {
           const target = event.target as HTMLElement
           const link = target.closest('a[href]')

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -198,6 +198,8 @@ const GRADE_FIELDS = [
   'graded_at',
   'graded_by',
   'returned_at',
+  'authenticity_score',
+  'authenticity_flags',
 ] as const
 
 /**

--- a/src/lib/authenticity.ts
+++ b/src/lib/authenticity.ts
@@ -1,0 +1,110 @@
+import type { AssignmentDocHistoryEntry, AuthenticityFlag } from '@/types'
+
+export interface AuthenticityResult {
+  score: number | null
+  flags: AuthenticityFlag[]
+}
+
+const WPS_THRESHOLD = 3 // ~180 WPM, faster than any human typist
+const KEYSTROKE_RATIO = 2 // chars added > keystrokes × 2 is suspicious
+const SKIP_TRIGGERS = new Set(['restore', 'baseline', 'submit'])
+
+/**
+ * Analyze assignment doc history to compute an authenticity score (0–100).
+ * Score = (organic words added / total words added) × 100.
+ *
+ * Three-tier signal hierarchy per interval:
+ * 1. paste_word_count (direct paste evidence, capped by word delta)
+ * 2. keystroke_count vs chars added (indirect evidence)
+ * 3. WPS > 3 (fallback for old entries + anti-spoof safety net)
+ *
+ * Pure function — no side effects, no API calls.
+ */
+export function analyzeAuthenticity(entries: AssignmentDocHistoryEntry[]): AuthenticityResult {
+  if (entries.length <= 1) {
+    return { score: null, flags: [] }
+  }
+
+  // Sort by created_at ascending
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  )
+
+  let organicWords = 0
+  let pasteWords = 0
+  const flags: AuthenticityFlag[] = []
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1]
+    const curr = sorted[i]
+
+    // Skip restore/baseline/submit triggers — legitimate non-typing events
+    if (SKIP_TRIGGERS.has(curr.trigger)) {
+      continue
+    }
+
+    const wordDelta = curr.word_count - prev.word_count
+    if (wordDelta <= 0) continue // deletions or no change don't count
+
+    const seconds = Math.max(
+      1,
+      Math.round(
+        (new Date(curr.created_at).getTime() - new Date(prev.created_at).getTime()) / 1000
+      )
+    )
+
+    const wps = wordDelta / seconds
+    const charsAdded = Math.max(0, curr.char_count - prev.char_count)
+
+    let flagged = false
+    let reason: AuthenticityFlag['reason'] | null = null
+
+    // Signal 1: direct paste evidence
+    if (curr.paste_word_count != null && curr.paste_word_count > 0) {
+      const effectivePasteWords = Math.min(curr.paste_word_count, Math.max(0, wordDelta))
+      if (effectivePasteWords > 0) {
+        flagged = true
+        reason = 'paste'
+      }
+    }
+
+    // Signal 2: keystroke mismatch (only if no paste detected)
+    if (
+      !flagged &&
+      curr.keystroke_count != null &&
+      curr.paste_word_count != null &&
+      curr.paste_word_count === 0 &&
+      charsAdded > curr.keystroke_count * KEYSTROKE_RATIO
+    ) {
+      flagged = true
+      reason = 'low_keystrokes'
+    }
+
+    // Signal 3: WPS fallback (old entries where paste_word_count is null, or anti-spoof)
+    if (!flagged && wps > WPS_THRESHOLD) {
+      flagged = true
+      reason = 'high_wps'
+    }
+
+    if (flagged && reason) {
+      pasteWords += wordDelta
+      flags.push({
+        timestamp: curr.created_at,
+        wordDelta,
+        seconds,
+        wps: Math.round(wps * 10) / 10,
+        reason,
+      })
+    } else {
+      organicWords += wordDelta
+    }
+  }
+
+  const totalAdded = organicWords + pasteWords
+  if (totalAdded === 0) {
+    return { score: null, flags: [] }
+  }
+
+  const score = Math.round(Math.min(100, Math.max(0, (organicWords / totalAdded) * 100)))
+  return { score, flags }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,9 +158,18 @@ export interface Assignment {
   position: number
   is_draft: boolean  // Whether assignment is a draft (not visible to students)
   released_at: string | null  // When the assignment was released to students
+  track_authenticity: boolean
   created_by: string
   created_at: string
   updated_at: string
+}
+
+export interface AuthenticityFlag {
+  timestamp: string
+  wordDelta: number
+  seconds: number
+  wps: number
+  reason: 'paste' | 'low_keystrokes' | 'high_wps'
 }
 
 export interface AssignmentDoc {
@@ -178,6 +187,8 @@ export interface AssignmentDoc {
   graded_at: string | null
   graded_by: string | null
   returned_at: string | null
+  authenticity_score: number | null
+  authenticity_flags: AuthenticityFlag[] | null
   created_at: string
   updated_at: string
 }
@@ -193,6 +204,8 @@ export interface AssignmentDocHistoryEntry {
   snapshot: TiptapContent | null
   word_count: number
   char_count: number
+  paste_word_count: number | null
+  keystroke_count: number | null
   trigger: AssignmentDocHistoryTrigger
   created_at: string
 }

--- a/supabase/migrations/030_assignment_authenticity.sql
+++ b/supabase/migrations/030_assignment_authenticity.sql
@@ -1,0 +1,4 @@
+-- Add authenticity scoring columns to assignment_docs
+ALTER TABLE assignment_docs
+  ADD COLUMN authenticity_score smallint CHECK (authenticity_score >= 0 AND authenticity_score <= 100),
+  ADD COLUMN authenticity_flags jsonb;

--- a/supabase/migrations/031_authenticity_refinements.sql
+++ b/supabase/migrations/031_authenticity_refinements.sql
@@ -1,0 +1,8 @@
+-- Per-assignment opt-in (default true for backwards compat with existing scores)
+ALTER TABLE assignments
+  ADD COLUMN track_authenticity boolean NOT NULL DEFAULT true;
+
+-- Client-side input tracking on history entries
+ALTER TABLE assignment_doc_history
+  ADD COLUMN paste_word_count smallint,
+  ADD COLUMN keystroke_count integer;

--- a/tests/lib/authenticity.test.ts
+++ b/tests/lib/authenticity.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest'
+import { analyzeAuthenticity } from '@/lib/authenticity'
+import type { AssignmentDocHistoryEntry } from '@/types'
+
+function makeEntry(
+  overrides: Partial<AssignmentDocHistoryEntry> & { word_count: number; created_at: string }
+): AssignmentDocHistoryEntry {
+  return {
+    id: Math.random().toString(),
+    assignment_doc_id: 'doc-1',
+    patch: null,
+    snapshot: null,
+    char_count: overrides.word_count * 5,
+    paste_word_count: null,
+    keystroke_count: null,
+    trigger: 'autosave',
+    ...overrides,
+  }
+}
+
+describe('analyzeAuthenticity', () => {
+  it('returns null score for empty entries', () => {
+    const result = analyzeAuthenticity([])
+    expect(result.score).toBeNull()
+    expect(result.flags).toEqual([])
+  })
+
+  it('returns null score for single entry', () => {
+    const result = analyzeAuthenticity([
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:00:00Z' }),
+    ])
+    expect(result.score).toBeNull()
+  })
+
+  it('scores ~100 for organic typing (~1 WPS)', () => {
+    // 10 words every 10 seconds = 1 WPS (organic)
+    const entries = Array.from({ length: 11 }, (_, i) =>
+      makeEntry({
+        word_count: i * 10,
+        created_at: new Date(Date.UTC(2025, 0, 1, 0, 0, i * 10)).toISOString(),
+        trigger: 'autosave',
+      })
+    )
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  it('scores low for pure paste (high WPS)', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 500, created_at: '2025-01-01T00:00:02Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].wordDelta).toBe(500)
+    expect(result.flags[0].reason).toBe('high_wps')
+  })
+
+  it('handles mixed organic and paste', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // Organic: 50 words in 50 seconds = 1 WPS
+      makeEntry({ word_count: 50, created_at: '2025-01-01T00:00:50Z', trigger: 'autosave' }),
+      // Paste: 50 words in 1 second = 50 WPS
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:00:51Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(50)
+    expect(result.flags).toHaveLength(1)
+  })
+
+  it('skips restore trigger entries', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 50, created_at: '2025-01-01T00:00:50Z', trigger: 'autosave' }),
+      // Restore — should be skipped even though it looks like a paste
+      makeEntry({ word_count: 200, created_at: '2025-01-01T00:00:51Z', trigger: 'restore' }),
+      makeEntry({ word_count: 250, created_at: '2025-01-01T00:01:41Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  it('skips baseline trigger entries', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:00:01Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 150, created_at: '2025-01-01T00:01:01Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    // Only the 100->150 interval counts (50 words in 60s = organic)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  it('ignores deletions (negative word deltas)', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:01:40Z', trigger: 'autosave' }),
+      makeEntry({ word_count: 50, created_at: '2025-01-01T00:01:45Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  it('returns null when only baseline + submit with no content change', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:01:00Z', trigger: 'submit' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBeNull()
+  })
+
+  it('skips submit trigger entries', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({ word_count: 50, created_at: '2025-01-01T00:00:50Z', trigger: 'autosave' }),
+      // Submit entry with same word count — should be skipped
+      makeEntry({ word_count: 50, created_at: '2025-01-01T00:01:00Z', trigger: 'submit' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  // Signal 1: paste_word_count
+  it('flags entry with paste_word_count > 0', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({
+        word_count: 50,
+        created_at: '2025-01-01T00:01:00Z',
+        trigger: 'autosave',
+        paste_word_count: 50,
+        keystroke_count: 0,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('paste')
+  })
+
+  it('caps effective paste words by word delta (rearrangement tolerance)', () => {
+    const entries = [
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // Word count went up by 20, but 100 words pasted (cut+paste rearrangement)
+      makeEntry({
+        word_count: 120,
+        created_at: '2025-01-01T00:01:00Z',
+        trigger: 'autosave',
+        paste_word_count: 100,
+        keystroke_count: 5,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    // 20 words flagged as paste, 0 organic → score 0
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('paste')
+  })
+
+  it('ignores paste when word delta is 0 (pure rearrangement)', () => {
+    const entries = [
+      makeEntry({ word_count: 100, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // Same word count — paste was just a rearrangement
+      makeEntry({
+        word_count: 100,
+        created_at: '2025-01-01T00:01:00Z',
+        trigger: 'autosave',
+        paste_word_count: 50,
+        keystroke_count: 10,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    // No words added → null score
+    expect(result.score).toBeNull()
+  })
+
+  // Signal 2: keystroke mismatch
+  it('flags low keystroke ratio when paste_word_count is 0', () => {
+    const entries = [
+      makeEntry({ word_count: 0, char_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({
+        word_count: 50,
+        char_count: 250,
+        created_at: '2025-01-01T00:01:00Z',
+        trigger: 'autosave',
+        paste_word_count: 0,
+        keystroke_count: 10, // 250 chars added but only 10 keystrokes
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('low_keystrokes')
+  })
+
+  it('does not flag keystroke mismatch when keystrokes are sufficient', () => {
+    const entries = [
+      makeEntry({ word_count: 0, char_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      makeEntry({
+        word_count: 50,
+        char_count: 250,
+        created_at: '2025-01-01T00:01:00Z',
+        trigger: 'autosave',
+        paste_word_count: 0,
+        keystroke_count: 200, // Sufficient keystrokes
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+
+  // Signal 3: WPS anti-spoof
+  it('uses WPS fallback for old entries (null paste_word_count)', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // 500 words in 2 seconds, no paste tracking
+      makeEntry({
+        word_count: 500,
+        created_at: '2025-01-01T00:00:02Z',
+        trigger: 'autosave',
+        paste_word_count: null,
+        keystroke_count: null,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('high_wps')
+  })
+
+  it('WPS acts as safety net when client reports 0 paste but speed is impossible', () => {
+    const entries = [
+      makeEntry({ word_count: 0, char_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // Client says 0 paste, 2000 keystrokes, but 500 words in 2 seconds
+      makeEntry({
+        word_count: 500,
+        char_count: 2500,
+        created_at: '2025-01-01T00:00:02Z',
+        trigger: 'autosave',
+        paste_word_count: 0,
+        keystroke_count: 2000,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(0)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('high_wps')
+  })
+
+  // Hybrid old + new entries
+  it('handles mix of old (null) and new (tracked) entries', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00Z', trigger: 'baseline' }),
+      // Old entry: organic by WPS
+      makeEntry({
+        word_count: 50,
+        created_at: '2025-01-01T00:00:50Z',
+        trigger: 'autosave',
+        paste_word_count: null,
+        keystroke_count: null,
+      }),
+      // New entry: flagged by paste
+      makeEntry({
+        word_count: 100,
+        created_at: '2025-01-01T00:01:50Z',
+        trigger: 'autosave',
+        paste_word_count: 50,
+        keystroke_count: 0,
+      }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    expect(result.score).toBe(50)
+    expect(result.flags).toHaveLength(1)
+    expect(result.flags[0].reason).toBe('paste')
+  })
+
+  it('clamps seconds to minimum of 1', () => {
+    const entries = [
+      makeEntry({ word_count: 0, created_at: '2025-01-01T00:00:00.000Z', trigger: 'baseline' }),
+      // Same timestamp (0 seconds apart) — should use 1 second minimum
+      makeEntry({ word_count: 2, created_at: '2025-01-01T00:00:00.500Z', trigger: 'autosave' }),
+    ]
+    const result = analyzeAuthenticity(entries)
+    // 2 words / 1 second = 2 WPS, under threshold
+    expect(result.score).toBe(100)
+    expect(result.flags).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds writing authenticity scoring (0–100) to assignment docs using a three-tier signal hierarchy: direct paste capture > keystroke/char mismatch > WPS timing fallback
- Client-side paste and keystroke counting in the editor, sent with each autosave
- Per-assignment opt-in toggle ("Track writing authenticity") for teachers
- Rearrangement tolerance: cut+paste within a doc (no net word increase) doesn't penalize
- Score computed on student submission and backfilled during auto-grade
- Authenticity gauge always visible in teacher grading panel (greyed out when no score)
- Server-side input validation clamps tracking values to non-negative integers
- Rate-limited history entries accumulate tracking counts instead of overwriting

## Changes
| Action | File |
|--------|------|
| Create | `supabase/migrations/030_assignment_authenticity.sql` |
| Create | `supabase/migrations/031_authenticity_refinements.sql` |
| Create | `src/lib/authenticity.ts` |
| Create | `tests/lib/authenticity.test.ts` (19 tests) |
| Edit | `src/types/index.ts` — `track_authenticity`, `paste_word_count`, `keystroke_count`, `AuthenticityFlag.reason` |
| Edit | `src/components/editor/RichTextEditor.tsx` — paste + keydown DOM handlers |
| Edit | `src/components/StudentAssignmentEditor.tsx` — tracking refs, send with saves |
| Edit | `src/components/AssignmentForm.tsx` + `AssignmentModal.tsx` — authenticity toggle |
| Edit | `src/components/TeacherStudentWorkPanel.tsx` — AuthenticityGauge component, grading UI tweaks |
| Edit | `src/app/api/assignment-docs/[id]/route.ts` — persist tracking fields, accumulate on rate-limited updates |
| Edit | `src/app/api/assignment-docs/[id]/submit/route.ts` — compute score on submit |
| Edit | `src/app/api/teacher/assignments/route.ts` + `[id]/route.ts` — accept/return `track_authenticity` |
| Edit | `src/app/api/teacher/assignments/[id]/auto-grade/route.ts` — backfill score |
| Edit | `src/lib/assignments.ts` — sanitize scores from student view |

## Test plan
- [x] Unit tests pass (`pnpm test` — 942 tests, all green)
- [x] TypeScript compiles clean (`pnpm tsc --noEmit`)
- [ ] `pnpm db:reset` — migrations apply cleanly
- [ ] Create assignment with authenticity off → submit → verify no score computed
- [ ] Create assignment with authenticity on → type → paste a paragraph → submit → verify score reflects paste ratio
- [ ] Cut+paste to reorder paragraphs → verify no score penalty
- [ ] Open teacher grading panel → gauge visible (greyed out before grading, colored after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)