### PR TITLE
Add repo review grading workflow

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -6948,3 +6948,29 @@
 **Validation:**
 - `pnpm exec eslint src/components/LessonCalendar.tsx` (pass)
 - Playwright screenshots re-verified the updated portrait modal in teacher and student classroom calendar views.
+
+## 2026-03-15 [AI - GPT-5 Codex]
+**Goal:** Implement repo review grading v1 for assignments, teacher workflow, and student returned feedback.
+**Completed:**
+- Added `repo_review` assignment support across the schema, shared types, teacher assignment APIs, repo review APIs, analytics helpers, and AI feedback generation.
+- Added teacher UI support for selecting repo review mode, configuring GitHub repo settings, viewing repo review assignment details, and applying draft repo-review grades into the existing grading flow.
+- Added student UI support for returned repo-review feedback cards while keeping unreturned repo-review assignments hidden.
+- Tightened repo-review validation so assignments cannot switch into repo-review mode without a GitHub repo, and ensured draft-apply creates safe empty assignment docs only for students who do not already have one.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-repo-review-apply.test.ts tests/api/teacher/assignments-repo-review-config.test.ts tests/unit/repo-review.test.ts` (pass)
+- `pnpm exec tsc --noEmit` (pass)
+- `pnpm exec supabase db push --local --yes` to apply `048_repo_review_grading.sql` to the local dev database
+- Playwright screenshots re-verified the repo-review teacher assignment detail view and the student returned-feedback view after creating and returning a local verification assignment.
+
+## 2026-03-16 [AI - GPT-5 Codex]
+**Goal:** Fix repo review follow-up issues found in review before PR.
+**Completed:**
+- Added a `loadLatestCompletedRepoReviewRun` path and updated repo-review apply/detail APIs to keep using the last completed analysis even if the most recent run failed.
+- Fixed repo-review sidebar next-student navigation to use the active student row set instead of the document-assignment row list.
+- Wired the ambiguous-change AI classifier into `analyzeRepoReviewAssignment` so heuristic ambiguities can now be overridden before weighting/scoring.
+- Added focused tests for completed-run fallback behavior and ambiguous classification overrides.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments-repo-review-apply.test.ts tests/api/teacher/assignments-repo-review-route.test.ts tests/unit/repo-review-analysis.test.ts` (pass)
+- `pnpm exec tsc --noEmit` (pass)

--- a/src/app/api/student/assignments/route.ts
+++ b/src/app/api/student/assignments/route.ts
@@ -65,6 +65,9 @@ export async function GET(request: NextRequest) {
       .filter((assignment) => isAssignmentVisibleToStudents(assignment))
       .map(assignment => {
       const doc = docMap.get(assignment.id)
+      if (assignment.evaluation_mode === 'repo_review' && !doc?.returned_at) {
+        return null
+      }
       const status = calculateAssignmentStatus(assignment, doc)
 
       return {
@@ -73,6 +76,7 @@ export async function GET(request: NextRequest) {
         doc: doc ? sanitizeDocForStudent(doc) : null
       }
       })
+      .filter(Boolean)
 
     return NextResponse.json({ assignments: assignmentsWithStatus })
   } catch (error: any) {

--- a/src/app/api/teacher/assignments/[id]/repo-review/apply/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-review/apply/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler, apiErrors } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+import {
+  assertTeacherOwnsAssignment,
+  loadLatestCompletedRepoReviewRun,
+  loadLatestRepoReviewRun,
+  loadRepoReviewResults,
+} from '@/lib/server/repo-review'
+
+export const POST = withErrorHandler('ApplyTeacherAssignmentRepoReview', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const assignment = await assertTeacherOwnsAssignment(user.id, id)
+
+  if ((assignment.evaluation_mode ?? 'document') !== 'repo_review') {
+    throw apiErrors.badRequest('Assignment is not configured for repo review')
+  }
+
+  const [latestRun, latestCompletedRun] = await Promise.all([
+    loadLatestRepoReviewRun(id),
+    loadLatestCompletedRepoReviewRun(id),
+  ])
+
+  if (!latestCompletedRun) {
+    throw apiErrors.badRequest('A completed repo review run is required before applying results')
+  }
+
+  const results = await loadRepoReviewResults(latestCompletedRun.id)
+  const supabase = getServiceRoleClient()
+  const studentIds = results.map((result) => result.student_id)
+  const { data: existingDocs, error: docsError } = studentIds.length > 0
+    ? await supabase
+        .from('assignment_docs')
+        .select('student_id')
+        .eq('assignment_id', id)
+        .in('student_id', studentIds)
+    : { data: [] as Array<{ student_id: string }>, error: null }
+
+  if (docsError) {
+    throw apiErrors.conflict('Failed to load existing assignment docs')
+  }
+
+  const existingStudentIds = new Set((existingDocs || []).map((doc) => doc.student_id))
+  const rows = results
+    .filter((result) =>
+      result.draft_score_completion != null
+      && result.draft_score_thinking != null
+      && result.draft_score_workflow != null
+    )
+    .map((result) => {
+      const row: Record<string, unknown> = {
+        assignment_id: id,
+        student_id: result.student_id,
+        score_completion: result.draft_score_completion,
+        score_thinking: result.draft_score_thinking,
+        score_workflow: result.draft_score_workflow,
+        feedback: result.draft_feedback,
+        graded_at: null,
+        graded_by: null,
+      }
+
+      if (!existingStudentIds.has(result.student_id)) {
+        row.content = { type: 'doc', content: [] }
+        row.is_submitted = false
+      }
+
+      return row
+    })
+
+  if (rows.length === 0) {
+    throw apiErrors.badRequest('No provisional repo review scores are available to apply')
+  }
+
+  const { error } = await supabase
+    .from('assignment_docs')
+    .upsert(rows, { onConflict: 'assignment_id,student_id' })
+
+  if (error) {
+    throw apiErrors.conflict('Failed to apply provisional repo review grades')
+  }
+
+  return NextResponse.json({
+    applied_count: rows.length,
+    run_id: latestCompletedRun.id,
+    latest_run_id: latestRun?.id || null,
+  })
+})

--- a/src/app/api/teacher/assignments/[id]/repo-review/config/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-review/config/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler, apiErrors } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { assertTeacherOwnsAssignment, parseAndValidateRepoUrl } from '@/lib/server/repo-review'
+import { repoReviewConfigSchema } from '@/lib/validations/repo-review'
+
+export const PUT = withErrorHandler('UpdateTeacherAssignmentRepoReviewConfig', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const assignment = await assertTeacherOwnsAssignment(user.id, id)
+
+  if (assignment.classrooms.archived_at) {
+    throw apiErrors.badRequest('Classroom is archived')
+  }
+
+  const body = repoReviewConfigSchema.parse(await request.json())
+  const repo = parseAndValidateRepoUrl(body.repo_url)
+  const supabase = getServiceRoleClient()
+
+  const { error: assignmentError } = await supabase
+    .from('assignments')
+    .update({ evaluation_mode: 'repo_review' })
+    .eq('id', id)
+
+  if (assignmentError) {
+    throw apiErrors.conflict('Failed to update assignment mode')
+  }
+
+  const { data: config, error: configError } = await supabase
+    .from('assignment_repo_reviews')
+    .upsert({
+      assignment_id: id,
+      provider: 'github',
+      repo_owner: repo.owner,
+      repo_name: repo.name,
+      default_branch: body.default_branch,
+      review_start_at: body.review_start_at ?? null,
+      review_end_at: body.review_end_at ?? null,
+      include_pr_reviews: body.include_pr_reviews,
+      config_json: {
+        metrics_version: 'v1',
+        prompt_version: 'v1',
+      },
+    }, { onConflict: 'assignment_id' })
+    .select()
+    .single()
+
+  if (configError || !config) {
+    throw apiErrors.conflict('Failed to save repo review config')
+  }
+
+  const rowsToUpsert = body.student_mappings
+    .filter((mapping) => mapping.github_login || mapping.commit_emails.length > 0)
+    .map((mapping) => ({
+      user_id: mapping.student_id,
+      github_login: mapping.github_login?.trim() || null,
+      commit_emails: mapping.commit_emails,
+    }))
+
+  if (rowsToUpsert.length > 0) {
+    const { error: identityError } = await supabase
+      .from('user_github_identities')
+      .upsert(rowsToUpsert, { onConflict: 'user_id' })
+    if (identityError) {
+      throw apiErrors.conflict('Failed to save GitHub identities')
+    }
+  }
+
+  const rowsToDelete = body.student_mappings
+    .filter((mapping) => !mapping.github_login && mapping.commit_emails.length === 0)
+    .map((mapping) => mapping.student_id)
+
+  if (rowsToDelete.length > 0) {
+    await supabase
+      .from('user_github_identities')
+      .delete()
+      .in('user_id', rowsToDelete)
+  }
+
+  return NextResponse.json({ config })
+})

--- a/src/app/api/teacher/assignments/[id]/repo-review/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-review/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler, apiErrors } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { calculateAssignmentStatus } from '@/lib/assignments'
+import {
+  assertTeacherOwnsAssignment,
+  loadLatestCompletedRepoReviewRun,
+  loadLatestRepoReviewRun,
+  loadRepoReviewConfig,
+  loadRepoReviewResults,
+  loadRepoReviewRosterStudents,
+} from '@/lib/server/repo-review'
+import type { AssignmentRepoReviewResult, RepoReviewTimelinePoint } from '@/types'
+
+function aggregateTimeline(results: AssignmentRepoReviewResult[]): RepoReviewTimelinePoint[] {
+  const byDate = new Map<string, RepoReviewTimelinePoint>()
+  for (const result of results) {
+    for (const point of result.timeline_json || []) {
+      const existing = byDate.get(point.date) || { date: point.date, weighted_contribution: 0, commit_count: 0 }
+      existing.weighted_contribution += Number(point.weighted_contribution || 0)
+      existing.commit_count += Number(point.commit_count || 0)
+      byDate.set(point.date, existing)
+    }
+  }
+  return [...byDate.values()].sort((left, right) => left.date.localeCompare(right.date))
+}
+
+export const GET = withErrorHandler('GetTeacherAssignmentRepoReview', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const assignment = await assertTeacherOwnsAssignment(user.id, id)
+
+  if ((assignment.evaluation_mode ?? 'document') !== 'repo_review') {
+    throw apiErrors.badRequest('Assignment is not configured for repo review')
+  }
+
+  const [config, rosterStudents, latestRun, latestCompletedRun] = await Promise.all([
+    loadRepoReviewConfig(id),
+    loadRepoReviewRosterStudents(assignment.classroom_id),
+    loadLatestRepoReviewRun(id),
+    loadLatestCompletedRepoReviewRun(id),
+  ])
+
+  const resultsRun = latestCompletedRun || latestRun
+  const latestResults = resultsRun ? await loadRepoReviewResults(resultsRun.id) : []
+  const resultsByStudent = new Map(latestResults.map((result) => [result.student_id, result]))
+
+  const supabase = getServiceRoleClient()
+  const studentIds = rosterStudents.map((student) => student.student_id)
+  const { data: docs } = studentIds.length > 0
+    ? await supabase
+        .from('assignment_docs')
+        .select('student_id, submitted_at, updated_at, score_completion, score_thinking, score_workflow, graded_at, returned_at, is_submitted')
+        .eq('assignment_id', id)
+        .in('student_id', studentIds)
+    : { data: [] as Array<any> }
+
+  const docsByStudent = new Map((docs || []).map((doc) => [doc.student_id, doc]))
+  const teamTimeline = aggregateTimeline(latestResults)
+  const confidence = latestResults.length > 0
+    ? latestResults.reduce((sum, result) => sum + Number(result.confidence || 0), 0) / latestResults.length
+    : 0
+
+  return NextResponse.json({
+    assignment: {
+      ...assignment,
+      evaluation_mode: assignment.evaluation_mode ?? 'document',
+    },
+    classroom: assignment.classrooms,
+    config,
+    latest_run: latestRun,
+    latest_completed_run: latestCompletedRun,
+    summary: {
+      confidence,
+      team_timeline: teamTimeline,
+      contribution_total: latestResults.reduce((sum, result) => sum + Number(result.weighted_contribution || 0), 0),
+      warnings: latestRun?.warnings_json || latestCompletedRun?.warnings_json || [],
+    },
+    students: rosterStudents.map((student) => {
+      const doc = docsByStudent.get(student.student_id) || null
+      const result = resultsByStudent.get(student.student_id) || null
+      return {
+        student_id: student.student_id,
+        student_email: student.student_email,
+        student_name: student.student_name,
+        github_login: student.github_identity?.github_login || null,
+        commit_emails: student.github_identity?.commit_emails || [],
+        status: calculateAssignmentStatus(assignment, doc),
+        doc,
+        result,
+      }
+    }),
+  })
+})

--- a/src/app/api/teacher/assignments/[id]/repo-review/run/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-review/run/route.ts
@@ -1,0 +1,182 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler, apiErrors } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { analyzeRepoReviewAssignment, buildRepoReviewWindow, formatRepoReviewRepoName } from '@/lib/repo-review'
+import { gradeRepoReviewFeedback } from '@/lib/repo-review-ai'
+import {
+  assertTeacherOwnsAssignment,
+  loadRepoReviewConfig,
+  loadRepoReviewRosterStudents,
+} from '@/lib/server/repo-review'
+
+export const POST = withErrorHandler('RunTeacherAssignmentRepoReview', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const assignment = await assertTeacherOwnsAssignment(user.id, id)
+
+  if ((assignment.evaluation_mode ?? 'document') !== 'repo_review') {
+    throw apiErrors.badRequest('Assignment is not configured for repo review')
+  }
+
+  const [config, rosterStudents] = await Promise.all([
+    loadRepoReviewConfig(id),
+    loadRepoReviewRosterStudents(assignment.classroom_id),
+  ])
+
+  if (!config) {
+    throw apiErrors.badRequest('Repo review config is missing')
+  }
+
+  const identities = rosterStudents.map((student) => ({
+    studentId: student.student_id,
+    email: student.student_email,
+    name: student.student_name,
+    githubLogin: student.github_identity?.github_login || null,
+    commitEmails: student.github_identity?.commit_emails?.length
+      ? student.github_identity.commit_emails
+      : [student.student_email],
+  }))
+
+  const supabase = getServiceRoleClient()
+  const { data: run, error: runError } = await supabase
+    .from('assignment_repo_review_runs')
+    .insert({
+      assignment_id: id,
+      status: 'running',
+      triggered_by: user.id,
+      started_at: new Date().toISOString(),
+      source_ref: config.default_branch,
+      metrics_version: 'v1',
+      prompt_version: 'v1',
+      warnings_json: [],
+    })
+    .select()
+    .single()
+
+  if (runError || !run) {
+    throw apiErrors.conflict('Failed to start repo review run')
+  }
+
+  const reviewWindow = buildRepoReviewWindow({
+    dueAt: assignment.due_at,
+    releasedAt: assignment.released_at,
+    reviewStartAt: config.review_start_at,
+    reviewEndAt: config.review_end_at,
+  })
+
+  try {
+    const analysis = await analyzeRepoReviewAssignment({
+      config,
+      identities,
+      reviewWindow,
+    })
+
+    const runWarnings = [...analysis.warnings]
+    for (const identity of identities) {
+      if (!identity.githubLogin && identity.commitEmails.length === 0) {
+        runWarnings.push({
+          code: 'missing-identity',
+          message: `No GitHub mapping is set for ${identity.name || identity.email}.`,
+          student_id: identity.studentId,
+        })
+      }
+    }
+
+    const repoName = formatRepoReviewRepoName(config)
+    const results = await Promise.all(
+      analysis.students.map(async (student) => {
+        const rosterStudent = rosterStudents.find((item) => item.student_id === student.studentId)
+        const feedback = await gradeRepoReviewFeedback({
+          assignmentTitle: assignment.title,
+          repoName,
+          studentName: rosterStudent?.student_name || rosterStudent?.student_email || 'Student',
+          githubLogin: student.githubLogin,
+          commitCount: student.commitCount,
+          activeDays: student.activeDays,
+          sessionCount: student.sessionCount,
+          burstRatio: student.burstRatio,
+          weightedContribution: student.weightedContribution,
+          relativeContributionShare: student.relativeContributionShare,
+          spreadScore: student.spreadScore,
+          iterationScore: student.iterationScore,
+          reviewActivityCount: student.reviewActivityCount,
+          areas: student.areas,
+          semanticBreakdown: student.semanticBreakdown,
+          evidence: student.evidence,
+          warnings: runWarnings
+            .filter((warning) => !warning.student_id || warning.student_id === student.studentId)
+            .map((warning) => warning.message),
+          confidence: analysis.confidence,
+        })
+
+        return {
+          run_id: run.id,
+          assignment_id: id,
+          student_id: student.studentId,
+          github_login: student.githubLogin,
+          commit_count: student.commitCount,
+          active_days: student.activeDays,
+          session_count: student.sessionCount,
+          burst_ratio: student.burstRatio,
+          weighted_contribution: student.weightedContribution,
+          relative_contribution_share: student.relativeContributionShare,
+          spread_score: student.spreadScore,
+          iteration_score: student.iterationScore,
+          semantic_breakdown_json: student.semanticBreakdown,
+          timeline_json: student.timeline,
+          evidence_json: student.evidence,
+          draft_score_completion: feedback.score_completion,
+          draft_score_thinking: feedback.score_thinking,
+          draft_score_workflow: feedback.score_workflow,
+          draft_feedback: feedback.feedback,
+          confidence: Math.min(1, Math.max(0, (feedback.confidence + analysis.confidence) / 2)),
+        }
+      })
+    )
+
+    const { error: resultsError } = await supabase
+      .from('assignment_repo_review_results')
+      .insert(results)
+
+    if (resultsError) {
+      throw apiErrors.conflict('Failed to save repo review results')
+    }
+
+    const { data: completedRun, error: completeError } = await supabase
+      .from('assignment_repo_review_runs')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        source_ref: analysis.sourceRef || config.default_branch,
+        model: 'repo-review-v1',
+        warnings_json: runWarnings,
+      })
+      .eq('id', run.id)
+      .select()
+      .single()
+
+    if (completeError || !completedRun) {
+      throw apiErrors.conflict('Failed to finalize repo review run')
+    }
+
+    return NextResponse.json({
+      run: completedRun,
+      review_window: reviewWindow,
+      analyzed_students: results.length,
+    })
+  } catch (error) {
+    await supabase
+      .from('assignment_repo_review_runs')
+      .update({
+        status: 'failed',
+        completed_at: new Date().toISOString(),
+        warnings_json: [
+          { code: 'run-failed', message: error instanceof Error ? error.message : 'Repo review run failed' },
+        ],
+      })
+      .eq('id', run.id)
+
+    throw error
+  }
+})

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -3,8 +3,9 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { calculateAssignmentStatus } from '@/lib/assignments'
 import { extractAssignmentArtifacts } from '@/lib/assignment-artifacts'
+import { parseAndValidateRepoUrl } from '@/lib/server/repo-review'
 import { extractPlainText } from '@/lib/tiptap-content'
