### PR TITLE
feat: add classroom announcements stream (#264)

### DIFF
--- a/src/app/api/student/classrooms/[id]/announcements/route.ts
+++ b/src/app/api/student/classrooms/[id]/announcements/route.ts
@@ -25,10 +25,12 @@ export async function GET(
 
     const supabase = getServiceRoleClient()
 
+    // Only return published announcements (scheduled_for is null or in the past)
     const { data: announcements, error } = await supabase
       .from('announcements')
       .select('*')
       .eq('classroom_id', classroomId)
+      .or('scheduled_for.is.null,scheduled_for.lte.now()')
       .order('created_at', { ascending: false })
 
     if (error) {
@@ -74,11 +76,12 @@ export async function POST(
 
     const supabase = getServiceRoleClient()
 
-    // Get all announcements for this classroom
+    // Get only published announcements for this classroom
     const { data: announcements, error: fetchError } = await supabase
       .from('announcements')
       .select('id')
       .eq('classroom_id', classroomId)
+      .or('scheduled_for.is.null,scheduled_for.lte.now()')
 
     if (fetchError) {
       console.error('Error fetching announcements:', fetchError)

--- a/src/app/api/student/classrooms/[id]/announcements/route.ts
+++ b/src/app/api/student/classrooms/[id]/announcements/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/student/classrooms/[id]/announcements - List announcements (newest first)
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: classroomId } = await params
+
+    const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+    if (!access.ok) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: announcements, error } = await supabase
+      .from('announcements')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching announcements:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch announcements' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ announcements: announcements || [] })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get announcements error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/student/classrooms/[id]/announcements - Mark all announcements as read
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('student')
+    const { id: classroomId } = await params
+
+    const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+    if (!access.ok) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    // Get all announcements for this classroom
+    const { data: announcements, error: fetchError } = await supabase
+      .from('announcements')
+      .select('id')
+      .eq('classroom_id', classroomId)
+
+    if (fetchError) {
+      console.error('Error fetching announcements:', fetchError)
+      return NextResponse.json(
+        { error: 'Failed to mark announcements as read' },
+        { status: 500 }
+      )
+    }
+
+    if (!announcements || announcements.length === 0) {
+      return NextResponse.json({ success: true, marked: 0 })
+    }
+
+    // Bulk upsert read records (ignore conflicts)
+    const readRecords = announcements.map((a) => ({
+      announcement_id: a.id,
+      user_id: user.id,
+    }))
+
+    const { error: upsertError } = await supabase
+      .from('announcement_reads')
+      .upsert(readRecords, {
+        onConflict: 'announcement_id,user_id',
+        ignoreDuplicates: true,
+      })
+
+    if (upsertError) {
+      console.error('Error marking announcements as read:', upsertError)
+      return NextResponse.json(
+        { error: 'Failed to mark announcements as read' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true, marked: announcements.length })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Mark announcements read error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/student/notifications/route.ts
+++ b/src/app/api/student/notifications/route.ts
@@ -165,13 +165,14 @@ export async function GET(request: NextRequest) {
       activeQuizzesCount = activeQuizIds.filter((id) => !respondedQuizIds.has(id)).length
     }
 
-    // Count unread announcements for this classroom
+    // Count unread announcements for this classroom (only published ones)
     let unreadAnnouncementsCount = 0
 
     const { data: announcements, error: announcementsError } = await supabase
       .from('announcements')
       .select('id')
       .eq('classroom_id', classroomId)
+      .or('scheduled_for.is.null,scheduled_for.lte.now()')
 
     if (announcementsError) {
       console.error('Error fetching announcements:', announcementsError)

--- a/src/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// Helper to verify teacher owns the announcement's classroom
+async function verifyAnnouncementOwnership(
+  userId: string,
+  classroomId: string,
+  announcementId: string
+) {
+  const supabase = getServiceRoleClient()
+
+  // Fetch announcement with classroom info
+  const { data: announcement, error } = await supabase
+    .from('announcements')
+    .select(`
+      *,
+      classrooms!inner (
+        id,
+        teacher_id,
+        archived_at
+      )
+    `)
+    .eq('id', announcementId)
+    .eq('classroom_id', classroomId)
+    .single()
+
+  if (error || !announcement) {
+    return { ok: false as const, error: 'Announcement not found', status: 404 }
+  }
+
+  if (announcement.classrooms.teacher_id !== userId) {
+    return { ok: false as const, error: 'Unauthorized', status: 403 }
+  }
+
+  return { ok: true as const, announcement, isArchived: !!announcement.classrooms.archived_at }
+}
+
+// PATCH /api/teacher/classrooms/[id]/announcements/[announcementId] - Update announcement
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; announcementId: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId, announcementId } = await params
+    const body = await request.json()
+    const { title, content } = body as { title?: string; content?: string }
+
+    const ownership = await verifyAnnouncementOwnership(user.id, classroomId, announcementId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    if (ownership.isArchived) {
+      return NextResponse.json(
+        { error: 'Classroom is archived' },
+        { status: 403 }
+      )
+    }
+
+    // Build update object
+    const updates: Record<string, string> = {}
+    if (title !== undefined) {
+      if (!title.trim()) {
+        return NextResponse.json(
+          { error: 'Title cannot be empty' },
+          { status: 400 }
+        )
+      }
+      updates.title = title.trim()
+    }
+    if (content !== undefined) {
+      if (!content.trim()) {
+        return NextResponse.json(
+          { error: 'Content cannot be empty' },
+          { status: 400 }
+        )
+      }
+      updates.content = content.trim()
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(
+        { error: 'No updates provided' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: announcement, error } = await supabase
+      .from('announcements')
+      .update(updates)
+      .eq('id', announcementId)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error updating announcement:', error)
+      return NextResponse.json(
+        { error: 'Failed to update announcement' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ announcement })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Update announcement error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// DELETE /api/teacher/classrooms/[id]/announcements/[announcementId] - Delete announcement
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; announcementId: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId, announcementId } = await params
+
+    const ownership = await verifyAnnouncementOwnership(user.id, classroomId, announcementId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    if (ownership.isArchived) {
+      return NextResponse.json(
+        { error: 'Classroom is archived' },
+        { status: 403 }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { error } = await supabase
+      .from('announcements')
+      .delete()
+      .eq('id', announcementId)
+
+    if (error) {
+      console.error('Error deleting announcement:', error)
+      return NextResponse.json(
+        { error: 'Failed to delete announcement' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Delete announcement error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/teacher/classrooms/[id]/announcements/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/announcements/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import {
+  assertTeacherOwnsClassroom,
+  assertTeacherCanMutateClassroom,
+} from '@/lib/server/classrooms'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// GET /api/teacher/classrooms/[id]/announcements - List announcements (newest first)
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId } = await params
+
+    const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: announcements, error } = await supabase
+      .from('announcements')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching announcements:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch announcements' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ announcements: announcements || [] })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Get announcements error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+// POST /api/teacher/classrooms/[id]/announcements - Create announcement
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: classroomId } = await params
+    const body = await request.json()
+    const { title, content } = body as { title?: string; content?: string }
+
+    if (!title || !title.trim()) {
+      return NextResponse.json(
+        { error: 'Title is required' },
+        { status: 400 }
+      )
+    }
+
+    if (!content || !content.trim()) {
+      return NextResponse.json(
+        { error: 'Content is required' },
+        { status: 400 }
+      )
+    }
+
+    const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json(
+        { error: ownership.error },
+        { status: ownership.status }
+      )
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: announcement, error } = await supabase
+      .from('announcements')
+      .insert({
+        classroom_id: classroomId,
+        title: title.trim(),
+        content: content.trim(),
+        created_by: user.id,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error creating announcement:', error)
+      return NextResponse.json(
+        { error: 'Failed to create announcement' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ announcement }, { status: 201 })
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error instanceof Error && error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Create announcement error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/teacher/classrooms/[id]/announcements/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/announcements/route.ts
@@ -67,14 +67,7 @@ export async function POST(
     const user = await requireRole('teacher')
     const { id: classroomId } = await params
     const body = await request.json()
-    const { title, content } = body as { title?: string; content?: string }
-
-    if (!title || !title.trim()) {
-      return NextResponse.json(
-        { error: 'Title is required' },
-        { status: 400 }
-      )
-    }
+    const { content } = body as { content?: string }
 
     if (!content || !content.trim()) {
       return NextResponse.json(
@@ -97,7 +90,6 @@ export async function POST(
       .from('announcements')
       .insert({
         classroom_id: classroomId,
-        title: title.trim(),
         content: content.trim(),
         created_by: user.id,
       })

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import type { Announcement, Classroom } from '@/types'
@@ -12,6 +13,7 @@ interface Props {
 export function StudentAnnouncementsSection({ classroom }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loading, setLoading] = useState(true)
+  const [showAll, setShowAll] = useState(false)
   const hasMarkedRead = useRef(false)
   const notifications = useStudentNotifications()
 
@@ -85,7 +87,7 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
 
   return (
     <div className="space-y-3">
-      {announcements.map((announcement) => (
+      {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => (
         <div
           key={announcement.id}
           className="bg-surface rounded-lg border border-border p-4"
@@ -104,6 +106,16 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
           </p>
         </div>
       ))}
+
+      {!showAll && announcements.length > 5 && (
+        <Button
+          variant="secondary"
+          onClick={() => setShowAll(true)}
+          className="w-full"
+        >
+          Show {announcements.length - 5} older announcement{announcements.length - 5 === 1 ? '' : 's'}
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -60,13 +60,10 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
 
   function formatDate(dateString: string) {
     const date = new Date(dateString)
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    })
+    const weekday = date.toLocaleDateString('en-US', { weekday: 'short' })
+    const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    const time = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    return `${weekday} ${monthDay}, ${time}`
   }
 
   if (loading) {
@@ -92,16 +89,11 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
           key={announcement.id}
           className="bg-surface rounded-lg border border-border p-4"
         >
-          <div className="min-w-0">
-            <h4 className="text-base font-semibold text-text-default">
-              {announcement.title}
-            </h4>
-            <p className="text-xs text-text-muted mt-0.5">
-              {formatDate(announcement.created_at)}
-              {announcement.updated_at !== announcement.created_at && ' (edited)'}
-            </p>
-          </div>
-          <p className="mt-3 text-sm text-text-default whitespace-pre-wrap">
+          <p className="text-xs text-text-muted mb-2">
+            {formatDate(announcement.created_at)}
+            {announcement.updated_at !== announcement.created_at && ' (edited)'}
+          </p>
+          <p className="text-sm text-text-default whitespace-pre-wrap">
             {announcement.content}
           </p>
         </div>

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
+import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
+import type { Announcement, Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+export function StudentAnnouncementsSection({ classroom }: Props) {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loading, setLoading] = useState(true)
+  const hasMarkedRead = useRef(false)
+  const notifications = useStudentNotifications()
+
+  const loadAnnouncements = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`)
+      if (!res.ok) throw new Error('Failed to load announcements')
+      const data = await res.json()
+      setAnnouncements(data.announcements || [])
+    } catch (err) {
+      console.error('Error loading announcements:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [classroom.id])
+
+  const markAllAsRead = useCallback(async () => {
+    if (hasMarkedRead.current) return
+    hasMarkedRead.current = true
+
+    try {
+      const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`, {
+        method: 'POST',
+      })
+      if (res.ok) {
+        // Clear the notification count for this classroom
+        notifications?.markAnnouncementsRead?.()
+      }
+    } catch (err) {
+      console.error('Error marking announcements as read:', err)
+    }
+  }, [classroom.id, notifications])
+
+  useEffect(() => {
+    loadAnnouncements()
+  }, [loadAnnouncements])
+
+  // Mark all as read when component mounts and announcements are loaded
+  useEffect(() => {
+    if (!loading && announcements.length > 0) {
+      markAllAsRead()
+    }
+  }, [loading, announcements.length, markAllAsRead])
+
+  function formatDate(dateString: string) {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (announcements.length === 0) {
+    return (
+      <div className="bg-surface rounded-lg border border-border p-8 text-center">
+        <p className="text-text-muted">No announcements yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {announcements.map((announcement) => (
+        <div
+          key={announcement.id}
+          className="bg-surface rounded-lg border border-border p-4"
+        >
+          <div className="min-w-0">
+            <h4 className="text-base font-semibold text-text-default">
+              {announcement.title}
+            </h4>
+            <p className="text-xs text-text-muted mt-0.5">
+              {formatDate(announcement.created_at)}
+              {announcement.updated_at !== announcement.created_at && ' (edited)'}
+            </p>
+          </div>
+          <p className="mt-3 text-sm text-text-default whitespace-pre-wrap">
+            {announcement.content}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -89,7 +89,7 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
           key={announcement.id}
           className="bg-surface rounded-lg border border-border p-4"
         >
-          <p className="text-xs text-text-muted mb-2">
+          <p className="text-[11px] text-text-muted mb-2">
             {formatDate(announcement.created_at)}
             {announcement.updated_at !== announcement.created_at && ' (edited)'}
           </p>

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -76,14 +76,14 @@ export function StudentAnnouncementsSection({ classroom }: Props) {
 
   if (announcements.length === 0) {
     return (
-      <div className="bg-surface rounded-lg border border-border p-8 text-center">
+      <div className="max-w-2xl mx-auto bg-surface rounded-lg border border-border p-8 text-center">
         <p className="text-text-muted">No announcements yet.</p>
       </div>
     )
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 max-w-2xl mx-auto">
       {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => (
         <div
           key={announcement.id}

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -8,7 +8,7 @@ import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useClassDays } from '@/hooks/useClassDays'
 import { readCookie, writeCookie } from '@/lib/cookies'
-import type { Classroom, LessonPlan, Assignment } from '@/types'
+import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 
 interface Props {
   classroom: Classroom
@@ -18,6 +18,7 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
   const router = useRouter()
   const [lessonPlans, setLessonPlans] = useState<LessonPlan[]>([])
   const [assignments, setAssignments] = useState<Assignment[]>([])
+  const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const classDays = useClassDays(classroom.id)
   const [loading, setLoading] = useState(true)
   const [viewMode, setViewMode] = useState<CalendarViewMode>(() => {
@@ -71,6 +72,20 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
     loadAssignments()
   }, [classroom.id])
 
+  // Fetch announcements for the classroom
+  useEffect(() => {
+    async function loadAnnouncements() {
+      try {
+        const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`)
+        const data = await res.json()
+        setAnnouncements(data.announcements || [])
+      } catch (err) {
+        console.error('Error loading announcements:', err)
+      }
+    }
+    loadAnnouncements()
+  }, [classroom.id])
+
   // Handle assignment click - navigate to assignments tab with the assignment selected
   const handleAssignmentClick = useCallback(
     (assignment: Assignment) => {
@@ -78,6 +93,11 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
     },
     [router, classroom.id]
   )
+
+  // Handle announcement click - navigate to Resources > Announcements
+  const handleAnnouncementClick = useCallback(() => {
+    router.push(`/classrooms/${classroom.id}?tab=resources&section=announcements`)
+  }, [router, classroom.id])
 
   // Prevent navigation beyond max date
   const handleDateChange = (newDate: Date) => {
@@ -110,6 +130,7 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
           classroom={classroom}
           lessonPlans={lessonPlans}
           assignments={assignments}
+          announcements={announcements}
           classDays={classDays}
           viewMode={viewMode}
           currentDate={currentDate}
@@ -117,6 +138,7 @@ export function StudentLessonCalendarTab({ classroom }: Props) {
           onDateChange={handleDateChange}
           onViewModeChange={handleViewModeChange}
           onAssignmentClick={handleAssignmentClick}
+          onAnnouncementClick={handleAnnouncementClick}
         />
       </PageContent>
     </PageLayout>

--- a/src/app/classrooms/[classroomId]/StudentResourcesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentResourcesTab.tsx
@@ -1,16 +1,25 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { PageContent, PageLayout } from '@/components/PageLayout'
+import { StudentAnnouncementsSection } from './StudentAnnouncementsSection'
 import type { Classroom, TiptapContent } from '@/types'
+
+type ResourcesSection = 'announcements' | 'class-resources'
 
 interface Props {
   classroom: Classroom
 }
 
 export function StudentResourcesTab({ classroom }: Props) {
+  const searchParams = useSearchParams()
+  const sectionParam = searchParams.get('section')
+  const section: ResourcesSection = sectionParam === 'class-resources' ? 'class-resources' : 'announcements'
+
   const [loading, setLoading] = useState(true)
   const [content, setContent] = useState<TiptapContent | null>(null)
 
@@ -30,33 +39,57 @@ export function StudentResourcesTab({ classroom }: Props) {
     loadResources()
   }, [classroom.id])
 
-  if (loading) {
-    return (
-      <PageLayout>
-        <PageContent>
-          <div className="flex items-center justify-center h-64">
-            <Spinner />
-          </div>
-        </PageContent>
-      </PageLayout>
-    )
-  }
-
   const hasContent = content && content.content && content.content.length > 0
 
   return (
     <PageLayout>
-      <PageContent>
-        <div className="bg-surface rounded-lg shadow-sm p-6">
-          {hasContent ? (
-            <RichTextViewer content={content} />
+      {/* Sub-tab navigation */}
+      <div className="flex border-b border-border mb-4">
+        <Link
+          href={`/classrooms/${classroom.id}?tab=resources&section=announcements`}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            section === 'announcements'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-text-muted hover:text-text-default hover:border-border'
+          }`}
+        >
+          Announcements
+        </Link>
+        <Link
+          href={`/classrooms/${classroom.id}?tab=resources&section=class-resources`}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            section === 'class-resources'
+              ? 'border-primary text-primary'
+              : 'border-transparent text-text-muted hover:text-text-default hover:border-border'
+          }`}
+        >
+          Class Resources
+        </Link>
+      </div>
+
+      {section === 'announcements' ? (
+        <PageContent>
+          <StudentAnnouncementsSection classroom={classroom} />
+        </PageContent>
+      ) : (
+        <PageContent>
+          {loading ? (
+            <div className="flex items-center justify-center h-64">
+              <Spinner />
+            </div>
           ) : (
-            <div className="text-center py-12">
-              <p className="text-text-muted">No resources have been added yet.</p>
+            <div className="bg-surface rounded-lg shadow-sm p-6">
+              {hasContent ? (
+                <RichTextViewer content={content} />
+              ) : (
+                <div className="text-center py-12">
+                  <p className="text-text-muted">No resources have been added yet.</p>
+                </div>
+              )}
             </div>
           )}
-        </div>
-      </PageContent>
+        </PageContent>
+      )}
     </PageLayout>
   )
 }

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -26,8 +26,8 @@ function combineDateTimeToDate(date: string, time?: string): Date {
   if (time) {
     return new Date(`${date}T${time}`)
   }
-  // Default to 9:00 AM if no time specified
-  return new Date(`${date}T09:00`)
+  // Default to 7:00 AM if no time specified
+  return new Date(`${date}T07:00`)
 }
 
 // Helper to combine date and optional time into ISO string

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -1,0 +1,297 @@
+'use client'
+
+import { useCallback, useEffect, useState, useId } from 'react'
+import { Pencil, Trash2, Plus } from 'lucide-react'
+import { Button, ConfirmDialog } from '@/ui'
+import { Spinner } from '@/components/Spinner'
+import type { Announcement, Classroom } from '@/types'
+
+interface Props {
+  classroom: Classroom
+}
+
+type FormMode = { type: 'closed' } | { type: 'create' } | { type: 'edit'; announcement: Announcement }
+
+export function TeacherAnnouncementsSection({ classroom }: Props) {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [formMode, setFormMode] = useState<FormMode>({ type: 'closed' })
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const titleId = useId()
+  const contentId = useId()
+  const isReadOnly = !!classroom.archived_at
+
+  const loadAnnouncements = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
+      if (!res.ok) throw new Error('Failed to load announcements')
+      const data = await res.json()
+      setAnnouncements(data.announcements || [])
+    } catch (err) {
+      console.error('Error loading announcements:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [classroom.id])
+
+  useEffect(() => {
+    loadAnnouncements()
+  }, [loadAnnouncements])
+
+  function openCreateForm() {
+    setFormMode({ type: 'create' })
+    setTitle('')
+    setContent('')
+    setError(null)
+  }
+
+  function openEditForm(announcement: Announcement) {
+    setFormMode({ type: 'edit', announcement })
+    setTitle(announcement.title)
+    setContent(announcement.content)
+    setError(null)
+  }
+
+  function closeForm() {
+    setFormMode({ type: 'closed' })
+    setTitle('')
+    setContent('')
+    setError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!title.trim() || !content.trim()) {
+      setError('Title and content are required')
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+
+    try {
+      if (formMode.type === 'create') {
+        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: title.trim(), content: content.trim() }),
+        })
+        if (!res.ok) {
+          const data = await res.json()
+          throw new Error(data.error || 'Failed to create announcement')
+        }
+        const data = await res.json()
+        setAnnouncements((prev) => [data.announcement, ...prev])
+      } else if (formMode.type === 'edit') {
+        const res = await fetch(
+          `/api/teacher/classrooms/${classroom.id}/announcements/${formMode.announcement.id}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title: title.trim(), content: content.trim() }),
+          }
+        )
+        if (!res.ok) {
+          const data = await res.json()
+          throw new Error(data.error || 'Failed to update announcement')
+        }
+        const data = await res.json()
+        setAnnouncements((prev) =>
+          prev.map((a) => (a.id === data.announcement.id ? data.announcement : a))
+        )
+      }
+      closeForm()
+    } catch (err: any) {
+      setError(err.message || 'An error occurred')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+
+    setDeleting(true)
+    try {
+      const res = await fetch(
+        `/api/teacher/classrooms/${classroom.id}/announcements/${deleteTarget.id}`,
+        { method: 'DELETE' }
+      )
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to delete announcement')
+      }
+      setAnnouncements((prev) => prev.filter((a) => a.id !== deleteTarget.id))
+      setDeleteTarget(null)
+    } catch (err: any) {
+      console.error('Delete error:', err)
+      setDeleteTarget(null)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  function formatDate(dateString: string) {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Spinner />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {isReadOnly && (
+        <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+          This classroom is archived. Announcements are read-only.
+        </div>
+      )}
+
+      {/* Form for create/edit */}
+      {formMode.type !== 'closed' && (
+        <div className="bg-surface rounded-lg border border-border p-4">
+          <h3 className="text-base font-semibold text-text-default mb-4">
+            {formMode.type === 'create' ? 'New Announcement' : 'Edit Announcement'}
+          </h3>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor={titleId} className="block text-sm font-medium text-text-default mb-1">
+                Title
+              </label>
+              <input
+                id={titleId}
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={saving}
+                className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                placeholder="Enter announcement title"
+                autoFocus
+              />
+            </div>
+            <div>
+              <label htmlFor={contentId} className="block text-sm font-medium text-text-default mb-1">
+                Content
+              </label>
+              <textarea
+                id={contentId}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                disabled={saving}
+                rows={4}
+                className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
+                placeholder="Enter announcement content"
+              />
+            </div>
+            {error && <div className="text-sm text-danger">{error}</div>}
+            <div className="flex gap-2 justify-end">
+              <Button type="button" variant="secondary" onClick={closeForm} disabled={saving}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" disabled={saving}>
+                {saving ? 'Saving...' : formMode.type === 'create' ? 'Post' : 'Save'}
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Header with create button */}
+      {formMode.type === 'closed' && !isReadOnly && (
+        <div className="flex justify-end">
+          <Button variant="primary" onClick={openCreateForm}>
+            <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+            New Announcement
+          </Button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {announcements.length === 0 && formMode.type === 'closed' && (
+        <div className="bg-surface rounded-lg border border-border p-8 text-center">
+          <p className="text-text-muted">
+            No announcements yet. Create one to share updates with your students.
+          </p>
+        </div>
+      )}
+
+      {/* Announcements list */}
+      {announcements.length > 0 && (
+        <div className="space-y-3">
+          {announcements.map((announcement) => (
+            <div
+              key={announcement.id}
+              className="bg-surface rounded-lg border border-border p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <h4 className="text-base font-semibold text-text-default">
+                    {announcement.title}
+                  </h4>
+                  <p className="text-xs text-text-muted mt-0.5">
+                    {formatDate(announcement.created_at)}
+                    {announcement.updated_at !== announcement.created_at && ' (edited)'}
+                  </p>
+                </div>
+                {!isReadOnly && (
+                  <div className="flex gap-1 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => openEditForm(announcement)}
+                      aria-label="Edit announcement"
+                    >
+                      <Pencil className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteTarget(announcement)}
+                      aria-label="Delete announcement"
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+              <p className="mt-3 text-sm text-text-default whitespace-pre-wrap">
+                {announcement.content}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Delete announcement?"
+        description="This will permanently remove the announcement. Students will no longer be able to see it."
+        confirmLabel={deleting ? 'Deleting...' : 'Delete'}
+        cancelLabel="Cancel"
+        confirmVariant="danger"
+        isConfirmDisabled={deleting}
+        isCancelDisabled={deleting}
+        onCancel={() => !deleting && setDeleteTarget(null)}
+        onConfirm={handleDelete}
+      />
+    </div>
+  )
+}

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -196,9 +196,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             value={newContent}
             onChange={(e) => setNewContent(e.target.value)}
             onKeyDown={handleNewKeyDown}
-            onBlur={(e) => {
-              // Don't save if clicking the Post button (it will handle it)
-              if (e.relatedTarget?.getAttribute('data-save-button')) return
+            onBlur={() => {
               if (newContent.trim()) {
                 createAnnouncement()
               } else {
@@ -215,7 +213,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             <Button
               variant="primary"
               size="sm"
-              data-save-button="true"
+              onMouseDown={(e) => e.preventDefault()}
               onClick={createAnnouncement}
               disabled={saving || !newContent.trim()}
             >
@@ -259,11 +257,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                     value={editContent}
                     onChange={(e) => setEditContent(e.target.value)}
                     onKeyDown={handleEditKeyDown}
-                    onBlur={(e) => {
-                      // Don't save if clicking the Save button (it will handle it)
-                      if (e.relatedTarget?.getAttribute('data-save-button')) return
-                      saveEdit()
-                    }}
+                    onBlur={saveEdit}
                     disabled={saving}
                     rows={3}
                     className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
@@ -272,7 +266,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                     <Button
                       variant="primary"
                       size="sm"
-                      data-save-button="true"
+                      onMouseDown={(e) => e.preventDefault()}
                       onClick={saveEdit}
                       disabled={saving || !editContent.trim()}
                     >

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -196,7 +196,9 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             value={newContent}
             onChange={(e) => setNewContent(e.target.value)}
             onKeyDown={handleNewKeyDown}
-            onBlur={() => {
+            onBlur={(e) => {
+              // Don't save if clicking the Post button (it will handle it)
+              if (e.relatedTarget?.getAttribute('data-save-button')) return
               if (newContent.trim()) {
                 createAnnouncement()
               } else {
@@ -209,6 +211,17 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
             placeholder="Write an announcement..."
           />
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              data-save-button="true"
+              onClick={createAnnouncement}
+              disabled={saving || !newContent.trim()}
+            >
+              {saving ? 'Posting...' : 'Post'}
+            </Button>
+          </div>
         </div>
       ) : (
         !isReadOnly && (
@@ -246,11 +259,26 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                     value={editContent}
                     onChange={(e) => setEditContent(e.target.value)}
                     onKeyDown={handleEditKeyDown}
-                    onBlur={saveEdit}
+                    onBlur={(e) => {
+                      // Don't save if clicking the Save button (it will handle it)
+                      if (e.relatedTarget?.getAttribute('data-save-button')) return
+                      saveEdit()
+                    }}
                     disabled={saving}
                     rows={3}
                     className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
                   />
+                  <div className="flex justify-end mt-2">
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      data-save-button="true"
+                      onClick={saveEdit}
+                      disabled={saving || !editContent.trim()}
+                    >
+                      {saving ? 'Saving...' : 'Save'}
+                    </Button>
+                  </div>
                 </div>
               ) : (
                 // View mode

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -1,13 +1,28 @@
 'use client'
 
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { Trash2, Plus } from 'lucide-react'
+import { Trash2, Plus, Clock, ChevronDown } from 'lucide-react'
 import { Button, ConfirmDialog } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import type { Announcement, Classroom } from '@/types'
 
 interface Props {
   classroom: Classroom
+}
+
+// Helper to check if announcement is scheduled (not yet published)
+function isScheduled(announcement: Announcement): boolean {
+  if (!announcement.scheduled_for) return false
+  return new Date(announcement.scheduled_for) > new Date()
+}
+
+// Helper to get minimum datetime (now + 1 minute, rounded to next minute)
+function getMinDatetime(): string {
+  const now = new Date()
+  now.setMinutes(now.getMinutes() + 1)
+  now.setSeconds(0)
+  now.setMilliseconds(0)
+  return now.toISOString().slice(0, 16)
 }
 
 export function TeacherAnnouncementsSection({ classroom }: Props) {
@@ -22,8 +37,11 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
   const [saving, setSaving] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
   const [deleting, setDeleting] = useState(false)
+  const [showScheduleDropdown, setShowScheduleDropdown] = useState(false)
+  const [scheduleDateTime, setScheduleDateTime] = useState('')
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
   const newTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
 
   const isReadOnly = !!classroom.archived_at
 
@@ -61,6 +79,19 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
       newTextareaRef.current.focus()
     }
   }, [isCreating])
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowScheduleDropdown(false)
+      }
+    }
+    if (showScheduleDropdown) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [showScheduleDropdown])
 
   function startEditing(announcement: Announcement) {
     if (isReadOnly || saving) return
@@ -109,21 +140,28 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
     }
   }
 
-  async function createAnnouncement() {
+  async function createAnnouncement(scheduledFor?: string) {
     if (!newContent.trim() || saving) return
 
     setSaving(true)
     try {
+      const body: { content: string; scheduled_for?: string } = { content: newContent.trim() }
+      if (scheduledFor) {
+        body.scheduled_for = new Date(scheduledFor).toISOString()
+      }
+
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: newContent.trim() }),
+        body: JSON.stringify(body),
       })
       if (!res.ok) throw new Error('Failed to create')
       const data = await res.json()
       setAnnouncements((prev) => [data.announcement, ...prev])
       setIsCreating(false)
       setNewContent('')
+      setScheduleDateTime('')
+      setShowScheduleDropdown(false)
     } catch (err) {
       console.error('Error creating announcement:', err)
     } finally {
@@ -196,29 +234,71 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             value={newContent}
             onChange={(e) => setNewContent(e.target.value)}
             onKeyDown={handleNewKeyDown}
-            onBlur={() => {
-              if (newContent.trim()) {
-                createAnnouncement()
-              } else {
-                setIsCreating(false)
-                setNewContent('')
-              }
-            }}
             disabled={saving}
             rows={3}
             className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
             placeholder="Write an announcement..."
           />
-          <div className="flex justify-end mt-2">
-            <Button
-              variant="primary"
-              size="sm"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={createAnnouncement}
-              disabled={saving || !newContent.trim()}
+          <div className="flex items-center justify-between mt-2">
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreating(false)
+                setNewContent('')
+                setScheduleDateTime('')
+                setShowScheduleDropdown(false)
+              }}
+              className="text-sm text-text-muted hover:text-text-default"
             >
-              {saving ? 'Posting...' : 'Post'}
-            </Button>
+              Cancel
+            </button>
+            <div className="relative flex items-center" ref={dropdownRef}>
+              <Button
+                variant="primary"
+                size="sm"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => createAnnouncement()}
+                disabled={saving || !newContent.trim()}
+                className="rounded-r-none"
+              >
+                {saving ? 'Posting...' : 'Post'}
+              </Button>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setShowScheduleDropdown(!showScheduleDropdown)}
+                disabled={saving || !newContent.trim()}
+                className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ChevronDown className="h-4 w-4" />
+              </button>
+
+              {/* Schedule dropdown */}
+              {showScheduleDropdown && (
+                <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-3 z-10 min-w-[280px]">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Clock className="h-4 w-4 text-text-muted" />
+                    <span className="text-sm font-medium text-text-default">Schedule for later</span>
+                  </div>
+                  <input
+                    type="datetime-local"
+                    value={scheduleDateTime}
+                    onChange={(e) => setScheduleDateTime(e.target.value)}
+                    min={getMinDatetime()}
+                    className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => createAnnouncement(scheduleDateTime)}
+                    disabled={saving || !scheduleDateTime}
+                    className="w-full mt-2"
+                  >
+                    {saving ? 'Scheduling...' : 'Schedule'}
+                  </Button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       ) : (
@@ -244,66 +324,81 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
       {/* Announcements list */}
       {announcements.length > 0 && (
         <div className="space-y-3">
-          {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => (
-            <div
-              key={announcement.id}
-              className="bg-surface rounded-lg border border-border p-4"
-            >
-              {editingId === announcement.id ? (
-                // Editing mode
-                <div>
-                  <textarea
-                    ref={editTextareaRef}
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    onKeyDown={handleEditKeyDown}
-                    onBlur={saveEdit}
-                    disabled={saving}
-                    rows={3}
-                    className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
-                  />
-                  <div className="flex justify-end mt-2">
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={saveEdit}
-                      disabled={saving || !editContent.trim()}
-                    >
-                      {saving ? 'Saving...' : 'Save'}
-                    </Button>
+          {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => {
+            const scheduled = isScheduled(announcement)
+
+            return (
+              <div
+                key={announcement.id}
+                className={`bg-surface rounded-lg border p-4 ${
+                  scheduled ? 'border-amber-500/50 bg-amber-500/5' : 'border-border'
+                }`}
+              >
+                {editingId === announcement.id ? (
+                  // Editing mode
+                  <div>
+                    <textarea
+                      ref={editTextareaRef}
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      onKeyDown={handleEditKeyDown}
+                      onBlur={saveEdit}
+                      disabled={saving}
+                      rows={3}
+                      className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
+                    />
+                    <div className="flex justify-end mt-2">
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={saveEdit}
+                        disabled={saving || !editContent.trim()}
+                      >
+                        {saving ? 'Saving...' : 'Save'}
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              ) : (
-                // View mode
-                <div className="flex items-start justify-between gap-3">
-                  <div
-                    className={`min-w-0 flex-1 ${!isReadOnly ? 'cursor-pointer' : ''}`}
-                    onClick={() => startEditing(announcement)}
-                  >
-                    <p className="text-xs text-text-muted mb-2">
-                      {formatDate(announcement.created_at)}
-                      {announcement.updated_at !== announcement.created_at && ' (edited)'}
-                    </p>
-                    <p className="text-sm text-text-default whitespace-pre-wrap">
-                      {announcement.content}
-                    </p>
-                  </div>
-                  {!isReadOnly && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setDeleteTarget(announcement)}
-                      aria-label="Delete announcement"
-                      className="flex-shrink-0"
+                ) : (
+                  // View mode
+                  <div className="flex items-start justify-between gap-3">
+                    <div
+                      className={`min-w-0 flex-1 ${!isReadOnly ? 'cursor-pointer' : ''}`}
+                      onClick={() => startEditing(announcement)}
                     >
-                      <Trash2 className="h-4 w-4" aria-hidden="true" />
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
-          ))}
+                      {scheduled ? (
+                        <div className="flex items-center gap-2 mb-2">
+                          <Clock className="h-3.5 w-3.5 text-amber-600" />
+                          <span className="text-xs font-medium text-amber-600">
+                            Scheduled for {formatDate(announcement.scheduled_for!)}
+                          </span>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-text-muted mb-2">
+                          {formatDate(announcement.created_at)}
+                          {announcement.updated_at !== announcement.created_at && ' (edited)'}
+                        </p>
+                      )}
+                      <p className={`text-sm whitespace-pre-wrap ${scheduled ? 'text-text-muted' : 'text-text-default'}`}>
+                        {announcement.content}
+                      </p>
+                    </div>
+                    {!isReadOnly && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteTarget(announcement)}
+                        aria-label="Delete announcement"
+                        className="flex-shrink-0"
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
 
           {!showAll && announcements.length > 5 && (
             <Button

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -119,12 +119,12 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
     setOriginalScheduledFor(null)
   }
 
-  async function saveEdit(publishNow?: boolean) {
+  async function saveEdit() {
     if (!editingId || !editContent.trim() || saving) return
 
     // Check if anything changed
     const contentChanged = editContent.trim() !== originalContent.trim()
-    const newScheduledFor = publishNow ? null : (editScheduleDateTime ? new Date(editScheduleDateTime).toISOString() : null)
+    const newScheduledFor = editScheduleDateTime ? new Date(editScheduleDateTime).toISOString() : null
     const scheduleChanged = newScheduledFor !== originalScheduledFor
 
     // Don't save if nothing changed
@@ -384,11 +384,11 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                         <button
                           type="button"
                           onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => saveEdit(true)}
+                          onClick={() => setEditScheduleDateTime('')}
                           disabled={saving}
-                          className="text-xs text-primary hover:text-primary-hover whitespace-nowrap"
+                          className="text-xs text-text-muted hover:text-text-default whitespace-nowrap"
                         >
-                          Publish now
+                          Clear
                         </button>
                       </div>
                     )}

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -362,7 +362,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     setPendingScheduleDate(getTodayDate())
-                    setPendingScheduleTime('')
+                    setPendingScheduleTime('07:00')
                     setShowScheduleDropdown(!showScheduleDropdown)
                   }}
                   disabled={saving || !newContent.trim()}
@@ -391,7 +391,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                       />
                     </div>
                     <div>
-                      <label className="block text-xs text-text-muted mb-1">Time (optional)</label>
+                      <label className="block text-xs text-text-muted mb-1">Time</label>
                       <input
                         type="time"
                         value={pendingScheduleTime}
@@ -519,7 +519,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                             onMouseDown={(e) => e.preventDefault()}
                             onClick={() => {
                               setPendingEditScheduleDate(getTodayDate())
-                              setPendingEditScheduleTime('')
+                              setPendingEditScheduleTime('07:00')
                               setShowEditScheduleDropdown(!showEditScheduleDropdown)
                             }}
                             disabled={saving || !editContent.trim()}
@@ -548,7 +548,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                                 />
                               </div>
                               <div>
-                                <label className="block text-xs text-text-muted mb-1">Time (optional)</label>
+                                <label className="block text-xs text-text-muted mb-1">Time</label>
                                 <input
                                   type="time"
                                   value={pendingEditScheduleTime}

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -279,6 +279,22 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
             placeholder="Write an announcement..."
           />
+          {/* Show scheduled date if set */}
+          {scheduleDateTime && (
+            <div className="flex items-center gap-2 mt-2">
+              <Clock className="h-4 w-4 text-amber-600 flex-shrink-0" />
+              <span className="text-sm text-amber-600">
+                Scheduled for {formatDate(new Date(scheduleDateTime).toISOString())}
+              </span>
+              <button
+                type="button"
+                onClick={() => setScheduleDateTime('')}
+                className="text-xs text-text-muted hover:text-text-default"
+              >
+                Clear
+              </button>
+            </div>
+          )}
           <div className="flex items-center justify-between mt-2">
             <button
               type="button"
@@ -297,21 +313,23 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                 variant="primary"
                 size="sm"
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => createAnnouncement()}
+                onClick={() => createAnnouncement(scheduleDateTime || undefined)}
                 disabled={saving || !newContent.trim()}
-                className="rounded-r-none"
+                className={scheduleDateTime ? '' : 'rounded-r-none'}
               >
-                {saving ? 'Posting...' : 'Post'}
+                {saving ? (scheduleDateTime ? 'Scheduling...' : 'Posting...') : (scheduleDateTime ? 'Schedule' : 'Post')}
               </Button>
-              <button
-                type="button"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setShowScheduleDropdown(!showScheduleDropdown)}
-                disabled={saving || !newContent.trim()}
-                className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </button>
+              {!scheduleDateTime && (
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setShowScheduleDropdown(!showScheduleDropdown)}
+                  disabled={saving || !newContent.trim()}
+                  className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+              )}
 
               {/* Schedule dropdown */}
               {showScheduleDropdown && (
@@ -323,19 +341,13 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                   <input
                     type="datetime-local"
                     value={scheduleDateTime}
-                    onChange={(e) => setScheduleDateTime(e.target.value)}
+                    onChange={(e) => {
+                      setScheduleDateTime(e.target.value)
+                      if (e.target.value) setShowScheduleDropdown(false)
+                    }}
                     min={getMinDatetime()}
                     className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={() => createAnnouncement(scheduleDateTime)}
-                    disabled={saving || !scheduleDateTime}
-                    className="w-full mt-2"
-                  >
-                    {saving ? 'Scheduling...' : 'Schedule'}
-                  </Button>
                 </div>
               )}
             </div>
@@ -438,7 +450,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                             disabled={saving || !editContent.trim()}
                             className="rounded-r-none"
                           >
-                            {saving ? 'Saving...' : 'Save'}
+                            {saving ? 'Posting...' : 'Post'}
                           </Button>
                           <button
                             type="button"
@@ -460,21 +472,13 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                               <input
                                 type="datetime-local"
                                 value={editScheduleDateTime}
-                                onChange={(e) => setEditScheduleDateTime(e.target.value)}
+                                onChange={(e) => {
+                                  setEditScheduleDateTime(e.target.value)
+                                  if (e.target.value) setShowEditScheduleDropdown(false)
+                                }}
                                 min={getMinDatetime()}
                                 className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
                               />
-                              <Button
-                                variant="primary"
-                                size="sm"
-                                onClick={() => {
-                                  setShowEditScheduleDropdown(false)
-                                }}
-                                disabled={!editScheduleDateTime}
-                                className="w-full mt-2"
-                              >
-                                Set Schedule
-                              </Button>
                             </div>
                           )}
                         </div>

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -21,13 +21,24 @@ function getTodayDate(): string {
   return new Date().toISOString().slice(0, 10)
 }
 
-// Helper to combine date and optional time into ISO string
-function combineDateTime(date: string, time?: string): string {
+// Helper to combine date and optional time into Date object
+function combineDateTimeToDate(date: string, time?: string): Date {
   if (time) {
-    return new Date(`${date}T${time}`).toISOString()
+    return new Date(`${date}T${time}`)
   }
   // Default to 9:00 AM if no time specified
-  return new Date(`${date}T09:00`).toISOString()
+  return new Date(`${date}T09:00`)
+}
+
+// Helper to combine date and optional time into ISO string
+function combineDateTime(date: string, time?: string): string {
+  return combineDateTimeToDate(date, time).toISOString()
+}
+
+// Helper to check if date/time is in the future
+function isScheduleInFuture(date: string, time?: string): boolean {
+  const scheduledDate = combineDateTimeToDate(date, time)
+  return scheduledDate > new Date()
 }
 
 // Helper to parse ISO datetime into date and time parts
@@ -389,17 +400,20 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                       />
                     </div>
                   </div>
+                  {pendingScheduleDate && !isScheduleInFuture(pendingScheduleDate, pendingScheduleTime) && (
+                    <p className="text-xs text-red-500 mt-2">Schedule must be in the future</p>
+                  )}
                   <Button
                     variant="primary"
                     size="sm"
                     onClick={() => {
-                      if (pendingScheduleDate) {
+                      if (pendingScheduleDate && isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)) {
                         setScheduleDateTime(combineDateTime(pendingScheduleDate, pendingScheduleTime))
+                        setShowScheduleDropdown(false)
                       }
-                      setShowScheduleDropdown(false)
                     }}
-                    disabled={!pendingScheduleDate}
-                    className="w-full mt-3"
+                    disabled={!pendingScheduleDate || !isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)}
+                    className="w-full mt-2"
                   >
                     Done
                   </Button>
@@ -543,17 +557,20 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                                 />
                               </div>
                             </div>
+                            {pendingEditScheduleDate && !isScheduleInFuture(pendingEditScheduleDate, pendingEditScheduleTime) && (
+                              <p className="text-xs text-red-500 mt-2">Schedule must be in the future</p>
+                            )}
                             <Button
                               variant="primary"
                               size="sm"
                               onClick={() => {
-                                if (pendingEditScheduleDate) {
+                                if (pendingEditScheduleDate && isScheduleInFuture(pendingEditScheduleDate, pendingEditScheduleTime)) {
                                   setEditScheduleDateTime(combineDateTime(pendingEditScheduleDate, pendingEditScheduleTime))
+                                  setShowEditScheduleDropdown(false)
                                 }
-                                setShowEditScheduleDropdown(false)
                               }}
-                              disabled={!pendingEditScheduleDate}
-                              className="w-full mt-3"
+                              disabled={!pendingEditScheduleDate || !isScheduleInFuture(pendingEditScheduleDate, pendingEditScheduleTime)}
+                              className="w-full mt-2"
                             >
                               Done
                             </Button>

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -181,7 +181,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 max-w-2xl mx-auto">
       {isReadOnly && (
         <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
           This classroom is archived. Announcements are read-only.
@@ -225,7 +225,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
         </div>
       ) : (
         !isReadOnly && (
-          <div className="flex justify-end">
+          <div className="flex justify-center">
             <Button variant="primary" onClick={() => setIsCreating(true)}>
               <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
               New Announcement

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -443,9 +443,23 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
       )}
 
       {/* Announcements list */}
-      {announcements.length > 0 && (
+      {announcements.length > 0 && (() => {
+        // Sort: scheduled announcements first (by scheduled_for), then published (by created_at)
+        const sortedAnnouncements = [...announcements].sort((a, b) => {
+          const aScheduled = isScheduled(a)
+          const bScheduled = isScheduled(b)
+          if (aScheduled && !bScheduled) return -1
+          if (!aScheduled && bScheduled) return 1
+          if (aScheduled && bScheduled) {
+            return new Date(a.scheduled_for!).getTime() - new Date(b.scheduled_for!).getTime()
+          }
+          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        })
+        const displayedAnnouncements = showAll ? sortedAnnouncements : sortedAnnouncements.slice(0, 5)
+
+        return (
         <div className="space-y-3">
-          {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => {
+          {displayedAnnouncements.map((announcement) => {
             const scheduled = isScheduled(announcement)
 
             return (
@@ -620,17 +634,18 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             )
           })}
 
-          {!showAll && announcements.length > 5 && (
+          {!showAll && sortedAnnouncements.length > 5 && (
             <Button
               variant="secondary"
               onClick={() => setShowAll(true)}
               className="w-full"
             >
-              Show {announcements.length - 5} older announcement{announcements.length - 5 === 1 ? '' : 's'}
+              Show {sortedAnnouncements.length - 5} older announcement{sortedAnnouncements.length - 5 === 1 ? '' : 's'}
             </Button>
           )}
         </div>
-      )}
+        )
+      })()}
 
       {/* Delete confirmation dialog */}
       <ConfirmDialog

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -40,10 +40,14 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [scheduleDateTime, setScheduleDateTime] = useState('')
+  const [showScheduleDropdown, setShowScheduleDropdown] = useState(false)
+  const [showEditScheduleDropdown, setShowEditScheduleDropdown] = useState(false)
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
   const newTextareaRef = useRef<HTMLTextAreaElement>(null)
   const scheduleDateInputRef = useRef<HTMLInputElement>(null)
   const editScheduleDateInputRef = useRef<HTMLInputElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const editDropdownRef = useRef<HTMLDivElement>(null)
 
   const isReadOnly = !!classroom.archived_at
 
@@ -82,6 +86,32 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
     }
   }, [isCreating])
 
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowScheduleDropdown(false)
+      }
+    }
+    if (showScheduleDropdown) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [showScheduleDropdown])
+
+  // Close edit dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (editDropdownRef.current && !editDropdownRef.current.contains(event.target as Node)) {
+        setShowEditScheduleDropdown(false)
+      }
+    }
+    if (showEditScheduleDropdown) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [showEditScheduleDropdown])
+
   function startEditing(announcement: Announcement) {
     if (isReadOnly || saving) return
     setEditingId(announcement.id)
@@ -104,6 +134,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
     setOriginalContent('')
     setEditScheduleDateTime('')
     setOriginalScheduledFor(null)
+    setShowEditScheduleDropdown(false)
   }
 
   async function saveEdit() {
@@ -255,7 +286,10 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             ref={scheduleDateInputRef}
             type="datetime-local"
             value={scheduleDateTime}
-            onChange={(e) => setScheduleDateTime(e.target.value)}
+            onChange={(e) => {
+              setScheduleDateTime(e.target.value)
+              if (e.target.value) setShowScheduleDropdown(false)
+            }}
             min={getMinDatetime()}
             className="sr-only"
             tabIndex={-1}
@@ -287,12 +321,13 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                 setIsCreating(false)
                 setNewContent('')
                 setScheduleDateTime('')
+                setShowScheduleDropdown(false)
               }}
               className="text-sm text-text-muted hover:text-text-default"
             >
               Cancel
             </button>
-            <div className="flex items-center">
+            <div className="relative flex items-center" ref={dropdownRef}>
               <Button
                 variant="primary"
                 size="sm"
@@ -307,12 +342,26 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                 <button
                   type="button"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => scheduleDateInputRef.current?.showPicker()}
+                  onClick={() => setShowScheduleDropdown(!showScheduleDropdown)}
                   disabled={saving || !newContent.trim()}
                   className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <ChevronDown className="h-4 w-4" />
                 </button>
+              )}
+
+              {/* Schedule dropdown */}
+              {showScheduleDropdown && (
+                <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-2 z-10">
+                  <button
+                    type="button"
+                    onClick={() => scheduleDateInputRef.current?.showPicker()}
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-text-default hover:bg-surface-2 rounded-md w-full"
+                  >
+                    <Calendar className="h-4 w-4" />
+                    <span>Schedule</span>
+                  </button>
+                </div>
               )}
             </div>
           </div>
@@ -367,7 +416,10 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                       ref={editScheduleDateInputRef}
                       type="datetime-local"
                       value={editScheduleDateTime}
-                      onChange={(e) => setEditScheduleDateTime(e.target.value)}
+                      onChange={(e) => {
+                        setEditScheduleDateTime(e.target.value)
+                        if (e.target.value) setShowEditScheduleDropdown(false)
+                      }}
                       min={getMinDatetime()}
                       className="sr-only"
                       tabIndex={-1}
@@ -402,7 +454,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                       >
                         Cancel
                       </button>
-                      <div className="flex items-center">
+                      <div className="relative flex items-center" ref={editDropdownRef}>
                         <Button
                           variant="primary"
                           size="sm"
@@ -417,12 +469,26 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                           <button
                             type="button"
                             onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => editScheduleDateInputRef.current?.showPicker()}
+                            onClick={() => setShowEditScheduleDropdown(!showEditScheduleDropdown)}
                             disabled={saving || !editContent.trim()}
                             className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
                           >
                             <ChevronDown className="h-4 w-4" />
                           </button>
+                        )}
+
+                        {/* Schedule dropdown */}
+                        {showEditScheduleDropdown && (
+                          <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-2 z-10">
+                            <button
+                              type="button"
+                              onClick={() => editScheduleDateInputRef.current?.showPicker()}
+                              className="flex items-center gap-2 px-3 py-2 text-sm text-text-default hover:bg-surface-2 rounded-md w-full"
+                            >
+                              <Calendar className="h-4 w-4" />
+                              <span>Schedule</span>
+                            </button>
+                          </div>
                         )}
                       </div>
                     </div>

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -15,6 +15,7 @@ type FormMode = { type: 'closed' } | { type: 'create' } | { type: 'edit'; announ
 export function TeacherAnnouncementsSection({ classroom }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [loading, setLoading] = useState(true)
+  const [showAll, setShowAll] = useState(false)
   const [formMode, setFormMode] = useState<FormMode>({ type: 'closed' })
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -235,7 +236,7 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
       {/* Announcements list */}
       {announcements.length > 0 && (
         <div className="space-y-3">
-          {announcements.map((announcement) => (
+          {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => (
             <div
               key={announcement.id}
               className="bg-surface rounded-lg border border-border p-4"
@@ -276,6 +277,16 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
               </p>
             </div>
           ))}
+
+          {!showAll && announcements.length > 5 && (
+            <Button
+              variant="secondary"
+              onClick={() => setShowAll(true)}
+              className="w-full"
+            >
+              Show {announcements.length - 5} older announcement{announcements.length - 5 === 1 ? '' : 's'}
+            </Button>
+          )}
         </div>
       )}
 

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -40,12 +40,12 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [scheduleDateTime, setScheduleDateTime] = useState('')
+  const [pendingScheduleDateTime, setPendingScheduleDateTime] = useState('')
+  const [pendingEditScheduleDateTime, setPendingEditScheduleDateTime] = useState('')
   const [showScheduleDropdown, setShowScheduleDropdown] = useState(false)
   const [showEditScheduleDropdown, setShowEditScheduleDropdown] = useState(false)
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
   const newTextareaRef = useRef<HTMLTextAreaElement>(null)
-  const scheduleDateInputRef = useRef<HTMLInputElement>(null)
-  const editScheduleDateInputRef = useRef<HTMLInputElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const editDropdownRef = useRef<HTMLDivElement>(null)
 
@@ -281,25 +281,15 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
             className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
             placeholder="Write an announcement..."
           />
-          {/* Hidden datetime input */}
-          <input
-            ref={scheduleDateInputRef}
-            type="datetime-local"
-            value={scheduleDateTime}
-            onChange={(e) => {
-              setScheduleDateTime(e.target.value)
-              if (e.target.value) setShowScheduleDropdown(false)
-            }}
-            min={getMinDatetime()}
-            className="sr-only"
-            tabIndex={-1}
-          />
           {/* Show scheduled date if set */}
           {scheduleDateTime && (
             <div className="flex items-center gap-2 mt-2">
               <button
                 type="button"
-                onClick={() => scheduleDateInputRef.current?.showPicker()}
+                onClick={() => {
+                  setPendingScheduleDateTime(scheduleDateTime)
+                  setShowScheduleDropdown(true)
+                }}
                 className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
               >
                 <Calendar className="h-4 w-4 flex-shrink-0" />
@@ -342,7 +332,10 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                 <button
                   type="button"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => setShowScheduleDropdown(!showScheduleDropdown)}
+                  onClick={() => {
+                    setPendingScheduleDateTime(getMinDatetime())
+                    setShowScheduleDropdown(!showScheduleDropdown)
+                  }}
                   disabled={saving || !newContent.trim()}
                   className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
                 >
@@ -352,15 +345,32 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
 
               {/* Schedule dropdown */}
               {showScheduleDropdown && (
-                <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-2 z-10">
-                  <button
-                    type="button"
-                    onClick={() => scheduleDateInputRef.current?.showPicker()}
-                    className="flex items-center gap-2 px-3 py-2 text-sm text-text-default hover:bg-surface-2 rounded-md w-full"
+                <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-3 z-10 min-w-[200px]">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Calendar className="h-4 w-4 text-text-muted" />
+                    <span className="text-sm font-medium text-text-default">Schedule</span>
+                  </div>
+                  <input
+                    type="datetime-local"
+                    value={pendingScheduleDateTime}
+                    onChange={(e) => setPendingScheduleDateTime(e.target.value)}
+                    min={getMinDatetime()}
+                    className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => {
+                      if (pendingScheduleDateTime) {
+                        setScheduleDateTime(pendingScheduleDateTime)
+                      }
+                      setShowScheduleDropdown(false)
+                    }}
+                    disabled={!pendingScheduleDateTime}
+                    className="w-full mt-2"
                   >
-                    <Calendar className="h-4 w-4" />
-                    <span>Schedule</span>
-                  </button>
+                    Done
+                  </Button>
                 </div>
               )}
             </div>
@@ -411,25 +421,15 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                       rows={3}
                       className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
                     />
-                    {/* Hidden datetime input */}
-                    <input
-                      ref={editScheduleDateInputRef}
-                      type="datetime-local"
-                      value={editScheduleDateTime}
-                      onChange={(e) => {
-                        setEditScheduleDateTime(e.target.value)
-                        if (e.target.value) setShowEditScheduleDropdown(false)
-                      }}
-                      min={getMinDatetime()}
-                      className="sr-only"
-                      tabIndex={-1}
-                    />
                     {/* Show scheduled date if set */}
                     {editScheduleDateTime && (
                       <div className="flex items-center gap-2 mt-2">
                         <button
                           type="button"
-                          onClick={() => editScheduleDateInputRef.current?.showPicker()}
+                          onClick={() => {
+                            setPendingEditScheduleDateTime(editScheduleDateTime)
+                            setShowEditScheduleDropdown(true)
+                          }}
                           className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
                         >
                           <Calendar className="h-4 w-4 flex-shrink-0" />
@@ -469,7 +469,10 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
                           <button
                             type="button"
                             onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => setShowEditScheduleDropdown(!showEditScheduleDropdown)}
+                            onClick={() => {
+                              setPendingEditScheduleDateTime(getMinDatetime())
+                              setShowEditScheduleDropdown(!showEditScheduleDropdown)
+                            }}
                             disabled={saving || !editContent.trim()}
                             className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
                           >
@@ -479,15 +482,32 @@ export function TeacherAnnouncementsSection({ classroom }: Props) {
 
                         {/* Schedule dropdown */}
                         {showEditScheduleDropdown && (
-                          <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-2 z-10">
-                            <button
-                              type="button"
-                              onClick={() => editScheduleDateInputRef.current?.showPicker()}
-                              className="flex items-center gap-2 px-3 py-2 text-sm text-text-default hover:bg-surface-2 rounded-md w-full"
+                          <div className="absolute right-0 top-full mt-1 bg-surface rounded-lg shadow-lg border border-border p-3 z-10 min-w-[200px]">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Calendar className="h-4 w-4 text-text-muted" />
+                              <span className="text-sm font-medium text-text-default">Schedule</span>
+                            </div>
+                            <input
+                              type="datetime-local"
+                              value={pendingEditScheduleDateTime}
+                              onChange={(e) => setPendingEditScheduleDateTime(e.target.value)}
+                              min={getMinDatetime()}
+                              className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            />
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              onClick={() => {
+                                if (pendingEditScheduleDateTime) {
+                                  setEditScheduleDateTime(pendingEditScheduleDateTime)
+                                }
+                                setShowEditScheduleDropdown(false)
+                              }}
+                              disabled={!pendingEditScheduleDateTime}
+                              className="w-full mt-2"
                             >
-                              <Calendar className="h-4 w-4" />
-                              <span>Schedule</span>
-                            </button>
+                              Done
+                            </Button>
                           </div>
                         )}
                       </div>

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -7,7 +7,7 @@ import { ChevronLeft, ChevronRight, PanelRight, PanelRightClose, CircleDot } fro
 import { LessonDayCell } from './LessonDayCell'
 import { useKeyboardShortcutHint } from '@/hooks/use-keyboard-shortcut-hint'
 import { Tooltip } from '@/ui'
-import type { ClassDay, LessonPlan, TiptapContent, Classroom, Assignment } from '@/types'
+import type { ClassDay, LessonPlan, TiptapContent, Classroom, Assignment, Announcement } from '@/types'
 
 const TIMEZONE = 'America/Toronto'
 
@@ -17,6 +17,7 @@ interface LessonCalendarProps {
   classroom: Classroom
   lessonPlans: LessonPlan[]
   assignments?: Assignment[]
+  announcements?: Announcement[]
   classDays?: ClassDay[]
   viewMode: CalendarViewMode
   currentDate: Date
@@ -27,6 +28,7 @@ interface LessonCalendarProps {
   onViewModeChange: (mode: CalendarViewMode) => void
   onContentChange?: (date: string, content: TiptapContent) => void
   onAssignmentClick?: (assignment: Assignment) => void
+  onAnnouncementClick?: () => void
   onMarkdownToggle?: () => void
   isSidebarOpen?: boolean
 }
@@ -68,6 +70,7 @@ export function LessonCalendar({
   classroom,
   lessonPlans,
   assignments = [],
+  announcements = [],
   classDays = [],
   viewMode,
   currentDate,
@@ -78,6 +81,7 @@ export function LessonCalendar({
   onViewModeChange,
   onContentChange,
   onAssignmentClick,
+  onAnnouncementClick,
   onMarkdownToggle,
   isSidebarOpen = false,
 }: LessonCalendarProps) {
@@ -110,6 +114,23 @@ export function LessonCalendar({
     })
     return map
   }, [assignments])
+
+  // Build a map of date -> announcements for quick lookup
+  const announcementsByDate = useMemo(() => {
+    const map = new Map<string, Announcement[]>()
+    announcements.forEach((announcement) => {
+      // Convert created_at to Toronto timezone before extracting date
+      const createdInToronto = toZonedTime(new Date(announcement.created_at), TIMEZONE)
+      const createdDate = format(createdInToronto, 'yyyy-MM-dd')
+      const existing = map.get(createdDate)
+      if (existing) {
+        existing.push(announcement)
+      } else {
+        map.set(createdDate, [announcement])
+      }
+    })
+    return map
+  }, [announcements])
 
   // Build a set of class day dates for quick lookup
   const classDayDates = useMemo(() => {
@@ -460,6 +481,7 @@ export function LessonCalendar({
                   day={day}
                   lessonPlan={lessonPlan}
                   assignments={assignmentsByDate.get(dateString) || []}
+                  announcements={announcementsByDate.get(dateString) || []}
                   isWeekend={isWeekendDay}
                   isToday={isToday}
                   isClassDay={isClassDay}
@@ -468,6 +490,7 @@ export function LessonCalendar({
                   plainTextOnly={viewMode === 'all'}
                   onContentChange={onContentChange}
                   onAssignmentClick={onAssignmentClick}
+                  onAnnouncementClick={onAnnouncementClick}
                 />
               </div>
             )

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -116,17 +116,21 @@ export function LessonCalendar({
   }, [assignments])
 
   // Build a map of date -> announcements for quick lookup
+  // Scheduled announcements appear on their scheduled_for date
+  // Published announcements appear on their created_at date
   const announcementsByDate = useMemo(() => {
     const map = new Map<string, Announcement[]>()
     announcements.forEach((announcement) => {
-      // Convert created_at to Toronto timezone before extracting date
-      const createdInToronto = toZonedTime(new Date(announcement.created_at), TIMEZONE)
-      const createdDate = format(createdInToronto, 'yyyy-MM-dd')
-      const existing = map.get(createdDate)
+      // Use scheduled_for date if scheduled, otherwise created_at
+      const isScheduled = announcement.scheduled_for && new Date(announcement.scheduled_for) > new Date()
+      const dateToUse = isScheduled ? announcement.scheduled_for! : announcement.created_at
+      const dateInToronto = toZonedTime(new Date(dateToUse), TIMEZONE)
+      const dateString = format(dateInToronto, 'yyyy-MM-dd')
+      const existing = map.get(dateString)
       if (existing) {
         existing.push(announcement)
       } else {
-        map.set(createdDate, [announcement])
+        map.set(dateString, [announcement])
       }
     })
     return map

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -192,7 +192,7 @@ export const LessonDayCell = memo(function LessonDayCell({
                     compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
                   } ${
                     scheduled
-                      ? 'bg-amber-500/40 text-amber-900 dark:text-amber-200 hover:bg-amber-500/60'
+                      ? 'bg-amber-500/40 text-amber-800 hover:bg-amber-500/60'
                       : 'bg-amber-500 text-white hover:bg-amber-600'
                   }`}
                 >

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -5,7 +5,7 @@ import { format } from 'date-fns'
 import { RichTextEditor } from '@/components/editor/RichTextEditor'
 import { extractTextFromTiptap } from '@/lib/lesson-plan-markdown'
 import { Tooltip } from '@/ui'
-import type { LessonPlan, TiptapContent, Assignment } from '@/types'
+import type { LessonPlan, TiptapContent, Assignment, Announcement } from '@/types'
 
 const EMPTY_CONTENT: TiptapContent = { type: 'doc', content: [] }
 
@@ -14,6 +14,7 @@ interface LessonDayCellProps {
   day: Date
   lessonPlan: LessonPlan | null
   assignments?: Assignment[]
+  announcements?: Announcement[]
   isWeekend: boolean
   isToday: boolean
   isClassDay?: boolean // undefined means class days not initialized
@@ -22,6 +23,7 @@ interface LessonDayCellProps {
   plainTextOnly?: boolean // Force plain text rendering (for 'all' view performance)
   onContentChange?: (date: string, content: TiptapContent) => void
   onAssignmentClick?: (assignment: Assignment) => void
+  onAnnouncementClick?: () => void
 }
 
 export const LessonDayCell = memo(function LessonDayCell({
@@ -29,6 +31,7 @@ export const LessonDayCell = memo(function LessonDayCell({
   day,
   lessonPlan,
   assignments = [],
+  announcements = [],
   isWeekend,
   isToday,
   isClassDay,
@@ -37,6 +40,7 @@ export const LessonDayCell = memo(function LessonDayCell({
   plainTextOnly = false,
   onContentChange,
   onAssignmentClick,
+  onAnnouncementClick,
 }: LessonDayCellProps) {
   const content = lessonPlan?.content || EMPTY_CONTENT
 
@@ -59,6 +63,7 @@ export const LessonDayCell = memo(function LessonDayCell({
   // Weekend cells are narrow and minimal
   if (isWeekend) {
     const assignmentTitles = assignments.map(a => a.title).join(', ')
+    const announcementCount = announcements.length
 
     return (
       <div
@@ -85,6 +90,21 @@ export const LessonDayCell = memo(function LessonDayCell({
                   }
                 }}
                 className={`w-full min-w-[12px] rounded bg-primary hover:bg-primary-hover cursor-pointer ${compact ? 'h-4' : 'h-6'}`}
+              />
+            </Tooltip>
+          </div>
+        )}
+        {/* Weekend announcement pill - no text, tooltip on hover */}
+        {announcementCount > 0 && (
+          <div className="px-0.5 mt-0.5 flex items-start justify-center">
+            <Tooltip content={`${announcementCount} announcement${announcementCount > 1 ? 's' : ''}`} side="right">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onAnnouncementClick?.()
+                }}
+                className={`w-full min-w-[12px] rounded bg-amber-500 hover:bg-amber-600 cursor-pointer ${compact ? 'h-4' : 'h-6'}`}
               />
             </Tooltip>
           </div>
@@ -135,6 +155,28 @@ export const LessonDayCell = memo(function LessonDayCell({
                 }`}
               >
                 {compact ? assignment.title : `Due: ${assignment.title}`}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+      )}
+
+      {/* Announcements - shown after assignments */}
+      {announcements.length > 0 && (
+        <div className={`min-w-0 ${compact ? 'px-0.5 space-y-0.5' : 'px-1 pb-1 space-y-1'}`}>
+          {announcements.map((announcement) => (
+            <Tooltip key={announcement.id} content={announcement.content.slice(0, 100) + (announcement.content.length > 100 ? '...' : '')}>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onAnnouncementClick?.()
+                }}
+                className={`w-full min-w-0 rounded bg-amber-500 text-white font-medium hover:bg-amber-600 text-center truncate ${
+                  compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
+                }`}
+              >
+                {compact ? 'Announcement' : 'Announcement'}
               </button>
             </Tooltip>
           ))}

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -9,6 +9,12 @@ import type { LessonPlan, TiptapContent, Assignment, Announcement } from '@/type
 
 const EMPTY_CONTENT: TiptapContent = { type: 'doc', content: [] }
 
+// Helper to check if announcement is scheduled (not yet published)
+function isScheduled(announcement: Announcement): boolean {
+  if (!announcement.scheduled_for) return false
+  return new Date(announcement.scheduled_for) > new Date()
+}
+
 interface LessonDayCellProps {
   date: string // YYYY-MM-DD
   day: Date
@@ -104,7 +110,11 @@ export const LessonDayCell = memo(function LessonDayCell({
                   e.stopPropagation()
                   onAnnouncementClick?.()
                 }}
-                className={`w-full min-w-[12px] rounded bg-amber-500 hover:bg-amber-600 cursor-pointer ${compact ? 'h-4' : 'h-6'}`}
+                className={`w-full min-w-[12px] rounded cursor-pointer ${compact ? 'h-4' : 'h-6'} ${
+                  announcements.some(isScheduled)
+                    ? 'bg-amber-500/40 hover:bg-amber-500/60'
+                    : 'bg-amber-500 hover:bg-amber-600'
+                }`}
               />
             </Tooltip>
           </div>
@@ -164,22 +174,33 @@ export const LessonDayCell = memo(function LessonDayCell({
       {/* Announcements - shown after assignments */}
       {announcements.length > 0 && (
         <div className={`min-w-0 ${compact ? 'px-0.5 space-y-0.5' : 'px-1 pb-1 space-y-1'}`}>
-          {announcements.map((announcement) => (
-            <Tooltip key={announcement.id} content={announcement.content.slice(0, 100) + (announcement.content.length > 100 ? '...' : '')}>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onAnnouncementClick?.()
-                }}
-                className={`w-full min-w-0 rounded bg-amber-500 text-white font-medium hover:bg-amber-600 text-center truncate ${
-                  compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
-                }`}
-              >
-                {compact ? 'Announcement' : 'Announcement'}
-              </button>
-            </Tooltip>
-          ))}
+          {announcements.map((announcement) => {
+            const scheduled = isScheduled(announcement)
+            const tooltipText = scheduled
+              ? `(Scheduled) ${announcement.content.slice(0, 80)}${announcement.content.length > 80 ? '...' : ''}`
+              : announcement.content.slice(0, 100) + (announcement.content.length > 100 ? '...' : '')
+
+            return (
+              <Tooltip key={announcement.id} content={tooltipText}>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onAnnouncementClick?.()
+                  }}
+                  className={`w-full min-w-0 rounded font-medium text-center truncate ${
+                    compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
+                  } ${
+                    scheduled
+                      ? 'bg-amber-500/40 text-amber-900 dark:text-amber-200 hover:bg-amber-500/60'
+                      : 'bg-amber-500 text-white hover:bg-amber-600'
+                  }`}
+                >
+                  {compact ? (scheduled ? 'Scheduled' : 'Announcement') : (scheduled ? 'Scheduled' : 'Announcement')}
+                </button>
+              </Tooltip>
+            )
+          })}
         </div>
       )}
 

--- a/src/components/StudentNotificationsProvider.tsx
+++ b/src/components/StudentNotificationsProvider.tsx
@@ -14,11 +14,13 @@ type NotificationState = {
   hasTodayEntry: boolean
   unviewedAssignmentsCount: number
   activeQuizzesCount: number
+  unreadAnnouncementsCount: number
   loading: boolean
   refresh: () => Promise<void>
   markTodayComplete: () => void
   decrementUnviewedCount: () => void
   clearActiveQuizzesCount: () => void
+  markAnnouncementsRead: () => void
 }
 
 const NotificationsContext = createContext<NotificationState | null>(null)
@@ -33,6 +35,7 @@ export function StudentNotificationsProvider({
   const [hasTodayEntry, setHasTodayEntry] = useState(true) // Assume complete to avoid flash
   const [unviewedAssignmentsCount, setUnviewedAssignmentsCount] = useState(0)
   const [activeQuizzesCount, setActiveQuizzesCount] = useState(0)
+  const [unreadAnnouncementsCount, setUnreadAnnouncementsCount] = useState(0)
   const [loading, setLoading] = useState(true)
 
   const fetchNotifications = useCallback(async () => {
@@ -46,6 +49,7 @@ export function StudentNotificationsProvider({
       setHasTodayEntry(data.hasTodayEntry)
       setUnviewedAssignmentsCount(data.unviewedAssignmentsCount)
       setActiveQuizzesCount(data.activeQuizzesCount ?? 0)
+      setUnreadAnnouncementsCount(data.unreadAnnouncementsCount ?? 0)
     } catch (error) {
       console.error('Error fetching notifications:', error)
     } finally {
@@ -83,18 +87,24 @@ export function StudentNotificationsProvider({
     setActiveQuizzesCount(0)
   }, [])
 
+  const markAnnouncementsRead = useCallback(() => {
+    setUnreadAnnouncementsCount(0)
+  }, [])
+
   const value = useMemo<NotificationState>(
     () => ({
       hasTodayEntry,
       unviewedAssignmentsCount,
       activeQuizzesCount,
+      unreadAnnouncementsCount,
       loading,
       refresh,
       markTodayComplete,
       decrementUnviewedCount,
       clearActiveQuizzesCount,
+      markAnnouncementsRead,
     }),
-    [hasTodayEntry, unviewedAssignmentsCount, activeQuizzesCount, loading, refresh, markTodayComplete, decrementUnviewedCount, clearActiveQuizzesCount]
+    [hasTodayEntry, unviewedAssignmentsCount, activeQuizzesCount, unreadAnnouncementsCount, loading, refresh, markTodayComplete, decrementUnviewedCount, clearActiveQuizzesCount, markAnnouncementsRead]
   )
 
   return (

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -119,6 +119,10 @@ export function NavItems({
     role === 'student' &&
     !notifications?.loading &&
     (notifications?.activeQuizzesCount ?? 0) > 0
+  const showResourcesPulse =
+    role === 'student' &&
+    !notifications?.loading &&
+    (notifications?.unreadAnnouncementsCount ?? 0) > 0
 
   const [assignments, setAssignments] = useState<SidebarAssignment[]>([])
   const [assignmentsExpanded, setAssignmentsExpanded] = useState(true)
@@ -446,7 +450,8 @@ export function NavItems({
         const shouldPulse =
           (item.id === 'today' && showTodayPulse) ||
           (item.id === 'assignments' && showAssignmentsPulse) ||
-          (item.id === 'quizzes' && showQuizzesPulse)
+          (item.id === 'quizzes' && showQuizzesPulse) ||
+          (item.id === 'resources' && showResourcesPulse)
 
         const navLink = (
           <Link

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -329,6 +329,7 @@ export interface Announcement {
   classroom_id: string
   content: string
   created_by: string
+  scheduled_for: string | null // NULL = published immediately, future timestamp = scheduled
   created_at: string
   updated_at: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -322,3 +322,14 @@ export interface QuizResultsAggregate {
   counts: number[] // count per option, same index
   total_responses: number
 }
+
+// Announcement types
+export interface Announcement {
+  id: string
+  classroom_id: string
+  title: string
+  content: string
+  created_by: string
+  created_at: string
+  updated_at: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -327,7 +327,6 @@ export interface QuizResultsAggregate {
 export interface Announcement {
   id: string
   classroom_id: string
-  title: string
   content: string
   created_by: string
   created_at: string

--- a/supabase/migrations/034_announcements.sql
+++ b/supabase/migrations/034_announcements.sql
@@ -4,6 +4,7 @@ CREATE TABLE announcements (
   classroom_id uuid NOT NULL REFERENCES classrooms(id) ON DELETE CASCADE,
   content text NOT NULL,
   created_by uuid NOT NULL REFERENCES users(id),
+  scheduled_for timestamptz, -- NULL = published immediately, future timestamp = scheduled
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );

--- a/supabase/migrations/034_announcements.sql
+++ b/supabase/migrations/034_announcements.sql
@@ -1,0 +1,39 @@
+-- announcements: stores announcement content
+CREATE TABLE announcements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  classroom_id uuid NOT NULL REFERENCES classrooms(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  content text NOT NULL,
+  created_by uuid NOT NULL REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_announcements_classroom ON announcements(classroom_id);
+CREATE INDEX idx_announcements_created ON announcements(classroom_id, created_at DESC);
+
+-- Auto-update updated_at on changes
+CREATE OR REPLACE FUNCTION update_announcements_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER announcements_updated_at_trigger
+  BEFORE UPDATE ON announcements
+  FOR EACH ROW
+  EXECUTE FUNCTION update_announcements_updated_at();
+
+-- announcement_reads: tracks which students have read announcements
+CREATE TABLE announcement_reads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  announcement_id uuid NOT NULL REFERENCES announcements(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  read_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(announcement_id, user_id)
+);
+
+CREATE INDEX idx_announcement_reads_user ON announcement_reads(user_id);
+CREATE INDEX idx_announcement_reads_announcement ON announcement_reads(announcement_id);

--- a/supabase/migrations/034_announcements.sql
+++ b/supabase/migrations/034_announcements.sql
@@ -11,6 +11,7 @@ CREATE TABLE announcements (
 
 CREATE INDEX idx_announcements_classroom ON announcements(classroom_id);
 CREATE INDEX idx_announcements_created ON announcements(classroom_id, created_at DESC);
+CREATE INDEX idx_announcements_scheduled ON announcements(classroom_id, scheduled_for);
 
 -- Auto-update updated_at on changes
 CREATE OR REPLACE FUNCTION update_announcements_updated_at()

--- a/supabase/migrations/034_announcements.sql
+++ b/supabase/migrations/034_announcements.sql
@@ -2,7 +2,6 @@
 CREATE TABLE announcements (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   classroom_id uuid NOT NULL REFERENCES classrooms(id) ON DELETE CASCADE,
-  title text NOT NULL,
   content text NOT NULL,
   created_by uuid NOT NULL REFERENCES users(id),
   created_at timestamptz NOT NULL DEFAULT now(),

--- a/tests/api/student/announcements.test.ts
+++ b/tests/api/student/announcements.test.ts
@@ -41,8 +41,8 @@ describe('GET /api/student/classrooms/[id]/announcements', () => {
 
   it('should return announcements sorted by created_at desc', async () => {
     const mockAnnouncements = [
-      { id: 'a-2', title: 'Second', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
-      { id: 'a-1', title: 'First', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
+      { id: 'a-2', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
+      { id: 'a-1', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
     ]
 
     const mockFrom = vi.fn(() => ({

--- a/tests/api/student/announcements.test.ts
+++ b/tests/api/student/announcements.test.ts
@@ -23,7 +23,9 @@ describe('GET /api/student/classrooms/[id]/announcements', () => {
     const mockFrom = vi.fn(() => ({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
-          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          or: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
         })),
       })),
     }))
@@ -48,7 +50,9 @@ describe('GET /api/student/classrooms/[id]/announcements', () => {
     const mockFrom = vi.fn(() => ({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
-          order: vi.fn().mockResolvedValue({ data: mockAnnouncements, error: null }),
+          or: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue({ data: mockAnnouncements, error: null }),
+          })),
         })),
       })),
     }))
@@ -100,7 +104,9 @@ describe('GET /api/student/classrooms/[id]/announcements', () => {
     const mockFrom = vi.fn(() => ({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
-          order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+          or: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+          })),
         })),
       })),
     }))
@@ -124,10 +130,12 @@ describe('POST /api/student/classrooms/[id]/announcements (mark all as read)', (
       if (table === 'announcements') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [{ id: 'a-1' }, { id: 'a-2' }],
-              error: null,
-            }),
+            eq: vi.fn(() => ({
+              or: vi.fn().mockResolvedValue({
+                data: [{ id: 'a-1' }, { id: 'a-2' }],
+                error: null,
+              }),
+            })),
           })),
         }
       }
@@ -156,10 +164,12 @@ describe('POST /api/student/classrooms/[id]/announcements (mark all as read)', (
       if (table === 'announcements') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
+            eq: vi.fn(() => ({
+              or: vi.fn().mockResolvedValue({
+                data: [],
+                error: null,
+              }),
+            })),
           })),
         }
       }
@@ -216,10 +226,12 @@ describe('POST /api/student/classrooms/[id]/announcements (mark all as read)', (
       if (table === 'announcements') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: null,
-              error: { message: 'DB error' },
-            }),
+            eq: vi.fn(() => ({
+              or: vi.fn().mockResolvedValue({
+                data: null,
+                error: { message: 'DB error' },
+              }),
+            })),
           })),
         }
       }
@@ -239,10 +251,12 @@ describe('POST /api/student/classrooms/[id]/announcements (mark all as read)', (
       if (table === 'announcements') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [{ id: 'a-1' }],
-              error: null,
-            }),
+            eq: vi.fn(() => ({
+              or: vi.fn().mockResolvedValue({
+                data: [{ id: 'a-1' }],
+                error: null,
+              }),
+            })),
           })),
         }
       }

--- a/tests/api/student/announcements.test.ts
+++ b/tests/api/student/announcements.test.ts
@@ -1,0 +1,264 @@
+/**
+ * API tests for GET/POST /api/student/classrooms/[id]/announcements
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET, POST } from '@/app/api/student/classrooms/[id]/announcements/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1' })) }))
+vi.mock('@/lib/server/classrooms', () => ({
+  assertStudentCanAccessClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/student/classrooms/[id]/announcements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return empty array when no announcements exist', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcements).toEqual([])
+  })
+
+  it('should return announcements sorted by created_at desc', async () => {
+    const mockAnnouncements = [
+      { id: 'a-2', title: 'Second', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
+      { id: 'a-1', title: 'First', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
+    ]
+
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: mockAnnouncements, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcements).toHaveLength(2)
+    expect(data.announcements[0].id).toBe('a-2')
+  })
+
+  it('should return 403 when student is not enrolled', async () => {
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Not enrolled in this classroom',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Not enrolled in this classroom')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})
+
+describe('POST /api/student/classrooms/[id]/announcements (mark all as read)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should mark all announcements as read', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'announcements') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ id: 'a-1' }, { id: 'a-2' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'announcement_reads') {
+        return {
+          upsert: vi.fn().mockResolvedValue({ error: null }),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.success).toBe(true)
+    expect(data.marked).toBe(2)
+  })
+
+  it('should return success with marked=0 when no announcements exist', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'announcements') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.success).toBe(true)
+    expect(data.marked).toBe(0)
+  })
+
+  it('should return 403 when student is not enrolled', async () => {
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Not enrolled in this classroom',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Not enrolled in this classroom')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 when fetching announcements fails', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'announcements') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'DB error' },
+            }),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+
+  it('should return 500 when upserting read records fails', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'announcements') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ id: 'a-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'announcement_reads') {
+        return {
+          upsert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/student/classrooms/c-1/announcements',
+      { method: 'POST' }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})

--- a/tests/api/student/notifications.test.ts
+++ b/tests/api/student/notifications.test.ts
@@ -43,7 +43,13 @@ function createTableMock(config: {
   assignment_docs?: { data: any; error: any }
   quizzes?: { data: any; error: any }
   quiz_responses?: { data: any; error: any }
+  announcements?: { data: any; error: any }
+  announcement_reads?: { data: any; error: any }
 }) {
+  // Default announcements to empty array if not specified
+  const announcementsConfig = config.announcements ?? { data: [], error: null }
+  const announcementReadsConfig = config.announcement_reads ?? { data: [], error: null }
+
   return vi.fn((table: string) => {
     if (table === 'class_days' && config.class_days) {
       return {
@@ -93,6 +99,23 @@ function createTableMock(config: {
           eq: vi.fn().mockReturnThis(),
           in: vi.fn().mockReturnThis(),
           then: vi.fn((resolve: any) => resolve(config.quiz_responses)),
+        })),
+      }
+    }
+    if (table === 'announcements') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          then: vi.fn((resolve: any) => resolve(announcementsConfig)),
+        })),
+      }
+    }
+    if (table === 'announcement_reads') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockReturnThis(),
+          then: vi.fn((resolve: any) => resolve(announcementReadsConfig)),
         })),
       }
     }

--- a/tests/api/student/notifications.test.ts
+++ b/tests/api/student/notifications.test.ts
@@ -106,6 +106,7 @@ function createTableMock(config: {
       return {
         select: vi.fn(() => ({
           eq: vi.fn().mockReturnThis(),
+          or: vi.fn().mockReturnThis(),
           then: vi.fn((resolve: any) => resolve(announcementsConfig)),
         })),
       }

--- a/tests/api/teacher/announcements-id.test.ts
+++ b/tests/api/teacher/announcements-id.test.ts
@@ -1,0 +1,331 @@
+/**
+ * API tests for PATCH/DELETE /api/teacher/classrooms/[id]/announcements/[announcementId]
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PATCH, DELETE } from '@/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+// Helper to create ownership check mock
+function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?: boolean } = {}) {
+  const { found = true, owned = true, archived = false } = opts
+
+  return vi.fn((table: string) => {
+    if (table === 'announcements') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: found ? {
+              id: 'a-1',
+              classroom_id: 'c-1',
+              title: 'Test',
+              content: 'Content',
+              classrooms: {
+                id: 'c-1',
+                teacher_id: owned ? 'teacher-1' : 'other-teacher',
+                archived_at: archived ? '2025-01-01T00:00:00Z' : null,
+              },
+            } : null,
+            error: found ? null : { code: 'PGRST116' },
+          }),
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'a-1', title: 'Updated', content: 'Updated Content' },
+                error: null,
+              }),
+            })),
+          })),
+        })),
+        delete: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      }
+    }
+    return { select: vi.fn() }
+  })
+}
+
+describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should update announcement successfully', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated Title', content: 'Updated Content' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcement).toBeDefined()
+  })
+
+  it('should update only title when content not provided', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated Title' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it('should update only content when title not provided', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ content: 'Updated Content' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it('should return 400 when no updates provided', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({}),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('No updates provided')
+  })
+
+  it('should return 400 when title is empty string', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: '   ' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Title cannot be empty')
+  })
+
+  it('should return 400 when content is empty string', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ content: '   ' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Content cannot be empty')
+  })
+
+  it('should return 404 when announcement not found', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ found: false })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-999',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-999' }),
+    })
+    expect(response.status).toBe(404)
+
+    const data = await response.json()
+    expect(data.error).toBe('Announcement not found')
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ owned: false })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('should return 403 when classroom is archived', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ archived: true })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Classroom is archived')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(401)
+  })
+})
+
+describe('DELETE /api/teacher/classrooms/[id]/announcements/[announcementId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should delete announcement successfully', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      { method: 'DELETE' }
+    )
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.success).toBe(true)
+  })
+
+  it('should return 404 when announcement not found', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ found: false })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-999',
+      { method: 'DELETE' }
+    )
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-999' }),
+    })
+    expect(response.status).toBe(404)
+
+    const data = await response.json()
+    expect(data.error).toBe('Announcement not found')
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ owned: false })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      { method: 'DELETE' }
+    )
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('should return 403 when classroom is archived', async () => {
+    ;(mockSupabaseClient.from as any) = mockOwnershipCheck({ archived: true })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      { method: 'DELETE' }
+    )
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Classroom is archived')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      { method: 'DELETE' }
+    )
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(401)
+  })
+})

--- a/tests/api/teacher/announcements-id.test.ts
+++ b/tests/api/teacher/announcements-id.test.ts
@@ -24,7 +24,6 @@ function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?:
             data: found ? {
               id: 'a-1',
               classroom_id: 'c-1',
-              title: 'Test',
               content: 'Content',
               classrooms: {
                 id: 'c-1',
@@ -39,7 +38,7 @@ function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?:
           eq: vi.fn(() => ({
             select: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({
-                data: { id: 'a-1', title: 'Updated', content: 'Updated Content' },
+                data: { id: 'a-1', content: 'Updated Content' },
                 error: null,
               }),
             })),
@@ -66,7 +65,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
       {
         method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated Title', content: 'Updated Content' }),
+        body: JSON.stringify({ content: 'Updated Content' }),
       }
     )
     const response = await PATCH(request, {
@@ -78,39 +77,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
     expect(data.announcement).toBeDefined()
   })
 
-  it('should update only title when content not provided', async () => {
-    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
-
-    const request = new NextRequest(
-      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
-      {
-        method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated Title' }),
-      }
-    )
-    const response = await PATCH(request, {
-      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
-    })
-    expect(response.status).toBe(200)
-  })
-
-  it('should update only content when title not provided', async () => {
-    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
-
-    const request = new NextRequest(
-      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
-      {
-        method: 'PATCH',
-        body: JSON.stringify({ content: 'Updated Content' }),
-      }
-    )
-    const response = await PATCH(request, {
-      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
-    })
-    expect(response.status).toBe(200)
-  })
-
-  it('should return 400 when no updates provided', async () => {
+  it('should return 400 when content is missing', async () => {
     ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
 
     const request = new NextRequest(
@@ -126,26 +93,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
     expect(response.status).toBe(400)
 
     const data = await response.json()
-    expect(data.error).toBe('No updates provided')
-  })
-
-  it('should return 400 when title is empty string', async () => {
-    ;(mockSupabaseClient.from as any) = mockOwnershipCheck()
-
-    const request = new NextRequest(
-      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
-      {
-        method: 'PATCH',
-        body: JSON.stringify({ title: '   ' }),
-      }
-    )
-    const response = await PATCH(request, {
-      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
-    })
-    expect(response.status).toBe(400)
-
-    const data = await response.json()
-    expect(data.error).toBe('Title cannot be empty')
+    expect(data.error).toBe('Content is required')
   })
 
   it('should return 400 when content is empty string', async () => {
@@ -164,7 +112,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
     expect(response.status).toBe(400)
 
     const data = await response.json()
-    expect(data.error).toBe('Content cannot be empty')
+    expect(data.error).toBe('Content is required')
   })
 
   it('should return 404 when announcement not found', async () => {
@@ -174,7 +122,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-999',
       {
         method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated' }),
+        body: JSON.stringify({ content: 'Updated' }),
       }
     )
     const response = await PATCH(request, {
@@ -193,7 +141,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
       {
         method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated' }),
+        body: JSON.stringify({ content: 'Updated' }),
       }
     )
     const response = await PATCH(request, {
@@ -212,7 +160,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
       {
         method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated' }),
+        body: JSON.stringify({ content: 'Updated' }),
       }
     )
     const response = await PATCH(request, {
@@ -234,7 +182,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
       {
         method: 'PATCH',
-        body: JSON.stringify({ title: 'Updated' }),
+        body: JSON.stringify({ content: 'Updated' }),
       }
     )
     const response = await PATCH(request, {

--- a/tests/api/teacher/announcements-id.test.ts
+++ b/tests/api/teacher/announcements-id.test.ts
@@ -112,7 +112,7 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
     expect(response.status).toBe(400)
 
     const data = await response.json()
-    expect(data.error).toBe('Content is required')
+    expect(data.error).toBe('Content cannot be empty')
   })
 
   it('should return 404 when announcement not found', async () => {

--- a/tests/api/teacher/announcements.test.ts
+++ b/tests/api/teacher/announcements.test.ts
@@ -1,0 +1,274 @@
+/**
+ * API tests for GET/POST /api/teacher/classrooms/[id]/announcements
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET, POST } from '@/app/api/teacher/classrooms/[id]/announcements/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherOwnsClassroom: vi.fn(async () => ({ ok: true })),
+  assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/teacher/classrooms/[id]/announcements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return empty array when no announcements exist', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcements).toEqual([])
+  })
+
+  it('should return announcements sorted by created_at desc', async () => {
+    const mockAnnouncements = [
+      { id: 'a-2', title: 'Second', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
+      { id: 'a-1', title: 'First', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
+    ]
+
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: mockAnnouncements, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcements).toHaveLength(2)
+    expect(data.announcements[0].id).toBe('a-2')
+  })
+
+  it('should return 403 when teacher does not own classroom', async () => {
+    const { assertTeacherOwnsClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherOwnsClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements'
+    )
+    const response = await GET(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})
+
+describe('POST /api/teacher/classrooms/[id]/announcements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should create announcement successfully', async () => {
+    const mockAnnouncement = {
+      id: 'a-1',
+      classroom_id: 'c-1',
+      title: 'Test Title',
+      content: 'Test Content',
+      created_by: 'teacher-1',
+      created_at: '2025-01-15T12:00:00Z',
+      updated_at: '2025-01-15T12:00:00Z',
+    }
+
+    const mockFrom = vi.fn(() => ({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: mockAnnouncement, error: null }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(201)
+
+    const data = await response.json()
+    expect(data.announcement.id).toBe('a-1')
+    expect(data.announcement.title).toBe('Test Title')
+  })
+
+  it('should return 400 when title is missing', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Title is required')
+  })
+
+  it('should return 400 when title is empty', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: '   ', content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Title is required')
+  })
+
+  it('should return 400 when content is missing', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Content is required')
+  })
+
+  it('should return 400 when content is empty', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title', content: '   ' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe('Content is required')
+  })
+
+  it('should return 403 when classroom is archived', async () => {
+    const { assertTeacherCanMutateClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherCanMutateClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(403)
+
+    const data = await response.json()
+    expect(data.error).toBe('Classroom is archived')
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const { requireRole } = await import('@/lib/auth')
+    const authError = new Error('Not authenticated')
+    authError.name = 'AuthenticationError'
+    ;(requireRole as any).mockRejectedValueOnce(authError)
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(401)
+  })
+
+  it('should return 500 on database error', async () => {
+    const mockFrom = vi.fn(() => ({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(500)
+  })
+})

--- a/tests/api/teacher/announcements.test.ts
+++ b/tests/api/teacher/announcements.test.ts
@@ -42,8 +42,8 @@ describe('GET /api/teacher/classrooms/[id]/announcements', () => {
 
   it('should return announcements sorted by created_at desc', async () => {
     const mockAnnouncements = [
-      { id: 'a-2', title: 'Second', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
-      { id: 'a-1', title: 'First', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
+      { id: 'a-2', content: 'Content 2', created_at: '2025-01-16T12:00:00Z' },
+      { id: 'a-1', content: 'Content 1', created_at: '2025-01-15T12:00:00Z' },
     ]
 
     const mockFrom = vi.fn(() => ({
@@ -121,7 +121,6 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
     const mockAnnouncement = {
       id: 'a-1',
       classroom_id: 'c-1',
-      title: 'Test Title',
       content: 'Test Content',
       created_by: 'teacher-1',
       created_at: '2025-01-15T12:00:00Z',
@@ -141,7 +140,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+        body: JSON.stringify({ content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -149,37 +148,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
 
     const data = await response.json()
     expect(data.announcement.id).toBe('a-1')
-    expect(data.announcement.title).toBe('Test Title')
-  })
-
-  it('should return 400 when title is missing', async () => {
-    const request = new NextRequest(
-      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
-      {
-        method: 'POST',
-        body: JSON.stringify({ content: 'Test Content' }),
-      }
-    )
-    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
-    expect(response.status).toBe(400)
-
-    const data = await response.json()
-    expect(data.error).toBe('Title is required')
-  })
-
-  it('should return 400 when title is empty', async () => {
-    const request = new NextRequest(
-      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
-      {
-        method: 'POST',
-        body: JSON.stringify({ title: '   ', content: 'Test Content' }),
-      }
-    )
-    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
-    expect(response.status).toBe(400)
-
-    const data = await response.json()
-    expect(data.error).toBe('Title is required')
+    expect(data.announcement.content).toBe('Test Content')
   })
 
   it('should return 400 when content is missing', async () => {
@@ -187,7 +156,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title' }),
+        body: JSON.stringify({}),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -202,7 +171,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title', content: '   ' }),
+        body: JSON.stringify({ content: '   ' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -224,7 +193,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+        body: JSON.stringify({ content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -244,7 +213,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+        body: JSON.stringify({ content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -265,7 +234,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: 'Test Title', content: 'Test Content' }),
+        body: JSON.stringify({ content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })


### PR DESCRIPTION
## Summary

- Add one-way announcement broadcast feature for teachers to share updates with students
- Teachers can create, edit, delete, and **schedule** announcements
- Students see announcements in a read-only list, automatically marked as read on view
- Resources tab now has sub-tabs: **Announcements** (default) | **Class Resources**
- Pulsing notification badge on Resources tab when students have unread announcements
- Announcements appear on calendar as clickable links (amber pills)

## Changes

**New files (6):**
- `supabase/migrations/034_announcements.sql` - Database tables for announcements and read tracking
- Teacher API routes for CRUD (`/api/teacher/classrooms/[id]/announcements/...`)
- Student API route for list + mark-as-read (`/api/student/classrooms/[id]/announcements`)
- `TeacherAnnouncementsSection.tsx` - Create/edit/delete/schedule UI
- `StudentAnnouncementsSection.tsx` - Read-only list with auto mark-as-read

**Modified files (7):**
- `src/types/index.ts` - Added `Announcement` type with `scheduled_for`
- `TeacherResourcesTab.tsx` / `StudentResourcesTab.tsx` - Added sub-tab navigation
- `StudentNotificationsProvider.tsx` - Track unread announcements count
- `NavItems.tsx` - Pulse Resources icon when unread
- `notifications/route.ts` - Return `unreadAnnouncementsCount`
- `LessonCalendar.tsx` / `LessonDayCell.tsx` - Display announcements on calendar

## Test plan

- [ ] Run migration on staging database
- [ ] Teacher: Create announcement → posts immediately
- [ ] Teacher: Schedule announcement for future → shows as "Scheduled for [date]"
- [ ] Teacher: Edit announcement → changes persist, `updated_at` updates
- [ ] Teacher: Delete announcement → confirmation dialog → removed
- [ ] Student: See pulsing badge on Resources tab when unread
- [ ] Student: Click Resources → Announcements section shows, pulse stops
- [ ] Student: Scheduled announcements NOT visible until publish time
- [ ] Student: Refresh → read state persists (no pulse)
- [ ] Calendar: Announcements appear as amber pills, click navigates to Resources
- [ ] Both: Switch to Class Resources → existing functionality works
- [ ] Edge: New classroom with no announcements → empty state shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)