### PR TITLE
Add gradebook foundation and weighted grading tab

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2484,3 +2484,22 @@
 - Files: src/components/TeacherStudentWorkPanel.tsx, src/components/StudentAssignmentEditor.tsx
 **Validation:**
 - `pnpm lint` passed
+
+---
+## 2026-02-12 [AI - GPT-5 Codex]
+**Goal:** Build PR A foundation for centralized gradebook (weights + percentages) and split PR B for modular TeachAssist sync engine
+**Completed:**
+- Added gradebook foundation migration with settings, assessment metadata, quiz override storage, and report-card snapshot tables
+- Added pure grade calculation utility and unit tests
+- Added teacher gradebook APIs for matrix/settings and quiz override updates
+- Added new teacher `gradebook` tab, layout/nav wiring, and gradebook roster-style table UI
+- Performed teacher/student screenshot verification and fixed loading-state validation by waiting for rendered selectors
+**Status:** completed
+**Artifacts:**
+- Branch: codex/gradebook-foundation
+- Worktree: /Users/stew/Repos/.worktrees/pika/codex-gradebook-foundation
+- Files: supabase/migrations/037_gradebook_foundation.sql, src/lib/gradebook.ts, src/app/api/teacher/gradebook/*, src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx, layout/nav wiring files
+**Validation:**
+- `pnpm lint` passed
+- `pnpm test -- tests/unit/gradebook.test.ts tests/unit/layout-config.test.ts` passed
+- Visual checks: `/tmp/teacher-gradebook-tab.png`, `/tmp/student-gradebook-tab.png`

--- a/src/app/api/teacher/gradebook/quiz-overrides/route.ts
+++ b/src/app/api/teacher/gradebook/quiz-overrides/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const body = await request.json()
+
+    const classroomId = String(body.classroom_id || '').trim()
+    const quizId = String(body.quiz_id || '').trim()
+    const studentId = String(body.student_id || '').trim()
+    const override = body.manual_override_score
+
+    if (!classroomId || !quizId || !studentId) {
+      return NextResponse.json(
+        { error: 'classroom_id, quiz_id, and student_id are required' },
+        { status: 400 }
+      )
+    }
+
+    if (override != null && (typeof override !== 'number' || Number.isNaN(override) || override < 0)) {
+      return NextResponse.json({ error: 'manual_override_score must be null or a non-negative number' }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: quiz, error: quizError } = await supabase
+      .from('quizzes')
+      .select('id, classroom_id, points_possible, classrooms!inner(teacher_id)')
+      .eq('id', quizId)
+      .single()
+
+    if (quizError || !quiz) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 })
+    }
+
+    if (quiz.classroom_id !== classroomId) {
+      return NextResponse.json({ error: 'Quiz does not belong to classroom' }, { status: 400 })
+    }
+
+    if (quiz.classrooms.teacher_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const max = Number(quiz.points_possible ?? 100)
+    if (override != null && override > max) {
+      return NextResponse.json({ error: `manual_override_score cannot exceed points_possible (${max})` }, { status: 400 })
+    }
+
+    const { data: enrollment } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', classroomId)
+      .eq('student_id', studentId)
+      .maybeSingle()
+
+    if (!enrollment) {
+      return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
+    }
+
+    const { error } = await supabase
+      .from('quiz_student_scores')
+      .upsert({
+        quiz_id: quizId,
+        student_id: studentId,
+        manual_override_score: override,
+        graded_at: new Date().toISOString(),
+        graded_by: 'teacher',
+      }, { onConflict: 'quiz_id,student_id' })
+
+    if (error) {
+      console.error('Error saving quiz override:', error)
+      return NextResponse.json({ error: 'Failed to save quiz override' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Quiz override PATCH error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/gradebook/quiz-overrides/route.ts
+++ b/src/app/api/teacher/gradebook/quiz-overrides/route.ts
@@ -42,7 +42,8 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'Quiz does not belong to classroom' }, { status: 400 })
     }
 
-    if (quiz.classrooms.teacher_id !== user.id) {
+    const classroomRelation = Array.isArray(quiz.classrooms) ? quiz.classrooms[0] : quiz.classrooms
+    if (!classroomRelation || classroomRelation.teacher_id !== user.id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 

--- a/src/app/api/teacher/gradebook/route.ts
+++ b/src/app/api/teacher/gradebook/route.ts
@@ -1,0 +1,314 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { calculateFinalPercent } from '@/lib/gradebook'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+const DEFAULT_SETTINGS = {
+  use_weights: false,
+  assignments_weight: 70,
+  quizzes_weight: 30,
+}
+
+async function assertTeacherOwnsClassroom(teacherId: string, classroomId: string) {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('classrooms')
+    .select('id, teacher_id, archived_at')
+    .eq('id', classroomId)
+    .single()
+
+  if (error || !data) return { ok: false as const, status: 404 as const, error: 'Classroom not found' }
+  if (data.teacher_id !== teacherId) return { ok: false as const, status: 403 as const, error: 'Forbidden' }
+  return { ok: true as const, classroom: data }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const classroomId = request.nextUrl.searchParams.get('classroom_id')
+
+    if (!classroomId) {
+      return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+    }
+
+    const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+    }
+
+    const supabase = getServiceRoleClient()
+
+    const { data: settingsRow } = await supabase
+      .from('gradebook_settings')
+      .select('use_weights, assignments_weight, quizzes_weight')
+      .eq('classroom_id', classroomId)
+      .maybeSingle()
+
+    const settings = settingsRow || DEFAULT_SETTINGS
+
+    const { data: enrollments, error: enrollmentError } = await supabase
+      .from('classroom_enrollments')
+      .select('student_id, users!inner(email)')
+      .eq('classroom_id', classroomId)
+
+    if (enrollmentError) {
+      console.error('Error loading enrollments:', enrollmentError)
+      return NextResponse.json({ error: 'Failed to load roster' }, { status: 500 })
+    }
+
+    const studentIds = (enrollments || []).map((row) => row.student_id)
+    const { data: profiles } = studentIds.length
+      ? await supabase
+          .from('student_profiles')
+          .select('user_id, first_name, last_name')
+          .in('user_id', studentIds)
+      : { data: [] as Array<{ user_id: string; first_name: string | null; last_name: string | null }> }
+
+    const profileMap = new Map((profiles || []).map((p) => [p.user_id, p]))
+
+    const { data: assignments } = await supabase
+      .from('assignments')
+      .select('id, title, points_possible, include_in_final, is_draft')
+      .eq('classroom_id', classroomId)
+      .eq('is_draft', false)
+
+    const assignmentIds = (assignments || []).map((a) => a.id)
+    const { data: docs } = assignmentIds.length
+      ? await supabase
+          .from('assignment_docs')
+          .select('assignment_id, student_id, score_completion, score_thinking, score_workflow')
+          .in('assignment_id', assignmentIds)
+      : { data: [] as Array<any> }
+
+    const assignmentMap = new Map((assignments || []).map((a) => [a.id, a]))
+    const assignmentRowsByStudent = new Map<string, Array<{ earned: number; possible: number }>>()
+
+    for (const doc of docs || []) {
+      const assignment = assignmentMap.get(doc.assignment_id)
+      if (!assignment || assignment.include_in_final === false) continue
+
+      const sc = doc.score_completion
+      const st = doc.score_thinking
+      const sw = doc.score_workflow
+      if (sc == null || st == null || sw == null) continue
+
+      const raw = Number(sc) + Number(st) + Number(sw)
+      const possible = Number(assignment.points_possible ?? 30)
+      const earned = (raw / 30) * possible
+
+      const rows = assignmentRowsByStudent.get(doc.student_id) || []
+      rows.push({ earned, possible })
+      assignmentRowsByStudent.set(doc.student_id, rows)
+    }
+
+    const { data: quizzes } = await supabase
+      .from('quizzes')
+      .select('id, title, points_possible, include_in_final')
+      .eq('classroom_id', classroomId)
+
+    const quizIds = (quizzes || []).map((q) => q.id)
+
+    const { data: quizQuestions } = quizIds.length
+      ? await supabase
+          .from('quiz_questions')
+          .select('id, quiz_id, correct_option')
+          .in('quiz_id', quizIds)
+      : { data: [] as Array<any> }
+
+    const { data: quizResponses } = quizIds.length && studentIds.length
+      ? await supabase
+          .from('quiz_responses')
+          .select('quiz_id, question_id, student_id, selected_option')
+          .in('quiz_id', quizIds)
+          .in('student_id', studentIds)
+      : { data: [] as Array<any> }
+
+    const { data: overrides } = quizIds.length && studentIds.length
+      ? await supabase
+          .from('quiz_student_scores')
+          .select('quiz_id, student_id, manual_override_score')
+          .in('quiz_id', quizIds)
+          .in('student_id', studentIds)
+      : { data: [] as Array<any> }
+
+    const quizMap = new Map((quizzes || []).map((q) => [q.id, q]))
+    const questionMap = new Map<string, { quiz_id: string; correct_option: number | null }>()
+    for (const q of quizQuestions || []) {
+      questionMap.set(q.id, { quiz_id: q.quiz_id, correct_option: q.correct_option })
+    }
+
+    const responsesByStudentQuiz = new Map<string, Map<string, Array<{ question_id: string; selected_option: number }>>>()
+    for (const response of quizResponses || []) {
+      const byQuiz = responsesByStudentQuiz.get(response.student_id) || new Map<string, Array<{ question_id: string; selected_option: number }>>()
+      const rows = byQuiz.get(response.quiz_id) || []
+      rows.push({ question_id: response.question_id, selected_option: response.selected_option })
+      byQuiz.set(response.quiz_id, rows)
+      responsesByStudentQuiz.set(response.student_id, byQuiz)
+    }
+
+    const overrideMap = new Map<string, number | null>()
+    for (const row of overrides || []) {
+      overrideMap.set(`${row.quiz_id}:${row.student_id}`, row.manual_override_score)
+    }
+
+    const questionIdsByQuiz = new Map<string, Array<{ id: string; correct_option: number | null }>>()
+    for (const question of quizQuestions || []) {
+      const rows = questionIdsByQuiz.get(question.quiz_id) || []
+      rows.push({ id: question.id, correct_option: question.correct_option })
+      questionIdsByQuiz.set(question.quiz_id, rows)
+    }
+
+    const quizRowsByStudent = new Map<string, Array<{ earned: number; possible: number }>>()
+
+    for (const studentId of studentIds) {
+      for (const quizId of quizIds) {
+        const quiz = quizMap.get(quizId)
+        if (!quiz || quiz.include_in_final === false) continue
+
+        const possible = Number(quiz.points_possible ?? 100)
+        const override = overrideMap.get(`${quizId}:${studentId}`)
+
+        let earned: number | null = override ?? null
+        if (earned == null) {
+          const quizQuestionsForQuiz = questionIdsByQuiz.get(quizId) || []
+          const scorable = quizQuestionsForQuiz.filter((q) => q.correct_option != null)
+          if (scorable.length > 0) {
+            const selected = responsesByStudentQuiz.get(studentId)?.get(quizId) || []
+            const selectedByQuestion = new Map(selected.map((s) => [s.question_id, s.selected_option]))
+
+            let correctCount = 0
+            for (const question of scorable) {
+              const studentAnswer = selectedByQuestion.get(question.id)
+              if (studentAnswer != null && studentAnswer === question.correct_option) {
+                correctCount += 1
+              }
+            }
+
+            // A quiz with no responses still participates as 0 when it has scorable questions.
+            earned = (correctCount / scorable.length) * possible
+          }
+        }
+
+        if (earned == null) continue
+
+        const rows = quizRowsByStudent.get(studentId) || []
+        rows.push({ earned, possible })
+        quizRowsByStudent.set(studentId, rows)
+      }
+    }
+
+    const students = (enrollments || []).map((enrollment) => {
+      const studentId = enrollment.student_id
+      const profile = profileMap.get(studentId)
+      const calc = calculateFinalPercent({
+        useWeights: settings.use_weights,
+        assignmentsWeight: settings.assignments_weight,
+        quizzesWeight: settings.quizzes_weight,
+        assignments: assignmentRowsByStudent.get(studentId) || [],
+        quizzes: quizRowsByStudent.get(studentId) || [],
+      })
+
+      return {
+        student_id: studentId,
+        student_email: (enrollment.users as unknown as { email: string }).email,
+        student_first_name: profile?.first_name ?? null,
+        student_last_name: profile?.last_name ?? null,
+        assignments_percent: calc.assignmentsPercent,
+        quizzes_percent: calc.quizzesPercent,
+        final_percent: calc.finalPercent,
+      }
+    })
+
+    students.sort((a, b) => {
+      const aName = `${a.student_last_name || ''} ${a.student_first_name || ''}`.trim() || a.student_email
+      const bName = `${b.student_last_name || ''} ${b.student_first_name || ''}`.trim() || b.student_email
+      return aName.localeCompare(bName)
+    })
+
+    return NextResponse.json({
+      settings,
+      students,
+      totals: {
+        assignments: assignments?.length || 0,
+        quizzes: quizzes?.length || 0,
+      },
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Gradebook GET error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const user = await requireRole('teacher')
+    const body = await request.json()
+    const classroomId = String(body.classroom_id || '').trim()
+
+    if (!classroomId) {
+      return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+    }
+
+    const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+    if (!ownership.ok) {
+      return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+    }
+
+    const useWeights = body.use_weights == null ? DEFAULT_SETTINGS.use_weights : Boolean(body.use_weights)
+    const assignmentsWeight = body.assignments_weight == null
+      ? DEFAULT_SETTINGS.assignments_weight
+      : Number(body.assignments_weight)
+    const quizzesWeight = body.quizzes_weight == null
+      ? DEFAULT_SETTINGS.quizzes_weight
+      : Number(body.quizzes_weight)
+
+    if (!Number.isInteger(assignmentsWeight) || assignmentsWeight < 0 || assignmentsWeight > 100) {
+      return NextResponse.json({ error: 'assignments_weight must be an integer 0-100' }, { status: 400 })
+    }
+
+    if (!Number.isInteger(quizzesWeight) || quizzesWeight < 0 || quizzesWeight > 100) {
+      return NextResponse.json({ error: 'quizzes_weight must be an integer 0-100' }, { status: 400 })
+    }
+
+    if (assignmentsWeight + quizzesWeight !== 100) {
+      return NextResponse.json({ error: 'assignments_weight + quizzes_weight must equal 100' }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+    const { data, error } = await supabase
+      .from('gradebook_settings')
+      .upsert({
+        classroom_id: classroomId,
+        use_weights: useWeights,
+        assignments_weight: assignmentsWeight,
+        quizzes_weight: quizzesWeight,
+      }, { onConflict: 'classroom_id' })
+      .select('use_weights, assignments_weight, quizzes_weight')
+      .single()
+
+    if (error || !data) {
+      console.error('Error saving gradebook settings:', error)
+      return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 })
+    }
+
+    return NextResponse.json({ settings: data })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Gradebook PATCH error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -694,22 +694,22 @@ function ClassroomPageContent({
                               item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
                             ].join(' ')}
                           >
-                            <div className="text-sm text-text-default">{item.title}</div>
-                            <div className="text-xs text-text-muted">
-                              {item.is_graded && item.earned != null && item.percent != null
-                                ? (
-                                  <>
-                                    {`Due ${formatTorontoDateShort(item.due_at)} . `}
-                                    <span className="font-semibold text-text-default">
-                                      {formatPoints(item.earned)}/{formatPoints(item.possible)}
-                                    </span>
-                                    {' . '}
-                                    <span className="font-semibold text-text-default">
-                                      {formatPercent1(item.percent)}
-                                    </span>
-                                  </>
-                                )
-                                : `Due ${formatTorontoDateShort(item.due_at)} . No grade (${formatPoints(item.possible)} pts)`}
+                            <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3">
+                              <div className="min-w-0">
+                                <div className="truncate text-sm text-text-default">{item.title}</div>
+                                <div className="text-xs text-text-muted">
+                                  {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
+                                  {!item.is_graded ? ` . No grade (${formatPoints(item.possible)} pts)` : ''}
+                                </div>
+                              </div>
+                              <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                                {item.is_graded && item.earned != null
+                                  ? `${formatPoints(item.earned)}/${formatPoints(item.possible)}`
+                                  : '—'}
+                              </div>
+                              <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                                {item.is_graded && item.percent != null ? `${item.percent.toFixed(1)}%` : '—'}
+                              </div>
                             </div>
                           </div>
                         ))}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -80,6 +80,10 @@ function formatTorontoDateShort(iso: string): string {
   })
 }
 
+function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
 export function ClassroomPageClient({
   classroom,
   user,
@@ -673,6 +677,33 @@ function ClassroomPageContent({
                         ? `${gradebookStudentDetail.final_percent.toFixed(2)}%`
                         : '—'}
                     </div>
+                    {(() => {
+                      if (!gradebookStudentDetail) return null
+                      const assignmentTotals = (gradebookStudentDetail.assignments || [])
+                        .filter((item) => item.is_graded && item.earned != null)
+                        .reduce(
+                          (totals, item) => ({
+                            earned: totals.earned + Number(item.earned),
+                            possible: totals.possible + Number(item.possible),
+                          }),
+                          { earned: 0, possible: 0 }
+                        )
+                      const quizTotals = (gradebookStudentDetail.quizzes || []).reduce(
+                        (totals, item) => ({
+                          earned: totals.earned + Number(item.earned),
+                          possible: totals.possible + Number(item.possible),
+                        }),
+                        { earned: 0, possible: 0 }
+                      )
+                      const earnedTotal = assignmentTotals.earned + quizTotals.earned
+                      const possibleTotal = assignmentTotals.possible + quizTotals.possible
+                      if (possibleTotal <= 0) return null
+                      return (
+                        <div className="mt-1 text-xs text-text-muted">
+                          {formatPoints(earnedTotal)}/{formatPoints(possibleTotal)} pts
+                        </div>
+                      )
+                    })()}
                   </div>
 
                   <div>
@@ -693,8 +724,8 @@ function ClassroomPageContent({
                             </div>
                             <div className="text-xs text-text-muted">
                               {item.is_graded && item.earned != null && item.percent != null
-                                ? `${item.earned.toFixed(2)} / ${item.possible.toFixed(2)} (${item.percent.toFixed(2)}%)`
-                                : `No grade (${item.possible.toFixed(2)} pts)`}
+                                ? `${formatPoints(item.earned)}/${formatPoints(item.possible)} (${item.percent.toFixed(2)}%)`
+                                : `No grade (${formatPoints(item.possible)} pts)`}
                             </div>
                           </div>
                         ))}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -761,7 +761,7 @@ function ClassroomPageContent({
                 {gradebookClassSummary?.assignments?.length ? (
                   <div className="mt-2 space-y-2">
                     <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3 px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
-                      <div className="truncate">Assignment</div>
+                      <div />
                       <div className="text-right">Avg</div>
                       <div className="text-right">Med</div>
                       <div className="text-right">#</div>

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -747,12 +747,8 @@ function ClassroomPageContent({
           ) : isTeacher && activeTab === 'gradebook' ? (
             <div className="space-y-4 p-4">
               <div className="rounded-md border border-border bg-surface-2 p-3">
-                <div className="text-xs text-text-muted">Class final average</div>
-                <div className="mt-1 text-lg font-semibold text-text-default">
+                <div className="text-lg font-semibold text-text-default">
                   {formatPercent1(gradebookClassSummary?.average_final_percent ?? null)}
-                </div>
-                <div className="text-xs text-text-muted">
-                  {gradebookClassSummary?.students_with_final ?? 0} / {gradebookClassSummary?.total_students ?? 0} students with final grade
                 </div>
               </div>
 

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -84,6 +84,11 @@ function formatPoints(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2)
 }
 
+function formatPercent1(value: number | null): string {
+  if (value == null) return '—'
+  return `${value.toFixed(1)} %`
+}
+
 export function ClassroomPageClient({
   classroom,
   user,
@@ -673,9 +678,7 @@ function ClassroomPageContent({
                   <div className="rounded-md border border-border bg-surface-2 p-3">
                     <div className="text-xs text-text-muted">Overall</div>
                     <div className="mt-1 text-lg font-semibold text-text-default">
-                      {gradebookStudentDetail?.final_percent != null
-                        ? `${gradebookStudentDetail.final_percent.toFixed(2)}%`
-                        : '—'}
+                      {formatPercent1(gradebookStudentDetail?.final_percent ?? null)}
                     </div>
                   </div>
 
@@ -693,12 +696,20 @@ function ClassroomPageContent({
                           >
                             <div className="text-sm text-text-default">{item.title}</div>
                             <div className="text-xs text-text-muted">
-                              {item.is_draft ? 'Draft' : 'Assigned'} . Due {formatTorontoDateShort(item.due_at)}
-                            </div>
-                            <div className="text-xs text-text-muted">
                               {item.is_graded && item.earned != null && item.percent != null
-                                ? `${formatPoints(item.earned)}/${formatPoints(item.possible)} (${item.percent.toFixed(2)}%)`
-                                : `No grade (${formatPoints(item.possible)} pts)`}
+                                ? (
+                                  <>
+                                    {`Due ${formatTorontoDateShort(item.due_at)} . `}
+                                    <span className="font-semibold text-text-default">
+                                      {formatPoints(item.earned)}/{formatPoints(item.possible)}
+                                    </span>
+                                    {' . '}
+                                    <span className="font-semibold text-text-default">
+                                      {formatPercent1(item.percent)}
+                                    </span>
+                                  </>
+                                )
+                                : `Due ${formatTorontoDateShort(item.due_at)} . No grade (${formatPoints(item.possible)} pts)`}
                             </div>
                           </div>
                         ))}
@@ -716,7 +727,11 @@ function ClassroomPageContent({
                           <div key={item.quiz_id} className="rounded-md border border-border px-3 py-2">
                             <div className="text-sm text-text-default">{item.title}</div>
                             <div className="text-xs text-text-muted">
-                              {item.earned.toFixed(2)} / {item.possible.toFixed(2)} ({item.percent.toFixed(2)}%)
+                              <span className="font-semibold text-text-default">
+                                {formatPoints(item.earned)}/{formatPoints(item.possible)}
+                              </span>
+                              {' . '}
+                              <span className="font-semibold text-text-default">{formatPercent1(item.percent)}</span>
                               {item.is_manual_override ? ' • Manual override' : ''}
                             </div>
                           </div>
@@ -734,9 +749,7 @@ function ClassroomPageContent({
               <div className="rounded-md border border-border bg-surface-2 p-3">
                 <div className="text-xs text-text-muted">Class final average</div>
                 <div className="mt-1 text-lg font-semibold text-text-default">
-                  {gradebookClassSummary?.average_final_percent != null
-                    ? `${gradebookClassSummary.average_final_percent.toFixed(2)}%`
-                    : '—'}
+                  {formatPercent1(gradebookClassSummary?.average_final_percent ?? null)}
                 </div>
                 <div className="text-xs text-text-muted">
                   {gradebookClassSummary?.students_with_final ?? 0} / {gradebookClassSummary?.total_students ?? 0} students with final grade
@@ -759,8 +772,8 @@ function ClassroomPageContent({
                         <div className="text-xs text-text-muted">
                           {[
                             `Due ${formatTorontoDateShort(item.due_at)}`,
-                            item.average_percent != null ? `Avg ${item.average_percent.toFixed(0)}%` : 'No graded work',
-                            item.median_percent != null ? `Med ${item.median_percent.toFixed(0)}%` : 'Med —',
+                            item.average_percent != null ? `Avg ${formatPercent1(item.average_percent)}` : 'No graded work',
+                            item.median_percent != null ? `Med ${formatPercent1(item.median_percent)}` : 'Med —',
                             `Graded ${item.graded_count}/${gradebookClassSummary.total_students}`,
                           ].join(' . ')}
                         </div>
@@ -781,7 +794,7 @@ function ClassroomPageContent({
                         <div className="text-sm text-text-default">{item.title}</div>
                         <div className="text-xs text-text-muted">
                           {item.status || 'unknown'} • {item.average_percent != null
-                            ? `Avg ${item.average_percent.toFixed(2)}% • Scored ${item.scored_count}/${gradebookClassSummary.total_students}`
+                            ? `Avg ${formatPercent1(item.average_percent)} • Scored ${item.scored_count}/${gradebookClassSummary.total_students}`
                             : `No scored responses • Scored ${item.scored_count}/${gradebookClassSummary.total_students}`}
                         </div>
                       </div>

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -72,6 +72,14 @@ interface ClassroomPageClientProps {
   initialTab?: string
 }
 
+function formatTorontoDateShort(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    timeZone: 'America/Toronto',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
 export function ClassroomPageClient({
   classroom,
   user,
@@ -671,14 +679,16 @@ function ClassroomPageContent({
                     {gradebookStudentDetail?.assignments?.length ? (
                       <div className="mt-2 space-y-2">
                         {gradebookStudentDetail.assignments.map((item) => (
-                          <div key={item.assignment_id} className="rounded-md border border-border px-3 py-2">
+                          <div
+                            key={item.assignment_id}
+                            className={[
+                              'rounded-md border px-3 py-2',
+                              item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
+                            ].join(' ')}
+                          >
                             <div className="text-sm text-text-default">{item.title}</div>
                             <div className="text-xs text-text-muted">
-                              {item.is_draft ? 'Draft' : 'Assigned'} • Due {new Date(item.due_at).toLocaleDateString('en-US', {
-                                timeZone: 'America/Toronto',
-                                month: 'short',
-                                day: 'numeric',
-                              })}
+                              {item.is_draft ? 'Draft' : 'Assigned'} . Due {formatTorontoDateShort(item.due_at)}
                             </div>
                             <div className="text-xs text-text-muted">
                               {item.is_graded && item.earned != null && item.percent != null
@@ -733,19 +743,21 @@ function ClassroomPageContent({
                 {gradebookClassSummary?.assignments?.length ? (
                   <div className="mt-2 space-y-2">
                     {gradebookClassSummary.assignments.map((item) => (
-                      <div key={item.assignment_id} className="rounded-md border border-border px-3 py-2">
+                      <div
+                        key={item.assignment_id}
+                        className={[
+                          'rounded-md border px-3 py-2',
+                          item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
+                        ].join(' ')}
+                      >
                         <div className="text-sm text-text-default">{item.title}</div>
                         <div className="text-xs text-text-muted">
-                          {item.is_draft ? 'Draft' : 'Assigned'} • Due {new Date(item.due_at).toLocaleDateString('en-US', {
-                            timeZone: 'America/Toronto',
-                            month: 'short',
-                            day: 'numeric',
-                          })}
-                        </div>
-                        <div className="text-xs text-text-muted">
-                          {item.average_percent != null
-                            ? `Avg ${item.average_percent.toFixed(2)}% • Graded ${item.graded_count}/${gradebookClassSummary.total_students}`
-                            : `No graded work • Graded ${item.graded_count}/${gradebookClassSummary.total_students}`}
+                          {[
+                            `Due ${formatTorontoDateShort(item.due_at)}`,
+                            item.average_percent != null ? `Avg ${item.average_percent.toFixed(0)}%` : 'No graded work',
+                            item.median_percent != null ? `Med ${item.median_percent.toFixed(0)}%` : 'Med —',
+                            `Graded ${item.graded_count}/${gradebookClassSummary.total_students}`,
+                          ].join(' . ')}
                         </div>
                       </div>
                     ))}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -760,6 +760,12 @@ function ClassroomPageContent({
                 <h3 className="text-sm font-semibold text-text-default">Assignments</h3>
                 {gradebookClassSummary?.assignments?.length ? (
                   <div className="mt-2 space-y-2">
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3 px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+                      <div className="truncate">Assignment</div>
+                      <div className="text-right">Avg</div>
+                      <div className="text-right">Med</div>
+                      <div className="text-right">#</div>
+                    </div>
                     {gradebookClassSummary.assignments.map((item) => (
                       <div
                         key={item.assignment_id}
@@ -768,14 +774,22 @@ function ClassroomPageContent({
                           item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
                         ].join(' ')}
                       >
-                        <div className="text-sm text-text-default">{item.title}</div>
-                        <div className="text-xs text-text-muted">
-                          {[
-                            `Due ${formatTorontoDateShort(item.due_at)}`,
-                            item.average_percent != null ? `Avg ${formatPercent1(item.average_percent)}` : 'No graded work',
-                            item.median_percent != null ? `Med ${formatPercent1(item.median_percent)}` : 'Med —',
-                            `Graded ${item.graded_count}/${gradebookClassSummary.total_students}`,
-                          ].join(' . ')}
+                        <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm text-text-default">{item.title}</div>
+                            <div className="text-xs text-text-muted">
+                              {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
+                            </div>
+                          </div>
+                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                            {item.average_percent != null ? item.average_percent.toFixed(1) : '—'}
+                          </div>
+                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                            {item.median_percent != null ? item.median_percent.toFixed(1) : '—'}
+                          </div>
+                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                            {item.graded_count}/{gradebookClassSummary.total_students}
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -9,6 +9,7 @@ import { StudentTodayTab } from './StudentTodayTab'
 import { StudentAssignmentsTab } from './StudentAssignmentsTab'
 import { TeacherAttendanceTab, type TeacherAttendanceTabHandle } from './TeacherAttendanceTab'
 import { TeacherRosterTab } from './TeacherRosterTab'
+import { TeacherGradebookTab } from './TeacherGradebookTab'
 import { TeacherSettingsTab } from './TeacherSettingsTab'
 import { TeacherLessonCalendarTab, TeacherLessonCalendarSidebar, CalendarSidebarState } from './TeacherLessonCalendarTab'
 import { StudentLessonCalendarTab } from './StudentLessonCalendarTab'
@@ -76,7 +77,7 @@ export function ClassroomPageClient({
   const tab = searchParams.get('tab') ?? initialTab
   const defaultTab = isTeacher ? 'attendance' : 'today'
   const validTabs = isTeacher
-    ? (['attendance', 'assignments', 'quizzes', 'calendar', 'resources', 'roster', 'settings'] as const)
+    ? (['attendance', 'gradebook', 'assignments', 'quizzes', 'calendar', 'resources', 'roster', 'settings'] as const)
     : (['today', 'assignments', 'quizzes', 'calendar', 'resources'] as const)
 
   const activeTab = (validTabs as readonly string[]).includes(tab ?? '') ? (tab as string) : defaultTab
@@ -352,7 +353,7 @@ function ClassroomPageContent({
   }, [isTeacher, activeTab, selectedStudent, setRightSidebarWidth])
 
   useEffect(() => {
-    if (activeTab === 'roster') {
+    if (activeTab === 'roster' || activeTab === 'gradebook') {
       setRightSidebarOpen(false)
     }
   }, [activeTab, setRightSidebarOpen])
@@ -408,6 +409,7 @@ function ClassroomPageContent({
                   onDateChange={setAttendanceDate}
                 />
               )}
+              {activeTab === 'gradebook' && <TeacherGradebookTab classroom={classroom} />}
               {activeTab === 'assignments' && (
                 <TeacherClassroomView
                   classroom={classroom}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -677,33 +677,6 @@ function ClassroomPageContent({
                         ? `${gradebookStudentDetail.final_percent.toFixed(2)}%`
                         : '—'}
                     </div>
-                    {(() => {
-                      if (!gradebookStudentDetail) return null
-                      const assignmentTotals = (gradebookStudentDetail.assignments || [])
-                        .filter((item) => item.is_graded && item.earned != null)
-                        .reduce(
-                          (totals, item) => ({
-                            earned: totals.earned + Number(item.earned),
-                            possible: totals.possible + Number(item.possible),
-                          }),
-                          { earned: 0, possible: 0 }
-                        )
-                      const quizTotals = (gradebookStudentDetail.quizzes || []).reduce(
-                        (totals, item) => ({
-                          earned: totals.earned + Number(item.earned),
-                          possible: totals.possible + Number(item.possible),
-                        }),
-                        { earned: 0, possible: 0 }
-                      )
-                      const earnedTotal = assignmentTotals.earned + quizTotals.earned
-                      const possibleTotal = assignmentTotals.possible + quizTotals.possible
-                      if (possibleTotal <= 0) return null
-                      return (
-                        <div className="mt-1 text-xs text-text-muted">
-                          {formatPoints(earnedTotal)}/{formatPoints(possibleTotal)} pts
-                        </div>
-                      )
-                    })()}
                   </div>
 
                   <div>

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -400,6 +400,7 @@ function ClassroomPageContent({
 
   useEffect(() => {
     if (!isTeacher || activeTab !== 'gradebook' || !selectedGradebookStudent) return
+    const selectedStudentId = selectedGradebookStudent.student_id
 
     if (window.innerWidth < DESKTOP_BREAKPOINT) {
       openRight()
@@ -414,7 +415,7 @@ function ClassroomPageContent({
       setGradebookStudentDetailError('')
       try {
         const response = await fetch(
-          `/api/teacher/gradebook?classroom_id=${classroom.id}&student_id=${selectedGradebookStudent.student_id}`
+          `/api/teacher/gradebook?classroom_id=${classroom.id}&student_id=${selectedStudentId}`
         )
         const data = await response.json()
         if (!response.ok) {

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -186,7 +186,10 @@ export function TeacherGradebookTab({
               Total: {totalWeight}%
             </div>
 
-            <Button onClick={saveSettings} disabled={isReadOnly || saving || totalWeight !== 100}>
+            <Button
+              onClick={saveSettings}
+              disabled={isReadOnly || saving || (settings.use_weights && totalWeight !== 100)}
+            >
               {saving ? 'Saving...' : 'Save'}
             </Button>
           </div>

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -35,6 +35,19 @@ function formatPercent(value: number | null): string {
   return `${value.toFixed(2)}%`
 }
 
+function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+function formatScoreWithPercent(
+  earned: number | null,
+  possible: number | null,
+  percent: number | null
+): string {
+  if (earned == null || possible == null || percent == null) return '—'
+  return `${formatPoints(earned)}/${formatPoints(possible)} (${percent.toFixed(2)}%)`
+}
+
 export function TeacherGradebookTab({
   classroom,
   selectedStudentId = null,
@@ -215,13 +228,13 @@ export function TeacherGradebookTab({
             >
               <DataTable>
                 <DataTableHead>
-                  <DataTableRow>
-                    <DataTableHeaderCell>Student</DataTableHeaderCell>
-                    <DataTableHeaderCell align="right">Assignments %</DataTableHeaderCell>
-                    <DataTableHeaderCell align="right">Quizzes %</DataTableHeaderCell>
-                    <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
-                  </DataTableRow>
-                </DataTableHead>
+                <DataTableRow>
+                  <DataTableHeaderCell>Student</DataTableHeaderCell>
+                  <DataTableHeaderCell align="right">Assignments</DataTableHeaderCell>
+                  <DataTableHeaderCell align="right">Quizzes</DataTableHeaderCell>
+                  <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
+                </DataTableRow>
+              </DataTableHead>
                 <DataTableBody>
                   {students.map((student) => {
                     const fullName = `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim()
@@ -233,14 +246,26 @@ export function TeacherGradebookTab({
                           'cursor-pointer transition-colors',
                           isSelected ? 'bg-info-bg hover:bg-info-bg-hover' : 'hover:bg-surface-hover',
                         ].join(' ')}
-                        onClick={() => onSelectStudent?.(isSelected ? null : student)}
-                      >
-                        <DataTableCell>{fullName || student.student_email}</DataTableCell>
-                        <DataTableCell align="right">{formatPercent(student.assignments_percent)}</DataTableCell>
-                        <DataTableCell align="right">{formatPercent(student.quizzes_percent)}</DataTableCell>
-                        <DataTableCell align="right" className="font-semibold">
-                          {formatPercent(student.final_percent)}
-                        </DataTableCell>
+                      onClick={() => onSelectStudent?.(isSelected ? null : student)}
+                    >
+                      <DataTableCell>{fullName || student.student_email}</DataTableCell>
+                      <DataTableCell align="right">
+                        {formatScoreWithPercent(
+                          student.assignments_earned,
+                          student.assignments_possible,
+                          student.assignments_percent
+                        )}
+                      </DataTableCell>
+                      <DataTableCell align="right">
+                        {formatScoreWithPercent(
+                          student.quizzes_earned,
+                          student.quizzes_possible,
+                          student.quizzes_percent
+                        )}
+                      </DataTableCell>
+                      <DataTableCell align="right" className="font-semibold">
+                        {formatPercent(student.final_percent)}
+                      </DataTableCell>
                       </DataTableRow>
                     )
                   })}

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 function formatPercent(value: number | null): string {
   if (value == null) return '—'
-  return `${value.toFixed(2)}%`
+  return `${value.toFixed(1)} %`
 }
 
 function formatPoints(value: number): string {
@@ -45,7 +45,7 @@ function formatScoreWithPercent(
   percent: number | null
 ): string {
   if (earned == null || possible == null || percent == null) return '—'
-  return `${formatPoints(earned)}/${formatPoints(possible)} (${percent.toFixed(2)}%)`
+  return `${formatPoints(earned)}/${formatPoints(possible)} (${percent.toFixed(1)} %)`
 }
 
 export function TeacherGradebookTab({

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -193,64 +193,66 @@ export function TeacherGradebookTab({
         }
       />
 
-      <PageContent ref={tableContainerRef}>
-        <TableCard>
-          {error && (
-            <div className="p-3 border-b border-border">
-              <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-                {error}
+      <PageContent>
+        <div ref={tableContainerRef}>
+          <TableCard>
+            {error && (
+              <div className="p-3 border-b border-border">
+                <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+                  {error}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          <KeyboardNavigableTable
-            rowKeys={rowKeys}
-            selectedKey={selectedStudentId}
-            onSelectKey={(studentId) => {
-              const student = students.find((row) => row.student_id === studentId) || null
-              onSelectStudent?.(student)
-            }}
-            onDeselect={() => onSelectStudent?.(null)}
-          >
-            <DataTable>
-              <DataTableHead>
-                <DataTableRow>
-                  <DataTableHeaderCell>Student</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Assignments %</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Quizzes %</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
-                </DataTableRow>
-              </DataTableHead>
-              <DataTableBody>
-                {students.map((student) => {
-                  const fullName = `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim()
-                  const isSelected = student.student_id === selectedStudentId
-                  return (
-                    <DataTableRow
-                      key={student.student_id}
-                      className={[
-                        'cursor-pointer transition-colors',
-                        isSelected ? 'bg-info-bg hover:bg-info-bg-hover' : 'hover:bg-surface-hover',
-                      ].join(' ')}
-                      onClick={() => onSelectStudent?.(isSelected ? null : student)}
-                    >
-                      <DataTableCell>{fullName || student.student_email}</DataTableCell>
-                      <DataTableCell align="right">{formatPercent(student.assignments_percent)}</DataTableCell>
-                      <DataTableCell align="right">{formatPercent(student.quizzes_percent)}</DataTableCell>
-                      <DataTableCell align="right" className="font-semibold">
-                        {formatPercent(student.final_percent)}
-                      </DataTableCell>
-                    </DataTableRow>
-                  )
-                })}
+            <KeyboardNavigableTable
+              rowKeys={rowKeys}
+              selectedKey={selectedStudentId}
+              onSelectKey={(studentId) => {
+                const student = students.find((row) => row.student_id === studentId) || null
+                onSelectStudent?.(student)
+              }}
+              onDeselect={() => onSelectStudent?.(null)}
+            >
+              <DataTable>
+                <DataTableHead>
+                  <DataTableRow>
+                    <DataTableHeaderCell>Student</DataTableHeaderCell>
+                    <DataTableHeaderCell align="right">Assignments %</DataTableHeaderCell>
+                    <DataTableHeaderCell align="right">Quizzes %</DataTableHeaderCell>
+                    <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {students.map((student) => {
+                    const fullName = `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim()
+                    const isSelected = student.student_id === selectedStudentId
+                    return (
+                      <DataTableRow
+                        key={student.student_id}
+                        className={[
+                          'cursor-pointer transition-colors',
+                          isSelected ? 'bg-info-bg hover:bg-info-bg-hover' : 'hover:bg-surface-hover',
+                        ].join(' ')}
+                        onClick={() => onSelectStudent?.(isSelected ? null : student)}
+                      >
+                        <DataTableCell>{fullName || student.student_email}</DataTableCell>
+                        <DataTableCell align="right">{formatPercent(student.assignments_percent)}</DataTableCell>
+                        <DataTableCell align="right">{formatPercent(student.quizzes_percent)}</DataTableCell>
+                        <DataTableCell align="right" className="font-semibold">
+                          {formatPercent(student.final_percent)}
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
 
-                {students.length === 0 && (
-                  <EmptyStateRow colSpan={4} message="No students enrolled yet" />
-                )}
-              </DataTableBody>
-            </DataTable>
-          </KeyboardNavigableTable>
-        </TableCard>
+                  {students.length === 0 && (
+                    <EmptyStateRow colSpan={4} message="No students enrolled yet" />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </KeyboardNavigableTable>
+          </TableCard>
+        </div>
       </PageContent>
     </PageLayout>
   )

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { Classroom, GradebookStudentSummary } from '@/types'
+import { Button } from '@/ui'
+import { Spinner } from '@/components/Spinner'
+import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCell,
+  DataTableHead,
+  DataTableHeaderCell,
+  DataTableRow,
+  EmptyStateRow,
+  TableCard,
+} from '@/components/DataTable'
+
+interface GradebookSettingsState {
+  use_weights: boolean
+  assignments_weight: number
+  quizzes_weight: number
+}
+
+interface Props {
+  classroom: Classroom
+}
+
+function formatPercent(value: number | null): string {
+  if (value == null) return '—'
+  return `${value.toFixed(2)}%`
+}
+
+export function TeacherGradebookTab({ classroom }: Props) {
+  const isReadOnly = !!classroom.archived_at
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [settings, setSettings] = useState<GradebookSettingsState>({
+    use_weights: false,
+    assignments_weight: 70,
+    quizzes_weight: 30,
+  })
+  const [students, setStudents] = useState<GradebookStudentSummary[]>([])
+
+  async function loadGradebook() {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to load gradebook')
+      }
+
+      setSettings(data.settings)
+      setStudents(data.students || [])
+    } catch (err: any) {
+      setError(err.message || 'Failed to load gradebook')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadGradebook()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classroom.id])
+
+  async function saveSettings() {
+    if (isReadOnly) return
+
+    setSaving(true)
+    setError('')
+    try {
+      const response = await fetch('/api/teacher/gradebook', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classroom_id: classroom.id,
+          use_weights: settings.use_weights,
+          assignments_weight: settings.assignments_weight,
+          quizzes_weight: settings.quizzes_weight,
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to save settings')
+      }
+
+      setSettings(data.settings)
+      await loadGradebook()
+    } catch (err: any) {
+      setError(err.message || 'Failed to save settings')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const totalWeight = useMemo(
+    () => Number(settings.assignments_weight || 0) + Number(settings.quizzes_weight || 0),
+    [settings.assignments_weight, settings.quizzes_weight]
+  )
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <PageLayout>
+      <PageActionBar
+        primary={
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="inline-flex items-center gap-2 text-sm text-text-default">
+              <input
+                type="checkbox"
+                checked={settings.use_weights}
+                onChange={(e) => setSettings((prev) => ({ ...prev, use_weights: e.target.checked }))}
+                disabled={isReadOnly}
+                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              Use weights
+            </label>
+
+            <label className="inline-flex items-center gap-2 text-sm text-text-default">
+              Assignments
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={settings.assignments_weight}
+                onChange={(e) => setSettings((prev) => ({ ...prev, assignments_weight: Number(e.target.value || 0) }))}
+                disabled={isReadOnly}
+                className="w-20 rounded border border-border bg-surface px-2 py-1"
+              />
+              %
+            </label>
+
+            <label className="inline-flex items-center gap-2 text-sm text-text-default">
+              Quizzes
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={settings.quizzes_weight}
+                onChange={(e) => setSettings((prev) => ({ ...prev, quizzes_weight: Number(e.target.value || 0) }))}
+                disabled={isReadOnly}
+                className="w-20 rounded border border-border bg-surface px-2 py-1"
+              />
+              %
+            </label>
+
+            <div className={`text-sm ${totalWeight === 100 ? 'text-success' : 'text-danger'}`}>
+              Total: {totalWeight}%
+            </div>
+
+            <Button onClick={saveSettings} disabled={isReadOnly || saving || totalWeight !== 100}>
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+        }
+      />
+
+      <PageContent>
+        <TableCard>
+          {error && (
+            <div className="p-3 border-b border-border">
+              <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+                {error}
+              </div>
+            </div>
+          )}
+
+          <DataTable>
+            <DataTableHead>
+              <DataTableRow>
+                <DataTableHeaderCell>Student</DataTableHeaderCell>
+                <DataTableHeaderCell align="right">Assignments %</DataTableHeaderCell>
+                <DataTableHeaderCell align="right">Quizzes %</DataTableHeaderCell>
+                <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
+              </DataTableRow>
+            </DataTableHead>
+            <DataTableBody>
+              {students.map((student) => {
+                const fullName = `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim()
+                return (
+                  <DataTableRow key={student.student_id}>
+                    <DataTableCell>{fullName || student.student_email}</DataTableCell>
+                    <DataTableCell align="right">{formatPercent(student.assignments_percent)}</DataTableCell>
+                    <DataTableCell align="right">{formatPercent(student.quizzes_percent)}</DataTableCell>
+                    <DataTableCell align="right" className="font-semibold">
+                      {formatPercent(student.final_percent)}
+                    </DataTableCell>
+                  </DataTableRow>
+                )
+              })}
+
+              {students.length === 0 && (
+                <EmptyStateRow colSpan={4} message="No students enrolled yet" />
+              )}
+            </DataTableBody>
+          </DataTable>
+        </TableCard>
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -35,19 +35,6 @@ function formatPercent(value: number | null): string {
   return `${value.toFixed(1)} %`
 }
 
-function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(2)
-}
-
-function formatScoreWithPercent(
-  earned: number | null,
-  possible: number | null,
-  percent: number | null
-): string {
-  if (earned == null || possible == null || percent == null) return '—'
-  return `${formatPoints(earned)}/${formatPoints(possible)} (${percent.toFixed(1)} %)`
-}
-
 export function TeacherGradebookTab({
   classroom,
   selectedStudentId = null,
@@ -250,18 +237,10 @@ export function TeacherGradebookTab({
                     >
                       <DataTableCell>{fullName || student.student_email}</DataTableCell>
                       <DataTableCell align="right">
-                        {formatScoreWithPercent(
-                          student.assignments_earned,
-                          student.assignments_possible,
-                          student.assignments_percent
-                        )}
+                        {formatPercent(student.assignments_percent)}
                       </DataTableCell>
                       <DataTableCell align="right">
-                        {formatScoreWithPercent(
-                          student.quizzes_earned,
-                          student.quizzes_possible,
-                          student.quizzes_percent
-                        )}
+                        {formatPercent(student.quizzes_percent)}
                       </DataTableCell>
                       <DataTableCell align="right" className="font-semibold">
                         {formatPercent(student.final_percent)}

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -58,9 +58,9 @@ type SidebarAssignment = {
 
 const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
-  { id: 'gradebook', label: 'Gradebook', icon: Percent },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
+  { id: 'gradebook', label: 'Gradebook', icon: Percent },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: StickyNote },
   { id: 'roster', label: 'Roster', icon: Users },

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -8,6 +8,7 @@ import {
   CircleHelp,
   ClipboardCheck,
   ClipboardList,
+  Percent,
   Settings,
   PenSquare,
   StickyNote,
@@ -30,6 +31,7 @@ import {
 
 export type ClassroomNavItemId =
   | 'attendance'
+  | 'gradebook'
   | 'assignments'
   | 'quizzes'
   | 'calendar'
@@ -56,6 +58,7 @@ type SidebarAssignment = {
 
 const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
+  { id: 'gradebook', label: 'Gradebook', icon: Percent },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
   { id: 'calendar', label: 'Calendar', icon: Calendar },

--- a/src/lib/gradebook.ts
+++ b/src/lib/gradebook.ts
@@ -1,0 +1,76 @@
+export interface GradebookCategoryInput {
+  earned: number
+  possible: number
+}
+
+export interface GradebookCalculationInput {
+  useWeights: boolean
+  assignmentsWeight: number
+  quizzesWeight: number
+  assignments: GradebookCategoryInput[]
+  quizzes: GradebookCategoryInput[]
+}
+
+export interface GradebookCalculationResult {
+  assignmentsPercent: number | null
+  quizzesPercent: number | null
+  finalPercent: number | null
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function toPercent(rows: GradebookCategoryInput[]): number | null {
+  const valid = rows.filter((row) => row.possible > 0 && row.earned >= 0)
+  if (valid.length === 0) return null
+
+  const earned = valid.reduce((sum, row) => sum + row.earned, 0)
+  const possible = valid.reduce((sum, row) => sum + row.possible, 0)
+
+  if (possible <= 0) return null
+  return round2((earned / possible) * 100)
+}
+
+export function calculateFinalPercent(input: GradebookCalculationInput): GradebookCalculationResult {
+  const assignmentsPercent = toPercent(input.assignments)
+  const quizzesPercent = toPercent(input.quizzes)
+
+  if (assignmentsPercent == null && quizzesPercent == null) {
+    return { assignmentsPercent: null, quizzesPercent: null, finalPercent: null }
+  }
+
+  // Unweighted: blend all scored items by points.
+  if (!input.useWeights) {
+    const all = [...input.assignments, ...input.quizzes]
+    return {
+      assignmentsPercent,
+      quizzesPercent,
+      finalPercent: toPercent(all),
+    }
+  }
+
+  // Weighted: normalize to categories that have scores.
+  const components: Array<{ percent: number; weight: number }> = []
+  if (assignmentsPercent != null && input.assignmentsWeight > 0) {
+    components.push({ percent: assignmentsPercent, weight: input.assignmentsWeight })
+  }
+  if (quizzesPercent != null && input.quizzesWeight > 0) {
+    components.push({ percent: quizzesPercent, weight: input.quizzesWeight })
+  }
+
+  if (components.length === 0) {
+    // fall back when scores exist but configured weights are zero
+    const fallback = assignmentsPercent ?? quizzesPercent
+    return { assignmentsPercent, quizzesPercent, finalPercent: fallback ?? null }
+  }
+
+  const weightTotal = components.reduce((sum, c) => sum + c.weight, 0)
+  const weighted = components.reduce((sum, c) => sum + c.percent * c.weight, 0) / weightTotal
+
+  return {
+    assignmentsPercent,
+    quizzesPercent,
+    finalPercent: round2(weighted),
+  }
+}

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -41,6 +41,7 @@ export type RouteKey =
   | 'settings'
   | 'attendance'
   | 'roster'
+  | 'gradebook'
   | 'today'
   | 'assignments-student'
   | 'assignments-teacher-list'
@@ -96,6 +97,10 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
   roster: {
     rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: 320 },
     mainContent: { maxWidth: 'wide' },
+  },
+  gradebook: {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'full' },
   },
   today: {
     rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: 360 },
@@ -202,6 +207,7 @@ export function getRouteKeyFromTab(
   if (tab === 'settings') return 'settings'
   if (tab === 'attendance') return 'attendance'
   if (tab === 'roster') return 'roster'
+  if (tab === 'gradebook') return 'gradebook'
   if (tab === 'today') return 'today'
 
   if (tab === 'calendar') {

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -99,7 +99,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'wide' },
   },
   gradebook: {
-    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: 420 },
     mainContent: { maxWidth: 'full' },
   },
   today: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,6 +159,8 @@ export interface Assignment {
   is_draft: boolean  // Whether assignment is a draft (not visible to students)
   released_at: string | null  // When the assignment was released to students
   track_authenticity: boolean
+  points_possible?: number
+  include_in_final?: boolean
   created_by: string
   created_at: string
   updated_at: string
@@ -271,6 +273,8 @@ export interface Quiz {
   status: QuizStatus
   show_results: boolean
   position: number
+  points_possible?: number
+  include_in_final?: boolean
   created_by: string
   created_at: string
   updated_at: string
@@ -282,6 +286,7 @@ export interface QuizQuestion {
   question_text: string
   options: string[]
   position: number
+  correct_option?: number | null
   created_at: string
   updated_at: string
 }
@@ -352,3 +357,22 @@ export interface Announcement {
   created_at: string
   updated_at: string
 }
+
+export interface GradebookSettings {
+  classroom_id: string
+  use_weights: boolean
+  assignments_weight: number
+  quizzes_weight: number
+}
+
+export interface GradebookStudentSummary {
+  student_id: string
+  student_email: string
+  student_first_name: string | null
+  student_last_name: string | null
+  assignments_percent: number | null
+  quizzes_percent: number | null
+  final_percent: number | null
+}
+
+export type ReportCardTerm = 'midterm' | 'final'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -370,7 +370,11 @@ export interface GradebookStudentSummary {
   student_email: string
   student_first_name: string | null
   student_last_name: string | null
+  assignments_earned: number | null
+  assignments_possible: number | null
   assignments_percent: number | null
+  quizzes_earned: number | null
+  quizzes_possible: number | null
   quizzes_percent: number | null
   final_percent: number | null
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -409,6 +409,7 @@ export interface GradebookClassAssignmentSummary {
   possible: number
   graded_count: number
   average_percent: number | null
+  median_percent: number | null
 }
 
 export interface GradebookClassQuizSummary {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -375,4 +375,57 @@ export interface GradebookStudentSummary {
   final_percent: number | null
 }
 
+export interface GradebookAssignmentDetail {
+  assignment_id: string
+  title: string
+  due_at: string
+  is_draft: boolean
+  earned: number | null
+  possible: number
+  percent: number | null
+  is_graded: boolean
+}
+
+export interface GradebookQuizDetail {
+  quiz_id: string
+  title: string
+  earned: number
+  possible: number
+  percent: number
+  status: 'draft' | 'active' | 'closed' | null
+  is_manual_override: boolean
+}
+
+export interface GradebookStudentDetail extends GradebookStudentSummary {
+  assignments: GradebookAssignmentDetail[]
+  quizzes: GradebookQuizDetail[]
+}
+
+export interface GradebookClassAssignmentSummary {
+  assignment_id: string
+  title: string
+  due_at: string
+  is_draft: boolean
+  possible: number
+  graded_count: number
+  average_percent: number | null
+}
+
+export interface GradebookClassQuizSummary {
+  quiz_id: string
+  title: string
+  status: 'draft' | 'active' | 'closed' | null
+  possible: number
+  scored_count: number
+  average_percent: number | null
+}
+
+export interface GradebookClassSummary {
+  total_students: number
+  students_with_final: number
+  average_final_percent: number | null
+  assignments: GradebookClassAssignmentSummary[]
+  quizzes: GradebookClassQuizSummary[]
+}
+
 export type ReportCardTerm = 'midterm' | 'final'

--- a/supabase/migrations/037_gradebook_foundation.sql
+++ b/supabase/migrations/037_gradebook_foundation.sql
@@ -1,0 +1,121 @@
+-- Gradebook foundation: settings, weighted assessment metadata, quiz overrides, report card snapshots
+
+-- 1) Gradebook settings per classroom
+create table if not exists public.gradebook_settings (
+  classroom_id uuid primary key references public.classrooms (id) on delete cascade,
+  use_weights boolean not null default false,
+  assignments_weight smallint not null default 70 check (assignments_weight >= 0 and assignments_weight <= 100),
+  quizzes_weight smallint not null default 30 check (quizzes_weight >= 0 and quizzes_weight <= 100),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.update_gradebook_settings_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_gradebook_settings_updated_at on public.gradebook_settings;
+create trigger update_gradebook_settings_updated_at
+  before update on public.gradebook_settings
+  for each row
+  execute function public.update_gradebook_settings_updated_at();
+
+-- 2) Assessment metadata for gradebook weighting/calculation
+alter table public.assignments
+  add column if not exists points_possible numeric(6,2) not null default 30 check (points_possible > 0),
+  add column if not exists include_in_final boolean not null default true;
+
+alter table public.quizzes
+  add column if not exists points_possible numeric(6,2) not null default 100 check (points_possible > 0),
+  add column if not exists include_in_final boolean not null default true;
+
+alter table public.quiz_questions
+  add column if not exists correct_option integer check (correct_option is null or correct_option >= 0);
+
+-- 3) Per-student quiz override scores (manual override takes precedence over auto score)
+create table if not exists public.quiz_student_scores (
+  id uuid primary key default gen_random_uuid(),
+  quiz_id uuid not null references public.quizzes (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  manual_override_score numeric(6,2) check (manual_override_score is null or manual_override_score >= 0),
+  graded_at timestamptz,
+  graded_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (quiz_id, student_id)
+);
+
+create index if not exists idx_quiz_student_scores_quiz_id on public.quiz_student_scores (quiz_id);
+create index if not exists idx_quiz_student_scores_student_id on public.quiz_student_scores (student_id);
+
+create or replace function public.update_quiz_student_scores_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_quiz_student_scores_updated_at on public.quiz_student_scores;
+create trigger update_quiz_student_scores_updated_at
+  before update on public.quiz_student_scores
+  for each row
+  execute function public.update_quiz_student_scores_updated_at();
+
+-- 4) Report card snapshots (midterm/final only)
+create table if not exists public.report_cards (
+  id uuid primary key default gen_random_uuid(),
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  term text not null check (term in ('midterm', 'final')),
+  locked_at timestamptz,
+  created_by uuid not null references public.users (id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (classroom_id, term)
+);
+
+create table if not exists public.report_card_rows (
+  id uuid primary key default gen_random_uuid(),
+  report_card_id uuid not null references public.report_cards (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  final_percent numeric(5,2) not null check (final_percent >= 0 and final_percent <= 100),
+  teacher_comment text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (report_card_id, student_id)
+);
+
+create index if not exists idx_report_cards_classroom_term on public.report_cards (classroom_id, term);
+create index if not exists idx_report_card_rows_report_card on public.report_card_rows (report_card_id);
+
+create or replace function public.update_report_cards_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_report_cards_updated_at on public.report_cards;
+create trigger update_report_cards_updated_at
+  before update on public.report_cards
+  for each row
+  execute function public.update_report_cards_updated_at();
+
+create or replace function public.update_report_card_rows_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_report_card_rows_updated_at on public.report_card_rows;
+create trigger update_report_card_rows_updated_at
+  before update on public.report_card_rows
+  for each row
+  execute function public.update_report_card_rows_updated_at();

--- a/tests/api/teacher/assignments-id-grade.test.ts
+++ b/tests/api/teacher/assignments-id-grade.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/assignments/[id]/grade/route'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('POST /api/teacher/assignments/[id]/grade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('upserts a grade (including 0) even when no submission doc exists', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'enroll-1' }, error: null }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          upsert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'doc-1',
+                  assignment_id: 'assignment-1',
+                  student_id: 'student-1',
+                  score_completion: 0,
+                  score_thinking: 0,
+                  score_workflow: 0,
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_id: 'student-1',
+        score_completion: 0,
+        score_thinking: 0,
+        score_workflow: 0,
+        feedback: 'No submission',
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.doc.score_completion).toBe(0)
+    expect(body.doc.score_thinking).toBe(0)
+    expect(body.doc.score_workflow).toBe(0)
+  })
+
+  it('returns 400 if student is not enrolled in the assignment classroom', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_id: 'student-missing',
+        score_completion: 0,
+        score_thinking: 0,
+        score_workflow: 0,
+        feedback: 'No submission',
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    expect(response.status).toBe(400)
+  })
+})

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -1,0 +1,503 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, PATCH } from '@/app/api/teacher/gradebook/route'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+type GradebookFixture = {
+  enrollments?: Array<{ student_id: string; users: { email: string } }>
+  profiles?: Array<{ user_id: string; first_name: string | null; last_name: string | null }>
+  assignments?: Array<any>
+  docs?: Array<any>
+  quizzes?: Array<any>
+  quizQuestions?: Array<any>
+  quizResponses?: Array<any>
+  quizOverrides?: Array<any>
+  settings?: { use_weights: boolean; assignments_weight: number; quizzes_weight: number } | null
+}
+
+function buildMockFrom(fixture: GradebookFixture) {
+  return vi.fn((table: string) => {
+    if (table === 'classrooms') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'gradebook_settings') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: fixture.settings ?? null,
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({
+            data:
+              fixture.enrollments ?? [
+                {
+                  student_id: 'student-1',
+                  users: { email: 'student1@example.com' },
+                },
+              ],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'student_profiles') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data:
+              fixture.profiles ?? [
+                { user_id: 'student-1', first_name: 'Student', last_name: 'One' },
+              ],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'assignments') {
+      const baseData = (fixture.assignments ?? [])
+        .slice()
+        .sort((a, b) => Number(a.position ?? 0) - Number(b.position ?? 0))
+
+      const query = {
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({
+          data: baseData,
+          error: null,
+        }),
+      }
+      return {
+        select: vi.fn(() => query),
+      }
+    }
+
+    if (table === 'assignment_docs') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: fixture.docs ?? [],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'quizzes') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({
+            data: fixture.quizzes ?? [],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'quiz_questions') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: fixture.quizQuestions ?? [],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'quiz_responses') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: fixture.quizResponses ?? [],
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'quiz_student_scores') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: fixture.quizOverrides ?? [],
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    throw new Error(`Unexpected table in test: ${table}`)
+  })
+}
+
+describe('GET /api/teacher/gradebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('excludes draft quizzes from grade calculations', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      quizzes: [
+        { id: 'quiz-active', title: 'Active Quiz', status: 'active', points_possible: 10, include_in_final: true },
+        { id: 'quiz-draft', title: 'Draft Quiz', status: 'draft', points_possible: 10, include_in_final: true },
+      ],
+      quizQuestions: [
+        { id: 'q1', quiz_id: 'quiz-active', correct_option: 0 },
+        { id: 'q2', quiz_id: 'quiz-draft', correct_option: 0 },
+      ],
+      quizResponses: [{ quiz_id: 'quiz-active', question_id: 'q1', student_id: 'student-1', selected_option: 0 }],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students).toHaveLength(1)
+
+    // Draft quiz should be ignored; only active quiz contributes.
+    expect(body.students[0].quizzes_percent).toBe(100)
+    expect(body.students[0].final_percent).toBe(100)
+  })
+
+  it('does not count unattempted active quizzes as zero before they are closed', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      quizzes: [{ id: 'quiz-active', title: 'Active Quiz', status: 'active', points_possible: 10, include_in_final: true }],
+      quizQuestions: [{ id: 'q1', quiz_id: 'quiz-active', correct_option: 1 }],
+      quizResponses: [],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students).toHaveLength(1)
+
+    // No attempt yet means no quiz mark in-progress.
+    expect(body.students[0].quizzes_percent).toBeNull()
+    expect(body.students[0].final_percent).toBeNull()
+  })
+
+  it('returns selected student assignment and quiz breakdown when student_id is provided', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      assignments: [{ id: 'a1', title: 'Essay', due_at: '2025-01-01T12:00:00.000Z', position: 2, is_draft: false, points_possible: 30, include_in_final: true }],
+      docs: [{ assignment_id: 'a1', student_id: 'student-1', score_completion: 9, score_thinking: 8, score_workflow: 7 }],
+      quizzes: [{ id: 'q1', title: 'Quiz 1', status: 'closed', points_possible: 10, include_in_final: true }],
+      quizQuestions: [{ id: 'qq1', quiz_id: 'q1', correct_option: 2 }],
+      quizResponses: [{ quiz_id: 'q1', question_id: 'qq1', student_id: 'student-1', selected_option: 2 }],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1&student_id=student-1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.selected_student).toBeTruthy()
+    expect(body.selected_student.assignments).toEqual([
+      {
+        assignment_id: 'a1',
+        title: 'Essay',
+        due_at: '2025-01-01T12:00:00.000Z',
+        is_draft: false,
+        earned: 24,
+        possible: 30,
+        percent: 80,
+        is_graded: true,
+      },
+    ])
+    expect(body.selected_student.quizzes).toEqual([
+      {
+        quiz_id: 'q1',
+        title: 'Quiz 1',
+        earned: 10,
+        possible: 10,
+        percent: 100,
+        status: 'closed',
+        is_manual_override: false,
+      },
+    ])
+  })
+
+  it('includes all assignments (graded/ungraded/future) in selected student details by assignment order', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      assignments: [
+        { id: 'a-graded', title: 'Past Due Graded', due_at: '2025-01-01T12:00:00.000Z', position: 2, is_draft: false, points_possible: 30, include_in_final: true },
+        { id: 'a-ungraded', title: 'Past Due Ungraded', due_at: '2025-01-02T12:00:00.000Z', position: 1, is_draft: false, points_possible: 30, include_in_final: true },
+        { id: 'a-future', title: 'Future Assignment', due_at: '2099-01-01T12:00:00.000Z', position: 3, is_draft: false, points_possible: 30, include_in_final: true },
+        { id: 'a-draft', title: 'Draft Assignment', due_at: '2025-01-03T12:00:00.000Z', position: 4, is_draft: true, points_possible: 30, include_in_final: true },
+      ],
+      docs: [{ assignment_id: 'a-graded', student_id: 'student-1', score_completion: 10, score_thinking: 10, score_workflow: 10 }],
+      quizzes: [],
+      quizQuestions: [],
+      quizResponses: [],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1&student_id=student-1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.selected_student.assignments).toEqual([
+      {
+        assignment_id: 'a-ungraded',
+        title: 'Past Due Ungraded',
+        due_at: '2025-01-02T12:00:00.000Z',
+        is_draft: false,
+        earned: null,
+        possible: 30,
+        percent: null,
+        is_graded: false,
+      },
+      {
+        assignment_id: 'a-graded',
+        title: 'Past Due Graded',
+        due_at: '2025-01-01T12:00:00.000Z',
+        is_draft: false,
+        earned: 30,
+        possible: 30,
+        percent: 100,
+        is_graded: true,
+      },
+      {
+        assignment_id: 'a-future',
+        title: 'Future Assignment',
+        due_at: '2099-01-01T12:00:00.000Z',
+        is_draft: false,
+        earned: null,
+        possible: 30,
+        percent: null,
+        is_graded: false,
+      },
+      {
+        assignment_id: 'a-draft',
+        title: 'Draft Assignment',
+        due_at: '2025-01-03T12:00:00.000Z',
+        is_draft: true,
+        earned: null,
+        possible: 30,
+        percent: null,
+        is_graded: false,
+      },
+    ])
+  })
+
+  it('falls back to legacy assignment/quiz columns when gradebook metadata columns are unavailable', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'gradebook_settings') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1', users: { email: 'student1@example.com' } }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'assignments') {
+        return {
+          select: vi.fn((selection: string) => {
+            const query = {
+              eq: vi.fn().mockReturnThis(),
+              order: vi.fn().mockResolvedValue(
+                selection.includes('points_possible')
+                  ? { data: null, error: { message: 'column assignments.points_possible does not exist' } }
+                  : {
+                      data: [{ id: 'a1', title: 'Essay', due_at: '2025-01-01T12:00:00.000Z', position: 1, is_draft: false }],
+                      error: null,
+                    }
+              ),
+            }
+            return query
+          }),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ assignment_id: 'a1', student_id: 'student-1', score_completion: 9, score_thinking: 8, score_workflow: 7 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'quizzes') {
+        return {
+          select: vi.fn((selection: string) => ({
+            eq: vi.fn().mockResolvedValue(
+              selection.includes('points_possible')
+                ? { data: null, error: { message: 'column quizzes.points_possible does not exist' } }
+                : { data: [], error: null }
+            ),
+          })),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'quiz_student_scores') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.totals.assignments).toBe(1)
+    expect(body.students[0].assignments_percent).toBe(80)
+    expect(body.students[0].final_percent).toBe(80)
+  })
+})
+
+describe('PATCH /api/teacher/gradebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('allows non-100 weights when use_weights is false', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'gradebook_settings') {
+        return {
+          upsert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { use_weights: false, assignments_weight: 10, quizzes_weight: 20 },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        classroom_id: 'c1',
+        use_weights: false,
+        assignments_weight: 10,
+        quizzes_weight: 20,
+      }),
+    })
+
+    const response = await PATCH(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.settings).toEqual({
+      use_weights: false,
+      assignments_weight: 10,
+      quizzes_weight: 20,
+    })
+  })
+})

--- a/tests/unit/gradebook.test.ts
+++ b/tests/unit/gradebook.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { calculateFinalPercent } from '@/lib/gradebook'
+
+describe('gradebook final percent', () => {
+  it('returns nulls when no scores exist', () => {
+    const result = calculateFinalPercent({
+      useWeights: false,
+      assignmentsWeight: 70,
+      quizzesWeight: 30,
+      assignments: [],
+      quizzes: [],
+    })
+
+    expect(result).toEqual({
+      assignmentsPercent: null,
+      quizzesPercent: null,
+      finalPercent: null,
+    })
+  })
+
+  it('computes unweighted percent using points across categories', () => {
+    const result = calculateFinalPercent({
+      useWeights: false,
+      assignmentsWeight: 70,
+      quizzesWeight: 30,
+      assignments: [
+        { earned: 24, possible: 30 },
+        { earned: 18, possible: 20 },
+      ],
+      quizzes: [{ earned: 8, possible: 10 }],
+    })
+
+    expect(result.assignmentsPercent).toBe(84)
+    expect(result.quizzesPercent).toBe(80)
+    expect(result.finalPercent).toBe(83.33)
+  })
+
+  it('computes weighted percent when enabled', () => {
+    const result = calculateFinalPercent({
+      useWeights: true,
+      assignmentsWeight: 70,
+      quizzesWeight: 30,
+      assignments: [{ earned: 24, possible: 30 }],
+      quizzes: [{ earned: 8, possible: 10 }],
+    })
+
+    expect(result.assignmentsPercent).toBe(80)
+    expect(result.quizzesPercent).toBe(80)
+    expect(result.finalPercent).toBe(80)
+  })
+
+  it('renormalizes weighted calc when one category has no scores', () => {
+    const result = calculateFinalPercent({
+      useWeights: true,
+      assignmentsWeight: 70,
+      quizzesWeight: 30,
+      assignments: [{ earned: 27, possible: 30 }],
+      quizzes: [],
+    })
+
+    expect(result.assignmentsPercent).toBe(90)
+    expect(result.quizzesPercent).toBeNull()
+    expect(result.finalPercent).toBe(90)
+  })
+})

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -118,6 +118,7 @@ describe('getRightSidebarCssWidth', () => {
 describe('getRouteKeyFromTab', () => {
   it('should return correct route key for teacher tabs', () => {
     expect(getRouteKeyFromTab('attendance', 'teacher')).toBe('attendance')
+    expect(getRouteKeyFromTab('gradebook', 'teacher')).toBe('gradebook')
     expect(getRouteKeyFromTab('roster', 'teacher')).toBe('roster')
     expect(getRouteKeyFromTab('settings', 'teacher')).toBe('settings')
   })
@@ -151,6 +152,7 @@ describe('ROUTE_CONFIGS', () => {
       'classrooms-list',
       'settings',
       'attendance',
+      'gradebook',
       'roster',
       'today',
       'assignments-student',


### PR DESCRIPTION
## Summary\n- add gradebook schema foundation (settings, assessment metadata, quiz overrides, report-card snapshot tables)\n- add pure grade calculation utility and tests\n- add teacher gradebook APIs for settings + matrix + quiz override writes\n- add teacher Gradebook tab with weight controls and roster-style final percentage table\n\n## Validation\n- pnpm lint\n- pnpm test -- tests/unit/gradebook.test.ts tests/unit/layout-config.test.ts\n- visual verification screenshots (teacher/student): /tmp/teacher-gradebook-tab.png, /tmp/student-gradebook-tab.png\n\n## Notes\n- migration was added only; no migrations were applied by AI\n