### PR TITLE
Make tests grading table sortable by first/last name

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6191,3 +6191,25 @@
   - Teacher classrooms: `/tmp/pika-teacher-classrooms-v2.png`
   - Student classrooms: `/tmp/pika-student-classrooms-v2.png`
   - Teacher tests grading header (no `.asc`): `/tmp/pika-teacher-tests-grading-header-no-asc-v2.png`
+
+## 2026-03-10 [AI - GPT-5 Codex]
+**Goal:** Fix test grading name sorting to use structured first/last names (avoid parsing `name`).
+**Completed:**
+- Updated `src/app/api/teacher/tests/[id]/results/route.ts`:
+  - Added `first_name` and `last_name` to each returned student row.
+  - Kept `name` for display/backward compatibility.
+- Updated `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`:
+  - Added `first_name`/`last_name` to grading row type.
+  - Updated sort logic to use structured `first_name`/`last_name` first.
+  - Kept display-name parsing only as fallback when structured fields are missing.
+- Updated `tests/components/TeacherQuizzesTab.test.tsx`:
+  - Strengthened sorting test with multi-word first name data to verify first-name sorting does not rely on splitting display name.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/TeacherQuizzesTab.test.tsx` (pass)
+- `pnpm exec vitest run tests/api/teacher/tests-results.test.ts` (pass)
+- `pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx` (pass)
+- Visual verification screenshots:
+  - Teacher classrooms: `/tmp/pika-teacher-classrooms-fix2.png`
+  - Student classrooms: `/tmp/pika-student-classrooms-fix2.png`
+  - Teacher tests grading view: `/tmp/pika-teacher-tests-grading-structured-names-fix-v2.png`

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -188,7 +188,10 @@ export async function GET(
       }
     }
 
-    const userById = new Map<string, { email: string; name: string | null }>()
+    const userById = new Map<
+      string,
+      { email: string; first_name: string | null; last_name: string | null; name: string | null }
+    >()
     if (classroomStudentIds.length > 0) {
       const { data: users } = await supabase
         .from('users')
@@ -199,15 +202,17 @@ export async function GET(
         .select('user_id, first_name, last_name')
         .in('user_id', classroomStudentIds)
       const profileMap = new Map(
-        (profiles || []).map((profile) => [
-          profile.user_id,
-          `${profile.first_name || ''} ${profile.last_name || ''}`.trim() || null,
-        ])
+        (profiles || []).map((profile) => [profile.user_id, profile])
       )
       for (const userRow of users || []) {
+        const profile = profileMap.get(userRow.id)
+        const firstName = (profile?.first_name || '').trim() || null
+        const lastName = (profile?.last_name || '').trim() || null
         userById.set(userRow.id, {
           email: userRow.email,
-          name: profileMap.get(userRow.id) || null,
+          first_name: firstName,
+          last_name: lastName,
+          name: `${firstName || ''} ${lastName || ''}`.trim() || null,
         })
       }
     }
@@ -305,6 +310,8 @@ export async function GET(
       return {
         student_id: studentId,
         name: userInfo?.name || null,
+        first_name: userInfo?.first_name || null,
+        last_name: userInfo?.last_name || null,
         email: userInfo?.email || '',
         status,
         submitted_at: submittedAt,

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -35,6 +35,8 @@ interface Props {
 interface TestGradingStudentRow {
   student_id: string
   name: string | null
+  first_name: string | null
+  last_name: string | null
   email: string
   status: 'not_started' | 'in_progress' | 'submitted' | 'returned'
   submitted_at: string | null
@@ -49,7 +51,7 @@ interface TestGradingStudentRow {
 
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
-function splitStudentName(name: string | null): { firstName: string | null; lastName: string | null } {
+function splitDisplayName(name: string | null): { firstName: string | null; lastName: string | null } {
   const trimmed = (name || '').trim()
   if (!trimmed) return { firstName: null, lastName: null }
 
@@ -60,6 +62,19 @@ function splitStudentName(name: string | null): { firstName: string | null; last
     firstName: parts[0],
     lastName: parts.slice(1).join(' '),
   }
+}
+
+function getSortableNameParts(student: TestGradingStudentRow): { firstName: string | null; lastName: string | null } {
+  const firstName = (student.first_name || '').trim()
+  const lastName = (student.last_name || '').trim()
+  if (firstName || lastName) {
+    return {
+      firstName: firstName || null,
+      lastName: lastName || null,
+    }
+  }
+
+  return splitDisplayName(student.name)
 }
 
 function formatTorontoTime(iso: string | null): { value: string; isPm: boolean } {
@@ -136,8 +151,8 @@ export function TeacherQuizzesTab({
   const sortedGradingStudents = useMemo(
     () =>
       [...gradingStudents].sort((a, b) => {
-        const aNameParts = splitStudentName(a.name)
-        const bNameParts = splitStudentName(b.name)
+        const aNameParts = getSortableNameParts(a)
+        const bNameParts = getSortableNameParts(b)
         return compareByNameFields(
           {
             firstName: aNameParts.firstName,

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -327,8 +327,10 @@ describe('TeacherQuizzesTab', () => {
           students: [
             {
               student_id: 'student-1',
-              name: 'Amy Clark',
-              email: 'amy@example.com',
+              name: 'Zoe Marie Anderson',
+              first_name: 'Zoe Marie',
+              last_name: 'Anderson',
+              email: 'zoe-marie@example.com',
               status: 'submitted',
               submitted_at: '2026-02-25T15:06:00.000Z',
               last_activity_at: '2026-02-25T23:07:00.000Z',
@@ -341,7 +343,9 @@ describe('TeacherQuizzesTab', () => {
             },
             {
               student_id: 'student-2',
-              name: 'Zoe Adams',
+              name: 'Zoe Zimmer',
+              first_name: 'Zoe',
+              last_name: 'Zimmer',
               email: 'zoe@example.com',
               status: 'submitted',
               submitted_at: '2026-02-25T15:06:00.000Z',
@@ -355,8 +359,10 @@ describe('TeacherQuizzesTab', () => {
             },
             {
               student_id: 'student-3',
-              name: 'Ben Brown',
-              email: 'ben@example.com',
+              name: 'Amy Brown',
+              first_name: 'Amy',
+              last_name: 'Brown',
+              email: 'amy@example.com',
               status: 'submitted',
               submitted_at: '2026-02-25T15:06:00.000Z',
               last_activity_at: '2026-02-25T23:07:00.000Z',
@@ -375,14 +381,14 @@ describe('TeacherQuizzesTab', () => {
     await screen.findByText('Sort Names Test')
     fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
-    await screen.findByText('Amy Clark')
-    expect(studentCheckboxOrder()).toEqual(['Zoe Adams', 'Ben Brown', 'Amy Clark'])
+    await screen.findByText('Zoe Marie Anderson')
+    expect(studentCheckboxOrder()).toEqual(['Zoe Marie Anderson', 'Amy Brown', 'Zoe Zimmer'])
 
     fireEvent.click(screen.getByRole('button', { name: 'Sort students by first name' }))
-    expect(studentCheckboxOrder()).toEqual(['Amy Clark', 'Ben Brown', 'Zoe Adams'])
+    expect(studentCheckboxOrder()).toEqual(['Amy Brown', 'Zoe Zimmer', 'Zoe Marie Anderson'])
 
     fireEvent.click(screen.getByRole('button', { name: 'Sort students by last name' }))
-    expect(studentCheckboxOrder()).toEqual(['Zoe Adams', 'Ben Brown', 'Amy Clark'])
+    expect(studentCheckboxOrder()).toEqual(['Zoe Marie Anderson', 'Amy Brown', 'Zoe Zimmer'])
   })
 
   it('prompts to close active test before return and sends close_test=true', async () => {


### PR DESCRIPTION
## Summary
- make the Tests > Grading student table sortable via the Student header toggle
- toggle sorting between ascending by last name and ascending by first name
- remove `.asc` from the header indicator (now `Last` / `First`)
- add component test coverage for the toggle ordering behavior

## Validation
- pnpm exec vitest run tests/components/TeacherQuizzesTab.test.tsx
- pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx
- visual verification screenshots taken for teacher/student views and teacher grading table header