### PR TITLE
feat(calendar): show all assignment due dates for teacher including drafts

### DIFF
--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -11,7 +11,7 @@ import { isEmpty as isEmptyTiptapContent } from '@/lib/tiptap-content'
 import { useClassDays } from '@/hooks/useClassDays'
 import type { Classroom, LessonPlan, TiptapContent, Assignment, Announcement } from '@/types'
 import { readCookie, writeCookie } from '@/lib/cookies'
-import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
+import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
 
 /**
  * Returns true if the content change is just Tiptap normalizing stored content
@@ -140,6 +140,18 @@ export function TeacherLessonCalendarTab({
       }
     }
     loadAssignments()
+
+    // Re-fetch when assignments are created, updated, or released
+    const handleAssignmentsUpdated = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (!detail?.classroomId || detail.classroomId === classroom.id) {
+        loadAssignments()
+      }
+    }
+    window.addEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
+    return () => {
+      window.removeEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
+    }
   }, [classroom.id])
 
   // Fetch announcements for the classroom
@@ -440,7 +452,7 @@ export function TeacherLessonCalendarTab({
         <LessonCalendar
           classroom={classroom}
           lessonPlans={lessonPlans}
-          assignments={assignments.filter((a) => !a.is_draft)}
+          assignments={assignments}
           announcements={announcements}
           classDays={classDays}
           viewMode={viewMode}

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -68,7 +68,7 @@ export const LessonDayCell = memo(function LessonDayCell({
 
   // Weekend cells are narrow and minimal
   if (isWeekend) {
-    const assignmentTitles = assignments.map(a => a.title).join(', ')
+    const assignmentTitles = assignments.map(a => a.is_draft ? `[Draft] ${a.title}` : a.title).join(', ')
     const announcementCount = announcements.length
 
     return (
@@ -95,7 +95,9 @@ export const LessonDayCell = memo(function LessonDayCell({
                     onAssignmentClick?.(assignments[0])
                   }
                 }}
-                className={`w-full min-w-[12px] rounded bg-primary hover:bg-primary-hover cursor-pointer ${compact ? 'h-4' : 'h-6'}`}
+                className={`w-full min-w-[12px] rounded bg-primary hover:bg-primary-hover cursor-pointer ${compact ? 'h-4' : 'h-6'} ${
+                  assignments.some(a => a.is_draft) ? 'opacity-50' : ''
+                }`}
               />
             </Tooltip>
           </div>
@@ -153,7 +155,7 @@ export const LessonDayCell = memo(function LessonDayCell({
       {assignments.length > 0 && (
         <div className={`min-w-0 ${compact ? 'px-0.5 space-y-0.5' : 'px-1 pb-1 space-y-1'}`}>
           {assignments.map((assignment) => (
-            <Tooltip key={assignment.id} content={assignment.title}>
+            <Tooltip key={assignment.id} content={assignment.is_draft ? `[Draft] ${assignment.title}` : assignment.title}>
               <button
                 type="button"
                 onClick={(e) => {
@@ -162,7 +164,7 @@ export const LessonDayCell = memo(function LessonDayCell({
                 }}
                 className={`w-full min-w-0 rounded bg-primary text-white font-medium hover:bg-primary-hover text-center truncate ${
                   compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
-                }`}
+                } ${assignment.is_draft ? 'opacity-50' : ''}`}
               >
                 {compact ? assignment.title : `Due: ${assignment.title}`}
               </button>


### PR DESCRIPTION
## Summary

- Removes the draft filter in `TeacherLessonCalendarTab` so draft assignments appear on the teacher's calendar
- Listens for `TEACHER_ASSIGNMENTS_UPDATED_EVENT` to re-fetch assignments when one is created, updated, or released — so the calendar updates without a page reload
- Renders draft assignment pills at 50% opacity to visually distinguish them from released assignments
- Shows `[Draft]` prefix in the tooltip for draft pills

Closes #340

## Test plan

- [ ] Create a draft assignment with a due date → should appear on teacher calendar as a faded pill
- [ ] Release the assignment → calendar should update and pill becomes fully opaque
- [ ] Student calendar should only show released assignments (unchanged)
- [ ] Hovering a draft pill shows `[Draft] <title>` in the tooltip
- [ ] Weekend draft pills also render at 50% opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)