### PR TITLE
Add exam-mode documentation panel and teacher documents editor

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -4051,3 +4051,597 @@
 - Cleanup result:
   - Deleted `da3d79b5-3ab6-4ba9-b446-f3267b2a7b60` (`Exam Mode UI 1772644538443`)
   - Deleted `a434d323-a3d1-463b-8fd0-af70ce9750ed` (`Split Check 1772644746324`)
+
+## 2026-03-04 — Exam mode docs panel toggles split (30/70 <-> 50/50)
+**Context:** User requested that in active student test exam mode, opening an allowed doc should switch layout from 30/70 to 50/50 (docs on left), and clicking back should restore 30/70.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added `activeDoc` panel state for exam mode.
+  - Extracted allowed doc links from question markdown/URLs in test questions.
+  - Added `Allowed Docs` buttons in the left exam info panel.
+  - Added docs viewer panel with back control (`Back to test info`) and `Open in new tab` action.
+  - Grid behavior now:
+    - default tests state: `lg:grid-cols-2` (50/50)
+    - active exam info state: `lg:grid-cols-[30%_70%]`
+    - active doc-open state: `lg:grid-cols-2` (50/50)
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Added test covering transition: exam mode `30/70` -> doc-open `50/50` -> back to `30/70`.
+
+**Verification:**
+- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-view.png`
+- Student screenshot: `/tmp/pika-student-view.png`
+
+## 2026-03-04 — Docs panel copy updated to "Documents"
+**Context:** User requested simplified copy in student test exam mode docs area: use "Documents" and show teacher-titled doc entries.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Renamed left-panel section heading from `Allowed Docs` to `Documents`.
+  - Updated empty state copy to `No documents provided for this test.`
+
+**Verification:**
+- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx`
+- Teacher screenshot: `/tmp/pika-teacher-view-2.png`
+- Student screenshot: `/tmp/pika-student-view-2.png`
+
+## 2026-03-04 — Teacher test documents editor (links + uploads) wired end-to-end
+**Context:** User requested an easy teacher workflow for managing allowed test documents, including link entry and file uploads, surfaced as a dedicated editor.
+
+**Changes:**
+- Added teacher-managed test document domain model and validation:
+  - `/src/types/index.ts`
+  - `/src/lib/test-documents.ts` (normalization, payload validation, file type/size limits)
+- Added migration for persistent documents + storage bucket/policies:
+  - `/supabase/migrations/042_test_documents.sql`
+- Updated teacher test APIs to read/write `documents` and return normalized payloads:
+  - `/src/app/api/teacher/tests/route.ts`
+  - `/src/app/api/teacher/tests/[id]/route.ts`
+  - `/src/app/api/teacher/tests/[id]/documents/upload/route.ts`
+- Updated student test APIs to include normalized `documents` in responses:
+  - `/src/app/api/student/tests/route.ts`
+  - `/src/app/api/student/tests/[id]/route.ts`
+- Added new teacher UI editor and integrated into test detail tabs:
+  - `/src/components/TestDocumentsEditor.tsx`
+  - `/src/components/QuizDetailPanel.tsx` (`Documents` tab)
+- Student exam-mode docs section now uses teacher-managed documents first (fallback to question link extraction):
+  - `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+
+**Testing:**
+- `bash scripts/verify-env.sh` (full suite pass in this worktree; 128/128 test files)
+- New/updated tests:
+  - `/tests/components/QuizDetailPanel.test.tsx`
+  - `/tests/api/teacher/tests-id-route.test.ts`
+  - `/tests/api/teacher/tests-documents-upload.test.ts`
+  - `/tests/unit/test-documents.test.ts`
+  - `/tests/components/StudentQuizzesTab.test.tsx`
+
+**Visual verification:**
+- Teacher documents editor view: `/tmp/pika-teacher-documents-editor.png`
+- Student tests view: `/tmp/pika-student-tests-view.png`
+- Student active exam-mode left panel with `Documents` section: `/tmp/pika-student-exam-doc-panel.png`
+
+**Migration note:**
+- Runtime save/upload currently returns migration gate until migration 042 is applied:
+  - `Test documents require migration 042 to be applied`
+
+## 2026-03-04 — Added pasted-text documents in test Documents editor
+**Context:** User requested an additional document option for teachers: paste/copy text directly into a textbox (not only links/uploads).
+
+**Changes:**
+- Extended test document model to support inline text docs:
+  - `/src/types/index.ts` (`TestDocumentSource` now includes `text`, `TestDocument` includes optional `content`)
+  - `/src/lib/test-documents.ts` now normalizes/validates both URL docs and text docs
+- Updated teacher editor UI:
+  - `/src/components/TestDocumentsEditor.tsx`
+  - Added new **Add Text** section (title + textarea + character counter)
+  - Added explicit accessibility labels for add actions (`Add link document`, `Add text document`)
+  - Existing docs list now renders text docs with inline editable textarea
+- Updated student exam-mode doc viewer:
+  - `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+  - Text docs now open in-panel as formatted text content (no new-tab action)
+  - Link/upload docs continue to open via iframe + optional new-tab button
+- Updated migration column comment for document schema shape:
+  - `/supabase/migrations/042_test_documents.sql`
+
+**Testing:**
+- `pnpm vitest run tests/unit/test-documents.test.ts tests/api/teacher/tests-id-route.test.ts tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+
+**Visual verification:**
+- Teacher Documents tab (shows new Add Text panel): `/tmp/pika-teacher-documents-editor-text.png`
+- Student exam mode view sanity check: `/tmp/pika-student-exam-doc-panel-text.png`
+
+## 2026-03-04 — Keep student docs embedded in exam mode (no new-tab path)
+**Context:** User flagged risk of students opening docs in a new tab/window and triggering exam-route exits/minimize indicators.
+
+**Changes:**
+- Updated student test docs viewer in `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Removed student-facing `Open in new tab` action.
+  - Added iframe sandbox (`allow-same-origin allow-scripts allow-forms`) for embedded link/upload docs.
+  - Added in-panel note: `Documentation stays in this panel during exam mode.`
+- Added assertion coverage in `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Confirms doc-open state no longer shows an `Open in new tab` button.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Student embedded-doc screenshot: `/tmp/pika-student-doc-embedded-no-tab.png`
+- Teacher view screenshot: `/tmp/pika-teacher-no-new-tab-view.png`
+
+## 2026-03-05 — Test builder tab order: Documents before Preview
+**Context:** User requested moving the Documents tab before Preview in teacher test builder.
+
+**Changes:**
+- Updated tab render order in `/src/components/QuizDetailPanel.tsx`:
+  - Tests now render tabs as: `Questions -> Documents -> Preview -> Results`
+  - Quizzes remain: `Questions -> Preview -> Results`
+- Added regression coverage in `/tests/components/QuizDetailPanel.test.tsx`:
+  - Asserts exact tab-strip order for tests.
+
+**Verification:**
+- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx`
+- `pnpm lint`
+- Teacher screenshot (tab order visible): `/tmp/pika-teacher-tab-order.png`
+- Student screenshot (sanity): `/tmp/pika-student-tab-order-check.png`
+
+## 2026-03-05 — Removed exam docs helper note in student panel
+**Context:** User requested removing the label `Documentation stays in this panel during exam mode.` from student exam-mode docs view.
+
+**Changes:**
+- Removed helper note from `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`.
+- Updated assertion in `/tests/components/StudentQuizzesTab.test.tsx`.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-note-removed.png`
+- Student screenshot: `/tmp/pika-student-doc-note-removed.png`
+
+## 2026-03-05 — Exam-mode header redesign + sidebar cleanup
+**Context:** User requested exam-mode UI changes:
+- Remove `Exam Mode` label in left panel
+- Move exam status into main top header as: `Test name · Thu Mar 5 · Exits X · Away m:ss · h:mm AM/PM`
+- Remove test title and indicator chips from exam left sidebar
+
+**Changes:**
+- Header pipeline:
+  - `/src/components/AppHeader.tsx`
+    - Added optional `examModeHeader` prop and renders condensed exam header line when present
+    - Uses Toronto time formatting: date `EEE MMM d`, local time `h:mm a`
+  - `/src/components/AppShell.tsx`
+    - Pass-through support for `examModeHeader`
+  - `/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
+    - Extended student exam-mode state to carry `testTitle`, `exitsCount`, `awayTotalSeconds`
+    - Listens to extended exam-mode event detail and forwards payload to `AppShell`
+- Student exam panel:
+  - `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+    - Removed left-panel `Exam Mode` heading
+    - Removed left-panel test title block
+    - Removed left-panel exits/away indicator chips
+    - Extended `STUDENT_TEST_EXAM_MODE_CHANGE_EVENT` detail payload with title/exits/away seconds
+- Tests:
+  - `/tests/components/StudentQuizzesTab.test.tsx`
+    - Updated expectations to reflect removed sidebar heading/indicator chips
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Teacher screenshot: `/tmp/pika-teacher-exam-header-change.png`
+- Student exam-mode screenshot: `/tmp/pika-student-exam-header-change.png`
+
+## 2026-03-05 — Exam header spacing: icon indicators + right-aligned combined date/time
+**Context:** User requested exam header layout as `TestTitle <spacing> indicators (icons) <spacing> date/time`, with date and time kept together and right-justified in the title bar.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` exam-mode center row:
+  - Uses icon indicators (`LogOut` for exits, `ClockAlert` for away time)
+  - Keeps condensed date/time as one token (`EEE MMM d h:mm a`)
+  - Right-aligns date/time within the exam-mode header row using `ml-auto`
+- Maintained non-exam header behavior unchanged.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-header-layout-v2.png`
+- Student screenshot: `/tmp/pika-student-header-layout-v2.png`
+
+## 2026-03-05 — Follow-up: hard right-align exam date/time in title bar
+**Context:** Final spacing request required date and time to remain together and be right-justified in the title bar.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` exam-mode layout:
+  - Center section now renders only `testTitle + icon indicators`
+  - Right section now renders combined `EEE MMM d h:mm a` immediately before the user avatar/menu
+  - Preserves requested order: `TestTitle <spacing> indicators <spacing> date/time`
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-header-layout-v3.png`
+- Student exam screenshot: `/tmp/pika-student-exam-header-layout-v4.png`
+
+## 2026-03-05 — Exam header micro-adjustment: timestamp flush to profile icon
+**Context:** User requested date/time to sit all the way right next to the profile icon in exam mode.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` right-section spacing from `gap-1` to `gap-0` so timestamp and profile avatar are adjacent.
+
+**Verification:**
+- Student exam screenshot: `/tmp/pika-student-exam-header-layout-v6.png`
+
+## 2026-03-05 — Student exam docs pane switched to dropdown + inline viewer
+**Context:** User requested removing the left-pane `Documents` heading and divider, and showing docs via a dropdown with selected content rendered directly below in the same pane.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Replaced button-list docs UI with `Select` dropdown (`Allowed documents`)
+  - Removed `Documents` title and divider line (`border-t ...`)
+  - Removed back-button doc mode (`Back to test info`) and kept docs inline in the same left pane
+  - Kept exam split at `30/70` while docs are viewed
+  - Auto-selects the first available document when docs are present
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Updated expectations from heading/buttons to dropdown-based doc selection
+  - Replaced old 50/50-toggle test with coverage for inline dropdown behavior
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-doc-dropdown-v1.png`
+- Student exam screenshot (with seeded sample docs): `/tmp/pika-student-doc-dropdown-v2.png`
+- Restored seeded sample docs back to empty after screenshot capture.
+
+## 2026-03-05 — Exam header time format tweak
+**Context:** User requested removing AM/PM and adding a bit of spacing after the time before the profile icon.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` exam-mode timestamp:
+  - Format changed from `EEE MMM d h:mm a` to `EEE MMM d h:mm`
+  - Added `mr-2` to timestamp span for padding before avatar/profile icon
+
+**Verification:**
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-time-padding-v1.png`
+- Student exam screenshot: `/tmp/pika-student-time-padding-v1.png`
+
+## 2026-03-05 — Docs panel UX revert: menu list -> doc view with `< Back` + 50/50 split
+**Context:** User requested replacing dropdown flow with sidebar menu behavior:
+- Left panel starts with selectable document list
+- Selecting a doc opens that doc in left panel
+- Layout switches from `30/70` to `50/50` while doc is open
+- Top control in doc view is `< Back` returning to main left panel menu
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Restored doc-open state (`activeDoc`) to drive `50/50` layout when a doc is selected
+  - Left exam menu now renders doc list buttons (no dropdown)
+  - Doc viewer mode now shows `< Back` (exact text) at top
+  - Returning via `< Back` resets to `30/70` menu layout
+  - Preserved no-new-tab behavior (embedded iframe/text only)
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Restored split-toggle test coverage (`30/70` -> `50/50` -> `30/70`)
+  - Replaced dropdown assertions with document-button and back-button assertions
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-doc-sidebar-flow-v1.png`
+- Student menu state screenshot (`30/70`): `/tmp/pika-student-doc-sidebar-menu-v2.png`
+- Student doc-open state screenshot (`50/50` + `< Back`): `/tmp/pika-student-doc-sidebar-open-v2.png`
+- Temporary sample docs were seeded for screenshoting and then restored to empty.
+
+## 2026-03-05 — Smooth split transition between docs menu and doc view
+**Context:** User requested a smoother visual transition when switching from docs menu (`30/70`) to doc-open (`50/50`) layout.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` split container classes to animate grid column changes on large screens:
+  - Added `lg:transition-[grid-template-columns] lg:duration-300 lg:ease-in-out`
+  - Added `motion-reduce:transition-none` for reduced-motion accessibility
+
+**Verification:**
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-time-padding-v1.png`
+- Student screenshot: `/tmp/pika-student-transition-v1.png`
+
+## 2026-03-05 — Doc-open view now full-bleed in left panel
+**Context:** User requested document content to fill the entire left panel when a doc is selected.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` doc-open rendering:
+  - Left section switches to `p-0 overflow-hidden` in doc mode
+  - Doc wrapper uses `h-full min-h-[65vh]` and removes inner card chrome
+  - Embedded docs (`iframe`) now fill left pane width/height directly
+  - Text docs use full-height scroll area
+  - `< Back` remains as an overlay control at top-left
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-doc-fullpanel-v1.png`
+- Student menu state: `/tmp/pika-student-doc-fullpanel-menu-v1.png`
+- Student doc-open state: `/tmp/pika-student-doc-fullpanel-open-v1.png`
+- Temporary seeded docs cleaned up via teacher API after screenshots.
+
+## 2026-03-05 — Titlebar date/time spacing + AM/PM restored
+**Context:** User requested a bit more space between date and time in exam header, and to restore AM/PM.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` exam timestamp rendering:
+  - Split date and time into separate inline spans
+  - Added `ml-2` before time to increase spacing
+  - Restored time format to `h:mm a` (AM/PM)
+
+**Verification:**
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-header-date-gap-v1.png`
+- Student exam screenshot: `/tmp/pika-student-header-date-gap-v1.png`
+
+## 2026-03-05 — Reduced jarring menu->doc transition in left exam sidebar
+**Context:** User reported transition still felt too abrupt when switching from doc menu to doc content.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` left exam pane to use animated layered content:
+  - Menu layer now fades/slides out (`opacity + translate`) when opening a doc
+  - Doc layer fades/slides in with matching timing
+  - Reverse animation on `< Back`
+  - Added pointer-event and tab-index guards for hidden layer controls
+- Kept existing split animation (`30/70` <-> `50/50`) and full-bleed doc content behavior.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-transition-smooth-v1.png`
+- Student menu state: `/tmp/pika-student-transition-smooth-menu-v1.png`
+- Student transition frame: `/tmp/pika-student-transition-smooth-mid-v1.png`
+- Student doc-open state: `/tmp/pika-student-transition-smooth-open-v1.png`
+- Temporary seeded docs cleaned up after verification.
+
+## 2026-03-05 — Preload external docs at exam start for faster doc switching
+**Context:** User requested preloading docs when exam begins so doc switches are faster and docs are locally available during exam mode.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added iframe prewarm behavior for all non-text docs during active exam mode
+  - Doc viewer now keeps a stacked set of doc iframes mounted and toggles visibility by selected doc id (instead of mounting a fresh iframe on each click)
+  - Added `loading="eager"` on preloaded iframes
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Added assertion that link-doc iframe exists before opening doc panel (preload coverage)
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-preload-v1.png`
+- Student menu screenshot: `/tmp/pika-student-preload-menu-v1.png`
+- Student transition frame: `/tmp/pika-student-preload-mid-v1.png`
+- Student open-doc screenshot: `/tmp/pika-student-preload-open-v1.png`
+- Temporary seeded docs were cleaned up after verification.
+
+## 2026-03-05 — Reduced pane padding + independent pane heights in exam layout
+**Context:** User requested less padding around exam panes/container and the ability for panes to use vertical space independently instead of appearing locked to same height.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Reduced outer spacing: `PageContent` from default `mt-2` to `mt-1`
+  - Reduced split gap from `gap-4` to `gap-2`
+  - Reduced pane paddings (`p-4 sm:p-5` -> `p-3 sm:p-4`)
+  - Added `lg:items-start` and `lg:self-start` so left/right panes do not force equal visual height
+  - Increased left exam-pane min height to use more vertical viewport space: `min-h-[calc(100dvh-8.5rem)]`
+  - Added `data-testid="student-test-split-container"` for stable split-layout test targeting
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - `getSplitContainer` now uses `data-testid` instead of fragile classname matching
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-pane-padding-v1.png`
+- Student menu screenshot: `/tmp/pika-student-pane-padding-menu-v1.png`
+- Student doc-open screenshot: `/tmp/pika-student-pane-padding-open-v1.png`
+- Temporary seeded docs cleaned up after verification.
+
+## 2026-03-05 — Force both exam panes to full vertical height
+**Context:** User requested both left/right panes occupy full vertical space because left pane could extend lower than short right content.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` exam split layout:
+  - Set split container min height: `lg:min-h-[calc(100dvh-7.5rem)]`
+  - Removed `lg:items-start` so grid items stretch by default
+  - Set both pane sections to `lg:h-full`
+  - Removed left-pane per-state min-height override and rely on shared split min-height
+- Retained tighter pane/container spacing from prior pass.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-fullheight-v1.png`
+- Student menu screenshot: `/tmp/pika-student-fullheight-menu-v2.png`
+- Student doc-open screenshot: `/tmp/pika-student-fullheight-open-v2.png`
+- Temporary seeded docs cleaned up after verification.
+
+## 2026-03-05 — Added dedicated documentation top bar for back navigation
+**Context:** User requested back control in a header bar because floating overlay obscured important doc content.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` doc-open layer:
+  - Replaced floating back button with fixed top bar (`h-10`) inside left pane
+  - Top bar now shows `< Back` and current doc title
+  - Moved content below the top bar (`flex-1`, `min-h-0`) so docs are not covered
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-doc-topbar-v1.png`
+- Student menu screenshot: `/tmp/pika-student-doc-topbar-menu-v1.png`
+- Student doc-open screenshot: `/tmp/pika-student-doc-topbar-open-v1.png`
+- Temporary seeded docs cleaned up after verification.
+
+## 2026-03-05 — Global centered maximize control in non-maximized exam mode
+**Context:** User reported students in doc view could not easily access maximize action when not maximized.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added fixed centered overlay action card with `Maximize Window` button when `showNotMaximizedWarning` is true
+  - Overlay is global to exam mode and remains visible in both docs menu and doc-open states
+  - Removed old left-pane-only maximize button to avoid hidden/duplicated controls
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-maximize-center-v1.png`
+- Student menu (forced non-fullscreen): `/tmp/pika-student-maximize-center-menu-v1.png`
+- Student doc-open (forced non-fullscreen): `/tmp/pika-student-maximize-center-doc-v1.png`
+- Temporary seeded docs cleaned up after verification.
+
+## 2026-03-05 — Compact away-time units in exam header indicator
+**Context:** User requested exam-mode away time to use compact units (`S/M/H`) instead of clock format (`m:ss`).
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` `formatDuration` for exam-mode away indicator:
+  - `< 60s` => `XS` (e.g., `0S`, `12S`)
+  - `< 3600s` => `XM` (e.g., `1M`, `2M`)
+  - `>= 3600s` => `XH` (e.g., `1H`)
+- Switched from rounding to floor-based conversion to avoid early unit rollovers.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-away-format-check.png`
+- Student screenshot: `/tmp/pika-student-away-format-check.png`
+- Student exam-mode screenshot (header indicator): `/tmp/pika-student-away-header-target.png`
+
+## 2026-03-05 — Obscure exam content when not maximized
+**Context:** User requested that exam content be hidden (or near-hidden) whenever exam mode is running in a non-maximized window.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added a fixed obscuring layer below the header when `showNotMaximizedWarning` is true.
+  - Layer uses `bg-page/90` + slight blur to heavily obscure exam body while preserving the centered `Maximize Window` control.
+  - Added `data-testid="exam-content-obscurer"` for regression coverage.
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Asserted the obscuring layer renders in non-maximized exam state.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-minimized-obscure-v2.png`
+- Student screenshot: `/tmp/pika-student-minimized-obscure-v2.png`
+- Student exam non-maximized screenshot: `/tmp/pika-student-minimized-obscure-exam-v4.png`
+
+## 2026-03-05 — Added centered non-maximized warning text above maximize action
+**Context:** User requested the centered overlay to include the message `Window must be maximized in exam mode.` above the `Maximize Window` button.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added centered warning text above the maximize button in the global non-maximized overlay card.
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Added assertion that the warning text is present in non-maximized exam mode (supports multiple matches due to left-pane + centered warning).
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-maxmsg-v1.png`
+- Student screenshot: `/tmp/pika-student-maxmsg-v1.png`
+- Student exam non-maximized screenshot: `/tmp/pika-student-maxmsg-exam-v1.png`
+
+## 2026-03-05 — Separated exam title and indicators in header layout
+**Context:** User requested clearer spacing so exam indicators sit visually between exam title and date/time in the title bar.
+
+**Changes:**
+- Updated `/src/components/AppHeader.tsx` exam-mode center section:
+  - Switched to a two-column layout (`title | indicators`) using grid.
+  - Increased separation (`gap-6`) between exam title and indicator group.
+  - Kept date/time in the right section before the profile icon so indicators read as the middle block.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-titlebar-gap-v1.png`
+- Student screenshot: `/tmp/pika-student-titlebar-gap-v1.png`
+- Student exam-mode screenshot: `/tmp/pika-student-titlebar-gap-exam-active-v1.png`
+
+## 2026-03-05 — Hard lock interactions while exam window is not maximized
+**Context:** User reported that exam UI was still interactive in non-maximized mode and requested app interaction to be disabled.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Added full-viewport interaction blocker (`data-testid="exam-interaction-blocker"`, `fixed inset-0 z-[64]`) during `showNotMaximizedWarning`.
+  - Keeps centered `Maximize Window` card clickable at higher z-index (`z-[65]`).
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Added assertion that the interaction blocker appears in non-maximized exam mode.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Playwright runtime check: textarea click blocked while non-maximized (`Interaction blocked: true`)
+- Teacher screenshot: `/tmp/pika-teacher-interaction-lock-v1.png`
+- Student screenshot: `/tmp/pika-student-interaction-lock-v1.png`
+- Student exam non-maximized screenshot: `/tmp/pika-student-interaction-lock-exam-v1.png`
+
+## 2026-03-05 — Centered documentation title in doc pane header
+**Context:** User requested the documentation content header title to be centered while keeping `< Back` left-justified.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` doc header bar:
+  - Switched header layout to a 3-column grid (`back | centered title | invisible balancing slot`).
+  - Kept `< Back` left-justified.
+  - Centered doc title text in the middle column.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-doc-title-center-v1.png`
+- Student screenshot: `/tmp/pika-student-doc-title-center-v1.png`
+- Student doc-open screenshot: `/tmp/pika-student-doc-title-center-open-v1.png`
+
+## 2026-03-05 — Hide doc-pane scrollbars until hover/focus
+**Context:** User requested hidden scrollbars by default for documentation pane, with scrollbars revealed only when the pane is hovered.
+
+**Changes:**
+- Updated `/src/app/globals.scss`:
+  - Added utility class `.scrollbar-hover` that hides scrollbars by default and reveals thin scrollbars on `:hover`/`:focus-within`.
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Applied `scrollbar-hover` to text document scroll container.
+  - For iframe documents, wrapped in `group overflow-hidden` and made the active iframe slightly wider by default (`w-[calc(100%+12px)]`) so the scrollbar gutter is clipped; restored to `w-full` on hover/focus.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-scrollbar-hover-v2.png`
+- Student screenshot: `/tmp/pika-student-scrollbar-hover-v2.png`
+- Student doc-open no-hover: `/tmp/pika-student-doc-scrollbar-nohover-v2.png`
+- Student doc-open hover: `/tmp/pika-student-doc-scrollbar-hover-v2.png`
+
+## 2026-03-05 — Made docs-pane back button more prominent
+**Context:** User requested a more prominent back action in documentation content view.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` doc header:
+  - Styled back action as a high-contrast pill button (`bg-info-bg`, `text-primary`, border, icon + label).
+  - Added `aria-label="Back to documents list"`.
+  - Kept centered title alignment via matching invisible placeholder on the right.
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Adjusted assertions for the new accessible button name (`Back to documents list`).
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-back-prominent-v1.png`
+- Student screenshot: `/tmp/pika-student-back-prominent-v1.png`
+- Student doc-open screenshot: `/tmp/pika-student-back-prominent-open-v1.png`
+
+## 2026-03-05 — Removed border from docs-pane back button
+**Context:** User requested removing the border from the now-prominent back button in documentation content view.
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Removed border classes from the docs-pane back button.
+  - Preserved prominent styling with fill color and icon+label.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Teacher screenshot: `/tmp/pika-teacher-back-noborder-v1.png`
+- Student screenshot: `/tmp/pika-student-back-noborder-v1.png`
+- Student doc-open screenshot: `/tmp/pika-student-back-noborder-open-v1.png`

--- a/src/app/api/student/tests/[id]/route.ts
+++ b/src/app/api/student/tests/[id]/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from '@/lib/auth'
 import { getStudentQuizStatus, summarizeQuizFocusEvents } from '@/lib/quizzes'
 import { assertStudentCanAccessTest, isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
 import { normalizeTestResponses, type TestResponses } from '@/lib/test-attempts'
+import { normalizeTestDocuments } from '@/lib/test-documents'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -160,6 +161,7 @@ export async function GET(
         assessment_type: 'test' as const,
         status: test.status,
         show_results: test.show_results,
+        documents: normalizeTestDocuments(test.documents),
         position: test.position,
         student_status: studentStatus,
         returned_at: attempt?.returned_at || null,

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from '@/lib/auth'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
 import { getStudentQuizStatus } from '@/lib/quizzes'
+import { normalizeTestDocuments } from '@/lib/test-documents'
 import type { Quiz } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -160,6 +161,7 @@ export async function GET(request: NextRequest) {
       return {
         ...test,
         assessment_type: 'test' as const,
+        documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
         student_status: studentStatus,
       }
     })

--- a/src/app/api/teacher/tests/[id]/documents/upload/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/upload/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { getTestDocumentValidationError } from '@/lib/test-documents'
+
+export const dynamic = 'force-dynamic'
+
+function safeExtension(filename: string): string {
+  const ext = filename.split('.').pop()?.trim().toLowerCase() || 'pdf'
+  return ext.replace(/[^a-z0-9]/g, '') || 'pdf'
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await requireRole('teacher')
+    const { id: testId } = await params
+    const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status })
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+    }
+
+    const validationError = getTestDocumentValidationError(file)
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 })
+    }
+
+    const supabase = getServiceRoleClient()
+    const ext = safeExtension(file.name)
+    const filename = `${user.id}/${testId}/${Date.now()}-${crypto.randomUUID()}.${ext}`
+    const buffer = Buffer.from(await file.arrayBuffer())
+
+    const { error: uploadError } = await supabase.storage
+      .from('test-documents')
+      .upload(filename, buffer, {
+        contentType: file.type,
+        upsert: false,
+      })
+
+    if (uploadError) {
+      const details = `${uploadError.message || ''} ${(uploadError as { details?: string }).details || ''}`.toLowerCase()
+      if (details.includes('bucket') || details.includes('not found')) {
+        return NextResponse.json(
+          { error: 'Test document uploads require migration 042 to be applied' },
+          { status: 400 }
+        )
+      }
+      console.error('Test document upload error:', uploadError)
+      return NextResponse.json({ error: 'Failed to upload document' }, { status: 500 })
+    }
+
+    const { data: urlData } = supabase.storage.from('test-documents').getPublicUrl(filename)
+
+    return NextResponse.json({
+      url: urlData.publicUrl,
+      title: file.name,
+      mime_type: file.type,
+      size: file.size,
+    })
+  } catch (error: any) {
+    if (error.name === 'AuthenticationError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (error.name === 'AuthorizationError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    console.error('Upload test document error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from '@/lib/auth'
 import { canActivateQuiz } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { normalizeTestDocuments, validateTestDocumentsPayload } from '@/lib/test-documents'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -43,6 +44,7 @@ export async function GET(
         assessment_type: 'test' as const,
         status: test.status,
         show_results: test.show_results,
+        documents: normalizeTestDocuments(test.documents),
         position: test.position,
         points_possible: test.points_possible,
         include_in_final: test.include_in_final,
@@ -74,7 +76,7 @@ export async function PATCH(
     const user = await requireRole('teacher')
     const { id } = await params
     const body = await request.json()
-    const { title, status, show_results } = body
+    const { title, status, show_results, documents } = body
 
     const access = await assertTeacherOwnsTest(user.id, id, { checkArchived: true })
     if (!access.ok) {
@@ -145,6 +147,13 @@ export async function PATCH(
     if (title !== undefined) updates.title = title.trim()
     if (status !== undefined) updates.status = status
     if (show_results !== undefined) updates.show_results = show_results
+    if (documents !== undefined) {
+      const validated = validateTestDocumentsPayload(documents)
+      if (!validated.valid) {
+        return NextResponse.json({ error: validated.error }, { status: 400 })
+      }
+      updates.documents = validated.documents
+    }
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: 'No updates provided' }, { status: 400 })
@@ -158,11 +167,26 @@ export async function PATCH(
       .single()
 
     if (error) {
+      if (
+        (error.code === '42703' || error.code === 'PGRST204') &&
+        `${error.message || ''} ${error.details || ''}`.toLowerCase().includes('documents')
+      ) {
+        return NextResponse.json(
+          { error: 'Test documents require migration 042 to be applied' },
+          { status: 400 }
+        )
+      }
       console.error('Error updating test:', error)
       return NextResponse.json({ error: 'Failed to update test' }, { status: 500 })
     }
 
-    return NextResponse.json({ quiz: { ...test, assessment_type: 'test' } })
+    return NextResponse.json({
+      quiz: {
+        ...test,
+        documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+        assessment_type: 'test',
+      },
+    })
   } catch (error: any) {
     if (error.name === 'AuthenticationError') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { normalizeTestDocuments } from '@/lib/test-documents'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -106,6 +107,7 @@ export async function GET(request: NextRequest) {
     const testsWithStats = (tests || []).map((test) => ({
       ...test,
       assessment_type: 'test' as const,
+      documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
       stats: {
         total_students: totalStudents || 0,
         responded: respondentCountMap[test.id] || 0,
@@ -183,7 +185,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to create test' }, { status: 500 })
     }
 
-    return NextResponse.json({ quiz: { ...test, assessment_type: 'test' } }, { status: 201 })
+    return NextResponse.json(
+      {
+        quiz: {
+          ...test,
+          documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+          assessment_type: 'test',
+        },
+      },
+      { status: 201 }
+    )
   } catch (error: any) {
     if (error.name === 'AuthenticationError') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -94,6 +94,9 @@ interface StudentTestExamModeDetail {
   classroomId?: string
   active?: boolean
   testId?: string | null
+  testTitle?: string | null
+  exitsCount?: number
+  awayTotalSeconds?: number
 }
 
 interface PendingExamNavigation {
@@ -253,7 +256,16 @@ function ClassroomPageContent({
   const [studentTestExamMode, setStudentTestExamMode] = useState<{
     active: boolean
     testId: string | null
-  }>({ active: false, testId: null })
+    testTitle: string | null
+    exitsCount: number
+    awayTotalSeconds: number
+  }>({
+    active: false,
+    testId: null,
+    testTitle: null,
+    exitsCount: 0,
+    awayTotalSeconds: 0,
+  })
   const hideLeftRailForExamMode = !isTeacher && activeTab === 'tests' && studentTestExamMode.active
 
   const logStudentTestRouteExitAttempt = useCallback((
@@ -323,6 +335,10 @@ function ClassroomPageContent({
       setStudentTestExamMode({
         active: detail?.active === true,
         testId: detail?.testId || null,
+        testTitle: detail?.active === true ? (detail?.testTitle || null) : null,
+        exitsCount: detail?.active === true ? Math.max(0, Number(detail?.exitsCount || 0)) : 0,
+        awayTotalSeconds:
+          detail?.active === true ? Math.max(0, Number(detail?.awayTotalSeconds || 0)) : 0,
       })
     }
 
@@ -835,6 +851,29 @@ function ClassroomPageContent({
   const isAssessmentTab = activeTab === 'quizzes' || activeTab === 'tests'
   const assessmentLabel = activeTab === 'tests' ? 'test' : 'quiz'
   const assessmentApiBasePath = activeTab === 'tests' ? '/api/teacher/tests' : '/api/teacher/quizzes'
+  const examHeaderData = useMemo(() => {
+    if (
+      isTeacher ||
+      activeTab !== 'tests' ||
+      !studentTestExamMode.active ||
+      !studentTestExamMode.testTitle
+    ) {
+      return null
+    }
+
+    return {
+      testTitle: studentTestExamMode.testTitle,
+      exitsCount: studentTestExamMode.exitsCount,
+      awayTotalSeconds: studentTestExamMode.awayTotalSeconds,
+    }
+  }, [
+    activeTab,
+    isTeacher,
+    studentTestExamMode.active,
+    studentTestExamMode.awayTotalSeconds,
+    studentTestExamMode.exitsCount,
+    studentTestExamMode.testTitle,
+  ])
   const gradingTestId =
     activeTab === 'tests'
       ? (testGradingContext.testId || selectedQuiz?.id || null)
@@ -864,6 +903,7 @@ function ClassroomPageContent({
       onNavigateHome={handleHomeNavigationAttempt}
       onNavigateClassroom={handleClassroomNavigationAttempt}
       mainClassName="max-w-none px-0 py-0"
+      examModeHeader={examHeaderData}
     >
       <ThreePanelShell leftWidthOverride={hideLeftRailForExamMode ? 0 : undefined}>
         {hideLeftRailForExamMode ? (

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -13,6 +13,7 @@ import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
 } from '@/lib/events'
+import { normalizeTestDocuments } from '@/lib/test-documents'
 import type {
   Classroom,
   QuizAssessmentType,
@@ -35,6 +36,14 @@ interface RouteExitAttemptDetail {
   dedupe?: boolean
 }
 
+interface AllowedDocItem {
+  id: string
+  title: string
+  source: 'link' | 'upload' | 'text'
+  url?: string
+  content?: string
+}
+
 type FullscreenCapableElement = HTMLElement & {
   requestFullscreen?: () => Promise<void>
 }
@@ -54,6 +63,31 @@ function isFullscreenActive(): boolean {
   return typeof document !== 'undefined' && Boolean(document.fullscreenElement)
 }
 
+function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
+  const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
+  const plainUrlPattern = /\bhttps?:\/\/[^\s)]+/g
+  const linksByUrl = new Map<string, AllowedDocItem>()
+
+  for (const question of questions) {
+    const text = question.question_text || ''
+
+    for (const match of text.matchAll(markdownLinkPattern)) {
+      const title = (match[1] || '').trim()
+      const url = (match[2] || '').trim()
+      if (!url || linksByUrl.has(url)) continue
+      linksByUrl.set(url, { id: url, title: title || url, source: 'link', url })
+    }
+
+    for (const match of text.matchAll(plainUrlPattern)) {
+      const url = (match[0] || '').trim()
+      if (!url || linksByUrl.has(url)) continue
+      linksByUrl.set(url, { id: url, title: url, source: 'link', url })
+    }
+  }
+
+  return Array.from(linksByUrl.values())
+}
+
 export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }: Props) {
   const notifications = useStudentNotifications()
   const [quizzes, setQuizzes] = useState<StudentQuizView[]>([])
@@ -70,6 +104,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const [showStartTestConfirm, setShowStartTestConfirm] = useState(false)
   const [pendingStartTestId, setPendingStartTestId] = useState<string | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [activeDoc, setActiveDoc] = useState<AllowedDocItem | null>(null)
   const selectedQuizIdRef = useRef<string | null>(null)
   const focusSessionIdRef = useRef<string | null>(null)
   const awayStartedAtRef = useRef<number | null>(null)
@@ -85,6 +120,25 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const hasStarted = startedTestId === selectedQuiz.quiz.id
     return isTestsView && isActive && !hasSubmitted && hasStarted
   }, [isActive, isTestsView, selectedQuiz, startedTestId])
+  const allowedDocs = useMemo(() => {
+    const teacherManagedDocs = normalizeTestDocuments(selectedQuiz?.quiz?.documents).map((doc) => ({
+      id: doc.id,
+      title: doc.title,
+      source: doc.source,
+      url: doc.url,
+      content: doc.content,
+    }))
+    if (teacherManagedDocs.length > 0) return teacherManagedDocs
+    return extractAllowedDocLinks(selectedQuiz?.questions || [])
+  }, [selectedQuiz?.questions, selectedQuiz?.quiz?.documents])
+
+  useEffect(() => {
+    if (!isTestsView) return
+    setActiveDoc((previous) => {
+      if (!previous) return null
+      return allowedDocs.some((doc) => doc.id === previous.id) ? previous : null
+    })
+  }, [allowedDocs, isTestsView])
 
   useEffect(() => {
     selectedQuizIdRef.current = selectedQuizId
@@ -121,6 +175,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   async function handleSelectQuiz(quizId: string) {
     setSelectedQuizId(quizId)
     setLoadingQuiz(true)
+    setActiveDoc(null)
     focusSessionIdRef.current = createFocusSessionId()
     awayStartedAtRef.current = null
     lastRouteExitRef.current = null
@@ -294,6 +349,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     setFocusSummary(null)
     setShowStartTestConfirm(false)
     setPendingStartTestId(null)
+    setActiveDoc(null)
     const fullscreenNow = isFullscreenActive()
     fullscreenActiveRef.current = fullscreenNow
     setIsFullscreen(fullscreenNow)
@@ -349,6 +405,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
 
   useEffect(() => {
     if (!isTestsView) return
+    const exitsCount = getQuizExitCount(focusSummary)
+    const awayTotalSeconds = Math.max(0, focusSummary?.away_total_seconds ?? 0)
 
     window.dispatchEvent(
       new CustomEvent(STUDENT_TEST_EXAM_MODE_CHANGE_EVENT, {
@@ -356,6 +414,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
           classroomId: classroom.id,
           active: focusEnabled,
           testId: focusEnabled ? selectedQuizIdRef.current : null,
+          testTitle: focusEnabled ? selectedQuiz?.quiz.title || null : null,
+          exitsCount: focusEnabled ? exitsCount : 0,
+          awayTotalSeconds: focusEnabled ? awayTotalSeconds : 0,
         },
       })
     )
@@ -367,11 +428,14 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
             classroomId: classroom.id,
             active: false,
             testId: null,
+            testTitle: null,
+            exitsCount: 0,
+            awayTotalSeconds: 0,
           },
         })
       )
     }
-  }, [classroom.id, focusEnabled, isTestsView])
+  }, [classroom.id, focusEnabled, focusSummary, isTestsView, selectedQuiz?.quiz.title])
 
   useEffect(() => {
     if (!isTestsView) return
@@ -611,12 +675,14 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       selectedQuiz.quiz.student_status === 'not_started' &&
       startedTestId !== selectedQuiz.quiz.id
     const showCurrentTestInfoPanel = hasSelectedQuiz && focusEnabled
+    const showDocPanel = showCurrentTestInfoPanel && activeDoc !== null
     const awayDurationLabel = formatDuration(focusSummary?.away_total_seconds ?? 0)
     const exitsCount = getQuizExitCount(focusSummary)
     const awayCount = focusSummary?.away_count ?? 0
     const routeExitAttempts = focusSummary?.route_exit_attempts ?? 0
     const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
     const showNotMaximizedWarning = hasSelectedQuiz && focusEnabled && !isFullscreen
+    const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
 
     return (
       <PageLayout className="relative">
@@ -626,61 +692,163 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
             className="pointer-events-none fixed inset-0 z-[60] border-[10px] border-warning bg-warning-bg/15"
           />
         )}
+        {showNotMaximizedWarning && (
+          <div
+            aria-hidden="true"
+            data-testid="exam-content-obscurer"
+            className="pointer-events-none fixed inset-x-0 bottom-0 top-12 z-[62] bg-page/90 backdrop-blur-[2px]"
+          />
+        )}
+        {showNotMaximizedWarning && (
+          <div
+            aria-hidden="true"
+            data-testid="exam-interaction-blocker"
+            className="fixed inset-0 z-[64] cursor-not-allowed"
+          />
+        )}
+        {showNotMaximizedWarning && (
+          <div className="pointer-events-none fixed inset-0 z-[65] flex items-center justify-center px-4">
+            <div className="pointer-events-auto rounded-xl border border-warning bg-surface p-4 shadow-xl">
+              <p className="mb-3 text-center text-sm font-medium text-warning">
+                Window must be maximized in exam mode.
+              </p>
+              <Button
+                type="button"
+                size="lg"
+                className="w-full gap-2"
+                onClick={() => {
+                  void requestExamFullscreen('center_overlay_maximize', { logFailures: true })
+                }}
+              >
+                <Maximize2 className="h-5 w-5" />
+                <span>Maximize Window</span>
+              </Button>
+            </div>
+          </div>
+        )}
 
-        <PageContent>
+        <PageContent className="mt-1">
           <div className="mx-auto w-full max-w-none">
             <div
-              className={`grid grid-cols-1 gap-4 ${
-                showCurrentTestInfoPanel ? 'lg:grid-cols-[30%_70%]' : 'lg:grid-cols-2'
-              }`}
+              data-testid="student-test-split-container"
+              className={`grid grid-cols-1 gap-2 ${
+                showDocPanel
+                  ? 'lg:grid-cols-2'
+                  : showCurrentTestInfoPanel
+                    ? 'lg:grid-cols-[30%_70%]'
+                    : 'lg:grid-cols-2'
+              } lg:min-h-[calc(100dvh-7.5rem)] lg:transition-[grid-template-columns] lg:duration-300 lg:ease-in-out motion-reduce:transition-none`}
             >
-              <section className="rounded-xl border border-border bg-surface p-4 sm:p-5">
+              <section
+                className={`rounded-xl border border-border bg-surface lg:h-full ${
+                  showCurrentTestInfoPanel ? 'relative overflow-hidden p-0' : 'p-3 sm:p-4'
+                }`}
+              >
                 {showCurrentTestInfoPanel ? (
-                  <div className="space-y-4">
-                    <h2 className="text-lg font-semibold text-text-default">Exam Mode</h2>
+                  <>
+                    <div
+                      aria-hidden={showDocPanel}
+                      className={`h-full p-3 sm:p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${
+                        showDocPanel
+                          ? 'pointer-events-none translate-x-2 opacity-0'
+                          : 'translate-x-0 opacity-100'
+                      }`}
+                    >
+                      <div className="space-y-4">
+                        {showNotMaximizedWarning && (
+                          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-xs text-warning">
+                            Window must be maximized in exam mode.
+                          </div>
+                        )}
 
-                    <div className="rounded-lg border border-border bg-surface-2 px-3 py-2">
-                      <p className="text-sm font-medium text-text-default">{selectedQuiz?.quiz.title}</p>
-                    </div>
-
-                    {showNotMaximizedWarning && (
-                      <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-xs text-warning">
-                        Window must be maximized in exam mode.
+                        {allowedDocs.length > 0 ? (
+                          <div className="space-y-2">
+                            {allowedDocs.map((doc) => (
+                              <Button
+                                key={doc.id}
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                className="w-full justify-start"
+                                onClick={() => setActiveDoc(doc)}
+                                tabIndex={showDocPanel ? -1 : 0}
+                              >
+                                {doc.title}
+                              </Button>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-text-muted">No documents provided for this test.</p>
+                        )}
                       </div>
-                    )}
-
-                    {focusEnabled && !isFullscreen && (
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="secondary"
-                        className="w-full justify-center gap-1.5 border border-warning bg-warning-bg text-warning shadow-sm ring-1 ring-warning/50 hover:bg-warning-bg/80"
-                        onClick={() => {
-                          void requestExamFullscreen('left_panel_maximize', { logFailures: true })
-                        }}
-                      >
-                        <span>Maximize Window</span>
-                        <Maximize2 className="h-4 w-4" />
-                      </Button>
-                    )}
-
-                    <div className="flex flex-wrap items-center gap-2 border-t border-border pt-2 text-sm text-text-muted">
-                      <span
-                        className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                        aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
-                      >
-                        <LogOut className="h-4 w-4" />
-                        <span>{exitsCount}</span>
-                      </span>
-                      <span
-                        className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                        aria-label={`Away time ${awayDurationLabel}.`}
-                      >
-                        <ClockAlert className="h-4 w-4" />
-                        <span>{awayDurationLabel}</span>
-                      </span>
                     </div>
-                  </div>
+
+                    <div
+                      aria-hidden={!showDocPanel}
+                      className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
+                        showDocPanel
+                          ? 'pointer-events-auto translate-x-0 opacity-100'
+                          : 'pointer-events-none -translate-x-2 opacity-0'
+                      }`}
+                    >
+                      <div className="flex h-full flex-col bg-surface">
+                        <div className="grid h-10 grid-cols-[auto_minmax(0,1fr)_auto] items-center border-b border-border bg-surface-2 px-3">
+                          <button
+                            type="button"
+                            onClick={() => setActiveDoc(null)}
+                            aria-label="Back to documents list"
+                            className="inline-flex items-center gap-1 justify-self-start whitespace-nowrap rounded-md bg-info-bg px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-info-bg-hover"
+                            tabIndex={showDocPanel ? 0 : -1}
+                          >
+                            <ChevronLeft className="h-3.5 w-3.5" />
+                            <span>Back</span>
+                          </button>
+                          <span className="min-w-0 truncate text-center text-sm text-text-muted">
+                            {activeDoc?.title || 'Documentation'}
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            className="invisible inline-flex items-center gap-1 justify-self-end whitespace-nowrap rounded-md border border-primary/40 px-2 py-1 text-xs font-semibold"
+                          >
+                            <ChevronLeft className="h-3.5 w-3.5" />
+                            <span>Back</span>
+                          </span>
+                        </div>
+
+                        {activeDoc?.source === 'text' ? (
+                          <div className="scrollbar-hover min-h-0 flex-1 overflow-auto bg-surface-2 p-3">
+                            <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
+                              {activeDoc.content || ''}
+                            </pre>
+                          </div>
+                        ) : iframeDocs.length > 0 ? (
+                          <div className="group relative min-h-0 flex-1 overflow-hidden bg-white">
+                            {iframeDocs.map((doc) => {
+                              const isVisible = activeDoc?.id === doc.id
+                              return (
+                                <iframe
+                                  key={doc.id}
+                                  src={doc.url}
+                                  title={doc.title || 'Documentation'}
+                                  className={`absolute inset-y-0 left-0 h-full transition-[opacity,width] duration-150 motion-reduce:transition-none ${
+                                    isVisible
+                                      ? 'w-[calc(100%+12px)] opacity-100 group-hover:w-full group-focus-within:w-full'
+                                      : 'pointer-events-none w-full opacity-0'
+                                  }`}
+                                  sandbox="allow-same-origin allow-scripts allow-forms"
+                                  loading="eager"
+                                />
+                              )
+                            })}
+                          </div>
+                        ) : (
+                          <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+                            <p className="text-sm text-text-muted">This document is unavailable.</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </>
                 ) : (
                   <>
                     <h2 className="mb-3 text-lg font-semibold text-text-default">Tests</h2>
@@ -690,7 +858,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
               </section>
 
               <section
-                className={`rounded-xl border border-border bg-surface p-4 sm:p-5 ${
+                className={`rounded-xl border border-border bg-surface p-3 sm:p-4 lg:h-full ${
                   showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
                 }`}
               >

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -5,3 +5,37 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .scrollbar-hover {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .scrollbar-hover::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .scrollbar-hover:hover,
+  .scrollbar-hover:focus-within {
+    scrollbar-width: thin;
+  }
+
+  .scrollbar-hover:hover::-webkit-scrollbar,
+  .scrollbar-hover:focus-within::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scrollbar-hover:hover::-webkit-scrollbar-thumb,
+  .scrollbar-hover:focus-within::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background: var(--color-border-strong);
+  }
+
+  .scrollbar-hover:hover::-webkit-scrollbar-track,
+  .scrollbar-hover:focus-within::-webkit-scrollbar-track {
+    background: transparent;
+  }
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Menu } from 'lucide-react'
+import { ClockAlert, LogOut, Menu } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ClassroomDropdown } from './ClassroomDropdown'
@@ -26,6 +26,18 @@ interface AppHeaderProps {
   onOpenSidebar?: () => void
   onNavigateHome?: (href: string) => boolean
   onNavigateClassroom?: (href: string) => boolean
+  examModeHeader?: {
+    testTitle: string
+    exitsCount: number
+    awayTotalSeconds: number
+  } | null
+}
+
+function formatDuration(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds))
+  if (safe < 60) return `${safe}S`
+  if (safe < 3600) return `${Math.floor(safe / 60)}M`
+  return `${Math.floor(safe / 3600)}H`
 }
 
 /**
@@ -39,6 +51,7 @@ export function AppHeader({
   onOpenSidebar,
   onNavigateHome,
   onNavigateClassroom,
+  examModeHeader,
 }: AppHeaderProps) {
   const [now, setNow] = useState(() => new Date())
 
@@ -48,7 +61,7 @@ export function AppHeader({
   }, [])
 
   return (
-    <header className="sticky top-0 z-50 h-12 bg-surface border-b border-border grid grid-cols-[1fr_auto_1fr] items-center px-4">
+    <header className="sticky top-0 z-50 h-12 bg-surface border-b border-border grid grid-cols-[1fr_minmax(0,1fr)_1fr] items-center px-4">
       {/* Left section */}
       <div className="flex items-center gap-3">
         {/* Mobile sidebar trigger (classroom pages) */}
@@ -94,20 +107,44 @@ export function AppHeader({
         )}
       </div>
 
-      {/* Center section - Date */}
-      <div>
-        {/* Mobile: Short format (Tue Dec 16) */}
-        <div className="lg:hidden text-lg sm:text-xl font-bold text-text-default tabular-nums">
-          {formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}
-        </div>
-        {/* Desktop: Long format (Monday January 12, 2026) */}
-        <div className="hidden lg:block text-xl font-bold text-text-default">
-          {formatInTimeZone(now, 'America/Toronto', 'EEEE MMMM d, yyyy')}
-        </div>
+      {/* Center section - Date / contextual status */}
+      <div className="min-w-0 px-2">
+        {examModeHeader ? (
+          <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-6 text-sm text-text-default">
+            <span className="truncate font-semibold">{examModeHeader.testTitle}</span>
+            <div className="inline-flex items-center gap-3 whitespace-nowrap text-text-muted tabular-nums">
+              <span className="inline-flex items-center gap-1">
+                <LogOut className="h-3.5 w-3.5" />
+                <span>{examModeHeader.exitsCount}</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <ClockAlert className="h-3.5 w-3.5" />
+                <span>{formatDuration(examModeHeader.awayTotalSeconds)}</span>
+              </span>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Mobile: Short format (Tue Dec 16) */}
+            <div className="lg:hidden text-lg sm:text-xl font-bold text-text-default tabular-nums">
+              {formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}
+            </div>
+            {/* Desktop: Long format (Monday January 12, 2026) */}
+            <div className="hidden lg:block text-xl font-bold text-text-default">
+              {formatInTimeZone(now, 'America/Toronto', 'EEEE MMMM d, yyyy')}
+            </div>
+          </>
+        )}
       </div>
 
       {/* Right section */}
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end gap-0">
+        {examModeHeader && (
+          <span className="mr-2 whitespace-nowrap text-sm font-semibold tabular-nums text-text-default">
+            <span>{formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}</span>
+            <span className="ml-2">{formatInTimeZone(now, 'America/Toronto', 'h:mm a')}</span>
+          </span>
+        )}
         <UserMenu user={user} />
       </div>
     </header>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -21,6 +21,11 @@ interface AppShellProps {
   onNavigateHome?: (href: string) => boolean
   onNavigateClassroom?: (href: string) => boolean
   mainClassName?: string
+  examModeHeader?: {
+    testTitle: string
+    exitsCount: number
+    awayTotalSeconds: number
+  } | null
 }
 
 /**
@@ -38,6 +43,7 @@ export function AppShell({
   onNavigateHome,
   onNavigateClassroom,
   mainClassName,
+  examModeHeader,
 }: AppShellProps) {
   return (
     <div className="min-h-screen bg-page">
@@ -50,6 +56,7 @@ export function AppShell({
           onOpenSidebar={onOpenSidebar}
           onNavigateHome={onNavigateHome}
           onNavigateClassroom={onNavigateClassroom}
+          examModeHeader={examModeHeader}
         />
       )}
       <main className={mainClassName || 'max-w-7xl mx-auto px-4 py-3'}>

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -23,11 +23,13 @@ import { canEditQuizQuestions } from '@/lib/quizzes'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
 import { TestQuestionEditor } from '@/components/TestQuestionEditor'
+import { TestDocumentsEditor } from '@/components/TestDocumentsEditor'
 import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
-import type { QuizQuestion, QuizWithStats, QuizResultsAggregate } from '@/types'
+import { normalizeTestDocuments } from '@/lib/test-documents'
+import type { QuizQuestion, QuizWithStats, QuizResultsAggregate, TestDocument } from '@/types'
 
 interface Props {
   quiz: QuizWithStats
@@ -44,9 +46,10 @@ export function QuizDetailPanel({
 }: Props) {
   const isTestsView = quiz.assessment_type === 'test' || apiBasePath.includes('/tests')
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
+  const [documents, setDocuments] = useState<TestDocument[]>([])
   const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
   const [loading, setLoading] = useState(true)
-  const [viewMode, setViewMode] = useState<'questions' | 'preview' | 'results'>('questions')
+  const [viewMode, setViewMode] = useState<'questions' | 'documents' | 'preview' | 'results'>('questions')
   const [error, setError] = useState('')
 
   // Inline title editing
@@ -124,6 +127,7 @@ export function QuizDetailPanel({
       const res = await fetch(`${apiBasePath}/${quiz.id}`)
       const data = await res.json()
       setQuestions(data.questions || [])
+      setDocuments(normalizeTestDocuments(data.quiz?.documents))
 
       if (hasResponses) {
         const resultsRes = await fetch(`${apiBasePath}/${quiz.id}/results`)
@@ -243,6 +247,19 @@ export function QuizDetailPanel({
         >
           Questions ({questions.length})
         </button>
+        {isTestsView && (
+          <button
+            type="button"
+            onClick={() => setViewMode('documents')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              viewMode === 'documents'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:text-text-default'
+            }`}
+          >
+            Documents ({documents.length})
+          </button>
+        )}
         <button
           type="button"
           onClick={() => setViewMode('preview')}
