### PR TITLE
Gate student test results on teacher return

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -4747,3 +4747,18 @@
 **Verification:**
 - `pnpm vitest run tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts`
 - Both suites passing.
+
+## 2026-03-06 — Added end-to-end API integration coverage for test return visibility
+**Context:** Review gap identified: no integration test proving teacher return action immediately unlocks student `can_view_results` and results endpoint access.
+
+**Changes:**
+- Added `/tests/api/integration/test-return-visibility-flow.test.ts`.
+- New integration scenario verifies full sequence with shared mock state:
+  1) student sees `responded` and gets 403 on results before return
+  2) teacher calls test return endpoint
+  3) student list/detail switch to `can_view_results`
+  4) student results endpoint returns 200 with returned metadata/score
+
+**Verification:**
+- `pnpm vitest run tests/api/integration/test-return-visibility-flow.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/teacher/tests-return.test.ts`
+- all passing.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -4164,6 +4164,20 @@
   - Added in-panel note: `Documentation stays in this panel during exam mode.`
 - Added assertion coverage in `/tests/components/StudentQuizzesTab.test.tsx`:
   - Confirms doc-open state no longer shows an `Open in new tab` button.
+## 2026-03-05 — Student test exam mode left header aligned to 50/50 style
+**Context:** Requested UI parity for the 30/70 exam-mode left pane header with the 50/50 header style, with exam-mode-specific behavior (`Documents` title, no back button, attached documents listed below).
+
+**Changes:**
+- Updated `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - Replaced exam-mode left heading `Exam Mode` with `Documents` using the same heading style as the 50/50 panel header.
+  - Added attached-document extraction for exam mode from:
+    - structured fields when present (`documents`, `attachments`, `attached_documents`, `resources`, `files`)
+    - markdown links and raw URLs in question text
+  - Rendered document links in the left pane (or `No attached documents.` fallback).
+  - Kept exam-mode maximize warning/button and focus metrics below the documents list.
+- Updated `/tests/components/StudentQuizzesTab.test.tsx`:
+  - Updated split behavior assertion to expect `Documents` in 30/70 mode.
+  - Added assertion that attached document links render in the 30/70 left pane.
 
 **Verification:**
 - `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
@@ -4645,3 +4659,76 @@
 - Teacher screenshot: `/tmp/pika-teacher-back-noborder-v1.png`
 - Student screenshot: `/tmp/pika-student-back-noborder-v1.png`
 - Student doc-open screenshot: `/tmp/pika-student-back-noborder-open-v1.png`
