### PR TITLE
Add assignment artifacts column with icon pills and previews

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6235,3 +6235,59 @@
   - Student classrooms view: `/tmp/pika-student-view.png`
   - Student exam mode (split view): `/tmp/pika-student-exam-mode.png`
   - Student exam mode (doc open): `/tmp/pika-student-exam-doc-open.png`
+
+## 2026-03-11 [AI - GPT-5 Codex]
+**Goal:** Replace teacher assignment instructions pane with in-table work artifacts (links/images) for each student submission.
+**Completed:**
+- Added artifact extraction utility in `src/lib/assignment-artifacts.ts`:
+  - Extracts `http/https` URLs from Tiptap link marks and plain text.
+  - Extracts image URLs from Tiptap image nodes.
+  - Classifies artifacts as `link` or `image` (including `submission-images` and image extensions).
+  - Excludes non-HTTP protocols (e.g., `mailto:`).
+- Updated `GET /api/teacher/assignments/[id]` (`src/app/api/teacher/assignments/[id]/route.ts`) to return per-student `artifacts` array and trim `doc` payload to grading/status fields used by the table.
+- Added new `AssignmentArtifactsCell` UI component (`src/components/AssignmentArtifactsCell.tsx`):
+  - Pill-based artifact display in the `Work` column.
+  - Desktop: up to 4 pills + `+N` overflow pill.
+  - Compact mode: summary pill (`N items`).
+  - Hover tooltip preview (image thumbnail or link summary).
+  - Click opens preview modal with link/image details and next/prev navigation.
+- Updated teacher assignments table (`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`):
+  - Added `Links / Images` column and artifact cell rendering.
+  - Adjusted empty-state colSpan.
+  - Kept right-sidebar toggle available only in summary mode.
+- Updated classroom shell behavior (`src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`):
+  - In teacher assignment mode with no selected student, auto-close the right pane.
+  - Removed assignment-instructions fallback from teacher assignment mode.
+- Updated assignments layout defaults (`src/lib/layout-config.ts`):
+  - `assignments-teacher-list` now defaults to right pane closed.
+
+**Validation:**
+- `pnpm test -- tests/lib/assignment-artifacts.test.ts` (full suite ran; pass)
+- `pnpm test -- tests/unit/layout-config.test.ts` (full suite ran; pass)
+- `pnpm exec vitest run tests/components/AssignmentArtifactsCell.test.tsx` (pass)
+- `pnpm lint` (pass)
+- Visual verification screenshots:
+  - Teacher assignment selected (new `Links / Images` column visible): `/tmp/pika-teacher-assignment-work.png`
+  - Teacher assignments summary (right pane not forced open): `/tmp/pika-teacher-assignments-summary.png`
+  - Student assignments view (regression check): `/tmp/pika-student-assignments.png`
+
+## 2026-03-11 [AI - GPT-5 Codex]
+**Goal:** Refine assignment artifacts table UX: icon-only type pills, move `Links / Images` to last column, and allow wrapped multi-row pills.
+**Completed:**
+- Updated `src/components/AssignmentArtifactsCell.tsx`:
+  - Pills now use link/image icons for type (no textual type prefix in visible pill text).
+  - Non-compact mode now renders all artifact pills (no `+N` overflow pill cap).
+  - Tuned pill/container sizing to encourage 2–3 pills per row and wrap extras to additional rows.
+- Updated `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`:
+  - Moved `Links / Images` to the last column in the assignment student table.
+  - Increased width allocation (`w-[38%] min-w-[24rem]`) for `Links / Images`.
+  - Tightened widths on first/last name columns to preserve horizontal space for artifacts.
+- Updated `tests/components/AssignmentArtifactsCell.test.tsx`:
+  - Replaced overflow-indicator expectation with assertion that one preview pill renders per artifact in non-compact mode.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/AssignmentArtifactsCell.test.tsx` (pass)
+- `pnpm lint` (pass)
+- Visual verification screenshots:
+  - Teacher assignments table with new final-column artifacts layout + wrapped icon pills: `/tmp/pika-teacher-links-images-column-layout.png`
+  - Student regression check: `/tmp/pika-student-3011-classrooms.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6291,3 +6291,15 @@
 - Visual verification screenshots:
   - Teacher assignments table with new final-column artifacts layout + wrapped icon pills: `/tmp/pika-teacher-links-images-column-layout.png`
   - Student regression check: `/tmp/pika-student-3011-classrooms.png`