@@ -393,6 +410,17 @@ export function QuizDetailPanel({
               )
             )}
 
+          </div>
+        ) : viewMode === 'documents' && isTestsView ? (
+          <div className="space-y-3">
+            <h3 className="text-lg font-semibold text-text-default">Documents</h3>
+            <TestDocumentsEditor
+              testId={quiz.id}
+              documents={documents}
+              apiBasePath={apiBasePath}
+              isEditable={isEditable}
+              onUpdated={loadQuizDetails}
+            />
           </div>
         ) : viewMode === 'preview' ? (
           <QuizPreview questions={questions} isTestsView={isTestsView} />

--- a/src/components/TestDocumentsEditor.tsx
+++ b/src/components/TestDocumentsEditor.tsx
@@ -1,0 +1,444 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ExternalLink, FileText, Link2, Trash2, Upload } from 'lucide-react'
+import { Button, Input } from '@/ui'
+import {
+  MAX_TEST_DOCUMENT_TEXT_LENGTH,
+  TEST_DOCUMENT_ACCEPT,
+  normalizeTestDocuments,
+  isValidHttpUrl,
+} from '@/lib/test-documents'
+import type { TestDocument } from '@/types'
+
+interface Props {
+  testId: string
+  documents?: TestDocument[]
+  apiBasePath?: string
+  isEditable: boolean
+  onUpdated: () => void
+}
+
+function makeEmptyLinkForm() {
+  return { title: '', url: '' }
+}
+
+function makeEmptyTextForm() {
+  return { title: '', content: '' }
+}
+
+export function TestDocumentsEditor({
+  testId,
+  documents = [],
+  apiBasePath = '/api/teacher/tests',
+  isEditable,
+  onUpdated,
+}: Props) {
+  const [localDocs, setLocalDocs] = useState<TestDocument[]>(() => normalizeTestDocuments(documents))
+  const [savedDocsJson, setSavedDocsJson] = useState(JSON.stringify(normalizeTestDocuments(documents)))
+  const [linkForm, setLinkForm] = useState(makeEmptyLinkForm())
+  const [textForm, setTextForm] = useState(makeEmptyTextForm())
+  const [uploadTitle, setUploadTitle] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const normalized = normalizeTestDocuments(documents)
+    setLocalDocs(normalized)
+    setSavedDocsJson(JSON.stringify(normalized))
+  }, [documents])
+
+  const isDirty = useMemo(
+    () => JSON.stringify(localDocs) !== savedDocsJson,
+    [localDocs, savedDocsJson]
+  )
+
+  async function persistDocuments(nextDocs: TestDocument[]) {
+    setSaving(true)
+    setError('')
+    setSuccess('')
+    try {
+      const res = await fetch(`${apiBasePath}/${testId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documents: nextDocs }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to save documents')
+      }
+
+      const normalized = normalizeTestDocuments(data.quiz?.documents || nextDocs)
+      setLocalDocs(normalized)
+      setSavedDocsJson(JSON.stringify(normalized))
+      setSuccess('Documents saved')
+      onUpdated()
+    } catch (err: any) {
+      setError(err.message || 'Failed to save documents')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleLocalDocChange(docId: string, partial: Partial<TestDocument>) {
+    setLocalDocs((prev) =>
+      prev.map((doc) => (doc.id === docId ? { ...doc, ...partial } : doc))
+    )
+  }
+
+  async function handleAddLink() {
+    if (!isEditable || saving) return
+    const title = linkForm.title.trim()
+    const url = linkForm.url.trim()
+    if (!title) {
+      setError('Document title is required')
+      return
+    }
+    if (!isValidHttpUrl(url)) {
+      setError('Document URL must be a valid http/https link')
+      return
+    }
+
+    const nextDocs = [
+      ...localDocs,
+      {
+        id: crypto.randomUUID(),
+        title: title.slice(0, 120),
+        url,
+        source: 'link' as const,
+      },
+    ]
+    setLocalDocs(nextDocs)
+    setLinkForm(makeEmptyLinkForm())
+    await persistDocuments(nextDocs)
+  }
+
+  async function handleAddText() {
+    if (!isEditable || saving) return
+    const title = textForm.title.trim()
+    const content = textForm.content
+    if (!title) {
+      setError('Document title is required')
+      return
+    }
+    if (!content.trim()) {
+      setError('Document text is required')
+      return
+    }
+
+    const nextDocs = [
+      ...localDocs,
+      {
+        id: crypto.randomUUID(),
+        title: title.slice(0, 120),
+        source: 'text' as const,
+        content: content.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH),
+      },
+    ]
+    setLocalDocs(nextDocs)
+    setTextForm(makeEmptyTextForm())
+    await persistDocuments(nextDocs)
+  }
+
+  async function handleUploadFile(file: File) {
+    if (!isEditable || uploading || saving) return
+    setUploading(true)
+    setError('')
+    setSuccess('')
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const uploadRes = await fetch(`${apiBasePath}/${testId}/documents/upload`, {
+        method: 'POST',
+        body: formData,
+      })
+      const uploadData = await uploadRes.json()
+      if (!uploadRes.ok) {
+        throw new Error(uploadData.error || 'Failed to upload document')
+      }
+
+      const title = uploadTitle.trim() || uploadData.title || file.name
+      const nextDocs = [
+        ...localDocs,
+        {
+          id: crypto.randomUUID(),
+          title: String(title).trim().slice(0, 120),
+          url: String(uploadData.url || ''),
+          source: 'upload' as const,
+        },
+      ]
+
+      setLocalDocs(nextDocs)
+      setUploadTitle('')
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+      await persistDocuments(nextDocs)
+    } catch (err: any) {
+      setError(err.message || 'Failed to upload document')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function handleDelete(docId: string) {
+    if (!isEditable || saving) return
+    const nextDocs = localDocs.filter((doc) => doc.id !== docId)
+    setLocalDocs(nextDocs)
+    await persistDocuments(nextDocs)
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-md border border-success bg-success-bg px-3 py-2 text-sm text-success">
+          {success}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-surface p-3">
+        <h4 className="mb-2 text-sm font-semibold text-text-default">Add Link</h4>
+        <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]">
+          <Input
+            placeholder="Title (e.g., Java API)"
+            value={linkForm.title}
+            onChange={(event) => setLinkForm((prev) => ({ ...prev, title: event.target.value }))}
+            disabled={!isEditable || saving || uploading}
+          />
+          <Input
+            placeholder="https://..."
+            value={linkForm.url}
+            onChange={(event) => setLinkForm((prev) => ({ ...prev, url: event.target.value }))}
+            disabled={!isEditable || saving || uploading}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              void handleAddLink()
+            }}
+            disabled={!isEditable || saving || uploading}
+            className="gap-1.5"
+            aria-label="Add link document"
+          >
+            <Link2 className="h-4 w-4" />
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-surface p-3">
+        <h4 className="mb-2 text-sm font-semibold text-text-default">Add Text</h4>
+        <div className="space-y-2">
+          <Input
+            placeholder="Title (e.g., Allowed formulas)"
+            value={textForm.title}
+            onChange={(event) => setTextForm((prev) => ({ ...prev, title: event.target.value }))}
+            disabled={!isEditable || saving || uploading}
+          />
+          <textarea
+            placeholder="Paste text students can reference during the test..."
+            value={textForm.content}
+            onChange={(event) =>
+              setTextForm((prev) => ({
+                ...prev,
+                content: event.target.value.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH),
+              }))
+            }
+            disabled={!isEditable || saving || uploading}
+            rows={6}
+            className="w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+          />
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-text-muted">
+              {textForm.content.length}/{MAX_TEST_DOCUMENT_TEXT_LENGTH} characters
+            </p>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                void handleAddText()
+              }}
+              disabled={!isEditable || saving || uploading}
+              className="gap-1.5"
+              aria-label="Add text document"
+            >
+              <FileText className="h-4 w-4" />
+              Add
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-surface p-3">
+        <h4 className="mb-2 text-sm font-semibold text-text-default">Upload Document</h4>
+        <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+          <Input
+            placeholder="Optional custom title"
+            value={uploadTitle}
+            onChange={(event) => setUploadTitle(event.target.value)}
+            disabled={!isEditable || saving || uploading}
+          />
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={TEST_DOCUMENT_ACCEPT}
+              className="hidden"
+              onChange={(event) => {
+                const file = event.target.files?.[0]
+                if (!file) return
+                void handleUploadFile(file)
+              }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!isEditable || saving || uploading}
+              className="gap-1.5"
+            >
+              <Upload className="h-4 w-4" />
+              {uploading ? 'Uploading...' : 'Choose file'}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h4 className="text-sm font-semibold text-text-default">Documents ({localDocs.length})</h4>
+        {localDocs.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-surface-2 px-3 py-4 text-sm text-text-muted">
+            No documents yet.
+          </p>
+        ) : (
+          localDocs.map((doc) => (
+            <div
+              key={doc.id}
+              className="rounded-lg border border-border bg-surface p-3"
+            >
+              {doc.source === 'text' ? (
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Input
+                      value={doc.title}
+                      onChange={(event) => handleLocalDocChange(doc.id, { title: event.target.value })}
+                      disabled={!isEditable || saving || uploading}
+                      aria-label="Document title"
+                      className="min-w-[220px] flex-1"
+                    />
+                    <span className="rounded-md bg-surface-2 px-2 py-1 text-xs text-text-muted">
+                      Text
+                    </span>
+                    <Button
+                      type="button"
+                      variant="danger"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => {
+                        void handleDelete(doc.id)
+                      }}
+                      disabled={!isEditable || saving || uploading}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Remove
+                    </Button>
+                  </div>
+                  <textarea
+                    value={doc.content || ''}
+                    onChange={(event) =>
+                      handleLocalDocChange(doc.id, {
+                        content: event.target.value.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH),
+                      })
+                    }
+                    disabled={!isEditable || saving || uploading}
+                    rows={6}
+                    className="w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+                    aria-label="Document text"
+                  />
+                </div>
+              ) : (
+                <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto_auto] md:items-center">
+                  <Input
+                    value={doc.title}
+                    onChange={(event) => handleLocalDocChange(doc.id, { title: event.target.value })}
+                    disabled={!isEditable || saving || uploading}
+                    aria-label="Document title"
+                  />
+                  <Input
+                    value={doc.url || ''}
+                    onChange={(event) => handleLocalDocChange(doc.id, { url: event.target.value })}
+                    disabled={!isEditable || saving || uploading}
+                    aria-label="Document URL"
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => {
+                      if (!doc.url) return
+                      window.open(doc.url, '_blank', 'noopener,noreferrer')
+                    }}
+                    disabled={!doc.url}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    Open
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="danger"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => {
+                      void handleDelete(doc.id)
+                    }}
+                    disabled={!isEditable || saving || uploading}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Remove
+                  </Button>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            const baseline = normalizeTestDocuments(JSON.parse(savedDocsJson) as unknown)
+            setLocalDocs(baseline)
+            setError('')
+            setSuccess('')
+          }}
+          disabled={!isDirty || saving || uploading}
+        >
+          Reset
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            void persistDocuments(localDocs)
+          }}
+          disabled={!isDirty || saving || uploading}
+        >
+          {saving ? 'Saving...' : 'Save Documents'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/server/tests.ts
+++ b/src/lib/server/tests.ts
@@ -7,6 +7,7 @@ export type TestAccessRecord = {
   status: QuizStatus
   title: string
   show_results: boolean
+  documents?: unknown
   position: number
   points_possible: number
   include_in_final: boolean

--- a/src/lib/test-documents.ts
+++ b/src/lib/test-documents.ts
@@ -1,0 +1,118 @@
+import type { TestDocument, TestDocumentSource } from '@/types'
+
+export const TEST_DOCUMENT_ALLOWED_TYPES = [
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'application/json',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+] as const
+
+export const TEST_DOCUMENT_MAX_SIZE = 25 * 1024 * 1024
+export const TEST_DOCUMENT_MAX_SIZE_MB = 25
+export const TEST_DOCUMENT_ACCEPT =
+  '.pdf,.txt,.md,.csv,.json,.doc,.docx,application/pdf,text/plain,text/markdown,text/csv,application/json,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+export const MAX_TEST_DOCUMENTS = 20
+export const MAX_TEST_DOCUMENT_TEXT_LENGTH = 20000
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function isValidHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function normalizeTestDocumentSource(value: unknown): TestDocumentSource {
+  if (value === 'upload') return 'upload'
+  if (value === 'text') return 'text'
+  return 'link'
+}
+
+export function normalizeTestDocuments(value: unknown): TestDocument[] {
+  if (!Array.isArray(value)) return []
+
+  const docs: TestDocument[] = []
+  for (const raw of value) {
+    if (!isRecord(raw)) continue
+    const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : ''
+    const title = typeof raw.title === 'string' ? raw.title.trim() : ''
+    const source = normalizeTestDocumentSource(raw.source)
+    const url = typeof raw.url === 'string' ? raw.url.trim() : ''
+    const content = typeof raw.content === 'string' ? raw.content : ''
+    if (!id || !title) continue
+
+    if (source === 'text') {
+      if (!content.trim()) continue
+      docs.push({
+        id,
+        title: title.slice(0, 120),
+        source,
+        content: content.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH),
+      })
+      continue
+    }
+
+    if (!url) continue
+    if (!isValidHttpUrl(url)) continue
+
+    docs.push({
+      id,
+      title: title.slice(0, 120),
+      url,
+      source,
+    })
+  }
+
+  return docs.slice(0, MAX_TEST_DOCUMENTS)
+}
+
+export function validateTestDocumentsPayload(value: unknown):
+  | { valid: true; documents: TestDocument[] }
+  | { valid: false; error: string } {
+  if (!Array.isArray(value)) {
+    return { valid: false, error: 'documents must be an array' }
+  }
+
+  if (value.length > MAX_TEST_DOCUMENTS) {
+    return {
+      valid: false,
+      error: `Maximum ${MAX_TEST_DOCUMENTS} documents allowed`,
+    }
+  }
+
+  const docs = normalizeTestDocuments(value)
+  if (docs.length !== value.length) {
+    return {
+      valid: false,
+      error: 'Each document must include valid id/title and either a valid http/https url or text content',
+    }
+  }
+
+  return { valid: true, documents: docs }
+}
+
+export function isAllowedTestDocumentType(mimeType: string): boolean {
+  return TEST_DOCUMENT_ALLOWED_TYPES.includes(mimeType as (typeof TEST_DOCUMENT_ALLOWED_TYPES)[number])
+}
+
+export function isWithinTestDocumentSizeLimit(size: number): boolean {
+  return size <= TEST_DOCUMENT_MAX_SIZE
+}
+
+export function getTestDocumentValidationError(file: File): string | null {
+  if (!isAllowedTestDocumentType(file.type)) {
+    return 'Invalid file type. Allowed: PDF, TXT, MD, CSV, JSON, DOC, DOCX'
+  }
+  if (!isWithinTestDocumentSizeLimit(file.size)) {
+    return `File too large. Maximum size is ${TEST_DOCUMENT_MAX_SIZE_MB}MB`
+  }
+  return null
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -272,6 +272,15 @@ export type QuizFocusEventType =
   | 'route_exit_attempt'
   | 'window_unmaximize_attempt'
 export type TestQuestionType = 'multiple_choice' | 'open_response'
+export type TestDocumentSource = 'link' | 'upload' | 'text'
+
+export interface TestDocument {
+  id: string
+  title: string
+  source: TestDocumentSource
+  url?: string
+  content?: string
+}
 
 export interface QuizFocusSummary {
   away_count: number
@@ -289,6 +298,7 @@ export interface Quiz {
   assessment_type: QuizAssessmentType
   status: QuizStatus
   show_results: boolean
+  documents?: TestDocument[]
   position: number
   points_possible?: number
   include_in_final?: boolean

--- a/supabase/migrations/042_test_documents.sql
+++ b/supabase/migrations/042_test_documents.sql
@@ -1,0 +1,46 @@
+-- Add teacher-managed test documents and storage bucket for uploaded files
+
+alter table public.tests
+  add column if not exists documents jsonb not null default '[]'::jsonb;
+
+comment on column public.tests.documents is
+  'Teacher-managed list of allowed test documents. JSON array of {id,title,source,url?,content?}.';
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'test-documents',
+  'test-documents',
+  true,
+  26214400, -- 25MB
+  array[
+    'application/pdf',
+    'text/plain',
+    'text/markdown',
+    'text/csv',
+    'application/json',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ]
+)
+on conflict (id) do nothing;
+
+drop policy if exists "Allow authenticated uploads for test documents" on storage.objects;
+create policy "Allow authenticated uploads for test documents"
+on storage.objects
+for insert
+to authenticated
+with check (bucket_id = 'test-documents');
+
+drop policy if exists "Allow public read access for test documents" on storage.objects;
+create policy "Allow public read access for test documents"
+on storage.objects
+for select
+to public
+using (bucket_id = 'test-documents');
+
+drop policy if exists "Allow owner deletes for test documents" on storage.objects;
+create policy "Allow owner deletes for test documents"
+on storage.objects
+for delete
+to authenticated
+using (bucket_id = 'test-documents' and (storage.foldername(name))[1] = auth.uid()::text);

--- a/tests/api/teacher/tests-documents-upload.test.ts
+++ b/tests/api/teacher/tests-documents-upload.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/tests/[id]/documents/upload/route'
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  assertTeacherOwnsTest: vi.fn(async () => ({ ok: true })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabase),
+}))
+
+const mockUpload = vi.fn()
+const mockGetPublicUrl = vi.fn()
+const mockSupabase = {
+  storage: {
+    from: vi.fn(() => ({
+      upload: mockUpload,
+      getPublicUrl: mockGetPublicUrl,
+    })),
+  },
+}
+
+function createRequest(file?: File): NextRequest {
+  const formData = new FormData()
+  if (file) formData.append('file', file)
+  return { formData: async () => formData } as unknown as NextRequest
+}
+
+describe('POST /api/teacher/tests/[id]/documents/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpload.mockResolvedValue({ error: null })
+    mockGetPublicUrl.mockReturnValue({
+      data: { publicUrl: 'https://example.com/test-documents/teacher-1/test-1/file.pdf' },
+    })
+  })
+
+  it('returns 400 when no file is provided', async () => {
+    const response = await POST(createRequest(), { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('No file provided')
+  })
+
+  it('returns 400 when file type is not allowed', async () => {
+    const file = new File(['bad'], 'bad.exe', { type: 'application/x-msdownload' })
+    const response = await POST(createRequest(file), { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('Invalid file type')
+  })
+
+  it('uploads valid files and returns public url', async () => {
+    const file = new File(['%PDF'], 'guide.pdf', { type: 'application/pdf' })
+    ;(file as any).arrayBuffer = async () => new ArrayBuffer(8)
+
+    const response = await POST(createRequest(file), { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockUpload).toHaveBeenCalledTimes(1)
+    expect(data.url).toContain('https://example.com/test-documents/')
+  })
+})

--- a/tests/api/teacher/tests-id-route.test.ts
+++ b/tests/api/teacher/tests-id-route.test.ts
@@ -152,4 +152,163 @@ describe('PATCH /api/teacher/tests/[id]', () => {
     expect(response.status).toBe(200)
     expect(data.quiz.status).toBe('active')
   })
+
+  it('updates test documents when payload is valid', async () => {
+    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'test-1',
+              classroom_id: 'classroom-1',
+              title: 'Unit Test',
+              status: 'draft',
+              show_results: false,
+              documents: payload.documents || [],
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          update: updateSpy,
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const documents = [
+      {
+        id: 'doc-1',
+        title: 'Java API',
+        url: 'https://docs.oracle.com/en/java/',
+        source: 'link',
+      },
+    ]
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ documents }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documents,
+      })
+    )
+    expect(data.quiz.documents).toEqual(documents)
+  })
+
+  it('returns 400 for invalid test documents payload', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          update: vi.fn(),
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          documents: [{ id: 'doc-1', title: 'Broken', url: 'javascript:alert(1)', source: 'link' }],
+        }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('valid id/title')
+  })
+
+  it('updates text documents when payload is valid', async () => {
+    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'test-1',
+              classroom_id: 'classroom-1',
+              title: 'Unit Test',
+              status: 'draft',
+              show_results: false,
+              documents: payload.documents || [],
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          update: updateSpy,
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const documents = [
+      {
+        id: 'doc-text',
+        title: 'Allowed formulas',
+        source: 'text',
+        content: 'distance = rate * time',
+      },
+    ]
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ documents }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documents,
+      })
+    )
+    expect(data.quiz.documents).toEqual(documents)
+  })
 })

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -91,6 +91,81 @@ describe('QuizDetailPanel', () => {
         expect(screen.getByText('Results (20)')).toBeInTheDocument()
       })
     })
+
+    it('shows Documents tab for tests', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [
+              { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
+            ],
+          },
+          questions: sampleQuestions,
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Docs Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Documents (1)')).toBeInTheDocument()
+      })
+    })
+
+    it('renders Documents tab before Preview in tests', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [
+              { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
+            ],
+          },
+          questions: sampleQuestions,
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Docs Tab Order Test',
+      })
+
+      const { container } = render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Documents (1)')).toBeInTheDocument()
+      })
+
+      const tabStrip = container.querySelector('.flex.border-b.border-border.shrink-0')
+      expect(tabStrip).toBeTruthy()
+      const tabLabels = Array.from(tabStrip!.querySelectorAll('button')).map((button) =>
+        button.textContent?.trim() || ''
+      )
+      expect(tabLabels).toEqual(['Questions (2)', 'Documents (1)', 'Preview', 'Results (0)'])
+    })
   })
 
   describe('Questions tab', () => {
@@ -230,6 +305,168 @@ describe('QuizDetailPanel', () => {
       const postCall = fetchMock.mock.calls.find((call: any[]) => call[1]?.method === 'POST')
       const postBody = JSON.parse(postCall?.[1]?.body ?? '{}')
       expect(postBody.question_text).toBe('')
+    })
+
+    it('adds a link document and sends documents payload to tests PATCH endpoint', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: { documents: [] },
+            questions: sampleQuestions,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [
+                { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
+              ],
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [
+                { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
+              ],
+            },
+            questions: sampleQuestions,
+          }),
+        })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Doc Save Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Documents (0)')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Documents (0)'))
+
+      fireEvent.change(screen.getByPlaceholderText('Title (e.g., Java API)'), {
+        target: { value: 'Java API' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('https://...'), {
+        target: { value: 'https://docs.oracle.com' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Add link document' }))
+
+      await waitFor(() => {
+        const patchCall = fetchMock.mock.calls.find((call: any[]) => call[1]?.method === 'PATCH')
+        expect(patchCall).toBeTruthy()
+        const body = JSON.parse(patchCall![1].body)
+        expect(body.documents).toEqual([
+          {
+            id: expect.any(String),
+            title: 'Java API',
+            url: 'https://docs.oracle.com',
+            source: 'link',
+          },
+        ])
+      })
+    })
+
+    it('adds a text document and sends text content in documents payload', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: { documents: [] },
+            questions: sampleQuestions,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [
+                {
+                  id: 'doc-text-1',
+                  title: 'Allowed formulas',
+                  source: 'text',
+                  content: 'distance = rate * time',
+                },
+              ],
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [
+                {
+                  id: 'doc-text-1',
+                  title: 'Allowed formulas',
+                  source: 'text',
+                  content: 'distance = rate * time',
+                },
+              ],
+            },
+            questions: sampleQuestions,
+          }),
+        })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Doc Text Save Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Documents (0)')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Documents (0)'))
+
+      fireEvent.change(screen.getByPlaceholderText('Title (e.g., Allowed formulas)'), {
+        target: { value: 'Allowed formulas' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('Paste text students can reference during the test...'), {
+        target: { value: 'distance = rate * time' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Add text document' }))
+
+      await waitFor(() => {
+        const patchCall = fetchMock.mock.calls.find((call: any[]) => call[1]?.method === 'PATCH')
+        expect(patchCall).toBeTruthy()
+        const body = JSON.parse(patchCall![1].body)
+        expect(body.documents).toEqual([
+          {
+            id: expect.any(String),
+            title: 'Allowed formulas',
+            source: 'text',
+            content: 'distance = rate * time',
+          },
+        ])
+      })
     })
   })
 

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -71,10 +71,9 @@ describe('StudentQuizzesTab exam mode', () => {
   }
 
   function getSplitContainer(container: HTMLElement): HTMLDivElement {
-    const splitContainer = Array.from(container.querySelectorAll('div')).find((element) => {
-      const className = element.className
-      return typeof className === 'string' && className.includes('grid-cols-1') && className.includes('gap-4')
-    })
+    const splitContainer = container.querySelector(
+      '[data-testid="student-test-split-container"]'
+    )
 
     if (!splitContainer || !(splitContainer instanceof HTMLDivElement)) {
       throw new Error('Split container not found')
@@ -204,7 +203,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
   })
 
-  it('shows combined exits and away indicators in active test detail', async () => {
+  it('hides left-panel exits and away indicators in active test detail', async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/api/student/tests?classroom_id=')) {
         return {
@@ -233,6 +232,14 @@ describe('StudentQuizzesTab exam mode', () => {
               assessment_type: 'test',
               status: 'active',
               show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
               position: 0,
               student_status: 'not_started',
             },
@@ -302,9 +309,12 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
     })
 
-    expect(screen.getByLabelText(/Exits 9\./)).toBeInTheDocument()
-    expect(screen.getByLabelText('Away time 0:13.')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Exits 9\./)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Away time 0:13.')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Window must be maximized in exam mode.').length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: /Maximize/i })).toBeInTheDocument()
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.getByTestId('exam-interaction-blocker')).toBeInTheDocument()
     expect(screen.queryByText(/Window status:/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Focus events:/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Browser minimization attempts/i)).not.toBeInTheDocument()
@@ -339,6 +349,14 @@ describe('StudentQuizzesTab exam mode', () => {
               assessment_type: 'test',
               status: 'active',
               show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
               position: 0,
               student_status: 'not_started',
             },
@@ -417,14 +435,251 @@ describe('StudentQuizzesTab exam mode', () => {
     const splitContainerAfterStart = getSplitContainer(container)
     expect(splitContainerAfterStart.className).toContain('lg:grid-cols-[30%_70%]')
     expect(splitContainerAfterStart.className).not.toContain('lg:grid-cols-2')
-    expect(screen.getByRole('heading', { name: 'Exam Mode' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
 
     const sections = container.querySelectorAll('section')
     const leftPane = sections.item(0)
     expect(leftPane).toBeTruthy()
     expect(within(leftPane).queryByRole('heading', { name: 'Tests' })).not.toBeInTheDocument()
-    expect(within(leftPane).getByLabelText(/Exits /)).toBeInTheDocument()
-    expect(within(leftPane).getByLabelText(/Away time/)).toBeInTheDocument()
+    expect(within(leftPane).queryByLabelText(/Exits /)).not.toBeInTheDocument()
+    expect(within(leftPane).queryByLabelText(/Away time/)).not.toBeInTheDocument()
+  })
+
+  it('switches to 50/50 split when opening a doc and restores 30/70 on back', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use documentation for this question.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: {
+              away_count: 0,
+              away_total_seconds: 0,
+              route_exit_attempts: 0,
+              window_unmaximize_attempts: 0,
+              last_away_started_at: null,
+              last_away_ended_at: null,
+            },
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: {
+              away_count: 0,
+              away_total_seconds: 0,
+              route_exit_attempts: 0,
+              window_unmaximize_attempts: 0,
+              last_away_started_at: null,
+              last_away_ended_at: null,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    const { container } = render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    })
+    expect(container.querySelector('iframe[title="Node.js API"]')).toBeInTheDocument()
+
+    const splitContainerExamMode = getSplitContainer(container)
+    expect(splitContainerExamMode.className).toContain('lg:grid-cols-[30%_70%]')
+    expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
+    const splitContainerDocOpen = getSplitContainer(container)
+    expect(splitContainerDocOpen.className).toContain('lg:grid-cols-2')
+    expect(splitContainerDocOpen.className).not.toContain('lg:grid-cols-[30%_70%]')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to documents list' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    })
+    const splitContainerBack = getSplitContainer(container)
+    expect(splitContainerBack.className).toContain('lg:grid-cols-[30%_70%]')
+  })
+
+  it('renders text documents inline in the left doc panel', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-text-1',
+                  title: 'Allowed formulas',
+                  source: 'text',
+                  content: 'distance = rate * time',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use provided formulas.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: {
+              away_count: 0,
+              away_total_seconds: 0,
+              route_exit_attempts: 0,
+              window_unmaximize_attempts: 0,
+              last_away_started_at: null,
+              last_away_ended_at: null,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Allowed formulas' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allowed formulas' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('distance = rate * time')).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
   })
 
   it('keeps the test list visible and refreshes statuses after submit', async () => {

--- a/tests/unit/test-documents.test.ts
+++ b/tests/unit/test-documents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTestDocumentValidationError,
+  normalizeTestDocuments,
+  validateTestDocumentsPayload,
+} from '@/lib/test-documents'
+
+describe('test-documents', () => {
+  it('normalizes valid documents and drops invalid entries', () => {
+    const result = normalizeTestDocuments([
+      { id: 'doc-1', title: ' Java API ', url: 'https://docs.oracle.com', source: 'link' },
+      { id: 'doc-2', title: ' Allowed Syntax ', source: 'text', content: 'if, else, switch' },
+      { id: 'bad', title: 'Bad', url: 'javascript:alert(1)', source: 'link' },
+    ])
+
+    expect(result).toEqual([
+      {
+        id: 'doc-1',
+        title: 'Java API',
+        url: 'https://docs.oracle.com',
+        source: 'link',
+      },
+      {
+        id: 'doc-2',
+        title: 'Allowed Syntax',
+        source: 'text',
+        content: 'if, else, switch',
+      },
+    ])
+  })
+
+  it('validates payload shape and urls', () => {
+    const valid = validateTestDocumentsPayload([
+      {
+        id: 'doc-1',
+        title: 'MDN',
+        url: 'https://developer.mozilla.org',
+        source: 'link',
+      },
+    ])
+    expect(valid.valid).toBe(true)
+
+    const validText = validateTestDocumentsPayload([
+      {
+        id: 'doc-3',
+        title: 'Pseudo code',
+        source: 'text',
+        content: 'for i in range(10):',
+      },
+    ])
+    expect(validText.valid).toBe(true)
+
+    const invalid = validateTestDocumentsPayload([
+      {
+        id: 'doc-2',
+        title: 'Oops',
+        url: 'ftp://example.com/file.pdf',
+        source: 'link',
+      },
+    ])
+    expect(invalid.valid).toBe(false)
+
+    const invalidText = validateTestDocumentsPayload([
+      {
+        id: 'doc-4',
+        title: 'Blank text',
+        source: 'text',
+        content: '   ',
+      },
+    ])
+    expect(invalidText.valid).toBe(false)
+  })
+
+  it('validates upload file constraints', () => {
+    const validFile = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    expect(getTestDocumentValidationError(validFile)).toBeNull()
+
+    const invalidType = new File(['{}'], 'data.exe', { type: 'application/x-msdownload' })
+    expect(getTestDocumentValidationError(invalidType)).toContain('Invalid file type')
+  })
+})


### PR DESCRIPTION
## Summary
- add teacher-managed test documents (links, uploads, and text content) with validation and API support
- add documents editor in test builder and wire document persistence into teacher test create/update flows
- add student exam-mode docs panel with smooth 30/70 <-> 50/50 transitions, in-panel doc rendering, and preload-ready iframe stack
- update exam header/info UX (title, indicators, date/time), plus non-maximized safeguards (center maximize CTA, content obscuring, interaction lock)
- refine docs-pane UX (centered doc title, prominent back action, hover-only scrollbar treatment)

## Verification
- pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-documents-upload.test.ts tests/unit/test-documents.test.ts
- pnpm run lint
- manual visual verification with Playwright screenshots for teacher/student and targeted exam-mode doc-open states