### PR TITLE
feat: add character count to editor toolbar + UI polish (#245)

### DIFF
--- a/src/app/api/student/notifications/route.ts
+++ b/src/app/api/student/notifications/route.ts
@@ -84,6 +84,8 @@ export async function GET(request: NextRequest) {
       .from('assignments')
       .select('id')
       .eq('classroom_id', classroomId)
+      .eq('is_draft', false)
+      .not('released_at', 'is', null)
 
     if (assignmentsError) {
       console.error('Error fetching assignments:', assignmentsError)

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -242,6 +242,7 @@ export function StudentAssignmentsTab({ classroom }: Props) {
         onClose={handleCloseInstructions}
         title="Instructions"
         subtitle={selectedAssignment?.title}
+        maxWidth="max-w-4xl"
       >
         {selectedAssignment?.rich_instructions ? (
           <RichTextViewer content={selectedAssignment.rich_instructions} />

--- a/src/components/HistoryList.tsx
+++ b/src/components/HistoryList.tsx
@@ -16,7 +16,9 @@ function getTriggerBadgeClasses(): string {
 }
 
 function getTriggerLabel(trigger: string): string {
-  return trigger === 'autosave' ? 'save' : trigger
+  if (trigger === 'autosave') return 'save'
+  if (trigger === 'baseline') return 'base'
+  return trigger
 }
 
 export function HistoryList({

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useImperativeHandle, forwardRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Tooltip } from '@/ui'
-import { Eye, EyeOff } from 'lucide-react'
+import { History } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextEditor, RichTextViewer } from '@/components/editor'
 import { ACTIONBAR_BUTTON_CLASSNAME, PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
@@ -509,11 +509,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 aria-expanded={isHistoryOpen}
                 aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
               >
-                {isHistoryOpen ? (
-                  <EyeOff className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <Eye className="h-4 w-4" aria-hidden="true" />
-                )}
+                <History className="h-4 w-4" aria-hidden="true" />
               </button>
             </Tooltip>
           </div>

--- a/src/components/TeacherStudentWorkModal.tsx
+++ b/src/components/TeacherStudentWorkModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { ChevronLeft, ChevronRight, Eye, EyeOff, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, History, X } from 'lucide-react'
 import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
@@ -237,11 +237,7 @@ export function TeacherStudentWorkModal({
                 aria-expanded={isHistoryOpen}
                 aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
               >
-                {isHistoryOpen ? (
-                  <EyeOff className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <Eye className="h-4 w-4" aria-hidden="true" />
-                )}
+                <History className="h-4 w-4" aria-hidden="true" />
               </button>
               <button
                 type="button"

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -109,7 +109,7 @@ function CharacterCount() {
   if (!editor) return null
   const count = editor.getText().replace(/\n/g, '').length
   return (
-    <span className="text-xs text-muted-foreground tabular-nums select-none">
+    <span className="text-xs text-text-muted tabular-nums select-none">
       {count}
     </span>
   )

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -107,7 +107,7 @@ const MainToolbarContent = ({
 function CharacterCount() {
   const { editor } = useCurrentEditor()
   if (!editor) return null
-  const count = editor.getText().length
+  const count = editor.getText().replace(/\n/g, '').length
   return (
     <span className="text-xs text-muted-foreground tabular-nums select-none">
       {count}

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { EditorContent, EditorContext, useEditor } from '@tiptap/react'
+import { EditorContent, EditorContext, useCurrentEditor, useEditor } from '@tiptap/react'
 import type { TiptapContent } from '@/types'
 import { isSafeLinkHref, sanitizeLinkHref } from '@/lib/tiptap-content'
 
@@ -98,7 +98,20 @@ const MainToolbarContent = ({
       </ToolbarGroup>
 
       <Spacer />
+
+      <CharacterCount />
     </>
+  )
+}
+
+function CharacterCount() {
+  const { editor } = useCurrentEditor()
+  if (!editor) return null
+  const count = editor.getText().length
+  return (
+    <span className="text-xs text-muted-foreground tabular-nums select-none">
+      {count}
+    </span>
   )
 }
 

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -6,7 +6,7 @@ import { Button } from './Button'
 
 // Dialog panel styles with CVA
 const dialogPanelStyles = cva([
-  'relative w-full max-w-sm',
+  'relative w-full',
   'rounded-dialog border shadow-dialog p-dialog',
   'bg-surface',
   'border-border',
@@ -115,7 +115,7 @@ export function AlertDialog({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={description ? descriptionId : undefined}
-        className={dialogPanelStyles()}
+        className={`${dialogPanelStyles()} max-w-sm`}
       >
         <div className="flex items-center gap-3">
           {icon}
@@ -223,7 +223,7 @@ export function ConfirmDialog({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={description ? descriptionId : undefined}
-        className={dialogPanelStyles()}
+        className={`${dialogPanelStyles()} max-w-sm`}
       >
         <div id={titleId} className={dialogTitleStyles}>{title}</div>
         {description && (


### PR DESCRIPTION
## Summary
- Add live character count (visible chars only) to the rich text editor toolbar, right-justified after the spacer
- Widen instructions popup from `max-w-2xl` to `max-w-4xl` for better readability
- Display 'baseline' trigger as 'base' in history list
- Replace Eye/EyeOff icon with History (clock) icon for history panel toggle
- Fix notification pulse never stopping by excluding draft/unreleased assignments from unviewed count

Closes #245

## Changes
| File | What |
|------|------|
| `RichTextEditor.tsx` | `CharacterCount` component using `useCurrentEditor()`, strips newlines |
| `Dialog.tsx` | Move `max-w-sm` out of CVA base into AlertDialog/ConfirmDialog callers |
| `StudentAssignmentsTab.tsx` | Pass `maxWidth="max-w-4xl"` to instructions dialog |
| `HistoryList.tsx` | Map `baseline` → `base` in `getTriggerLabel` |
| `StudentAssignmentEditor.tsx` | `Eye`/`EyeOff` → `History` icon |
| `TeacherStudentWorkModal.tsx` | `Eye`/`EyeOff` → `History` icon |
| `notifications/route.ts` | Filter `.eq('is_draft', false).not('released_at', 'is', null)` |

## Test plan
- [ ] Open student assignment editor, type text — character count appears right-justified in toolbar
- [ ] Count updates live, only counts visible characters (no inflated numbers from newlines)
- [ ] Instructions popup is wider and readable
- [ ] History panel toggle shows clock icon (not eye)
- [ ] History list shows "base" instead of "baseline"
- [ ] After viewing all assignments, the Assignments tab pulse stops
- [ ] Alert/Confirm dialogs still render at `max-w-sm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)