-import type { TiptapContent } from '@/types'
+import type { AssignmentEvaluationMode, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -162,6 +163,7 @@ export async function GET(
         position: assignment.position ?? 0,
         is_draft: assignment.is_draft ?? false,
         released_at: assignment.released_at ?? null,
+        evaluation_mode: assignment.evaluation_mode ?? 'document',
         track_authenticity: assignment.track_authenticity ?? true,
         created_by: assignment.created_by,
         created_at: assignment.created_at,
@@ -199,12 +201,20 @@ export async function PATCH(
     const user = await requireRole('teacher')
     const { id } = await params
     const body = await request.json()
-    const { title, rich_instructions, due_at, is_draft, released_at } = body as {
+    const { title, rich_instructions, due_at, is_draft, released_at, evaluation_mode, repo_review } = body as {
       title?: string
       rich_instructions?: TiptapContent
       due_at?: string
       is_draft?: boolean
       released_at?: string | null
+      evaluation_mode?: AssignmentEvaluationMode
+      repo_review?: {
+        repo_url?: string
+        default_branch?: string
+        review_start_at?: string | null
+        review_end_at?: string | null
+        include_pr_reviews?: boolean
+      }
     }
 
     const supabase = getServiceRoleClient()
@@ -250,6 +260,30 @@ export async function PATCH(
       )
     }
 
+    if (evaluation_mode !== undefined && evaluation_mode !== 'document' && evaluation_mode !== 'repo_review') {
+      return NextResponse.json(
+        { error: 'evaluation_mode must be "document" or "repo_review"' },
+        { status: 400 }
+      )
+    }
+
+    const nextEvaluationMode = (evaluation_mode ?? existing.evaluation_mode ?? 'document') as AssignmentEvaluationMode
+    const repoUrl = typeof repo_review?.repo_url === 'string' ? repo_review.repo_url.trim() : ''
+
+    if (nextEvaluationMode === 'repo_review' && existing.evaluation_mode !== 'repo_review' && !repoUrl) {
+      return NextResponse.json(
+        { error: 'repo_review.repo_url is required when evaluation_mode is "repo_review"' },
+        { status: 400 }
+      )
+    }
+
+    if (repo_review && !repoUrl) {
+      return NextResponse.json(
+        { error: 'repo_review.repo_url must not be empty' },
+        { status: 400 }
+      )
+    }
+
     // Build update object
     const updates: Record<string, any> = {}
     if (title !== undefined) updates.title = title.trim()
@@ -259,6 +293,7 @@ export async function PATCH(
       updates.description = extractPlainText(instructions)  // Keep plain text in sync
     }
     if (due_at !== undefined) updates.due_at = due_at
+    if (evaluation_mode !== undefined) updates.evaluation_mode = evaluation_mode
 
     const now = new Date()
     const existingReleaseDate = existing.released_at ? new Date(existing.released_at) : null
@@ -334,6 +369,39 @@ export async function PATCH(
         { error: 'Failed to update assignment' },
         { status: 500 }
       )
+    }
+
+    if (nextEvaluationMode === 'repo_review' && repo_review?.repo_url) {
+      const parsedRepo = parseAndValidateRepoUrl(String(repo_review.repo_url))
+      const { error: configError } = await supabase
+        .from('assignment_repo_reviews')
+        .upsert({
+          assignment_id: id,
+          provider: 'github',
+          repo_owner: parsedRepo.owner,
+          repo_name: parsedRepo.name,
+          default_branch: String(repo_review.default_branch || 'main').trim() || 'main',
+          review_start_at: repo_review.review_start_at ?? null,
+          review_end_at: repo_review.review_end_at ?? null,
+          include_pr_reviews: repo_review.include_pr_reviews !== false,
+          config_json: {
+            metrics_version: 'v1',
+            prompt_version: 'v1',
+          },
+        }, { onConflict: 'assignment_id' })
+
+      if (configError) {
+        console.error('Error updating repo review config:', configError)
+        return NextResponse.json(
+          { error: 'Failed to update repo review config' },
+          { status: 500 }
+        )
+      }
+    } else if (nextEvaluationMode === 'document') {
+      await supabase
+        .from('assignment_repo_reviews')
+        .delete()
+        .eq('assignment_id', id)
     }
 
     return NextResponse.json({ assignment })

--- a/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { calculateAssignmentStatus } from '@/lib/assignments'
+import {
+  loadLatestCompletedRepoReviewRun,
+  loadLatestRepoReviewRun,
+  loadRepoReviewResults,
+} from '@/lib/server/repo-review'
 import type { TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -105,6 +110,16 @@ export async function GET(
     }
 
     const status = calculateAssignmentStatus(assignment, doc)
+    const [latestRun, latestCompletedRun] = assignment.evaluation_mode === 'repo_review'
+      ? await Promise.all([
+          loadLatestRepoReviewRun(assignmentId),
+          loadLatestCompletedRepoReviewRun(assignmentId),
+        ])
+      : [null, null]
+    const resultsRun = latestCompletedRun || latestRun
+    const repoReviewResult = resultsRun
+      ? (await loadRepoReviewResults(resultsRun.id)).find((result) => result.student_id === studentId) || null
+      : null
 
     return NextResponse.json({
       assignment: {
@@ -112,6 +127,7 @@ export async function GET(
         classroom_id: assignment.classroom_id,
         title: assignment.title,
         description: assignment.description,
+        evaluation_mode: assignment.evaluation_mode ?? 'document',
         due_at: assignment.due_at,
         position: assignment.position ?? 0,
         created_by: assignment.created_by,
@@ -125,7 +141,14 @@ export async function GET(
         name: studentName
       },
       doc: doc || null,
-      status
+      status,
+      repo_review: assignment.evaluation_mode === 'repo_review'
+        ? {
+            latest_run: latestRun,
+            latest_completed_run: latestCompletedRun,
+            result: repoReviewResult,
+          }
+        : null,
     })
   } catch (error: any) {
     // Authentication error (401)

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { parseAndValidateRepoUrl } from '@/lib/server/repo-review'
 import { extractPlainText } from '@/lib/tiptap-content'
-import type { TiptapContent } from '@/types'
+import type { AssignmentEvaluationMode, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -118,7 +119,7 @@ export async function POST(request: NextRequest) {
   try {
     const user = await requireRole('teacher')
     const body = await request.json()
-    const { classroom_id, title, rich_instructions, due_at } = body
+    const { classroom_id, title, rich_instructions, due_at, evaluation_mode, repo_review } = body
 
     // Validate required fields
     if (!classroom_id) {
@@ -136,6 +137,23 @@ export async function POST(request: NextRequest) {
     if (!due_at) {
       return NextResponse.json(
         { error: 'Due date is required' },
+        { status: 400 }
+      )
+    }
+
+    if (evaluation_mode !== undefined && evaluation_mode !== 'document' && evaluation_mode !== 'repo_review') {
+      return NextResponse.json(
+        { error: 'evaluation_mode must be "document" or "repo_review"' },
+        { status: 400 }
+      )
+    }
+
+    const nextEvaluationMode: AssignmentEvaluationMode = evaluation_mode === 'repo_review' ? 'repo_review' : 'document'
+    const repoUrl = typeof repo_review?.repo_url === 'string' ? repo_review.repo_url.trim() : ''
+
+    if (nextEvaluationMode === 'repo_review' && !repoUrl) {
+      return NextResponse.json(
+        { error: 'repo_review.repo_url is required when evaluation_mode is "repo_review"' },
         { status: 400 }
       )
     }
@@ -169,6 +187,7 @@ export async function POST(request: NextRequest) {
       rich_instructions: instructions,
       description: extractPlainText(instructions),  // Keep plain text for backwards compatibility
       due_at,
+      evaluation_mode: nextEvaluationMode,
       created_by: user.id,
       track_authenticity: true,
     }
@@ -190,6 +209,34 @@ export async function POST(request: NextRequest) {
         { error: 'Failed to create assignment' },
         { status: 500 }
       )
+    }
+
+    if (assignment && nextEvaluationMode === 'repo_review' && repo_review?.repo_url) {
+      const parsedRepo = parseAndValidateRepoUrl(String(repo_review.repo_url))
+      const { error: configError } = await supabase
+        .from('assignment_repo_reviews')
+        .upsert({
+          assignment_id: assignment.id,
+          provider: 'github',
+          repo_owner: parsedRepo.owner,
+          repo_name: parsedRepo.name,
+          default_branch: String(repo_review.default_branch || 'main').trim() || 'main',
+          review_start_at: repo_review.review_start_at ?? null,
+          review_end_at: repo_review.review_end_at ?? null,
+          include_pr_reviews: repo_review.include_pr_reviews !== false,
+          config_json: {
+            metrics_version: 'v1',
+            prompt_version: 'v1',
+          },
+        }, { onConflict: 'assignment_id' })
+
+      if (configError) {
+        console.error('Error creating repo review config:', configError)
+        return NextResponse.json(
+          { error: 'Failed to create repo review config' },
+          { status: 500 }
+        )
+      }
     }
 
     return NextResponse.json({ assignment }, { status: 201 })

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -93,6 +93,7 @@ export function StudentAssignmentsTab({
     if (!selectedAssignment) return 'summary'
     return 'edit'
   }, [selectedAssignment, selectedAssignmentId])
+  const isRepoReviewAssignment = selectedAssignment?.evaluation_mode === 'repo_review'
 
   const navigate = useCallback(
     (next: { assignmentId?: string | null }) => {
@@ -186,7 +187,7 @@ export function StudentAssignmentsTab({
           )
         }
         trailing={
-          selectedAssignment ? (
+          selectedAssignment && !isRepoReviewAssignment ? (
             <Button
               size="sm"
               variant={editorState.isSubmitted ? 'secondary' : 'primary'}
@@ -241,6 +242,9 @@ export function StudentAssignmentsTab({
                               <p className="text-xs text-text-muted mt-1">
                                 {formatRelativeDueDate(assignment.due_at)}
                               </p>
+                              {assignment.evaluation_mode === 'repo_review' && (
+                                <p className="text-xs text-primary mt-1">Repo review</p>
+                              )}
                             </div>
                             <span
                               className={`px-2 py-1 rounded text-xs font-medium ${getAssignmentStatusBadgeClass(assignment.status)}`}
@@ -258,6 +262,39 @@ export function StudentAssignmentsTab({
               <div className="bg-surface rounded-lg shadow-sm">
                 <div className="p-6 text-sm text-text-muted">
                   That assignment is no longer available.
+                </div>
+              </div>
+            ) : isRepoReviewAssignment ? (
+              <div className="bg-surface rounded-lg shadow-sm">
+                <div className="space-y-4 p-6">
+                  <div>
+                    <h3 className="text-lg font-semibold text-text-default">{selectedAssignment.title}</h3>
+                    <p className="mt-1 text-sm text-text-muted">
+                      Repo review feedback is shared here after your teacher returns it.
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-lg border border-border bg-surface-2 p-3">
+                      <div className="text-xs text-text-muted">Completion</div>
+                      <div className="mt-1 text-lg font-semibold text-text-default">{selectedAssignment.doc?.score_completion ?? '—'}/10</div>
+                    </div>
+                    <div className="rounded-lg border border-border bg-surface-2 p-3">
+                      <div className="text-xs text-text-muted">Thinking</div>
+                      <div className="mt-1 text-lg font-semibold text-text-default">{selectedAssignment.doc?.score_thinking ?? '—'}/10</div>
+                    </div>
+                    <div className="rounded-lg border border-border bg-surface-2 p-3">
+                      <div className="text-xs text-text-muted">Workflow</div>
+                      <div className="mt-1 text-lg font-semibold text-text-default">{selectedAssignment.doc?.score_workflow ?? '—'}/10</div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-surface-2 p-4">
+                    <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Feedback</div>
+                    <div className="mt-2 whitespace-pre-wrap text-sm text-text-default">
+                      {selectedAssignment.doc?.feedback?.trim() || 'No feedback has been returned yet.'}
+                    </div>
+                  </div>
                 </div>
               </div>
             ) : (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -17,6 +17,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import {
+  BarChart3,
   Check,
   Circle,
   Clock,
@@ -25,7 +26,7 @@ import {
   RotateCcw,
   Send,
 } from 'lucide-react'
-import { ConfirmDialog, RefreshingIndicator, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, Input, RefreshingIndicator, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -49,7 +50,18 @@ import {
 } from '@/lib/assignments'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 import { isVisibleAtNow } from '@/lib/scheduling'
-import type { Classroom, Assignment, AssignmentStats, AssignmentStatus, ClassDay, TiptapContent, SelectedStudentInfo } from '@/types'
+import type {
+  AssignmentRepoReviewConfig,
+  AssignmentRepoReviewResult,
+  AssignmentRepoReviewRun,
+  Classroom,
+  Assignment,
+  AssignmentStats,
+  AssignmentStatus,
+  ClassDay,
+  TiptapContent,
+  SelectedStudentInfo,
+} from '@/types'
 import {
   DataTable,
   DataTableBody,
@@ -96,6 +108,40 @@ interface StudentSubmissionRow {
     graded_at?: string | null
     returned_at?: string | null
   } | null
+}
+
+interface RepoReviewStudentRow {
+  student_id: string
+  student_email: string
+  student_name: string | null
+  github_login: string | null
+  commit_emails: string[]
+  status: AssignmentStatus
+  doc: {
+    submitted_at?: string | null
+    updated_at?: string | null
+    score_completion?: number | null
+    score_thinking?: number | null
+    score_workflow?: number | null
+    graded_at?: string | null
+    returned_at?: string | null
+  } | null
+  result: AssignmentRepoReviewResult | null
+}
+
+interface SelectedRepoReviewData {
+  assignment: Assignment
+  classroom: { id: string; title: string; teacher_id: string; archived_at: string | null }
+  config: AssignmentRepoReviewConfig | null
+  latest_run: AssignmentRepoReviewRun | null
+  latest_completed_run: AssignmentRepoReviewRun | null
+  summary: {
+    confidence: number
+    team_timeline: Array<{ date: string; weighted_contribution: number; commit_count: number }>
+    contribution_total: number
+    warnings: Array<{ message: string }>
+  }
+  students: RepoReviewStudentRow[]
 }
 
 export type AssignmentViewMode = 'summary' | 'assignment'
@@ -157,6 +203,18 @@ function getRowClassName(isSelected: boolean): string {
 
 const STATUS_ICON_CLASS = 'h-4 w-4'
 const LATE_CLOCK_CLASS = 'h-3 w-3'
+
+function MetricBar({ value }: { value: number }) {
+  const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
+  return (
+    <div className="h-2 w-full rounded-full bg-surface-2">
+      <div
+        className="h-full rounded-full bg-primary transition-[width]"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  )
+}
 
 function StatusIcon({
   status,
@@ -251,8 +309,13 @@ export function TeacherClassroomView({
     assignment: Assignment
     students: StudentSubmissionRow[]
   } | null>(null)
+  const [selectedRepoReviewData, setSelectedRepoReviewData] = useState<SelectedRepoReviewData | null>(null)
   const [selectedAssignmentLoading, setSelectedAssignmentLoading] = useState(false)
   const [selectedAssignmentError, setSelectedAssignmentError] = useState<string>('')
+  const [repoReviewSaving, setRepoReviewSaving] = useState(false)
+  const [repoReviewRunning, setRepoReviewRunning] = useState(false)
+  const [repoReviewApplying, setRepoReviewApplying] = useState(false)
+  const [repoReviewMappings, setRepoReviewMappings] = useState<Record<string, { github_login: string; commit_emails: string }>>({})
 
   const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
     column: 'first' | 'last' | 'status'
@@ -425,36 +488,50 @@ export function TeacherClassroomView({
   useEffect(() => {
     if (selection.mode !== 'assignment') {
       setSelectedAssignmentData(null)
+      setSelectedRepoReviewData(null)
       setSelectedAssignmentError('')
       setSelectedAssignmentLoading(false)
       return
     }
 
     const assignmentId = selection.assignmentId
+    const assignmentMeta = assignments.find((item) => item.id === assignmentId)
 
     async function loadSelectedAssignment() {
       setSelectedAssignmentLoading(true)
       setSelectedAssignmentError('')
       try {
-        const response = await fetch(`/api/teacher/assignments/${assignmentId}`)
+        const response = await fetch(
+          assignmentMeta?.evaluation_mode === 'repo_review'
+            ? `/api/teacher/assignments/${assignmentId}/repo-review`
+            : `/api/teacher/assignments/${assignmentId}`
+        )
         const data = await response.json()
         if (!response.ok) {
           throw new Error(data.error || 'Failed to load assignment')
         }
-        setSelectedAssignmentData({
-          assignment: data.assignment,
-          students: (data.students || []) as StudentSubmissionRow[],
-        })
+
+        if (assignmentMeta?.evaluation_mode === 'repo_review') {
+          setSelectedRepoReviewData(data as SelectedRepoReviewData)
+          setSelectedAssignmentData(null)
+        } else {
+          setSelectedAssignmentData({
+            assignment: data.assignment,
+            students: (data.students || []) as StudentSubmissionRow[],
+          })
+          setSelectedRepoReviewData(null)
+        }
       } catch (err: any) {
         setSelectedAssignmentError(err.message || 'Failed to load assignment')
         setSelectedAssignmentData(null)
+        setSelectedRepoReviewData(null)
       } finally {
         setSelectedAssignmentLoading(false)
       }
     }
 
     loadSelectedAssignment()
-  }, [selection, refreshCounter])
+  }, [assignments, refreshCounter, selection])
 
   // Notify parent about selected assignment for sidebar
   useEffect(() => {
@@ -466,8 +543,29 @@ export function TeacherClassroomView({
         title: assignment.title,
         instructions: assignment.rich_instructions || assignment.description,
       })
+    } else if (selectedRepoReviewData) {
+      onSelectAssignment?.(null)
     }
-  }, [selection.mode, selectedAssignmentData, onSelectAssignment])
+  }, [selection.mode, selectedAssignmentData, selectedRepoReviewData, onSelectAssignment])
+
+  useEffect(() => {
+    if (!selectedRepoReviewData) {
+      setRepoReviewMappings({})
+      return
+    }
+
+    setRepoReviewMappings(
+      Object.fromEntries(
+        selectedRepoReviewData.students.map((student) => [
+          student.student_id,
+          {
+            github_login: student.github_login || '',
+            commit_emails: student.commit_emails.join(', '),
+          },
+        ])
+      )
+    )
+  }, [selectedRepoReviewData])
 
   // Notify parent of view mode changes
   useEffect(() => {
@@ -550,7 +648,44 @@ export function TeacherClassroomView({
     return rows
   }, [selectedAssignmentData, sortColumn, sortDirection])
 
-  const studentRowIds = useMemo(() => sortedStudents.map((s) => s.student_id), [sortedStudents])
+  const sortedRepoReviewStudents = useMemo(() => {
+    if (!selectedRepoReviewData) return []
+    const rows = [...selectedRepoReviewData.students]
+    if (sortColumn === 'status') {
+      rows.sort((a, b) => {
+        const scoreA = a.result?.relative_contribution_share ?? 0
+        const scoreB = b.result?.relative_contribution_share ?? 0
+        const cmp = scoreB - scoreA
+        if (cmp !== 0) return applyDirection(cmp, sortDirection)
+        return (a.student_name || a.student_email).localeCompare(b.student_name || b.student_email)
+      })
+      return rows
+    }
+
+    const nameColumn = sortColumn === 'first' ? 'first_name' as const : 'last_name' as const
+    rows.sort((a, b) =>
+      compareByNameFields(
+        {
+          firstName: a.student_name?.split(' ')[0] || null,
+          lastName: a.student_name?.split(' ').slice(1).join(' ') || null,
+          id: a.student_email,
+        },
+        {
+          firstName: b.student_name?.split(' ')[0] || null,
+          lastName: b.student_name?.split(' ').slice(1).join(' ') || null,
+          id: b.student_email,
+        },
+        nameColumn,
+        sortDirection
+      )
+    )
+    return rows
+  }, [selectedRepoReviewData, sortColumn, sortDirection])
+
+  const isRepoReviewSelection = !!selectedRepoReviewData
+  const currentStudentRows = isRepoReviewSelection ? sortedRepoReviewStudents : sortedStudents
+
+  const studentRowIds = useMemo(() => currentStudentRows.map((s) => s.student_id), [currentStudentRows])
   const dueAtMs = useMemo(() => selectedAssignmentData ? new Date(selectedAssignmentData.assignment.due_at).getTime() : 0, [selectedAssignmentData])
   const {
     selectedIds: batchSelectedIds,
@@ -561,9 +696,9 @@ export function TeacherClassroomView({
     selectedCount: batchSelectedCount,
   } = useStudentSelection(studentRowIds)
   const batchSelectedGradedCount = useMemo(() => {
-    if (!selectedAssignmentData) return 0
+    if (currentStudentRows.length === 0) return 0
     let graded = 0
-    for (const student of selectedAssignmentData.students) {
+    for (const student of currentStudentRows) {
       const doc = student.doc
       const hasDraftScores = !!(
         doc &&
@@ -576,7 +711,7 @@ export function TeacherClassroomView({
       }
     }
     return graded
-  }, [selectedAssignmentData, batchSelectedIds])
+  }, [batchSelectedIds, currentStudentRows])
   const batchSelectedUngradedCount = batchSelectedCount - batchSelectedGradedCount
 
   // Auto-dismiss warning after 3 seconds, or immediately when students are selected
@@ -654,28 +789,29 @@ export function TeacherClassroomView({
 
   const selectedStudentIndex = useMemo(() => {
     if (!selectedStudentId) return -1
-    return sortedStudents.findIndex((student) => student.student_id === selectedStudentId)
-  }, [sortedStudents, selectedStudentId])
+    return currentStudentRows.findIndex((student) => student.student_id === selectedStudentId)
+  }, [currentStudentRows, selectedStudentId])
 
   const canGoPrevStudent = selectedStudentIndex > 0
-  const canGoNextStudent = selectedStudentIndex !== -1 && selectedStudentIndex < sortedStudents.length - 1
+  const canGoNextStudent = selectedStudentIndex !== -1 && selectedStudentIndex < currentStudentRows.length - 1
 
   const handleGoPrevStudent = useCallback(() => {
     if (selectedStudentIndex <= 0) return
-    setSelectedStudentId(sortedStudents[selectedStudentIndex - 1].student_id)
-  }, [selectedStudentIndex, sortedStudents])
+    setSelectedStudentId(currentStudentRows[selectedStudentIndex - 1].student_id)
+  }, [currentStudentRows, selectedStudentIndex])
 
   const handleGoNextStudent = useCallback(() => {
-    if (selectedStudentIndex === -1 || selectedStudentIndex >= sortedStudents.length - 1) return
-    setSelectedStudentId(sortedStudents[selectedStudentIndex + 1].student_id)
-  }, [selectedStudentIndex, sortedStudents])
+    if (selectedStudentIndex === -1 || selectedStudentIndex >= currentStudentRows.length - 1) return
+    setSelectedStudentId(currentStudentRows[selectedStudentIndex + 1].student_id)
+  }, [currentStudentRows, selectedStudentIndex])
 
   // Notify parent when student selection changes
   useEffect(() => {
-    if (selectedStudentId && selection.mode === 'assignment' && selectedAssignmentData?.assignment?.id) {
+    const activeAssignment = selectedAssignmentData?.assignment || selectedRepoReviewData?.assignment || null
+    if (selectedStudentId && selection.mode === 'assignment' && activeAssignment?.id) {
       onSelectStudent?.({
-        assignmentId: selectedAssignmentData.assignment.id,
-        assignmentTitle: selectedAssignmentData.assignment.title,
+        assignmentId: activeAssignment.id,
+        assignmentTitle: activeAssignment.title,
         studentId: selectedStudentId,
         canGoPrev: canGoPrevStudent,
         canGoNext: canGoNextStudent,
@@ -685,7 +821,7 @@ export function TeacherClassroomView({
     } else {
       onSelectStudent?.(null)
     }
-  }, [selectedStudentId, selection.mode, selectedAssignmentData?.assignment?.id, selectedAssignmentData?.assignment?.title, canGoPrevStudent, canGoNextStudent, handleGoPrevStudent, handleGoNextStudent, onSelectStudent])
+  }, [selectedAssignmentData?.assignment, selectedRepoReviewData?.assignment, selectedStudentId, selection.mode, canGoPrevStudent, canGoNextStudent, handleGoPrevStudent, handleGoNextStudent, onSelectStudent])
 
   // Auto-open right sidebar and collapse left sidebar when student is selected
   const prevSelectedStudentIdRef = useRef<string | null>(null)
@@ -795,7 +931,92 @@ export function TeacherClassroomView({
   }
 
   const canEditAssignment =
-    selection.mode === 'assignment' && !!selectedAssignmentData && !selectedAssignmentLoading && !isReadOnly
+    selection.mode === 'assignment' && (!!selectedAssignmentData || !!selectedRepoReviewData) && !selectedAssignmentLoading && !isReadOnly
+
+  async function handleRunRepoReview() {
+    if (!selectedRepoReviewData) return
+    setRepoReviewRunning(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/assignments/${selectedRepoReviewData.assignment.id}/repo-review/run`, {
+        method: 'POST',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to run repo review')
+      setInfo(`Analyzed ${data.analyzed_students ?? 0} student(s)`)
+      setRefreshCounter((count) => count + 1)
+    } catch (err: any) {
+      setError(err.message || 'Failed to run repo review')
+    } finally {
+      setRepoReviewRunning(false)
+    }
+  }
+
+  async function handleApplyRepoReview() {
+    if (!selectedRepoReviewData) return
+    setRepoReviewApplying(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/assignments/${selectedRepoReviewData.assignment.id}/repo-review/apply`, {
+        method: 'POST',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to apply repo review drafts')
+      setInfo(`Applied draft grades for ${data.applied_count ?? 0} student(s)`)
+      setRefreshCounter((count) => count + 1)
+    } catch (err: any) {
+      setError(err.message || 'Failed to apply repo review drafts')
+    } finally {
+      setRepoReviewApplying(false)
+    }
+  }
+
+  function updateRepoReviewMapping(studentId: string, field: 'github_login' | 'commit_emails', value: string) {
+    setRepoReviewMappings((prev) => ({
+      ...prev,
+      [studentId]: {
+        github_login: prev[studentId]?.github_login || '',
+        commit_emails: prev[studentId]?.commit_emails || '',
+        [field]: value,
+      },
+    }))
+  }
+
+  async function handleSaveRepoReviewMappings() {
+    if (!selectedRepoReviewData?.config) return
+    setRepoReviewSaving(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/teacher/assignments/${selectedRepoReviewData.assignment.id}/repo-review/config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'github',
+          repo_url: `${selectedRepoReviewData.config.repo_owner}/${selectedRepoReviewData.config.repo_name}`,
+          default_branch: selectedRepoReviewData.config.default_branch,
+          review_start_at: selectedRepoReviewData.config.review_start_at,
+          review_end_at: selectedRepoReviewData.config.review_end_at,
+          include_pr_reviews: selectedRepoReviewData.config.include_pr_reviews,
+          student_mappings: selectedRepoReviewData.students.map((student) => ({
+            student_id: student.student_id,
+            github_login: repoReviewMappings[student.student_id]?.github_login?.trim() || null,
+            commit_emails: (repoReviewMappings[student.student_id]?.commit_emails || '')
+              .split(',')
+              .map((item) => item.trim())
+              .filter(Boolean),
+          })),
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save GitHub mappings')
+      setInfo('Saved repo review mappings')
+      setRefreshCounter((count) => count + 1)
+    } catch (err: any) {
+      setError(err.message || 'Failed to save GitHub mappings')
+    } finally {
+      setRepoReviewSaving(false)
+    }
+  }
 
   const primaryButtons =
     selection.mode === 'summary' ? (
@@ -809,6 +1030,62 @@ export function TeacherClassroomView({
         <Plus className="h-5 w-5" aria-hidden="true" />
         <span>New</span>
       </button>
+    ) : selectedRepoReviewData ? (
+      <div className="flex gap-2 flex-wrap items-center">
+        <button
+          type="button"
+          className={`${ACTIONBAR_BUTTON_CLASSNAME} flex items-center gap-1`}
+          onClick={() => {
+            setEditAssignment(selectedRepoReviewData.assignment)
+          }}
+          disabled={!canEditAssignment}
+          aria-label="Edit assignment"
+        >
+          <Pencil className="h-5 w-5" aria-hidden="true" />
+          <span>Edit</span>
+        </button>
+        <button
+          type="button"
+          className={`${ACTIONBAR_BUTTON_CLASSNAME} flex items-center gap-1`}
+          onClick={() => {
+            void handleRunRepoReview()
+          }}
+          disabled={repoReviewRunning || isReadOnly}
+          aria-label="Analyze repo"
+        >
+          <BarChart3 className="h-5 w-5" aria-hidden="true" />
+          <span>{repoReviewRunning ? 'Analyzing...' : 'Analyze'}</span>
+        </button>
+        <button
+          type="button"
+          className={`${ACTIONBAR_BUTTON_CLASSNAME} flex items-center gap-1`}
+          onClick={() => {
+            void handleApplyRepoReview()
+          }}
+          disabled={repoReviewApplying || isReadOnly || !selectedRepoReviewData.latest_completed_run}
+          aria-label="Apply draft grades"
+        >
+          <Check className="h-5 w-5" aria-hidden="true" />
+          <span>{repoReviewApplying ? 'Applying...' : 'Apply Drafts'}</span>
+        </button>
+        <Tooltip content={batchSelectedCount > 0 ? `Return (${batchSelectedCount})` : 'Select students to return'}>
+          <button
+            type="button"
+            className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} ${batchSelectedCount === 0 ? 'opacity-50' : ''}`}
+            onClick={() => {
+              if (batchSelectedCount === 0) {
+                setWarning('Select students to return')
+                return
+              }
+              setShowReturnConfirm(true)
+            }}
+            disabled={isReturning || isReadOnly}
+            aria-label={batchSelectedCount > 0 ? `Return to ${batchSelectedCount} students` : 'Select students to return'}
+          >
+            <Send className={`h-5 w-5 ${batchSelectedCount > 0 ? 'text-blue-500' : ''}`} aria-hidden="true" />
+          </button>
+        </Tooltip>
+      </div>
     ) : (
       <div className="flex gap-2 flex-wrap items-center">
         <button
@@ -938,10 +1215,210 @@ export function TeacherClassroomView({
             </DndContext>
           )}
         </div>
+      ) : isRepoReviewSelection ? (
+        <KeyboardNavigableTable
+          ref={tableContainerRef}
+          rowKeys={currentStudentRows.map((s) => s.student_id)}
+          selectedKey={selectedStudentId}
+          onSelectKey={setSelectedStudentId}
+        >
+          <div className="space-y-3">
+            {selectedAssignmentLoading ? (
+              <TableCard>
+                <div className="flex justify-center py-10">
+                  <Spinner />
+                </div>
+              </TableCard>
+            ) : selectedAssignmentError || !selectedRepoReviewData ? (
+              <TableCard>
+                <div className="p-4 text-sm text-danger">
+                  {selectedAssignmentError || 'Failed to load repo review'}
+                </div>
+              </TableCard>
+            ) : (
+              <>
+                <div className="grid gap-3 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+                  <div className="rounded-lg border border-border bg-surface p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="text-xs uppercase tracking-wide text-text-muted">Repo Review</div>
+                        <div className="mt-1 text-lg font-semibold text-text-default">
+                          {selectedRepoReviewData.config
+                            ? `${selectedRepoReviewData.config.repo_owner}/${selectedRepoReviewData.config.repo_name}`
+                            : 'Repo not configured'}
+                        </div>
+                        <div className="mt-1 text-sm text-text-muted">
+                          Branch {selectedRepoReviewData.config?.default_branch || 'main'}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-text-default">
+                          Confidence {Math.round((selectedRepoReviewData.summary.confidence || 0) * 100)}%
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => {
+                            void handleSaveRepoReviewMappings()
+                          }}
+                          disabled={repoReviewSaving || !selectedRepoReviewData.config}
+                        >
+                          {repoReviewSaving ? 'Saving...' : 'Save mappings'}
+                        </Button>
+                      </div>
+                    </div>
+                    {selectedRepoReviewData.latest_run?.warnings_json?.length ? (
+                      <div className="mt-3 rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+                        {selectedRepoReviewData.latest_run.warnings_json.map((warning) => warning.message).join(' ')}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-surface p-4">
+                    <div className="text-xs uppercase tracking-wide text-text-muted">Team Timeline</div>
+                    <div className="mt-3 flex items-end gap-1">
+                      {selectedRepoReviewData.summary.team_timeline.length ? (
+                        selectedRepoReviewData.summary.team_timeline.map((point) => (
+                          <Tooltip
+                            key={point.date}
+                            content={`${point.date}: ${point.commit_count} commit${point.commit_count === 1 ? '' : 's'}`}
+                          >
+                            <div
+                              className="flex-1 rounded-t bg-primary/80"
+                              style={{ height: `${Math.max(12, Math.round(point.weighted_contribution * 24))}px` }}
+                            />
+                          </Tooltip>
+                        ))
+                      ) : (
+                        <div className="text-sm text-text-muted">Run analysis to populate workflow activity.</div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <TableCard>
+                  <DataTable density={isCompactTable ? 'tight' : 'compact'}>
+                    <DataTableHead>
+                      <DataTableRow>
+                        <DataTableHeaderCell className="w-10">
+                          <input
+                            type="checkbox"
+                            checked={batchAllSelected}
+                            onChange={batchToggleSelectAll}
+                            onClick={(e) => e.stopPropagation()}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            aria-label="Select all students"
+                          />
+                        </DataTableHeaderCell>
+                        <SortableHeaderCell
+                          label={isCompactTable ? 'First' : 'First Name'}
+                          isActive={sortColumn === 'first'}
+                          direction={sortDirection}
+                          onClick={() => toggleSort('first')}
+                          className={isCompactTable ? 'w-[5.5rem]' : 'w-[8rem]'}
+                        />
+                        <SortableHeaderCell
+                          label={isCompactTable ? 'L.' : 'Last Name'}
+                          isActive={sortColumn === 'last'}
+                          direction={sortDirection}
+                          onClick={() => toggleSort('last')}
+                          className={isCompactTable ? 'w-[4.5rem]' : 'w-[8rem]'}
+                        />
+                        <DataTableHeaderCell className="w-[14rem]">GitHub Mapping</DataTableHeaderCell>
+                        <DataTableHeaderCell className="w-[8rem]">Contribution</DataTableHeaderCell>
+                        <DataTableHeaderCell className="w-[8rem]">Consistency</DataTableHeaderCell>
+                        <DataTableHeaderCell className="w-[8rem]">Iteration</DataTableHeaderCell>
+                        <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
+                      </DataTableRow>
+                    </DataTableHead>
+                    <DataTableBody>
+                      {sortedRepoReviewStudents.map((student) => {
+                        const isSelected = selectedStudentId === student.student_id
+                        const totalScore =
+                          student.doc?.score_completion != null &&
+                          student.doc?.score_thinking != null &&
+                          student.doc?.score_workflow != null
+                            ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
+                            : null
+                        const [firstName, ...lastNameParts] = (student.student_name || '').split(' ')
+                        return (
+                          <DataTableRow
+                            key={student.student_id}
+                            className={getRowClassName(isSelected)}
+                            onClick={() => setSelectedStudentId(isSelected ? null : student.student_id)}
+                          >
+                            <DataTableCell>
+                              <input
+                                type="checkbox"
+                                checked={batchSelectedIds.has(student.student_id)}
+                                onChange={() => batchToggleSelect(student.student_id)}
+                                onClick={(e) => e.stopPropagation()}
+                                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                                aria-label={`Select ${student.student_name || student.student_email}`}
+                              />
+                            </DataTableCell>
+                            <DataTableCell>{firstName || '—'}</DataTableCell>
+                            <DataTableCell>{lastNameParts.join(' ') || '—'}</DataTableCell>
+                            <DataTableCell className="align-top">
+                              <div className="space-y-2">
+                                <Input
+                                  value={repoReviewMappings[student.student_id]?.github_login || ''}
+                                  onChange={(event) => updateRepoReviewMapping(student.student_id, 'github_login', event.target.value)}
+                                  placeholder="github login"
+                                  onClick={(event) => event.stopPropagation()}
+                                />
+                                <Input
+                                  value={repoReviewMappings[student.student_id]?.commit_emails || ''}
+                                  onChange={(event) => updateRepoReviewMapping(student.student_id, 'commit_emails', event.target.value)}
+                                  placeholder="commit emails (comma separated)"
+                                  onClick={(event) => event.stopPropagation()}
+                                />
+                              </div>
+                            </DataTableCell>
+                            <DataTableCell>
+                              <div className="space-y-1">
+                                <MetricBar value={student.result?.relative_contribution_share || 0} />
+                                <div className="text-xs text-text-muted">
+                                  {Math.round((student.result?.relative_contribution_share || 0) * 100)}%
+                                </div>
+                              </div>
+                            </DataTableCell>
+                            <DataTableCell>
+                              <div className="space-y-1">
+                                <MetricBar value={student.result?.spread_score || 0} />
+                                <div className="text-xs text-text-muted">
+                                  {Math.round((student.result?.spread_score || 0) * 100)}%
+                                </div>
+                              </div>
+                            </DataTableCell>
+                            <DataTableCell>
+                              <div className="space-y-1">
+                                <MetricBar value={student.result?.iteration_score || 0} />
+                                <div className="text-xs text-text-muted">
+                                  {Math.round((student.result?.iteration_score || 0) * 100)}%
+                                </div>
+                              </div>
+                            </DataTableCell>
+                            <DataTableCell className="whitespace-nowrap text-text-muted">
+                              {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}%` : '—'}
+                            </DataTableCell>
+                          </DataTableRow>
+                        )
+                      })}
+                      {sortedRepoReviewStudents.length === 0 && (
+                        <EmptyStateRow colSpan={8} message="No students enrolled" />
+                      )}
+                    </DataTableBody>
+                  </DataTable>
+                </TableCard>
+              </>
+            )}
+          </div>
+        </KeyboardNavigableTable>
       ) : (
         <KeyboardNavigableTable
           ref={tableContainerRef}
-          rowKeys={sortedStudents.map((s) => s.student_id)}
+          rowKeys={currentStudentRows.map((s) => s.student_id)}
           selectedKey={selectedStudentId}
           onSelectKey={setSelectedStudentId}
         >

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -62,6 +62,7 @@ interface AssignmentFormProps {
   instructions: TiptapContent
   dueAt: string
   classDays?: ClassDay[]
+  extraFields?: ReactNode
   onTitleChange: (next: string) => void
   onInstructionsChange: (next: TiptapContent) => void
   onDueAtChange: (next: string) => void
@@ -90,6 +91,7 @@ export function AssignmentForm({
   instructions,
   dueAt,
   classDays,
+  extraFields,
   onTitleChange,
   onInstructionsChange,
   onDueAtChange,
@@ -138,6 +140,8 @@ export function AssignmentForm({
           />
         </div>
       </div>
+
+      {extraFields}
 
       <div>
         {(() => {

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useRef, useState, useCallback, type FormEvent } from 'react'
 import { X } from 'lucide-react'
-import type { Assignment, ClassDay, TiptapContent } from '@/types'
+import type { Assignment, AssignmentEvaluationMode, ClassDay, TiptapContent } from '@/types'
 import { AssignmentForm } from '@/components/AssignmentForm'
-import { ConfirmDialog, DialogPanel, SplitButton } from '@/ui'
+import { ConfirmDialog, DialogPanel, FormField, Input, Select, SplitButton } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
 import { format } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
@@ -23,6 +23,25 @@ const EMPTY_INSTRUCTIONS: TiptapContent = { type: 'doc', content: [] }
 const AUTOSAVE_DEBOUNCE_MS = 3000
 const AUTOSAVE_MIN_INTERVAL_MS = 10000
 type CreateSubmitAction = 'post' | 'schedule' | 'draft'
+type AssignmentEditorValues = {
+  title: string
+  instructions: TiptapContent
+  dueAt: string
+  evaluationMode: AssignmentEvaluationMode
+  repoUrl: string
+  repoDefaultBranch: string
+  reviewStartAt: string
+  reviewEndAt: string
+  includePrReviews: boolean
+}
+
+function validateAssignmentValues(values: AssignmentEditorValues): string | null {
+  if (values.evaluationMode === 'repo_review' && !values.repoUrl.trim()) {
+    return 'GitHub repo is required for Repo Review assignments'
+  }
+
+  return null
+}
 
 interface AssignmentModalProps {
   isOpen: boolean
@@ -42,6 +61,12 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   const [title, setTitle] = useState('')
   const [instructions, setInstructions] = useState<TiptapContent>(EMPTY_INSTRUCTIONS)
+  const [evaluationMode, setEvaluationMode] = useState<AssignmentEvaluationMode>('document')
+  const [repoUrl, setRepoUrl] = useState('')
+  const [repoDefaultBranch, setRepoDefaultBranch] = useState('main')
+  const [reviewStartAt, setReviewStartAt] = useState('')
+  const [reviewEndAt, setReviewEndAt] = useState('')
+  const [includePrReviews, setIncludePrReviews] = useState(true)
   const [saving, setSaving] = useState(false)
   const [creating, setCreating] = useState(false)
   const [showPostNowConfirm, setShowPostNowConfirm] = useState(false)
@@ -60,10 +85,29 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const throttledSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAtRef = useRef<number>(0)
-  const lastSavedValuesRef = useRef<{ title: string; instructions: TiptapContent; dueAt: string } | null>(null)
-  const pendingValuesRef = useRef<{ title: string; instructions: TiptapContent; dueAt: string } | null>(null)
+  const lastSavedValuesRef = useRef<AssignmentEditorValues | null>(null)
+  const pendingValuesRef = useRef<AssignmentEditorValues | null>(null)
 
   const isCreateMode = !assignment
+
+  function toDateTimeLocal(value: string | null | undefined): string {
+    if (!value) return ''
+    return new Date(value).toISOString().slice(0, 16)
+  }
+
+  const toRepoReviewPayload = useCallback((values: AssignmentEditorValues) => {
+    if (values.evaluationMode !== 'repo_review' || !values.repoUrl.trim()) {
+      return undefined
+    }
+
+    return {
+      repo_url: values.repoUrl.trim(),
+      default_branch: values.repoDefaultBranch.trim() || 'main',
+      review_start_at: values.reviewStartAt ? new Date(values.reviewStartAt).toISOString() : null,
+      review_end_at: values.reviewEndAt ? new Date(values.reviewEndAt).toISOString() : null,
+      include_pr_reviews: values.includePrReviews,
+    }
+  }, [])
 
   useEffect(() => {
     if (!isOpen) return
@@ -87,6 +131,12 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       setTitle(nextTitle)
       setInstructions(nextInstructions)
       setDueAt(nextDueAt)
+      setEvaluationMode(assignment.evaluation_mode ?? 'document')
+      setRepoUrl('')
+      setRepoDefaultBranch('main')
+      setReviewStartAt('')
+      setReviewEndAt('')
+      setIncludePrReviews(true)
       if (assignment.released_at && !isVisibleAtNow(assignment.released_at)) {
         const scheduled = parseScheduleIsoToParts(assignment.released_at)
         setScheduleDate(scheduled.date)
@@ -97,7 +147,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         setScheduleTime(DEFAULT_SCHEDULE_TIME)
         setPrimaryAction('post')
       }
-      lastSavedValuesRef.current = { title: nextTitle, instructions: nextInstructions, dueAt: nextDueAt }
+      lastSavedValuesRef.current = {
+        title: nextTitle,
+        instructions: nextInstructions,
+        dueAt: nextDueAt,
+        evaluationMode: assignment.evaluation_mode ?? 'document',
+        repoUrl: '',
+        repoDefaultBranch: 'main',
+        reviewStartAt: '',
+        reviewEndAt: '',
+        includePrReviews: true,
+      }
       setSaveStatus('saved')
     } else {
       // Create mode: immediately create a draft
@@ -105,6 +165,12 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       setTitle('')
       setInstructions(EMPTY_INSTRUCTIONS)
       setDueAt(defaultDueAt)
+      setEvaluationMode('document')
+      setRepoUrl('')
+      setRepoDefaultBranch('main')
+      setReviewStartAt('')
+      setReviewEndAt('')
+      setIncludePrReviews(true)
       setScheduleDate(getTodayInSchedulingTimezone())
       setScheduleTime(DEFAULT_SCHEDULE_TIME)
       setPrimaryAction('post')
@@ -141,8 +207,51 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
   }, [assignment, isOpen, setDueAt, setError, defaultDueAt])
 
+  useEffect(() => {
+    if (!isOpen || !assignment || assignment.evaluation_mode !== 'repo_review') return
+
+    let isMounted = true
+
+    void (async () => {
+      try {
+        const res = await fetch(`/api/teacher/assignments/${assignment.id}/repo-review`)
+        const data = await res.json()
+        if (!res.ok || !data.config || !isMounted) return
+
+        const config = data.config
+        const nextRepoUrl = `${config.repo_owner}/${config.repo_name}`
+        const nextReviewStart = toDateTimeLocal(config.review_start_at)
+        const nextReviewEnd = toDateTimeLocal(config.review_end_at)
+        const nextIncludePrReviews = config.include_pr_reviews !== false
+
+        setRepoUrl(nextRepoUrl)
+        setRepoDefaultBranch(config.default_branch || 'main')
+        setReviewStartAt(nextReviewStart)
+        setReviewEndAt(nextReviewEnd)
+        setIncludePrReviews(nextIncludePrReviews)
+        lastSavedValuesRef.current = {
+          title: assignment.title,
+          instructions: assignment.rich_instructions ?? EMPTY_INSTRUCTIONS,
+          dueAt: formatDateInToronto(new Date(assignment.due_at)),
+          evaluationMode: assignment.evaluation_mode ?? 'document',
+          repoUrl: nextRepoUrl,
+          repoDefaultBranch: config.default_branch || 'main',
+          reviewStartAt: nextReviewStart,
+          reviewEndAt: nextReviewEnd,
+          includePrReviews: nextIncludePrReviews,
+        }
+      } catch {
+        // Leave repo review fields empty if config load fails.
+      }
+    })()
+
+    return () => {
+      isMounted = false
+    }
+  }, [assignment, isOpen])
+
   // Get only the fields that changed compared to last saved values
-  function getChangedFields(values: { title: string; instructions: TiptapContent; dueAt: string }) {
+  const getChangedFields = useCallback((values: AssignmentEditorValues) => {
     const saved = lastSavedValuesRef.current
     if (!saved) return null
 
@@ -152,13 +261,26 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     if (JSON.stringify(values.instructions) !== JSON.stringify(saved.instructions)) {
       changes.rich_instructions = values.instructions
     }
+    if (values.evaluationMode !== saved.evaluationMode) {
+      changes.evaluation_mode = values.evaluationMode
+    }
+    if (
+      values.repoUrl !== saved.repoUrl
+      || values.repoDefaultBranch !== saved.repoDefaultBranch
+      || values.reviewStartAt !== saved.reviewStartAt
+      || values.reviewEndAt !== saved.reviewEndAt
+      || values.includePrReviews !== saved.includePrReviews
+      || values.evaluationMode !== saved.evaluationMode
+    ) {
+      changes.repo_review = toRepoReviewPayload(values)
+    }
 
     return Object.keys(changes).length > 0 ? changes : null
-  }
+  }, [toRepoReviewPayload])
 
   // Create a new assignment
   const createAssignment = useCallback(async (
-    values: { title: string; instructions: TiptapContent; dueAt: string }
+    values: AssignmentEditorValues
   ): Promise<Assignment | null> => {
     try {
       const response = await fetch('/api/teacher/assignments', {
@@ -169,6 +291,8 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           title: values.title.trim() || `Untitled (${format(nowInToronto(), 'yyyy-MM-dd HH:mm:ss')})`,
           rich_instructions: values.instructions,
           due_at: toTorontoEndOfDayIso(values.dueAt),
+          evaluation_mode: values.evaluationMode,
+          repo_review: toRepoReviewPayload(values),
         }),
       })
 
@@ -186,14 +310,24 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       setError(err.message || 'Failed to create assignment')
       return null
     }
-  }, [classroomId, setError])
+  }, [classroomId, setError, toRepoReviewPayload])
 
   // Automatically create draft when modal opens in create mode
   useEffect(() => {
     if (!creating) return
 
     const createDraft = async () => {
-      const initialValues = { title: '', instructions: EMPTY_INSTRUCTIONS, dueAt: defaultDueAt }
+      const initialValues: AssignmentEditorValues = {
+        title: '',
+        instructions: EMPTY_INSTRUCTIONS,
+        dueAt: defaultDueAt,
+        evaluationMode: 'document',
+        repoUrl: '',
+        repoDefaultBranch: 'main',
+        reviewStartAt: '',
+        reviewEndAt: '',
+        includePrReviews: true,
+      }
       const newAssignment = await createAssignment(initialValues)
       setCreating(false)
 
@@ -203,7 +337,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         setInstructions(newAssignment.rich_instructions ?? EMPTY_INSTRUCTIONS)
         const assignmentDueAt = formatDateInToronto(new Date(newAssignment.due_at))
         setDueAt(assignmentDueAt)
-        lastSavedValuesRef.current = { title: newAssignment.title, instructions: newAssignment.rich_instructions ?? EMPTY_INSTRUCTIONS, dueAt: assignmentDueAt }
+        lastSavedValuesRef.current = {
+          title: newAssignment.title,
+          instructions: newAssignment.rich_instructions ?? EMPTY_INSTRUCTIONS,
+          dueAt: assignmentDueAt,
+          evaluationMode: newAssignment.evaluation_mode ?? 'document',
+          repoUrl: '',
+          repoDefaultBranch: 'main',
+          reviewStartAt: '',
+          reviewEndAt: '',
+          includePrReviews: true,
+        }
         setSaveStatus('saved')
 
         // Focus and select title after creation
@@ -222,9 +366,16 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   // Save changes to the server (create or update)
   const saveChanges = useCallback(async (
-    values: { title: string; instructions: TiptapContent; dueAt: string },
+    values: AssignmentEditorValues,
     options?: { closeAfter?: boolean }
   ) => {
+    const validationError = validateAssignmentValues(values)
+    if (validationError) {
+      setError(validationError)
+      setSaveStatus('unsaved')
+      return
+    }
+
     setSaveStatus('saving')
     lastSaveAtRef.current = Date.now()
 
@@ -284,11 +435,11 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       setError(err.message || 'Failed to save assignment')
       setSaveStatus('unsaved')
     }
-  }, [currentAssignment, createAssignment, onClose, onSuccess, setError])
+  }, [currentAssignment, createAssignment, getChangedFields, onClose, onSuccess, setError])
 
   // Schedule a debounced save with minimum interval throttling
   const scheduleSave = useCallback((
-    values: { title: string; instructions: TiptapContent; dueAt: string },
+    values: AssignmentEditorValues,
     options?: { force?: boolean }
   ) => {
     pendingValuesRef.current = values
@@ -317,7 +468,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
   }, [saveChanges])
 
   // Schedule autosave after a debounce period
-  function scheduleAutosave(values: { title: string; instructions: TiptapContent; dueAt: string }) {
+  function scheduleAutosave(values: AssignmentEditorValues) {
     pendingValuesRef.current = values
     setSaveStatus('unsaved')
 
@@ -332,7 +483,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   function handleTitleChange(newTitle: string) {
     setTitle(newTitle)
-    scheduleAutosave({ title: newTitle, instructions, dueAt })
+    scheduleAutosave({
+      title: newTitle,
+      instructions,
+      dueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    })
   }
 
   function handleInstructionsChange(newInstructions: TiptapContent) {
@@ -344,12 +505,81 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       return
     }
     setInstructions(newInstructions)
-    scheduleAutosave({ title, instructions: newInstructions, dueAt })
+    scheduleAutosave({
+      title,
+      instructions: newInstructions,
+      dueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    })
   }
 
   function handleDueAtChange(newDueAt: string) {
     updateDueDate(newDueAt)
-    scheduleAutosave({ title, instructions, dueAt: newDueAt })
+    scheduleAutosave({
+      title,
+      instructions,
+      dueAt: newDueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    })
+  }
+
+  function handleEvaluationModeChange(nextMode: AssignmentEvaluationMode) {
+    setEvaluationMode(nextMode)
+    scheduleAutosave({
+      title,
+      instructions,
+      dueAt,
+      evaluationMode: nextMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    })
+  }
+
+  function handleRepoFieldChange(field: 'repoUrl' | 'repoDefaultBranch' | 'reviewStartAt' | 'reviewEndAt', value: string) {
+    if (field === 'repoUrl') setRepoUrl(value)
+    if (field === 'repoDefaultBranch') setRepoDefaultBranch(value)
+    if (field === 'reviewStartAt') setReviewStartAt(value)
+    if (field === 'reviewEndAt') setReviewEndAt(value)
+
+    scheduleAutosave({
+      title,
+      instructions,
+      dueAt,
+      evaluationMode,
+      repoUrl: field === 'repoUrl' ? value : repoUrl,
+      repoDefaultBranch: field === 'repoDefaultBranch' ? value : repoDefaultBranch,
+      reviewStartAt: field === 'reviewStartAt' ? value : reviewStartAt,
+      reviewEndAt: field === 'reviewEndAt' ? value : reviewEndAt,
+      includePrReviews,
+    })
+  }
+
+  function handleIncludePrReviewsChange(nextValue: boolean) {
+    setIncludePrReviews(nextValue)
+    scheduleAutosave({
+      title,
+      instructions,
+      dueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews: nextValue,
+    })
   }
 
   function handlePrevDate() {
@@ -388,7 +618,21 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
 
     if ((saveStatus === 'unsaved' || pendingValuesRef.current) && currentAssignment) {
-      const valuesToSave = pendingValuesRef.current ?? { title, instructions, dueAt }
+      const valuesToSave = pendingValuesRef.current ?? {
+        title,
+        instructions,
+        dueAt,
+        evaluationMode,
+        repoUrl,
+        repoDefaultBranch,
+        reviewStartAt,
+        reviewEndAt,
+        includePrReviews,
+      }
+      const validationError = validateAssignmentValues(valuesToSave)
+      if (validationError) {
+        throw new Error(validationError)
+      }
       const changedFields = getChangedFields(valuesToSave)
 
       if (changedFields) {
@@ -425,7 +669,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
     pendingValuesRef.current = null
     setSaving(true)
-    await saveChanges({ title, instructions, dueAt }, { closeAfter: true })
+    await saveChanges({
+      title,
+      instructions,
+      dueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    }, { closeAfter: true })
     setSaving(false)
   }
 
@@ -441,7 +695,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
     pendingValuesRef.current = null
     setSaving(true)
-    await saveChanges({ title, instructions, dueAt }, { closeAfter: true })
+    await saveChanges({
+      title,
+      instructions,
+      dueAt,
+      evaluationMode,
+      repoUrl,
+      repoDefaultBranch,
+      reviewStartAt,
+      reviewEndAt,
+      includePrReviews,
+    }, { closeAfter: true })
     setSaving(false)
   }
 
@@ -478,7 +742,17 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
     // If there are unsaved changes, save before closing
     if (saveStatus === 'unsaved' || pendingValuesRef.current) {
-      const valuesToSave = pendingValuesRef.current ?? { title, instructions, dueAt }
+      const valuesToSave = pendingValuesRef.current ?? {
+        title,
+        instructions,
+        dueAt,
+        evaluationMode,
+        repoUrl,
+        repoDefaultBranch,
+        reviewStartAt,
+        reviewEndAt,
+        includePrReviews,
+      }
       await saveChanges(valuesToSave, { closeAfter: true })
     } else {
       if (currentAssignment) {
@@ -770,6 +1044,73 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             instructions={instructions}
             dueAt={dueAt}
             classDays={classDays}
+            extraFields={(
+              <>
+                <FormField label="Evaluation Mode">
+                  <Select
+                    value={evaluationMode}
+                    onChange={(event) => handleEvaluationModeChange(event.target.value as AssignmentEvaluationMode)}
+                    options={[
+                      { value: 'document', label: 'Document Submission' },
+                      { value: 'repo_review', label: 'Repo Review' },
+                    ]}
+                    disabled={saving || releasing || creating}
+                  />
+                </FormField>
+
+                {evaluationMode === 'repo_review' && (
+                  <div className="space-y-3 rounded-lg border border-border bg-surface-2 p-3">
+                    <FormField label="GitHub Repo" required>
+                      <Input
+                        value={repoUrl}
+                        onChange={(event) => handleRepoFieldChange('repoUrl', event.target.value)}
+                        placeholder="owner/repo or https://github.com/owner/repo"
+                        disabled={saving || releasing || creating}
+                      />
+                    </FormField>
+
+                    <FormField label="Default Branch">
+                      <Input
+                        value={repoDefaultBranch}
+                        onChange={(event) => handleRepoFieldChange('repoDefaultBranch', event.target.value)}
+                        placeholder="main"
+                        disabled={saving || releasing || creating}
+                      />
+                    </FormField>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <FormField label="Review Start">
+                        <Input
+                          type="datetime-local"
+                          value={reviewStartAt}
+                          onChange={(event) => handleRepoFieldChange('reviewStartAt', event.target.value)}
+                          disabled={saving || releasing || creating}
+                        />
+                      </FormField>
+                      <FormField label="Review End">
+                        <Input
+                          type="datetime-local"
+                          value={reviewEndAt}
+                          onChange={(event) => handleRepoFieldChange('reviewEndAt', event.target.value)}
+                          disabled={saving || releasing || creating}
+                        />
+                      </FormField>
+                    </div>
+
+                    <label className="flex items-center gap-2 text-sm text-text-default">
+                      <input
+                        type="checkbox"
+                        checked={includePrReviews}
+                        onChange={(event) => handleIncludePrReviewsChange(event.target.checked)}
+                        disabled={saving || releasing || creating}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                      />
+                      Include pull requests and review comments
+                    </label>
+                  </div>
+                )}
+              </>
+            )}
             onTitleChange={handleTitleChange}
             onInstructionsChange={handleInstructionsChange}
             onDueAtChange={handleDueAtChange}

--- a/src/components/SortableAssignmentCard.tsx
+++ b/src/components/SortableAssignmentCard.tsx
@@ -117,6 +117,9 @@ export function SortableAssignmentCard({
           <p className="text-xs text-text-muted">
             Due: {formatDueDate(assignment.due_at)}
           </p>
+          {assignment.evaluation_mode === 'repo_review' && (
+            <p className="text-xs text-primary">Repo review</p>
+          )}
           {isScheduled && (
             <p className="text-xs text-warning">{scheduledOpenLabel}</p>
           )}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -112,6 +112,33 @@ interface StudentWorkData {
   student: { id: string; email: string; name: string | null }
   doc: AssignmentDoc | null
   status: AssignmentStatus
+  repo_review?: {
+    latest_run: {
+      id: string
+      status: string
+      started_at: string
+      completed_at: string | null
+      warnings_json?: Array<{ message: string }>
+    } | null
+    result: {
+      commit_count: number
+      active_days: number
+      session_count: number
+      burst_ratio: number
+      weighted_contribution: number
+      relative_contribution_share: number
+      spread_score: number
+      iteration_score: number
+      draft_feedback: string | null
+      evidence_json: Array<{
+        id: string
+        type: string
+        title: string
+        summary?: string
+        authored_at?: string
+      }>
+    } | null
+  } | null
 }
 
 interface TeacherStudentWorkPanelProps {
@@ -251,6 +278,13 @@ export function TeacherStudentWorkPanel({
 
   // Load history
   useEffect(() => {
+    if (data?.assignment.evaluation_mode === 'repo_review') {
+      setHistoryEntries([])
+      setHistoryLoading(false)
+      setHistoryError('')
+      return
+    }
+
     setHistoryLoading(true)
     setHistoryError('')
 
@@ -272,7 +306,7 @@ export function TeacherStudentWorkPanel({
     }
 
     loadHistory()
-  }, [assignmentId, studentId])
+  }, [assignmentId, data?.assignment.evaluation_mode, studentId])
 
   async function handleSaveGrade(selectedSaveMode: GradeSaveMode) {
     if (!data) return
@@ -406,6 +440,8 @@ export function TeacherStudentWorkPanel({
 
   const isPreviewLocked = lockedEntryId !== null
   const displayContent = previewContent || data.doc?.content
+  const isRepoReviewAssignment = data.assignment.evaluation_mode === 'repo_review'
+  const repoReviewResult = data.repo_review?.result || null
 
   const sc = Number(scoreCompletion) || 0
   const st = Number(scoreThinking) || 0
@@ -428,7 +464,46 @@ export function TeacherStudentWorkPanel({
               : ''
           }`}
         >
-          {displayContent && !isEmpty(displayContent) ? (
+          {isRepoReviewAssignment ? (
+            <div className="space-y-4 p-4">
+              <div>
+                <h3 className="text-lg font-semibold text-text-default">{data.student.name || data.student.email}</h3>
+                <p className="mt-1 text-sm text-text-muted">
+                  Repo review evidence for {data.assignment.title}
+                </p>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-xs text-text-muted">Commits</div>
+                  <div className="mt-1 text-lg font-semibold text-text-default">{repoReviewResult?.commit_count ?? 0}</div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-xs text-text-muted">Active Days</div>
+                  <div className="mt-1 text-lg font-semibold text-text-default">{repoReviewResult?.active_days ?? 0}</div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-xs text-text-muted">Contribution</div>
+                  <div className="mt-1 text-lg font-semibold text-text-default">
+                    {repoReviewResult ? `${Math.round((repoReviewResult.relative_contribution_share || 0) * 100)}%` : '—'}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-xs text-text-muted">Burst Ratio</div>
+                  <div className="mt-1 text-lg font-semibold text-text-default">
+                    {repoReviewResult ? `${Math.round((repoReviewResult.burst_ratio || 0) * 100)}%` : '—'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border bg-surface p-4">
+                <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Draft AI Feedback</div>
+                <div className="mt-2 whitespace-pre-wrap text-sm text-text-default">
+                  {repoReviewResult?.draft_feedback?.trim() || 'Run repo analysis to generate feedback.'}
+                </div>
+              </div>
+            </div>
+          ) : displayContent && !isEmpty(displayContent) ? (
             <div>
               <RichTextViewer content={displayContent} />
               <div className="mt-4 text-center text-xs text-text-muted">
@@ -455,7 +530,7 @@ export function TeacherStudentWorkPanel({
               }`}
               onClick={() => handleRightTabChange('history')}
             >
-              History
+              {isRepoReviewAssignment ? 'Evidence' : 'History'}
             </button>
             <button
               type="button"
@@ -476,7 +551,35 @@ export function TeacherStudentWorkPanel({
                 className="flex-1 min-h-0 overflow-y-auto"
                 onMouseLeave={handleHistoryMouseLeave}
               >
-                {historyLoading && historyEntries.length === 0 ? (
+                {isRepoReviewAssignment ? (
+                  <div className="space-y-3 p-3">
+                    {data.repo_review?.latest_run && (
+                      <div className="rounded-lg border border-border bg-surface p-3 text-xs text-text-muted">
+                        Latest run {formatInTimeZone(new Date(data.repo_review.latest_run.started_at), 'America/Toronto', 'MMM d, h:mm a')}
+                      </div>
+                    )}
+                    {repoReviewResult?.evidence_json?.length ? (
+                      repoReviewResult.evidence_json.map((item) => (
+                        <div key={item.id} className="rounded-lg border border-border bg-surface p-3">
+                          <div className="text-sm font-medium text-text-default">{item.title}</div>
+                          {item.summary && <div className="mt-1 text-xs text-text-muted">{item.summary}</div>}
+                          {item.authored_at && (
+                            <div className="mt-2 text-[11px] text-text-muted">
+                              {formatInTimeZone(new Date(item.authored_at), 'America/Toronto', 'MMM d, h:mm a')}
+                            </div>
+                          )}
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-xs text-text-muted">No evidence captured yet.</p>
+                    )}
+                    {data.repo_review?.latest_run?.warnings_json?.length ? (
+                      <div className="rounded-lg border border-warning bg-warning-bg p-3 text-xs text-warning">
+                        {data.repo_review.latest_run.warnings_json.map((warning) => warning.message).join(' ')}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : historyLoading && historyEntries.length === 0 ? (
                   <div className="p-4 text-center">
                     <Spinner size="sm" />
                   </div>
@@ -500,7 +603,7 @@ export function TeacherStudentWorkPanel({
                   <RefreshingIndicator label="Refreshing history..." className="px-3 pb-2 pt-0" />
                 )}
               </div>
-              {isPreviewLocked && previewEntry && (
+              {!isRepoReviewAssignment && isPreviewLocked && previewEntry && (
                 <div className="px-3 py-2 border-t border-border">
                   <Button onClick={handleExitPreview} variant="secondary" size="sm" className="w-full">
                     Exit preview
@@ -510,10 +613,12 @@ export function TeacherStudentWorkPanel({
             </>
           ) : (
             <div className="flex h-full min-h-0 flex-col gap-3 p-3">
-              <AuthenticityGauge
-                score={data.doc?.authenticity_score ?? null}
-                flags={data.doc?.authenticity_flags ?? []}
-              />
+              {!isRepoReviewAssignment && (
+                <AuthenticityGauge
+                  score={data.doc?.authenticity_score ?? null}
+                  flags={data.doc?.authenticity_flags ?? []}
+                />
+              )}
 
               {gradeError && (
                 <div className="text-xs text-danger">{gradeError}</div>
@@ -557,9 +662,11 @@ export function TeacherStudentWorkPanel({
               </div>
 
               <div className="flex shrink-0 items-center gap-2">
-                <Button size="sm" variant="secondary" className="flex-1" onClick={handleAutoGrade} disabled={autoGrading}>
-                  {autoGrading ? 'Grading...' : 'AI grade'}
-                </Button>
+                {!isRepoReviewAssignment && (
+                  <Button size="sm" variant="secondary" className="flex-1" onClick={handleAutoGrade} disabled={autoGrading}>
+                    {autoGrading ? 'Grading...' : 'AI grade'}
+                  </Button>
+                )}
                 <SplitButton
                   label={gradeSaving ? 'Saving...' : 'Save'}
                   onPrimaryClick={() => {

--- a/src/lib/repo-review-ai.ts
+++ b/src/lib/repo-review-ai.ts
@@ -1,0 +1,314 @@
+import { z } from 'zod'
+import type { RepoReviewEvidenceItem, RepoReviewSemanticBreakdown } from '@/types'
+
+const DEFAULT_MODEL = 'gpt-5-nano'
+
+function getOpenAIKey(): string | null {
+  const key = process.env.OPENAI_API_KEY
+  if (!key) return null
+  return key.trim() || null
+}
+
+function extractResponseOutputText(payload: any): string | null {
+  if (typeof payload?.output_text === 'string' && payload.output_text.trim()) {
+    return payload.output_text.trim()
+  }
+
+  const output = payload?.output
+  if (!Array.isArray(output)) return null
+
+  for (const item of output) {
+    const content = item?.content
+    if (!Array.isArray(content)) continue
+    for (const c of content) {
+      if (c?.type === 'output_text' && typeof c?.text === 'string' && c.text.trim()) {
+        return c.text.trim()
+      }
+    }
+  }
+
+  return null
+}
+
+const feedbackSchema = z.object({
+  score_completion: z.number().int().min(0).max(10),
+  score_thinking: z.number().int().min(0).max(10),
+  score_workflow: z.number().int().min(0).max(10),
+  summary: z.string().min(1),
+  strengths: z.array(z.string()).default([]),
+  concerns: z.array(z.string()).default([]),
+  feedback: z.string().min(1),
+  confidence: z.number().min(0).max(1),
+})
+
+const classificationSchema = z.object({
+  items: z.array(z.object({
+    id: z.string(),
+    category: z.enum(['feature', 'bugfix', 'test', 'refactor', 'docs', 'styling', 'config', 'generated']),
+  })),
+})
+
+export interface RepoReviewFeedbackResult {
+  score_completion: number
+  score_thinking: number
+  score_workflow: number
+  summary: string
+  strengths: string[]
+  concerns: string[]
+  feedback: string
+  confidence: number
+  model: string
+}
+
+export interface RepoReviewFeedbackInput {
+  assignmentTitle: string
+  repoName: string
+  studentName: string
+  githubLogin: string | null
+  commitCount: number
+  activeDays: number
+  sessionCount: number
+  burstRatio: number
+  weightedContribution: number
+  relativeContributionShare: number
+  spreadScore: number
+  iterationScore: number
+  reviewActivityCount: number
+  areas: string[]
+  semanticBreakdown: Partial<RepoReviewSemanticBreakdown>
+  evidence: RepoReviewEvidenceItem[]
+  warnings: string[]
+  confidence: number
+}
+
+function parseJsonResponse<T>(outputText: string, schema: z.ZodSchema<T>): T {
+  let jsonText = outputText
+  const codeBlockMatch = outputText.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (codeBlockMatch) {
+    jsonText = codeBlockMatch[1].trim()
+  }
+
+  const parsed = JSON.parse(jsonText)
+  return schema.parse(parsed)
+}
+
+function scoreFromUnit(value: number): number {
+  return Math.max(0, Math.min(10, Math.round(value * 10)))
+}
+
+function formatStrengths(strengths: string[]): string {
+  if (!strengths.length) return ''
+  return `Strengths: ${strengths.join('; ')}`
+}
+
+function formatConcerns(concerns: string[]): string {
+  if (!concerns.length) return ''
+  return `Concerns: ${concerns.join('; ')}`
+}
+
+export function buildHeuristicRepoReviewFeedback(input: RepoReviewFeedbackInput): RepoReviewFeedbackResult {
+  const completion = scoreFromUnit(
+    input.relativeContributionShare * 0.55
+      + Math.min(input.areas.length, 4) / 4 * 0.25
+      + Math.min((input.semanticBreakdown.test || 0) + (input.semanticBreakdown.refactor || 0), input.weightedContribution) / Math.max(input.weightedContribution || 1, 1) * 0.2
+  )
+  const thinking = scoreFromUnit(
+    Math.min(input.areas.length, 4) / 4 * 0.4
+      + Math.min((input.semanticBreakdown.feature || 0) + (input.semanticBreakdown.refactor || 0), input.weightedContribution) / Math.max(input.weightedContribution || 1, 1) * 0.35
+      + Math.min(input.reviewActivityCount, 4) / 4 * 0.25
+  )
+  const workflow = scoreFromUnit(
+    input.spreadScore * 0.4
+      + (1 - input.burstRatio) * 0.35
+      + input.iterationScore * 0.25
+  )
+
+  const strengths: string[] = []
+  const concerns: string[] = []
+
+  if (input.commitCount > 0) {
+    strengths.push(`${input.commitCount} commit${input.commitCount === 1 ? '' : 's'} mapped to this student`)
+  }
+  if (input.spreadScore >= 0.5) {
+    strengths.push('work was spread across the assignment window')
+  }
+  if (input.reviewActivityCount > 0) {
+    strengths.push(`${input.reviewActivityCount} PR/review activit${input.reviewActivityCount === 1 ? 'y' : 'ies'} contributed collaboration evidence`)
+  }
+  if (input.burstRatio >= 0.75) {
+    concerns.push('most work landed near the deadline')
+  }
+  if (input.commitCount <= 1 && input.reviewActivityCount === 0) {
+    concerns.push('very limited visible activity was available to assess')
+  }
+  if (input.warnings.length > 0) {
+    concerns.push(input.warnings[0])
+  }
+
+  const summary = `${input.studentName} contributed ${Math.round(input.relativeContributionShare * 100)}% of mapped weighted work in ${input.repoName}.`
+  const improvement = workflow <= 5
+    ? 'Improve: Break work into more sessions across the assignment window so the process is easier to evaluate.'
+    : ''
+  const parts = [
+    summary,
+    formatStrengths(strengths),
+    formatConcerns(concerns),
+    `Next Step: ${workflow <= 5 ? 'show a steadier workflow over time' : 'keep pairing implementation with visible iteration and tests'}.`,
+    improvement,
+  ].filter(Boolean)
+
+  return {
+    score_completion: completion,
+    score_thinking: thinking,
+    score_workflow: workflow,
+    summary,
+    strengths,
+    concerns,
+    feedback: parts.join(' '),
+    confidence: input.confidence,
+    model: 'heuristic',
+  }
+}
+
+export async function classifyAmbiguousRepoReviewChanges(items: Array<{ id: string; summary: string }>): Promise<Record<string, string>> {
+  const apiKey = getOpenAIKey()
+  if (!apiKey || items.length === 0) return {}
+
+  const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
+  const systemPrompt = `You classify software change summaries into one category.
+
+Allowed categories:
+- feature
+- bugfix
+- test
+- refactor
+- docs
+- styling
+- config
+- generated
+
+Respond with JSON only:
+{"items":[{"id":"...","category":"feature"}]}`
+
+  const userPrompt = items
+    .map((item) => `- ${item.id}: ${item.summary}`)
+    .join('\n')
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
+        { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
+      ],
+    }),
+  })
+
+  if (!res.ok) {
+    return {}
+  }
+
+  const payload = await res.json()
+  const outputText = extractResponseOutputText(payload)
+  if (!outputText) return {}
+
+  const parsed = parseJsonResponse(outputText, classificationSchema)
+  return Object.fromEntries(parsed.items.map((item) => [item.id, item.category]))
+}
+
+export async function gradeRepoReviewFeedback(input: RepoReviewFeedbackInput): Promise<RepoReviewFeedbackResult> {
+  const apiKey = getOpenAIKey()
+  if (!apiKey) {
+    return buildHeuristicRepoReviewFeedback(input)
+  }
+
+  const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
+  const systemPrompt = `You are grading repository contribution evidence for a teacher.
+
+Use these rubric definitions:
+- Completion (0-10): meaningful implementation ownership, task coverage, tests/refinement
+- Thinking (0-10): complexity, debugging/refactoring evidence, review/problem-solving quality
+- Workflow (0-10): consistency over time, iteration, commit hygiene, responsiveness to feedback
+
+Rules:
+- Use only the supplied evidence.
+- Do not infer hidden work.
+- Low confidence or incomplete evidence should lower confidence and lead to cautious scoring.
+- Distinguish contribution size from workflow quality.
+- Feedback must be 3-5 sentences total.
+- If workflow is weak, include one sentence starting with "Improve:" and give a concrete workflow improvement.
+
+Respond with JSON only:
+{"score_completion":0,"score_thinking":0,"score_workflow":0,"summary":"","strengths":[""],"concerns":[""],"feedback":"","confidence":0.0}`
+
+  const userPrompt = JSON.stringify({
+    assignment_title: input.assignmentTitle,
+    repo_name: input.repoName,
+    student_name: input.studentName,
+    github_login: input.githubLogin,
+    metrics: {
+      commit_count: input.commitCount,
+      active_days: input.activeDays,
+      session_count: input.sessionCount,
+      burst_ratio: input.burstRatio,
+      weighted_contribution: input.weightedContribution,
+      relative_contribution_share: input.relativeContributionShare,
+      spread_score: input.spreadScore,
+      iteration_score: input.iterationScore,
+      review_activity_count: input.reviewActivityCount,
+      areas: input.areas,
+      semantic_breakdown: input.semanticBreakdown,
+      confidence: input.confidence,
+    },
+    evidence: input.evidence,
+    warnings: input.warnings,
+  })
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        input: [
+          { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
+          { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
+        ],
+      }),
+    })
+
+    if (!res.ok) {
+      return buildHeuristicRepoReviewFeedback(input)
+    }
+
+    const payload = await res.json()
+    const outputText = extractResponseOutputText(payload)
+    if (!outputText) {
+      return buildHeuristicRepoReviewFeedback(input)
+    }
+
+    const parsed = parseJsonResponse(outputText, feedbackSchema)
+    const formattedFeedback = [
+      parsed.summary,
+      formatStrengths(parsed.strengths),
+      formatConcerns(parsed.concerns),
+      parsed.feedback,
+    ].filter(Boolean).join(' ')
+
+    return {
+      ...parsed,
+      feedback: formattedFeedback,
+      model,
+    }
+  } catch {
+    return buildHeuristicRepoReviewFeedback(input)
+  }
+}

--- a/src/lib/repo-review.ts
+++ b/src/lib/repo-review.ts
@@ -1,0 +1,787 @@
+import { formatInTimeZone } from 'date-fns-tz'
+import { classifyAmbiguousRepoReviewChanges } from '@/lib/repo-review-ai'
+import type {
+  AssignmentRepoReviewConfig,
+  RepoReviewEvidenceItem,
+  RepoReviewSemanticBreakdown,
+  RepoReviewSemanticCategory,
+  RepoReviewTimelinePoint,
+  RepoReviewWarning,
+  UserGitHubIdentity,
+} from '@/types'
+
+const GITHUB_API_BASE = 'https://api.github.com'
+const SESSION_GAP_MS = 90 * 60 * 1000
+const CONTRIBUTION_SCALE = 40
+const MAX_COMMITS = 250
+const MAX_PULLS = 100
+const MAX_EVIDENCE_ITEMS = 10
+const TORONTO_TIMEZONE = 'America/Toronto'
+
+export const REPO_REVIEW_METRICS_VERSION = 'v1'
+export const REPO_REVIEW_PROMPT_VERSION = 'v1'
+
+export const REPO_REVIEW_SEMANTIC_WEIGHTS: Record<RepoReviewSemanticCategory, number> = {
+  feature: 1.0,
+  bugfix: 0.9,
+  test: 0.8,
+  refactor: 0.7,
+  docs: 0.4,
+  styling: 0.4,
+  config: 0.2,
+  generated: 0.0,
+}
+
+export interface RepoReviewStudentIdentityInput {
+  studentId: string
+  email: string
+  name: string | null
+  githubLogin: string | null
+  commitEmails: string[]
+}
+
+export interface RepoReviewWindow {
+  startAt: string
+  endAt: string
+}
+
+export interface RepoReviewCommitFile {
+  filename: string
+  status: string
+  additions: number
+  deletions: number
+}
+
+export interface RepoReviewAnalyzedCommit {
+  sha: string
+  authoredAt: string
+  message: string
+  githubLogin: string | null
+  authorEmail: string | null
+  files: RepoReviewCommitFile[]
+  category: RepoReviewSemanticCategory
+  weightedContribution: number
+  areas: string[]
+}
+
+export interface RepoReviewStudentMetrics {
+  studentId: string
+  githubLogin: string | null
+  commitCount: number
+  activeDays: number
+  sessionCount: number
+  burstRatio: number
+  weightedContribution: number
+  relativeContributionShare: number
+  spreadScore: number
+  iterationScore: number
+  semanticBreakdown: RepoReviewSemanticBreakdown
+  timeline: RepoReviewTimelinePoint[]
+  evidence: RepoReviewEvidenceItem[]
+  areas: string[]
+  reviewActivityCount: number
+}
+
+export interface RepoReviewAnalysisResult {
+  sourceRef: string
+  warnings: RepoReviewWarning[]
+  confidence: number
+  students: RepoReviewStudentMetrics[]
+}
+
+type GitHubCommitSummary = {
+  sha: string
+  commit: {
+    author: {
+      email?: string | null
+      date?: string | null
+      name?: string | null
+    }
+    message?: string | null
+  }
+  author?: {
+    login?: string | null
+  } | null
+  parents?: Array<{ sha: string }>
+}
+
+type GitHubCommitDetail = GitHubCommitSummary & {
+  files?: Array<{
+    filename?: string
+    status?: string
+    additions?: number
+    deletions?: number
+  }>
+}
+
+type GitHubPullSummary = {
+  number: number
+  html_url?: string | null
+  title?: string | null
+  body?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+  merged_at?: string | null
+  user?: { login?: string | null } | null
+}
+
+type GitHubReview = {
+  id: number
+  html_url?: string | null
+  submitted_at?: string | null
+  body?: string | null
+  user?: { login?: string | null } | null
+  state?: string | null
+}
+
+function getGitHubToken(): string | null {
+  const key = process.env.GITHUB_PAT?.trim() || process.env.GITHUB_FEEDBACK_TOKEN?.trim() || ''
+  return key || null
+}
+
+async function githubRequest<T>(path: string): Promise<T> {
+  const token = getGitHubToken()
+  const res = await fetch(`${GITHUB_API_BASE}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`GitHub request failed (${res.status}): ${text}`)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export function parseGitHubRepoUrl(input: string): { owner: string; name: string } | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/i)
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], name: httpsMatch[2] }
+  }
+
+  const shorthandMatch = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/)
+  if (shorthandMatch) {
+    return { owner: shorthandMatch[1], name: shorthandMatch[2] }
+  }
+
+  return null
+}
+
+export function normalizeCommitEmails(emails: string[] | null | undefined): string[] {
+  return [...new Set((emails || []).map((email) => email.trim().toLowerCase()).filter(Boolean))]
+}
+
+function isMergeCommit(commit: GitHubCommitSummary): boolean {
+  return (commit.parents?.length || 0) > 1 || /^merge\b/i.test(commit.commit.message || '')
+}
+
+function getTorontoDay(iso: string): string {
+  return formatInTimeZone(new Date(iso), TORONTO_TIMEZONE, 'yyyy-MM-dd')
+}
+
+function enumerateTorontoDays(startAt: string, endAt: string): string[] {
+  const days: string[] = []
+  const cursor = new Date(startAt)
+  const end = new Date(endAt)
+  cursor.setHours(0, 0, 0, 0)
+  while (cursor <= end) {
+    days.push(formatInTimeZone(cursor, TORONTO_TIMEZONE, 'yyyy-MM-dd'))
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return [...new Set(days)]
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function round(value: number, digits = 4): number {
+  const factor = 10 ** digits
+  return Math.round(value * factor) / factor
+}
+
+function createEmptySemanticBreakdown(): RepoReviewSemanticBreakdown {
+  return {
+    feature: 0,
+    bugfix: 0,
+    test: 0,
+    refactor: 0,
+    docs: 0,
+    styling: 0,
+    config: 0,
+    generated: 0,
+  }
+}
+
+function inferAreaFromPath(path: string): string {
+  const normalized = path.replace(/^\/+/, '')
+  const segments = normalized.split('/')
+  if (segments.length >= 2) return `${segments[0]}/${segments[1]}`
+  return segments[0] || 'root'
+}
+
+function isGeneratedPath(path: string): boolean {
+  return (
+    path.includes('/dist/') ||
+    path.includes('/build/') ||
+    path.includes('/coverage/') ||
+    path.endsWith('.map') ||
+    path.endsWith('.min.js') ||
+    path.endsWith('pnpm-lock.yaml') ||
+    path.endsWith('package-lock.json') ||
+    path.endsWith('yarn.lock')
+  )
+}
+
+function isTestPath(path: string): boolean {
+  return /(^|\/)(tests?|__tests__)\//.test(path) || /\.test\.[a-z]+$/i.test(path) || /\.spec\.[a-z]+$/i.test(path)
+}
+
+function isDocsPath(path: string): boolean {
+  return /(^|\/)(docs|guides)\//.test(path) || /\.(md|mdx|txt)$/i.test(path)
+}
+
+function isStylingPath(path: string): boolean {
+  return /\.(css|scss|sass)$/i.test(path) || /tailwind|theme|tokens/i.test(path)
+}
+
+function isConfigPath(path: string): boolean {
+  return (
+    /\.(json|ya?ml|toml|ini)$/i.test(path) ||
+    /(^|\/)(\.github|scripts)\//.test(path) ||
+    /(^|\/)(next\.config|tsconfig|eslint|prettier|vitest|playwright|package\.json|pnpm-workspace)/i.test(path)
+  )
+}
+
+function inferCategoryFromFiles(files: RepoReviewCommitFile[]): RepoReviewSemanticCategory | null {
+  if (!files.length) return null
+  if (files.every((file) => isGeneratedPath(file.filename))) return 'generated'
+  if (files.every((file) => isDocsPath(file.filename))) return 'docs'
+  if (files.every((file) => isTestPath(file.filename))) return 'test'
+  if (files.every((file) => isStylingPath(file.filename))) return 'styling'
+  if (files.every((file) => isConfigPath(file.filename))) return 'config'
+  return null
+}
+
+function inferCategoryFromMessage(message: string): RepoReviewSemanticCategory | null {
+  if (/\b(test|spec|coverage)\b/i.test(message)) return 'test'
+  if (/\b(fix|bug|regression|issue|patch)\b/i.test(message)) return 'bugfix'
+  if (/\b(refactor|cleanup|rename|restructure|extract)\b/i.test(message)) return 'refactor'
+  if (/\b(doc|readme|comment)\b/i.test(message)) return 'docs'
+  if (/\b(style|ui|css|layout|spacing)\b/i.test(message)) return 'styling'
+  if (/\b(config|ci|workflow|lint|deps|dependency)\b/i.test(message)) return 'config'
+  if (/\b(add|implement|create|build|feature)\b/i.test(message)) return 'feature'
+  return null
+}
+
+export function categorizeRepoReviewChange(
+  message: string,
+  files: RepoReviewCommitFile[],
+): { category: RepoReviewSemanticCategory; ambiguous: boolean } {
+  const fromFiles = inferCategoryFromFiles(files)
+  const fromMessage = inferCategoryFromMessage(message)
+
+  if (fromFiles && fromMessage && fromFiles !== fromMessage && fromFiles !== 'config' && fromFiles !== 'generated') {
+    return { category: fromMessage, ambiguous: true }
+  }
+
+  if (fromFiles) return { category: fromFiles, ambiguous: false }
+  if (fromMessage) return { category: fromMessage, ambiguous: false }
+  return { category: 'feature', ambiguous: true }
+}
+
+function isRepoReviewSemanticCategory(value: string | undefined): value is RepoReviewSemanticCategory {
+  return value === 'feature'
+    || value === 'bugfix'
+    || value === 'test'
+    || value === 'refactor'
+    || value === 'docs'
+    || value === 'styling'
+    || value === 'config'
+    || value === 'generated'
+}
+
+function buildAmbiguousClassificationSummary(message: string, files: RepoReviewCommitFile[]): string {
+  const topLine = message.split('\n')[0]?.trim() || 'Untitled change'
+  const topFiles = files
+    .map((file) => file.filename)
+    .filter(Boolean)
+    .slice(0, 5)
+    .join(', ')
+
+  return topFiles ? `${topLine} | files: ${topFiles}` : topLine
+}
+
+function computeWeightedContribution(category: RepoReviewSemanticCategory, files: RepoReviewCommitFile[]): number {
+  const churn = files.reduce((sum, file) => sum + file.additions + file.deletions, 0)
+  const volume = clamp(churn / CONTRIBUTION_SCALE, 0.25, 3)
+  return round(REPO_REVIEW_SEMANTIC_WEIGHTS[category] * volume)
+}
+
+function determineStudentId(
+  commit: GitHubCommitSummary,
+  identities: RepoReviewStudentIdentityInput[],
+): { studentId: string | null; githubLogin: string | null } {
+  const commitLogin = commit.author?.login?.toLowerCase() || null
+  const commitEmail = commit.commit.author.email?.toLowerCase() || null
+
+  for (const identity of identities) {
+    if (identity.githubLogin && commitLogin && identity.githubLogin.toLowerCase() === commitLogin) {
+      return { studentId: identity.studentId, githubLogin: identity.githubLogin }
+    }
+  }
+
+  for (const identity of identities) {
+    if (commitEmail && identity.commitEmails.includes(commitEmail)) {
+      return { studentId: identity.studentId, githubLogin: identity.githubLogin }
+    }
+  }
+
+  return { studentId: null, githubLogin: commitLogin }
+}
+
+async function listCommits(
+  owner: string,
+  repo: string,
+  branch: string,
+  window: RepoReviewWindow,
+): Promise<{ commits: GitHubCommitSummary[]; truncated: boolean }> {
+  const commits: GitHubCommitSummary[] = []
+  let page = 1
+  let truncated = false
+
+  while (page <= 5) {
+    const result = await githubRequest<GitHubCommitSummary[]>(
+      `/repos/${owner}/${repo}/commits?sha=${encodeURIComponent(branch)}&since=${encodeURIComponent(window.startAt)}&until=${encodeURIComponent(window.endAt)}&per_page=100&page=${page}`
+    )
+
+    if (!result.length) break
+    commits.push(...result)
+
+    if (commits.length >= MAX_COMMITS) {
+      truncated = true
+      return { commits: commits.slice(0, MAX_COMMITS), truncated }
+    }
+
+    if (result.length < 100) break
+    page += 1
+  }
+
+  return { commits, truncated }
+}
+
+async function listPulls(
+  owner: string,
+  repo: string,
+  window: RepoReviewWindow,
+): Promise<GitHubPullSummary[]> {
+  const pulls = await githubRequest<GitHubPullSummary[]>(
+    `/repos/${owner}/${repo}/pulls?state=all&sort=updated&direction=desc&per_page=${MAX_PULLS}`
+  )
+
+  return pulls.filter((pull) => {
+    const relevantAt = pull.merged_at || pull.updated_at || pull.created_at
+    if (!relevantAt) return false
+    const ms = new Date(relevantAt).getTime()
+    return ms >= new Date(window.startAt).getTime() && ms <= new Date(window.endAt).getTime()
+  })
+}
+
+async function listReviews(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<GitHubReview[]> {
+  return githubRequest<GitHubReview[]>(`/repos/${owner}/${repo}/pulls/${pullNumber}/reviews?per_page=100`)
+}
+
+async function fetchCommitDetails(
+  owner: string,
+  repo: string,
+  summaries: GitHubCommitSummary[],
+): Promise<GitHubCommitDetail[]> {
+  const queue = [...summaries]
+  const details: GitHubCommitDetail[] = []
+  const concurrency = Math.min(8, queue.length)
+
+  async function worker() {
+    while (queue.length > 0) {
+      const commit = queue.shift()
+      if (!commit) break
+      const detail = await githubRequest<GitHubCommitDetail>(`/repos/${owner}/${repo}/commits/${commit.sha}`)
+      details.push(detail)
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+  return details
+}
+
+function buildEvidenceForCommits(commits: RepoReviewAnalyzedCommit[]): RepoReviewEvidenceItem[] {
+  return commits
+    .sort((a, b) => new Date(b.authoredAt).getTime() - new Date(a.authoredAt).getTime())
+    .slice(0, MAX_EVIDENCE_ITEMS)
+    .map((commit) => ({
+      type: 'commit',
+      id: commit.sha,
+      title: commit.message.split('\n')[0] || commit.sha.slice(0, 7),
+      authored_at: commit.authoredAt,
+      summary: `${commit.category} • ${commit.files.length} file${commit.files.length === 1 ? '' : 's'}`,
+      category: commit.category,
+    }))
+}
+
+function appendEvidence(items: RepoReviewEvidenceItem[], next: RepoReviewEvidenceItem[]) {
+  for (const item of next) {
+    if (items.length >= MAX_EVIDENCE_ITEMS) return
+    items.push(item)
+  }
+}
+
+export function computeRepoReviewMetrics(opts: {
+  identities: RepoReviewStudentIdentityInput[]
+  commits: RepoReviewAnalyzedCommit[]
+  reviewWindow: RepoReviewWindow
+  reviewEvidenceByLogin?: Map<string, RepoReviewEvidenceItem[]>
+}): RepoReviewAnalysisResult {
+  const warnings: RepoReviewWarning[] = []
+  const byStudent = new Map<string, RepoReviewAnalyzedCommit[]>()
+  const unmatchedCommits: RepoReviewAnalyzedCommit[] = []
+
+  for (const commit of opts.commits) {
+    const identity = opts.identities.find((item) => {
+      if (item.githubLogin && commit.githubLogin && item.githubLogin.toLowerCase() === commit.githubLogin.toLowerCase()) {
+        return true
+      }
+      if (commit.authorEmail && item.commitEmails.includes(commit.authorEmail.toLowerCase())) {
+        return true
+      }
+      return false
+    })
+
+    if (!identity) {
+      unmatchedCommits.push(commit)
+      continue
+    }
+
+    const commits = byStudent.get(identity.studentId) || []
+    commits.push(commit)
+    byStudent.set(identity.studentId, commits)
+  }
+
+  if (unmatchedCommits.length > 0) {
+    warnings.push({
+      code: 'unmatched-commits',
+      message: `${unmatchedCommits.length} commit(s) could not be matched to a student mapping and were excluded.`,
+    })
+  }
+
+  const totalWeightedContribution = Array.from(byStudent.values())
+    .flat()
+    .reduce((sum, commit) => sum + commit.weightedContribution, 0)
+
+  const totalDays = enumerateTorontoDays(opts.reviewWindow.startAt, opts.reviewWindow.endAt).length || 1
+  const burstCutoffMs = new Date(opts.reviewWindow.endAt).getTime() - (48 * 60 * 60 * 1000)
+
+  const students = opts.identities.map((identity) => {
+    const commits = (byStudent.get(identity.studentId) || []).sort(
+      (left, right) => new Date(left.authoredAt).getTime() - new Date(right.authoredAt).getTime()
+    )
+
+    const activeDaysSet = new Set(commits.map((commit) => getTorontoDay(commit.authoredAt)))
+    const timelineMap = new Map<string, RepoReviewTimelinePoint>()
+    const breakdown = createEmptySemanticBreakdown()
+    const areaCounts = new Map<string, number>()
+    let weightedContribution = 0
+    let lastCommitAt = 0
+    let sessionCount = 0
+    let burstWeightedContribution = 0
+
+    for (const commit of commits) {
+      weightedContribution += commit.weightedContribution
+      breakdown[commit.category] += commit.weightedContribution
+
+      if (new Date(commit.authoredAt).getTime() >= burstCutoffMs) {
+        burstWeightedContribution += commit.weightedContribution
+      }
+
+      const commitAt = new Date(commit.authoredAt).getTime()
+      if (!lastCommitAt || commitAt - lastCommitAt > SESSION_GAP_MS) {
+        sessionCount += 1
+      }
+      lastCommitAt = commitAt
+
+      const day = getTorontoDay(commit.authoredAt)
+      const existingTimelinePoint = timelineMap.get(day) || {
+        date: day,
+        weighted_contribution: 0,
+        commit_count: 0,
+      }
+      existingTimelinePoint.weighted_contribution = round(
+        existingTimelinePoint.weighted_contribution + commit.weightedContribution
+      )
+      existingTimelinePoint.commit_count += 1
+      timelineMap.set(day, existingTimelinePoint)
+
+      for (const area of commit.areas) {
+        areaCounts.set(area, (areaCounts.get(area) || 0) + 1)
+      }
+    }
+
+    const featureLike = breakdown.feature + breakdown.bugfix
+    const refinement = breakdown.test + breakdown.refactor
+    const spreadScore = commits.length === 0 ? 0 : round(clamp(activeDaysSet.size / Math.max(totalDays, 1), 0, 1))
+    const iterationScore = commits.length === 0
+      ? 0
+      : round(clamp((refinement / Math.max(weightedContribution, 0.0001)) * 0.7 + Math.min(sessionCount, 6) / 6 * 0.3, 0, 1))
+    const burstRatio = commits.length === 0 ? 0 : round(clamp(burstWeightedContribution / Math.max(weightedContribution, 0.0001), 0, 1))
+    const relativeContributionShare = totalWeightedContribution === 0
+      ? 0
+      : round(weightedContribution / totalWeightedContribution)
+
+    const evidence = buildEvidenceForCommits(commits)
+    if (identity.githubLogin && opts.reviewEvidenceByLogin?.has(identity.githubLogin.toLowerCase())) {
+      appendEvidence(evidence, opts.reviewEvidenceByLogin.get(identity.githubLogin.toLowerCase()) || [])
+    }
+
+    const areas = [...areaCounts.entries()]
+      .sort((left, right) => right[1] - left[1])
+      .slice(0, 4)
+      .map(([area]) => area)
+
+    return {
+      studentId: identity.studentId,
+      githubLogin: identity.githubLogin,
+      commitCount: commits.length,
+      activeDays: activeDaysSet.size,
+      sessionCount,
+      burstRatio,
+      weightedContribution: round(weightedContribution),
+      relativeContributionShare,
+      spreadScore,
+      iterationScore,
+      semanticBreakdown: breakdown,
+      timeline: [...timelineMap.values()].sort((left, right) => left.date.localeCompare(right.date)),
+      evidence,
+      areas,
+      reviewActivityCount: (opts.reviewEvidenceByLogin?.get(identity.githubLogin?.toLowerCase() || '') || [])
+        .filter((item) => item.type === 'review' || item.type === 'pull_request' || item.type === 'issue')
+        .length,
+    }
+  })
+
+  const matchedStudents = students.filter((student) => student.commitCount > 0 || student.reviewActivityCount > 0)
+  const confidence = matchedStudents.length === 0
+    ? 0.2
+    : round(clamp(
+        0.55
+        + (matchedStudents.length / Math.max(opts.identities.length, 1)) * 0.25
+        - (unmatchedCommits.length / Math.max(opts.commits.length || 1, 1)) * 0.3,
+        0.2,
+        1,
+      ))
+
+  return {
+    sourceRef: '',
+    warnings,
+    confidence,
+    students,
+  }
+}
+
+async function buildReviewEvidenceByLogin(
+  owner: string,
+  repo: string,
+  window: RepoReviewWindow,
+  includePrReviews: boolean,
+): Promise<Map<string, RepoReviewEvidenceItem[]>> {
+  const byLogin = new Map<string, RepoReviewEvidenceItem[]>()
+  if (!includePrReviews) return byLogin
+
+  const pulls = await listPulls(owner, repo, window)
+  for (const pull of pulls) {
+    const authorLogin = pull.user?.login?.toLowerCase()
+    const relevantAt = pull.merged_at || pull.updated_at || pull.created_at || undefined
+    if (authorLogin) {
+      const items = byLogin.get(authorLogin) || []
+      items.push({
+        type: 'pull_request',
+        id: String(pull.number),
+        title: pull.title || `Pull request #${pull.number}`,
+        url: pull.html_url || undefined,
+        authored_at: relevantAt,
+        summary: 'Pull request activity',
+      })
+      byLogin.set(authorLogin, items)
+    }
+
+    const reviews = await listReviews(owner, repo, pull.number)
+    for (const review of reviews) {
+      const submittedAt = review.submitted_at
+      if (!submittedAt) continue
+      const submittedMs = new Date(submittedAt).getTime()
+      if (submittedMs < new Date(window.startAt).getTime() || submittedMs > new Date(window.endAt).getTime()) {
+        continue
+      }
+
+      const login = review.user?.login?.toLowerCase()
+      if (!login) continue
+
+      const items = byLogin.get(login) || []
+      items.push({
+        type: 'review',
+        id: String(review.id),
+        title: `${review.state || 'Review'} on PR #${pull.number}`,
+        url: review.html_url || undefined,
+        authored_at: submittedAt,
+        summary: review.body?.trim() ? review.body.trim().slice(0, 180) : 'Review comment',
+      })
+      byLogin.set(login, items)
+    }
+  }
+
+  return byLogin
+}
+
+export async function analyzeRepoReviewAssignment(opts: {
+  config: AssignmentRepoReviewConfig
+  identities: RepoReviewStudentIdentityInput[]
+  reviewWindow: RepoReviewWindow
+}): Promise<RepoReviewAnalysisResult> {
+  const { config, identities, reviewWindow } = opts
+  const warnings: RepoReviewWarning[] = []
+  const { commits: commitSummaries, truncated } = await listCommits(
+    config.repo_owner,
+    config.repo_name,
+    config.default_branch,
+    reviewWindow,
+  )
+
+  if (truncated) {
+    warnings.push({
+      code: 'truncated-commits',
+      message: `Commit analysis was limited to the first ${MAX_COMMITS} commits in the review window.`,
+    })
+  }
+
+  const nonMergeSummaries = commitSummaries.filter((commit) => !isMergeCommit(commit))
+  const commitDetails = await fetchCommitDetails(config.repo_owner, config.repo_name, nonMergeSummaries)
+
+  const provisionalCommits = commitDetails.map((commit) => {
+    const files = (commit.files || []).map((file) => ({
+      filename: file.filename || '',
+      status: file.status || 'modified',
+      additions: Number(file.additions || 0),
+      deletions: Number(file.deletions || 0),
+    }))
+    const { category, ambiguous } = categorizeRepoReviewChange(commit.commit.message || '', files)
+
+    return {
+      sha: commit.sha,
+      authoredAt: commit.commit.author.date || new Date().toISOString(),
+      message: commit.commit.message || '',
+      githubLogin: commit.author?.login || null,
+      authorEmail: commit.commit.author.email || null,
+      files,
+      category,
+      ambiguous,
+      areas: [...new Set(files.map((file) => inferAreaFromPath(file.filename)).filter(Boolean))],
+    }
+  })
+
+  const ambiguousOverrides: Record<string, string> = await classifyAmbiguousRepoReviewChanges(
+    provisionalCommits
+      .filter((commit) => commit.ambiguous)
+      .map((commit) => ({
+        id: commit.sha,
+        summary: buildAmbiguousClassificationSummary(commit.message, commit.files),
+      }))
+  ).catch((error): Record<string, string> => {
+    warnings.push({
+      code: 'ai-classification-failed',
+      message: `Ambiguous change classification fell back to heuristics: ${error instanceof Error ? error.message : 'unknown error'}`,
+    })
+    return {}
+  })
+
+  const analyzedCommits = provisionalCommits.map((commit) => {
+    const override = ambiguousOverrides[commit.sha]
+    const category = isRepoReviewSemanticCategory(override) ? override : commit.category
+    return {
+      sha: commit.sha,
+      authoredAt: commit.authoredAt,
+      message: commit.message,
+      githubLogin: commit.githubLogin,
+      authorEmail: commit.authorEmail,
+      files: commit.files,
+      category,
+      weightedContribution: computeWeightedContribution(category, commit.files),
+      areas: commit.areas,
+    } satisfies RepoReviewAnalyzedCommit
+  })
+
+  const reviewEvidenceByLogin = await buildReviewEvidenceByLogin(
+    config.repo_owner,
+    config.repo_name,
+    reviewWindow,
+    config.include_pr_reviews,
+  ).catch((error) => {
+    warnings.push({
+      code: 'github-review-fetch-failed',
+      message: `PR/review evidence could not be loaded: ${error instanceof Error ? error.message : 'unknown error'}`,
+    })
+    return new Map<string, RepoReviewEvidenceItem[]>()
+  })
+
+  const analysis = computeRepoReviewMetrics({
+    identities: identities.map((identity) => ({
+      ...identity,
+      commitEmails: normalizeCommitEmails(identity.commitEmails),
+    })),
+    commits: analyzedCommits,
+    reviewWindow,
+    reviewEvidenceByLogin,
+  })
+
+  return {
+    sourceRef: config.default_branch,
+    warnings: [...analysis.warnings, ...warnings],
+    confidence: analysis.confidence,
+    students: analysis.students,
+  }
+}
+
+export function buildRepoReviewWindow(opts: {
+  dueAt: string
+  releasedAt?: string | null
+  reviewStartAt?: string | null
+  reviewEndAt?: string | null
+}): RepoReviewWindow {
+  const startAt = opts.reviewStartAt || opts.releasedAt || new Date(new Date(opts.dueAt).getTime() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const endAt = opts.reviewEndAt || opts.dueAt
+  return { startAt, endAt }
+}
+
+export function formatRepoReviewRepoName(config: Pick<AssignmentRepoReviewConfig, 'repo_owner' | 'repo_name'>): string {
+  return `${config.repo_owner}/${config.repo_name}`
+}
+
+export function hydrateIdentityRow(
+  userId: string,
+  githubIdentity: UserGitHubIdentity | null | undefined,
+): { githubLogin: string | null; commitEmails: string[] } {
+  if (!githubIdentity || githubIdentity.user_id !== userId) {
+    return { githubLogin: null, commitEmails: [] }
+  }
+  return {
+    githubLogin: githubIdentity.github_login,
+    commitEmails: normalizeCommitEmails(githubIdentity.commit_emails),
+  }
+}

--- a/src/lib/server/assignments.ts
+++ b/src/lib/server/assignments.ts
@@ -1,6 +1,7 @@
 type AssignmentVisibilityRecord = {
   is_draft: boolean
   released_at: string | null
+  evaluation_mode?: 'document' | 'repo_review'
 }
 
 export function isAssignmentVisibleToStudents(
@@ -11,4 +12,3 @@ export function isAssignmentVisibleToStudents(
   if (!assignment.released_at) return true
   return new Date(assignment.released_at).getTime() <= now.getTime()
 }
-

--- a/src/lib/server/repo-review.ts
+++ b/src/lib/server/repo-review.ts
@@ -1,0 +1,176 @@
+import { getServiceRoleClient } from '@/lib/supabase'
+import { parseGitHubRepoUrl } from '@/lib/repo-review'
+import { ApiError, apiErrors } from '@/lib/api-handler'
+import type {
+  Assignment,
+  AssignmentRepoReviewConfig,
+  AssignmentRepoReviewResult,
+  AssignmentRepoReviewRun,
+  UserGitHubIdentity,
+} from '@/types'
+
+type AssignmentWithClassroom = Assignment & {
+  classrooms: {
+    id: string
+    title: string
+    teacher_id: string
+    archived_at: string | null
+  }
+}
+
+export interface RepoReviewRosterStudent {
+  student_id: string
+  student_email: string
+  student_name: string | null
+  github_identity: UserGitHubIdentity | null
+}
+
+export async function assertTeacherOwnsAssignment(teacherId: string, assignmentId: string): Promise<AssignmentWithClassroom> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('assignments')
+    .select(`
+      *,
+      classrooms!inner (
+        id,
+        title,
+        teacher_id,
+        archived_at
+      )
+    `)
+    .eq('id', assignmentId)
+    .single()
+
+  if (error || !data) {
+    throw apiErrors.notFound('Assignment not found')
+  }
+
+  if (data.classrooms.teacher_id !== teacherId) {
+    throw new ApiError(403, 'Unauthorized')
+  }
+
+  return data as AssignmentWithClassroom
+}
+
+export async function loadRepoReviewConfig(assignmentId: string): Promise<AssignmentRepoReviewConfig | null> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('assignment_repo_reviews')
+    .select('*')
+    .eq('assignment_id', assignmentId)
+    .maybeSingle()
+
+  if (error) {
+    throw new ApiError(500, 'Failed to load repo review config')
+  }
+
+  return data as AssignmentRepoReviewConfig | null
+}
+
+export async function loadRepoReviewRosterStudents(classroomId: string): Promise<RepoReviewRosterStudent[]> {
+  const supabase = getServiceRoleClient()
+  const { data: enrollments, error: enrollmentsError } = await supabase
+    .from('classroom_enrollments')
+    .select(`
+      student_id,
+      users!inner (
+        email
+      )
+    `)
+    .eq('classroom_id', classroomId)
+
+  if (enrollmentsError) {
+    throw new ApiError(500, 'Failed to load classroom roster')
+  }
+
+  const studentIds = (enrollments || []).map((row) => row.student_id)
+  const { data: profiles } = studentIds.length > 0
+    ? await supabase
+        .from('student_profiles')
+        .select('user_id, first_name, last_name')
+        .in('user_id', studentIds)
+    : { data: [] as Array<{ user_id: string; first_name: string | null; last_name: string | null }> }
+
+  const { data: githubIdentities } = studentIds.length > 0
+    ? await supabase
+        .from('user_github_identities')
+        .select('*')
+        .in('user_id', studentIds)
+    : { data: [] as UserGitHubIdentity[] }
+
+  const profileMap = new Map(
+    (profiles || []).map((profile) => [
+      profile.user_id,
+      `${profile.first_name || ''} ${profile.last_name || ''}`.trim() || null,
+    ])
+  )
+  const identityMap = new Map(
+    (githubIdentities || []).map((identity) => [identity.user_id, identity as UserGitHubIdentity])
+  )
+
+  return (enrollments || [])
+    .map((row) => ({
+      student_id: row.student_id,
+      student_email: (row.users as unknown as { email: string }).email,
+      student_name: profileMap.get(row.student_id) || null,
+      github_identity: identityMap.get(row.student_id) || null,
+    }))
+    .sort((left, right) => (left.student_name || left.student_email).localeCompare(right.student_name || right.student_email))
+}
+
+export async function loadLatestRepoReviewRun(assignmentId: string): Promise<AssignmentRepoReviewRun | null> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('assignment_repo_review_runs')
+    .select('*')
+    .eq('assignment_id', assignmentId)
+    .order('started_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new ApiError(500, 'Failed to load repo review run')
+  }
+
+  return data as AssignmentRepoReviewRun | null
+}
+
+export async function loadLatestCompletedRepoReviewRun(assignmentId: string): Promise<AssignmentRepoReviewRun | null> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('assignment_repo_review_runs')
+    .select('*')
+    .eq('assignment_id', assignmentId)
+    .eq('status', 'completed')
+    .order('started_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new ApiError(500, 'Failed to load completed repo review run')
+  }
+
+  return data as AssignmentRepoReviewRun | null
+}
+
+export async function loadRepoReviewResults(runId: string): Promise<AssignmentRepoReviewResult[]> {
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase
+    .from('assignment_repo_review_results')
+    .select('*')
+    .eq('run_id', runId)
+
+  if (error) {
+    throw new ApiError(500, 'Failed to load repo review results')
+  }
+
+  return (data || []) as AssignmentRepoReviewResult[]
+}
+
+export function parseAndValidateRepoUrl(repoUrl: string): { owner: string; name: string } {
+  const parsed = parseGitHubRepoUrl(repoUrl)
+  if (!parsed) {
+    throw apiErrors.badRequest('repo_url must be a GitHub URL or owner/name')
+  }
+  return parsed
+}

--- a/src/lib/validations/repo-review.ts
+++ b/src/lib/validations/repo-review.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const repoReviewConfigSchema = z.object({
+  provider: z.literal('github').default('github'),
+  repo_url: z.string().min(1, 'repo_url is required'),
+  default_branch: z.string().trim().min(1, 'default_branch is required').default('main'),
+  review_start_at: z.string().datetime().nullable().optional(),
+  review_end_at: z.string().datetime().nullable().optional(),
+  include_pr_reviews: z.boolean().default(true),
+  student_mappings: z.array(
+    z.object({
+      student_id: z.string().uuid().or(z.string().min(1)),
+      github_login: z.string().trim().min(1).nullable().optional(),
+      commit_emails: z.array(z.string().email()).default([]),
+    })
+  ).default([]),
+})
+
+export const repoReviewRunSchema = z.object({
+  force: z.boolean().optional(),
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,6 +148,8 @@ export interface TiptapMark {
 }
 
 // Assignment types
+export type AssignmentEvaluationMode = 'document' | 'repo_review'
+
 export interface Assignment {
   id: string
   classroom_id: string
@@ -158,6 +160,7 @@ export interface Assignment {
   position: number
   is_draft: boolean  // Whether assignment is a draft (not visible to students)
   released_at: string | null  // When the assignment was released to students
+  evaluation_mode: AssignmentEvaluationMode
   track_authenticity: boolean
   points_possible?: number
   include_in_final?: boolean
@@ -239,6 +242,115 @@ export interface AssignmentStats {
   total_students: number
   submitted: number
   late: number
+}
+
+export type RepoReviewProvider = 'github'
+export type RepoReviewRunStatus = 'queued' | 'running' | 'completed' | 'failed'
+export type RepoReviewSemanticCategory =
+  | 'feature'
+  | 'bugfix'
+  | 'test'
+  | 'refactor'
+  | 'docs'
+  | 'styling'
+  | 'config'
+  | 'generated'
+
+export interface AssignmentRepoReviewConfig {
+  assignment_id: string
+  provider: RepoReviewProvider
+  repo_owner: string
+  repo_name: string
+  default_branch: string
+  review_start_at: string | null
+  review_end_at: string | null
+  include_pr_reviews: boolean
+  config_json: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface UserGitHubIdentity {
+  id: string
+  user_id: string
+  github_login: string | null
+  commit_emails: string[]
+  created_at: string
+  updated_at: string
+}
+
+export interface RepoReviewWarning {
+  code: string
+  message: string
+  student_id?: string
+  github_login?: string
+}
+
+export interface AssignmentRepoReviewRun {
+  id: string
+  assignment_id: string
+  status: RepoReviewRunStatus
+  triggered_by: string
+  started_at: string
+  completed_at: string | null
+  source_ref: string | null
+  metrics_version: string
+  prompt_version: string
+  model: string | null
+  warnings_json: RepoReviewWarning[]
+  created_at: string
+}
+
+export interface RepoReviewTimelinePoint {
+  date: string
+  weighted_contribution: number
+  commit_count: number
+}
+
+export interface RepoReviewEvidenceItem {
+  type: 'commit' | 'pull_request' | 'review' | 'issue'
+  id: string
+  title: string
+  url?: string
+  authored_at?: string
+  summary?: string
+  category?: RepoReviewSemanticCategory
+}
+
+export interface RepoReviewSemanticBreakdown {
+  feature: number
+  bugfix: number
+  test: number
+  refactor: number
+  docs: number
+  styling: number
+  config: number
+  generated: number
+}
+
+export interface AssignmentRepoReviewResult {
+  id: string
+  run_id: string
+  assignment_id: string
+  student_id: string
+  github_login: string | null
+  commit_count: number
+  active_days: number
+  session_count: number
+  burst_ratio: number
+  weighted_contribution: number
+  relative_contribution_share: number
+  spread_score: number
+  iteration_score: number
+  semantic_breakdown_json: Partial<RepoReviewSemanticBreakdown>
+  timeline_json: RepoReviewTimelinePoint[]
+  evidence_json: RepoReviewEvidenceItem[]
+  draft_score_completion: number | null
+  draft_score_thinking: number | null
+  draft_score_workflow: number | null
+  draft_feedback: string | null
+  confidence: number
+  created_at: string
 }
 
 /**

--- a/supabase/migrations/048_repo_review_grading.sql
+++ b/supabase/migrations/048_repo_review_grading.sql
@@ -1,0 +1,236 @@
+-- Repo review grading: assignment mode, GitHub identity mapping, analysis runs/results
+
+alter table public.assignments
+  add column if not exists evaluation_mode text not null default 'document'
+    check (evaluation_mode in ('document', 'repo_review'));
+
+create table if not exists public.assignment_repo_reviews (
+  assignment_id uuid primary key references public.assignments (id) on delete cascade,
+  provider text not null default 'github' check (provider in ('github')),
+  repo_owner text not null,
+  repo_name text not null,
+  default_branch text not null default 'main',
+  review_start_at timestamptz,
+  review_end_at timestamptz,
+  include_pr_reviews boolean not null default true,
+  config_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.user_github_identities (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users (id) on delete cascade,
+  github_login text,
+  commit_emails text[] not null default '{}'::text[],
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id)
+);
+
+create unique index if not exists idx_user_github_identities_login
+  on public.user_github_identities (lower(github_login))
+  where github_login is not null;
+
+create table if not exists public.assignment_repo_review_runs (
+  id uuid primary key default gen_random_uuid(),
+  assignment_id uuid not null references public.assignments (id) on delete cascade,
+  status text not null default 'queued'
+    check (status in ('queued', 'running', 'completed', 'failed')),
+  triggered_by uuid not null references public.users (id),
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  source_ref text,
+  metrics_version text not null default 'v1',
+  prompt_version text not null default 'v1',
+  model text,
+  warnings_json jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_assignment_repo_review_runs_assignment_started
+  on public.assignment_repo_review_runs (assignment_id, started_at desc);
+
+create table if not exists public.assignment_repo_review_results (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.assignment_repo_review_runs (id) on delete cascade,
+  assignment_id uuid not null references public.assignments (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  github_login text,
+  commit_count integer not null default 0,
+  active_days integer not null default 0,
+  session_count integer not null default 0,
+  burst_ratio numeric(6,4) not null default 0 check (burst_ratio >= 0 and burst_ratio <= 1),
+  weighted_contribution numeric(12,4) not null default 0,
+  relative_contribution_share numeric(6,4) not null default 0
+    check (relative_contribution_share >= 0 and relative_contribution_share <= 1),
+  spread_score numeric(6,4) not null default 0 check (spread_score >= 0 and spread_score <= 1),
+  iteration_score numeric(6,4) not null default 0 check (iteration_score >= 0 and iteration_score <= 1),
+  semantic_breakdown_json jsonb not null default '{}'::jsonb,
+  timeline_json jsonb not null default '[]'::jsonb,
+  evidence_json jsonb not null default '[]'::jsonb,
+  draft_score_completion smallint check (draft_score_completion is null or (draft_score_completion >= 0 and draft_score_completion <= 10)),
+  draft_score_thinking smallint check (draft_score_thinking is null or (draft_score_thinking >= 0 and draft_score_thinking <= 10)),
+  draft_score_workflow smallint check (draft_score_workflow is null or (draft_score_workflow >= 0 and draft_score_workflow <= 10)),
+  draft_feedback text,
+  confidence numeric(6,4) not null default 0 check (confidence >= 0 and confidence <= 1),
+  created_at timestamptz not null default now(),
+  unique (run_id, student_id)
+);
+
+create index if not exists idx_assignment_repo_review_results_assignment_student
+  on public.assignment_repo_review_results (assignment_id, student_id);
+
+create or replace function public.update_assignment_repo_reviews_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_assignment_repo_reviews_updated_at on public.assignment_repo_reviews;
+create trigger update_assignment_repo_reviews_updated_at
+  before update on public.assignment_repo_reviews
+  for each row
+  execute function public.update_assignment_repo_reviews_updated_at();
+
+create or replace function public.update_user_github_identities_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_user_github_identities_updated_at on public.user_github_identities;
+create trigger update_user_github_identities_updated_at
+  before update on public.user_github_identities
+  for each row
+  execute function public.update_user_github_identities_updated_at();
+
+alter table public.assignment_repo_reviews enable row level security;
+alter table public.user_github_identities enable row level security;
+alter table public.assignment_repo_review_runs enable row level security;
+alter table public.assignment_repo_review_results enable row level security;
+
+drop policy if exists "Teachers can view repo review configs" on public.assignment_repo_reviews;
+create policy "Teachers can view repo review configs"
+  on public.assignment_repo_reviews for select
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_reviews.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Teachers can manage repo review configs" on public.assignment_repo_reviews;
+create policy "Teachers can manage repo review configs"
+  on public.assignment_repo_reviews for all
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_reviews.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_reviews.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Users can view their GitHub identity" on public.user_github_identities;
+create policy "Users can view their GitHub identity"
+  on public.user_github_identities for select
+  using (user_id = auth.uid());
+
+drop policy if exists "Users can manage their GitHub identity" on public.user_github_identities;
+create policy "Users can manage their GitHub identity"
+  on public.user_github_identities for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+drop policy if exists "Teachers can view repo review runs" on public.assignment_repo_review_runs;
+create policy "Teachers can view repo review runs"
+  on public.assignment_repo_review_runs for select
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_runs.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Teachers can create repo review runs" on public.assignment_repo_review_runs;
+create policy "Teachers can create repo review runs"
+  on public.assignment_repo_review_runs for insert
+  with check (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_runs.assignment_id
+        and classrooms.teacher_id = auth.uid()
+        and assignment_repo_review_runs.triggered_by = auth.uid()
+    )
+  );
+
+drop policy if exists "Teachers can update repo review runs" on public.assignment_repo_review_runs;
+create policy "Teachers can update repo review runs"
+  on public.assignment_repo_review_runs for update
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_runs.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Teachers can view repo review results" on public.assignment_repo_review_results;
+create policy "Teachers can view repo review results"
+  on public.assignment_repo_review_results for select
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_results.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Teachers can manage repo review results" on public.assignment_repo_review_results;
+create policy "Teachers can manage repo review results"
+  on public.assignment_repo_review_results for all
+  using (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_results.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.assignments
+      join public.classrooms on classrooms.id = assignments.classroom_id
+      where assignments.id = assignment_repo_review_results.assignment_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -212,6 +212,43 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     const response = await PATCH(request, { params: { id: 'a-1' } })
     expect(response.status).toBe(400)
   })
+
+  it('requires a repo url when switching an assignment to repo review mode', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'a-1',
+                  title: 'Assignment 1',
+                  evaluation_mode: 'document',
+                  classrooms: { teacher_id: 'teacher-1', archived_at: null },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        evaluation_mode: 'repo_review',
+      }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('repo_review.repo_url')
+  })
 })
 
 describe('DELETE /api/teacher/assignments/[id]', () => {

--- a/tests/api/teacher/assignments-repo-review-apply.test.ts
+++ b/tests/api/teacher/assignments-repo-review-apply.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/assignments/[id]/repo-review/apply/route'
+
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherOwnsAssignment: vi.fn(async () => ({
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    evaluation_mode: 'repo_review',
+    classrooms: { archived_at: null },
+  })),
+  loadLatestRepoReviewRun: vi.fn(async () => ({ id: 'run-2', status: 'failed' })),
+  loadLatestCompletedRepoReviewRun: vi.fn(async () => ({ id: 'run-1', status: 'completed' })),
+  loadRepoReviewResults: vi.fn(async () => ([
+    {
+      student_id: 'student-1',
+      draft_score_completion: 8,
+      draft_score_thinking: 7,
+      draft_score_workflow: 9,
+      draft_feedback: 'Strong ownership and steady workflow.',
+    },
+  ])),
+}))
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('POST /api/teacher/assignments/[id]/repo-review/apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('upserts provisional repo review scores into assignment docs', async () => {
+    let capturedPayload: unknown = null
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [],
+                error: null,
+              }),
+            })),
+          })),
+          upsert: vi.fn((payload: unknown) => {
+            capturedPayload = payload
+            return Promise.resolve({ error: null })
+          }),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/repo-review/apply', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.applied_count).toBe(1)
+    expect(body.run_id).toBe('run-1')
+    expect(body.latest_run_id).toBe('run-2')
+    expect(capturedPayload).toEqual([
+      {
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
+        score_completion: 8,
+        score_thinking: 7,
+        score_workflow: 9,
+        feedback: 'Strong ownership and steady workflow.',
+        graded_at: null,
+        graded_by: null,
+        content: { type: 'doc', content: [] },
+        is_submitted: false,
+      },
+    ])
+  })
+})

--- a/tests/api/teacher/assignments-repo-review-config.test.ts
+++ b/tests/api/teacher/assignments-repo-review-config.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PUT } from '@/app/api/teacher/assignments/[id]/repo-review/config/route'
+
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherOwnsAssignment: vi.fn(async () => ({
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    evaluation_mode: 'document',
+    classrooms: { archived_at: null },
+  })),
+  parseAndValidateRepoUrl: vi.fn(() => ({ owner: 'codepetca', name: 'pika-student-team' })),
+}))
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('PUT /api/teacher/assignments/[id]/repo-review/config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves repo config and student mappings', async () => {
+    const calls: Array<{ table: string; payload: unknown }> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          update: vi.fn((payload: unknown) => {
+            calls.push({ table, payload })
+            return { eq: vi.fn().mockResolvedValue({ error: null }) }
+          }),
+        }
+      }
+
+      if (table === 'assignment_repo_reviews') {
+        return {
+          upsert: vi.fn((payload: unknown) => {
+            calls.push({ table, payload })
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: { assignment_id: 'assignment-1', repo_owner: 'codepetca', repo_name: 'pika-student-team' },
+                  error: null,
+                }),
+              })),
+            }
+          }),
+        }
+      }
+
+      if (table === 'user_github_identities') {
+        return {
+          upsert: vi.fn((payload: unknown) => {
+            calls.push({ table, payload })
+            return Promise.resolve({ error: null })
+          }),
+          delete: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/repo-review/config', {
+      method: 'PUT',
+      body: JSON.stringify({
+        provider: 'github',
+        repo_url: 'codepetca/pika-student-team',
+        default_branch: 'main',
+        include_pr_reviews: true,
+        student_mappings: [
+          {
+            student_id: 'student-1',
+            github_login: 'alexlee',
+            commit_emails: ['student1@example.com'],
+          },
+        ],
+      }),
+    })
+
+    const response = await PUT(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(3)
+  })
+})

--- a/tests/api/teacher/assignments-repo-review-route.test.ts
+++ b/tests/api/teacher/assignments-repo-review-route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/teacher/assignments/[id]/repo-review/route'
+
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherOwnsAssignment: vi.fn(async () => ({
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    evaluation_mode: 'repo_review',
+    due_at: '2026-03-20T23:59:59.000Z',
+    classrooms: { id: 'classroom-1', title: 'Test Classroom', teacher_id: 'teacher-1', archived_at: null },
+  })),
+  loadRepoReviewConfig: vi.fn(async () => ({
+    assignment_id: 'assignment-1',
+    provider: 'github',
+    repo_owner: 'codepetca',
+    repo_name: 'pika-demo',
+    default_branch: 'main',
+    review_start_at: null,
+    review_end_at: null,
+    include_pr_reviews: true,
+    config_json: {},
+  })),
+  loadRepoReviewRosterStudents: vi.fn(async () => ([
+    {
+      student_id: 'student-1',
+      student_email: 'student1@example.com',
+      student_name: 'Student One',
+      github_identity: { github_login: 'student1', commit_emails: ['student1@example.com'] },
+    },
+  ])),
+  loadLatestRepoReviewRun: vi.fn(async () => ({
+    id: 'run-failed',
+    assignment_id: 'assignment-1',
+    status: 'failed',
+    warnings_json: [{ message: 'Latest run failed' }],
+  })),
+  loadLatestCompletedRepoReviewRun: vi.fn(async () => ({
+    id: 'run-completed',
+    assignment_id: 'assignment-1',
+    status: 'completed',
+    warnings_json: [],
+  })),
+  loadRepoReviewResults: vi.fn(async (runId: string) => (
+    runId === 'run-completed'
+      ? [{
+          student_id: 'student-1',
+          timeline_json: [{ date: '2026-03-10', weighted_contribution: 1.2, commit_count: 2 }],
+          weighted_contribution: 1.2,
+          confidence: 0.8,
+        }]
+      : []
+  )),
+}))
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/assignments', () => ({ calculateAssignmentStatus: vi.fn(() => 'returned') }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/teacher/assignments/[id]/repo-review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the latest completed run for results while still exposing the latest run status', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [{
+                  student_id: 'student-1',
+                  score_completion: 8,
+                  score_thinking: 7,
+                  score_workflow: 9,
+                  returned_at: '2026-03-12T14:00:00.000Z',
+                  graded_at: '2026-03-12T13:00:00.000Z',
+                  submitted_at: null,
+                  updated_at: '2026-03-12T13:00:00.000Z',
+                  is_submitted: false,
+                }],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET({} as Request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.latest_run.id).toBe('run-failed')
+    expect(body.latest_completed_run.id).toBe('run-completed')
+    expect(body.summary.confidence).toBe(0.8)
+    expect(body.summary.warnings).toEqual([{ message: 'Latest run failed' }])
+    expect(body.students[0].result.weighted_contribution).toBe(1.2)
+  })
+})

--- a/tests/api/teacher/assignments.test.ts
+++ b/tests/api/teacher/assignments.test.ts
@@ -81,4 +81,22 @@ describe('POST /api/teacher/assignments', () => {
     const response = await POST(request)
     expect(response.status).toBe(400)
   })
+
+  it('requires a repo url for repo review assignments', async () => {
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments', {
+      method: 'POST',
+      body: JSON.stringify({
+        classroom_id: 'c1',
+        title: 'Repo Review',
+        due_at: '2026-03-20T23:59:59.000Z',
+        evaluation_mode: 'repo_review',
+      }),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('repo_review.repo_url')
+  })
 })

--- a/tests/unit/repo-review-analysis.test.ts
+++ b/tests/unit/repo-review-analysis.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/repo-review-ai', () => ({
+  classifyAmbiguousRepoReviewChanges: vi.fn(async () => ({ commit1: 'bugfix' })),
+}))
+
+import { analyzeRepoReviewAssignment } from '@/lib/repo-review'
+
+describe('analyzeRepoReviewAssignment', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    global.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+
+      if (url.includes('/repos/codepetca/pika-demo/commits?')) {
+        return new Response(JSON.stringify([
+          {
+            sha: 'commit1',
+            commit: {
+              author: {
+                email: 'student1@example.com',
+                date: '2026-03-10T12:00:00.000Z',
+                name: 'Student One',
+              },
+              message: 'update auth flow',
+            },
+            author: { login: 'student1' },
+            parents: [{ sha: 'parent-1' }],
+          },
+        ]), { status: 200 })
+      }
+
+      if (url.includes('/repos/codepetca/pika-demo/commits/commit1')) {
+        return new Response(JSON.stringify({
+          sha: 'commit1',
+          commit: {
+            author: {
+              email: 'student1@example.com',
+              date: '2026-03-10T12:00:00.000Z',
+              name: 'Student One',
+            },
+            message: 'update auth flow',
+          },
+          author: { login: 'student1' },
+          parents: [{ sha: 'parent-1' }],
+          files: [{
+            filename: 'src/app/login/page.tsx',
+            status: 'modified',
+            additions: 18,
+            deletions: 6,
+          }],
+        }), { status: 200 })
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    }) as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.clearAllMocks()
+  })
+
+  it('applies AI overrides for ambiguous change classification', async () => {
+    const analysis = await analyzeRepoReviewAssignment({
+      config: {
+        assignment_id: 'assignment-1',
+        provider: 'github',
+        repo_owner: 'codepetca',
+        repo_name: 'pika-demo',
+        default_branch: 'main',
+        review_start_at: null,
+        review_end_at: null,
+        include_pr_reviews: false,
+        config_json: {},
+        created_at: '2026-03-01T00:00:00.000Z',
+        updated_at: '2026-03-01T00:00:00.000Z',
+      },
+      identities: [{
+        studentId: 'student-1',
+        email: 'student1@example.com',
+        name: 'Student One',
+        githubLogin: 'student1',
+        commitEmails: ['student1@example.com'],
+      }],
+      reviewWindow: {
+        startAt: '2026-03-01T00:00:00.000Z',
+        endAt: '2026-03-20T23:59:59.000Z',
+      },
+    })
+
+    expect(analysis.students).toHaveLength(1)
+    expect(analysis.students[0].semanticBreakdown.bugfix).toBeGreaterThan(0)
+    expect(analysis.students[0].semanticBreakdown.feature).toBe(0)
+  })
+})

--- a/tests/unit/repo-review.test.ts
+++ b/tests/unit/repo-review.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { categorizeRepoReviewChange, computeRepoReviewMetrics, parseGitHubRepoUrl } from '@/lib/repo-review'
+
+describe('repo-review utilities', () => {
+  it('parses GitHub repo URLs and owner/name shorthand', () => {
+    expect(parseGitHubRepoUrl('https://github.com/openai/openai-node')).toEqual({
+      owner: 'openai',
+      name: 'openai-node',
+    })
+    expect(parseGitHubRepoUrl('openai/openai-node')).toEqual({
+      owner: 'openai',
+      name: 'openai-node',
+    })
+    expect(parseGitHubRepoUrl('not a repo')).toBeNull()
+  })
+
+  it('categorizes obvious test and bugfix changes', () => {
+    expect(categorizeRepoReviewChange('add regression test for login', [
+      { filename: 'tests/api/login.test.ts', status: 'modified', additions: 12, deletions: 0 },
+    ])).toEqual({ category: 'test', ambiguous: false })
+
+    expect(categorizeRepoReviewChange('fix classroom roster bug', [
+      { filename: 'src/app/api/teacher/classrooms/route.ts', status: 'modified', additions: 12, deletions: 4 },
+    ])).toEqual({ category: 'bugfix', ambiguous: false })
+  })
+
+  it('computes contribution and workflow metrics per student', () => {
+    const analysis = computeRepoReviewMetrics({
+      identities: [
+        {
+          studentId: 'student-1',
+          email: 'student1@example.com',
+          name: 'Alex Lee',
+          githubLogin: 'alexlee',
+          commitEmails: ['student1@example.com'],
+        },
+        {
+          studentId: 'student-2',
+          email: 'student2@example.com',
+          name: 'Sam Cruz',
+          githubLogin: 'samcruz',
+          commitEmails: ['student2@example.com'],
+        },
+      ],
+      commits: [
+        {
+          sha: 'a1',
+          authoredAt: '2026-03-01T14:00:00.000Z',
+          message: 'implement attendance filters',
+          githubLogin: 'alexlee',
+          authorEmail: 'student1@example.com',
+          files: [{ filename: 'src/lib/attendance.ts', status: 'modified', additions: 50, deletions: 10 }],
+          category: 'feature',
+          weightedContribution: 1.5,
+          areas: ['src/lib'],
+        },
+        {
+          sha: 'a2',
+          authoredAt: '2026-03-03T14:00:00.000Z',
+          message: 'add attendance tests',
+          githubLogin: 'alexlee',
+          authorEmail: 'student1@example.com',
+          files: [{ filename: 'tests/unit/attendance.test.ts', status: 'modified', additions: 20, deletions: 0 }],
+          category: 'test',
+          weightedContribution: 0.8,
+          areas: ['tests/unit'],
+        },
+        {
+          sha: 'b1',
+          authoredAt: '2026-03-04T13:00:00.000Z',
+          message: 'fix gradebook bug',
+          githubLogin: 'samcruz',
+          authorEmail: 'student2@example.com',
+          files: [{ filename: 'src/app/api/teacher/gradebook/route.ts', status: 'modified', additions: 18, deletions: 5 }],
+          category: 'bugfix',
+          weightedContribution: 0.9,
+          areas: ['src/app'],
+        },
+      ],
+      reviewWindow: {
+        startAt: '2026-03-01T00:00:00.000Z',
+        endAt: '2026-03-07T23:59:59.000Z',
+      },
+      reviewEvidenceByLogin: new Map([
+        ['alexlee', [{ type: 'pull_request', id: '12', title: 'PR 12', authored_at: '2026-03-03T16:00:00.000Z' }]],
+      ]),
+    })
+
+    expect(analysis.students).toHaveLength(2)
+
+    const alex = analysis.students.find((student) => student.studentId === 'student-1')
+    const sam = analysis.students.find((student) => student.studentId === 'student-2')
+
+    expect(alex?.commitCount).toBe(2)
+    expect(alex?.activeDays).toBe(2)
+    expect(alex?.relativeContributionShare).toBeGreaterThan(sam?.relativeContributionShare || 0)
+    expect(alex?.reviewActivityCount).toBe(1)
+    expect(alex?.evidence[0]?.type).toBe('commit')
+    expect(sam?.commitCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add a new `repo_review` assignment evaluation mode with schema, shared types, teacher APIs, and repo review config/run/result tables
- add repo analytics and AI-assisted feedback generation for contribution, workflow, and evidence-backed draft scoring
- add teacher repo-review assignment UI plus student returned-feedback UI while keeping raw analytics teacher-only

## Testing
- pnpm exec vitest run tests/api/teacher/assignments.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-repo-review-apply.test.ts tests/api/teacher/assignments-repo-review-config.test.ts tests/api/teacher/assignments-repo-review-route.test.ts tests/unit/repo-review.test.ts tests/unit/repo-review-analysis.test.ts
- pnpm exec tsc --noEmit
- pnpm exec supabase db push --local --yes
- Playwright manual verification of teacher repo-review detail view and student returned-feedback view
