### PR TITLE
Fix notifications route type error in build

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -5076,3 +5076,15 @@
 **Verification:**
 - `pnpm vitest run tests/api/teacher/tests-students-grades.test.ts tests/api/student/tests-results.test.ts tests/api/teacher/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-focus-events.test.ts tests/api/student/notifications.test.ts tests/api/student/tests-respond.test.ts tests/unit/ai-test-grading.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-attempt.test.ts`
 - `pnpm lint`
+
+## 2026-03-06 (hotfix): Fix student notifications TypeScript build failure
+
+- Fixed `src/app/api/student/notifications/route.ts` type-check failure introduced by dynamic Supabase `select(...)` on a union table path.
+- Replaced dynamic response query with explicit branches:
+  - quizzes: `quiz_responses.select('quiz_id')`
+  - tests: `test_responses.select('test_id, selected_option, response_text')`
+- Preserved meaningful-response filtering for test placeholders via `hasMeaningfulTestResponse`.
+
+**Verification:**
+- `pnpm vitest run tests/api/student/notifications.test.ts`
+- `pnpm build`

--- a/src/app/api/student/notifications/route.ts
+++ b/src/app/api/student/notifications/route.ts
@@ -130,8 +130,6 @@ export async function GET(request: NextRequest) {
 
     async function countActiveUnanswered(
       table: 'quizzes' | 'tests',
-      responsesTable: 'quiz_responses' | 'test_responses',
-      responseIdColumn: 'quiz_id' | 'test_id',
       opts?: { tolerateMissingTable?: boolean }
     ): Promise<{ count: number; error: boolean }> {
       const tolerateMissingTable = opts?.tolerateMissingTable === true
@@ -155,29 +153,50 @@ export async function GET(request: NextRequest) {
         return { count: 0, error: false }
       }
 
-      const { data: responses, error: responsesError } = await supabase
-        .from(responsesTable)
-        .select(table === 'tests' ? `${responseIdColumn}, selected_option, response_text` : responseIdColumn)
-        .eq('student_id', user.id)
-        .in(responseIdColumn, activeIds)
+      let responses:
+        | Array<{ quiz_id: string }>
+        | Array<{ test_id: string; selected_option: unknown; response_text: unknown }>
+        | null = null
+      let responsesError: { code?: string; message?: string; details?: string; hint?: string } | null = null
+
+      if (table === 'tests') {
+        const testResponsesResult = await supabase
+          .from('test_responses')
+          .select('test_id, selected_option, response_text')
+          .eq('student_id', user.id)
+          .in('test_id', activeIds)
+
+        responses = (testResponsesResult.data as typeof responses) || null
+        responsesError = testResponsesResult.error
+      } else {
+        const quizResponsesResult = await supabase
+          .from('quiz_responses')
+          .select('quiz_id')
+          .eq('student_id', user.id)
+          .in('quiz_id', activeIds)
+
+        responses = (quizResponsesResult.data as typeof responses) || null
+        responsesError = quizResponsesResult.error
+      }
 
       if (responsesError) {
         if (tolerateMissingTable && responsesError.code === 'PGRST205') {
           return { count: 0, error: false }
         }
-        console.error(`Error fetching ${responsesTable}:`, responsesError)
+        console.error(`Error fetching ${table} responses:`, responsesError)
         return { count: 0, error: true }
       }
 
       const respondedIds = new Set<string>()
       for (const row of responses || []) {
-        if (table === 'tests' && !hasMeaningfulTestResponse(row)) {
-          continue
+        let assessmentId: string | null = null
+        if (table === 'tests') {
+          if (!hasMeaningfulTestResponse(row)) continue
+          assessmentId = (row as { test_id: string }).test_id
+        } else {
+          assessmentId = (row as { quiz_id: string }).quiz_id
         }
-        const assessmentId =
-          responseIdColumn === 'quiz_id'
-            ? (row as { quiz_id: string }).quiz_id
-            : (row as { test_id: string }).test_id
+
         if (assessmentId) {
           respondedIds.add(assessmentId)
         }
@@ -210,8 +229,6 @@ export async function GET(request: NextRequest) {
 
     const activeQuizzesResult = await countActiveUnanswered(
       'quizzes',
-      'quiz_responses',
-      'quiz_id'
     )
     if (activeQuizzesResult.error) {
       return NextResponse.json(
@@ -222,8 +239,6 @@ export async function GET(request: NextRequest) {
 
     const activeTestsResult = await countActiveUnanswered(
       'tests',
-      'test_responses',
-      'test_id',
       { tolerateMissingTable: true }
     )
     if (activeTestsResult.error) {


### PR DESCRIPTION
## Summary
- fix TypeScript compile error in `src/app/api/student/notifications/route.ts`
- replace dynamic Supabase `select(...)` on union response tables with explicit quiz/test query branches
- keep placeholder-test-response filtering via `hasMeaningfulTestResponse`

## Verification
- `pnpm vitest run tests/api/student/notifications.test.ts`
- `pnpm build`
