### PR TITLE
fix(assignments): persist teacher History/Grading panel mode

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2580,3 +2580,41 @@
 - `pnpm lint` passed
 - `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/ThreePanelProvider.test.tsx` passed
 - `npx playwright test e2e/classroom-loading.spec.ts --project=chromium-desktop -g "same-classroom"` passed
+
+---
+## 2026-02-20 [AI - GPT-5 Codex]
+**Goal:** Resolve GH issues #334 and #335 in worktree `codex/334-335-assignment-pane-history`
+**Completed:**
+- Closed issue #334 per reporter confirmation (no code change required).
+- Fixed #335 by preserving teacher-selected right-panel mode (`History`/`Grading`) across student switches in `TeacherStudentWorkPanel`.
+- Added regression tests covering both persistence directions:
+  - keep `Grading` selected when switching students
+  - keep `History` selected when switching students
+- Performed required visual verification screenshots for teacher and student views.
+- Closed issue #335 with implementation and validation summary.
+**Status:** completed
+**Artifacts:**
+- Branch: `codex/334-335-assignment-pane-history`
+- Worktree: `/Users/stew/Repos/.worktrees/pika/codex-334-335-assignment-pane-history`
+- Screenshots: `/tmp/issue335-teacher-view.png`, `/tmp/issue335-student-view.png`
+- Key files: `src/components/TeacherStudentWorkPanel.tsx`, `tests/components/TeacherStudentWorkPanel.test.tsx`
+**Validation:**
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` passed
+- `pnpm lint` passed
+
+---
+## 2026-02-20 [AI - GPT-5 Codex] (follow-up)
+**Goal:** Add reload persistence for teacher assignment right-panel mode (`History`/`Grading`)
+**Completed:**
+- Added cookie-backed mode persistence in `TeacherStudentWorkPanel` using key `pika_teacher_student_work_tab`.
+- Restored mode from cookie on mount and persisted mode on tab changes.
+- Persisted auto-grade transition to `Grading` via the same cookie path.
+- Extended tests to cover reload persistence and cookie writes.
+- Re-ran mandatory teacher/student screenshots after UI behavior update.
+**Status:** completed
+**Artifacts:**
+- Screenshots: `/tmp/issue335b-teacher-view.png`, `/tmp/issue335b-student-view.png`
+- Key files: `src/components/TeacherStudentWorkPanel.tsx`, `tests/components/TeacherStudentWorkPanel.test.tsx`
+**Validation:**
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` passed
+- `pnpm lint` passed

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2618,3 +2618,18 @@
 **Validation:**
 - `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` passed
 - `pnpm lint` passed