+- Playwright screenshots (manual visual verification):
+  - Teacher `/classrooms`: `/tmp/teacher-view-exam-header-fix.png`
+  - Student `/classrooms`: `/tmp/student-view-exam-header-fix.png`
+  - Student exam mode (30/70 with `Documents` + link): `/tmp/student-exam-mode-documents-header.png`
+
+**Note:**
+- Created one temporary active test to produce deterministic exam-mode screenshot, then removed it:
+  - Created: `b92a03cb-540e-4f5d-9673-d35ffb8b9d73` (`Exam Header Fix 1772734699`)
+  - Deleted via teacher API after verification.
+
+## 2026-03-05 — Merge-from-main reconciliation for exam-mode left header request
+**Context:** After syncing `codex/exam-mode-left-header` with latest `origin/main` (commit `d5c23b9`), the branch picked up the new test documents panel architecture. Needed to preserve the user-requested behavior in 30/70 exam mode.
+
+**Changes:**
+- Resolved merge conflicts in:
+  - `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+  - `/tests/components/StudentQuizzesTab.test.tsx`
+- Kept latest main behavior for test documents (teacher-managed docs, list/doc-panel toggle behavior).
+- Applied requested exam-mode left header behavior in 30/70 list state:
+  - Heading is `Documents` (matching 50/50 heading style)
+  - No back button in list state
+  - Exit/away telemetry badges remain visible below the documents section
+- Updated/realigned tests to reflect merged behavior and requested header state.
+
+**Verification:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx` (9/9 passing)
+- `pnpm lint`
+- Playwright screenshots:
+  - Teacher `/classrooms`: `/tmp/teacher-view-exam-header-continue2.png`
+  - Student `/classrooms`: `/tmp/student-view-exam-header-continue2.png`
+  - Student tests list view: `/tmp/student-tests-loaded-continue.png`
+  - Student exam mode 30/70 list state with `Documents` header: `/tmp/student-exam-mode-documents-list-continue2.png`
+
+**Note:**
+- Created temporary active test for deterministic exam-mode verification and deleted it afterward:
+  - Created: `85ab4788-79ce-481d-8cf3-85e2fcfda3f1` (`Exam Header Verify 1772736597`)
+  - Deleted after screenshot capture.
+
+## 2026-03-05 — Test results visibility switched to teacher-return gating
+**Context:** User reported confusion with the test `Visibility` control and requested a simpler policy: students should see test results only after teacher return in grading flow.
+
+**Changes:**
+- Updated test result/status logic to use teacher return state (`returned_at`) instead of `show_results`:
+  - `/src/lib/quizzes.ts`
+    - Added `canStudentViewTestResults()` and `getStudentTestStatus()`.
+  - `/src/app/api/student/tests/route.ts`
+    - Student list status for tests now derives from `status + responded + returned_at`.
+  - `/src/app/api/student/tests/[id]/route.ts`
+    - Detail `student_status` now uses return-based test status.
+  - `/src/app/api/student/tests/[id]/results/route.ts`
+    - Results now require returned test work (403 until returned).
+- Removed confusing teacher visibility control for tests:
+  - `/src/components/QuizCard.tsx`
+    - Eye toggle remains for quizzes only; hidden for tests.
+- Updated student test messaging:
+  - `/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+    - Test results rendering now keys off `student_status === 'can_view_results'`.
+    - Submitted messaging now explains teacher close/return flow.
+- Updated tests:
+  - `/tests/unit/quizzes.test.ts`
+  - `/tests/api/student/tests-results.test.ts`
+  - `/tests/components/QuizCard.test.tsx`
+
+**Verification:**
+- `pnpm vitest run tests/unit/quizzes.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/components/QuizCard.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- Playwright screenshots:
+  - Teacher `/classrooms`: `/tmp/teacher-view-tests-returned-policy.png`
+  - Student `/classrooms`: `/tmp/student-view-tests-returned-policy.png`
+  - Teacher tests tab loaded: `/tmp/teacher-tests-tab-returned-policy-loaded.png`
+  - Student tests tab loaded: `/tmp/student-tests-tab-returned-policy-loaded.png`
+  - Teacher tests tab selected state: `/tmp/teacher-tests-selected-debug-wait8s.png`
+  - Student tests tab selected state: `/tmp/student-tests-tab-selected-returned-policy.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -4732,3 +4732,18 @@
   - Student tests tab loaded: `/tmp/student-tests-tab-returned-policy-loaded.png`
   - Teacher tests tab selected state: `/tmp/teacher-tests-selected-debug-wait8s.png`
   - Student tests tab selected state: `/tmp/student-tests-tab-selected-returned-policy.png`
+
+## 2026-03-06 — Added return-gated student_status regression coverage
+**Context:** Follow-up review found missing direct assertions for `student_status` transitions in student tests list/detail APIs after return-gated policy change.
+
+**Changes:**
+- Updated `/tests/api/student/tests-route.test.ts`:
+  - Added explicit coverage for closed responded tests where:
+    - `returned_at` present -> `student_status=can_view_results`
+    - `returned_at` null -> `student_status=responded`
+- Updated `/tests/api/student/tests-id.test.ts`:
+  - Added detail-route coverage for closed submitted tests with and without `returned_at`.
+
+**Verification:**
+- `pnpm vitest run tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts`
+- Both suites passing.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -4762,3 +4762,26 @@
 **Verification:**
 - `pnpm vitest run tests/api/integration/test-return-visibility-flow.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/teacher/tests-return.test.ts`
 - all passing.
+
+## 2026-03-06 — Return flow now closes active tests + test status pill uses Open
+**Context:** Teacher could return while a test remained active, which blocked student result visibility under close+return gating. Also requested wording update from Active -> Open for test status pill.
+
+**Changes:**
+- Teacher return API (`/api/teacher/tests/[id]/return`):
+  - Enforces explicit close confirmation for active tests (`409` unless `close_test=true`).
+  - Closes active test before returning selected students when confirmed.
+  - Adds migration-aware error handling for missing `test_attempts.returned_at/returned_by`.
+- Added migration `043_backfill_test_attempt_return_columns.sql` to ensure return metadata columns/index exist.
+- Teacher grading UI:
+  - Return confirmation dialog now switches to "Close and Return" copy when selected test is active.
+  - Sends `close_test=true` in that path and refreshes list after auto-close.
+- Test status pill wording:
+  - Active **tests** now display `Open`; quizzes continue to display `Active`.
+
+**Verification:**
+- `pnpm exec vitest run tests/api/teacher/tests-return.test.ts tests/components/TeacherQuizzesTab.test.tsx`
+- `pnpm exec vitest run tests/unit/quizzes.test.ts tests/components/QuizCard.test.tsx`
+- Visual screenshots:
+  - Teacher active-return confirm modal: `/tmp/teacher-return-flow-3100.png`
+  - Teacher test cards showing `Open`: `/tmp/teacher-open-pill.png`
+  - Student tests tab sanity: `/tmp/student-open-pill-sanity.png`

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { aggregateResults, canStudentViewResults } from '@/lib/quizzes'
+import { aggregateResults, canStudentViewTestResults } from '@/lib/quizzes'
 import { assertStudentCanAccessTest, isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
 import type { QuizQuestion, QuizResponse } from '@/types'
 
@@ -75,9 +75,9 @@ export async function GET(
 
     const hasResponded = Boolean(attempt?.is_submitted) || (studentResponses?.length || 0) > 0
 
-    if (!canStudentViewResults(test, hasResponded)) {
+    if (!canStudentViewTestResults(test, hasResponded, attempt?.returned_at)) {
       return NextResponse.json(
-        { error: 'Results are not available for this test' },
+        { error: 'Results are available after your teacher returns this test' },
         { status: 403 }
       )
     }
@@ -91,16 +91,6 @@ export async function GET(
     if (questionsError) {
       console.error('Error fetching test questions:', questionsError)
       return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
-    }
-
-    const hasOpenResponseQuestions = (questions || []).some(
-      (question) => question.question_type === 'open_response'
-    )
-    if (hasOpenResponseQuestions && !attempt?.returned_at) {
-      return NextResponse.json(
-        { error: 'Results are not available until this test is returned by your teacher' },
-        { status: 403 }
-      )
     }
 
     const { data: responses, error: responsesError } = await supabase

--- a/src/app/api/student/tests/[id]/route.ts
+++ b/src/app/api/student/tests/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { getStudentQuizStatus, summarizeQuizFocusEvents } from '@/lib/quizzes'
+import { getStudentTestStatus, summarizeQuizFocusEvents } from '@/lib/quizzes'
 import { assertStudentCanAccessTest, isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
 import { normalizeTestResponses, type TestResponses } from '@/lib/test-attempts'
 import { normalizeTestDocuments } from '@/lib/test-documents'
@@ -102,15 +102,7 @@ export async function GET(
       return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
     }
 
-    const hasOpenResponseQuestions = (questions || []).some(
-      (question) => question.question_type === 'open_response'
-    )
-    const canViewResults =
-      test.show_results &&
-      test.status === 'closed' &&
-      hasSubmitted &&
-      (!hasOpenResponseQuestions || Boolean(attempt?.returned_at))
-    const studentStatus = canViewResults ? 'can_view_results' : getStudentQuizStatus(test, hasSubmitted)
+    const studentStatus = getStudentTestStatus(test, hasSubmitted, attempt?.returned_at)
 
     let studentResponses: TestResponses = draftResponses
     if (hasSubmitted) {

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -3,7 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
-import { getStudentQuizStatus } from '@/lib/quizzes'
+import { getStudentTestStatus } from '@/lib/quizzes'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import type { Quiz } from '@/types'
 
@@ -124,39 +124,11 @@ export async function GET(request: NextRequest) {
     )
 
     const allTests = [...(activeTests || []), ...respondedClosedTests]
-    const allTestIds = allTests.map((test) => test.id)
-    const hasOpenByTestId = new Map<string, boolean>()
-
-    if (allTestIds.length > 0) {
-      const { data: questionRows, error: questionError } = await supabase
-        .from('test_questions')
-        .select('test_id, question_type')
-        .in('test_id', allTestIds)
-
-      if (questionError && questionError.code !== 'PGRST205') {
-        console.error('Error fetching test question types:', questionError)
-        return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
-      }
-
-      for (const row of questionRows || []) {
-        if (row.question_type === 'open_response') {
-          hasOpenByTestId.set(row.test_id, true)
-        } else if (!hasOpenByTestId.has(row.test_id)) {
-          hasOpenByTestId.set(row.test_id, false)
-        }
-      }
-    }
 
     const testsWithStatus = allTests.map((test: Quiz) => {
       const hasResponded = respondedTestIds.has(test.id)
-      const hasOpen = hasOpenByTestId.get(test.id) === true
       const isReturned = returnedTestIds.has(test.id)
-      const canViewResults =
-        test.show_results &&
-        test.status === 'closed' &&
-        hasResponded &&
-        (!hasOpen || isReturned)
-      const studentStatus = canViewResults ? 'can_view_results' : getStudentQuizStatus(test, hasResponded)
+      const studentStatus = getStudentTestStatus(test, hasResponded, isReturned)
 
       return {
         ...test,

--- a/src/app/api/teacher/tests/[id]/return/route.ts
+++ b/src/app/api/teacher/tests/[id]/return/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -12,6 +12,13 @@ function hasGradedOpenResponse(score: unknown, feedback: unknown): boolean {
     Number.isFinite(score) &&
     typeof feedback === 'string' &&
     feedback.trim().length > 0
+  )
+}
+
+function migrationRequiredResponse() {
+  return NextResponse.json(
+    { error: 'Returning tests requires migration 043 to be applied' },
+    { status: 400 }
   )
 }
 
@@ -44,12 +51,34 @@ export async function POST(
       return NextResponse.json({ error: 'Cannot return more than 100 students at once' }, { status: 400 })
     }
 
+    const closeTest = body?.close_test === true
+
     const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
     if (!access.ok) {
       return NextResponse.json({ error: access.error }, { status: access.status })
     }
 
     const supabase = getServiceRoleClient()
+
+    if (access.test.status === 'active' && !closeTest) {
+      return NextResponse.json(
+        { error: 'Test is still active. Confirm close and return to close it first.' },
+        { status: 409 }
+      )
+    }
+
+    if (access.test.status === 'active' && closeTest) {
+      const { error: closeError } = await supabase
+        .from('tests')
+        .update({ status: 'closed' })
+        .eq('id', testId)
+        .eq('status', 'active')
+
+      if (closeError) {
+        console.error('Error closing test during return:', closeError)
+        return NextResponse.json({ error: 'Failed to close test before return' }, { status: 500 })
+      }
+    }
 
     const { data: openQuestionRows, error: openQuestionError } = await supabase
       .from('test_questions')
@@ -132,6 +161,9 @@ export async function POST(
         .in('student_id', eligibleStudentIds)
 
       if (updateError && updateError.code !== 'PGRST205') {
+        if (isMissingTestAttemptReturnColumnsError(updateError)) {
+          return migrationRequiredResponse()
+        }
         console.error('Error updating existing attempts during return:', updateError)
         return NextResponse.json({ error: 'Failed to return test work' }, { status: 500 })
       }
@@ -166,6 +198,9 @@ export async function POST(
           .insert(missingAttemptRows)
 
         if (insertMissingError) {
+          if (isMissingTestAttemptReturnColumnsError(insertMissingError)) {
+            return migrationRequiredResponse()
+          }
           console.error('Error creating missing attempts during return:', insertMissingError)
           return NextResponse.json({ error: 'Failed to return test work' }, { status: 500 })
         }
@@ -175,6 +210,7 @@ export async function POST(
     return NextResponse.json({
       returned_count: eligibleStudentIds.length,
       skipped_count: studentIds.length - eligibleStudentIds.length,
+      test_closed: access.test.status === 'active' && closeTest,
     })
   } catch (error: any) {
     if (error.name === 'AuthenticationError') {

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -639,20 +639,44 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
             >
               <div className="flex items-center justify-between">
                 <h3 className="font-medium text-text-default">{quiz.title}</h3>
-                {quiz.student_status === 'not_started' && (
-                  <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
-                    New
-                  </span>
-                )}
-                {quiz.student_status === 'responded' && (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
-                    Submitted
-                  </span>
-                )}
-                {quiz.student_status === 'can_view_results' && (
-                  <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
-                    View Results
-                  </span>
+                {isTestsView ? (
+                  <>
+                    {quiz.student_status === 'can_view_results' ? (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
+                        Returned
+                      </span>
+                    ) : quiz.status === 'closed' ? (
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('closed')}`}>
+                        Closed
+                      </span>
+                    ) : quiz.student_status === 'responded' ? (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                        Submitted
+                      </span>
+                    ) : (
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
+                        New
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {quiz.student_status === 'not_started' && (
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
+                        New
+                      </span>
+                    )}
+                    {quiz.student_status === 'responded' && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                        Submitted
+                      </span>
+                    )}
+                    {quiz.student_status === 'can_view_results' && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
+                        View Results
+                      </span>
+                    )}
+                  </>
                 )}
               </div>
               {quiz.status === 'closed' && (
@@ -674,6 +698,10 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       hasSelectedQuiz &&
       selectedQuiz.quiz.student_status === 'not_started' &&
       startedTestId !== selectedQuiz.quiz.id
+    const isViewingResults =
+      hasSelectedQuiz &&
+      hasResponded &&
+      selectedQuiz.quiz.student_status === 'can_view_results'
     const showCurrentTestInfoPanel = hasSelectedQuiz && focusEnabled
     const showDocPanel = showCurrentTestInfoPanel && activeDoc !== null
     const awayDurationLabel = formatDuration(focusSummary?.away_total_seconds ?? 0)
@@ -683,6 +711,10 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
     const showNotMaximizedWarning = hasSelectedQuiz && focusEnabled && !isFullscreen
     const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
+    const selectedTestTitle = hasSelectedQuiz ? selectedQuiz.quiz.title : ''
+    const selectedTestPanelTitle = isViewingResults
+      ? `${selectedTestTitle} Results`
+      : selectedTestTitle
 
     return (
       <PageLayout className="relative">
@@ -733,11 +765,11 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
               data-testid="student-test-split-container"
               className={`grid grid-cols-1 gap-2 ${
                 showDocPanel
-                  ? 'lg:grid-cols-2'
-                  : showCurrentTestInfoPanel
+                  ? 'lg:grid-cols-[50%_50%]'
+                  : showCurrentTestInfoPanel || isViewingResults
                     ? 'lg:grid-cols-[30%_70%]'
-                    : 'lg:grid-cols-2'
-              } lg:min-h-[calc(100dvh-7.5rem)] lg:transition-[grid-template-columns] lg:duration-300 lg:ease-in-out motion-reduce:transition-none`}
+                    : 'lg:grid-cols-[50%_50%]'
+              } lg:min-h-[calc(100dvh-7.5rem)] lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
             >
               <section
                 className={`rounded-xl border border-border bg-surface lg:h-full ${
@@ -887,7 +919,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   </div>
                 ) : hasSelectedQuiz ? (
                   <div className="space-y-4">
-                    <h2 className="text-xl font-bold text-text-default">{selectedQuiz.quiz.title}</h2>
+                    <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
 
                     {requiresStart ? (
                       <Button
@@ -903,6 +935,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                         myResponses={selectedQuiz.studentResponses}
                         assessmentType={assessmentType}
                         apiBasePath={apiBasePath}
+                        showSubmissionBanner={!(isTestsView && selectedQuiz.quiz.student_status === 'can_view_results')}
                       />
                     ) : hasResponded ? (
                       <div className="p-4 bg-success-bg rounded-lg text-center">

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -755,6 +755,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                       }`}
                     >
                       <div className="space-y-4">
+                        <h2 className="mb-3 text-lg font-semibold text-text-default">Documents</h2>
+
                         {showNotMaximizedWarning && (
                           <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-xs text-warning">
                             Window must be maximized in exam mode.
@@ -780,6 +782,23 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                         ) : (
                           <p className="text-sm text-text-muted">No documents provided for this test.</p>
                         )}
+
+                        <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+                          <span
+                            className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                            aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
+                          >
+                            <LogOut className="h-4 w-4" />
+                            <span>{exitsCount}</span>
+                          </span>
+                          <span
+                            className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                            aria-label={`Away time ${awayDurationLabel}.`}
+                          >
+                            <ClockAlert className="h-4 w-4" />
+                            <span>{awayDurationLabel}</span>
+                          </span>
+                        </div>
                       </div>
                     </div>
 
@@ -878,7 +897,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                       >
                         Start the Test
                       </Button>
-                    ) : hasResponded && selectedQuiz.quiz.show_results && selectedQuiz.quiz.status === 'closed' ? (
+                    ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
                       <StudentQuizResults
                         quizId={selectedQuizId!}
                         myResponses={selectedQuiz.studentResponses}
@@ -888,15 +907,15 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                     ) : hasResponded ? (
                       <div className="p-4 bg-success-bg rounded-lg text-center">
                         <p className="text-success font-medium">Response Submitted</p>
-                        {selectedQuiz.quiz.status !== 'closed' && selectedQuiz.quiz.show_results ? (
+                        {selectedQuiz.quiz.status !== 'closed' ? (
                           <p className="text-sm text-text-muted mt-1">
-                            Results will be available after the test closes.
+                            Results will be available after this test is closed and returned by your teacher.
                           </p>
-                        ) : selectedQuiz.quiz.status === 'closed' && !selectedQuiz.quiz.show_results ? (
+                        ) : (
                           <p className="text-sm text-text-muted mt-1">
-                            Results are not available for this test.
+                            Results will be available after your teacher returns this test.
                           </p>
-                        ) : null}
+                        )}
                       </div>
                     ) : (
                       <StudentQuizForm

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -309,7 +309,7 @@ export function TeacherQuizzesTab({
     }
   }
 
-  async function handleBatchReturn() {
+  async function handleBatchReturn(options?: { closeTest?: boolean }) {
     if (!selectedQuizId || batchSelectedCount === 0) return
 
     setIsBatchReturning(true)
@@ -319,7 +319,10 @@ export function TeacherQuizzesTab({
       const res = await fetch(`${apiBasePath}/${selectedQuizId}/return`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: Array.from(batchSelectedIds) }),
+        body: JSON.stringify({
+          student_ids: Array.from(batchSelectedIds),
+          close_test: options?.closeTest === true,
+        }),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Return failed')
@@ -332,6 +335,9 @@ export function TeacherQuizzesTab({
 
       clearBatchSelection()
       setShowReturnConfirm(false)
+      if (data.test_closed) {
+        await loadQuizzes()
+      }
       await loadGradingRows()
     } catch (err: any) {
       setGradingError(err.message || 'Return failed')
@@ -398,7 +404,9 @@ export function TeacherQuizzesTab({
 
   const assessmentLabel = isTestsView ? 'test' : 'quiz'
   const assessmentLabelPlural = isTestsView ? 'Tests' : 'Quizzes'
-  const selectedTestTitle = sortedQuizzes.find((quiz) => quiz.id === selectedQuizId)?.title || 'No test selected'
+  const selectedTest = sortedQuizzes.find((quiz) => quiz.id === selectedQuizId) || null
+  const selectedTestTitle = selectedTest?.title || 'No test selected'
+  const returnWillCloseActiveTest = isTestsView && testsMode === 'grading' && selectedTest?.status === 'active'
 
   return (
     <PageLayout>
@@ -746,15 +754,31 @@ export function TeacherQuizzesTab({
 
       <ConfirmDialog
         isOpen={showReturnConfirm}
-        title={`Return test work to ${batchSelectedCount} selected student(s)?`}
-        description="Only students with fully graded open-response questions will be returned."
-        confirmLabel={isBatchReturning ? 'Returning...' : 'Return Test'}
+        title={
+          returnWillCloseActiveTest
+            ? `Close test and return work to ${batchSelectedCount} selected student(s)?`
+            : `Return test work to ${batchSelectedCount} selected student(s)?`
+        }
+        description={
+          returnWillCloseActiveTest
+            ? 'This test is still open. Confirming will close it for all students before returning selected work.'
+            : 'Only students with fully graded open-response questions will be returned.'
+        }
+        confirmLabel={
+          isBatchReturning
+            ? returnWillCloseActiveTest
+              ? 'Closing and Returning...'
+              : 'Returning...'
+            : returnWillCloseActiveTest
+              ? 'Close and Return'
+              : 'Return Test'
+        }
         cancelLabel="Cancel"
         isConfirmDisabled={isBatchReturning}
         isCancelDisabled={isBatchReturning}
         onCancel={() => setShowReturnConfirm(false)}
         onConfirm={() => {
-          void handleBatchReturn()
+          void handleBatchReturn({ closeTest: returnWillCloseActiveTest })
         }}
       />
     </PageLayout>

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Check, ClockAlert, LogOut, Plus, Send } from 'lucide-react'
+import { Check, Circle, ClockAlert, LogOut, Plus, Send } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
@@ -66,12 +66,12 @@ function formatPoints(value: number): string {
 
 const STATUS_META: Record<
   TestGradingStudentRow['status'],
-  { label: string; symbol: string; className: string }
+  { label: string; icon: typeof Circle; className: string }
 > = {
-  not_started: { label: 'Not started', symbol: '○', className: 'text-text-muted' },
-  in_progress: { label: 'In progress', symbol: '◔', className: 'text-warning' },
-  submitted: { label: 'Submitted', symbol: '●', className: 'text-success' },
-  returned: { label: 'Returned', symbol: '✓', className: 'text-primary' },
+  not_started: { label: 'Not started', icon: Circle, className: 'text-gray-400' },
+  in_progress: { label: 'In progress', icon: Circle, className: 'text-yellow-500' },
+  submitted: { label: 'Submitted', icon: Check, className: 'text-green-500' },
+  returned: { label: 'Returned', icon: Send, className: 'text-blue-500' },
 }
 
 export function TeacherQuizzesTab({
@@ -604,6 +604,7 @@ export function TeacherQuizzesTab({
                           ? '—'
                           : `${formatPoints(student.points_earned)}/${formatPoints(student.points_possible)}`
                       const statusMeta = STATUS_META[student.status]
+                      const StatusIcon = statusMeta.icon
                       const awayCount = student.focus_summary?.away_count ?? 0
                       const awaySeconds = student.focus_summary?.away_total_seconds ?? 0
                       const awayMinutes = Math.floor(awaySeconds / 60)
@@ -646,7 +647,7 @@ export function TeacherQuizzesTab({
                                 className={`inline-flex min-w-5 cursor-help items-center justify-center text-sm font-semibold ${statusMeta.className}`}
                                 aria-label={statusMeta.label}
                               >
-                                {statusMeta.symbol}
+                                <StatusIcon className="h-4 w-4" />
                               </span>
                             </Tooltip>
                           </td>

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useState } from 'react'
 import { Trash2, Eye, EyeOff, Play, Square } from 'lucide-react'
-import { getQuizStatusLabel, getQuizStatusBadgeClass, canActivateQuiz } from '@/lib/quizzes'
+import {
+  getAssessmentStatusLabel,
+  getQuizStatusBadgeClass,
+  canActivateQuiz,
+} from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
@@ -169,7 +173,7 @@ export function QuizCard({
               <span
                 className={`inline-flex items-center shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${getQuizStatusBadgeClass(quiz.status)}`}
               >
-                {getQuizStatusLabel(quiz.status)}
+                {getAssessmentStatusLabel(quiz.status, quiz.assessment_type)}
               </span>
             </div>
             <p className="text-xs text-text-muted mt-0.5">

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -28,6 +28,7 @@ export function QuizCard({
   onQuizUpdate,
 }: QuizCardProps) {
   const isDraft = quiz.status === 'draft'
+  const isTest = quiz.assessment_type === 'test'
   const assessmentLabel = quiz.assessment_type === 'test' ? 'test' : 'quiz'
   const [updating, setUpdating] = useState(false)
   const [checkingActivation, setCheckingActivation] = useState(false)
@@ -233,23 +234,24 @@ export function QuizCard({
               </Tooltip>
             )}
 
-            {/* Show/hide results */}
-            <Tooltip content={quiz.show_results ? 'Results visible to students' : 'Results hidden from students'}>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`p-1.5 ${quiz.show_results ? 'text-primary' : ''}`}
-                aria-label={quiz.show_results ? 'Hide results from students' : 'Show results to students'}
-                disabled={isReadOnly || updating}
-                onClick={handleToggleShowResults}
-              >
-                {quiz.show_results ? (
-                  <Eye className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <EyeOff className="h-4 w-4" aria-hidden="true" />
-                )}
-              </Button>
-            </Tooltip>
+            {!isTest && (
+              <Tooltip content={quiz.show_results ? 'Results visible to students' : 'Results hidden from students'}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={`p-1.5 ${quiz.show_results ? 'text-primary' : ''}`}
+                  aria-label={quiz.show_results ? 'Hide results from students' : 'Show results to students'}
+                  disabled={isReadOnly || updating}
+                  onClick={handleToggleShowResults}
+                >
+                  {quiz.show_results ? (
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </Button>
+              </Tooltip>
+            )}
 
             {/* Delete */}
             <Tooltip content={`Delete ${assessmentLabel}`}>

--- a/src/components/StudentQuizResults.tsx
+++ b/src/components/StudentQuizResults.tsx
@@ -50,6 +50,7 @@ interface Props {
   myResponses: Record<string, number | TestResponseDraftValue>
   assessmentType?: QuizAssessmentType
   apiBasePath?: string
+  showSubmissionBanner?: boolean
 }
 
 export function StudentQuizResults({
@@ -57,6 +58,7 @@ export function StudentQuizResults({
   myResponses,
   assessmentType,
   apiBasePath = '/api/student/quizzes',
+  showSubmissionBanner = true,
 }: Props) {
   const [payload, setPayload] = useState<ResultsPayload | null>(null)
   const [loading, setLoading] = useState(true)
@@ -120,11 +122,15 @@ export function StudentQuizResults({
 
   return (
     <div className="mt-6 space-y-6">
-      <div className="p-4 bg-success-bg rounded-lg">
-        <p className="text-success font-medium">Your response has been submitted.</p>
-      </div>
+      {showSubmissionBanner && (
+        <div className="p-4 bg-success-bg rounded-lg">
+          <p className="text-success font-medium">Your response has been submitted.</p>
+        </div>
+      )}
 
-      <h3 className="font-semibold text-text-default">Results</h3>
+      {!isTestsView && (
+        <h3 className="font-semibold text-text-default">Results</h3>
+      )}
 
       {isTestsView && summary && (
         <div className="rounded-lg border border-border bg-surface p-4">

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -26,6 +26,14 @@ export function getQuizStatusLabel(status: QuizStatus): string {
   return labels[status]
 }
 
+export function getAssessmentStatusLabel(
+  status: QuizStatus,
+  assessmentType: QuizAssessmentType
+): string {
+  if (assessmentType === 'test' && status === 'active') return 'Open'
+  return getQuizStatusLabel(status)
+}
+
 /**
  * Get badge CSS classes for quiz status
  */

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -60,6 +60,18 @@ export function canStudentViewResults(
 }
 
 /**
+ * Check if a student can view test results.
+ * Tests are released when work has been explicitly returned by the teacher.
+ */
+export function canStudentViewTestResults(
+  test: Pick<Quiz, 'status'>,
+  hasResponded: boolean,
+  returnedAt: string | null | undefined | boolean
+): boolean {
+  return test.status === 'closed' && hasResponded && Boolean(returnedAt)
+}
+
+/**
  * Get the student's status for a quiz
  */
 export function getStudentQuizStatus(
@@ -68,6 +80,20 @@ export function getStudentQuizStatus(
 ): StudentQuizStatus {
   if (!hasResponded) return 'not_started'
   if (quiz.show_results && quiz.status === 'closed') return 'can_view_results'
+  return 'responded'
+}
+
+/**
+ * Get the student's status for a test.
+ * Tests become viewable once the teacher returns the submitted work.
+ */
+export function getStudentTestStatus(
+  test: Pick<Quiz, 'status'>,
+  hasResponded: boolean,
+  returnedAt: string | null | undefined | boolean
+): StudentQuizStatus {
+  if (!hasResponded) return 'not_started'
+  if (canStudentViewTestResults(test, hasResponded, returnedAt)) return 'can_view_results'
   return 'responded'
 }
 

--- a/supabase/migrations/043_backfill_test_attempt_return_columns.sql
+++ b/supabase/migrations/043_backfill_test_attempt_return_columns.sql
@@ -1,0 +1,9 @@
+-- Backfill return metadata columns for legacy test_attempts schemas that predate return flow.
+alter table if exists public.test_attempts
+  add column if not exists returned_at timestamptz;
+
+alter table if exists public.test_attempts
+  add column if not exists returned_by uuid references public.users (id);
+
+create index if not exists idx_test_attempts_test_returned
+  on public.test_attempts (test_id, returned_at);

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -136,6 +136,26 @@ function setupSupabaseMock() {
           ),
           error: null,
         })),
+        update: vi.fn((updates: Record<string, unknown>) => {
+          const updateFilters: Record<string, string> = {}
+          const updateChain: any = {
+            eq: vi.fn((column: string, value: string) => {
+              updateFilters[column] = value
+
+              if (updateFilters.id && updateFilters.status) {
+                for (const test of state.tests) {
+                  if (test.id === updateFilters.id && test.status === updateFilters.status) {
+                    Object.assign(test, updates)
+                  }
+                }
+                return Promise.resolve({ error: null })
+              }
+
+              return updateChain
+            }),
+          }
+          return updateChain
+        }),
       }
       return builder
     }
@@ -275,6 +295,7 @@ describe('Test Return Visibility Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     currentUser = { id: 'student-1', role: 'student' }
+    state.tests[0].status = 'closed'
     state.testAttempts[0].returned_at = null
     state.testAttempts[0].returned_by = null
     setupSupabaseMock()
@@ -342,5 +363,58 @@ describe('Test Return Visibility Integration', () => {
     expect(resultsAfter.status).toBe(200)
     expect(resultsAfterData.quiz.returned_at).not.toBeNull()
     expect(resultsAfterData.summary.earned_points).toBe(4)
+  })
+
+  it('closes active tests before return when close_test is confirmed and then unlocks student results', async () => {
+    state.tests[0].status = 'active'
+
+    currentUser = { id: 'teacher-1', role: 'teacher' }
+    const returnWithoutClose = await returnTeacherTest(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: ['student-1'] }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const returnWithoutCloseData = await returnWithoutClose.json()
+    expect(returnWithoutClose.status).toBe(409)
+    expect(returnWithoutCloseData.error).toContain('still active')
+    expect(state.tests[0].status).toBe('active')
+    expect(state.testAttempts[0].returned_at).toBeNull()
+
+    const returnWithClose = await returnTeacherTest(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: ['student-1'], close_test: true }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const returnWithCloseData = await returnWithClose.json()
+    expect(returnWithClose.status).toBe(200)
+    expect(returnWithCloseData.test_closed).toBe(true)
+    expect(state.tests[0].status).toBe('closed')
+    expect(state.testAttempts[0].returned_at).not.toBeNull()
+
+    currentUser = { id: 'student-1', role: 'student' }
+    const listAfter = await getStudentTests(
+      new NextRequest('http://localhost:3000/api/student/tests?classroom_id=classroom-1')
+    )
+    const listAfterData = await listAfter.json()
+    expect(listAfter.status).toBe(200)
+    expect(listAfterData.quizzes[0].student_status).toBe('can_view_results')
+
+    const detailAfter = await getStudentTestDetail(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const detailAfterData = await detailAfter.json()
+    expect(detailAfter.status).toBe(200)
+    expect(detailAfterData.student_status).toBe('can_view_results')
+
+    const resultsAfter = await getStudentTestResults(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    expect(resultsAfter.status).toBe(200)
   })
 })

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as getStudentTests } from '@/app/api/student/tests/route'
+import { GET as getStudentTestDetail } from '@/app/api/student/tests/[id]/route'
+import { GET as getStudentTestResults } from '@/app/api/student/tests/[id]/results/route'
+import { POST as returnTeacherTest } from '@/app/api/teacher/tests/[id]/return/route'
+
+type Role = 'student' | 'teacher'
+
+let currentUser: { id: string; role: Role } = { id: 'student-1', role: 'student' }
+
+const state = {
+  tests: [
+    {
+      id: 'test-1',
+      classroom_id: 'classroom-1',
+      title: 'Integration Test',
+      status: 'closed',
+      show_results: false,
+      position: 0,
+      documents: [],
+      created_by: 'teacher-1',
+      created_at: '2026-03-01T00:00:00.000Z',
+      updated_at: '2026-03-01T00:00:00.000Z',
+    },
+  ],
+  testQuestions: [
+    {
+      id: 'q-open-1',
+      test_id: 'test-1',
+      question_type: 'open_response',
+      question_text: 'Explain your reasoning.',
+      options: [],
+      correct_option: null,
+      points: 5,
+      response_max_chars: 5000,
+      response_monospace: false,
+      position: 0,
+    },
+  ],
+  testResponses: [
+    {
+      id: 'response-1',
+      test_id: 'test-1',
+      question_id: 'q-open-1',
+      student_id: 'student-1',
+      selected_option: null,
+      response_text: 'My explanation',
+      score: 4,
+      feedback: 'Solid reasoning',
+      graded_at: '2026-03-05T12:00:00.000Z',
+      submitted_at: '2026-03-05T11:30:00.000Z',
+    },
+  ],
+  testAttempts: [
+    {
+      test_id: 'test-1',
+      student_id: 'student-1',
+      responses: {
+        'q-open-1': {
+          question_type: 'open_response',
+          response_text: 'My explanation',
+        },
+      },
+      is_submitted: true,
+      submitted_at: '2026-03-05T11:30:00.000Z',
+      returned_at: null as string | null,
+      returned_by: null as string | null,
+    },
+  ],
+}
+
+const mockSupabaseClient = { from: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async (role: Role) => {
+    if (role !== currentUser.role) {
+      const err = new Error('Forbidden')
+      err.name = 'AuthorizationError'
+      throw err
+    }
+    return {
+      id: currentUser.id,
+      email: `${currentUser.role}@example.com`,
+      role: currentUser.role,
+    }
+  }),
+}))
+
+vi.mock('@/lib/server/classrooms', () => ({
+  assertStudentCanAccessClassroom: vi.fn(async () => ({
+    ok: true,
+    classroom: { id: 'classroom-1', archived_at: null },
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  isMissingTestAttemptReturnColumnsError: vi.fn(() => false),
+  assertStudentCanAccessTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      ...state.tests[0],
+      classrooms: { id: 'classroom-1', teacher_id: 'teacher-1', archived_at: null },
+    },
+  })),
+  assertTeacherOwnsTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      ...state.tests[0],
+      classrooms: { id: 'classroom-1', teacher_id: 'teacher-1', archived_at: null },
+    },
+  })),
+}))
+
+function setupSupabaseMock() {
+  ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+    if (table === 'tests') {
+      let classroomId: string | null = null
+      let status: string | null = null
+      const builder: any = {
+        select: vi.fn(() => builder),
+        eq: vi.fn((column: string, value: string) => {
+          if (column === 'classroom_id') classroomId = value
+          if (column === 'status') status = value
+          return builder
+        }),
+        order: vi.fn(async () => ({
+          data: state.tests.filter(
+            (test) =>
+              (classroomId ? test.classroom_id === classroomId : true) &&
+              (status ? test.status === status : true)
+          ),
+          error: null,
+        })),
+      }
+      return builder
+    }
+
+    if (table === 'test_questions') {
+      return {
+        select: vi.fn((_columns: string) => {
+          let testId: string | null = null
+          const chain: any = {
+            eq: vi.fn((column: string, value: string) => {
+              if (column === 'test_id') {
+                testId = value
+                return chain
+              }
+              if (column === 'question_type') {
+                return Promise.resolve({
+                  data: state.testQuestions
+                    .filter((q) => (testId ? q.test_id === testId : true))
+                    .filter((q) => q.question_type === value)
+                    .map((q) => ({ id: q.id })),
+                  error: null,
+                })
+              }
+              return chain
+            }),
+            order: vi.fn(async () => ({
+              data: state.testQuestions
+                .filter((q) => (testId ? q.test_id === testId : true))
+                .sort((a, b) => a.position - b.position),
+              error: null,
+            })),
+          }
+          return chain
+        }),
+      }
+    }
+
+    if (table === 'test_responses') {
+      return {
+        select: vi.fn((_columns: string) => {
+          let eqFilters: Record<string, string> = {}
+          const chain: any = {
+            eq: vi.fn((column: string, value: string) => {
+              eqFilters[column] = value
+              return chain
+            }),
+            in: vi.fn(async (column: string, values: string[]) => ({
+              data: state.testResponses.filter((row) => {
+                const eqMatch = Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                return eqMatch && values.includes(String((row as any)[column]))
+              }),
+              error: null,
+            })),
+            limit: vi.fn(async (count: number) => ({
+              data: state.testResponses
+                .filter((row) =>
+                  Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                )
+                .slice(0, count),
+              error: null,
+            })),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: state.testResponses.filter((row) =>
+                  Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                ),
+                error: null,
+              })
+            ),
+          }
+          return chain
+        }),
+      }
+    }
+
+    if (table === 'test_attempts') {
+      return {
+        select: vi.fn((_columns: string) => {
+          let eqFilters: Record<string, string> = {}
+          const chain: any = {
+            eq: vi.fn((column: string, value: string) => {
+              eqFilters[column] = value
+              return chain
+            }),
+            in: vi.fn(async (column: string, values: string[]) => ({
+              data: state.testAttempts.filter((row) => {
+                const eqMatch = Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                return eqMatch && values.includes(String((row as any)[column]))
+              }),
+              error: null,
+            })),
+            maybeSingle: vi.fn(async () => {
+              const found = state.testAttempts.find((row) =>
+                Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+              )
+              return { data: found || null, error: null }
+            }),
+          }
+          return chain
+        }),
+        update: vi.fn((updates: Record<string, unknown>) => ({
+          eq: vi.fn((column: string, value: string) => ({
+            in: vi.fn(async (inColumn: string, values: string[]) => {
+              for (const attempt of state.testAttempts) {
+                if (
+                  String((attempt as any)[column]) === value &&
+                  values.includes(String((attempt as any)[inColumn]))
+                ) {
+                  Object.assign(attempt, updates)
+                }
+              }
+              return { error: null }
+            }),
+          })),
+        })),
+        insert: vi.fn(async (rows: Array<Record<string, unknown>>) => {
+          state.testAttempts.push(...(rows as any))
+          return { error: null }
+        }),
+      }
+    }
+
+    if (table === 'test_focus_events') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn(async () => ({ data: [], error: null })),
+        })),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
+describe('Test Return Visibility Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentUser = { id: 'student-1', role: 'student' }
+    state.testAttempts[0].returned_at = null
+    state.testAttempts[0].returned_by = null
+    setupSupabaseMock()
+  })
+
+  it('reveals student test results only after teacher returns test work', async () => {
+    const listBefore = await getStudentTests(
+      new NextRequest('http://localhost:3000/api/student/tests?classroom_id=classroom-1')
+    )
+    const listBeforeData = await listBefore.json()
+    expect(listBefore.status).toBe(200)
+    expect(listBeforeData.quizzes[0].student_status).toBe('responded')
+
+    const detailBefore = await getStudentTestDetail(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const detailBeforeData = await detailBefore.json()
+    expect(detailBefore.status).toBe(200)
+    expect(detailBeforeData.student_status).toBe('responded')
+
+    const resultsBefore = await getStudentTestResults(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const resultsBeforeData = await resultsBefore.json()
+    expect(resultsBefore.status).toBe(403)
+    expect(resultsBeforeData.error).toContain('after your teacher returns this test')
+
+    currentUser = { id: 'teacher-1', role: 'teacher' }
+    const returnResponse = await returnTeacherTest(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: ['student-1'] }),
+      }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const returnData = await returnResponse.json()
+    expect(returnResponse.status).toBe(200)
+    expect(returnData.returned_count).toBe(1)
+    expect(state.testAttempts[0].returned_at).not.toBeNull()
+
+    currentUser = { id: 'student-1', role: 'student' }
+    const listAfter = await getStudentTests(
+      new NextRequest('http://localhost:3000/api/student/tests?classroom_id=classroom-1')
+    )
+    const listAfterData = await listAfter.json()
+    expect(listAfter.status).toBe(200)
+    expect(listAfterData.quizzes[0].student_status).toBe('can_view_results')
+
+    const detailAfter = await getStudentTestDetail(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const detailAfterData = await detailAfter.json()
+    expect(detailAfter.status).toBe(200)
+    expect(detailAfterData.student_status).toBe('can_view_results')
+    expect(detailAfterData.quiz.returned_at).not.toBeNull()
+
+    const resultsAfter = await getStudentTestResults(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const resultsAfterData = await resultsAfter.json()
+    expect(resultsAfter.status).toBe(200)
+    expect(resultsAfterData.quiz.returned_at).not.toBeNull()
+    expect(resultsAfterData.summary.earned_points).toBe(4)
+  })
+})

--- a/tests/api/student/tests-id.test.ts
+++ b/tests/api/student/tests-id.test.ts
@@ -226,4 +226,162 @@ describe('GET /api/student/tests/[id]', () => {
     expect(data.quiz.id).toBe('test-1')
     expect(data.quiz.returned_at).toBeNull()
   })
+
+  it('returns student_status=responded when closed test is submitted but not returned', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        classroom_id: 'classroom-1',
+        title: 'Unit Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    } as any)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { responses: {}, is_submitted: true, returned_at: null },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') {
+        let isLimitQuery = false
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn(() => {
+              isLimitQuery = true
+              return Promise.resolve({ data: [], error: null })
+            }),
+            then: vi.fn((resolve: any) =>
+              resolve(
+                isLimitQuery
+                  ? { data: [], error: null }
+                  : { data: [], error: null }
+              )
+            ),
+          })),
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_focus_events') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.student_status).toBe('responded')
+    expect(data.quiz.student_status).toBe('responded')
+  })
+
+  it('returns student_status=can_view_results when closed test has been returned', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        classroom_id: 'classroom-1',
+        title: 'Unit Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    } as any)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                responses: {},
+                is_submitted: true,
+                returned_at: '2026-03-05T12:00:00.000Z',
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') {
+        let isLimitQuery = false
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn(() => {
+              isLimitQuery = true
+              return Promise.resolve({ data: [], error: null })
+            }),
+            then: vi.fn((resolve: any) =>
+              resolve(
+                isLimitQuery
+                  ? { data: [], error: null }
+                  : { data: [], error: null }
+              )
+            ),
+          })),
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_focus_events') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.student_status).toBe('can_view_results')
+    expect(data.quiz.student_status).toBe('can_view_results')
+  })
 })

--- a/tests/api/student/tests-results.test.ts
+++ b/tests/api/student/tests-results.test.ts
@@ -49,7 +49,7 @@ describe('GET /api/student/tests/[id]/results', () => {
     vi.clearAllMocks()
   })
 
-  it('falls back when test_attempts return columns are missing', async () => {
+  it('blocks results when return columns are missing (cannot verify returned state)', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_attempts') {
         return {
@@ -69,6 +69,79 @@ describe('GET /api/student/tests/[id]/results', () => {
                     error: null,
                   }
             ),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn((columns: string) => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue({ data: [{ id: 'response-1' }], error: null }),
+            then: vi.fn((resolve: any) => {
+              if (columns.includes('submitted_at')) {
+                resolve({
+                  data: [
+                    {
+                      id: 'response-1',
+                      test_id: 'test-1',
+                      question_id: 'question-1',
+                      student_id: 'student-1',
+                      selected_option: 0,
+                      response_text: null,
+                      score: 1,
+                      feedback: null,
+                      graded_at: null,
+                      submitted_at: '2026-01-01T00:00:00.000Z',
+                    },
+                  ],
+                  error: null,
+                })
+                return
+              }
+
+              resolve({
+                data: [
+                  {
+                    id: 'response-1',
+                    question_id: 'question-1',
+                    selected_option: 0,
+                    response_text: null,
+                    score: 1,
+                    feedback: null,
+                    graded_at: null,
+                  },
+                ],
+                error: null,
+              })
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Results are available after your teacher returns this test')
+  })
+
+  it('returns results when test work has been returned', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { is_submitted: true, returned_at: '2026-03-05T11:00:00.000Z' },
+              error: null,
+            }),
           })),
         }
       }
