### PR TITLE
[codex] Fix student test submit visibility and closure UX

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8968,3 +8968,26 @@
 
 **Notes:**
 - The targeted command expanded to the full Vitest suite in this worktree; all 194 files / 1708 tests passed.
+**Goal:** Close student exam sessions gracefully when a teacher closes a test in progress (Issue #431).
+
+**Completed:**
+- Added a lightweight student session-status route at `src/app/api/student/tests/[id]/session-status/route.ts` so active test sessions can revalidate without polling the heavier test-detail payload
+- Updated `src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx` to:
+  - poll active started tests every 30 seconds
+  - recheck immediately on window focus / visibility return
+  - exit exam mode cleanly when the teacher closes the test
+  - show an in-place blocking notice with `Return to tests` instead of abruptly redirecting the student
+- Updated `src/components/StudentQuizForm.tsx` so submit/autosave failures caused by a remotely closed test notify the parent view and trigger immediate session revalidation
+- Added regression coverage for the new route and the new student-side closure behavior
+
+**Validation:**
+- `pnpm test tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-attempt.test.ts tests/api/student/tests-respond.test.ts tests/api/student/tests-session-status.test.ts tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx` (35 tests passing)
+- `pnpm lint`
+- Visual verification:
+  - `/tmp/pika-student-test-closure.png`
+  - `/tmp/pika-teacher-tests.png`
+  - `/tmp/pika-teacher-tests-mobile.png`
+
+**Notes:**
+- No `.ai/features.json` update was needed because this is a targeted behavior fix rather than an epic-level feature change
+- Student visual verification used the seeded active test with a Playwright route override for the new session-status endpoint so the exact closure notice state could be reviewed in-browser

--- a/src/app/api/student/tests/[id]/session-status/route.ts
+++ b/src/app/api/student/tests/[id]/session-status/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { getStudentTestStatus } from '@/lib/quizzes'
+import { assertStudentCanAccessTest, isMissingTestAttemptReturnColumnsError } from '@/lib/server/tests'
+import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
+import { withErrorHandler } from '@/lib/api-handler'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+function getSessionMessage(studentStatus: 'not_started' | 'responded' | 'can_view_results'): string | null {
+  if (studentStatus === 'can_view_results') {
+    return 'Your current work has been submitted. Results are now available from the tests list.'
+  }
+  if (studentStatus === 'responded') {
+    return 'Your current work has been submitted.'
+  }
+  return null
+}
+
+// GET /api/student/tests/[id]/session-status - Lightweight student test session revalidation
+export const GET = withErrorHandler('GetStudentTestSessionStatus', async (_request, context) => {
+  const user = await requireRole('student')
+  const { id: testId } = await context.params
+
+  const access = await assertStudentCanAccessTest(user.id, testId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const test = access.test
+  const supabase = getServiceRoleClient()
+
+  type AttemptRow = {
+    is_submitted: boolean
+    returned_at: string | null
+  }
+
+  let attempt: AttemptRow | null = null
+  let attemptError: { code?: string; message?: string; details?: string; hint?: string } | null = null
+
+  {
+    const attemptWithReturnResult = await supabase
+      .from('test_attempts')
+      .select('is_submitted, returned_at')
+      .eq('test_id', testId)
+      .eq('student_id', user.id)
+      .maybeSingle()
+
+    attempt = (attemptWithReturnResult.data as AttemptRow | null) || null
+    attemptError = attemptWithReturnResult.error
+  }
+
+  if (attemptError && isMissingTestAttemptReturnColumnsError(attemptError)) {
+    const legacyAttemptResult = await supabase
+      .from('test_attempts')
+      .select('is_submitted')
+      .eq('test_id', testId)
+      .eq('student_id', user.id)
+      .maybeSingle()
+
+    attempt = (legacyAttemptResult.data
+      ? {
+          ...(legacyAttemptResult.data as { is_submitted: boolean }),
+          returned_at: null,
+        }
+      : null)
+    attemptError = legacyAttemptResult.error
+  }
+
+  if (attemptError && attemptError.code !== 'PGRST205') {
+    console.error('Error fetching student test session status:', attemptError)
+    return NextResponse.json({ error: 'Failed to fetch test session status' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } = await supabase
+    .from('test_responses')
+    .select('selected_option, response_text')
+    .eq('test_id', testId)
+    .eq('student_id', user.id)
+
+  if (responsesError) {
+    console.error('Error checking submitted test responses for session status:', responsesError)
+    return NextResponse.json({ error: 'Failed to fetch test session status' }, { status: 500 })
+  }
+
+  const hasSubmitted = Boolean(attempt?.is_submitted) || hasAnyMeaningfulTestResponse(responses)
+
+  if (test.status === 'draft') {
+    return NextResponse.json({ error: 'Test not found' }, { status: 404 })
+  }
+
+  if (test.status === 'closed' && !hasSubmitted) {
+    return NextResponse.json({ error: 'Test not found' }, { status: 404 })
+  }
+
+  const studentStatus = getStudentTestStatus(test, hasSubmitted, attempt?.returned_at)
+  const canContinue = test.status === 'active' && !hasSubmitted
+
+  return NextResponse.json({
+    quiz: {
+      id: test.id,
+      status: test.status,
+      assessment_type: 'test' as const,
+      student_status: studentStatus,
+      returned_at: attempt?.returned_at || null,
+    },
+    student_status: studentStatus,
+    returned_at: attempt?.returned_at || null,
+    can_continue: canContinue,
+    message: canContinue ? null : getSessionMessage(studentStatus),
+  })
+})

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -23,6 +23,7 @@ import type {
   QuizAssessmentType,
   QuizFocusSummary,
   QuizQuestion,
+  StudentQuizStatus,
   StudentQuizView,
   TestResponseDraftValue,
 } from '@/types'
@@ -46,6 +47,25 @@ interface AllowedDocItem {
   source: 'link' | 'upload' | 'text'
   url?: string
   content?: string
+}
+
+interface RemoteClosureNotice {
+  title: string
+  description: string
+}
+
+interface StudentTestSessionStatusResponse {
+  quiz: {
+    id: string
+    status: 'draft' | 'active' | 'closed'
+    assessment_type: 'test'
+    student_status: StudentQuizStatus
+    returned_at: string | null
+  }
+  student_status: StudentQuizStatus
+  returned_at: string | null
+  can_continue: boolean
+  message: string | null
 }
 
 type FullscreenCapableElement = HTMLElement & {
@@ -99,6 +119,20 @@ function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
   return Array.from(linksByUrl.values())
 }
 
+function getRemoteClosureDescription(
+  studentStatus: StudentQuizStatus | 'unavailable',
+  message?: string | null
+): string {
+  if (message?.trim()) return message
+  if (studentStatus === 'can_view_results') {
+    return 'Your current work has been submitted. Results are now available from the tests list.'
+  }
+  if (studentStatus === 'responded') {
+    return 'Your current work has been submitted.'
+  }
+  return 'This test is no longer available.'
+}
+
 export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }: Props) {
   const notifications = useStudentNotifications()
   const [quizzes, setQuizzes] = useState<StudentQuizView[]>([])
@@ -116,6 +150,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const [pendingStartTestId, setPendingStartTestId] = useState<string | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [activeDoc, setActiveDoc] = useState<AllowedDocItem | null>(null)
+  const [remoteClosureNotice, setRemoteClosureNotice] = useState<RemoteClosureNotice | null>(null)
   const selectedQuizIdRef = useRef<string | null>(null)
   const focusSessionIdRef = useRef<string | null>(null)
   const awayStartedAtRef = useRef<number | null>(null)
@@ -126,6 +161,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const findIntentUntilRef = useRef(0)
   const findSuppressionUntilRef = useRef(0)
   const docsInteractionSuppressionUntilRef = useRef(0)
+  const sessionStatusInFlightRef = useRef(false)
   const isTestsView = assessmentType === 'test'
   const apiBasePath = isTestsView ? '/api/student/tests' : '/api/student/quizzes'
   const focusEnabled = useMemo(() => {
@@ -200,10 +236,41 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     loadQuizzes()
   }, [loadQuizzes])
 
+  const handleRemoteTestClosure = useCallback((options?: {
+    studentStatus?: StudentQuizStatus
+    message?: string | null
+  }) => {
+    const nextStudentStatus = options?.studentStatus ?? 'responded'
+    setSelectedQuiz((current) => {
+      if (!current) return current
+      return {
+        ...current,
+        quiz: {
+          ...current.quiz,
+          status: 'closed',
+          student_status: nextStudentStatus,
+        },
+      }
+    })
+    setStartedTestId(null)
+    setShowStartTestConfirm(false)
+    setPendingStartTestId(null)
+    setActiveDoc(null)
+    setRemoteClosureNotice({
+      title: 'This test was closed by your teacher.',
+      description: getRemoteClosureDescription(nextStudentStatus, options?.message),
+    })
+    focusSessionIdRef.current = null
+    awayStartedAtRef.current = null
+    lastRouteExitRef.current = null
+    lastWindowSignalRef.current = null
+  }, [])
+
   async function handleSelectQuiz(quizId: string) {
     setSelectedQuizId(quizId)
     setLoadingQuiz(true)
     setActiveDoc(null)
+    setRemoteClosureNotice(null)
     focusSessionIdRef.current = createFocusSessionId()
     awayStartedAtRef.current = null
     lastRouteExitRef.current = null
@@ -229,6 +296,46 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       setLoadingQuiz(false)
     }
   }
+
+  const revalidateActiveTestSession = useCallback(async () => {
+    if (!isTestsView || !focusEnabledRef.current) return
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+
+    const quizId = selectedQuizIdRef.current
+    if (!quizId || sessionStatusInFlightRef.current) return
+
+    sessionStatusInFlightRef.current = true
+    try {
+      const res = await fetch(`${apiBasePath}/${quizId}/session-status`, {
+        cache: 'no-store',
+      })
+      const data = await res.json().catch(() => ({}))
+
+      if (selectedQuizIdRef.current !== quizId) return
+
+      if (res.status === 404) {
+        handleRemoteTestClosure({ message: 'This test is no longer available.' })
+        return
+      }
+
+      if (!res.ok) {
+        console.error('Error checking student test session status:', data?.error || res.status)
+        return
+      }
+
+      const sessionStatus = data as StudentTestSessionStatusResponse
+      if (sessionStatus.can_continue) return
+
+      handleRemoteTestClosure({
+        studentStatus: sessionStatus.student_status,
+        message: sessionStatus.message,
+      })
+    } catch (err) {
+      console.error('Error checking student test session status:', err)
+    } finally {
+      sessionStatusInFlightRef.current = false
+    }
+  }, [apiBasePath, handleRemoteTestClosure, isTestsView])
 
   const postFocusEvent = useCallback(async (
     eventType: 'away_start' | 'away_end' | 'route_exit_attempt' | 'window_unmaximize_attempt',
@@ -422,6 +529,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     setShowStartTestConfirm(false)
     setPendingStartTestId(null)
     setActiveDoc(null)
+    setRemoteClosureNotice(null)
     const fullscreenNow = isFullscreenActive()
     fullscreenActiveRef.current = fullscreenNow
     setIsFullscreen(fullscreenNow)
@@ -440,6 +548,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   }
 
   function handleQuizSubmitted() {
+    setRemoteClosureNotice(null)
     if (isTestsView) {
       notifications?.clearActiveTestsCount()
     } else {
@@ -539,6 +648,20 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   useEffect(() => {
     if (!focusEnabled) return
 
+    const intervalId = window.setInterval(() => {
+      void revalidateActiveTestSession()
+    }, 30_000)
+
+    const handleSessionVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void revalidateActiveTestSession()
+      }
+    }
+
+    const handleSessionFocus = () => {
+      void revalidateActiveTestSession()
+    }
+
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       logRouteExitAttempt(
         'beforeunload',
@@ -557,13 +680,18 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       )
     }
 
+    document.addEventListener('visibilitychange', handleSessionVisibility)
+    window.addEventListener('focus', handleSessionFocus)
     window.addEventListener('beforeunload', handleBeforeUnload)
     window.addEventListener('pagehide', handlePageHide)
     return () => {
+      window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', handleSessionVisibility)
+      window.removeEventListener('focus', handleSessionFocus)
       window.removeEventListener('beforeunload', handleBeforeUnload)
       window.removeEventListener('pagehide', handlePageHide)
     }
-  }, [focusEnabled, logRouteExitAttempt])
+  }, [focusEnabled, logRouteExitAttempt, revalidateActiveTestSession])
 
   useEffect(() => {
     if (!focusEnabled) {
@@ -1046,7 +1174,25 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   <div className="space-y-4">
                     <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
 
-                    {requiresStart ? (
+                    {remoteClosureNotice ? (
+                      <div className="rounded-xl border border-warning bg-warning-bg/20 p-4">
+                        <div className="space-y-3">
+                          <p className="text-base font-semibold text-text-default">
+                            {remoteClosureNotice.title}
+                          </p>
+                          <p className="text-sm text-text-muted">
+                            {remoteClosureNotice.description}
+                          </p>
+                          <Button
+                            type="button"
+                            className="w-full sm:w-auto"
+                            onClick={performBackToAssessmentList}
+                          >
+                            Return to tests
+                          </Button>
+                        </div>
+                      </div>
+                    ) : requiresStart ? (
                       <Button
                         type="button"
                         className="w-full sm:w-auto"
@@ -1084,6 +1230,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                         isInteractionLocked={showNotMaximizedWarning}
                         assessmentType={assessmentType}
                         apiBasePath={apiBasePath}
+                        onAvailabilityLoss={() => {
+                          void revalidateActiveTestSession()
+                        }}
                         onSubmitted={handleQuizSubmitted}
                       />
                     )}

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -257,7 +257,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     setPendingStartTestId(null)
     setActiveDoc(null)
     setRemoteClosureNotice({
-      title: 'This test was closed by your teacher.',
+      title: 'This test is now closed.',
       description: getRemoteClosureDescription(nextStudentStatus, options?.message),
     })
     focusSessionIdRef.current = null
@@ -1003,377 +1003,397 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
               }`}
             >
               {showSplitExamShell ? (
-              <div
-                data-testid="student-test-split-container"
-                className={`grid grid-cols-1 gap-2 ${
-                  showDocPanel ? 'lg:grid-cols-[50%_50%]' : 'lg:grid-cols-[30%_70%]'
-                } lg:h-full lg:min-h-0 lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
-              >
-              <section
-                className={`rounded-xl border border-border bg-surface ${
-                  showCurrentTestInfoPanel
-                    ? 'relative p-0 overflow-x-hidden overflow-y-auto scrollbar-hover lg:sticky lg:top-12 lg:h-[calc(100dvh-3rem)]'
-                    : 'lg:h-full lg:min-h-0 p-3 sm:p-4'
-                }`}
-              >
-                {showCurrentTestInfoPanel ? (
-                  <>
-                    <div
-                      aria-hidden={showDocPanel}
-                      className={`p-3 sm:p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${
-                        showDocPanel
-                          ? 'pointer-events-none translate-x-2 opacity-0'
-                          : 'translate-x-0 opacity-100'
-                      }`}
-                    >
-                      <div className="space-y-4">
-                        <h2 className="mb-3 text-lg font-semibold text-text-default">Documents</h2>
+                <div
+                  data-testid="student-test-split-container"
+                  className={`grid grid-cols-1 gap-2 ${
+                    showDocPanel ? 'lg:grid-cols-[50%_50%]' : 'lg:grid-cols-[30%_70%]'
+                  } lg:min-h-0 lg:h-[calc(100dvh-3rem)] lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
+                >
+                  <section
+                    data-testid="student-test-documents-pane"
+                    className={`rounded-xl border border-border bg-surface ${
+                      showCurrentTestInfoPanel
+                        ? 'relative min-h-0 overflow-x-hidden overflow-y-auto scrollbar-hover p-0'
+                        : 'lg:h-full lg:min-h-0 p-3 sm:p-4'
+                    }`}
+                  >
+                    {showCurrentTestInfoPanel ? (
+                      <>
+                        <div
+                          aria-hidden={showDocPanel}
+                          className={`p-3 sm:p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${
+                            showDocPanel
+                              ? 'pointer-events-none translate-x-2 opacity-0'
+                              : 'translate-x-0 opacity-100'
+                          }`}
+                        >
+                          <div className="space-y-4">
+                            <h2 className="mb-3 text-lg font-semibold text-text-default">Documents</h2>
 
-                        {allowedDocs.length > 0 ? (
-                          <div className="space-y-2">
-                            {allowedDocs.map((doc) => (
-                              <Button
-                                key={doc.id}
+                            {allowedDocs.length > 0 ? (
+                              <div className="space-y-2">
+                                {allowedDocs.map((doc) => (
+                                  <Button
+                                    key={doc.id}
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    className="w-full justify-start"
+                                    onClick={() => {
+                                      markAllowedDocInteraction()
+                                      setActiveDoc(doc)
+                                    }}
+                                    tabIndex={showDocPanel ? -1 : 0}
+                                  >
+                                    {doc.title}
+                                  </Button>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="text-sm text-text-muted">No documents provided for this test.</p>
+                            )}
+
+                            <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
+                              <span
+                                className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                                aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
+                              >
+                                <LogOut className="h-4 w-4" />
+                                <span>{exitsCount}</span>
+                              </span>
+                              <span
+                                className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                                aria-label={`Away time ${awayDurationLabel}.`}
+                              >
+                                <ClockAlert className="h-4 w-4" />
+                                <span>{awayDurationLabel}</span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div
+                          aria-hidden={!showDocPanel}
+                          onPointerDown={markAllowedDocInteraction}
+                          onPointerMove={markAllowedDocInteraction}
+                          onWheel={markAllowedDocInteraction}
+                          className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
+                            showDocPanel
+                              ? 'pointer-events-auto translate-x-0 opacity-100'
+                              : 'pointer-events-none -translate-x-2 opacity-0'
+                          }`}
+                        >
+                          <div className="flex h-full flex-col bg-surface">
+                            <div className="grid h-10 grid-cols-[auto_minmax(0,1fr)_auto] items-center border-b border-border bg-surface-2 px-3">
+                              <button
                                 type="button"
-                                variant="secondary"
-                                size="sm"
-                                className="w-full justify-start"
                                 onClick={() => {
                                   markAllowedDocInteraction()
-                                  setActiveDoc(doc)
+                                  setActiveDoc(null)
                                 }}
-                                tabIndex={showDocPanel ? -1 : 0}
+                                aria-label="Back to documents list"
+                                className="inline-flex items-center gap-1 justify-self-start whitespace-nowrap rounded-md bg-info-bg px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-info-bg-hover"
+                                tabIndex={showDocPanel ? 0 : -1}
                               >
-                                {doc.title}
+                                <ChevronLeft className="h-3.5 w-3.5" />
+                                <span>Back</span>
+                              </button>
+                              <span className="min-w-0 truncate text-center text-sm text-text-muted">
+                                {activeDoc?.title || 'Documentation'}
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                className="invisible inline-flex items-center gap-1 justify-self-end whitespace-nowrap rounded-md border border-primary/40 px-2 py-1 text-xs font-semibold"
+                              >
+                                <ChevronLeft className="h-3.5 w-3.5" />
+                                <span>Back</span>
+                              </span>
+                            </div>
+
+                            {activeDoc?.source === 'text' ? (
+                              <div
+                                className="scrollbar-hover min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3"
+                                onMouseUp={handleTextDocPointerUp}
+                                onKeyUp={handleTextDocPointerUp}
+                              >
+                                <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
+                                  {activeDoc.content || ''}
+                                </pre>
+                              </div>
+                            ) : iframeDocs.length > 0 ? (
+                              <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
+                                {iframeDocs.map((doc) => {
+                                  const isVisible = activeDoc?.id === doc.id
+                                  return (
+                                    <iframe
+                                      key={doc.id}
+                                      src={doc.url}
+                                      title={doc.title || 'Documentation'}
+                                      onFocus={markAllowedDocInteraction}
+                                      onPointerEnter={markAllowedDocInteraction}
+                                      className={`absolute inset-y-0 left-0 h-full w-[calc(100%+10px)] transition-opacity duration-150 motion-reduce:transition-none ${
+                                        isVisible
+                                          ? 'opacity-100'
+                                          : 'pointer-events-none opacity-0'
+                                      }`}
+                                      sandbox="allow-same-origin allow-scripts allow-forms"
+                                      loading="eager"
+                                    />
+                                  )
+                                })}
+                              </div>
+                            ) : (
+                              <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+                                <p className="text-sm text-text-muted">This document is unavailable.</p>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <h2 className="mb-3 text-lg font-semibold text-text-default">Tests</h2>
+                        {renderAssessmentList(true)}
+                      </>
+                    )}
+                  </section>
+
+                  <section
+                    data-testid="student-test-detail-pane"
+                    className={`rounded-xl border border-border bg-surface p-3 sm:p-4 ${
+                      showCurrentTestInfoPanel
+                        ? 'min-h-0 overflow-y-auto scrollbar-hover'
+                        : 'lg:h-full'
+                    } ${
+                      showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
+                    }`}
+                  >
+                    {selectedQuizId && loadingQuiz ? (
+                      <div className="flex justify-center py-12">
+                        <Spinner size="lg" />
+                      </div>
+                    ) : hasSelectedQuiz ? (
+                      <div className="space-y-4">
+                        <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
+
+                        {remoteClosureNotice ? (
+                          <div className="rounded-xl border border-warning bg-warning-bg/20 p-4">
+                            <div className="space-y-3">
+                              <p className="text-base font-semibold text-text-default">
+                                {remoteClosureNotice.title}
+                              </p>
+                              <p className="text-sm text-text-muted">
+                                {remoteClosureNotice.description}
+                              </p>
+                              <Button
+                                type="button"
+                                className="w-full sm:w-auto"
+                                onClick={performBackToAssessmentList}
+                              >
+                                Return to tests
                               </Button>
-                            ))}
+                            </div>
                           </div>
-                        ) : (
-                          <p className="text-sm text-text-muted">No documents provided for this test.</p>
-                        )}
-
-                        <div className="flex flex-wrap items-center gap-2 text-sm text-text-muted">
-                          <span
-                            className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                            aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
-                          >
-                            <LogOut className="h-4 w-4" />
-                            <span>{exitsCount}</span>
-                          </span>
-                          <span
-                            className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                            aria-label={`Away time ${awayDurationLabel}.`}
-                          >
-                            <ClockAlert className="h-4 w-4" />
-                            <span>{awayDurationLabel}</span>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-
-                      <div
-                        aria-hidden={!showDocPanel}
-                        onPointerDown={markAllowedDocInteraction}
-                        onPointerMove={markAllowedDocInteraction}
-                        onWheel={markAllowedDocInteraction}
-                        className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
-                          showDocPanel
-                            ? 'pointer-events-auto translate-x-0 opacity-100'
-                          : 'pointer-events-none -translate-x-2 opacity-0'
-                      }`}
-                    >
-                      <div className="flex h-full flex-col bg-surface">
-                        <div className="grid h-10 grid-cols-[auto_minmax(0,1fr)_auto] items-center border-b border-border bg-surface-2 px-3">
-                          <button
-                            type="button"
-                            onClick={() => {
-                              markAllowedDocInteraction()
-                              setActiveDoc(null)
-                            }}
-                            aria-label="Back to documents list"
-                            className="inline-flex items-center gap-1 justify-self-start whitespace-nowrap rounded-md bg-info-bg px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-info-bg-hover"
-                            tabIndex={showDocPanel ? 0 : -1}
-                          >
-                            <ChevronLeft className="h-3.5 w-3.5" />
-                            <span>Back</span>
-                          </button>
-                          <span className="min-w-0 truncate text-center text-sm text-text-muted">
-                            {activeDoc?.title || 'Documentation'}
-                          </span>
-                          <span
-                            aria-hidden="true"
-                            className="invisible inline-flex items-center gap-1 justify-self-end whitespace-nowrap rounded-md border border-primary/40 px-2 py-1 text-xs font-semibold"
-                          >
-                            <ChevronLeft className="h-3.5 w-3.5" />
-                            <span>Back</span>
-                          </span>
-                        </div>
-
-                        {activeDoc?.source === 'text' ? (
-                          <div
-                            className="scrollbar-hover min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3"
-                            onMouseUp={handleTextDocPointerUp}
-                            onKeyUp={handleTextDocPointerUp}
-                          >
-                            <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
-                              {activeDoc.content || ''}
-                            </pre>
-                          </div>
-                        ) : iframeDocs.length > 0 ? (
-                          <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
-                            {iframeDocs.map((doc) => {
-                              const isVisible = activeDoc?.id === doc.id
-                              return (
-                                <iframe
-                                  key={doc.id}
-                                  src={doc.url}
-                                  title={doc.title || 'Documentation'}
-                                  onFocus={markAllowedDocInteraction}
-                                  onPointerEnter={markAllowedDocInteraction}
-                                  className={`absolute inset-y-0 left-0 h-full w-[calc(100%+10px)] transition-opacity duration-150 motion-reduce:transition-none ${
-                                    isVisible
-                                      ? 'opacity-100'
-                                      : 'pointer-events-none opacity-0'
-                                  }`}
-                                  sandbox="allow-same-origin allow-scripts allow-forms"
-                                  loading="eager"
-                                />
-                              )
-                            })}
-                          </div>
-                        ) : (
-                          <div className="flex min-h-0 flex-1 items-center justify-center p-4">
-                            <p className="text-sm text-text-muted">This document is unavailable.</p>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <h2 className="mb-3 text-lg font-semibold text-text-default">Tests</h2>
-                    {renderAssessmentList(true)}
-                  </>
-                )}
-              </section>
-
-              <section
-                className={`rounded-xl border border-border bg-surface p-3 sm:p-4 ${
-                  showCurrentTestInfoPanel
-                    ? 'lg:overflow-y-auto scrollbar-hover lg:sticky lg:top-12 lg:h-[calc(100dvh-3rem)]'
-                    : 'lg:h-full'
-                } ${
-                  showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
-                }`}
-              >
-                {selectedQuizId && loadingQuiz ? (
-                  <div className="flex justify-center py-12">
-                    <Spinner size="lg" />
-                  </div>
-                ) : hasSelectedQuiz ? (
-                  <div className="space-y-4">
-                    <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
-
-                    {remoteClosureNotice ? (
-                      <div className="rounded-xl border border-warning bg-warning-bg/20 p-4">
-                        <div className="space-y-3">
-                          <p className="text-base font-semibold text-text-default">
-                            {remoteClosureNotice.title}
-                          </p>
-                          <p className="text-sm text-text-muted">
-                            {remoteClosureNotice.description}
-                          </p>
+                        ) : requiresStart ? (
                           <Button
                             type="button"
                             className="w-full sm:w-auto"
-                            onClick={performBackToAssessmentList}
+                            onClick={() => handleRequestStartTest(selectedQuiz.quiz.id)}
                           >
-                            Return to tests
+                            Start the Test
                           </Button>
-                        </div>
-                      </div>
-                    ) : requiresStart ? (
-                      <Button
-                        type="button"
-                        className="w-full sm:w-auto"
-                        onClick={() => handleRequestStartTest(selectedQuiz.quiz.id)}
-                      >
-                        Start the Test
-                      </Button>
-                    ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
-                      <StudentQuizResults
-                        quizId={selectedQuizId!}
-                        myResponses={selectedQuiz.studentResponses}
-                        assessmentType={assessmentType}
-                        apiBasePath={apiBasePath}
-                        showSubmissionBanner={!(isTestsView && selectedQuiz.quiz.student_status === 'can_view_results')}
-                      />
-                    ) : hasResponded ? (
-                      <div className="p-4 bg-success-bg rounded-lg text-center">
-                        <p className="text-success font-medium">Response Submitted</p>
-                        {selectedQuiz.quiz.status !== 'closed' ? (
-                          <p className="text-sm text-text-muted mt-1">
-                            Results will be available after this test is closed and returned by your teacher.
-                          </p>
+                        ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
+                          <StudentQuizResults
+                            quizId={selectedQuizId!}
+                            myResponses={selectedQuiz.studentResponses}
+                            assessmentType={assessmentType}
+                            apiBasePath={apiBasePath}
+                            showSubmissionBanner={!(isTestsView && selectedQuiz.quiz.student_status === 'can_view_results')}
+                          />
+                        ) : hasResponded ? (
+                          <div className="p-4 bg-success-bg rounded-lg text-center">
+                            <p className="text-success font-medium">Response Submitted</p>
+                            {selectedQuiz.quiz.status !== 'closed' ? (
+                              <p className="text-sm text-text-muted mt-1">
+                                Results will be available after this test is closed and returned by your teacher.
+                              </p>
+                            ) : (
+                              <p className="text-sm text-text-muted mt-1">
+                                Results will be available after your teacher returns this test.
+                              </p>
+                            )}
+                          </div>
                         ) : (
-                          <p className="text-sm text-text-muted mt-1">
-                            Results will be available after your teacher returns this test.
-                          </p>
+                          <StudentQuizForm
+                            quizId={selectedQuizId!}
+                            questions={selectedQuiz.questions}
+                            initialResponses={selectedQuiz.studentResponses}
+                            enableDraftAutosave
+                            isInteractionLocked={showNotMaximizedWarning}
+                            assessmentType={assessmentType}
+                            apiBasePath={apiBasePath}
+                            onAvailabilityLoss={() => {
+                              void revalidateActiveTestSession()
+                            }}
+                            onSubmitted={handleQuizSubmitted}
+                          />
+                        )}
+
+                        {!showCurrentTestInfoPanel && (
+                          <div className="flex flex-wrap items-center gap-2 border-t border-border pt-2 text-sm text-text-muted">
+                            <span
+                              className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                              aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
+                            >
+                              <LogOut className="h-4 w-4" />
+                              <span>{exitsCount}</span>
+                            </span>
+                            <span
+                              className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
+                              aria-label={`Away time ${awayDurationLabel}.`}
+                            >
+                              <ClockAlert className="h-4 w-4" />
+                              <span>{awayDurationLabel}</span>
+                            </span>
+                          </div>
                         )}
                       </div>
                     ) : (
-                      <StudentQuizForm
-                        quizId={selectedQuizId!}
-                        questions={selectedQuiz.questions}
-                        initialResponses={selectedQuiz.studentResponses}
-                        enableDraftAutosave
-                        isInteractionLocked={showNotMaximizedWarning}
-                        assessmentType={assessmentType}
-                        apiBasePath={apiBasePath}
-                        onAvailabilityLoss={() => {
-                          void revalidateActiveTestSession()
-                        }}
-                        onSubmitted={handleQuizSubmitted}
-                      />
-                    )}
-
-                    {!showCurrentTestInfoPanel && (
-                      <div className="flex flex-wrap items-center gap-2 border-t border-border pt-2 text-sm text-text-muted">
-                        <span
-                          className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                          aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
-                        >
-                          <LogOut className="h-4 w-4" />
-                          <span>{exitsCount}</span>
-                        </span>
-                        <span
-                          className="inline-flex items-center gap-1.5 rounded-md bg-surface-2 px-2 py-1 tabular-nums"
-                          aria-label={`Away time ${awayDurationLabel}.`}
-                        >
-                          <ClockAlert className="h-4 w-4" />
-                          <span>{awayDurationLabel}</span>
-                        </span>
+                      <div className="flex h-full min-h-[240px] items-center justify-center rounded-lg border border-dashed border-border bg-surface-2 px-4 text-center">
+                        <p className="text-sm text-text-muted">
+                          Select a test from the list to view and complete it.
+                        </p>
                       </div>
                     )}
-                  </div>
-                ) : (
-                  <div className="flex h-full min-h-[240px] items-center justify-center rounded-lg border border-dashed border-border bg-surface-2 px-4 text-center">
-                    <p className="text-sm text-text-muted">
-                      Select a test from the list to view and complete it.
-                    </p>
-                  </div>
-                )}
-              </section>
-              </div>
+                  </section>
+                </div>
               ) : !hasSelectedQuiz ? (
-              quizzes.length === 0 ? (
-                <EmptyState
-                  title="No tests available."
-                  description="When your teacher publishes a test, it will show up here."
-                />
-              ) : (
-                <div className="min-w-0 h-full flex flex-col max-w-none">
-                  {renderAssessmentList(false)}
-                </div>
-              )
-            ) : selectedQuizId && loadingQuiz ? (
-              <div className="flex justify-center py-12">
-                <Spinner size="lg" />
-              </div>
-            ) : (
-              <div className="min-w-0">
-                <button
-                  type="button"
-                  onClick={handleBack}
-                  className="mb-4 flex items-center gap-1 text-sm text-text-muted hover:text-text-default"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  Back to tests
-                </button>
-
-                <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <h2 className="truncate text-xl font-bold text-text-default">
-                      {selectedTestPanelTitle}
-                    </h2>
-                    {allowedDocs.length > 0 && requiresStart ? (
-                      <p className="mt-1 text-sm text-text-muted">
-                        {allowedDocs.length} reference document{allowedDocs.length === 1 ? '' : 's'} will be available during the test.
-                      </p>
-                    ) : null}
-                  </div>
-                  <span
-                    className={[
-                      'rounded-badge px-2.5 py-1 text-xs font-semibold',
-                      selectedQuiz?.quiz.student_status === 'can_view_results'
-                        ? 'bg-info-bg text-info'
-                        : selectedQuiz?.quiz.student_status === 'responded'
-                          ? 'bg-surface-2 text-text-muted'
-                          : selectedQuiz?.quiz.status === 'closed'
-                            ? getQuizStatusBadgeClass('closed')
-                            : getQuizStatusBadgeClass('active'),
-                    ].join(' ')}
-                  >
-                    {selectedQuiz?.quiz.student_status === 'can_view_results'
-                      ? 'Returned'
-                      : selectedQuiz?.quiz.student_status === 'responded'
-                        ? 'Submitted'
-                        : selectedQuiz?.quiz.status === 'closed'
-                          ? 'Closed'
-                          : 'New'}
-                  </span>
-                </div>
-
-                {requiresStart ? (
-                  <div className="rounded-card border border-border bg-surface-panel p-5 shadow-elevated">
-                    <p className="text-sm text-text-muted">
-                      Review the test details, then start when you are ready.
-                    </p>
-                    <div className="mt-4">
-                      <Button
-                        type="button"
-                        className="w-full sm:w-auto"
-                        onClick={() => handleRequestStartTest(selectedQuiz.quiz.id)}
-                      >
-                        Start the Test
-                      </Button>
-                    </div>
-                  </div>
-                ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
-                  <StudentQuizResults
-                    quizId={selectedQuizId!}
-                    myResponses={selectedQuiz.studentResponses}
-                    assessmentType={assessmentType}
-                    apiBasePath={apiBasePath}
-                    showSubmissionBanner={false}
+                quizzes.length === 0 ? (
+                  <EmptyState
+                    title="No tests available."
+                    description="When your teacher publishes a test, it will show up here."
                   />
-                ) : hasResponded ? (
-                  <div className="rounded-card border border-success bg-success-bg p-5 text-center shadow-elevated">
-                    <p className="font-medium text-success">Response Submitted</p>
-                    {selectedQuiz.quiz.status !== 'closed' ? (
-                      <p className="mt-1 text-sm text-text-muted">
-                        Results will be available after this test is closed and returned by your teacher.
-                      </p>
-                    ) : (
-                      <p className="mt-1 text-sm text-text-muted">
-                        Results will be available after your teacher returns this test.
-                      </p>
-                    )}
-                  </div>
                 ) : (
-                  <StudentQuizForm
-                    quizId={selectedQuizId!}
-                    questions={selectedQuiz.questions}
-                    initialResponses={selectedQuiz.studentResponses}
-                    enableDraftAutosave
-                    isInteractionLocked={showNotMaximizedWarning}
-                    assessmentType={assessmentType}
-                    apiBasePath={apiBasePath}
-                    onSubmitted={handleQuizSubmitted}
-                  />
-                )}
-              </div>
-            )}
+                  <div className="min-w-0 h-full flex flex-col max-w-none">
+                    {renderAssessmentList(false)}
+                  </div>
+                )
+              ) : selectedQuizId && loadingQuiz ? (
+                <div className="flex justify-center py-12">
+                  <Spinner size="lg" />
+                </div>
+              ) : (
+                <div className="min-w-0">
+                  <button
+                    type="button"
+                    onClick={handleBack}
+                    className="mb-4 flex items-center gap-1 text-sm text-text-muted hover:text-text-default"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    Back to tests
+                  </button>
+
+                  <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="truncate text-xl font-bold text-text-default">
+                        {selectedTestPanelTitle}
+                      </h2>
+                      {allowedDocs.length > 0 && requiresStart ? (
+                        <p className="mt-1 text-sm text-text-muted">
+                          {allowedDocs.length} reference document{allowedDocs.length === 1 ? '' : 's'} will be available during the test.
+                        </p>
+                      ) : null}
+                    </div>
+                    <span
+                      className={[
+                        'rounded-badge px-2.5 py-1 text-xs font-semibold',
+                        selectedQuiz?.quiz.student_status === 'can_view_results'
+                          ? 'bg-info-bg text-info'
+                          : selectedQuiz?.quiz.student_status === 'responded'
+                            ? 'bg-surface-2 text-text-muted'
+                            : selectedQuiz?.quiz.status === 'closed'
+                              ? getQuizStatusBadgeClass('closed')
+                              : getQuizStatusBadgeClass('active'),
+                      ].join(' ')}
+                    >
+                      {selectedQuiz?.quiz.student_status === 'can_view_results'
+                        ? 'Returned'
+                        : selectedQuiz?.quiz.student_status === 'responded'
+                          ? 'Submitted'
+                          : selectedQuiz?.quiz.status === 'closed'
+                            ? 'Closed'
+                            : 'New'}
+                    </span>
+                  </div>
+
+                  {remoteClosureNotice ? (
+                    <div className="rounded-xl border border-warning bg-warning-bg/20 p-4">
+                      <div className="space-y-3">
+                        <p className="text-base font-semibold text-text-default">
+                          {remoteClosureNotice.title}
+                        </p>
+                        <p className="text-sm text-text-muted">
+                          {remoteClosureNotice.description}
+                        </p>
+                        <Button
+                          type="button"
+                          className="w-full sm:w-auto"
+                          onClick={performBackToAssessmentList}
+                        >
+                          Return to tests
+                        </Button>
+                      </div>
+                    </div>
+                  ) : requiresStart ? (
+                    <div className="rounded-card border border-border bg-surface-panel p-5 shadow-elevated">
+                      <p className="text-sm text-text-muted">
+                        Review the test details, then start when you are ready.
+                      </p>
+                      <div className="mt-4">
+                        <Button
+                          type="button"
+                          className="w-full sm:w-auto"
+                          onClick={() => handleRequestStartTest(selectedQuiz.quiz.id)}
+                        >
+                          Start the Test
+                        </Button>
+                      </div>
+                    </div>
+                  ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
+                    <StudentQuizResults
+                      quizId={selectedQuizId!}
+                      myResponses={selectedQuiz.studentResponses}
+                      assessmentType={assessmentType}
+                      apiBasePath={apiBasePath}
+                      showSubmissionBanner={false}
+                    />
+                  ) : hasResponded ? (
+                    <div className="rounded-card border border-success bg-success-bg p-5 text-center shadow-elevated">
+                      <p className="font-medium text-success">Response Submitted</p>
+                      {selectedQuiz.quiz.status !== 'closed' ? (
+                        <p className="mt-1 text-sm text-text-muted">
+                          Results will be available after this test is closed and returned by your teacher.
+                        </p>
+                      ) : (
+                        <p className="mt-1 text-sm text-text-muted">
+                          Results will be available after your teacher returns this test.
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    <StudentQuizForm
+                      quizId={selectedQuizId!}
+                      questions={selectedQuiz.questions}
+                      initialResponses={selectedQuiz.studentResponses}
+                      enableDraftAutosave
+                      isInteractionLocked={showNotMaximizedWarning}
+                      assessmentType={assessmentType}
+                      apiBasePath={apiBasePath}
+                      onSubmitted={handleQuizSubmitted}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </PageContent>
         )}

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -26,7 +26,18 @@ interface Props {
   isInteractionLocked?: boolean
   assessmentType?: QuizAssessmentType
   apiBasePath?: string
+  onAvailabilityLoss?: () => void
   onSubmitted: () => void
+}
+
+function isAssessmentAvailabilityError(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return (
+    normalized.includes('not active') ||
+    normalized.includes('not found') ||
+    normalized.includes('submitted test') ||
+    normalized.includes('already responded')
+  )
 }
 
 export function StudentQuizForm({
@@ -38,6 +49,7 @@ export function StudentQuizForm({
   isInteractionLocked = false,
   assessmentType,
   apiBasePath = '/api/student/quizzes',
+  onAvailabilityLoss,
   onSubmitted,
 }: Props) {
   const OPEN_RESPONSE_TAB_INDENT = '\t'
@@ -137,9 +149,13 @@ export function StudentQuizForm({
       setSaveStatus('saved')
     } catch (saveError) {
       console.error('Error saving test draft:', saveError)
+      const message = saveError instanceof Error ? saveError.message : 'Failed to save draft'
+      if (isAssessmentAvailabilityError(message)) {
+        onAvailabilityLoss?.()
+      }
       setSaveStatus('unsaved')
     }
-  }, [apiBasePath, quizId, shouldAutosave])
+  }, [apiBasePath, onAvailabilityLoss, quizId, shouldAutosave])
 
   useEffect(() => {
     return () => {
@@ -368,7 +384,11 @@ export function StudentQuizForm({
       setFlaggedQuestions([])
       onSubmitted()
     } catch (err: any) {
-      setError(err.message || 'Failed to submit response')
+      const message = err?.message || 'Failed to submit response'
+      if (isAssessmentAvailabilityError(message)) {
+        onAvailabilityLoss?.()
+      }
+      setError(message)
     } finally {
       setSubmitting(false)
       setShowConfirm(false)

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -90,6 +90,8 @@ export function StudentQuizForm({
     }
     return response.question_type === 'multiple_choice'
   })
+  const saveStatusLabel =
+    saveStatus === 'saving' ? 'Saving...' : saveStatus === 'saved' ? 'Saved' : 'Unsaved changes'
   useEffect(() => {
     const normalized = normalizeTestResponses(initialResponses)
     setResponses(normalized)
@@ -403,163 +405,165 @@ export function StudentQuizForm({
   }
 
   return (
-    <div className="mt-4 space-y-6">
-      {questions.map((question, index) => (
-        <div key={question.id} data-question-id={question.id} className="space-y-2">
-          {(() => {
-            const response = responses[question.id]
-            const openResponseText =
-              response?.question_type === 'open_response' ? response.response_text : ''
-            const selectedOption =
-              response?.question_type === 'multiple_choice' ? response.selected_option : null
-            const isFlagged = isQuestionFlagged(quizId, question.id)
+    <>
+      <div className="mt-4 flex min-h-full flex-col gap-6">
+        <div className="space-y-6">
+          {questions.map((question, index) => (
+            <div key={question.id} data-question-id={question.id} className="space-y-2">
+              {(() => {
+                const response = responses[question.id]
+                const openResponseText =
+                  response?.question_type === 'open_response' ? response.response_text : ''
+                const selectedOption =
+                  response?.question_type === 'multiple_choice' ? response.selected_option : null
+                const isFlagged = isQuestionFlagged(quizId, question.id)
 
-            return (
-              <>
-                <div
-                  data-question-title-id={question.id}
-                  className={`group relative space-y-1 cursor-pointer rounded-lg px-3 py-2 transition-colors ${
-                    isFlagged ? 'bg-info-bg' : 'hover:bg-surface-hover'
-                  } ${isInteractionLocked ? 'cursor-not-allowed opacity-50' : ''}`}
-                  onClick={() => !isInteractionLocked && handleToggleFlagged(question.id)}
-                  title={isFlagged ? 'Unflag question' : 'Flag for review'}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if ((e.key === 'Enter' || e.key === ' ') && !isInteractionLocked) {
-                      handleToggleFlagged(question.id)
-                    }
-                  }}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex-1">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                        Q{index + 1}
-                        {isTestMode && typeof question.points === 'number'
-                          ? ` · ${question.points} pts`
-                          : ''}
-                      </p>
-                      <QuestionMarkdown content={question.question_text} />
-                    </div>
+                return (
+                  <>
                     <div
-                      className={`text-2xl leading-none flex-shrink-0 pt-1 transition-opacity ${
-                        isFlagged ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-                      }`}
+                      data-question-title-id={question.id}
+                      className={`group relative space-y-1 cursor-pointer rounded-lg px-3 py-2 transition-colors ${
+                        isFlagged ? 'bg-info-bg' : 'hover:bg-surface-hover'
+                      } ${isInteractionLocked ? 'cursor-not-allowed opacity-50' : ''}`}
+                      onClick={() => !isInteractionLocked && handleToggleFlagged(question.id)}
+                      title={isFlagged ? 'Unflag question' : 'Flag for review'}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if ((e.key === 'Enter' || e.key === ' ') && !isInteractionLocked) {
+                          handleToggleFlagged(question.id)
+                        }
+                      }}
                     >
-                      {isFlagged ? '★' : '☆'}
-                    </div>
-                  </div>
-                </div>
-                {question.question_type === 'open_response' ? (
-                  <div className="space-y-2">
-                    <textarea
-                      value={openResponseText}
-                      disabled={isInteractionLocked}
-                      onChange={(event) =>
-                        handleOpenResponseChange(
-                          question.id,
-                          event.target.value,
-                          Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)
-                        )
-                      }
-                      onKeyDown={(event) =>
-                        handleOpenResponseKeyDown(
-                          event,
-                          question.id,
-                          Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)
-                        )
-                      }
-                      rows={6}
-                      maxLength={Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)}
-                      className={`w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary ${
-                        question.response_monospace ? 'font-mono leading-6' : ''
-                      }`}
-                      style={{ tabSize: OPEN_RESPONSE_TAB_SIZE }}
-                      placeholder="Write your response..."
-                    />
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    {question.options.map((option, optionIndex) => {
-                      const isSelected = selectedOption === optionIndex
-
-                      return (
-                        <label
-                          key={optionIndex}
-                          className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
-                            isSelected
-                              ? 'border-primary bg-primary/5'
-                              : 'border-border hover:bg-surface-hover'
-                          } ${isInteractionLocked ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'}`}
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                            Q{index + 1}
+                            {isTestMode && typeof question.points === 'number'
+                              ? ` · ${question.points} pts`
+                              : ''}
+                          </p>
+                          <QuestionMarkdown content={question.question_text} />
+                        </div>
+                        <div
+                          className={`text-2xl leading-none flex-shrink-0 pt-1 transition-opacity ${
+                            isFlagged ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                          }`}
                         >
-                          <input
-                            type="radio"
-                            name={`question-${question.id}`}
-                            checked={isSelected}
-                            disabled={isInteractionLocked}
-                            onChange={() => handleOptionSelect(question.id, optionIndex)}
-                            className="sr-only"
-                          />
-                          <span
-                            className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
-                              isSelected ? 'border-primary' : 'border-border'
-                            }`}
-                          >
-                            {isSelected && (
-                              <span className="w-2.5 h-2.5 rounded-full bg-primary" />
-                            )}
-                          </span>
-                          <span className="text-text-default">{option}</span>
-                        </label>
-                      )
-                    })}
-                  </div>
-                )}
-              </>
-            )
-          })()}
+                          {isFlagged ? '★' : '☆'}
+                        </div>
+                      </div>
+                    </div>
+                    {question.question_type === 'open_response' ? (
+                      <div className="space-y-2">
+                        <textarea
+                          value={openResponseText}
+                          disabled={isInteractionLocked}
+                          onChange={(event) =>
+                            handleOpenResponseChange(
+                              question.id,
+                              event.target.value,
+                              Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)
+                            )
+                          }
+                          onKeyDown={(event) =>
+                            handleOpenResponseKeyDown(
+                              event,
+                              question.id,
+                              Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)
+                            )
+                          }
+                          rows={6}
+                          maxLength={Number(question.response_max_chars ?? DEFAULT_OPEN_RESPONSE_MAX_CHARS)}
+                          className={`w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary ${
+                            question.response_monospace ? 'font-mono leading-6' : ''
+                          }`}
+                          style={{ tabSize: OPEN_RESPONSE_TAB_SIZE }}
+                          placeholder="Write your response..."
+                        />
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {question.options.map((option, optionIndex) => {
+                          const isSelected = selectedOption === optionIndex
+
+                          return (
+                            <label
+                              key={optionIndex}
+                              className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                                isSelected
+                                  ? 'border-primary bg-primary/5'
+                                  : 'border-border hover:bg-surface-hover'
+                              } ${isInteractionLocked ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'}`}
+                            >
+                              <input
+                                type="radio"
+                                name={`question-${question.id}`}
+                                checked={isSelected}
+                                disabled={isInteractionLocked}
+                                onChange={() => handleOptionSelect(question.id, optionIndex)}
+                                className="sr-only"
+                              />
+                              <span
+                                className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                                  isSelected ? 'border-primary' : 'border-border'
+                                }`}
+                              >
+                                {isSelected && (
+                                  <span className="w-2.5 h-2.5 rounded-full bg-primary" />
+                                )}
+                              </span>
+                              <span className="text-text-default">{option}</span>
+                            </label>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </>
+                )
+              })()}
+            </div>
+          ))}
+
+          {error && (
+            <div className="rounded-lg bg-danger-bg p-3 text-sm text-danger">{error}</div>
+          )}
+
+          {previewSubmitMessage && (
+            <div className="rounded-lg border border-success bg-success-bg px-3 py-2 text-sm text-success">
+              {previewSubmitMessage}
+            </div>
+          )}
         </div>
-      ))}
 
-      {error && (
-        <div className="p-3 bg-danger-bg text-danger text-sm rounded-lg">{error}</div>
-      )}
-
-      {shouldAutosave && (
-        <p className="text-xs text-text-muted">
-          {saveStatus === 'saving'
-            ? 'Saving...'
-            : saveStatus === 'saved'
-              ? 'Saved'
-              : 'Unsaved changes'}
-        </p>
-      )}
-
-      {previewSubmitMessage && (
-        <div className="rounded-lg border border-success bg-success-bg px-3 py-2 text-sm text-success">
-          {previewSubmitMessage}
-        </div>
-      )}
-
-      <div className="pt-4 space-y-3">
-        <Button
-          onClick={() => {
-            if (flaggedQuestions.length > 0) {
-              setShowFlaggedWarning(true)
-            } else {
-              setShowConfirm(true)
-            }
-          }}
-          disabled={isInteractionLocked || !allAnswered || submitting}
-          className="w-full"
+        <div
+          data-testid="student-quiz-action-footer"
+          className="sticky bottom-0 z-10 mt-auto rounded-lg border border-border bg-surface p-3 shadow-sm"
         >
-          Submit
-        </Button>
-        {!allAnswered && (
-          <p className="text-sm text-text-muted text-center">
-            Answer all questions to submit
-          </p>
-        )}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              {shouldAutosave && (
+                <p className="text-xs text-text-muted">{saveStatusLabel}</p>
+              )}
+              {!allAnswered && (
+                <p className="text-sm text-text-muted">Answer all questions to submit</p>
+              )}
+            </div>
+            <Button
+              onClick={() => {
+                if (flaggedQuestions.length > 0) {
+                  setShowFlaggedWarning(true)
+                } else {
+                  setShowConfirm(true)
+                }
+              }}
+              disabled={isInteractionLocked || !allAnswered || submitting}
+              className="w-full sm:min-w-[10rem] sm:w-auto"
+            >
+              Submit
+            </Button>
+          </div>
+        </div>
       </div>
 
       <ConfirmDialog
@@ -594,6 +598,6 @@ export function StudentQuizForm({
         onCancel={() => setShowConfirm(false)}
         onConfirm={handleSubmit}
       />
-    </div>
+    </>
   )
 }

--- a/tests/api/student/tests-session-status.test.ts
+++ b/tests/api/student/tests-session-status.test.ts
@@ -133,6 +133,59 @@ describe('GET /api/student/tests/[id]/session-status', () => {
     expect(data.message).toBe('Your current work has been submitted.')
   })
 
+  it('returns the results-available closure message when the test has been returned', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        classroom_id: 'classroom-1',
+        title: 'Unit Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    } as any)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { is_submitted: true, returned_at: '2026-01-02T00:00:00.000Z' },
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/session-status'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.can_continue).toBe(false)
+    expect(data.student_status).toBe('can_view_results')
+    expect(data.message).toBe('Your current work has been submitted. Results are now available from the tests list.')
+  })
+
   it('returns 404 when a closed test has no submitted work to preserve student access rules', async () => {
     const serverTests = await import('@/lib/server/tests')
     vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({

--- a/tests/api/student/tests-session-status.test.ts
+++ b/tests/api/student/tests-session-status.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/student/tests/[id]/session-status/route'
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'student-1',
+    email: 'student1@example.com',
+    role: 'student',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  isMissingTestAttemptReturnColumnsError: vi.fn((error: { code?: string; message?: string } | null | undefined) => {
+    if (!error) return false
+    const message = (error.message || '').toLowerCase()
+    return error.code === 'PGRST204' && message.includes('returned_at')
+  }),
+  assertStudentCanAccessTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      id: 'test-1',
+      classroom_id: 'classroom-1',
+      title: 'Unit Test',
+      status: 'active',
+      show_results: false,
+      position: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+  })),
+}))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('GET /api/student/tests/[id]/session-status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns can_continue for an active in-progress test', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { is_submitted: false, returned_at: null },
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/session-status'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.can_continue).toBe(true)
+    expect(data.student_status).toBe('not_started')
+    expect(data.message).toBeNull()
+  })
+
+  it('returns a closure message when the test has been closed and submitted', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        classroom_id: 'classroom-1',
+        title: 'Unit Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    } as any)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { is_submitted: true, returned_at: null },
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/session-status'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.can_continue).toBe(false)
+    expect(data.student_status).toBe('responded')
+    expect(data.message).toBe('Your current work has been submitted.')
+  })
+
+  it('returns 404 when a closed test has no submitted work to preserve student access rules', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        classroom_id: 'classroom-1',
+        title: 'Unit Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    } as any)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: [{ selected_option: null, response_text: '   ' }],
+                error: null,
+              })
+            ),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/session-status'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Test not found')
+  })
+})

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
 import { createMockQuizQuestion } from '../helpers/mocks'
 
@@ -126,5 +126,46 @@ describe('StudentQuizForm preview mode', () => {
     await waitFor(() => {
       expect(screen.getByText(/You have 1 question flagged/)).toBeInTheDocument()
     })
+  })
+
+  it('notifies the parent when a submit fails because the test is no longer active', async () => {
+    const onSubmitted = vi.fn()
+    const onAvailabilityLoss = vi.fn()
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Test is not active' }),
+    })
+
+    render(
+      <StudentQuizForm
+        quizId="test-closed-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Which option is correct?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        assessmentType="test"
+        apiBasePath="/api/student/tests"
+        onAvailabilityLoss={onAvailabilityLoss}
+        onSubmitted={onSubmitted}
+      />
+    )
+
+    fireEvent.click(screen.getByText('A'))
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    const confirmDialog = screen.getByRole('dialog')
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() => {
+      expect(onAvailabilityLoss).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onSubmitted).not.toHaveBeenCalled()
+    expect(screen.getByText('Test is not active')).toBeInTheDocument()
   })
 })

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -128,6 +128,38 @@ describe('StudentQuizForm preview mode', () => {
     })
   })
 
+  it('renders a persistent action footer with save state and submit controls', async () => {
+    const onSubmitted = vi.fn()
+
+    render(
+      <StudentQuizForm
+        quizId="test-footer-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Which option is correct?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        initialResponses={{
+          q1: {
+            question_type: 'multiple_choice',
+            selected_option: 1,
+          },
+        }}
+        assessmentType="test"
+        enableDraftAutosave
+        onSubmitted={onSubmitted}
+      />
+    )
+
+    const footer = screen.getByTestId('student-quiz-action-footer')
+    expect(within(footer).getByText('Saved')).toBeInTheDocument()
+    expect(within(footer).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+  })
+
   it('notifies the parent when a submit fails because the test is no longer active', async () => {
     const onSubmitted = vi.fn()
     const onAvailabilityLoss = vi.fn()

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -232,11 +232,7 @@ describe('StudentQuizzesTab exam mode', () => {
         focus_summary: makeFocusSummary(),
       }),
     })
-    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(document.documentElement, 'requestFullscreen', {
-      configurable: true,
-      value: requestFullscreen,
-    })
+    const { requestFullscreen } = mockFullscreenSuccess()
 
     render(
       <StudentQuizzesTab classroom={classroom} assessmentType="test" />
@@ -337,11 +333,7 @@ describe('StudentQuizzesTab exam mode', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     })
 
-    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(document.documentElement, 'requestFullscreen', {
-      configurable: true,
-      value: requestFullscreen,
-    })
+    mockFullscreenSuccess()
 
     render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
 
@@ -371,16 +363,124 @@ describe('StudentQuizzesTab exam mode', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('This test was closed by your teacher.')).toBeInTheDocument()
+      expect(screen.getByText('This test is now closed.')).toBeInTheDocument()
     })
     expect(screen.getByText('Your current work has been submitted.')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Return to tests' }))
 
     await waitFor(() => {
-      expect(screen.queryByText('This test was closed by your teacher.')).not.toBeInTheDocument()
+      expect(screen.queryByText('This test is now closed.')).not.toBeInTheDocument()
       expect(screen.getByText('This test is closed')).toBeInTheDocument()
     })
+  })
+
+  it('shows the results-available closure copy when the returned-work session is closed remotely', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [
+              {
+                id: 'test-1',
+                title: 'Midterm Test',
+                assessment_type: 'test',
+                status: 'active',
+                show_results: false,
+                position: 0,
+                student_status: 'not_started',
+              },
+            ],
+          }),
+        }
+      }
+
+      if (url === '/api/student/tests/test-1') {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1/session-status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              status: 'closed',
+              assessment_type: 'test',
+              student_status: 'can_view_results',
+              returned_at: '2026-01-02T00:00:00.000Z',
+            },
+            student_status: 'can_view_results',
+            returned_at: '2026-01-02T00:00:00.000Z',
+            can_continue: false,
+            message: 'Your current work has been submitted. Results are now available from the tests list.',
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    mockFullscreenSuccess()
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('This test is now closed.')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Your current work has been submitted. Results are now available from the tests list.')).toBeInTheDocument()
   })
 
   it('shows left-panel exits and away indicators in active test detail', async () => {
@@ -746,14 +846,17 @@ describe('StudentQuizzesTab exam mode', () => {
     const splitContainerExamMode = getSplitContainer(container)
     expect(splitContainerExamMode.className).toContain('lg:grid-cols-[30%_70%]')
     expect(splitContainerExamMode.className).not.toContain('lg:grid-cols-[50%_50%]')
-    expect(splitContainerExamMode.className).toContain('lg:h-full')
+    expect(splitContainerExamMode.className).toContain('lg:h-[calc(100dvh-3rem)]')
     expect(splitContainerExamMode.className).toContain('lg:min-h-0')
 
-    const paneSections = splitContainerExamMode.querySelectorAll('section')
-    expect(paneSections[0]?.className || '').toContain('lg:sticky')
-    expect(paneSections[0]?.className || '').toContain('lg:h-[calc(100dvh-3rem)]')
-    expect(paneSections[1]?.className || '').toContain('lg:sticky')
-    expect(paneSections[1]?.className || '').toContain('overflow-y-auto')
+    const documentsPane = screen.getByTestId('student-test-documents-pane')
+    const detailPane = screen.getByTestId('student-test-detail-pane')
+    expect(documentsPane.className).toContain('min-h-0')
+    expect(documentsPane.className).toContain('overflow-y-auto')
+    expect(documentsPane.className).not.toContain('lg:sticky')
+    expect(detailPane.className).toContain('min-h-0')
+    expect(detailPane.className).toContain('overflow-y-auto')
+    expect(detailPane.className).not.toContain('lg:sticky')
 
     const docsHeading = screen.getByRole('heading', { name: 'Documents' })
     const leftPaneScroller = docsHeading.closest('.scrollbar-hover')
@@ -784,6 +887,100 @@ describe('StudentQuizzesTab exam mode', () => {
     })
     const splitContainerBack = getSplitContainer(container)
     expect(splitContainerBack.className).toContain('lg:grid-cols-[30%_70%]')
+  })
+
+  it('keeps the submit footer mounted while the right pane scrolls through a long active test', async () => {
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+      }),
+    })
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: Array.from({ length: 12 }, (_, index) => ({
+              id: `q${index + 1}`,
+              quiz_id: 'test-1',
+              question_text: `Question ${index + 1}?`,
+              options: ['A', 'B'],
+              question_type: 'multiple_choice' as const,
+              points: 1,
+              response_max_chars: 5000,
+              position: index,
+            })),
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Question 12?')).toBeInTheDocument()
+    })
+
+    const detailPane = screen.getByTestId('student-test-detail-pane')
+    const actionFooter = within(detailPane).getByTestId('student-quiz-action-footer')
+
+    fireEvent.scroll(detailPane, { target: { scrollTop: 1200 } })
+
+    expect(detailPane.className).toContain('overflow-y-auto')
+    expect(within(actionFooter).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+    expect(within(actionFooter).getByText('Answer all questions to submit')).toBeInTheDocument()
   })
 
   it('suppresses iframe doc-triggered fullscreen and resize exits', async () => {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { StudentQuizzesTab } from '@/app/classrooms/[classroomId]/StudentQuizzesTab'
 import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
@@ -18,6 +18,7 @@ describe('StudentQuizzesTab exam mode', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     cleanup()
     vi.useRealTimers()
     Object.defineProperty(window, 'innerWidth', {
@@ -257,6 +258,128 @@ describe('StudentQuizzesTab exam mode', () => {
 
     await waitFor(() => {
       expect(requestFullscreen).toHaveBeenCalled()
+    })
+  })
+
+  it('shows a closure notice when an active test is closed remotely and returns to the tests list after acknowledgment', async () => {
+    let listReads = 0
+    const setIntervalSpy = vi.spyOn(window, 'setInterval')
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        listReads += 1
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: listReads === 1 ? 'active' : 'closed',
+              show_results: false,
+              position: 0,
+              student_status: listReads === 1 ? 'not_started' : 'responded',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1/session-status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              status: 'closed',
+              assessment_type: 'test',
+              student_status: 'responded',
+              returned_at: null,
+            },
+            student_status: 'responded',
+            returned_at: null,
+            can_continue: false,
+            message: 'Your current work has been submitted.',
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    })
+
+    expect(setIntervalSpy.mock.calls.some(([, delay]) => delay === 30_000)).toBe(true)
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('This test was closed by your teacher.')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Your current work has been submitted.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Return to tests' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('This test was closed by your teacher.')).not.toBeInTheDocument()
+      expect(screen.getByText('This test is closed')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## What changed
- moved the desktop exam-mode viewport height constraint to the split-shell container instead of the individual panes
- removed the brittle sticky pane layout for the active student test shell and made both panes independent scroll containers
- added a persistent in-pane footer for save state and submit controls so the action area stays reachable during long tests
- preserved outcome-specific student closure messaging for submitted vs returned tests
- tightened component and API tests, including an isolated returned-results closure test that now sets fullscreen state correctly

## Why
A reported student session suggested the submit control could appear only intermittently near the bottom of the test form. The underlying issue was a fragile desktop exam-mode layout: pane-level sticky plus viewport-height sizing could clip the bottom action area depending on viewport state. The follow-up review also caught two correctness issues in the supporting tests and closure messaging, which are included here.

## Impact
- students in active desktop tests keep the submit/save area reachable while scrolling long forms
- students see clearer closure copy when a test is submitted vs returned
- regression coverage is stronger for both the session-status API and the exam-mode UI shell

## Validation
- `pnpm exec vitest run tests/components/StudentQuizzesTab.test.tsx -t "shows the results-available closure copy when the returned-work session is closed remotely"`
- `pnpm exec vitest run tests/components/StudentQuizzesTab.test.tsx tests/api/student/tests-session-status.test.ts tests/components/StudentQuizForm.test.tsx`
- `pnpm exec eslint 'tests/components/StudentQuizzesTab.test.tsx' 'tests/api/student/tests-session-status.test.ts' 'src/app/api/student/tests/[id]/session-status/route.ts'`
