### PR TITLE
Fix student grade feedback card layout in assignment editor

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2523,3 +2523,5 @@
 - Visual checks: `/tmp/teacher-view-grade-card-2.png`, `/tmp/student-view-grade-card-full.png`
 - Follow-up polish: moved Grade to left / Feedback to right, restored divider, and adjusted score chips to box only earned values (max values unboxed/muted).
 - Final visual checks: `/tmp/student-view-grade-card-6.png`, `/tmp/teacher-view-grade-card-6.png`
+- Final polish pass: card title changed to "Feedback", removed feedback column subheading, set grade/feedback columns to 1/3 and 2/3 with centered inline 80% in Total row.
+- Visual checks: `/tmp/student-view-grade-card-10.png`, `/tmp/teacher-view-grade-card-10.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2527,3 +2527,6 @@
 - Visual checks: `/tmp/student-view-grade-card-10.png`, `/tmp/teacher-view-grade-card-10.png`
 - Review fix: grade card now renders only when all three score components are present (completion, thinking, workflow) to prevent partial/null score rows.
 - Verification: `pnpm test tests/components/StudentAssignmentsTab.test.tsx`, `/tmp/student-view-grade-card-11.png`, `/tmp/teacher-view-grade-card-11.png`
+- Behavior update: show returned feedback card when returned_at and either feedback text exists or any score exists.
+- Score section now supports incomplete grades (renders available rows), shows Total only for full score set, and shows "No score assigned." when none.
+- Verification: `pnpm test tests/components/StudentAssignmentsTab.test.tsx`, `/tmp/student-view-grade-card-12.png`, `/tmp/teacher-view-grade-card-12.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2530,3 +2530,6 @@
 - Behavior update: show returned feedback card when returned_at and either feedback text exists or any score exists.
 - Score section now supports incomplete grades (renders available rows), shows Total only for full score set, and shows "No score assigned." when none.
 - Verification: `pnpm test tests/components/StudentAssignmentsTab.test.tsx`, `/tmp/student-view-grade-card-12.png`, `/tmp/teacher-view-grade-card-12.png`
+- Added regression tests for returned feedback card behavior in `tests/components/StudentAssignmentEditor.feedback-card.test.tsx`.
+- Covered feedback-only return, partial-score return, and full-score return with total/percent.
+- Validation: `pnpm test tests/components/StudentAssignmentEditor.feedback-card.test.tsx` and `pnpm test tests/components/StudentAssignmentsTab.test.tsx`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2503,3 +2503,23 @@
 - `pnpm lint` passed
 - `pnpm test -- tests/unit/gradebook.test.ts tests/unit/layout-config.test.ts` passed
 - Visual checks: `/tmp/teacher-gradebook-tab.png`, `/tmp/student-gradebook-tab.png`
+
+---
+## 2026-02-15 [AI - GPT-5 Codex]
+**Goal:** Fix student assignment grade feedback card layout to a two-column split
+**Completed:**
+- Updated returned-work grade panel to a responsive two-column layout
+- Left column now contains completion/thinking/workflow scores and total
+- Right column now contains feedback text with fallback when empty
+- Added a vertical divider on desktop (`md`) and stacked layout on smaller screens
+- Performed visual verification screenshots for both teacher and student roles
+**Status:** completed
+**Artifacts:**
+- Branch: codex/student-grade-feedback-card
+- Worktree: /Users/stew/Repos/.worktrees/pika/codex-student-grade-feedback-card
+- File: src/components/StudentAssignmentEditor.tsx
+**Validation:**
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx` passed
+- Visual checks: `/tmp/teacher-view-grade-card-2.png`, `/tmp/student-view-grade-card-full.png`
+- Follow-up polish: moved Grade to left / Feedback to right, restored divider, and adjusted score chips to box only earned values (max values unboxed/muted).
+- Final visual checks: `/tmp/student-view-grade-card-6.png`, `/tmp/teacher-view-grade-card-6.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2525,3 +2525,5 @@
 - Final visual checks: `/tmp/student-view-grade-card-6.png`, `/tmp/teacher-view-grade-card-6.png`
 - Final polish pass: card title changed to "Feedback", removed feedback column subheading, set grade/feedback columns to 1/3 and 2/3 with centered inline 80% in Total row.
 - Visual checks: `/tmp/student-view-grade-card-10.png`, `/tmp/teacher-view-grade-card-10.png`
