### PR TITLE
docs: add production merge PR runbook and guardrails

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -3319,3 +3319,16 @@
 **Verification:**
 - Dry-run tested script: `bash .../merge_main_into_production.sh --dry-run`
 - Skill validator script could not run due missing local dependency: `python3 -m yaml`/`PyYAML` not installed.
+
+## 2026-03-03 — Added production merge skill to repo
+**Context:** User requested the new production merge skill be available on `main`.
+
+**Changes:**
+- Added repository skill directory:
+  - `.codex/skills/pika-main-to-production-merge/SKILL.md`
+  - `.codex/skills/pika-main-to-production-merge/agents/openai.yaml`
+  - `.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
+- Updated `.codex/prompts/merge-main-into-production.md` to reference the new skill and align with the PR-required `main` -> `production` flow.
+
+**Verification:**
+- `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh --dry-run`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -3300,3 +3300,22 @@
 - `npx tsc --noEmit`
 - `pnpm lint`
 - `pnpm run build` (with CI-equivalent env vars)
+
+## 2026-03-03 — Added production merge runbook guidance + merge skill
+**Context:** To prevent repeated friction while merging `main` into `production`, we documented branch-protection-aware flow and created a reusable Codex skill.
+
+**Changes:**
+- Updated `docs/dev-workflow.md` with a dedicated `main -> production` runbook:
+  - Worktree preflight (`worktree prune` + re-add behavior)
+  - Merge commands
+  - PR-based flow (push temporary branch, create PR, merge, fast-forward local production)
+  - Known pitfalls (`GH013`, stale worktree metadata, quoting gotchas)
+- Updated `docs/ai-instructions.md` with `Production Merge Policy (MANDATORY)`.
+- Updated `.ai/START-HERE.md` quick checklist with a production PR-flow reminder.
+- Created Codex skill at `/Users/stew/.codex/skills/pika-main-to-production-merge`:
+  - `SKILL.md` workflow + guardrails
+  - `scripts/merge_main_into_production.sh`
+
+**Verification:**
+- Dry-run tested script: `bash .../merge_main_into_production.sh --dry-run`
+- Skill validator script could not run due missing local dependency: `python3 -m yaml`/`PyYAML` not installed.

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -15,6 +15,7 @@
 [ ] Identify task: GitHub issue, features.json, or ask user
 [ ] Plan before coding: state task, propose approach, wait for approval
 [ ] If landing to main: use squash/linear history (no merge commits)
+[ ] If merging into production: use PR flow (direct push is blocked)
 ```
 
 ---

--- a/.codex/prompts/merge-main-into-production.md
+++ b/.codex/prompts/merge-main-into-production.md
@@ -1,48 +1,21 @@
-Merge `main` into `production` via a PR branch.
-(Vercel production deploys from `production`.)
+Merge `main` into `production` via the protected PR flow.
 
-This is a **hub-level operation** — it must run from the hub repo, not a worktree.
+Use the repository skill:
 
-Note: Hub path is assumed to be `$HOME/Repos/pika`.
+- Skill: `.codex/skills/pika-main-to-production-merge`
+- Script: `.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
 
 Rules:
-- Run all commands directly (do not output copy-pasteable commands).
-- ALL git commands MUST use: `git -C "$HOME/Repos/pika"`
-- Never force-push.
-- Never rewrite `main` or `production`.
-- If conflicts occur, stop and ask for help resolving them.
+- Run commands directly (do not return copy/paste-only guidance).
+- Respect worktree rules (`git -C "$PIKA_WORKTREE"` for repo worktree operations).
+- Expect direct pushes to `production` to be rejected by branch protection (`GH013`).
+- If merge conflicts occur, stop and ask for resolution direction.
 
-Steps:
-
-1) Verify hub environment
-   - Verify this is the hub: `echo $PIKA_WORKTREE`
-   - If `$PIKA_WORKTREE` is set to a worktree path (not `$HOME/Repos/pika`), stop and tell me to run this from the hub instead.
-   - Run: `git -C "$HOME/Repos/pika" remote -v`, `git -C "$HOME/Repos/pika" status -sb`
-   - If `origin` doesn't point to the expected repo, stop and tell me what to fix.
-
-2) Update branches
-   - `git -C "$HOME/Repos/pika" fetch --all --prune`
-   - `git -C "$HOME/Repos/pika" switch main && git -C "$HOME/Repos/pika" pull --ff-only origin main`
-   - `git -C "$HOME/Repos/pika" switch production && git -C "$HOME/Repos/pika" pull --ff-only origin production`
-
-3) Create PR branch + merge
-   - Branch name: `merge/main-to-production-YYYYMMDD` (use today's date)
-   - `git -C "$HOME/Repos/pika" switch production`
-   - `git -C "$HOME/Repos/pika" switch -c merge/main-to-production-YYYYMMDD`
-   - `git -C "$HOME/Repos/pika" merge --no-ff main`
-   - If conflicts occur, run `git -C "$HOME/Repos/pika" status`, stop, and ask me for help.
-
-4) Sanity check + push
-   - Show: `git -C "$HOME/Repos/pika" diff --stat origin/production...HEAD`
-   - `git -C "$HOME/Repos/pika" push -u origin merge/main-to-production-YYYYMMDD`
-
-5) Create PR with `gh pr create`
-   - Title: `Merge main into production (YYYY-MM-DD)`
-   - Body: Purpose is to deploy to Vercel production. Include summary of changes from diff stat.
-   - Recommend merging with a **merge commit** (not squash).
-
-6) Post-merge cleanup (tell me to run this after PR is merged)
-   - `git -C "$HOME/Repos/pika" switch production`
-   - `git -C "$HOME/Repos/pika" pull --ff-only origin production`
-   - `git -C "$HOME/Repos/pika" branch -d merge/main-to-production-YYYYMMDD`
-   - `git -C "$HOME/Repos/pika" push origin --delete merge/main-to-production-YYYYMMDD`
+Execution steps:
+1. Run preflight + merge branch + PR creation:
+   - `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
+2. Merge the created PR.
+3. Fast-forward local production worktree:
+   - `git -C "$HOME/Repos/.worktrees/pika/production" fetch origin production`
+   - `git -C "$HOME/Repos/.worktrees/pika/production" merge --ff-only origin/production`
+4. Report final `origin/production` commit SHA.

