### PR TITLE
fix(classroom): eliminate attendance tab flickering on initial load

### DIFF
--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1154,8 +1154,10 @@ function ClassroomPageContent({
               studentId={selectedStudentId}
               classroomId={classroom.id}
             />
-          ) : isTeacher && activeTab === 'attendance' ? (
+          ) : isTeacher && activeTab === 'attendance' && attendanceDate ? (
             <LogSummary classroomId={classroom.id} date={attendanceDate} onStudentClick={handleSummaryStudentClick} />
+          ) : isTeacher && activeTab === 'attendance' ? (
+            null
           ) : isTeacher && activeTab === 'assignments' && selectedStudent ? (
             <TeacherStudentWorkPanel
               classroomId={classroom.id}

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -76,7 +76,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     const today = getTodayInToronto()
     const previousClassDay = getMostRecentClassDayBefore(classDays, today)
     setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
-    setLoading(false)
+    // Do NOT setLoading(false) here — the logs fetch (Effect 3) handles it
   }, [classDaysLoading, classDays, selectedDate])
 
   // Notify parent of date changes


### PR DESCRIPTION
## Summary
- Remove premature `setLoading(false)` in `TeacherAttendanceTab` that caused a brief empty/loaded flash before the logs fetch fired — eliminates the double-spinner transition on initial classroom load
- Guard `<LogSummary>` render against empty `attendanceDate` so the right sidebar doesn't mount with a spinner before the date is available

Closes #339

## Test plan
- [ ] Navigate to a classroom as teacher — attendance table appears in a single clean transition
- [ ] Right sidebar shows no premature spinner before date is set
- [ ] Navigate between dates — `RefreshingIndicator` only (no blocking spinner)
- [ ] Select/deselect students — right sidebar switches between LogSummary and StudentLogHistory correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)