### PR TITLE
Replace pulsing sidebar tab indicator with notification dot

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -3259,3 +3259,30 @@
 - Visual verification (Playwright screenshots):
   - Teacher classroom sidebar: `/tmp/teacher-gradebook-sidebar-fix.png`
   - Student classroom view: `/tmp/student-gradebook-sidebar-fix.png`
+
+## 2026-03-03 — Issue #356: Replaced pulsing sidebar indicators with static notification dots
+**Context:** Sidebar tab activity indicators were using pulse animation and felt visually noisy. Requirement was to switch to a static top-left notification dot while preserving existing notification logic and behavior.
+
+**Changes:**
+- Updated `/src/components/layout/NavItems.tsx`:
+  - Added reusable `NavIconWithDot` wrapper that renders tab icon + static dot.
+  - Replaced `animate-notification-pulse` usage for student activity indicators with static dot rendering.
+  - Added accessible `aria-label` suffix when activity exists: `"(new activity)"`.
+  - Applied dot behavior to both regular student tabs and special student assignments nav branch.
+- Removed obsolete pulse styling:
+  - Deleted `notification-pulse` keyframes and `.animate-notification-pulse` class from `/src/styles/_keyframe-animations.scss`.
+  - Removed `--tt-transition-duration-pulse` from `/src/styles/_variables.scss`.
+- Added `/tests/components/NavItems.test.tsx` covering:
+  - Dot + aria-label behavior when student notifications are present.
+  - No-dot behavior when no notifications are present.
+  - Student assignments special branch dot rendering.
+  - Teacher non-regression (no notification dot rendering).
+  - Assertion that no `animate-notification-pulse` class is rendered.
+
+**Verification:**
+- `pnpm exec vitest run tests/components/NavItems.test.tsx`
+- `pnpm test`
+- Visual verification screenshots:
+  - Teacher expanded/collapsed sidebar: `/tmp/pika-356-teacher-expanded.png`, `/tmp/pika-356-teacher-collapsed.png`
+  - Student expanded/collapsed sidebar: `/tmp/pika-356-student-expanded.png`, `/tmp/pika-356-student-collapsed.png`
+  - Student dot placement (mocked notification payload to force visible indicators): `/tmp/pika-356-student-expanded-dot.png`, `/tmp/pika-356-student-collapsed-dot.png`

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -90,6 +90,26 @@ function tabHref(classroomId: string, tabId: ClassroomNavItemId) {
   return `/classrooms/${classroomId}?tab=${encodeURIComponent(tabId)}`
 }
 
+type NavIconWithDotProps = {
+  Icon: LucideIcon
+  showDot: boolean
+}
+
+function NavIconWithDot({ Icon, showDot }: NavIconWithDotProps) {
+  return (
+    <span className="relative inline-flex h-6 w-6 flex-shrink-0 items-center justify-center">
+      <Icon className="h-6 w-6" aria-hidden="true" />
+      {showDot && (
+        <span
+          aria-hidden="true"
+          data-new-activity-dot="true"
+          className="pointer-events-none absolute left-0 top-0 h-2.5 w-2.5 -translate-x-1/4 -translate-y-1/4 rounded-full bg-primary ring-2 ring-surface"
+        />
+      )}
+    </span>
+  )
+}
+
 // ============================================================================
 // Component
 // ============================================================================