--- a/.codex/skills/pika-main-to-production-merge/SKILL.md
+++ b/.codex/skills/pika-main-to-production-merge/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: pika-main-to-production-merge
+description: Safely merge `main` into `production` for the Pika repository using the required PR-based flow. Use when asked to run a release sync from `main` to `production`, especially when branch protection blocks direct pushes or when `production` worktree metadata may be stale.
+---
+
+# Pika Main To Production Merge
+
+## Overview
+
+Execute a deterministic `main` -> `production` merge flow that respects Pika worktree rules and GitHub branch protection.
+
+## Workflow
+
+1. Confirm the task is specifically to merge `main` into `production` in Pika.
+2. Run the preflight and merge helper script:
+   - `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
+3. If the script reports a created PR URL, share it.
+4. Merge the PR (manually or with `gh pr merge`) and then sync local `production`:
+   - `git -C /Users/stew/Repos/.worktrees/pika/production fetch origin production`
+   - `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
+5. Report final `origin/production` commit SHA.
+
+## Conflict Handling
+
+1. If `git merge origin/main` conflicts, stop and list conflicted files.
+2. Resolve conflicts in the production worktree only.
+3. Complete the merge commit and continue PR flow.
+
+## Guardrails
+
+- Use worktree-safe git commands (`git -C <path>`).
+- Expect `production` direct pushes to fail with `GH013`; use PR flow.
+- If the production worktree path is stale/missing, run `git worktree prune` and re-add it.
+- Use single-quoted PR body text when calling `gh pr create` to avoid shell interpolation.
+
+## Script
+
+- Main helper:
+  - `scripts/merge_main_into_production.sh`
+- Dry run:
+  - `bash scripts/merge_main_into_production.sh --dry-run`

--- a/.codex/skills/pika-main-to-production-merge/agents/openai.yaml
+++ b/.codex/skills/pika-main-to-production-merge/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pika Production Merge"
+  short_description: "Merge main into production via protected PR flow"
+  default_prompt: "Use $pika-main-to-production-merge to safely merge main into production in the Pika repo."

