### PR TITLE
fix: require entry content for attendance marking (#258)

### DIFF
--- a/src/lib/attendance.ts
+++ b/src/lib/attendance.ts
@@ -1,6 +1,13 @@
 import type { AttendanceStatus, ClassDay, Entry, AttendanceRecord } from '@/types'
 
 /**
+ * Checks if an entry has actual content (non-whitespace text)
+ */
+function entryHasContent(entry: Entry): boolean {
+  return entry.text.trim().length > 0
+}
+
+/**
  * Computes attendance status for a single student across all class days
  * Pure function - no side effects
  *
@@ -9,9 +16,9 @@ import type { AttendanceStatus, ClassDay, Entry, AttendanceRecord } from '@/type
  * @param today - Today's date in YYYY-MM-DD format (Toronto timezone)
  *
  * Status logic:
- * - present: entry exists for that class day
- * - absent: past class day with no entry
- * - pending: today or future class day with no entry yet
+ * - present: entry exists with content for that class day
+ * - absent: past class day with no entry or empty entry
+ * - pending: today or future class day with no entry or empty entry yet
  */
 export function computeAttendanceStatusForStudent(
   classDays: ClassDay[],
@@ -33,7 +40,7 @@ export function computeAttendanceStatusForStudent(
   actualClassDays.forEach(classDay => {
     const entry = entryMap.get(classDay.date)
 
-    if (entry) {
+    if (entry && entryHasContent(entry)) {
       result[classDay.date] = 'present'
     } else if (classDay.date >= today) {
       // Today or future: pending (student still has time to submit)

--- a/tests/unit/attendance.test.ts
+++ b/tests/unit/attendance.test.ts
@@ -150,6 +150,70 @@ describe('attendance utilities', () => {
       expect(result['2024-09-04']).toBeUndefined()
       expect(Object.keys(result)).not.toContain('2024-09-04')
     })
+
+    it('should return absent when entry exists but text is empty', () => {
+      const entries: Entry[] = [
+        {
+          id: '1',
+          student_id: 'student1',
+          course_code: 'GLD2O',
+          date: '2024-09-01',
+          text: '',
+          minutes_reported: 0,
+          mood: null,
+          created_at: '2024-09-01T20:00:00Z',
+          updated_at: '2024-09-01T20:00:00Z',
+          on_time: true,
+        },
+      ]
+
+      const result = computeAttendanceStatusForStudent(classDays, entries, pastToday)
+
+      expect(result['2024-09-01']).toBe('absent')
+    })
+
+    it('should return absent when entry exists but text is only whitespace', () => {
+      const entries: Entry[] = [
+        {
+          id: '1',
+          student_id: 'student1',
+          course_code: 'GLD2O',
+          date: '2024-09-01',
+          text: '   \n\t  ',
+          minutes_reported: 0,
+          mood: null,
+          created_at: '2024-09-01T20:00:00Z',
+          updated_at: '2024-09-01T20:00:00Z',
+          on_time: true,
+        },
+      ]
+
+      const result = computeAttendanceStatusForStudent(classDays, entries, pastToday)
+
+      expect(result['2024-09-01']).toBe('absent')
+    })
+
+    it('should return pending for today when entry exists but is empty', () => {
+      const today = '2024-09-02'
+      const entries: Entry[] = [
+        {
+          id: '1',
+          student_id: 'student1',
+          course_code: 'GLD2O',
+          date: '2024-09-02',
+          text: '',
+          minutes_reported: 0,
+          mood: null,
+          created_at: '2024-09-02T15:00:00Z',
+          updated_at: '2024-09-02T15:00:00Z',
+          on_time: true,
+        },
+      ]
+
+      const result = computeAttendanceStatusForStudent(classDays, entries, today)
+
+      expect(result['2024-09-02']).toBe('pending')
+    })
   })
 
   describe('computeAttendanceRecords', () => {


### PR DESCRIPTION
## Summary

- Students were being marked "present" when any `Entry` record existed, even with empty text
- Now attendance only counts entries with actual content (non-whitespace text)
- Empty entries (from autosave) are treated as absent/pending instead of present

Closes #258

## Changes

- Added `entryHasContent()` helper function to check for non-empty trimmed text
- Updated `computeAttendanceStatusForStudent` to require content for "present" status
- Added 3 new unit tests for empty/whitespace-only entry edge cases

## Test plan

- [x] Unit tests pass (`pnpm test tests/unit/attendance.test.ts`)
- [ ] Manual test: Student taps into Today but doesn't type anything → should show as pending/absent
- [ ] Manual test: Student types content → should show as present
- [ ] Manual test: Student types content then deletes it all → should revert to pending/absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)