+
+## 2026-03-11 [AI - GPT-5 Codex]
+**Goal:** Close test coverage gap for teacher assignment detail API shape (`artifacts` + trimmed `doc`).
+**Completed:**
+- Updated `tests/api/teacher/assignments-id.test.ts`:
+  - Added GET route test verifying student rows include extracted `artifacts`.
+  - Added assertions that `doc` is trimmed to grading/submission fields only (no raw `content` or `is_submitted`).
+  - Added assertion that `student_updated_at` is sourced from latest `assignment_doc_history` timestamp.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments-id.test.ts tests/lib/assignment-artifacts.test.ts` (pass)
+- `pnpm lint` (pass)

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { calculateAssignmentStatus } from '@/lib/assignments'
+import { extractAssignmentArtifacts } from '@/lib/assignment-artifacts'
 import { extractPlainText } from '@/lib/tiptap-content'
 import type { TiptapContent } from '@/types'
 
@@ -118,6 +119,7 @@ export async function GET(
       // users is a single object due to the foreign key relationship
       const userEmail = (enrollment.users as unknown as { id: string; email: string }).email
       const profile = profileMap.get(enrollment.student_id) || null
+      const artifacts = doc ? extractAssignmentArtifacts(doc.content) : []
 
       return {
         student_id: enrollment.student_id,
@@ -127,7 +129,18 @@ export async function GET(
         student_name: profile?.full_name || null,
         status,
         student_updated_at: doc ? (studentUpdatedAtByDocId.get(doc.id) ?? null) : null,
-        doc: doc || null
+        doc: doc
+          ? {
+              submitted_at: doc.submitted_at,
+              updated_at: doc.updated_at,
+              score_completion: doc.score_completion,
+              score_thinking: doc.score_thinking,
+              score_workflow: doc.score_workflow,
+              graded_at: doc.graded_at,
+              returned_at: doc.returned_at,
+            }
+          : null,
+        artifacts,
       }
     })
 

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -679,6 +679,21 @@ function ClassroomPageContent({
   }, [isTeacher, activeTab, selectedStudent, setRightSidebarWidth])
 
   useEffect(() => {
+    if (!isTeacher || activeTab !== 'assignments') return
+    if (assignmentViewMode !== 'assignment') return
+    if (selectedStudent) return
+    setRightSidebarOpen(false)
+    closeMobileDrawer()
+  }, [
+    isTeacher,
+    activeTab,
+    assignmentViewMode,
+    selectedStudent,
+    setRightSidebarOpen,
+    closeMobileDrawer,
+  ])
+
+  useEffect(() => {
     if (activeTab === 'roster') {
       setRightSidebarOpen(false)
     }
@@ -1189,6 +1204,8 @@ function ClassroomPageContent({
               ? ''
               : isTeacher && activeTab === 'assignments' && selectedStudent
               ? selectedStudent.assignmentTitle
+              : isTeacher && activeTab === 'assignments'
+              ? ''
               : activeTab === 'assignments'
               ? (selectedAssignment?.title || 'Instructions')
               : activeTab === 'today'
@@ -1498,6 +1515,12 @@ function ClassroomPageContent({
               assignmentId={selectedStudent.assignmentId}
               studentId={selectedStudent.studentId}
             />
+          ) : isTeacher && activeTab === 'assignments' ? (
+            <div className="p-4">
+              <p className="text-sm text-text-muted">
+                Select a student to view work.
+              </p>
+            </div>
           ) : activeTab === 'assignments' ? (
             <div>
               {selectedAssignment ? (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -32,6 +32,7 @@ import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
+import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import {
   ACTIONBAR_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
@@ -68,6 +69,7 @@ import {
 import { applyDirection, compareByNameFields, toggleSort as toggleSortState } from '@/lib/table-sort'
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
 
 interface AssignmentWithStats extends Assignment {
   stats: AssignmentStats
@@ -82,6 +84,7 @@ interface StudentSubmissionRow {
   student_last_name: string | null
   status: AssignmentStatus
   student_updated_at?: string | null
+  artifacts: AssignmentArtifact[]
   doc: {
     submitted_at?: string | null
     updated_at?: string | null
@@ -204,7 +207,7 @@ export function TeacherClassroomView({
 }: Props) {
   const isReadOnly = !!classroom.archived_at
   const { setOpen: setSidebarOpen, width: sidebarWidth } = useRightSidebar()
-  const { openRight: openMobileSidebar } = useMobileDrawer()
+  const { openRight: openMobileSidebar, close: closeMobileSidebar } = useMobileDrawer()
   const { setExpanded: setLeftSidebarExpanded } = useLeftSidebar()
 
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([])
@@ -454,19 +457,15 @@ export function TeacherClassroomView({
     onViewModeChange?.(selection.mode)
   }, [selection.mode, onViewModeChange])
 
-  // Auto-open sidebar when assignment is selected (separate effect)
-  const prevSelectionModeRef = useRef<'summary' | 'assignment'>('summary')
+  // Keep inspector closed for assignment list view (work now lives in-table).
   useEffect(() => {
-    // Only open sidebar when transitioning from summary to assignment view
-    if (selection.mode === 'assignment' && prevSelectionModeRef.current === 'summary' && selectedAssignmentData) {
-      if (window.innerWidth < DESKTOP_BREAKPOINT) {
-        openMobileSidebar()
-      } else {
-        setSidebarOpen(true)
-      }
+    if (selection.mode !== 'assignment' || selectedStudentId) return
+    if (window.innerWidth < DESKTOP_BREAKPOINT) {
+      closeMobileSidebar()
+    } else {
+      setSidebarOpen(false)
     }
-    prevSelectionModeRef.current = selection.mode
-  }, [selection.mode, selectedAssignmentData, setSidebarOpen, openMobileSidebar])
+  }, [selection.mode, selectedStudentId, closeMobileSidebar, setSidebarOpen])
 
   function handleCreateSuccess(created: Assignment) {
     // Optimistically add the new assignment to the list
@@ -826,11 +825,9 @@ export function TeacherClassroomView({
       </div>
     )
 
-  // Show mobile toggle only when viewing an assignment (not a student)
-  // Summary mode: no toggle (mobile has no way to open panel)
-  // Assignment selected (no student): toggle visible (mobile can open instructions)
-  // Student selected: no toggle (panel auto-opens)
-  const showMobileToggle = selection.mode === 'assignment' && selectedStudentId === null
+  // Keep the panel toggle only in summary mode (markdown view).
+  // Assignment mode now shows work artifacts in-table instead of instructions.
+  const showMobileToggle = selection.mode === 'summary'
 
   return (
     <PageLayout>
@@ -944,12 +941,14 @@ export function TeacherClassroomView({
                       isActive={sortColumn === 'first'}
                       direction={sortDirection}
                       onClick={() => toggleSort('first')}
+                      className={isCompactTable ? 'w-[5.5rem]' : 'w-[8rem]'}
                     />
                     <SortableHeaderCell
                       label={isCompactTable ? 'L.' : 'Last Name'}
                       isActive={sortColumn === 'last'}
                       direction={sortDirection}
                       onClick={() => toggleSort('last')}
+                      className={isCompactTable ? 'w-[4.5rem]' : 'w-[8rem]'}
                     />
                     <SortableHeaderCell
                       label={isCompactTable ? '' : 'Status'}
@@ -960,6 +959,9 @@ export function TeacherClassroomView({
                     />
                     <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
                     {!isCompactTable && <DataTableHeaderCell className="w-[5.5rem]">Updated</DataTableHeaderCell>}
+                    <DataTableHeaderCell className={isCompactTable ? 'w-[6.5rem]' : 'w-[38%] min-w-[24rem]'}>
+                      {isCompactTable ? 'Work' : 'Links / Images'}
+                    </DataTableHeaderCell>
                   </DataTableRow>
                 </DataTableHead>
                 <DataTableBody>
@@ -988,14 +990,14 @@ export function TeacherClassroomView({
                           aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
                         />
                       </DataTableCell>
-                      <DataTableCell className={isCompactTable ? 'max-w-[80px] truncate' : 'max-w-[120px] truncate'}>
+                      <DataTableCell className={isCompactTable ? 'w-[5.5rem] max-w-[5.5rem] truncate' : 'w-[8rem] max-w-[8rem] truncate'}>
                         {student.student_first_name ? (
                           <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
                             <span>{student.student_first_name}</span>
                           </Tooltip>
                         ) : '—'}
                       </DataTableCell>
-                      <DataTableCell className={isCompactTable ? 'w-8' : 'max-w-[120px] truncate'}>
+                      <DataTableCell className={isCompactTable ? 'w-[4.5rem] max-w-[4.5rem] truncate' : 'w-[8rem] max-w-[8rem] truncate'}>
                         {student.student_last_name ? (
                           isCompactTable ? (
                             <Tooltip content={student.student_last_name}>
@@ -1030,11 +1032,17 @@ export function TeacherClassroomView({
                           ) : '—'}
                         </DataTableCell>
                       )}
+                      <DataTableCell className={isCompactTable ? 'w-[6.5rem]' : 'w-[38%] min-w-[24rem] align-top'}>
+                        <AssignmentArtifactsCell
+                          artifacts={student.artifacts || []}
+                          isCompact={isCompactTable}
+                        />
+                      </DataTableCell>
                     </DataTableRow>
                     )
                   })}
                   {sortedStudents.length === 0 && (
-                    <EmptyStateRow colSpan={isCompactTable ? 5 : 6} message="No students enrolled" />
+                    <EmptyStateRow colSpan={isCompactTable ? 6 : 7} message="No students enrolled" />
                   )}
                 </DataTableBody>
               </DataTable>

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { ExternalLink, Image as ImageIcon, Link2 } from 'lucide-react'
+import {
+  summarizeArtifactUrl,
+  type AssignmentArtifact,
+} from '@/lib/assignment-artifacts'
+import { ContentDialog, Tooltip } from '@/ui'
+
+interface AssignmentArtifactsCellProps {
+  artifacts: AssignmentArtifact[]
+  isCompact: boolean
+}
+
+function getArtifactLabel(artifact: AssignmentArtifact): string {
+  const prefix = artifact.type === 'image' ? 'Image' : 'Link'
+  return `${prefix} . ${summarizeArtifactUrl(artifact.url)}`
+}
+
+function getArtifactSummary(artifact: AssignmentArtifact): string {
+  return summarizeArtifactUrl(artifact.url)
+}
+
+function ArtifactTypeIcon({ artifact }: { artifact: AssignmentArtifact }) {
+  if (artifact.type === 'image') {
+    return <ImageIcon className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+  }
+  return <Link2 className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+}
+
+function getBackgroundImageStyle(url: string): { backgroundImage: string } {
+  return { backgroundImage: `url("${encodeURI(url)}")` }
+}
+
+function ArtifactTooltipContent({ artifact }: { artifact: AssignmentArtifact }) {
+  const label = getArtifactLabel(artifact)
+
+  if (artifact.type === 'image') {
+    return (
+      <div className="w-44">
+        <div className="mb-1 rounded border border-border bg-surface p-1">
+          <div
+            className="h-24 w-full rounded bg-surface-2 bg-contain bg-center bg-no-repeat"
+            style={getBackgroundImageStyle(artifact.url)}
+          />
+        </div>
+        <div className="truncate text-[11px] text-text-default">{label}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-56">
+      <div className="truncate text-[11px] font-medium text-text-default">{label}</div>
+      <div className="truncate text-[11px] text-text-muted">{artifact.url}</div>
+    </div>
+  )
+}
+
+export function AssignmentArtifactsCell({
+  artifacts,
+  isCompact,
+}: AssignmentArtifactsCellProps) {
+  const [modalIndex, setModalIndex] = useState<number | null>(null)
+  const selectedArtifact = modalIndex !== null ? artifacts[modalIndex] : null
+
+  const visibleArtifacts = useMemo(() => (isCompact ? [] : artifacts), [artifacts, isCompact])
+
+  if (artifacts.length === 0) {
+    return <span className="text-text-muted">-</span>
+  }
+
+  return (
+    <>
+      {isCompact ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            setModalIndex(0)
+          }}
+          className="inline-flex max-w-[7.5rem] items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
+          aria-label={`View ${artifacts.length} work item${artifacts.length === 1 ? '' : 's'}`}
+        >
+          {artifacts.length} items
+        </button>
+      ) : (
+        <div className="flex w-full max-w-[32rem] flex-wrap gap-1">
+          {visibleArtifacts.map((artifact, index) => (
+            <Tooltip key={`${artifact.url}:${index}`} content={<ArtifactTooltipContent artifact={artifact} />} side="top" align="start">
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setModalIndex(index)
+                }}
+                className="inline-flex w-full max-w-[10rem] items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
+                aria-label={`Preview ${getArtifactLabel(artifact)}`}
+              >
+                <ArtifactTypeIcon artifact={artifact} />
+                <span className="ml-1 truncate">{getArtifactSummary(artifact)}</span>
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+      )}
+
+      <ContentDialog
+        isOpen={selectedArtifact !== null}
+        onClose={() => setModalIndex(null)}
+        title={selectedArtifact?.type === 'image' ? 'Image Preview' : 'Link Preview'}
+        subtitle={
+          modalIndex !== null
+            ? `${modalIndex + 1} of ${artifacts.length}`
+            : undefined
+        }
+        maxWidth="max-w-3xl"
+      >
+        {selectedArtifact && (
+          <div className="space-y-3">
+            {artifacts.length > 1 && modalIndex !== null && (
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setModalIndex((current) => (current !== null && current > 0 ? current - 1 : current))}
+                  disabled={modalIndex === 0}
+                  className="rounded border border-border px-2 py-1 text-xs text-text-default disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setModalIndex((current) =>
+                      current !== null && current < artifacts.length - 1 ? current + 1 : current
+                    )
+                  }
+                  disabled={modalIndex >= artifacts.length - 1}
+                  className="rounded border border-border px-2 py-1 text-xs text-text-default disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+
+            {selectedArtifact.type === 'image' ? (
+              <div className="rounded border border-border bg-surface p-2">
+                <div
+                  className="h-[60vh] w-full rounded bg-surface-2 bg-contain bg-center bg-no-repeat"
+                  style={getBackgroundImageStyle(selectedArtifact.url)}
+                />
+              </div>
+            ) : (
+              <div className="rounded border border-border bg-surface p-3">
+                <p className="text-sm text-text-default break-all">{selectedArtifact.url}</p>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs text-text-muted truncate">
+                {getArtifactLabel(selectedArtifact)}
+              </p>
+              <a
+                href={selectedArtifact.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-text-default hover:bg-surface-hover"
+              >
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                Open
+              </a>
+            </div>
+          </div>
+        )}
+      </ContentDialog>
+    </>
+  )
+}

--- a/src/lib/assignment-artifacts.ts
+++ b/src/lib/assignment-artifacts.ts
@@ -1,0 +1,175 @@
+import type { TiptapContent, TiptapMark, TiptapNode } from '@/types'
+
+export type AssignmentArtifactType = 'image' | 'link'
+
+export interface AssignmentArtifact {
+  type: AssignmentArtifactType
+  url: string
+}
+
+const HTTP_PROTOCOLS = new Set(['http:', 'https:'])
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.bmp',
+  '.tiff',
+  '.avif',
+  '.heic',
+  '.heif',
+])
+const URL_REGEX = /https?:\/\/[^\s<>"'`]+/gi
+
+function toHttpUrl(value: string): string | null {
+  const trimmed = String(value ?? '').trim()
+  if (!trimmed) return null
+
+  try {
+    const parsed = new URL(trimmed)
+    if (!HTTP_PROTOCOLS.has(parsed.protocol)) return null
+    return parsed.href
+  } catch {
+    return null
+  }
+}
+
+function stripTrailingPunctuation(raw: string): string {
+  let url = raw
+  while (/[),.;:!?]$/.test(url)) {
+    if (url.endsWith(')')) {
+      const opening = (url.match(/\(/g) || []).length
+      const closing = (url.match(/\)/g) || []).length
+      if (closing <= opening) break
+    }
+    url = url.slice(0, -1)
+  }
+  return url
+}
+
+function extractUrlsFromText(text: string): string[] {
+  if (!text) return []
+
+  const matches = text.match(URL_REGEX) || []
+  const urls: string[] = []
+  for (const candidate of matches) {
+    const normalized = toHttpUrl(stripTrailingPunctuation(candidate))
+    if (normalized) {
+      urls.push(normalized)
+    }
+  }
+  return urls
+}
+
+function getLinkMarkHref(mark: TiptapMark): string | null {
+  if (mark.type !== 'link') return null
+  const href = typeof mark.attrs?.href === 'string' ? mark.attrs.href : ''
+  return toHttpUrl(href)
+}
+
+function isLikelyImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    const pathname = parsed.pathname.toLowerCase()
+    for (const ext of IMAGE_EXTENSIONS) {
+      if (pathname.endsWith(ext)) return true
+    }
+    return pathname.includes('/submission-images/')
+  } catch {
+    return false
+  }
+}
+
+type ArtifactSource = 'image' | 'link'
+
+function walkNode(
+  node: TiptapNode,
+  pushUrl: (url: string, source: ArtifactSource) => void
+): void {
+  if (node.type === 'image') {
+    const src = typeof node.attrs?.src === 'string' ? node.attrs.src : ''
+    const normalized = toHttpUrl(src)
+    if (normalized) {
+      pushUrl(normalized, 'image')
+    }
+  }
+
+  if (node.type === 'text') {
+    const text = typeof node.text === 'string' ? node.text : ''
+    for (const url of extractUrlsFromText(text)) {
+      pushUrl(url, 'link')
+    }
+
+    for (const mark of node.marks || []) {
+      const href = getLinkMarkHref(mark)
+      if (href) {
+        pushUrl(href, 'link')
+      }
+    }
+  }
+
+  for (const child of node.content || []) {
+    walkNode(child, pushUrl)
+  }
+}
+
+function parseUnknownContent(content: unknown): TiptapContent | null {
+  if (!content) return null
+  if (typeof content === 'string') {
+    try {
+      const parsed = JSON.parse(content)
+      if (parsed && typeof parsed === 'object' && parsed.type === 'doc') {
+        return parsed as TiptapContent
+      }
+      return null
+    } catch {
+      return null
+    }
+  }
+  if (typeof content === 'object' && (content as TiptapContent).type === 'doc') {
+    return content as TiptapContent
+  }
+  return null
+}
+
+export function extractAssignmentArtifactsFromContent(
+  content: TiptapContent
+): AssignmentArtifact[] {
+  const byUrl = new Map<string, AssignmentArtifactType>()
+
+  const pushUrl = (url: string, source: ArtifactSource) => {
+    const nextType: AssignmentArtifactType =
+      source === 'image' || isLikelyImageUrl(url) ? 'image' : 'link'
+    const previous = byUrl.get(url)
+
+    // If the same URL appears as both link and image, keep image.
+    if (previous === 'image' || nextType === previous) return
+    byUrl.set(url, nextType)
+  }
+
+  for (const node of content.content || []) {
+    walkNode(node, pushUrl)
+  }
+
+  return Array.from(byUrl.entries()).map(([url, type]) => ({ type, url }))
+}
+
+export function extractAssignmentArtifacts(content: unknown): AssignmentArtifact[] {
+  const parsed = parseUnknownContent(content)
+  if (!parsed) return []
+  return extractAssignmentArtifactsFromContent(parsed)
+}
+
+export function summarizeArtifactUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const host = parsed.hostname.replace(/^www\./, '')
+    const pathParts = parsed.pathname.split('/').filter(Boolean).slice(0, 2)
+    return pathParts.length > 0 ? `${host}/${pathParts.join('/')}` : host
+  } catch {
+    return url
+  }
+}
+

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -113,7 +113,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   'assignments-teacher-list': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%', desktopAlwaysOpen: true },
+    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   'assignments-teacher-viewing': {

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -28,6 +28,160 @@ describe('GET /api/teacher/assignments/[id]', () => {
     const response = await GET(request, { params: { id: 'a-999' } })
     expect(response.status).toBe(404)
   })
+
+  it('returns artifacts and trimmed doc fields for each student row', async () => {
+    const historyCreatedAt = '2026-03-10T10:00:00.000Z'
+    const submittedAt = '2026-03-10T09:00:00.000Z'
+    const updatedAt = '2026-03-10T09:30:00.000Z'
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'a-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Assignment 1',
+                  description: 'Desc',
+                  rich_instructions: null,
+                  due_at: '2099-03-10T23:59:00.000Z',
+                  position: 0,
+                  is_draft: false,
+                  released_at: null,
+                  track_authenticity: true,
+                  created_by: 'teacher-1',
+                  created_at: '2026-03-01T00:00:00.000Z',
+                  updated_at: '2026-03-02T00:00:00.000Z',
+                  classrooms: {
+                    id: 'classroom-1',
+                    teacher_id: 'teacher-1',
+                    title: 'Test Classroom',
+                    archived_at: null,
+                  },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  student_id: 'student-1',
+                  users: { id: 'student-1', email: 'student1@example.com' },
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  user_id: 'student-1',
+                  first_name: 'Alex',
+                  last_name: 'Lee',
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'doc-1',
+                  assignment_id: 'a-1',
+                  student_id: 'student-1',
+                  content: {
+                    type: 'doc',
+                    content: [
+                      {
+                        type: 'paragraph',
+                        content: [
+                          {
+                            type: 'text',
+                            text: 'Source https://example.com/resource',
+                            marks: [{ type: 'link', attrs: { href: 'mailto:nope@example.com' } }],
+                          },
+                        ],
+                      },
+                      {
+                        type: 'image',
+                        attrs: { src: 'https://cdn.example.com/submission-images/shot.png' },
+                      },
+                    ],
+                  },
+                  is_submitted: true,
+                  submitted_at: submittedAt,
+                  updated_at: updatedAt,
+                  score_completion: 9,
+                  score_thinking: 8,
+                  score_workflow: 7,
+                  graded_at: '2026-03-10T12:00:00.000Z',
+                  returned_at: null,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'assignment_doc_history') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ assignment_doc_id: 'doc-1', created_at: historyCreatedAt }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1')
+    const response = await GET(request, { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students).toHaveLength(1)
+    expect(data.students[0].student_updated_at).toBe(historyCreatedAt)
+    expect(data.students[0].artifacts).toEqual([
+      { type: 'link', url: 'https://example.com/resource' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/shot.png' },
+    ])
+    expect(data.students[0].doc).toEqual({
+      submitted_at: submittedAt,
+      updated_at: updatedAt,
+      score_completion: 9,
+      score_thinking: 8,
+      score_workflow: 7,
+      graded_at: '2026-03-10T12:00:00.000Z',
+      returned_at: null,
+    })
+    expect(data.students[0].doc).not.toHaveProperty('content')
+    expect(data.students[0].doc).not.toHaveProperty('is_submitted')
+  })
 })
 
 describe('PATCH /api/teacher/assignments/[id]', () => {

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, it } from 'vitest'
+import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
+import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
+import { TooltipProvider } from '@/ui'
+
+function renderWithTooltipProvider(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>)
+}
+
+describe('AssignmentArtifactsCell', () => {
+  it('renders dash when there are no artifacts', () => {
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={[]} isCompact={false} />)
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('renders one pill per artifact in non-compact mode', () => {
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/a' },
+      { type: 'link', url: 'https://example.com/b' },
+      { type: 'link', url: 'https://example.com/c' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
+      { type: 'link', url: 'https://example.com/d' },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact={false} />)
+    expect(screen.getAllByRole('button', { name: /preview/i })).toHaveLength(5)
+  })
+
+  it('renders compact summary in compact mode', () => {
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/a' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
+    expect(screen.getByRole('button', { name: /view 2 work items/i })).toHaveTextContent('2 items')
+  })
+
+  it('opens a link preview modal when a pill is clicked', () => {
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/docs' },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact={false} />)
+    fireEvent.click(screen.getByRole('button', { name: /preview link/i }))
+    expect(screen.getByText('Link Preview')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute('href', 'https://example.com/docs')
+  })
+})

--- a/tests/lib/assignment-artifacts.test.ts
+++ b/tests/lib/assignment-artifacts.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractAssignmentArtifacts,
+  summarizeArtifactUrl,
+} from '@/lib/assignment-artifacts'
+import type { TiptapContent } from '@/types'
+
+describe('extractAssignmentArtifacts', () => {
+  it('extracts links from link marks and plain text URLs', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Visit https://example.com/docs and also click here',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'https://github.com/codepetca/pika' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      { type: 'link', url: 'https://example.com/docs' },
+      { type: 'link', url: 'https://github.com/codepetca/pika' },
+    ])
+  })
+
+  it('extracts image artifacts and deduplicates repeated URLs', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'https://cdn.example.com/submission-images/shot.png',
+          },
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'https://cdn.example.com/submission-images/shot.png',
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      {
+        type: 'image',
+        url: 'https://cdn.example.com/submission-images/shot.png',
+      },
+    ])
+  })
+
+  it('ignores mailto and non-http urls', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Valid https://example.com bad ftp://example.com',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'mailto:teacher@example.com' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      { type: 'link', url: 'https://example.com/' },
+    ])
+  })
+
+  it('accepts legacy stringified JSON content', () => {
+    const content = JSON.stringify({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'https://example.com/a' }],
+        },
+      ],
+    })
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      { type: 'link', url: 'https://example.com/a' },
+    ])
+  })
+})
+
+describe('summarizeArtifactUrl', () => {
+  it('returns host plus short path summary', () => {
+    expect(
+      summarizeArtifactUrl('https://www.github.com/codepetca/pika/issues/1')
+    ).toBe('github.com/codepetca/pika')
+  })
+})
+

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -46,10 +46,10 @@ describe('getLayoutConfig', () => {
     expect(config.rightSidebar.desktopAlwaysOpen).toBe(true)
   })
 
