### PR TITLE
fix: constrain modal dialogs to viewport with DialogPanel primitive

### DIFF
--- a/e2e/assignment-modal-viewport.spec.ts
+++ b/e2e/assignment-modal-viewport.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const TEACHER_STORAGE = '.auth/teacher.json'
+
+async function openAssignmentModal(page: Page) {
+  await page.goto('/classrooms')
+  const classroomCard = page.locator('[data-testid="classroom-card"]').first()
+  await expect(classroomCard).toBeVisible({ timeout: 15_000 })
+  await classroomCard.click()
+  await page.waitForURL('**/classrooms/**', { timeout: 15_000 })
+
+  // Navigate to Assignments tab
+  await page.getByRole('link', { name: 'Assignments' }).click()
+  await page.waitForLoadState('networkidle')
+
+  // Look for a "New Assignment" button or an existing assignment's edit button
+  // First try to click on an existing assignment row to edit
+  const assignmentRow = page.locator('[data-testid="assignment-row"]').first()
+  const hasAssignments = await assignmentRow.isVisible().catch(() => false)
+
+  if (hasAssignments) {
+    // Click the assignment row to open the edit modal
+    await assignmentRow.click()
+  } else {
+    // Click "New Assignment" to create one
+    const newButton = page.getByRole('button', { name: /new assignment/i })
+    await expect(newButton).toBeVisible({ timeout: 5_000 })
+    await newButton.click()
+  }
+
+  const modal = page.getByRole('dialog')
+  await expect(modal).toBeVisible({ timeout: 5000 })
+  return modal
+}
+
+test.describe('AssignmentModal viewport constraints', () => {
+  test.use({ storageState: TEACHER_STORAGE })
+
+  test('modal stays within viewport on small screen', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 500 })
+    const modal = await openAssignmentModal(page)
+
+    const viewport = page.viewportSize()!
+    const modalBox = await modal.boundingBox()
+
+    expect(modalBox).not.toBeNull()
+    if (modalBox) {
+      // Modal should not exceed 90% of viewport height
+      expect(modalBox.height).toBeLessThanOrEqual(viewport.height * 0.9)
+      // Modal should be fully within viewport
+      expect(modalBox.y + modalBox.height).toBeLessThanOrEqual(viewport.height)
+    }
+  })
+
+  test('modal content is scrollable on small viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 400 })
+    const modal = await openAssignmentModal(page)
+
+    // Scrollable content area should exist
+    const contentArea = modal.locator('.overflow-y-auto').first()
+    await expect(contentArea).toBeVisible()
+
+    // Submit button exists and can be scrolled to
+    const submitButton = modal.getByRole('button', { name: /done|save/i })
+    await expect(submitButton).toBeVisible()
+
+    // Scroll to the submit button and verify it becomes visible in viewport
+    await submitButton.scrollIntoViewIfNeeded()
+    await expect(submitButton).toBeInViewport()
+  })
+})

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback, type FormEvent } from 'react'
 import type { Assignment, ClassDay, TiptapContent } from '@/types'
 import { AssignmentForm } from '@/components/AssignmentForm'
-import { ConfirmDialog } from '@/ui'
+import { ConfirmDialog, DialogPanel } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
 import { format } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
@@ -453,20 +453,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
   }
 
-  if (!isOpen) return null
-
-  function handleBackdropClick(e: React.MouseEvent) {
-    if (e.target === e.currentTarget) {
-      void handleClose()
-    }
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Escape') {
-      void handleClose()
-    }
-  }
-
   // Determine if this is a draft (new or existing draft)
   const isDraft = !currentAssignment || currentAssignment.is_draft
 
@@ -480,18 +466,14 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         : 'Edit Assignment'
 
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-    >
-      <div
-        className="bg-surface rounded-lg shadow-xl border border-border w-[min(90vw,56rem)] p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="assignment-modal-title"
+    <>
+      <DialogPanel
+        isOpen={isOpen}
+        onClose={handleClose}
+        maxWidth="w-[min(90vw,56rem)]"
+        className="p-6"
       >
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between mb-4 flex-shrink-0">
           <h2 id="assignment-modal-title" className="text-xl font-bold text-text-default">
             {modalTitle}
           </h2>