@@ -153,7 +226,7 @@ describe('GET /api/student/tests/[id]/results', () => {
 
     expect(response.status).toBe(200)
     expect(data.quiz.id).toBe('test-1')
-    expect(data.quiz.returned_at).toBeNull()
+    expect(data.quiz.returned_at).toBe('2026-03-05T11:00:00.000Z')
     expect(data.summary.earned_points).toBe(1)
   })
 })

--- a/tests/api/student/tests-route.test.ts
+++ b/tests/api/student/tests-route.test.ts
@@ -173,4 +173,105 @@ describe('GET /api/student/tests', () => {
     expect(data.quizzes).toHaveLength(1)
     expect(data.quizzes[0].id).toBe('test-1')
   })
+
+  it('computes test student_status from returned state for closed responded tests', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        let statusFilter: string | null = null
+        const builder: any = {
+          select: vi.fn(() => builder),
+          eq: vi.fn((column: string, value: string) => {
+            if (column === 'status') statusFilter = value
+            return builder
+          }),
+          order: vi.fn(() => builder),
+          then: vi.fn((resolve: any) => {
+            if (statusFilter === 'active') {
+              resolve({ data: [], error: null })
+              return
+            }
+            resolve({
+              data: [
+                {
+                  id: 'test-closed-returned',
+                  classroom_id: 'classroom-1',
+                  title: 'Returned Test',
+                  status: 'closed',
+                  show_results: false,
+                  position: 0,
+                  points_possible: 10,
+                  include_in_final: true,
+                  created_by: 'teacher-1',
+                  created_at: '2026-02-01T00:00:00.000Z',
+                  updated_at: '2026-02-01T00:00:00.000Z',
+                },
+                {
+                  id: 'test-closed-responded',
+                  classroom_id: 'classroom-1',
+                  title: 'Pending Return Test',
+                  status: 'closed',
+                  show_results: false,
+                  position: 1,
+                  points_possible: 10,
+                  include_in_final: true,
+                  created_by: 'teacher-1',
+                  created_at: '2026-02-01T00:00:00.000Z',
+                  updated_at: '2026-02-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          }),
+        }
+        return builder
+      }
+
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  test_id: 'test-closed-returned',
+                  is_submitted: true,
+                  returned_at: '2026-03-05T12:00:00.000Z',
+                },
+                {
+                  test_id: 'test-closed-responded',
+                  is_submitted: true,
+                  returned_at: null,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes).toHaveLength(2)
+    const byId = Object.fromEntries(
+      (data.quizzes as Array<{ id: string; student_status: string }>).map((quiz) => [quiz.id, quiz.student_status])
+    )
+    expect(byId['test-closed-returned']).toBe('can_view_results')
+    expect(byId['test-closed-responded']).toBe('responded')
+  })
 })

--- a/tests/api/teacher/tests-return.test.ts
+++ b/tests/api/teacher/tests-return.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/tests/[id]/return/route'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -20,10 +21,16 @@ vi.mock('@/lib/server/tests', () => ({
     test: {
       id: 'test-1',
       title: 'Unit Test',
+      status: 'closed',
       classroom_id: 'classroom-1',
       classrooms: { archived_at: null },
     },
   })),
