### PR TITLE
Assignments grading: split Save button (graded primary, Draft menu)

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6004,3 +6004,23 @@
 
 **Validation:**
 - `pnpm exec vitest run tests/components/QuizDetailPanel.test.tsx` (pass, 24 tests)
+
+## 2026-03-10 [AI - GPT-5 Codex]
+**Goal:** Change assignment grading save controls to a split button (`Save` graded primary + `Draft` menu action).
+**Completed:**
+- Updated `src/components/TeacherStudentWorkPanel.tsx`:
+  - Replaced `Save mode` select + `Save` button with `SplitButton`.
+  - Primary `Save` now sends `save_mode: 'graded'`.
+  - Dropdown menu now provides `Draft`, which sends `save_mode: 'draft'`.
+  - Refactored `handleSaveGrade` to accept explicit mode per action.
+- Updated `tests/components/TeacherStudentWorkPanel.test.tsx`:
+  - Adjusted UI mock from `Select` to `SplitButton`.
+  - Updated assertions for new behavior (primary save => graded, menu `Draft` => draft).
+
+**Validation:**
+- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx` (pass)
+- `pnpm lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx` (pass)
+- Visual verification screenshots:
+  - Teacher grading panel split button: `/tmp/pika-teacher-grading-splitbutton.png`
+  - Teacher grading panel with dropdown open (`Draft` visible): `/tmp/pika-teacher-grading-splitbutton-menu.png`
+  - Student assignments view sanity check: `/tmp/pika-student-assignments-view.png`

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { Button, RefreshingIndicator, Select, Tooltip } from '@/ui'
+import { Button, RefreshingIndicator, SplitButton, Tooltip } from '@/ui'
 import { RichTextViewer } from '@/components/editor'
 import { HistoryList } from '@/components/HistoryList'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
@@ -154,7 +154,6 @@ export function TeacherStudentWorkPanel({
   const [scoreThinking, setScoreThinking] = useState<string>('')
   const [scoreWorkflow, setScoreWorkflow] = useState<string>('')
   const [feedback, setFeedback] = useState<string>('')
-  const [saveMode, setSaveMode] = useState<GradeSaveMode>('draft')
   const [gradeSaving, setGradeSaving] = useState(false)
   const [gradeError, setGradeError] = useState('')
   const [autoGrading, setAutoGrading] = useState(false)
@@ -206,13 +205,11 @@ export function TeacherStudentWorkPanel({
       setScoreThinking(doc.score_thinking?.toString() ?? '')
       setScoreWorkflow(doc.score_workflow?.toString() ?? '')
       setFeedback(doc.feedback ?? '')
-      setSaveMode(doc.graded_at ? 'graded' : 'draft')
     } else {
       setScoreCompletion('')
       setScoreThinking('')
       setScoreWorkflow('')
       setFeedback('')
-      setSaveMode('draft')
     }
   }
 
@@ -268,9 +265,8 @@ export function TeacherStudentWorkPanel({
     loadHistory()
   }, [assignmentId, studentId])
 
-  async function handleSaveGrade() {
+  async function handleSaveGrade(selectedSaveMode: GradeSaveMode) {
     if (!data) return
-    const selectedSaveMode = saveMode
     const sc = Number(scoreCompletion)
     const st = Number(scoreThinking)
     const sw = Number(scoreWorkflow)
@@ -555,19 +551,26 @@ export function TeacherStudentWorkPanel({
                 <Button size="sm" variant="secondary" className="flex-1" onClick={handleAutoGrade} disabled={autoGrading}>
                   {autoGrading ? 'Grading...' : 'AI grade'}
                 </Button>
-                <Select
-                  className="h-8 w-[7.5rem] px-2 py-1 text-xs"
-                  aria-label="Save mode"
-                  value={saveMode}
-                  onChange={(event) => setSaveMode(event.target.value as GradeSaveMode)}
+                <SplitButton
+                  label={gradeSaving ? 'Saving...' : 'Save'}
+                  onPrimaryClick={() => {
+                    void handleSaveGrade('graded')
+                  }}
                   options={[
-                    { value: 'draft', label: 'Draft' },
-                    { value: 'graded', label: 'Graded' },
+                    {
+                      id: 'draft',
+                      label: 'Draft',
+                      onSelect: () => {
+                        void handleSaveGrade('draft')
+                      },
+                    },
                   ]}
+                  size="sm"
+                  className="flex-1"
+                  disabled={gradeSaving}
+                  toggleAriaLabel="Choose save mode"
+                  primaryButtonProps={{ className: 'flex-1 justify-center' }}
                 />
-                <Button size="sm" className="flex-1" onClick={handleSaveGrade} disabled={gradeSaving}>
-                  {gradeSaving ? 'Saving...' : 'Save'}
-                </Button>
               </div>
 
               {data.doc?.graded_at && (

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -18,14 +18,20 @@ vi.mock('@/components/HistoryList', () => ({
 
 vi.mock('@/ui', () => ({
   Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-  Select: ({ options, ...props }: any) => (
-    <select {...props}>
-      {options.map((option: { value: string; label: string }) => (
-        <option key={option.value} value={option.value}>
+  SplitButton: ({ label, onPrimaryClick, options, toggleAriaLabel, ...props }: any) => (
+    <div {...props}>
+      <button type="button" onClick={onPrimaryClick}>
+        {label}
+      </button>
+      <button type="button" aria-label={toggleAriaLabel || 'More actions'}>
+        Toggle
+      </button>
+      {options.map((option: { id: string; label: string; onSelect: () => void }) => (
+        <button key={option.id} type="button" onClick={option.onSelect}>
           {option.label}
-        </option>
+        </button>
       ))}
-    </select>
+    </div>
   ),
   Tooltip: ({ children }: any) => <>{children}</>,
   RefreshingIndicator: ({ label = 'Refreshing...' }: { label?: string }) => <div>{label}</div>,
@@ -238,7 +244,7 @@ describe('TeacherStudentWorkPanel right-tab persistence', () => {
     expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
   })
 
-  it('saves as draft by default', async () => {
+  it('saves as graded with the primary save action', async () => {
     const savedBodies: Array<Record<string, unknown>> = []
     mockFetchByStudent(
       {
@@ -253,31 +259,6 @@ describe('TeacherStudentWorkPanel right-tab persistence', () => {
     render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
 
     await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-
-    await waitFor(() => {
-      expect(savedBodies).toHaveLength(1)
-    })
-    expect(savedBodies[0].save_mode).toBe('draft')
-    expect(screen.queryByText(/^Graded /)).not.toBeInTheDocument()
-  })
-
-  it('saves as graded when selected from save mode dropdown', async () => {
-    const savedBodies: Array<Record<string, unknown>> = []
-    mockFetchByStudent(
-      {
-        'student-1': { graded: false },
-      },
-      {
-        onGradeSave: (body) => savedBodies.push(body),
-      }
-    )
-
-    const user = userEvent.setup()
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    await user.selectOptions(screen.getByLabelText('Save mode'), 'graded')
     await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
@@ -285,5 +266,30 @@ describe('TeacherStudentWorkPanel right-tab persistence', () => {
     })
     expect(savedBodies[0].save_mode).toBe('graded')
     expect(await screen.findByText(/^Graded /)).toBeInTheDocument()
+  })
+
+  it('saves as draft from split-button menu action', async () => {
+    const savedBodies: Array<Record<string, unknown>> = []
+    mockFetchByStudent(
+      {
+        'student-1': { graded: false },
+      },
+      {
+        onGradeSave: (body) => savedBodies.push(body),
+      }
+    )
+
+    const user = userEvent.setup()
+    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
+
+    await user.click(await screen.findByRole('button', { name: 'Grading' }))
+    await user.click(screen.getByRole('button', { name: 'Choose save mode' }))
+    await user.click(screen.getByRole('button', { name: 'Draft' }))
+
+    await waitFor(() => {
+      expect(savedBodies).toHaveLength(1)
+    })
+    expect(savedBodies[0].save_mode).toBe('draft')
+    expect(screen.queryByText(/^Graded /)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- replace grading panel `Save mode` select + `Save` button with a split button
- set primary `Save` action to save as graded
- move draft save to dropdown action (`Draft`)
- update TeacherStudentWorkPanel tests for the new split-button behavior

## Validation
- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
- visual checks:
  - `/tmp/pika-teacher-grading-splitbutton.png`
  - `/tmp/pika-teacher-grading-splitbutton-menu.png`
  - `/tmp/pika-student-assignments-view.png`