@@ -508,38 +490,40 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           </span>
         </div>
 
-        <AssignmentForm
-          title={title}
-          instructions={instructions}
-          dueAt={dueAt}
-          classDays={classDays}
-          trackAuthenticity={trackAuthenticity}
-          onTitleChange={handleTitleChange}
-          onInstructionsChange={handleInstructionsChange}
-          onDueAtChange={handleDueAtChange}
-          onTrackAuthenticityChange={handleTrackAuthenticityChange}
-          onPrevDate={handlePrevDate}
-          onNextDate={handleNextDate}
-          onSubmit={handleSubmit}
-          submitLabel={saving ? 'Saving...' : saveStatus === 'saved' ? 'Done' : 'Save'}
-          disabled={saving || releasing || creating}
-          error={error}
-          titleInputRef={titleInputRef}
-          onBlur={flushAutosave}
-          extraAction={isDraft && !creating ? {
-            label: releasing ? 'Posting...' : (
-              <span className="inline-flex items-center gap-1.5">
-                Post
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-                </svg>
-              </span>
-            ),
-            onClick: () => setShowReleaseConfirm(true),
-            variant: 'success',
-          } : undefined}
-        />
-      </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <AssignmentForm
+            title={title}
+            instructions={instructions}
+            dueAt={dueAt}
+            classDays={classDays}
+            trackAuthenticity={trackAuthenticity}
+            onTitleChange={handleTitleChange}
+            onInstructionsChange={handleInstructionsChange}
+            onDueAtChange={handleDueAtChange}
+            onTrackAuthenticityChange={handleTrackAuthenticityChange}
+            onPrevDate={handlePrevDate}
+            onNextDate={handleNextDate}
+            onSubmit={handleSubmit}
+            submitLabel={saving ? 'Saving...' : saveStatus === 'saved' ? 'Done' : 'Save'}
+            disabled={saving || releasing || creating}
+            error={error}
+            titleInputRef={titleInputRef}
+            onBlur={flushAutosave}
+            extraAction={isDraft && !creating ? {
+              label: releasing ? 'Posting...' : (
+                <span className="inline-flex items-center gap-1.5">
+                  Post
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+                  </svg>
+                </span>
+              ),
+              onClick: () => setShowReleaseConfirm(true),
+              variant: 'success',
+            } : undefined}
+          />
+        </div>
+      </DialogPanel>
 
       <ConfirmDialog
         isOpen={showReleaseConfirm}
@@ -552,6 +536,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         onCancel={() => setShowReleaseConfirm(false)}
         onConfirm={handleRelease}
       />
-    </div>
+    </>
   )
 }

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -472,6 +472,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         onClose={handleClose}
         maxWidth="w-[min(90vw,56rem)]"
         className="p-6"
+        ariaLabelledBy="assignment-modal-title"
       >
         <div className="flex items-center justify-between mb-4 flex-shrink-0">
           <h2 id="assignment-modal-title" className="text-xl font-bold text-text-default">

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -134,8 +134,9 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
       onClose={handleClose}
       maxWidth="max-w-lg"
       className="p-6"
+      ariaLabelledBy="create-classroom-title"
     >
-      <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Create Classroom</h2>
+      <h2 id="create-classroom-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Create Classroom</h2>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
         {/* Progress Indicator */}
@@ -287,7 +288,7 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
       </div>
 
       {/* Navigation Buttons */}
-        <div className="flex gap-3 mt-6 flex-shrink-0">
+      <div className="flex gap-3 mt-6 flex-shrink-0">
           <Button
             type="button"
             variant="secondary"

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, FormEvent, useId } from 'react'
-import { Input, Button, FormField } from '@/ui'
+import { Input, Button, DialogPanel, FormField } from '@/ui'
 import { format } from 'date-fns'
 
 type WizardStep = 'name' | 'calendar'
@@ -126,15 +126,18 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
     onClose()
   }
 