+  isMissingTestAttemptReturnColumnsError: vi.fn((error: { code?: string; message?: string } | null) => {
+    if (!error) return false
+    const message = `${error.message || ''}`.toLowerCase()
+    return (error.code === 'PGRST204' || error.code === '42703') && message.includes('returned_at')
+  }),
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -136,5 +143,199 @@ describe('POST /api/teacher/tests/[id]/return', () => {
         student_id: 'student-1',
       }),
     ])
+  })
+
+  it('returns 409 for active tests when close_test is not provided', async () => {
+    vi.mocked(assertTeacherOwnsTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        status: 'active',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      } as any,
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1'] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(data.error).toBe('Test is still active. Confirm close and return to close it first.')
+  })
+
+  it('closes active tests when close_test is provided', async () => {
+    const closeUpdates: Array<{ status: string }> = []
+
+    vi.mocked(assertTeacherOwnsTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        status: 'active',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      } as any,
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          update: vi.fn((payload: { status: string }) => {
+            closeUpdates.push(payload)
+            return {
+              eq: vi.fn(() => ({
+                eq: vi.fn(async () => ({ error: null })),
+              })),
+            }
+          }),
+        }
+      }
+
+      if (table === 'test_questions') {
+        const query = {
+          eq: vi.fn().mockReturnThis(),
+        } as any
+        query.eq.mockImplementationOnce(() => query)
+        query.eq.mockImplementationOnce(async () => ({
+          data: [],
+          error: null,
+        }))
+        return {
+          select: vi.fn(() => query),
+        }
+      }
+
+      if (table === 'test_responses') {
+        const query = {
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn(async () => ({
+            data: [
+              {
+                student_id: 'student-1',
+                question_id: 'q-1',
+                score: null,
+                feedback: null,
+                submitted_at: '2026-02-24T15:00:00.000Z',
+              },
+            ],
+            error: null,
+          })),
+        }
+        return {
+          select: vi.fn(() => query),
+        }
+      }
+
+      if (table === 'test_attempts') {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn(async () => ({ error: null })),
+            })),
+          })),
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn(async () => ({
+              data: [],
+              error: null,
+            })),
+          })),
+          insert: vi.fn(async () => ({ error: null })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1'], close_test: true }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.test_closed).toBe(true)
+    expect(closeUpdates).toEqual([{ status: 'closed' }])
+  })
+
+  it('returns migration error when returned_at column is missing', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        const query = {
+          eq: vi.fn().mockReturnThis(),
+        } as any
+        query.eq.mockImplementationOnce(() => query)
+        query.eq.mockImplementationOnce(async () => ({
+          data: [],
+          error: null,
+        }))
+        return {
+          select: vi.fn(() => query),
+        }
+      }
+
+      if (table === 'test_responses') {
+        const query = {
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn(async () => ({
+            data: [
+              {
+                student_id: 'student-1',
+                question_id: 'q-1',
+                score: null,
+                feedback: null,
+                submitted_at: '2026-02-24T15:00:00.000Z',
+              },
+            ],
+            error: null,
+          })),
+        }
+        return {
+          select: vi.fn(() => query),
+        }
+      }
+
+      if (table === 'test_attempts') {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn(async () => ({
+                error: {
+                  code: 'PGRST204',
+                  message:
+                    "Could not find the 'returned_at' column of 'test_attempts' in the schema cache",
+                },
+              })),
+            })),
+          })),
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn(async () => ({
+              data: [],
+              error: null,
+            })),
+          })),
+          insert: vi.fn(async () => ({ error: null })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1'] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Returning tests requires migration 043 to be applied')
   })
 })

