### PR TITLE
feat: pika CLI v2 - auto-create worktrees from issue numbers

### DIFF
--- a/scripts/pika
+++ b/scripts/pika
@@ -645,9 +645,8 @@ prompt_for_worktree() {
             MENU_HEADER_LINES=("Choose one or (n)ew worktree:")
         fi
 
-        MENU_LABELS+=("n) New worktree")
-        MENU_VALUES+=("__new__")
-        MENU_HOTKEYS+=("n")
+        MENU_GLOBAL_KEYS+=("n")
+        MENU_GLOBAL_VALUES+=("__new__")
 
         if (( total > 0 && (page + 1) * WORKTREE_PAGE_SIZE < total )); then
             MENU_LABELS+=("m) More")


### PR DESCRIPTION
## Summary

- `pika claude 280` auto-creates worktree `280-slug-from-title` from main and launches Claude directly in it
- `pika codex 280` same behavior for Codex
- Escape key quits menus instead of 'q'
- Runs `git worktree prune` before showing interactive menu
- AI tool now runs from inside the worktree directory (prevents context drift back to hub)

## Test plan

- [ ] Run `pika claude <issue#>` with a new issue number - should create worktree and launch Claude
- [ ] Run `pika claude <issue#>` with existing worktree - should cd into it and launch Claude
- [ ] Run `pika claude` with no args - should show interactive menu
- [ ] Press escape in menu - should quit
- [ ] Verify `pwd` inside Claude session matches the worktree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)