### PR TITLE
fix: align student sidebar icons with teacher sidebar

### DIFF
--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -290,7 +290,7 @@ export function NavItems({
                 aria-current={isActive ? 'page' : undefined}
                 aria-label={item.label}
                 className={[
-                  'group flex flex-1 items-center rounded-md text-base font-medium transition-colors',
+                  'group flex items-center rounded-md text-base font-medium transition-colors',
                   layoutClass,
                   isActive
                     ? 'bg-info-bg text-info'
@@ -314,13 +314,11 @@ export function NavItems({
 
           return (
             <div key={item.id} className={canShowNested ? 'space-y-1' : undefined}>
-              <div className="flex items-center">
-                {!isExpanded ? (
-                  <Tooltip content={item.label}>{studentAssignmentsLink}</Tooltip>
-                ) : (
-                  studentAssignmentsLink
-                )}
-              </div>
+              {!isExpanded ? (
+                <Tooltip content={item.label}>{studentAssignmentsLink}</Tooltip>
+              ) : (
+                studentAssignmentsLink
+              )}
 
               {canShowNested && assignments && assignments.length > 0 && (
                 <div className="pl-10 pr-3 space-y-1">


### PR DESCRIPTION
## Summary
- Remove extra wrapper div around student assignments link that prevented `mx-auto` from centering correctly
- Remove unnecessary `flex-1` class from student assignments link
- Student sidebar now matches teacher sidebar structure exactly

## Root Cause
The student assignments link was wrapped in `<div className="flex items-center">` which didn't stretch to full width, preventing `mx-auto` on the link from centering the icon within the sidebar.

## Measured Evidence
| State | Student Assignments | Other Icons |
|-------|---------------------|-------------|
| **Before** | width=43px, offset=-0.5px | width=48px, offset=+2.0px |
| **After** | width=48px, offset=+2.0px | width=48px, offset=+2.0px |

## Test plan
- [ ] Verify collapsed student sidebar icons are horizontally centered
- [ ] Verify student Assignments icon aligns with Today, Quizzes, Calendar, Resources
- [ ] Compare student and teacher collapsed sidebars - icons should be at same horizontal position
- [ ] Test expanded sidebar still works correctly

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)