### PR TITLE
fix: eliminate redundant API calls across student and teacher views

### DIFF
--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -81,19 +81,13 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     setActiveClassrooms(initialClassrooms)
   }, [initialClassrooms])
 
-  // Refetch when navigating back to this page
+  // Refetch when navigating back to this page (not on initial mount — server data is fresh)
   useEffect(() => {
-    // Only refetch if we navigated back (pathname changed from something else to /classrooms)
     if (pathname === '/classrooms' && lastPathRef.current !== '/classrooms') {
       refreshActiveClassrooms()
     }
     lastPathRef.current = pathname
   }, [pathname, refreshActiveClassrooms])
-
-  // Also fetch on initial mount
-  useEffect(() => {
-    refreshActiveClassrooms()
-  }, [refreshActiveClassrooms])
 
   useEffect(() => {
     if (view !== 'archived') return

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -164,6 +164,7 @@ function ClassroomPageContent({
   const prevSidebarOpenRef = useRef(false)
   const prevViewModeRef = useRef<AssignmentViewMode>('summary')
   const abortControllerRef = useRef<AbortController | null>(null)
+  const markdownStaleRef = useRef(true) // Start stale so first open loads
 
   const handleSelectEntry = useCallback((_entry: Entry | null, studentName: string, studentId: string | null) => {
     setSelectedStudentName(studentName)
@@ -216,6 +217,7 @@ function ClassroomPageContent({
       setHasRichContent(result.hasRichContent)
       setIsMarkdownMode(true)
       setRightSidebarWidth('50%')
+      markdownStaleRef.current = false
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         return
@@ -239,7 +241,7 @@ function ClassroomPageContent({
     const sidebarJustOpened = isRightSidebarOpen && !wasOpen
     const returnedToSummary = assignmentViewMode === 'summary' && wasViewMode === 'assignment'
 
-    if (assignmentViewMode === 'summary' && (sidebarJustOpened || (returnedToSummary && isRightSidebarOpen))) {
+    if (assignmentViewMode === 'summary' && (sidebarJustOpened || (returnedToSummary && isRightSidebarOpen)) && markdownStaleRef.current) {
       loadAssignmentsMarkdown()
     } else if (!isRightSidebarOpen && wasOpen) {
       setIsMarkdownMode(false)
@@ -251,6 +253,7 @@ function ClassroomPageContent({
     if (!isTeacher || activeTab !== 'assignments' || !isMarkdownMode) return
 
     const handleAssignmentsUpdated = () => {
+      markdownStaleRef.current = true
       loadAssignmentsMarkdown()
     }
 

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -75,7 +75,6 @@ export function TeacherQuizzesTab({ classroom, onSelectQuiz }: Props) {
 
   function handleQuizCreated() {
     setShowModal(false)
-    loadQuizzes()
     window.dispatchEvent(
       new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
     )
@@ -93,7 +92,6 @@ export function TeacherQuizzesTab({ classroom, onSelectQuiz }: Props) {
       if (selectedQuizId === deleteQuiz.quiz.id) {
         setSelectedQuizId(null)
       }
-      loadQuizzes()
       window.dispatchEvent(
         new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
       )

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useMemo, useState, useId } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { Info } from 'lucide-react'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
 import { PageContent, PageLayout } from '@/components/PageLayout'
@@ -24,7 +24,6 @@ interface Props {
 }
 
 export function TeacherSettingsTab({ classroom }: Props) {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const sectionParam = searchParams.get('section')
   const section: SettingsSection = sectionParam === 'class-days' ? 'class-days' : 'general'
@@ -99,7 +98,6 @@ export function TeacherSettingsTab({ classroom }: Props) {
       setTitle(data.classroom?.title || trimmed)
       setTitleSuccess('Course name updated.')
       setTimeout(() => setTitleSuccess(''), 2000)
-      router.refresh()
     } catch (err: any) {
       setTitleError(err.message || 'Failed to update course name')
     } finally {

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { StudentLessonCalendarTab } from '@/app/classrooms/[classroomId]/StudentLessonCalendarTab'
+import { createMockClassroom } from '../helpers/mocks'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useClassDays', () => ({
+  useClassDays: () => [],
+}))
+
+vi.mock('@/lib/cookies', () => ({
+  readCookie: () => 'week',
+  writeCookie: vi.fn(),
+}))
+
+vi.mock('@/components/LessonCalendar', () => ({
+  LessonCalendar: () => <div data-testid="lesson-calendar" />,
+  CalendarViewMode: {},
+}))
+
+describe('StudentLessonCalendarTab', () => {
+  const classroom = createMockClassroom({
+    start_date: '2025-01-01',
+    end_date: '2025-06-30',
+  })
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('fires all 3 API calls in parallel via Promise.all (#306)', async () => {
+    // Track the order calls were initiated
+    const callOrder: string[] = []
+    let resolveAll: (() => void)[] = []
+
+    fetchMock.mockImplementation((url: string) => {
+      callOrder.push(url)
+      return new Promise((resolve) => {
+        resolveAll.push(() =>
+          resolve({
+            ok: true,
+            json: async () => {
+              if (url.includes('lesson-plans')) return { lesson_plans: [] }
+              if (url.includes('assignments')) return { assignments: [] }
+              if (url.includes('announcements')) return { announcements: [] }
+              return {}
+            },
+          })
+        )
+      })
+    })
+
+    render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    // All 3 fetches should be initiated before any resolve
+    await waitFor(() => {
+      expect(callOrder).toHaveLength(3)
+    })
+
+    expect(callOrder.some((u) => u.includes('lesson-plans'))).toBe(true)
+    expect(callOrder.some((u) => u.includes('assignments'))).toBe(true)
+    expect(callOrder.some((u) => u.includes('announcements'))).toBe(true)
+
+    // Resolve all
+    resolveAll.forEach((r) => r())
+  })
+
+  it('fires exactly 3 fetch calls total (not 3 separate useEffects)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ lesson_plans: [], assignments: [], announcements: [] }),
+    })
+
+    render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+
+    // Wait a tick — no additional calls should fire
+    await new Promise((r) => setTimeout(r, 50))
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/components/StudentNotificationsProvider.test.tsx
+++ b/tests/components/StudentNotificationsProvider.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
+
+function notificationFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]: [string]) => typeof url === 'string' && url.includes('/api/student/notifications')
+  )
+}
+
+describe('StudentNotificationsProvider', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  function mockNotificationsResponse() {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hasTodayEntry: true,
+        unviewedAssignmentsCount: 0,
+        activeQuizzesCount: 0,
+        unreadAnnouncementsCount: 0,
+      }),
+    })
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('fetches notifications once on mount', async () => {
+    mockNotificationsResponse()
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <div />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+    })
+  })
+
+  it('fetches on first focus event after mount', async () => {
+    mockNotificationsResponse()
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <div />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    // Wait for cooldown from mount fetch to expire
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 31_000)
+    mockNotificationsResponse()
+
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(2)
+    })
+  })
+
+  it('does not refetch on rapid focus events within cooldown (#303)', async () => {
+    mockNotificationsResponse()
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <div />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    // Focus immediately (within 30s cooldown) — should be skipped
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+
+    // Focus again — still within cooldown
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+  })
+})

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -17,6 +17,16 @@ vi.mock('@/ui', async (importOriginal) => {
   }
 })
 
+vi.mock('@/hooks/useClassDays', () => ({
+  useClassDaysContext: () => ({
+    classDays: [
+      { id: 'd1', classroom_id: 'c1', date: '2025-12-16', prompt_text: null, is_class_day: true },
+    ],
+    isLoading: false,
+    refresh: vi.fn(),
+  }),
+}))
+
 const classroom: Classroom = {
   id: 'c1',
   teacher_id: 't1',
@@ -81,19 +91,6 @@ describe('StudentTodayTab history section', () => {
   it('toggles history without refetching', async () => {
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
-      if (url.startsWith(`/api/classrooms/${classroom.id}/class-days`)) {
-        return mockJson({
-          class_days: [
-            {
-              id: 'd1',
-              classroom_id: classroom.id,
-              date: '2025-12-16',
-              prompt_text: null,
-              is_class_day: true,
-            },
-          ],
-        })
-      }
       if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
         return mockJson({ entries })
       }
@@ -126,9 +123,6 @@ describe('StudentTodayTab history section', () => {
   it('persists toggle state via cookie', async () => {
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
-      if (url.startsWith(`/api/classrooms/${classroom.id}/class-days`)) {
-        return mockJson({ class_days: [{ id: 'd1', classroom_id: classroom.id, date: '2025-12-16', prompt_text: null, is_class_day: true }] })
-      }
       if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
         return mockJson({ entries })
       }
@@ -160,9 +154,6 @@ describe('StudentTodayTab history section', () => {
 
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
-      if (url.startsWith(`/api/classrooms/${classroom.id}/class-days`)) {
-        return mockJson({ class_days: [{ id: 'd1', classroom_id: classroom.id, date: '2025-12-16', prompt_text: null, is_class_day: true }] })
-      }
       if (url.startsWith(`/api/student/entries?`)) {
         return mockJson({ entries })
       }

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { TeacherClassroomsIndex } from '@/app/classrooms/TeacherClassroomsIndex'
+import { createMockClassroom } from '../helpers/mocks'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/classrooms',
+}))
+
+describe('TeacherClassroomsIndex', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('does not refetch classrooms on initial mount (#302)', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+
+    // Show the server-provided data
+    expect(await waitFor(() => document.querySelector('[data-testid="classroom-card"]'))).toBeTruthy()
+
+    // Wait a tick — no fetch should have fired
+    await new Promise((r) => setTimeout(r, 50))
+
+    const classroomFetchCalls = fetchMock.mock.calls.filter(
+      ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/classrooms'
+    )
+    expect(classroomFetchCalls).toHaveLength(0)
+  })
+})

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { TeacherQuizzesTab } from '@/app/classrooms/[classroomId]/TeacherQuizzesTab'
+import { TooltipProvider } from '@/ui'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
+import type { QuizWithStats } from '@/types'
+
+vi.mock('@/components/layout', () => ({
+  useRightSidebar: () => ({ setOpen: vi.fn() }),
+}))
+
+vi.mock('@/components/QuizModal', () => ({
+  QuizModal: ({ isOpen, onSuccess }: { isOpen: boolean; onSuccess: () => void }) =>
+    isOpen ? <button data-testid="mock-quiz-save" onClick={onSuccess}>Save Quiz</button> : null,
+}))
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>
+}
+
+function makeQuiz(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
+  const base = createMockQuiz(overrides)
+  return {
+    ...base,
+    stats: { total_students: 10, responded: 5, questions_count: 3 },
+    ...overrides,
+  } as QuizWithStats
+}
+
+function quizzesFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/quizzes?')
+  )
+}
+
+describe('TeacherQuizzesTab', () => {
+  const classroom = createMockClassroom()
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function mockQuizzesResponse(quizzes: QuizWithStats[] = []) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ quizzes }),
+    })
+  }
+
+  it('fetches quizzes once on mount', async () => {
+    mockQuizzesResponse([])
+    render(<TeacherQuizzesTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(1)
+    })
+  })
+
+  it('fetches quizzes once when update event fires (not twice)', async () => {
+    mockQuizzesResponse([])
+    render(<TeacherQuizzesTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    // Provide response for the event-triggered reload
+    mockQuizzesResponse([])
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, {
+          detail: { classroomId: classroom.id },
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(2)
+    })
+
+    // Wait a tick to ensure no additional fetch sneaks in
+    await new Promise((r) => setTimeout(r, 50))
+    expect(quizzesFetchCalls(fetchMock)).toHaveLength(2)
+  })
+
+  it('does not double-fetch after quiz creation', async () => {
+    mockQuizzesResponse([])
+    render(<TeacherQuizzesTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    // Provide response for the post-creation reload
+    mockQuizzesResponse([makeQuiz()])
+
+    // Open modal and trigger creation success
+    fireEvent.click(screen.getByText('New Quiz'))
+    fireEvent.click(screen.getByTestId('mock-quiz-save'))
+
+    // The event listener should trigger exactly one reload
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(2)
+    })
+
+    // Confirm no extra fetch
+    await new Promise((r) => setTimeout(r, 50))
+    expect(quizzesFetchCalls(fetchMock)).toHaveLength(2)
+  })
+
+  it('does not double-fetch after quiz deletion', async () => {
+    const quiz = makeQuiz({ id: 'quiz-del', title: 'Delete Me' })
+    mockQuizzesResponse([quiz])
+    render(<TeacherQuizzesTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Me')).toBeInTheDocument()
+    })
+
+    // Click delete on the quiz card — triggers handleRequestDelete which fetches results
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stats: { responded: 0 } }),
+    })
+    fireEvent.click(screen.getByLabelText('Delete Delete Me'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete quiz?')).toBeInTheDocument()
+    })
+
+    // Provide response for the DELETE call
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    // Provide response for the event-triggered reload
+    mockQuizzesResponse([])
+
+    const countBefore = quizzesFetchCalls(fetchMock).length
+
+    fireEvent.click(screen.getByText('Delete'))
+
+    // Wait for delete + reload
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock).length).toBe(countBefore + 1)
+    })
+
+    // Confirm no extra fetch
+    await new Promise((r) => setTimeout(r, 50))
+    expect(quizzesFetchCalls(fetchMock).length).toBe(countBefore + 1)
+  })
+
+  it('ignores update events for other classrooms', async () => {
+    mockQuizzesResponse([])
+    render(<TeacherQuizzesTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(quizzesFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, {
+          detail: { classroomId: 'other-classroom' },
+        })
+      )
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(quizzesFetchCalls(fetchMock)).toHaveLength(1)
+  })
+})

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -139,7 +139,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     })
   })
 
