### PR TITLE
fix: expand calendar cell textarea to fill full cell height

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js Dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    },
+    {
+      "name": "Vitest UI",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["test:ui"],
+      "port": 51204
+    }
+  ]
+}

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -292,7 +292,7 @@ export const LessonDayCell = memo(function LessonDayCell({
         }
       }}
       className={`
-        relative h-full min-w-0 overflow-hidden
+        relative h-full min-w-0 overflow-hidden flex flex-col
         ${isToday ? 'ring-2 ring-inset ring-blue-500' : ''}
         ${isNonClassDay ? 'bg-surface-2/50' : ''}
         ${!editable && !hasContent && !isNonClassDay ? 'bg-surface-2/50' : ''}
@@ -367,7 +367,7 @@ export const LessonDayCell = memo(function LessonDayCell({
       )}
 
       {/* Content area */}
-      <div className={`calendar-day-text ${compact ? 'px-0.5' : 'px-2 py-0.5'} [&_.ProseMirror]:!p-0 [&_.ProseMirror_p]:!my-0 overflow-hidden`}>
+      <div className={`calendar-day-text flex-1 min-h-0 ${compact ? 'px-0.5' : 'px-2 py-0.5'} [&_.ProseMirror]:!p-0 [&_.ProseMirror_p]:!my-0 overflow-hidden`}>
         {isEditing ? (
           <textarea
             ref={textareaRef}
@@ -375,7 +375,7 @@ export const LessonDayCell = memo(function LessonDayCell({
             onChange={(event) => handleMarkdownChange(event.target.value)}
             onKeyDown={handleKeyDown}
             onBlur={() => setIsEditing(false)}
-            className={`w-full resize-none border-none bg-transparent font-mono text-text-default focus:outline-none ${compact ? 'min-h-[4.5rem] text-[10px] leading-tight' : 'min-h-[6rem] text-sm leading-snug'}`}
+            className={`w-full h-full resize-none border-none bg-transparent font-mono text-text-default focus:outline-none ${compact ? 'text-[10px] leading-tight' : 'text-sm leading-snug'}`}
           />
         ) : (
           <button


### PR DESCRIPTION
## Summary

- Convert the calendar cell container to a flex column layout so children stack vertically
- Set the content area div to `flex-1 min-h-0` so it fills all remaining height below the date header and pills
- Give the textarea `h-full` so it stretches to fill its flex container (replaces fixed `min-h` constraints)

## Test plan

- [ ] Click a calendar cell in **week view** — textarea should fill the full cell height
- [ ] Click a calendar cell in **month view** (normal and expanded row heights)
- [ ] Click a calendar cell in **all view**
- [ ] Verify compact mode cells look correct
- [ ] Verify cells with assignment/announcement pills still lay out correctly
- [ ] Verify non-class days (gray background) are unaffected
- [ ] Verify today's cell (blue ring) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)