### PR TITLE
fix: improve assignment submission status icons

### DIFF
--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -150,18 +150,18 @@ function StatusIcon({ status, wasLate }: { status: AssignmentStatus; wasLate?: b
     case 'not_started':
     case 'in_progress':
     case 'in_progress_late':
-      icon = <Circle className={showLate ? `${STATUS_ICON_CLASS} ${colorClass}` : cls} />
+      icon = <Circle className={cls} />
       break
     case 'submitted_on_time':
     case 'submitted_late':
     case 'graded':
-      icon = <Check className={showLate ? `${STATUS_ICON_CLASS} ${colorClass}` : cls} />
+      icon = <Check className={cls} />
       break
     case 'returned':
-      icon = <Send className={showLate ? `${STATUS_ICON_CLASS} ${colorClass}` : cls} />
+      icon = <Send className={cls} />
       break
     case 'resubmitted':
-      icon = <RotateCcw className={showLate ? `${STATUS_ICON_CLASS} ${colorClass}` : cls} />
+      icon = <RotateCcw className={cls} />
       break
     default:
       icon = <Circle className={cls} />
@@ -465,6 +465,7 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
   }, [selectedAssignmentData, sortColumn, sortDirection])
 
   const studentRowIds = useMemo(() => sortedStudents.map((s) => s.student_id), [sortedStudents])
+  const dueAtMs = useMemo(() => selectedAssignmentData ? new Date(selectedAssignmentData.assignment.due_at).getTime() : 0, [selectedAssignmentData])
   const {
     selectedIds: batchSelectedIds,
     toggleSelect: batchToggleSelect,
@@ -855,9 +856,7 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
                   </DataTableRow>
                 </DataTableHead>
                 <DataTableBody>
-                  {(() => {
-                    const dueAtMs = selectedAssignmentData ? new Date(selectedAssignmentData.assignment.due_at).getTime() : 0
-                    return sortedStudents.map((student) => {
+                  {sortedStudents.map((student) => {
                     const isSelected = selectedStudentId === student.student_id
                     const totalScore =
                       student.doc?.score_completion != null &&
@@ -904,7 +903,7 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
                       </DataTableCell>
                       <DataTableCell>
                         <Tooltip content={getAssignmentStatusLabel(student.status)}>
-                          <span className="inline-flex" aria-label={getAssignmentStatusLabel(student.status)}>
+                          <span className="inline-flex" role="img" aria-label={getAssignmentStatusLabel(student.status)}>
                             <StatusIcon
                               status={student.status}
                               wasLate={wasLate}
@@ -922,8 +921,7 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
                       )}
                     </DataTableRow>
                     )
-                  })
-                  })()}
+                  })}
                   {sortedStudents.length === 0 && (
                     <EmptyStateRow colSpan={isCompactTable ? 5 : 6} message="No students enrolled" />
                   )}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -18,9 +18,8 @@ import {
 } from '@dnd-kit/sortable'
 import {
   Check,
-  CheckCircle,
   Circle,
-  ClockAlert,
+  Clock,
   Pencil,
   Plus,
   RotateCcw,
@@ -133,26 +132,28 @@ function getRowClassName(isSelected: boolean): string {
 
 const STATUS_ICON_CLASS = 'h-4 w-4'
 
-function StatusIcon({ status }: { status: AssignmentStatus }) {
+function StatusIcon({ status, wasLate }: { status: AssignmentStatus; wasLate?: boolean }) {
   const colorClass = getAssignmentStatusIconClass(status)
   const cls = `${STATUS_ICON_CLASS} ${colorClass}`
+  const late = wasLate ? <Clock className="h-3 w-3" /> : null
+
   switch (status) {
     case 'not_started':
       return <Circle className={cls} />
     case 'in_progress':
-      return <Pencil className={cls} />
+      return <Circle className={cls} />
     case 'in_progress_late':
-      return <ClockAlert className={cls} />
+      return <span className={`inline-flex items-center gap-0.5 ${colorClass}`}><Circle className={STATUS_ICON_CLASS} /><Clock className="h-3 w-3" /></span>
     case 'submitted_on_time':
-      return <CheckCircle className={cls} />
-    case 'submitted_late':
-      return <ClockAlert className={cls} />
-    case 'graded':
       return <Check className={cls} />
+    case 'submitted_late':
+      return <span className={`inline-flex items-center gap-0.5 ${colorClass}`}><Check className={STATUS_ICON_CLASS} /><Clock className="h-3 w-3" /></span>
+    case 'graded':
+      return late ? <span className={`inline-flex items-center gap-0.5 ${colorClass}`}><Check className={STATUS_ICON_CLASS} />{late}</span> : <Check className={cls} />
     case 'returned':
-      return <Send className={cls} />
+      return late ? <span className={`inline-flex items-center gap-0.5 ${colorClass}`}><Send className={STATUS_ICON_CLASS} />{late}</span> : <Send className={cls} />
     case 'resubmitted':
-      return <RotateCcw className={cls} />
+      return late ? <span className={`inline-flex items-center gap-0.5 ${colorClass}`}><RotateCcw className={STATUS_ICON_CLASS} />{late}</span> : <RotateCcw className={cls} />
     default:
       return <Circle className={cls} />
   }
@@ -887,7 +888,10 @@ export function TeacherClassroomView({ classroom, onSelectAssignment, onSelectSt
                       <DataTableCell>
                         <Tooltip content={getAssignmentStatusLabel(student.status)}>
                           <span className="inline-flex">
-                            <StatusIcon status={student.status} />
+                            <StatusIcon
+                              status={student.status}
+                              wasLate={!!(student.doc?.submitted_at && selectedAssignmentData && new Date(student.doc.submitted_at) > new Date(selectedAssignmentData.assignment.due_at))}
+                            />
                           </span>
                         </Tooltip>
                       </DataTableCell>

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -127,7 +127,7 @@ export function getAssignmentStatusIconClass(status: AssignmentStatus): string {
     case 'submitted_on_time':
       return 'text-green-500'
     case 'submitted_late':
-      return 'text-lime-600'
+      return 'text-green-500'
     case 'graded':
       return 'text-purple-500'
     case 'returned':

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './src/ui/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/lib/**/*.{js,ts}',
   ],
   theme: {
     extend: {

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -440,8 +440,8 @@ describe('assignment utilities', () => {
       expect(getAssignmentStatusIconClass('submitted_on_time')).toBe('text-green-500')
     })
 
-    it('should return lime for submitted_late', () => {
-      expect(getAssignmentStatusIconClass('submitted_late')).toBe('text-lime-600')
+    it('should return green for submitted_late', () => {
+      expect(getAssignmentStatusIconClass('submitted_late')).toBe('text-green-500')
     })
 
     it('should return purple for graded', () => {


### PR DESCRIPTION
## Summary
- Fix status icon colors not rendering by adding `src/lib/` to Tailwind content paths
- Simplify icon set: circle for in-progress, check for submitted, send for returned, rotate for resubmitted
- Late indicator: small clock icon appears next to the base icon for any late submission
- Late clock persists through graded/returned/resubmitted statuses (computed from `submitted_at` vs `due_at`)
- Unify submitted color to green for both on-time and late (was lime for late)

## Test plan
- [x] Unit tests updated and passing (73/73)
- [ ] Verify colored icons render correctly in teacher assignment detail view
- [ ] Verify late clock icon appears for late submissions in all downstream statuses
- [ ] Verify on-time submissions show clean icons without clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)