### PR TITLE
Fix exam-mode pane scrolling and markdown tab indentation

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6213,3 +6213,25 @@
   - Teacher classrooms: `/tmp/pika-teacher-classrooms-fix2.png`
   - Student classrooms: `/tmp/pika-student-classrooms-fix2.png`
   - Teacher tests grading view: `/tmp/pika-teacher-tests-grading-structured-names-fix-v2.png`
+## 2026-03-11 [AI - GPT-5 Codex]
+**Goal:** Fix student exam-mode split-pane scrolling and preserve tab indentation in rendered test question markdown.
+**Completed:**
+- Updated `src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`:
+  - In active exam mode (`showCurrentTestInfoPanel`), constrained split container to viewport height and prevented outer page scrolling (`lg:h-[calc(100dvh-7.5rem)]` + `lg:overflow-hidden`).
+  - Enabled independent right-pane scrolling via `lg:overflow-y-auto` on the right section.
+  - Enabled independent left-pane scrolling in the documents list panel via `overflow-y-auto` and applied `scrollbar-hover` so the scrollbar stays hidden until hover/focus interaction.
+- Updated `src/components/QuestionMarkdown.tsx`:
+  - Removed destructive top-level `.trim()` that stripped leading tab indentation from markdown input.
+  - Trimmed only blank boundary lines while preserving meaningful leading whitespace.
+  - Added `whitespace-pre-wrap` to paragraph/list/blockquote render paths so tabs and indentation display correctly in student question prompts.
+- Added/updated tests:
+  - `tests/components/QuestionMarkdown.test.tsx`: added tab-indented paragraph coverage.
+  - `tests/components/StudentQuizzesTab.test.tsx`: added assertions for exam-mode fixed-height/overflow split behavior and left-pane scroller class.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/QuestionMarkdown.test.tsx tests/components/StudentQuizzesTab.test.tsx` (pass)
+- Visual verification screenshots:
+  - Teacher classrooms view: `/tmp/pika-teacher-view.png`
+  - Student classrooms view: `/tmp/pika-student-view.png`
+  - Student exam mode (split view): `/tmp/pika-student-exam-mode.png`
+  - Student exam mode (doc open): `/tmp/pika-student-exam-doc-open.png`

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -769,10 +769,14 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   : showCurrentTestInfoPanel || isViewingResults
                     ? 'lg:grid-cols-[30%_70%]'
                     : 'lg:grid-cols-[50%_50%]'
-              } lg:min-h-[calc(100dvh-7.5rem)] lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
+              } ${
+                showCurrentTestInfoPanel
+                  ? 'lg:h-[calc(100dvh-7.5rem)] lg:min-h-[calc(100dvh-7.5rem)] lg:overflow-hidden'
+                  : 'lg:min-h-[calc(100dvh-7.5rem)]'
+              } lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
             >
               <section
-                className={`rounded-xl border border-border bg-surface lg:h-full ${
+                className={`rounded-xl border border-border bg-surface lg:h-full lg:min-h-0 ${
                   showCurrentTestInfoPanel ? 'relative overflow-hidden p-0' : 'p-3 sm:p-4'
                 }`}
               >
@@ -780,7 +784,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   <>
                     <div
                       aria-hidden={showDocPanel}
-                      className={`h-full p-3 sm:p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${
+                      className={`scrollbar-hover h-full overflow-y-auto p-3 sm:p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${
                         showDocPanel
                           ? 'pointer-events-none translate-x-2 opacity-0'
                           : 'translate-x-0 opacity-100'
@@ -910,6 +914,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
 
               <section
                 className={`rounded-xl border border-border bg-surface p-3 sm:p-4 lg:h-full ${
+                  showCurrentTestInfoPanel ? 'lg:min-h-0 lg:overflow-y-auto' : ''
+                } ${
                   showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
                 }`}
               >

--- a/src/components/QuestionMarkdown.tsx
+++ b/src/components/QuestionMarkdown.tsx
@@ -152,10 +152,15 @@ function isStartOfBlock(line: string): boolean {
 }
 
 function parseBlocks(rawContent: string): MarkdownBlock[] {
-  const normalized = String(rawContent ?? '').replace(/\r\n?/g, '\n').trim()
-  if (!normalized) return []
+  const normalized = String(rawContent ?? '').replace(/\r\n?/g, '\n')
+  if (!normalized.trim()) return []
 
-  const lines = normalized.split('\n')
+  const rawLines = normalized.split('\n')
+  let start = 0
+  let end = rawLines.length
+  while (start < end && rawLines[start].trim().length === 0) start += 1
+  while (end > start && rawLines[end - 1].trim().length === 0) end -= 1
+  const lines = rawLines.slice(start, end)
   const blocks: MarkdownBlock[] = []
   let index = 0
 
@@ -275,9 +280,11 @@ export function QuestionMarkdown({ content, className = '' }: QuestionMarkdownPr
 
         if (block.type === 'unordered-list') {
           return (
-            <ul key={key} className="list-disc space-y-1 pl-5 text-sm text-text-default">
+            <ul key={key} className="list-disc space-y-1 pl-5 text-sm text-text-default whitespace-pre-wrap">
               {block.items.map((item, itemIndex) => (
-                <li key={`${key}-item-${itemIndex}`}>{parseInline(item, `${key}-${itemIndex}`)}</li>
+                <li key={`${key}-item-${itemIndex}`} className="whitespace-pre-wrap">
+                  {parseInline(item, `${key}-${itemIndex}`)}
+                </li>
               ))}
             </ul>
           )
@@ -285,9 +292,11 @@ export function QuestionMarkdown({ content, className = '' }: QuestionMarkdownPr
 
         if (block.type === 'ordered-list') {
           return (
-            <ol key={key} className="list-decimal space-y-1 pl-5 text-sm text-text-default">
+            <ol key={key} className="list-decimal space-y-1 pl-5 text-sm text-text-default whitespace-pre-wrap">
               {block.items.map((item, itemIndex) => (
-                <li key={`${key}-item-${itemIndex}`}>{parseInline(item, `${key}-${itemIndex}`)}</li>
+                <li key={`${key}-item-${itemIndex}`} className="whitespace-pre-wrap">
+                  {parseInline(item, `${key}-${itemIndex}`)}
+                </li>
               ))}
             </ol>
           )
@@ -295,7 +304,7 @@ export function QuestionMarkdown({ content, className = '' }: QuestionMarkdownPr
 
         if (block.type === 'blockquote') {
           return (
-            <blockquote key={key} className="border-l-2 border-border pl-3 text-sm text-text-muted">
+            <blockquote key={key} className="border-l-2 border-border pl-3 text-sm text-text-muted whitespace-pre-wrap">
               {parseInlineWithLineBreaks(block.text, key)}
             </blockquote>
           )
@@ -313,7 +322,7 @@ export function QuestionMarkdown({ content, className = '' }: QuestionMarkdownPr
         }
 
         return (
-          <p key={key} className="text-sm text-text-default">
+          <p key={key} className="text-sm text-text-default whitespace-pre-wrap">
             {parseInlineWithLineBreaks(block.text, key)}
           </p>
         )

--- a/tests/components/QuestionMarkdown.test.tsx
+++ b/tests/components/QuestionMarkdown.test.tsx
@@ -38,4 +38,15 @@ describe('QuestionMarkdown', () => {
     render(<QuestionMarkdown content="   " />)
     expect(screen.getByText('—')).toBeInTheDocument()
   })
+
+  it('preserves tab-indented question text in paragraph rendering', () => {
+    const { container } = render(
+      <QuestionMarkdown content={`\tfor (let i = 0; i < 3; i++) {\n\t\tconsole.log(i)\n\t}`} />
+    )
+
+    const paragraph = container.querySelector('p')
+    expect(paragraph).toBeInTheDocument()
+    expect(paragraph).toHaveClass('whitespace-pre-wrap')
+    expect(paragraph?.textContent).toContain('\t\tconsole.log(i)')
+  })
 })

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -557,6 +557,16 @@ describe('StudentQuizzesTab exam mode', () => {
     const splitContainerExamMode = getSplitContainer(container)
     expect(splitContainerExamMode.className).toContain('lg:grid-cols-[30%_70%]')
     expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-[50%_50%]')
+    expect(splitContainerExamMode.className).toContain('lg:h-[calc(100dvh-7.5rem)]')
+    expect(splitContainerExamMode.className).toContain('lg:overflow-hidden')
+
+    const paneSections = splitContainerExamMode.querySelectorAll('section')
+    expect(paneSections[1]?.className || '').toContain('lg:overflow-y-auto')
+
+    const docsHeading = screen.getByRole('heading', { name: 'Documents' })
+    const leftPaneScroller = docsHeading.closest('.scrollbar-hover')
+    expect(leftPaneScroller).toBeInTheDocument()
+    expect(leftPaneScroller?.className || '').toContain('overflow-y-auto')
 
     fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
 


### PR DESCRIPTION
## Summary
- make student exam-mode split panes scroll independently by constraining the split container height and isolating left/right overflow
- hide left pane scrollbar until hover/focus interaction by applying existing `scrollbar-hover` behavior to the documents list pane
- preserve tab indentation in student-rendered question markdown by avoiding destructive global trim and rendering prose/list/blockquote blocks with whitespace preservation
- add coverage for new scroll container classes and tab-indented markdown rendering

## Validation
- `pnpm exec vitest run tests/components/QuestionMarkdown.test.tsx tests/components/StudentQuizzesTab.test.tsx`
- Visual screenshots captured:
  - teacher: `/tmp/pika-teacher-view.png`
  - student: `/tmp/pika-student-view.png`
  - student exam mode: `/tmp/pika-student-exam-mode.png`
  - student exam doc open: `/tmp/pika-student-exam-doc-open.png`