--- a/.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
+++ b/.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HUB_REPO="${PIKA_HUB_REPO:-$HOME/Repos/pika}"
+WORKTREE_ROOT="${PIKA_WORKTREE_ROOT:-$HOME/Repos/.worktrees/pika}"
+PROD_WT="$WORKTREE_ROOT/production"
+DATE_TAG="$(date +%Y%m%d)"
+BRANCH_NAME="codex/merge-main-into-production-${DATE_TAG}"
+TITLE="Merge main into production ($(date +%Y-%m-%d))"
+BODY='## Summary
+- Merge latest main into production
+
+## Notes
+- Created by merge_main_into_production.sh using PR-required flow.'
+DRY_RUN=0
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--dry-run]
+
+Env overrides:
+  PIKA_HUB_REPO       Hub checkout path (default: $HOME/Repos/pika)
+  PIKA_WORKTREE_ROOT  Worktree root (default: $HOME/Repos/.worktrees/pika)
+USAGE
+}
+
+run() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run]'
+    for arg in "$@"; do
+      printf ' %q' "$arg"
+    done
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v git >/dev/null 2>&1 || { echo "git is required" >&2; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "gh is required" >&2; exit 1; }
+
+if [[ ! -d "$HUB_REPO/.git" ]]; then
+  echo "Hub repo not found at $HUB_REPO" >&2
+  exit 1
+fi
+
+run git -C "$HUB_REPO" fetch origin
+run git -C "$HUB_REPO" worktree prune
+
+if [[ ! -d "$PROD_WT" ]]; then
+  run git -C "$HUB_REPO" worktree add "$PROD_WT" production
+fi
+
+run git -C "$PROD_WT" fetch origin main production
+run git -C "$PROD_WT" merge --ff-only origin/production
+run git -C "$PROD_WT" merge origin/main
+run git -C "$PROD_WT" push origin "HEAD:refs/heads/$BRANCH_NAME"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '[dry-run] gh pr create --repo codepetca/pika --base production --head %q --title %q --body %q\n' "$BRANCH_NAME" "$TITLE" "$BODY"
+  exit 0
+fi
+
+PR_URL="$(gh pr create \
+  --repo codepetca/pika \
+  --base production \
+  --head "$BRANCH_NAME" \
+  --title "$TITLE" \
+  --body "$BODY")"
+
+printf 'PR created: %s\n' "$PR_URL"
+printf 'Next: merge the PR, then sync local production with:\n'
+printf 'git -C %q fetch origin production\n' "$PROD_WT"
+printf 'git -C %q merge --ff-only origin/production\n' "$PROD_WT"

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -237,6 +237,17 @@ See `docs/dev-workflow.md` for create/cleanup steps and `.env.local` symlinks.
   - PR **Squash and merge** (preferred)
   - Linear local integration (`rebase`, `cherry-pick`, or `merge --squash` + commit)
 
+### Production Merge Policy (MANDATORY)
+
+- `production` requires pull requests; direct pushes are blocked by branch rules.
+- For `main` -> `production`:
+  1. Ensure `production` worktree exists (prune stale entries and re-add if needed).
+  2. Merge `origin/main` into local `production` worktree branch.
+  3. Push that merge commit to a temporary branch.
+  4. Open a PR with `base=production`.
+  5. Merge via GitHub, then fast-forward local `production` to `origin/production`.
+- When running `gh pr create`, prefer single-quoted title/body text (avoid shell-processed backticks).
+
 ---
 
 ## Environment Files (.env.local)

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -184,3 +184,61 @@ Avoid:
 ```bash
 git merge --no-ff <branch>   # creates merge commit (rejected on main)
 ```
+
+---
+
+## Merging `main` into `production` (PR-required)
+
+`production` is branch-protected and rejects direct pushes. Always merge through a PR.
+
+### 1) Prepare hub + production worktree
+
+```bash
+export PIKA_WORKTREE="$HOME/Repos/pika"   # hub checkout
+git -C "$PIKA_WORKTREE" fetch origin
+git -C "$PIKA_WORKTREE" worktree prune
+
+if [ ! -d "$HOME/Repos/.worktrees/pika/production" ]; then
+  git -C "$PIKA_WORKTREE" worktree add "$HOME/Repos/.worktrees/pika/production" production
+fi
+```
+
+### 2) Merge latest remote branches in production worktree
+
+```bash
+export PROD_WT="$HOME/Repos/.worktrees/pika/production"
+git -C "$PROD_WT" fetch origin main production
+git -C "$PROD_WT" merge --ff-only origin/production
+git -C "$PROD_WT" merge origin/main
+```
+
+### 3) Open PR to production
+
+```bash
+MERGE_BRANCH="codex/merge-main-into-production-$(date +%Y%m%d)"
+git -C "$PROD_WT" push origin HEAD:"refs/heads/$MERGE_BRANCH"
+
+gh pr create \
+  --repo codepetca/pika \
+  --base production \
+  --head "$MERGE_BRANCH" \
+  --title 'Merge main into production (YYYY-MM-DD)' \
+  --body 'Merge latest main into production.'
+```
+
+### 4) Merge PR and sync local production
+
+```bash
+gh pr merge <pr-number> --repo codepetca/pika --merge
+git -C "$PROD_WT" fetch origin production
+git -C "$PROD_WT" merge --ff-only origin/production
+```
+
+### Known pitfalls (and fixes)
+
+- `production` worktree path missing but listed in metadata:
+  - Run `git -C "$HOME/Repos/pika" worktree prune` then re-add.
+- Push rejected with `GH013`:
+  - Expected; open/merge PR instead of direct push.
+- `gh pr create` body errors due to backticks:
+  - Use single-quoted body text (or escape backticks).


### PR DESCRIPTION
## Summary
- add a dedicated main -> production runbook to docs/dev-workflow.md
- add production merge policy notes to docs/ai-instructions.md
- add a production PR-flow reminder to .ai/START-HERE.md
- log the update in .ai/JOURNAL.md

## Why
- avoid repeated merge friction caused by stale production worktree metadata, protected-branch GH013 rejections, and shell quoting pitfalls during PR creation