### PR TITLE
fix: show warning when AI grading skips submissions with no gradable content

### DIFF
--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -430,6 +430,9 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Auto-grade failed')
+      if (data.graded_count === 0) {
+        setError('No gradable content found — submissions may be empty')
+      }
       batchClearSelection()
       // Reload assignment data to refresh statuses/grades
       setRefreshCounter((c) => c + 1)

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -430,8 +430,11 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Auto-grade failed')
+      const total = (data.graded_count ?? 0) + (data.skipped_count ?? 0)
       if (data.graded_count === 0) {
         setError('No gradable content found — submissions may be empty')
+      } else if (data.skipped_count > 0) {
+        setError(`Graded ${data.graded_count} of ${total} — ${data.skipped_count} skipped (empty content)`)
       }
       batchClearSelection()
       // Reload assignment data to refresh statuses/grades

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -274,6 +274,10 @@ export function TeacherStudentWorkPanel({
         setGradeError(result.errors.join(', '))
         return // Don't reload — grading failed
       }
+      if (result.graded_count === 0) {
+        setGradeError('No gradable content found — the submission may be empty')
+        return
+      }
       // Reload data to get updated grades
       const reloadRes = await fetch(`/api/teacher/assignments/${assignmentId}/students/${studentId}`)
       const reloadData = await reloadRes.json()


### PR DESCRIPTION
## Summary
- Show a warning message when AI grading returns `graded_count: 0`, indicating submissions were skipped (e.g. empty content, no doc row)
- Applies to both individual grading (TeacherStudentWorkPanel) and batch grading (TeacherClassroomView)
- Previously this scenario produced no visible feedback, making it look like the feature was broken

## Test plan
- [ ] Click "AI grade" on a student with no submitted content — verify warning appears
- [ ] Batch select students with empty submissions and click "AI grade" — verify warning appears
- [ ] Grade a student with actual content — verify grading still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)