### PR TITLE
fix: add missing .not() to notifications test mock chain

### DIFF
--- a/tests/api/student/notifications.test.ts
+++ b/tests/api/student/notifications.test.ts
@@ -65,6 +65,7 @@ function createTableMock(config: {
       return {
         select: vi.fn(() => ({
           eq: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
           then: vi.fn((resolve: any) => resolve(config.assignments)),
         })),
       }


### PR DESCRIPTION
## Summary
- Adds missing `not` method to the assignments table mock in `notifications.test.ts`
- The `.not('released_at', 'is', null)` filter added in #248 broke the mock chain, causing all 16 notification tests to return 500

## Test plan
- [x] All 21 notification tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)