### PR TITLE
fix: replace dark: classes with semantic tokens in warning banner

### DIFF
--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -734,7 +734,7 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
           </div>
         )}
         {warning && (
-          <div className="rounded-md border border-yellow-400 bg-yellow-50 px-3 py-2 text-sm text-yellow-700 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-600">
+          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
             {warning}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Replaces `dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-600` with semantic tokens `border-warning bg-warning-bg text-warning` in the batch action warning banner
- Fixes the "No dark: Classes in App Code" CI check that failed on PR #289

## Test plan
- [ ] Warning banner displays correctly in light mode
- [ ] Warning banner displays correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)