--- a/tests/components/QuizCard.test.tsx
+++ b/tests/components/QuizCard.test.tsx
@@ -115,6 +115,21 @@ describe('QuizCard', () => {
     expect(screen.getByLabelText('Show results to students')).toBeInTheDocument()
   })
 
+  it('does not render results visibility toggle for tests', () => {
+    const test = makeQuizWithStats({ assessment_type: 'test', show_results: true })
+    render(
+      <QuizCard
+        quiz={test}
+        {...defaultProps}
+        apiBasePath="/api/teacher/tests"
+      />,
+      { wrapper: Wrapper }
+    )
+
+    expect(screen.queryByLabelText('Hide results from students')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Show results to students')).not.toBeInTheDocument()
+  })
+
   it('calls onDelete when delete button is clicked', () => {
     const onDelete = vi.fn()
     const quiz = makeQuizWithStats({ title: 'My Quiz' })

--- a/tests/components/QuizCard.test.tsx
+++ b/tests/components/QuizCard.test.tsx
@@ -64,6 +64,20 @@ describe('QuizCard', () => {
     expect(screen.getByText('Active')).toBeInTheDocument()
   })
 
+  it('shows Open badge for active tests', () => {
+    const test = makeQuizWithStats({ status: 'active', assessment_type: 'test' })
+    render(
+      <QuizCard
+        quiz={test}
+        {...defaultProps}
+        apiBasePath="/api/teacher/tests"
+      />,
+      { wrapper: Wrapper }
+    )
+
+    expect(screen.getByText('Open')).toBeInTheDocument()
+  })
+
   it('shows Closed badge for closed quizzes', () => {
     const quiz = makeQuizWithStats({ status: 'closed' })
     render(<QuizCard quiz={quiz} {...defaultProps} />, { wrapper: Wrapper })

--- a/tests/components/StudentQuizResults.test.tsx
+++ b/tests/components/StudentQuizResults.test.tsx
@@ -125,6 +125,53 @@ describe('StudentQuizResults', () => {
     })
   })
 
+  it('hides submission confirmation banner when disabled', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        question_results: [
+          {
+            question_id: 'q1',
+            question_type: 'multiple_choice',
+            question_text: 'What is 2 + 2?',
+            options: ['3', '4'],
+            points: 1,
+            response_max_chars: 5000,
+            correct_option: 1,
+            selected_option: 1,
+            response_text: null,
+            score: 1,
+            feedback: 'Correct',
+            graded_at: '2026-03-06T10:00:00.000Z',
+            is_correct: true,
+          },
+        ],
+        summary: {
+          earned_points: 1,
+          possible_points: 1,
+          percent: 100,
+        },
+      }),
+    })
+
+    render(
+      <StudentQuizResults
+        quizId="quiz-1"
+        myResponses={{ q1: 1 }}
+        assessmentType="test"
+        apiBasePath="/api/student/tests"
+        showSubmissionBanner={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Score')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Your response has been submitted.')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Results' })).not.toBeInTheDocument()
+  })
+
   it('uses muted bar color for non-selected options', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -203,7 +203,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
   })
 