@@ -299,6 +319,9 @@ export function NavItems({
         // Student assignments with nested list (always shown)
         if (role === 'student' && item.id === 'assignments') {
           const canShowNested = isExpanded
+          const assignmentsAriaLabel = showAssignmentsPulse
+            ? `${item.label} (new activity)`
+            : item.label
 
           const studentAssignmentsLink = (
               <a
@@ -312,7 +335,7 @@ export function NavItems({
                 onMouseEnter={() => handleTabIntent('assignments')}
                 onFocus={() => handleTabIntent('assignments')}
                 aria-current={isActive ? 'page' : undefined}
-                aria-label={item.label}
+                aria-label={assignmentsAriaLabel}
                 className={[
                   'group flex items-center rounded-md text-base font-medium transition-colors',
                   layoutClass,
@@ -321,16 +344,7 @@ export function NavItems({
                     : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
                 ].join(' ')}
               >
-                <Icon
-                  className={[
-                    'h-6 w-6 flex-shrink-0',
-                    showAssignmentsPulse &&
-                      'animate-notification-pulse motion-reduce:animate-none',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                  aria-hidden="true"
-                />
+                <NavIconWithDot Icon={Icon} showDot={showAssignmentsPulse} />
                 {isExpanded && <span className="truncate">{item.label}</span>}
                 {!isExpanded && <span className="sr-only">{item.label}</span>}
               </a>
@@ -474,6 +488,7 @@ export function NavItems({
           (item.id === 'quizzes' && showQuizzesPulse) ||
           (item.id === 'tests' && showTestsPulse) ||
           (item.id === 'resources' && showResourcesPulse)
+        const ariaLabel = shouldPulse ? `${item.label} (new activity)` : item.label
 
         const navLink = (
           <a
@@ -486,7 +501,7 @@ export function NavItems({
             onMouseEnter={() => handleTabIntent(item.id)}
             onFocus={() => handleTabIntent(item.id)}
             aria-current={isActive ? 'page' : undefined}
-            aria-label={item.label}
+            aria-label={ariaLabel}
             className={[
               'group flex items-center rounded-md text-base font-medium transition-colors',
               layoutClass,
@@ -495,15 +510,7 @@ export function NavItems({
                 : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
             ].join(' ')}
           >
-            <Icon
-              className={[
-                'h-6 w-6 flex-shrink-0',
-                shouldPulse && 'animate-notification-pulse motion-reduce:animate-none',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              aria-hidden="true"
-            />
+            <NavIconWithDot Icon={Icon} showDot={shouldPulse} />
             {isExpanded && <span className="truncate">{item.label}</span>}
             {!isExpanded && <span className="sr-only">{item.label}</span>}
           </a>

--- a/src/styles/_keyframe-animations.scss
+++ b/src/styles/_keyframe-animations.scss
@@ -89,19 +89,3 @@
     transform: rotate(360deg);
   }
 }
-
-@keyframes notification-pulse {
-  0%, 100% {
-    transform: scale(1);
-    filter: drop-shadow(0 0 0 transparent);
-  }
-  50% {
-    transform: scale(1.25);
-    filter: drop-shadow(0 0 6px rgb(59 130 246));
-  }
-}
-
-// Force the animation class to work
-.animate-notification-pulse {
-  animation: notification-pulse var(--tt-transition-duration-pulse) var(--tt-transition-easing-default) infinite !important;
-}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -148,7 +148,6 @@
   --tt-transition-duration-medium: 0.15s;
   --tt-transition-duration-default: 0.2s;
   --tt-transition-duration-long: 0.64s;
-  --tt-transition-duration-pulse: 1.5s;
   --tt-transition-easing-default: cubic-bezier(0.46, 0.03, 0.52, 0.96);
   --tt-transition-easing-cubic: cubic-bezier(0.65, 0.05, 0.36, 1);
   --tt-transition-easing-quart: cubic-bezier(0.77, 0, 0.18, 1);

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { NavItems } from '@/components/layout/NavItems'
+
+type MockNotifications = {
+  hasTodayEntry: boolean
+  unviewedAssignmentsCount: number
+  activeQuizzesCount: number
+  activeTestsCount: number
+  unreadAnnouncementsCount: number
+  loading: boolean
+}
+
+let mockNotifications: MockNotifications | null = null
+const fetchJSONWithCacheMock = vi.fn()
+
+vi.mock('@/components/layout/ThreePanelProvider', () => ({
+  useLeftSidebar: () => ({ isExpanded: true }),
+  useMobileDrawer: () => ({ close: vi.fn() }),
+}))
+
+vi.mock('@/components/StudentNotificationsProvider', () => ({
+  useStudentNotifications: () => mockNotifications,
+}))
+
+vi.mock('@/ui', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/lib/cookies', () => ({
+  readCookie: vi.fn(() => undefined),
+  writeCookie: vi.fn(),
+}))
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: (...args: unknown[]) => fetchJSONWithCacheMock(...args),
+}))
+
+function baseNotifications(overrides: Partial<MockNotifications> = {}): MockNotifications {
+  return {
+    hasTodayEntry: true,
+    unviewedAssignmentsCount: 0,
+    activeQuizzesCount: 0,
+    activeTestsCount: 0,
+    unreadAnnouncementsCount: 0,
+    loading: false,
+    ...overrides,
+  }
+}
+
+function renderNav(role: 'student' | 'teacher', activeTab = 'today') {
+  return render(
+    <NavItems
+      classroomId="classroom-1"
+      role={role}
+      activeTab={activeTab}
+      isReadOnly={false}
+      assignmentId={null}
+      onTabChange={vi.fn()}
+      updateSearchParams={vi.fn()}
+    />
+  )
+}
+
+describe('NavItems notification dots', () => {
+  beforeEach(() => {
+    mockNotifications = baseNotifications()
+    fetchJSONWithCacheMock.mockReset()
+    fetchJSONWithCacheMock.mockImplementation(() => new Promise(() => {}))
+  })
+
+  it('shows dot and aria-label suffix for student today tab with new activity', () => {
+    mockNotifications = baseNotifications({ hasTodayEntry: false })
+    const { container } = renderNav('student', 'today')
+
+    const todayLink = screen.getByRole('link', { name: 'Today (new activity)' })
+    expect(todayLink.querySelector('[data-new-activity-dot="true"]')).toBeTruthy()
+    expect(container.querySelector('.animate-notification-pulse')).toBeNull()
+  })
+
+  it('shows no dot and original aria-label when there is no new student activity', () => {
+    renderNav('student', 'today')
+
+    const todayLink = screen.getByRole('link', { name: 'Today' })
+    expect(todayLink.querySelector('[data-new-activity-dot="true"]')).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Today (new activity)' })).toBeNull()
+  })
+
+  it('uses dot path for student assignments nav item', () => {
+    mockNotifications = baseNotifications({ unviewedAssignmentsCount: 2 })
+    renderNav('student', 'assignments')
+
+    const assignmentsLink = screen.getByRole('link', { name: 'Assignments (new activity)' })
+    expect(assignmentsLink.querySelector('[data-new-activity-dot="true"]')).toBeTruthy()
+  })
+
+  it('does not render notification dots for teacher nav items', () => {
+    mockNotifications = baseNotifications({
+      hasTodayEntry: false,
+      unviewedAssignmentsCount: 3,
+      activeQuizzesCount: 2,
+      activeTestsCount: 1,
+      unreadAnnouncementsCount: 4,
+    })
+    const { container } = renderNav('teacher', 'attendance')
+
+    expect(screen.getByRole('link', { name: 'Attendance' })).toBeInTheDocument()
+    expect(container.querySelector('[data-new-activity-dot="true"]')).toBeNull()
+    expect(screen.queryByRole('link', { name: /new activity/i })).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- replace pulsing classroom sidebar tab indicators with static top-left notification dots
- keep existing notification logic/clear behavior unchanged, and add aria-label suffix `(new activity)` when an indicator is present
- remove obsolete pulse animation styles and variable
- add focused `NavItems` component tests for student/teacher indicator behavior

## Testing
- `pnpm exec vitest run tests/components/NavItems.test.tsx`
- `pnpm test`
- `pnpm lint`

## Visual Verification
- Teacher expanded/collapsed: `/tmp/pika-356-teacher-expanded.png`, `/tmp/pika-356-teacher-collapsed.png`
- Student expanded/collapsed: `/tmp/pika-356-student-expanded.png`, `/tmp/pika-356-student-collapsed.png`
- Forced notification dot placement (mocked notifications API): `/tmp/pika-356-student-expanded-dot.png`, `/tmp/pika-356-student-collapsed-dot.png`

Closes #356