+- Review fix: grade card now renders only when all three score components are present (completion, thinking, workflow) to prevent partial/null score rows.
+- Verification: `pnpm test tests/components/StudentAssignmentsTab.test.tsx`, `/tmp/student-view-grade-card-11.png`, `/tmp/teacher-view-grade-card-11.png`

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -666,7 +666,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       )}
 
       {/* Grade panel (shown when work has been returned) */}
-      {doc?.returned_at && doc.score_completion != null && (
+      {doc?.returned_at && doc.score_completion != null && doc.score_thinking != null && doc.score_workflow != null && (
         <div className="bg-surface rounded-lg shadow-sm border border-border p-4 space-y-3">
           <h3 className="text-sm font-semibold text-text-default">Feedback</h3>
           <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -461,6 +461,12 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
 
   const status = calculateAssignmentStatus(assignment, doc)
   const isPreviewLocked = lockedEntryId !== null
+  const hasFeedback = Boolean(doc?.feedback?.trim())
+  const hasCompletionScore = doc?.score_completion != null
+  const hasThinkingScore = doc?.score_thinking != null
+  const hasWorkflowScore = doc?.score_workflow != null
+  const hasAnyScore = hasCompletionScore || hasThinkingScore || hasWorkflowScore
+  const hasFullScoreSet = hasCompletionScore && hasThinkingScore && hasWorkflowScore
 
   const editorContent = (
     <div className="flex flex-col gap-6 h-full min-h-0">
@@ -666,52 +672,63 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       )}
 
       {/* Grade panel (shown when work has been returned) */}
-      {doc?.returned_at && doc.score_completion != null && doc.score_thinking != null && doc.score_workflow != null && (
+      {doc?.returned_at && (hasFeedback || hasAnyScore) && (
         <div className="bg-surface rounded-lg shadow-sm border border-border p-4 space-y-3">
           <h3 className="text-sm font-semibold text-text-default">Feedback</h3>
           <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
             <div className="space-y-2 text-sm md:pr-4 md:border-r md:border-border">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-text-muted">Completion</span>
-                <span className="inline-flex items-center gap-1 font-medium">
-                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
-                    {doc.score_completion}
-                  </span>
-                  <span className="text-xs text-text-muted">10</span>
-                </span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-text-muted">Thinking</span>
-                <span className="inline-flex items-center gap-1 font-medium">
-                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
-                    {doc.score_thinking}
-                  </span>
-                  <span className="text-xs text-text-muted">10</span>
-                </span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-text-muted">Workflow</span>
-                <span className="inline-flex items-center gap-1 font-medium">
-                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
-                    {doc.score_workflow}
-                  </span>
-                  <span className="text-xs text-text-muted">10</span>
-                </span>
-              </div>
-              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 pt-1">
-                <span className="text-text-default font-medium">Total</span>
-                <div className="flex justify-center">
-                  <span className="inline-flex items-center border border-border rounded-md px-3 py-1 text-xl font-semibold text-text-default">
-                    {Math.round((((doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)) / 30) * 100)}%
+              {hasCompletionScore && (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-text-muted">Completion</span>
+                  <span className="inline-flex items-center gap-1 font-medium">
+                    <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                      {doc.score_completion}
+                    </span>
+                    <span className="text-xs text-text-muted">10</span>
                   </span>
                 </div>
-                <span className="inline-flex items-center gap-1 font-semibold">
-                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
-                    {(doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)}
+              )}
+              {hasThinkingScore && (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-text-muted">Thinking</span>
+                  <span className="inline-flex items-center gap-1 font-medium">
+                    <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                      {doc.score_thinking}
+                    </span>
+                    <span className="text-xs text-text-muted">10</span>
                   </span>
-                  <span className="text-xs text-text-muted">30</span>
-                </span>
-              </div>
+                </div>
+              )}
+              {hasWorkflowScore && (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-text-muted">Workflow</span>
+                  <span className="inline-flex items-center gap-1 font-medium">
+                    <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                      {doc.score_workflow}
+                    </span>
+                    <span className="text-xs text-text-muted">10</span>
+                  </span>
+                </div>
+              )}
+              {hasFullScoreSet && (
+                <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 pt-1">
+                  <span className="text-text-default font-medium">Total</span>
+                  <div className="flex justify-center">
+                    <span className="inline-flex items-center border border-border rounded-md px-3 py-1 text-xl font-semibold text-text-default">
+                      {Math.round((((doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)) / 30) * 100)}%
+                    </span>
+                  </div>
+                  <span className="inline-flex items-center gap-1 font-semibold">
+                    <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                      {(doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)}
+                    </span>
+                    <span className="text-xs text-text-muted">30</span>
+                  </span>
+                </div>
+              )}
+              {!hasAnyScore && (
+                <div className="text-xs text-text-muted">No score assigned.</div>
+              )}
             </div>
             <div>
               <div className="text-sm text-text-default whitespace-pre-wrap">

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -668,8 +668,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       {/* Grade panel (shown when work has been returned) */}
       {doc?.returned_at && doc.score_completion != null && (
         <div className="bg-surface rounded-lg shadow-sm border border-border p-4 space-y-3">
-          <h3 className="text-sm font-semibold text-text-default">Grade</h3>
-          <div className="grid gap-4 md:grid-cols-2">
+          <h3 className="text-sm font-semibold text-text-default">Feedback</h3>
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
             <div className="space-y-2 text-sm md:pr-4 md:border-r md:border-border">
               <div className="flex items-center justify-between gap-3">
                 <span className="text-text-muted">Completion</span>
@@ -698,8 +698,13 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                   <span className="text-xs text-text-muted">10</span>
                 </span>
               </div>
-              <div className="flex items-center justify-between gap-3 pt-1">
+              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 pt-1">
                 <span className="text-text-default font-medium">Total</span>
+                <div className="flex justify-center">
+                  <span className="inline-flex items-center border border-border rounded-md px-3 py-1 text-xl font-semibold text-text-default">
+                    {Math.round((((doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)) / 30) * 100)}%
+                  </span>
+                </div>
                 <span className="inline-flex items-center gap-1 font-semibold">
                   <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
                     {(doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)}
@@ -707,14 +712,8 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                   <span className="text-xs text-text-muted">30</span>
                 </span>
               </div>
-              <div className="flex justify-end">
-                <span className="inline-flex items-center border border-border rounded-md px-3 py-1 text-xl font-semibold text-text-default">
-                  {Math.round((((doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)) / 30) * 100)}%
-                </span>
-              </div>
             </div>
             <div>
-              <div className="text-xs text-text-muted mb-1">Feedback</div>
               <div className="text-sm text-text-default whitespace-pre-wrap">
                 {doc.feedback?.trim() || 'No feedback provided yet.'}
               </div>

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -669,29 +669,57 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       {doc?.returned_at && doc.score_completion != null && (
         <div className="bg-surface rounded-lg shadow-sm border border-border p-4 space-y-3">
           <h3 className="text-sm font-semibold text-text-default">Grade</h3>
-          <div className="grid grid-cols-3 gap-3 text-sm">
-            <div>
-              <div className="text-text-muted text-xs">Completion</div>
-              <div className="font-medium">{doc.score_completion}/10</div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2 text-sm md:pr-4 md:border-r md:border-border">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-text-muted">Completion</span>
+                <span className="inline-flex items-center gap-1 font-medium">
+                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                    {doc.score_completion}
+                  </span>
+                  <span className="text-xs text-text-muted">10</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-text-muted">Thinking</span>
+                <span className="inline-flex items-center gap-1 font-medium">
+                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                    {doc.score_thinking}
+                  </span>
+                  <span className="text-xs text-text-muted">10</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-text-muted">Workflow</span>
+                <span className="inline-flex items-center gap-1 font-medium">
+                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                    {doc.score_workflow}
+                  </span>
+                  <span className="text-xs text-text-muted">10</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3 pt-1">
+                <span className="text-text-default font-medium">Total</span>
+                <span className="inline-flex items-center gap-1 font-semibold">
+                  <span className="inline-flex items-center border border-border rounded-md px-2 py-1 text-base text-text-default">
+                    {(doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)}
+                  </span>
+                  <span className="text-xs text-text-muted">30</span>
+                </span>
+              </div>
+              <div className="flex justify-end">
+                <span className="inline-flex items-center border border-border rounded-md px-3 py-1 text-xl font-semibold text-text-default">
+                  {Math.round((((doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)) / 30) * 100)}%
+                </span>
+              </div>
             </div>
-            <div>
-              <div className="text-text-muted text-xs">Thinking</div>
-              <div className="font-medium">{doc.score_thinking}/10</div>
-            </div>
-            <div>
-              <div className="text-text-muted text-xs">Workflow</div>
-              <div className="font-medium">{doc.score_workflow}/10</div>
-            </div>
-          </div>
-          <div className="text-sm font-medium">
-            Total: {(doc.score_completion ?? 0) + (doc.score_thinking ?? 0) + (doc.score_workflow ?? 0)}/30
-          </div>
-          {doc.feedback && (
             <div>
               <div className="text-xs text-text-muted mb-1">Feedback</div>
-              <div className="text-sm text-text-default whitespace-pre-wrap">{doc.feedback}</div>
+              <div className="text-sm text-text-default whitespace-pre-wrap">
+                {doc.feedback?.trim() || 'No feedback provided yet.'}
+              </div>
             </div>
-          )}
+          </div>
         </div>
       )}
 

--- a/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
+++ b/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { StudentAssignmentEditor } from '@/components/StudentAssignmentEditor'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/components/StudentNotificationsProvider', () => ({
+  useStudentNotifications: () => null,
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}))
+
+vi.mock('@/components/HistoryList', () => ({
+  HistoryList: () => <div data-testid="history-list" />,
+}))
+
+vi.mock('@/components/editor', () => ({
+  RichTextEditor: () => <div data-testid="rich-text-editor" />,
+  RichTextViewer: () => <div data-testid="rich-text-viewer" />,
+}))
+
+vi.mock('@/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Tooltip: ({ children }: any) => <>{children}</>,
+}))
+
+function makeAssignment() {
+  return {
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    title: 'Assignment Title',
+    description: 'Assignment description',
+    due_at: '2026-02-20T00:00:00Z',
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+  } as any
+}
+
+function makeDoc(overrides: Record<string, unknown>) {
+  return {
+    id: 'doc-1',
+    assignment_id: 'assignment-1',
+    student_id: 'student-1',
+    content: { type: 'doc', content: [] },
+    is_submitted: false,
+    submitted_at: null,
+    viewed_at: '2026-02-10T00:00:00Z',
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+    score_completion: null,
+    score_thinking: null,
+    score_workflow: null,
+    feedback: null,
+    graded_at: null,
+    graded_by: null,
+    returned_at: '2026-02-15T00:00:00Z',
+    ...overrides,
+  } as any
+}
+
+describe('StudentAssignmentEditor feedback card rendering', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function mockLoadResponses(doc: any) {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ assignment: makeAssignment(), doc, wasFirstView: false }),
+      })
+    })
+  }
+
+  it('shows returned feedback card for feedback-only (no scores)', async () => {
+    mockLoadResponses(
+      makeDoc({
+        feedback: 'Teacher comment only.',
+        score_completion: null,
+        score_thinking: null,
+        score_workflow: null,
+      }),
+    )
+
+    render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Feedback')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Teacher comment only.')).toBeInTheDocument()
+    expect(screen.getByText('No score assigned.')).toBeInTheDocument()
+    expect(screen.queryByText('Total')).not.toBeInTheDocument()
+  })
+
+  it('shows available score rows for partial grades and hides total', async () => {
+    mockLoadResponses(
+      makeDoc({
+        feedback: '',
+        score_completion: 7,
+        score_thinking: null,
+        score_workflow: null,
+      }),
+    )
+
+    render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Feedback')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Completion')).toBeInTheDocument()
+    expect(screen.queryByText('Thinking')).not.toBeInTheDocument()
+    expect(screen.queryByText('Workflow')).not.toBeInTheDocument()
+    expect(screen.queryByText('Total')).not.toBeInTheDocument()
+    expect(screen.getByText('No feedback provided yet.')).toBeInTheDocument()
+  })
+
+  it('shows full score set and total percent when all scores exist', async () => {
+    mockLoadResponses(
+      makeDoc({
+        feedback: 'Strong effort and clear structure.',
+        score_completion: 9,
+        score_thinking: 8,
+        score_workflow: 7,
+      }),
+    )
+
+    render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Feedback')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Completion')).toBeInTheDocument()
+    expect(screen.getByText('Thinking')).toBeInTheDocument()
+    expect(screen.getByText('Workflow')).toBeInTheDocument()
+    expect(screen.getByText('Total')).toBeInTheDocument()
+    expect(screen.getByText('80%')).toBeInTheDocument()
+    expect(screen.getByText('Strong effort and clear structure.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- reworked the returned grade card into a two-column desktop layout
- placed Grade details on the left and Feedback on the right with a divider
- updated score presentation so only earned values are boxed and max values are muted text
- displayed total raw score inline with subtotals and emphasized percentage below

## Validation
- pnpm test tests/components/StudentAssignmentsTab.test.tsx
- visual verification (teacher + student):
  - /tmp/teacher-view-grade-card-6.png
  - /tmp/student-view-grade-card-6.png