-  it('hides left-panel exits and away indicators in active test detail', async () => {
+  it('shows left-panel exits and away indicators in active test detail', async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/api/student/tests?classroom_id=')) {
         return {
@@ -309,8 +309,8 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
     })
 
-    expect(screen.queryByLabelText(/Exits 9\./)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Away time 0:13.')).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/Exits 9\./)).toBeInTheDocument()
+    expect(screen.getByLabelText('Away time 0:13.')).toBeInTheDocument()
     expect(screen.getAllByText('Window must be maximized in exam mode.').length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: /Maximize/i })).toBeInTheDocument()
     expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
@@ -365,7 +365,7 @@ describe('StudentQuizzesTab exam mode', () => {
               {
                 id: 'q1',
                 quiz_id: 'test-1',
-                question_text: '2 + 2 = ?',
+                question_text: 'Use [Formula Sheet](https://example.com/formula.pdf). 2 + 2 = ?',
                 options: ['3', '4'],
                 question_type: 'multiple_choice',
                 points: 1,
@@ -429,20 +429,22 @@ describe('StudentQuizzesTab exam mode', () => {
     fireEvent.click(screen.getByText('Start test'))
 
     await waitFor(() => {
-      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(screen.getByText(/2 \+ 2 = \?/)).toBeInTheDocument()
     })
 
     const splitContainerAfterStart = getSplitContainer(container)
     expect(splitContainerAfterStart.className).toContain('lg:grid-cols-[30%_70%]')
     expect(splitContainerAfterStart.className).not.toContain('lg:grid-cols-2')
-    expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Documents' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Exam Mode' })).not.toBeInTheDocument()
 
     const sections = container.querySelectorAll('section')
     const leftPane = sections.item(0)
     expect(leftPane).toBeTruthy()
     expect(within(leftPane).queryByRole('heading', { name: 'Tests' })).not.toBeInTheDocument()
-    expect(within(leftPane).queryByLabelText(/Exits /)).not.toBeInTheDocument()
-    expect(within(leftPane).queryByLabelText(/Away time/)).not.toBeInTheDocument()
+    expect(within(leftPane).getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    expect(within(leftPane).getByLabelText(/Exits /)).toBeInTheDocument()
+    expect(within(leftPane).getByLabelText(/Away time/)).toBeInTheDocument()
   })
 
   it('switches to 50/50 split when opening a doc and restores 30/70 on back', async () => {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -413,7 +413,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
 
     const splitContainerBeforeStart = getSplitContainer(container)
-    expect(splitContainerBeforeStart.className).toContain('lg:grid-cols-2')
+    expect(splitContainerBeforeStart.className).toContain('lg:grid-cols-[50%_50%]')
     expect(splitContainerBeforeStart.className).not.toContain('lg:grid-cols-[30%_70%]')
     expect(screen.getByRole('heading', { name: 'Tests' })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Exam Mode' })).not.toBeInTheDocument()
@@ -434,7 +434,7 @@ describe('StudentQuizzesTab exam mode', () => {
 
     const splitContainerAfterStart = getSplitContainer(container)
     expect(splitContainerAfterStart.className).toContain('lg:grid-cols-[30%_70%]')
-    expect(splitContainerAfterStart.className).not.toContain('lg:grid-cols-2')
+    expect(splitContainerAfterStart.className).not.toContain('lg:grid-cols-[50%_50%]')
     expect(screen.getByRole('heading', { name: 'Documents' })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Exam Mode' })).not.toBeInTheDocument()
 
@@ -556,7 +556,7 @@ describe('StudentQuizzesTab exam mode', () => {
 
     const splitContainerExamMode = getSplitContainer(container)
     expect(splitContainerExamMode.className).toContain('lg:grid-cols-[30%_70%]')
-    expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-2')
+    expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-[50%_50%]')
 
     fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
 
@@ -565,7 +565,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
     expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
     const splitContainerDocOpen = getSplitContainer(container)
-    expect(splitContainerDocOpen.className).toContain('lg:grid-cols-2')
+    expect(splitContainerDocOpen.className).toContain('lg:grid-cols-[50%_50%]')
     expect(splitContainerDocOpen.className).not.toContain('lg:grid-cols-[30%_70%]')
 
     fireEvent.click(screen.getByRole('button', { name: 'Back to documents list' }))
@@ -575,6 +575,177 @@ describe('StudentQuizzesTab exam mode', () => {
     })
     const splitContainerBack = getSplitContainer(container)
     expect(splitContainerBack.className).toContain('lg:grid-cols-[30%_70%]')
+  })
+
+  it('uses 30/70 split when student is viewing returned test results', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'closed',
+              show_results: false,
+              position: 0,
+              student_status: 'can_view_results',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'closed',
+              show_results: false,
+              position: 0,
+              student_status: 'can_view_results',
+            },
+            student_status: 'can_view_results',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {
+              q1: {
+                question_type: 'multiple_choice',
+                selected_option: 1,
+              },
+            },
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1/results')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              status: 'closed',
+              returned_at: '2026-03-06T10:00:00.000Z',
+            },
+            results: [],
+            question_results: [
+              {
+                question_id: 'q1',
+                question_type: 'multiple_choice',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                points: 1,
+                response_max_chars: 5000,
+                correct_option: 1,
+                selected_option: 1,
+                response_text: null,
+                score: 1,
+                feedback: 'Correct',
+                graded_at: '2026-03-06T10:00:00.000Z',
+                is_correct: true,
+              },
+            ],
+            summary: {
+              earned_points: 1,
+              possible_points: 1,
+              percent: 100,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    const { container } = render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Score')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('heading', { name: 'Midterm Test Results' })).toBeInTheDocument()
+    expect(screen.queryByText('Your response has been submitted.')).not.toBeInTheDocument()
+    expect(screen.getByText('Returned')).toBeInTheDocument()
+    expect(screen.queryByText('View Results')).not.toBeInTheDocument()
+
+    const splitContainer = getSplitContainer(container)
+    expect(splitContainer.className).toContain('lg:grid-cols-[30%_70%]')
+    expect(splitContainer.className).not.toContain('lg:grid-cols-[50%_50%]')
+  })
+
+  it('shows Closed, Submitted, and Returned status pills for tests', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        quizzes: [
+          {
+            id: 'test-closed',
+            title: 'Closed Test',
+            assessment_type: 'test',
+            status: 'closed',
+            show_results: false,
+            position: 0,
+            student_status: 'responded',
+          },
+          {
+            id: 'test-submitted',
+            title: 'Submitted Test',
+            assessment_type: 'test',
+            status: 'active',
+            show_results: false,
+            position: 1,
+            student_status: 'responded',
+          },
+          {
+            id: 'test-returned',
+            title: 'Returned Test',
+            assessment_type: 'test',
+            status: 'closed',
+            show_results: false,
+            position: 2,
+            student_status: 'can_view_results',
+          },
+        ],
+      }),
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Closed Test')).toBeInTheDocument()
+      expect(screen.getByText('Submitted Test')).toBeInTheDocument()
+      expect(screen.getByText('Returned Test')).toBeInTheDocument()
+    })
+
+    const closedCard = screen.getByRole('button', { name: /Closed Test/i })
+    const submittedCard = screen.getByRole('button', { name: /Submitted Test/i })
+    const returnedCard = screen.getByRole('button', { name: /Returned Test/i })
+
+    expect(within(closedCard).getByText('Closed')).toBeInTheDocument()
+    expect(within(submittedCard).getByText('Submitted')).toBeInTheDocument()
+    expect(within(returnedCard).getByText('Returned')).toBeInTheDocument()
+    expect(screen.queryByText('View Results')).not.toBeInTheDocument()
   })
 
   it('renders text documents inline in the left doc panel', async () => {

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -332,4 +332,102 @@ describe('TeacherQuizzesTab', () => {
     expect(screen.queryByLabelText(/Focus events/i)).not.toBeInTheDocument()
     expect(statusIcon).toHaveAttribute('aria-label', 'Submitted')
   })
+
+  it('prompts to close active test before return and sends close_test=true', async () => {
+    const quiz = makeQuiz({
+      id: 'test-active-return',
+      title: 'Active Return Test',
+      assessment_type: 'test',
+      status: 'active',
+    })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ quizzes: [quiz] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
+          questions: [],
+          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
+          students: [
+            {
+              student_id: 'student-1',
+              name: 'Student One',
+              email: 'student1@example.com',
+              status: 'submitted',
+              submitted_at: '2026-02-25T15:06:00.000Z',
+              last_activity_at: '2026-02-25T23:07:00.000Z',
+              points_earned: 1,
+              points_possible: 6,
+              percent: 16.7,
+              graded_open_responses: 0,
+              ungraded_open_responses: 1,
+              focus_summary: null,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ returned_count: 1, skipped_count: 0, test_closed: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ quizzes: [{ ...quiz, status: 'closed' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
+          questions: [],
+          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
+          students: [
+            {
+              student_id: 'student-1',
+              name: 'Student One',
+              email: 'student1@example.com',
+              status: 'returned',
+              submitted_at: '2026-02-25T15:06:00.000Z',
+              last_activity_at: '2026-02-25T23:07:00.000Z',
+              points_earned: 1,
+              points_possible: 6,
+              percent: 16.7,
+              graded_open_responses: 0,
+              ungraded_open_responses: 1,
+              focus_summary: null,
+            },
+          ],
+        }),
+      })
+
+    renderTab('test')
+    await screen.findByText('Active Return Test')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    await screen.findByText('Student One')
+
+    fireEvent.click(screen.getByLabelText('Select Student One'))
+    fireEvent.click(screen.getByRole('button', { name: 'Return 1 selected tests' }))
+
+    expect(await screen.findByText('Close test and return work to 1 selected student(s)?')).toBeInTheDocument()
+    expect(screen.getByText('This test is still open. Confirming will close it for all students before returning selected work.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Close and Return'))
+
+    await waitFor(() => {
+      const returnCall = fetchMock.mock.calls.find(
+        ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/test-active-return/return')
+      )
+      expect(returnCall).toBeDefined()
+      const [, init] = returnCall as [string, RequestInit]
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(String(init.body))).toEqual({
+        student_ids: ['student-1'],
+        close_test: true,
+      })
+    })
+  })
 })

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -331,6 +331,7 @@ describe('TeacherQuizzesTab', () => {
     )
     expect(screen.queryByLabelText(/Focus events/i)).not.toBeInTheDocument()
     expect(statusIcon).toHaveAttribute('aria-label', 'Submitted')
+    expect(statusIcon.querySelector('.lucide-check')).not.toBeNull()
   })
 
   it('prompts to close active test before return and sends close_test=true', async () => {
@@ -429,5 +430,8 @@ describe('TeacherQuizzesTab', () => {
         close_test: true,
       })
     })