-  it('calls router.refresh() after successful save', async () => {
+  it('does not call router.refresh() after successful save (#304)', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -153,8 +153,9 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     fireEvent.blur(input)
 
     await waitFor(() => {
-      expect(mockRefresh).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('Course name updated.')).toBeInTheDocument()
     })
+    expect(mockRefresh).not.toHaveBeenCalled()
   })
 
   it('shows error message on API failure', async () => {


### PR DESCRIPTION
## Summary

Fixes #300, #301, #302, #303, #304, #305, #306 — a batch of data-fetching inefficiency fixes that reduce unnecessary network requests across the app.

- **#300** — Remove double-fetch after quiz create/delete (direct `loadQuizzes()` call + event dispatch both triggered reload)
- **#301** — Wire `TeacherAttendanceTab`, `TeacherCalendarTab`, `StudentTodayTab` to use shared `ClassDaysProvider` context instead of fetching `/class-days` independently
- **#302** — Remove redundant mount refetch in `TeacherClassroomsIndex` (server component already provides fresh data via `initialClassrooms`)
- **#303** — Add 30s cooldown to `StudentNotificationsProvider` focus refetch (prevents hammering on rapid alt-tab)
- **#304** — Remove `router.refresh()` from `TeacherSettingsTab` title save (local state already updated, no need to invalidate entire app cache)
- **#305** — Add staleness flag to assignment sidebar markdown reload (skip refetch on reopen if data hasn't changed)
- **#306** — Batch `StudentLessonCalendarTab`'s 3 sequential API calls into a single `Promise.all`

Net result: **-56 lines of source code**, 4 new test files, 1018 tests all passing.

## Test plan

- [x] `pnpm test` — 97 files, 1018 tests all green
- [ ] **#300**: Open DevTools Network, create a quiz → confirm 1 fetch to quizzes endpoint (not 2). Delete a quiz → same.
- [ ] **#301**: Load classroom page, filter Network by `class-days` → confirm only 1 request fires. Switch tabs → no additional requests.
- [ ] **#302**: Navigate to `/classrooms` → confirm no `/api/teacher/classrooms` fetch on initial load. Navigate away and back → confirm 1 refetch.
- [ ] **#303**: Filter Network by notifications endpoint. Alt-tab away and back → 1 fetch. Immediately alt-tab again → no fetch. Wait 30s, alt-tab → 1 fetch.
- [ ] **#304**: Change course name in Settings → confirm no burst of server component re-fetches in Network tab. Title updates in UI.
- [ ] **#305**: Open assignment sidebar → 1 fetch. Close and reopen (no changes) → no fetch. Edit an assignment, reopen → 1 fetch.
- [ ] **#306**: Open student calendar tab → confirm all 3 API calls fire simultaneously (parallel), not sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)