### PR TITLE
Update classroom nav icons for resources and gradebook

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -2633,3 +2633,21 @@
 **Validation:**
 - `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` passed (5 tests)
 - `pnpm lint` passed
+
+---
+## 2026-03-03 [AI - GPT-5 Codex]
+**Goal:** Swap classroom nav icons: use `LibraryBig` for Resources and `BookA` for Gradebook.
+**Completed:**
+- Updated `src/components/layout/NavItems.tsx` icon imports and mappings.
+- Replaced `StickyNote` with `LibraryBig` for the Resources tab (teacher + student sidebars).
+- Replaced `Percent` with `BookA` for the Gradebook tab (teacher sidebar).
+- Performed mandatory visual verification with Playwright screenshots for both teacher and student classroom views.
+**Status:** completed
+**Artifacts:**
+- Branch: `codex/resources-gradebook-icons`
+- Worktree: `/Users/stew/Repos/.worktrees/pika/codex-resources-gradebook-icons`
+- Screenshots: `/tmp/pika-icons-teacher-classroom.png`, `/tmp/pika-icons-student-classroom.png`
+- Key file: `src/components/layout/NavItems.tsx`
+**Validation:**
+- `pnpm lint` passed
+- `E2E_BASE_URL=http://localhost:3004 pnpm e2e:auth` passed

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -3,13 +3,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Calendar,
+  BookA,
   CircleHelp,
   ClipboardCheck,
   ClipboardList,
-  Percent,
+  LibraryBig,
   Settings,
   PenSquare,
-  StickyNote,
   Users,
   ChevronDown,
   type LucideIcon,
@@ -59,9 +59,9 @@ const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
-  { id: 'gradebook', label: 'Gradebook', icon: Percent },
+  { id: 'gradebook', label: 'Gradebook', icon: BookA },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
-  { id: 'resources', label: 'Resources', icon: StickyNote },
+  { id: 'resources', label: 'Resources', icon: LibraryBig },
   { id: 'roster', label: 'Roster', icon: Users },
   { id: 'settings', label: 'Settings', icon: Settings },
 ]
@@ -71,7 +71,7 @@ const studentItems: NavItem[] = [
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
-  { id: 'resources', label: 'Resources', icon: StickyNote },
+  { id: 'resources', label: 'Resources', icon: LibraryBig },
 ]
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- switch classroom nav `resources` icon to `LibraryBig` for teacher and student sidebars
- switch classroom nav `gradebook` icon to `BookA` for teacher sidebar
- append `.ai/JOURNAL.md` session log entry

## Validation
- `pnpm lint`
- `E2E_BASE_URL=http://localhost:3004 pnpm e2e:auth`
- Playwright screenshot checks on classroom page for teacher and student views
