### PR TITLE
Fix duplicate Gradebook sidebar icon

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -3245,3 +3245,17 @@
 
 **Verification:**
 - Manual doc review to confirm the rule appears in startup ritual, authoritative AI instructions, and developer workflow docs.
+
+## 2026-03-03 — Fixed duplicate Gradebook sidebar icon and switched to SquarePercent
+**Context:** Teacher reported duplicate Gradebook icons in the classroom left sidebar and requested Lucide `SquarePercent`.
+
+**Changes:**
+- Updated `/src/components/layout/NavItems.tsx`:
+  - Removed the first duplicate `gradebook` nav item from `teacherItems`.
+  - Replaced Gradebook icon from `BookA` to `SquarePercent` for the remaining item.
+
+**Verification:**
+- `pnpm lint`
+- Visual verification (Playwright screenshots):
+  - Teacher classroom sidebar: `/tmp/teacher-gradebook-sidebar-fix.png`
+  - Student classroom view: `/tmp/student-gradebook-sidebar-fix.png`

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Calendar,
-  BookA,
   CircleHelp,
   ClipboardCheck,
   ClipboardList,
@@ -11,6 +10,7 @@ import {
   FileCheck,
   Settings,
   PenSquare,
+  SquarePercent,
   Users,
   ChevronDown,
   type LucideIcon,
@@ -61,9 +61,8 @@ const teacherItems: NavItem[] = [
   { id: 'attendance', label: 'Attendance', icon: ClipboardCheck },
   { id: 'assignments', label: 'Assignments', icon: ClipboardList },
   { id: 'quizzes', label: 'Quizzes', icon: CircleHelp },
-  { id: 'gradebook', label: 'Gradebook', icon: BookA },
   { id: 'tests', label: 'Tests', icon: FileCheck },
-  { id: 'gradebook', label: 'Gradebook', icon: BookA },
+  { id: 'gradebook', label: 'Gradebook', icon: SquarePercent },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: LibraryBig },
   { id: 'roster', label: 'Roster', icon: Users },


### PR DESCRIPTION
## Summary
- remove duplicated teacher sidebar Gradebook nav entry (first instance)
- keep a single Gradebook nav entry
- switch Gradebook icon to Lucide `SquarePercent`

## Verification
- pnpm lint
- visual check via Playwright screenshots:
  - /tmp/teacher-gradebook-sidebar-fix.png
  - /tmp/student-gradebook-sidebar-fix.png
