### PR TITLE
Fix assignments sidebar not restoring markdown on summary return

### DIFF
--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -250,8 +250,13 @@ function ClassroomPageContent({
     const sidebarJustOpened = isRightSidebarOpen && !wasOpen
     const returnedToSummary = assignmentViewMode === 'summary' && wasViewMode === 'assignment'
 
-    if (assignmentViewMode === 'summary' && (sidebarJustOpened || (returnedToSummary && isRightSidebarOpen)) && markdownStaleRef.current) {
-      loadAssignmentsMarkdown()
+    if (assignmentViewMode === 'summary' && (sidebarJustOpened || (returnedToSummary && isRightSidebarOpen))) {
+      if (markdownStaleRef.current) {
+        loadAssignmentsMarkdown()
+      } else {
+        // Reuse cached markdown when returning from assignment detail.
+        setIsMarkdownMode(true)
+      }
     } else if (!isRightSidebarOpen && wasOpen) {
       setIsMarkdownMode(false)
     }


### PR DESCRIPTION
## Summary\n- fix teacher assignments sidebar state when returning from assignment detail to summary\n- restore markdown sidebar immediately when cached markdown is still valid\n- keep existing stale-path behavior (reload markdown when stale)\n\n## Validation\n- pnpm lint\n- visual verification with Playwright screenshots (teacher + student)