-  if (!isOpen) return null
-
   const { semester1Year, semester2Year } = getSemesterYears()
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50">
-      <div className="bg-surface rounded-lg shadow-xl border border-border max-w-lg w-full p-6">
-        <h2 className="text-xl font-bold text-text-default mb-4">Create Classroom</h2>
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={handleClose}
+      maxWidth="max-w-lg"
+      className="p-6"
+    >
+      <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Create Classroom</h2>
 
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {/* Progress Indicator */}
         <div className="flex items-center mb-6">
           <div className={`flex-1 h-1 rounded ${step === 'name' ? 'bg-primary' : 'bg-info-bg'}`} />
@@ -281,9 +284,10 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
             {error}
           </div>
         )}
+      </div>
 
-        {/* Navigation Buttons */}
-        <div className="flex gap-3 mt-6">
+      {/* Navigation Buttons */}
+        <div className="flex gap-3 mt-6 flex-shrink-0">
           <Button
             type="button"
             variant="secondary"
@@ -312,7 +316,6 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
             {loading ? 'Creating...' : step === 'calendar' ? 'Create' : 'Next'}
           </Button>
         </div>
-      </div>
-    </div>
+    </DialogPanel>
   )
 }

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -289,34 +289,34 @@ export function CreateClassroomModal({ isOpen, onClose, onSuccess }: CreateClass
 
       {/* Navigation Buttons */}
       <div className="flex gap-3 mt-6 flex-shrink-0">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={step === 'name' ? handleClose : () => {
-              setStep('name')
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={step === 'name' ? handleClose : () => {
+            setStep('name')
+            setError('')
+          }}
+          disabled={loading}
+          className="flex-1"
+        >
+          {step === 'name' ? 'Cancel' : 'Back'}
+        </Button>
+        <Button
+          type="button"
+          onClick={() => {
+            if (step === 'name' && title) {
+              setStep('calendar')
               setError('')
-            }}
-            disabled={loading}
-            className="flex-1"
-          >
-            {step === 'name' ? 'Cancel' : 'Back'}
-          </Button>
-          <Button
-            type="button"
-            onClick={() => {
-              if (step === 'name' && title) {
-                setStep('calendar')
-                setError('')
-              } else if (step === 'calendar') {
-                handleCreate()
-              }
-            }}
-            disabled={loading || (step === 'name' && !title)}
-            className="flex-1"
-          >
-            {loading ? 'Creating...' : step === 'calendar' ? 'Create' : 'Next'}
-          </Button>
-        </div>
+            } else if (step === 'calendar') {
+              handleCreate()
+            }
+          }}
+          disabled={loading || (step === 'name' && !title)}
+          className="flex-1"
+        >
+          {loading ? 'Creating...' : step === 'calendar' ? 'Create' : 'Next'}
+        </Button>
+      </div>
     </DialogPanel>
   )
 }

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -90,6 +90,7 @@ export function QuizModal({ isOpen, classroomId, quiz, onClose, onSuccess }: Qui
       onClose={onClose}
       maxWidth="w-[min(90vw,28rem)]"
       className="p-6"
+      ariaLabelledBy="quiz-modal-title"
     >
       <h2 id="quiz-modal-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">
         {isEditMode ? 'Edit Quiz' : 'New Quiz'}

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -88,7 +88,7 @@ export function QuizModal({ isOpen, classroomId, quiz, onClose, onSuccess }: Qui
     <DialogPanel
       isOpen={isOpen}
       onClose={onClose}
-      maxWidth="w-[min(90vw,28rem)]"
+      maxWidth="max-w-xs"
       className="p-6"
       ariaLabelledBy="quiz-modal-title"
     >

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
-import { Button, FormField, Input } from '@/ui'
+import { Button, DialogPanel, FormField, Input } from '@/ui'
 import type { Quiz } from '@/types'
 
 interface QuizModalProps {
@@ -84,77 +84,57 @@ export function QuizModal({ isOpen, classroomId, quiz, onClose, onSuccess }: Qui
     }
   }
 
-  if (!isOpen) return null
-
-  function handleBackdropClick(e: React.MouseEvent) {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Escape') {
-      onClose()
-    }
-  }
-
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50"
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="w-[min(90vw,28rem)]"
+      className="p-6"
     >
-      <div
-        className="bg-surface rounded-lg shadow-xl border border-border w-[min(90vw,28rem)] p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="quiz-modal-title"
-      >
-        <h2 id="quiz-modal-title" className="text-xl font-bold text-text-default mb-4">
-          {isEditMode ? 'Edit Quiz' : 'New Quiz'}
-        </h2>
+      <h2 id="quiz-modal-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">
+        {isEditMode ? 'Edit Quiz' : 'New Quiz'}
+      </h2>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <FormField label="Title" error={error}>
-            <Input
-              ref={titleInputRef}
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Enter quiz title"
+      <form onSubmit={handleSubmit} className="space-y-4 flex-1 min-h-0 overflow-y-auto">
+        <FormField label="Title" error={error}>
+          <Input
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Enter quiz title"
+            disabled={saving}
+          />
+        </FormField>
+
+        {isEditMode && (
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showResults}
+              onChange={(e) => setShowResults(e.target.checked)}
               disabled={saving}
+              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
             />
-          </FormField>
+            <span className="text-sm text-text-default">Show results to students after responding</span>
+          </label>
+        )}
 
