### PR TITLE
fix: independent pane scrolling in exam mode and teacher preview

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -769,7 +769,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   : showCurrentTestInfoPanel || isViewingResults
                     ? 'lg:grid-cols-[30%_70%]'
                     : 'lg:grid-cols-[50%_50%]'
-              } lg:h-full lg:min-h-0 lg:overflow-hidden lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
+              } lg:h-full lg:min-h-0 lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
             >
               <section
                 className={`rounded-xl border border-border bg-surface ${

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -276,12 +276,47 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
             showDocPanel ? 'lg:grid-cols-[50%_50%]' : 'lg:grid-cols-[30%_70%]'
           } lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)]`}
         >
-          <section
-            className={`rounded-xl border border-border bg-surface h-full ${
-              showDocPanel ? 'relative overflow-hidden p-0' : 'p-3 sm:p-4 overflow-y-auto scrollbar-hover'
-            }`}
-          >
-            {showDocPanel ? (
+          <section className="rounded-xl border border-border bg-surface h-full relative overflow-hidden">
+            {/* Doc list — always in DOM so switching back is instant */}
+            <div
+              aria-hidden={showDocPanel}
+              className={`p-3 sm:p-4 overflow-y-auto scrollbar-hover h-full transition-all duration-200 ease-out motion-reduce:transition-none ${
+                showDocPanel
+                  ? 'pointer-events-none translate-x-2 opacity-0'
+                  : 'translate-x-0 opacity-100'
+              }`}
+            >
+              <h2 className="mb-3 text-lg font-semibold text-text-default">Documents</h2>
+              {allowedDocs.length > 0 ? (
+                <div className="space-y-2">
+                  {allowedDocs.map((doc) => (
+                    <Button
+                      key={doc.id}
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="w-full justify-start"
+                      onClick={() => setActiveDoc(doc)}
+                      tabIndex={showDocPanel ? -1 : 0}
+                    >
+                      {doc.title}
+                    </Button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-text-muted">No documents provided for this test.</p>
+              )}
+            </div>
+
+            {/* Doc viewer — always in DOM so iframes preload before user opens them */}
+            <div
+              aria-hidden={!showDocPanel}
+              className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
+                showDocPanel
+                  ? 'pointer-events-auto translate-x-0 opacity-100'
+                  : 'pointer-events-none -translate-x-2 opacity-0'
+              }`}
+            >
               <div className="flex h-full flex-col bg-surface">
                 <div className="grid h-10 grid-cols-[auto_minmax(0,1fr)_auto] items-center border-b border-border bg-surface-2 px-3">
                   <button
@@ -289,6 +324,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                     onClick={() => setActiveDoc(null)}
                     aria-label="Back to documents list"
                     className="inline-flex items-center gap-1 justify-self-start whitespace-nowrap rounded-md bg-info-bg px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-info-bg-hover"
+                    tabIndex={showDocPanel ? 0 : -1}
                   >
                     <ChevronLeft className="h-3.5 w-3.5" />
                     <span>Back</span>
@@ -337,29 +373,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                   </div>
                 )}
               </div>
-            ) : (
-              <>
-                <h2 className="mb-3 text-lg font-semibold text-text-default">Documents</h2>
-                {allowedDocs.length > 0 ? (
-                  <div className="space-y-2">
-                    {allowedDocs.map((doc) => (
-                      <Button
-                        key={doc.id}
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        className="w-full justify-start"
-                        onClick={() => setActiveDoc(doc)}
-                      >
-                        {doc.title}
-                      </Button>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-text-muted">No documents provided for this test.</p>
-                )}
-              </>
-            )}
+            </div>
           </section>
 
           <section

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -214,7 +214,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
   const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
 
   return (
-    <div className="min-h-screen bg-page">
+    <div className="h-dvh overflow-hidden flex flex-col bg-page">
       {showNotMaximizedWarning && (
         <div
           aria-hidden="true"
@@ -248,7 +248,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
         </div>
       )}
 
-      <div className="mx-auto w-full max-w-none px-3 py-3 sm:px-4">
+      <div className="flex-shrink-0 mx-auto w-full max-w-none px-3 pt-3 sm:px-4">
         <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
           <Button type="button" variant="secondary" size="sm" className="gap-1.5" onClick={handleClosePreview}>
             <X className="h-4 w-4" />
@@ -258,15 +258,17 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
             Preview Mode
           </span>
         </div>
+      </div>
 
+      <div className="flex-1 min-h-0 mx-auto w-full max-w-none px-3 pb-3 sm:px-4">
         <div
-          className={`grid grid-cols-1 gap-2 ${
+          className={`grid grid-cols-1 gap-2 h-full grid-rows-[1fr] ${
             showDocPanel ? 'lg:grid-cols-[50%_50%]' : 'lg:grid-cols-[30%_70%]'
-          } lg:min-h-[calc(100dvh-6rem)] lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)]`}
+          } lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)]`}
         >
           <section
-            className={`rounded-xl border border-border bg-surface lg:h-full ${
-              showDocPanel ? 'relative overflow-hidden p-0' : 'p-3 sm:p-4'
+            className={`rounded-xl border border-border bg-surface h-full ${
+              showDocPanel ? 'relative overflow-hidden p-0' : 'p-3 sm:p-4 overflow-y-auto scrollbar-hover'
             }`}
           >
             {showDocPanel ? (
@@ -351,7 +353,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
           </section>
 
           <section
-            className={`rounded-xl border border-border bg-surface p-3 sm:p-4 lg:h-full ${
+            className={`rounded-xl border border-border bg-surface p-3 sm:p-4 h-full overflow-y-auto scrollbar-hover ${
               showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
             }`}
           >

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -125,6 +125,16 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
     setIsFullscreen(fullscreenNow)
   }, [])
 
+  // Lock body scroll so the page-level container never scrolls in preview mode.
+  // The root layout sets body.min-h-screen which allows body growth; this overrides it.
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [])
+
   useEffect(() => {
     if (loading || error) return
     maximizePreviewWindow()

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -559,10 +559,12 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-[50%_50%]')
     expect(splitContainerExamMode.className).toContain('lg:h-full')
     expect(splitContainerExamMode.className).toContain('lg:min-h-0')
-    expect(splitContainerExamMode.className).toContain('lg:overflow-hidden')
 
     const paneSections = splitContainerExamMode.querySelectorAll('section')
-    expect(paneSections[1]?.className || '').toContain('lg:overflow-y-auto')
+    expect(paneSections[0]?.className || '').toContain('lg:sticky')
+    expect(paneSections[0]?.className || '').toContain('lg:h-[calc(100dvh-3rem)]')
+    expect(paneSections[1]?.className || '').toContain('lg:sticky')
+    expect(paneSections[1]?.className || '').toContain('overflow-y-auto')
 
     const docsHeading = screen.getByRole('heading', { name: 'Documents' })
     const leftPaneScroller = docsHeading.closest('.scrollbar-hover')


### PR DESCRIPTION
## Summary

- Exam mode split-pane layout now scrolls left and right panes independently — the main container no longer scrolls
- Uses `lg:sticky lg:top-12 lg:h-[calc(100dvh-3rem)]` on each section (mirrors how the app header is pinned) instead of fighting the broken `h-full` chain caused by `AppShell.min-h-dvh`
- `AppShell` gains `lg:h-dvh lg:overflow-hidden` when `examModeHeader` is set to lock the outer frame at desktop breakpoint
- Teacher test preview page (`TeacherTestPreviewPage`) gets the same independent-pane treatment via `h-dvh overflow-hidden flex flex-col` on its root and `document.body.style.overflow = 'hidden'` to prevent body-level scroll (root layout uses `min-h-screen`)
- Updated `StudentQuizzesTab` tests to assert the new sticky pane classes

## Test plan

- [ ] Open student exam on desktop (≥1024px): scroll the left (documents) pane without the right (questions) pane moving
- [ ] Scroll the right (questions) pane without the left pane moving
- [ ] Confirm the header / top bar does not scroll away
- [ ] Open teacher test preview: verify same independent pane scrolling behaviour
- [ ] Close preview tab and confirm body scroll is restored on the previous page
- [ ] Resize below `lg` breakpoint (< 1024px): panes stack normally, single-column layout
- [ ] Verify document viewer (iframe / text) still shows and switches correctly
- [ ] Run unit tests: `pnpm test`

🤖 Generated with [Claude Code](https://claude.ai/code)