### PR TITLE
fix: quote YAML values containing colons in ui-policy workflow

### DIFF
--- a/.github/workflows/ui-policy.yml
+++ b/.github/workflows/ui-policy.yml
@@ -61,14 +61,14 @@ jobs:
 
   # Enforce no dark: classes in app code (only allowed in /ui CVA definitions)
   check-dark-mode:
-    name: Check No dark: Classes in App Code
+    name: "Check No dark: Classes in App Code"
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for dark: classes outside /ui
+      - name: "Check for dark: classes outside /ui"
         run: |
           echo "Checking for dark: classes outside /ui..."
 


### PR DESCRIPTION
## Summary
- Fixes YAML syntax error in `.github/workflows/ui-policy.yml` that was causing all workflow runs to fail
- The `dark:` text followed by a space was being parsed as a YAML key-value separator
- Quoted both affected step/job names to fix parsing

## Test plan
- [x] YAML validates locally (`npx yaml-lint .github/workflows/ui-policy.yml`)
- [ ] CI workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)