-          {isEditMode && (
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showResults}
-                onChange={(e) => setShowResults(e.target.checked)}
-                disabled={saving}
-                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              <span className="text-sm text-text-default">Show results to students after responding</span>
-            </label>
-          )}
-
-          <div className="flex gap-3 pt-2">
-            <Button
-              type="button"
-              variant="secondary"
-              className="flex-1"
-              onClick={onClose}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary" className="flex-1" disabled={saving}>
-              {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div className="flex gap-3 pt-2">
+          <Button
+            type="button"
+            variant="secondary"
+            className="flex-1"
+            onClick={onClose}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" className="flex-1" disabled={saving}>
+            {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
+          </Button>
+        </div>
+      </form>
+    </DialogPanel>
   )
 }

--- a/src/components/UploadRosterModal.tsx
+++ b/src/components/UploadRosterModal.tsx
@@ -147,8 +147,9 @@ export function UploadRosterModal({ isOpen, onClose, classroomId, onSuccess }: U
         onClose={handleCancelConfirmation}
         maxWidth="max-w-lg"
         className="p-6"
+        ariaLabelledBy="confirm-roster-title"
       >
-        <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Confirm Roster Update</h2>
+        <h2 id="confirm-roster-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Confirm Roster Update</h2>
 
         <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="mb-4 p-4 bg-warning-bg border border-warning rounded">
@@ -244,8 +245,9 @@ export function UploadRosterModal({ isOpen, onClose, classroomId, onSuccess }: U
       onClose={handleClose}
       maxWidth="max-w-lg"
       className="p-6"
+      ariaLabelledBy="upload-roster-title"
     >
-      <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Upload Roster</h2>
+      <h2 id="upload-roster-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Upload Roster</h2>
 
       {!result ? (
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">

--- a/src/components/UploadRosterModal.tsx
+++ b/src/components/UploadRosterModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, FormEvent, ChangeEvent, useId } from 'react'
-import { Button } from '@/ui'
+import { Button, DialogPanel } from '@/ui'
 
 interface StudentChange {
   email: string
@@ -139,15 +139,18 @@ export function UploadRosterModal({ isOpen, onClose, classroomId, onSuccess }: U
     onClose()
   }
 
-  if (!isOpen) return null
-
   // Confirmation screen - show when existing students would be overwritten
   if (confirmationData) {
     return (
-      <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50">
-        <div className="bg-surface rounded-lg shadow-xl border border-border max-w-lg w-full p-6">
-          <h2 className="text-xl font-bold text-text-default mb-4">Confirm Roster Update</h2>
+      <DialogPanel
+        isOpen={isOpen}
+        onClose={handleCancelConfirmation}
+        maxWidth="max-w-lg"
+        className="p-6"
+      >
+        <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Confirm Roster Update</h2>
 
+        <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="mb-4 p-4 bg-warning-bg border border-warning rounded">
             <p className="text-sm font-medium text-warning mb-2">
               {confirmationData.updateCount} student{confirmationData.updateCount !== 1 ? 's' : ''} will be updated
@@ -210,110 +213,115 @@ export function UploadRosterModal({ isOpen, onClose, classroomId, onSuccess }: U
               {error}
             </div>
           )}
+        </div>
 
-          <div className="flex gap-3">
+        <div className="flex gap-3 flex-shrink-0">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleCancelConfirmation}
+            disabled={loading}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirmUpload}
+            disabled={loading}
+            className="flex-1"
+          >
+            {loading ? 'Uploading...' : 'Confirm Update'}
+          </Button>
+        </div>
+      </DialogPanel>
+    )
+  }
+
+  return (
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={handleClose}
+      maxWidth="max-w-lg"
+      className="p-6"
+    >
+      <h2 className="text-xl font-bold text-text-default mb-4 flex-shrink-0">Upload Roster</h2>
+
+      {!result ? (
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
+          <div className="mb-4 space-y-3 flex-1 min-h-0 overflow-y-auto">
+            <label className="block text-sm font-medium text-text-muted">
+              CSV File Format
+            </label>
+            <div className="rounded-md border border-border bg-surface text-xs text-text-default overflow-hidden max-w-full">
+              <div className="grid grid-cols-[minmax(0,_1.2fr)_minmax(0,_1fr)_minmax(0,_1fr)_minmax(0,_1fr)_minmax(0,_1.2fr)] gap-0 text-center text-[10px] leading-tight">
+                {[
+                  { label: 'Student Number', optional: false },
+                  { label: 'First Name', optional: false },
+                  { label: 'Last Name', optional: false },
+                  { label: 'Email', optional: false },
+                  { label: 'Counselor Email', optional: true },
+                ].map(({ label, optional }, index, arr) => (
+                  <span
+                    key={label}
+                    className={`bg-surface-2 py-2 px-1 font-semibold ${
+                      index < arr.length - 1 ? 'border-r border-border' : ''
+                    } whitespace-nowrap`}
+                  >
+                    {label}
+                    {optional && <span className="text-text-muted font-normal"> (opt)</span>}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <label htmlFor={fileInputId} className="block text-sm font-medium text-text-muted mb-2">
+              Choose CSV file
+            </label>
+            <div className="rounded-lg border border-dashed border-border bg-surface-2 p-3">
+              <input
+                id={fileInputId}
+                type="file"
+                accept=".csv"
+                onChange={handleFileChange}
+                disabled={loading}
+                className="block w-full text-sm text-text-default
+                  file:mr-4 file:py-2 file:px-4
+                  file:rounded file:border-0
+                  file:text-sm file:font-medium
+                  file:bg-info-bg file:text-info
+                  hover:file:bg-info-bg
+                  disabled:opacity-50"
+              />
+            </div>
+            {error && (
+              <div className="text-sm text-danger">
+                {error}
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-3 flex-shrink-0">
             <Button
               type="button"
               variant="secondary"
-              onClick={handleCancelConfirmation}
+              onClick={handleClose}
               disabled={loading}
               className="flex-1"
             >
               Cancel
             </Button>
             <Button
-              type="button"
-              onClick={handleConfirmUpload}
-              disabled={loading}
+              type="submit"
+              disabled={loading || !csvFile}
               className="flex-1"
             >
-              {loading ? 'Uploading...' : 'Confirm Update'}
+              {loading ? 'Uploading...' : 'Upload'}
             </Button>
           </div>
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50">
-      <div className="bg-surface rounded-lg shadow-xl border border-border max-w-lg w-full p-6">
-        <h2 className="text-xl font-bold text-text-default mb-4">Upload Roster</h2>
-
-        {!result ? (
-          <form onSubmit={handleSubmit}>
-            <div className="mb-4 space-y-3">
-              <label className="block text-sm font-medium text-text-muted">
-                CSV File Format
-              </label>
-              <div className="rounded-md border border-border bg-surface text-xs text-text-default overflow-hidden max-w-full">
-                <div className="grid grid-cols-[minmax(0,_1.2fr)_minmax(0,_1fr)_minmax(0,_1fr)_minmax(0,_1fr)_minmax(0,_1.2fr)] gap-0 text-center text-[10px] leading-tight">
-                  {[
-                    { label: 'Student Number', optional: false },
-                    { label: 'First Name', optional: false },
-                    { label: 'Last Name', optional: false },
-                    { label: 'Email', optional: false },
-                    { label: 'Counselor Email', optional: true },
-                  ].map(({ label, optional }, index, arr) => (
-                    <span
-                      key={label}
-                      className={`bg-surface-2 py-2 px-1 font-semibold ${
-                        index < arr.length - 1 ? 'border-r border-border' : ''
-                      } whitespace-nowrap`}
-                    >
-                      {label}
-                      {optional && <span className="text-text-muted font-normal"> (opt)</span>}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <label htmlFor={fileInputId} className="block text-sm font-medium text-text-muted mb-2">
-                Choose CSV file
-              </label>
-              <div className="rounded-lg border border-dashed border-border bg-surface-2 p-3">
-                <input
-                  id={fileInputId}
-                  type="file"
-                  accept=".csv"
-                  onChange={handleFileChange}
-                  disabled={loading}
-                  className="block w-full text-sm text-text-default
-                    file:mr-4 file:py-2 file:px-4
-                    file:rounded file:border-0
-                    file:text-sm file:font-medium
-                    file:bg-info-bg file:text-info
-                    hover:file:bg-info-bg
-                    disabled:opacity-50"
-                />
-              </div>
-            </div>
-            {error && (
-              <div className="mb-4 text-sm text-danger">
-                {error}
-              </div>
-            )}
-
-            <div className="flex gap-3">
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={handleClose}
-                disabled={loading}
-                className="flex-1"
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={loading || !csvFile}
-                className="flex-1"
-              >
-                {loading ? 'Uploading...' : 'Upload'}
-              </Button>
-            </div>
-          </form>
-        ) : (
-          <div>
+        </form>
+      ) : (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="flex-1 min-h-0 overflow-y-auto">
             <div className="mb-4 p-4 bg-success-bg border border-success rounded">
               <p className="text-sm text-success">
                 Successfully processed {result.totalProcessed} students
@@ -338,13 +346,13 @@ export function UploadRosterModal({ isOpen, onClose, classroomId, onSuccess }: U
                 </ul>
               </div>
             )}
-
-            <Button onClick={handleClose} className="w-full">
-              Done
-            </Button>
           </div>
-        )}
-      </div>
-    </div>
+
+          <Button onClick={handleClose} className="w-full flex-shrink-0">
+            Done
+          </Button>
+        </div>
+      )}
+    </DialogPanel>
   )
 }

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -258,6 +258,75 @@ export function ConfirmDialog({
 }
 
 // ============================================================================
+// DialogPanel
+// ============================================================================
+
+export interface DialogPanelProps {
+  isOpen: boolean
+  onClose: () => void
+  maxWidth?: string
+  className?: string
+  children: ReactNode
+}
+
+/**
+ * DialogPanel is a lower-level primitive for building custom modal dialogs.
+ *
+ * Unlike ContentDialog, it provides no built-in header or footer structure —
+ * children control their own layout via flex utilities. Use this when you need
+ * full control over the dialog content (e.g., forms, wizards, multi-step flows).
+ *
+ * Features:
+ * - Backdrop click closes dialog
+ * - Escape key closes dialog
+ * - Viewport constraints (max-h-[85vh]) with flex layout for scrollable content
+ * - Consistent styling with other dialog components
+ *
+ * @example
+ * <DialogPanel isOpen={isOpen} onClose={handleClose} maxWidth="max-w-lg">
+ *   <div className="flex-shrink-0">Header content</div>
+ *   <div className="flex-1 min-h-0 overflow-y-auto">Scrollable content</div>
+ *   <div className="flex-shrink-0">Footer with buttons</div>
+ * </DialogPanel>
+ */
+export function DialogPanel({
+  isOpen,
+  onClose,
+  maxWidth = 'max-w-2xl',
+  className,
+  children,
+}: DialogPanelProps) {
+  useEffect(() => {
+    if (!isOpen) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        className={dialogBackdropStyles}
+        aria-label="Close dialog"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={`${dialogPanelStyles()} ${maxWidth} max-w-[90vw] max-h-[85vh] flex flex-col ${className ?? ''}`}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
 // ContentDialog
 // ============================================================================
 

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -266,6 +266,8 @@ export interface DialogPanelProps {
   onClose: () => void
   maxWidth?: string
   className?: string
+  /** ID of the element that labels the dialog (for accessibility) */
+  ariaLabelledBy?: string
   children: ReactNode
 }
 
@@ -283,8 +285,8 @@ export interface DialogPanelProps {
  * - Consistent styling with other dialog components
  *
  * @example
- * <DialogPanel isOpen={isOpen} onClose={handleClose} maxWidth="max-w-lg">
- *   <div className="flex-shrink-0">Header content</div>
+ * <DialogPanel isOpen={isOpen} onClose={handleClose} maxWidth="max-w-lg" ariaLabelledBy="modal-title">
+ *   <h2 id="modal-title" className="flex-shrink-0">Header content</h2>
  *   <div className="flex-1 min-h-0 overflow-y-auto">Scrollable content</div>
  *   <div className="flex-shrink-0">Footer with buttons</div>
  * </DialogPanel>
@@ -294,6 +296,7 @@ export function DialogPanel({
   onClose,
   maxWidth = 'max-w-2xl',
   className,
+  ariaLabelledBy,
   children,
 }: DialogPanelProps) {
   useEffect(() => {
@@ -318,6 +321,7 @@ export function DialogPanel({
       <div
         role="dialog"
         aria-modal="true"
+        aria-labelledby={ariaLabelledBy}
         className={`${dialogPanelStyles()} ${maxWidth} max-w-[90vw] max-h-[85vh] flex flex-col ${className ?? ''}`}
       >
         {children}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -13,7 +13,7 @@ export { Button, type ButtonProps } from './Button'
 export { Input, type InputProps } from './Input'
 export { Select, type SelectProps, type SelectOption } from './Select'
 export { FormField, type FormFieldProps } from './FormField'
-export { AlertDialog, ConfirmDialog, ContentDialog, type AlertDialogProps, type AlertDialogState, type AlertDialogVariant, type ConfirmDialogProps, type ContentDialogProps } from './Dialog'
+export { AlertDialog, ConfirmDialog, ContentDialog, DialogPanel, type AlertDialogProps, type AlertDialogState, type AlertDialogVariant, type ConfirmDialogProps, type ContentDialogProps, type DialogPanelProps } from './Dialog'
 export { Card, type CardProps } from './Card'
 export { Tooltip, TooltipProvider, type TooltipProps } from './Tooltip'
 


### PR DESCRIPTION
## Summary
- Create `DialogPanel` primitive component for standardized modal viewport constraints
- Refactor 4 modals to use the new primitive, fixing viewport overflow issues
- Add E2E tests verifying modal stays within viewport

Fixes #280

## Changes
| File | Change |
|------|--------|
| `src/ui/Dialog.tsx` | Add `DialogPanel` component with `max-h-[85vh]`, flex layout |
| `src/ui/index.ts` | Export `DialogPanel` and `DialogPanelProps` |
| `src/components/AssignmentModal.tsx` | Refactor to use `DialogPanel` |
| `src/components/QuizModal.tsx` | Refactor to use `DialogPanel` |
| `src/components/CreateClassroomModal.tsx` | Refactor to use `DialogPanel` (also adds missing Escape-to-close) |
| `src/components/UploadRosterModal.tsx` | Refactor both panels to use `DialogPanel` |
| `e2e/assignment-modal-viewport.spec.ts` | New E2E tests for viewport constraints |

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (1003 tests)
- [x] E2E tests pass for modal viewport constraints
- [ ] Manual verification: open each modal, resize viewport to 1024x500, verify modal stays within viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)