+
+    const returnedStatusIcon = await screen.findByLabelText('Returned')
+    expect(returnedStatusIcon.querySelector('.lucide-send')).not.toBeNull()
   })
 })

--- a/tests/unit/quizzes.test.ts
+++ b/tests/unit/quizzes.test.ts
@@ -9,7 +9,9 @@ import {
   getQuizStatusBadgeClass,
   canStudentRespond,
   canStudentViewResults,
+  canStudentViewTestResults,
   getStudentQuizStatus,
+  getStudentTestStatus,
   canEditQuizQuestions,
   aggregateResults,
   validateQuizOptions,
@@ -121,6 +123,32 @@ describe('quiz utilities', () => {
   })
 
   // ==========================================================================
+  // canStudentViewTestResults()
+  // ==========================================================================
+
+  describe('canStudentViewTestResults', () => {
+    it('should return true when test is closed, responded, and returned', () => {
+      const test = createMockQuiz({ status: 'closed' })
+      expect(canStudentViewTestResults(test, true, '2026-03-05T10:00:00.000Z')).toBe(true)
+    })
+
+    it('should return false when test is not closed', () => {
+      const test = createMockQuiz({ status: 'active' })
+      expect(canStudentViewTestResults(test, true, '2026-03-05T10:00:00.000Z')).toBe(false)
+    })
+
+    it('should return false when student has not responded', () => {
+      const test = createMockQuiz({ status: 'closed' })
+      expect(canStudentViewTestResults(test, false, '2026-03-05T10:00:00.000Z')).toBe(false)
+    })
+
+    it('should return false when test is not returned', () => {
+      const test = createMockQuiz({ status: 'closed' })
+      expect(canStudentViewTestResults(test, true, null)).toBe(false)
+    })
+  })
+
+  // ==========================================================================
   // getStudentQuizStatus()
   // ==========================================================================
 
@@ -143,6 +171,27 @@ describe('quiz utilities', () => {
     it('should return "responded" when student has responded but results are disabled', () => {
       const quiz = createMockQuiz({ status: 'closed', show_results: false })
       expect(getStudentQuizStatus(quiz, true)).toBe('responded')
+    })
+  })
+
+  // ==========================================================================
+  // getStudentTestStatus()
+  // ==========================================================================
+
+  describe('getStudentTestStatus', () => {
+    it('should return "not_started" when student has not responded', () => {
+      const test = createMockQuiz({ status: 'active' })
+      expect(getStudentTestStatus(test, false, null)).toBe('not_started')
+    })
+
+    it('should return "responded" when test is responded but not returned', () => {
+      const test = createMockQuiz({ status: 'closed' })
+      expect(getStudentTestStatus(test, true, null)).toBe('responded')
+    })
+
+    it('should return "can_view_results" when test is closed and returned', () => {
+      const test = createMockQuiz({ status: 'closed' })
+      expect(getStudentTestStatus(test, true, '2026-03-05T10:00:00.000Z')).toBe('can_view_results')
     })
   })
 

--- a/tests/unit/quizzes.test.ts
+++ b/tests/unit/quizzes.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   getQuizStatusLabel,
+  getAssessmentStatusLabel,
   getQuizStatusBadgeClass,
   canStudentRespond,
   canStudentViewResults,
@@ -38,6 +39,16 @@ describe('quiz utilities', () => {
 
     it('should return "Closed" for closed status', () => {
       expect(getQuizStatusLabel('closed')).toBe('Closed')
+    })
+  })
+
+  describe('getAssessmentStatusLabel', () => {
+    it('should return "Open" for active tests', () => {
+      expect(getAssessmentStatusLabel('active', 'test')).toBe('Open')
+    })
+
+    it('should keep "Active" for active quizzes', () => {
+      expect(getAssessmentStatusLabel('active', 'quiz')).toBe('Active')
     })
   })
 


### PR DESCRIPTION
## Summary
- gate student test visibility using returned status for tests (`closed + responded + returned_at`)
- keep quiz visibility behavior unchanged (`show_results`)
- hide the eye/visibility toggle for tests in teacher controls while keeping it for quizzes
- update student test messaging and rendering to rely on `student_status === can_view_results`

## Validation
- pnpm vitest run tests/unit/quizzes.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/components/QuizCard.test.tsx tests/components/StudentQuizzesTab.test.tsx
- pnpm lint
- Playwright screenshots for teacher/student test tabs (loaded + selected states)