+
+---
+## 2026-02-20 [AI - GPT-5 Codex] (follow-up 2)
+**Goal:** Scope teacher work-panel mode persistence by classroom
+**Completed:**
+- Updated `TeacherStudentWorkPanel` cookie key to be classroom-scoped (`pika_teacher_student_work_tab:<classroomId>`).
+- Passed `classroomId` prop from classroom page into `TeacherStudentWorkPanel`.
+- Extended regression tests with classroom-scoping coverage.
+- Re-ran mandatory teacher/student UI screenshots after behavior update.
+**Status:** completed
+**Artifacts:**
+- Screenshots: `/tmp/issue335c-teacher-view.png`, `/tmp/issue335c-student-view.png`
+**Validation:**
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` passed (5 tests)
+- `pnpm lint` passed

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1158,6 +1158,7 @@ function ClassroomPageContent({
             <LogSummary classroomId={classroom.id} date={attendanceDate} onStudentClick={handleSummaryStudentClick} />
           ) : isTeacher && activeTab === 'assignments' && selectedStudent ? (
             <TeacherStudentWorkPanel
+              classroomId={classroom.id}
               assignmentId={selectedStudent.assignmentId}
               studentId={selectedStudent.studentId}
             />

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -115,14 +115,20 @@ interface StudentWorkData {
 }
 
 interface TeacherStudentWorkPanelProps {
+  classroomId: string
   assignmentId: string
   studentId: string
 }
 
 type RightTab = 'history' | 'grading'
-const RIGHT_TAB_COOKIE = 'pika_teacher_student_work_tab'
+const RIGHT_TAB_COOKIE_PREFIX = 'pika_teacher_student_work_tab'
+
+function getRightTabCookieName(classroomId: string) {
+  return `${RIGHT_TAB_COOKIE_PREFIX}:${classroomId}`
+}
 
 export function TeacherStudentWorkPanel({
+  classroomId,
   assignmentId,
   studentId,
 }: TeacherStudentWorkPanelProps) {
@@ -137,10 +143,11 @@ export function TeacherStudentWorkPanel({
   const [previewEntry, setPreviewEntry] = useState<AssignmentDocHistoryEntry | null>(null)
   const [previewContent, setPreviewContent] = useState<TiptapContent | null>(null)
   const [lockedEntryId, setLockedEntryId] = useState<string | null>(null)
+  const rightTabCookieName = getRightTabCookieName(classroomId)
 
   // Grading state
   const [rightTab, setRightTab] = useState<RightTab>(() => (
-    readCookie(RIGHT_TAB_COOKIE) === 'grading' ? 'grading' : 'history'
+    readCookie(getRightTabCookieName(classroomId)) === 'grading' ? 'grading' : 'history'
   ))
   const [scoreCompletion, setScoreCompletion] = useState<string>('')
   const [scoreThinking, setScoreThinking] = useState<string>('')
@@ -153,7 +160,7 @@ export function TeacherStudentWorkPanel({
 
   function handleRightTabChange(nextTab: RightTab) {
     setRightTab(nextTab)
-    writeCookie(RIGHT_TAB_COOKIE, nextTab)
+    writeCookie(rightTabCookieName, nextTab)
   }
 
   function updatePreview(entry: AssignmentDocHistoryEntry): boolean {

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
+import { readCookie } from '@/lib/cookies'
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}))
+
+vi.mock('@/components/editor', () => ({
+  RichTextViewer: () => <div data-testid="rich-text-viewer" />,
+}))
+
+vi.mock('@/components/HistoryList', () => ({
+  HistoryList: () => <div data-testid="history-list" />,
+}))
+
+vi.mock('@/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Tooltip: ({ children }: any) => <>{children}</>,
+  RefreshingIndicator: ({ label = 'Refreshing...' }: { label?: string }) => <div>{label}</div>,
+}))
+
+function makeStudentWork(studentId: string, opts: { graded: boolean }) {
+  const doc = {
+    id: `doc-${studentId}`,
+    assignment_id: 'assignment-1',
+    student_id: studentId,
+    content: { type: 'doc', content: [] },
+    is_submitted: true,
+    submitted_at: '2026-02-20T12:00:00Z',
+    viewed_at: '2026-02-20T12:00:00Z',
+    score_completion: opts.graded ? 7 : null,
+    score_thinking: opts.graded ? 8 : null,
+    score_workflow: opts.graded ? 9 : null,
+    feedback: opts.graded ? 'Nice work' : null,
+    graded_at: opts.graded ? '2026-02-20T13:00:00Z' : null,
+    graded_by: opts.graded ? 'teacher@example.com' : null,
+    returned_at: null,
+    authenticity_score: null,
+    authenticity_flags: [],
+    created_at: '2026-02-20T12:00:00Z',
+    updated_at: '2026-02-20T12:00:00Z',
+  }
+
+  return {
+    assignment: {
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+      title: 'Assignment',
+      description: null,
+      due_at: '2026-02-20T12:00:00Z',
+      order_index: 0,
+      is_draft: false,
+      created_at: '2026-02-20T12:00:00Z',
+      updated_at: '2026-02-20T12:00:00Z',
+    },
+    classroom: { id: 'classroom-1', title: 'Classroom' },
+    student: { id: studentId, email: `${studentId}@example.com`, name: studentId },
+    doc,
+    status: 'submitted',
+  }
+}
+
+function mockFetchByStudent(studentMap: Record<string, { graded: boolean }>) {
+  ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input)
+
+    if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+      const match = url.match(/\/students\/([^/?]+)/)
+      const studentId = match?.[1] || ''
+      const config = studentMap[studentId]
+      if (!config) {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ error: 'Student not found in test mock' }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: async () => makeStudentWork(studentId, config),
+      })
+    }
+
+    if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ history: [] }),
+      })
+    }
+
+    return Promise.resolve({
+      ok: false,
+      json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+    })
+  })
+}
+
+function clearRightTabCookie() {
+  document.cookie = 'pika_teacher_student_work_tab=; Path=/; Max-Age=0; SameSite=Lax'
+}
+
+describe('TeacherStudentWorkPanel right-tab persistence', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    clearRightTabCookie()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    clearRightTabCookie()
+  })
+
+  it('keeps grading tab selected when switching students', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+      'student-2': { graded: false },
+    })
+
+    const user = userEvent.setup()
+    const { rerender } = render(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-1" />)
+
+    await user.click(await screen.findByRole('button', { name: 'Grading' }))
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+
+    rerender(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-2" />)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/teacher/assignments/assignment-1/students/student-2')
+    })
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.queryByText('No saves yet')).not.toBeInTheDocument()
+  })
+
+  it('keeps history tab selected when switching students', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: true },
+      'student-2': { graded: true },
+    })
+
+    const user = userEvent.setup()
+    const { rerender } = render(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-1" />)
+
+    await user.click(await screen.findByRole('button', { name: 'Grading' }))
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'History' }))
+    expect(await screen.findByText('No saves yet')).toBeInTheDocument()
+
+    rerender(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-2" />)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/teacher/assignments/assignment-1/students/student-2')
+    })
+    expect(await screen.findByText('No saves yet')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+  })
+
+  it('restores grading tab from cookie on initial load', async () => {
+    document.cookie = 'pika_teacher_student_work_tab=grading; Path=/; SameSite=Lax'
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    render(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-1" />)
+
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.queryByText('No saves yet')).not.toBeInTheDocument()
+  })
+
+  it('writes selected right-tab to cookie when toggled', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    const user = userEvent.setup()
+    render(<TeacherStudentWorkPanel assignmentId="assignment-1" studentId="student-1" />)
+
+    await user.click(await screen.findByRole('button', { name: 'Grading' }))
+    expect(readCookie('pika_teacher_student_work_tab')).toBe('grading')
+
+    await user.click(screen.getByRole('button', { name: 'History' }))
+    expect(readCookie('pika_teacher_student_work_tab')).toBe('history')
+  })
+})


### PR DESCRIPTION
## Summary
- preserve teacher-selected right panel mode (`History` or `Grading`) while switching students in `TeacherStudentWorkPanel`
- persist the selected mode across reloads using a **classroom-scoped** cookie key:
  - `pika_teacher_student_work_tab:<classroomId>`
- keep auto-grade behavior on `Grading` while also persisting that selection
- add regression coverage for:
  - student-switch persistence
  - cookie restore/write behavior
  - classroom scoping behavior
- close #334 as no-op per reporter confirmation (no code change required)

## Issue Mapping
- #334: closed as no change needed (confirmed by reporter)
- #335: fixed by this PR behavior and tests

## Validation
- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm lint`

## Visual Verification
- Teacher screenshot: `/tmp/issue335c-teacher-view.png`
- Student screenshot: `/tmp/issue335c-student-view.png`
