### PR TITLE
feat: add prev/next navigation to calendar day modal

### DIFF
--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useMemo, useState, useEffect } from 'react'
-import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, isSameDay, startOfMonth, endOfMonth, addMonths, subMonths, isWeekend } from 'date-fns'
+import { useMemo, useState, useEffect, useCallback } from 'react'
+import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, isSameDay, startOfMonth, endOfMonth, addMonths, subMonths, isWeekend, addDays } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import { ChevronLeft, ChevronRight, PanelRight, PanelRightClose } from 'lucide-react'
 import { LessonDayCell } from './LessonDayCell'
@@ -91,6 +91,25 @@ export function LessonCalendar({
   const today = useMemo(() => toZonedTime(new Date(), TIMEZONE), [])
   const [expandedWeekIdx, setExpandedWeekIdx] = useState<number | null>(null)
   const [presentedDay, setPresentedDay] = useState<Date | null>(null)
+
+  const handlePresentedDayPrev = useCallback(() => {
+    setPresentedDay((d) => (d ? addDays(d, -1) : d))
+  }, [])
+
+  const handlePresentedDayNext = useCallback(() => {
+    setPresentedDay((d) => (d ? addDays(d, 1) : d))
+  }, [])
+
+  useEffect(() => {
+    if (!presentedDay) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'ArrowLeft') handlePresentedDayPrev()
+      if (e.key === 'ArrowRight') handlePresentedDayNext()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [presentedDay, handlePresentedDayPrev, handlePresentedDayNext])
+
   const { rightPanel: shortcutHint } = useKeyboardShortcutHint()
 
   // Build a map of date -> lesson plan for quick lookup
@@ -571,12 +590,32 @@ export function LessonCalendar({
       >
         {presentedDayDetails && (
           <div className="flex min-h-[76vh] flex-col">
-            <h2
-              id="calendar-day-presentation-title"
-              className="text-4xl font-semibold tracking-tight text-text-default sm:text-5xl"
-            >
-              {format(presentedDayDetails.day, 'EEEE, MMMM d, yyyy')}
-            </h2>
+            <div className="flex items-center justify-between gap-3">
+              <h2
+                id="calendar-day-presentation-title"
+                className="text-4xl font-semibold tracking-tight text-text-default sm:text-5xl"
+              >
+                {format(presentedDayDetails.day, 'EEEE, MMMM d, yyyy')}
+              </h2>
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={handlePresentedDayPrev}
+                  className="rounded p-1 hover:bg-surface-hover"
+                  aria-label="Previous day"
+                >
+                  <ChevronLeft className="h-6 w-6" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handlePresentedDayNext}
+                  className="rounded p-1 hover:bg-surface-hover"
+                  aria-label="Next day"
+                >
+                  <ChevronRight className="h-6 w-6" />
+                </button>
+              </div>
+            </div>
 
             <div className="mt-8 flex-1 overflow-y-auto">
               {presentedDayDetails.lessonMarkdown ? (


### PR DESCRIPTION
## Summary

- Adds **Previous** and **Next** chevron buttons to the calendar day modal so users can navigate between days without closing and reopening the modal
- Adds **arrow key support** (← / →) to navigate days while the modal is open
- Navigation wraps correctly at month boundaries

## Changes

- `src/components/LessonCalendar.tsx`: Added day navigation state, chevron button UI, and `keydown` event listener for arrow keys

## Test plan

- [ ] Open calendar and click on a day to open the day modal
- [ ] Click the **‹** (left chevron) to go to the previous day — verify date updates correctly
- [ ] Click the **›** (right chevron) to go to the next day — verify date updates correctly
- [ ] Press the **← arrow key** while modal is open — verify it navigates to the previous day
- [ ] Press the **→ arrow key** while modal is open — verify it navigates to the next day
- [ ] Test navigation at month boundaries (first/last day of month)
- [ ] Verify closing the modal and reopening another day still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)