-  it('should return desktopAlwaysOpen for teacher assignment routes', () => {
+  it('should only force desktopAlwaysOpen while viewing teacher work', () => {
     const listConfig = getLayoutConfig('assignments-teacher-list')
     const viewingConfig = getLayoutConfig('assignments-teacher-viewing')
-    expect(listConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
+    expect(listConfig.rightSidebar.desktopAlwaysOpen).toBeUndefined()
     expect(viewingConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add artifact extraction utility to parse http/https links and screenshots from assignment docs
- include `artifacts` in teacher assignment students API payload
- replace assignment right-pane instructions flow with in-table student artifacts in a new `Links / Images` column
- add `AssignmentArtifactsCell` with icon pills, hover previews, and preview modal navigation
- move `Links / Images` to the last table column, allocate max width, and wrap pills across rows (2-3 per row target)
- close teacher assignment right sidebar by default in list mode

## Tests
- `pnpm exec vitest run tests/lib/assignment-artifacts.test.ts tests/components/AssignmentArtifactsCell.test.tsx tests/unit/layout-config.test.ts tests/api/teacher/assignments-id.test.ts`
- `pnpm lint`

## Visual Verification
- Teacher assignment table layout verified locally: `/tmp/pika-teacher-links-images-column-layout.png`
- Student regression check verified locally: `/tmp/pika-student-3011-classrooms.png`