### PR TITLE
[codex] Suppress false exam exits for test docs

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -7724,3 +7724,25 @@
 - The live student results route on `3002` currently errors with `Failed to fetch questions` because the new `sample_solution` DB column has not been applied yet. Per repo rules, I created the migration file but did not run/apply migrations.
 
 **Status:** Code and tests are complete; live student verification needs migration `051_test_sample_solution.sql` to be applied before the returned-results UI can exercise the new sample-solution block end-to-end.
+
+## 2026-04-02 [AI - Codex]
+
+**Goal:** Fix false exam-mode exits caused by allowed test-doc interactions in the student tests view.
+
+**Completed:**
+- Added a docs-interaction suppression window in the student test exam flow so allowed docs-pane activity does not log `away_start`, `route_exit_attempt`, or `window_unmaximize_attempt` telemetry.
+- Wired suppression markers for docs list clicks, text-doc selection, iframe focus/pointer entry, pane pointer and wheel activity, and the in-panel back action.
+- Kept real classroom navigation sources unsuppressed and left teacher-facing focus summaries unchanged.
+- Reworked the inline iframe docs panel to remove the old hover-reveal width trick, then refined the pane edge treatment to hide the iframe scrollbar cleanly without leaving a visible divider gutter.
+- Removed the outer horizontal padding from the student test split layout so the left and right panes sit flush against the viewport edges.
+- Added focused regression coverage for iframe-triggered fullscreen/resize noise, text-doc blur/visibility noise, returning from an open doc to the docs list, and real exits after the suppression window.
+
+**Validation:**
+- `npm test -- tests/components/StudentQuizzesTab.test.tsx`
+- `npm test -- tests/components/TeacherQuizzesTab.test.tsx tests/unit/quizzes.test.ts`
+- `npm run lint -- --file 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' --file 'tests/components/StudentQuizzesTab.test.tsx'`
+- Visual verification on the worktree dev server at `http://localhost:3000`:
+  - student docs-open screenshot: `/tmp/pika-issue-441-seed-doc-open-edges.png`
+  - teacher tests screenshot: `/tmp/pika-issue-441-teacher-tests-clean.png`
+
+**Status:** The docs pane no longer produces false exam exits during allowed interaction, and the split layout now renders cleanly at both the divider and the outer edges.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -7746,3 +7746,47 @@
   - teacher tests screenshot: `/tmp/pika-issue-441-teacher-tests-clean.png`
 
 **Status:** The docs pane no longer produces false exam exits during allowed interaction, and the split layout now renders cleanly at both the divider and the outer edges.
+
+## 2026-04-02 [AI - Codex]
+
+**Goal:** Replace live external test-doc rendering with manually synced same-origin snapshots while keeping teacher authoring as simple URL input plus refresh.
+
+**Completed:**
+- Extended link test documents with optional snapshot metadata (`snapshot_path`, `snapshot_content_type`, `synced_at`) and preserved it through normalization.
+- Added snapshot helpers for supported link content types, compact relative-age formatting, HTML sanitization, and snapshot clearing on URL changes.
+- Implemented server-side link snapshot sync plus same-origin teacher/student snapshot routes backed by Supabase Storage.
+- Updated the teacher document editor so new and edited link docs auto-sync, failed syncs fall back to unsynced saved docs, and synced docs show a minimal refresh icon plus compact age label.
+- Updated teacher preview and student exam-mode rendering to load synced link docs through app-hosted snapshot routes instead of live external URLs, with unsynced link docs falling back to the unavailable state.
+- Added unit, API, and component coverage for metadata preservation, age formatting, HTML sanitization, sync success/failure, snapshot streaming, auto-sync-on-save, manual refresh, and synced versus unsynced student rendering.
+
+**Validation:**
+- `pnpm exec vitest run tests/unit/test-documents.test.ts tests/api/teacher/tests-documents-sync.test.ts tests/api/teacher/tests-documents-snapshot.test.ts tests/api/student/tests-documents-snapshot.test.ts tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm exec next lint --file 'src/components/TestDocumentsEditor.tsx' --file 'src/components/TeacherTestPreviewPage.tsx' --file 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' --file 'src/lib/test-documents.ts' --file 'src/lib/server/test-document-snapshots.ts' --file 'src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts' --file 'src/app/api/teacher/tests/[id]/documents/[docId]/snapshot/route.ts' --file 'src/app/api/student/tests/[id]/documents/[docId]/snapshot/route.ts' --file 'tests/unit/test-documents.test.ts' --file 'tests/api/teacher/tests-documents-sync.test.ts' --file 'tests/api/teacher/tests-documents-snapshot.test.ts' --file 'tests/api/student/tests-documents-snapshot.test.ts' --file 'tests/components/QuizDetailPanel.test.tsx' --file 'tests/components/StudentQuizzesTab.test.tsx'`
+- Visual verification on the worktree dev server at `http://localhost:3000`:
+  - teacher documents editor row: `/tmp/pika-issue-441-teacher-documents-tab-synced.png`
+  - teacher preview route: `/tmp/pika-issue-441-teacher-preview-snapshot.png`
+  - student exam docs pane: `/tmp/pika-issue-441-student-docs-snapshot.png`
+  - student mobile exam view: `/tmp/pika-issue-441-student-mobile-tests.png`
+
+**Notes:**
+- For visual verification only, I temporarily injected snapshot metadata and a plain-text snapshot into the local seeded test document, then removed both after screenshots so the dev database returned to its prior state.
+
+**Status:** Snapshot-backed external link docs are implemented, covered, visually verified, and the temporary local verification data has been cleaned up.
+
+## 2026-04-03 [AI - Codex]
+
+**Goal:** Add teacher-view auto-sync for stale external link docs without making every view trigger a refresh.
+
+**Completed:**
+- Added a reusable `24h` stale-snapshot threshold helper for link test docs.
+- Moved background auto-sync to the teacher test-detail load path so stale link docs refresh as soon as a teacher opens a test, even before visiting the `Documents` tab.
+- Added the same silent stale-doc auto-sync behavior to the teacher preview route.
+- Kept manual refresh in the documents editor unchanged as an immediate override.
+- Added migration `052_allow_html_test_document_snapshots.sql` after confirming the existing `test-documents` bucket does not permit `text/html`, which would otherwise block sanitized HTML snapshots from syncing.
+- Updated sync error handling to surface the missing HTML-bucket migration clearly.
+
+**Validation:**
+- `pnpm exec vitest run tests/unit/test-documents.test.ts tests/api/teacher/tests-documents-sync.test.ts tests/api/teacher/tests-documents-snapshot.test.ts tests/api/student/tests-documents-snapshot.test.ts tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm exec next lint --file 'src/components/QuizDetailPanel.tsx' --file 'src/components/TeacherTestPreviewPage.tsx' --file 'src/components/TestDocumentsEditor.tsx' --file 'src/lib/test-documents.ts' --file 'src/lib/server/test-document-snapshots.ts' --file 'tests/unit/test-documents.test.ts' --file 'tests/components/QuizDetailPanel.test.tsx'`
+
+**Status:** Teachers now auto-refresh stale link snapshots on open with a `24h` threshold, and HTML snapshot syncs are unblocked once migration `052` is applied.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -7790,3 +7790,23 @@
 - `pnpm exec next lint --file 'src/components/QuizDetailPanel.tsx' --file 'src/components/TeacherTestPreviewPage.tsx' --file 'src/components/TestDocumentsEditor.tsx' --file 'src/lib/test-documents.ts' --file 'src/lib/server/test-document-snapshots.ts' --file 'tests/unit/test-documents.test.ts' --file 'tests/components/QuizDetailPanel.test.tsx'`
 
 **Status:** Teachers now auto-refresh stale link snapshots on open with a `24h` threshold, and HTML snapshot syncs are unblocked once migration `052` is applied.
+
+## 2026-04-03 [AI - Codex]
+
+**Goal:** Remove the unnecessary horizontal scrollbar that appeared in the left docs pane when the pane became active.
+
+**Completed:**
+- Hid horizontal overflow on the student exam docs pane container so the clipped iframe edge no longer produces a hover-triggered horizontal scrollbar.
+- Applied the same horizontal overflow clamp to the teacher preview docs pane and both text-document scroll containers for consistency.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm exec next lint --file 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' --file 'src/components/TeacherTestPreviewPage.tsx'`
+- Visual verification on the worktree dev server at `http://localhost:3000`:
+  - student exam docs pane: `/tmp/pika-issue-441-student-docs-no-hscroll.png`
+  - teacher preview docs pane: `/tmp/pika-issue-441-teacher-preview-no-hscroll.png`
+
+**Notes:**
+- For visual verification only, I temporarily restored the local seeded test snapshot metadata and removed it again after screenshots.
+
+**Status:** The left docs pane no longer shows an unnecessary horizontal scrollbar when activated.

--- a/src/app/api/student/tests/[id]/documents/[docId]/snapshot/route.ts
+++ b/src/app/api/student/tests/[id]/documents/[docId]/snapshot/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertStudentCanAccessTest } from '@/lib/server/tests'
+import { buildSnapshotResponse, findTestDocument } from '@/lib/server/test-document-snapshots'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetStudentTestDocumentSnapshot', async (_request, context) => {
+  const user = await requireRole('student')
+  const { id: testId, docId } = await context.params
+
+  const access = await assertStudentCanAccessTest(user.id, testId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const doc = findTestDocument(access.test, docId)
+  if (!doc || doc.source !== 'link' || !doc.snapshot_path) {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+  }
+
+  return buildSnapshotResponse(doc)
+})

--- a/src/app/api/teacher/tests/[id]/documents/[docId]/snapshot/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/[docId]/snapshot/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { buildSnapshotResponse, findTestDocument } from '@/lib/server/test-document-snapshots'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetTeacherTestDocumentSnapshot', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id: testId, docId } = await context.params
+
+  const access = await assertTeacherOwnsTest(user.id, testId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const doc = findTestDocument(access.test, docId)
+  if (!doc || doc.source !== 'link' || !doc.snapshot_path) {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+  }
+
+  return buildSnapshotResponse(doc)
+})

--- a/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { clearTestDocumentSnapshot, normalizeTestDocuments } from '@/lib/test-documents'
+import { findTestDocument, syncExternalLinkTestDocument } from '@/lib/server/test-document-snapshots'
+
+export const dynamic = 'force-dynamic'
+
+export const POST = withErrorHandler('SyncTeacherTestDocument', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id: testId, docId } = await context.params
+
+  const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const doc = findTestDocument(access.test, docId)
+  if (!doc || doc.source !== 'link' || !doc.url) {
+    return NextResponse.json({ error: 'Link document not found' }, { status: 404 })
+  }
+
+  const snapshot = await syncExternalLinkTestDocument({
+    teacherId: user.id,
+    testId,
+    doc,
+  })
+
+  const nextDocuments = normalizeTestDocuments(access.test.documents).map((currentDoc) => {
+    if (currentDoc.id !== docId) return currentDoc
+    return {
+      ...clearTestDocumentSnapshot(currentDoc),
+      ...snapshot,
+    }
+  })
+
+  const supabase = getServiceRoleClient()
+  const { data: test, error } = await supabase
+    .from('tests')
+    .update({ documents: nextDocuments })
+    .eq('id', testId)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Error updating synced test document:', error)
+    return NextResponse.json({ error: 'Failed to save synced document' }, { status: 500 })
+  }
+
+  const syncedDoc = normalizeTestDocuments((test as { documents?: unknown }).documents).find(
+    (currentDoc) => currentDoc.id === docId
+  )
+
+  return NextResponse.json({
+    doc: syncedDoc,
+    quiz: {
+      ...test,
+      documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+      assessment_type: 'test',
+    },
+  })
+})

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -871,7 +871,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
               <section
                 className={`rounded-xl border border-border bg-surface ${
                   showCurrentTestInfoPanel
-                    ? 'relative p-0 overflow-y-auto scrollbar-hover lg:sticky lg:top-12 lg:h-[calc(100dvh-3rem)]'
+                    ? 'relative p-0 overflow-x-hidden overflow-y-auto scrollbar-hover lg:sticky lg:top-12 lg:h-[calc(100dvh-3rem)]'
                     : 'lg:h-full lg:min-h-0 p-3 sm:p-4'
                 }`}
               >
@@ -976,7 +976,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
 
                         {activeDoc?.source === 'text' ? (
                           <div
-                            className="scrollbar-hover min-h-0 flex-1 overflow-auto bg-surface-2 p-3"
+                            className="scrollbar-hover min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3"
                             onMouseUp={handleTextDocPointerUp}
                             onKeyUp={handleTextDocPointerUp}
                           >

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -135,16 +135,23 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     return isTestsView && isActive && !hasSubmitted && hasStarted
   }, [isActive, isTestsView, selectedQuiz, startedTestId])
   const allowedDocs = useMemo(() => {
-    const teacherManagedDocs = normalizeTestDocuments(selectedQuiz?.quiz?.documents).map((doc) => ({
-      id: doc.id,
-      title: doc.title,
-      source: doc.source,
-      url: doc.url,
-      content: doc.content,
-    }))
+    const teacherManagedDocs = normalizeTestDocuments(selectedQuiz?.quiz?.documents).map((doc) => {
+      const snapshotUrl =
+        doc.source === 'link' && selectedQuiz?.quiz?.id && doc.snapshot_path
+          ? `/api/student/tests/${selectedQuiz.quiz.id}/documents/${doc.id}/snapshot`
+          : undefined
+
+      return {
+        id: doc.id,
+        title: doc.title,
+        source: doc.source,
+        url: doc.source === 'link' ? snapshotUrl : doc.url,
+        content: doc.content,
+      }
+    })
     if (teacherManagedDocs.length > 0) return teacherManagedDocs
     return extractAllowedDocLinks(selectedQuiz?.questions || [])
-  }, [selectedQuiz?.questions, selectedQuiz?.quiz?.documents])
+  }, [selectedQuiz?.questions, selectedQuiz?.quiz?.documents, selectedQuiz?.quiz?.id])
 
   useEffect(() => {
     if (!isTestsView) return

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -67,6 +67,13 @@ function isFullscreenActive(): boolean {
   return typeof document !== 'undefined' && Boolean(document.fullscreenElement)
 }
 
+const DOCS_EXIT_SUPPRESSION_WINDOW_MS = 1200
+const UNSUPPRESSED_ROUTE_EXIT_SOURCES = new Set([
+  'tab_navigation',
+  'home_navigation',
+  'classroom_switch',
+])
+
 function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
   const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
   const plainUrlPattern = /\bhttps?:\/\/[^\s)]+/g
@@ -118,6 +125,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const lastWindowSignalRef = useRef<{ source: string; loggedAtMs: number } | null>(null)
   const findIntentUntilRef = useRef(0)
   const findSuppressionUntilRef = useRef(0)
+  const docsInteractionSuppressionUntilRef = useRef(0)
   const isTestsView = assessmentType === 'test'
   const apiBasePath = isTestsView ? '/api/student/tests' : '/api/student/quizzes'
   const focusEnabled = useMemo(() => {
@@ -157,6 +165,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       lastWindowSignalRef.current = null
       findIntentUntilRef.current = 0
       findSuppressionUntilRef.current = 0
+      docsInteractionSuppressionUntilRef.current = 0
     }
   }, [focusEnabled])
 
@@ -194,6 +203,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     lastWindowSignalRef.current = null
     findIntentUntilRef.current = 0
     findSuppressionUntilRef.current = 0
+    docsInteractionSuppressionUntilRef.current = 0
 
     try {
       const res = await fetch(`${apiBasePath}/${quizId}`)
@@ -263,6 +273,24 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     return false
   }, [])
 
+  const markAllowedDocInteraction = useCallback(() => {
+    if (!focusEnabledRef.current || !isTestsView) return
+    docsInteractionSuppressionUntilRef.current = Date.now() + DOCS_EXIT_SUPPRESSION_WINDOW_MS
+  }, [isTestsView])
+
+  const shouldSuppressForDocInteraction = useCallback((source?: string) => {
+    if (!focusEnabledRef.current || !isTestsView) return false
+    if (source && UNSUPPRESSED_ROUTE_EXIT_SOURCES.has(source)) return false
+    return Date.now() <= docsInteractionSuppressionUntilRef.current
+  }, [isTestsView])
+
+  const handleTextDocPointerUp = useCallback(() => {
+    const selectedText = window.getSelection?.()?.toString().trim()
+    if (selectedText) {
+      markAllowedDocInteraction()
+    }
+  }, [markAllowedDocInteraction])
+
   const logRouteExitAttempt = useCallback((
     source: string,
     metadata?: Record<string, unknown>,
@@ -271,6 +299,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       updateSummary?: boolean
     }
   ) => {
+    if (shouldSuppressForDocInteraction(source)) {
+      return
+    }
     const now = Date.now()
     if (
       options?.dedupe &&
@@ -289,7 +320,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       },
       { updateSummary: options?.updateSummary }
     )
-  }, [postFocusEvent])
+  }, [postFocusEvent, shouldSuppressForDocInteraction])
 
   const logWindowUnmaximizeAttempt = useCallback((
     source: string,
@@ -301,6 +332,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       updateSummary?: boolean
     }
   ) => {
+    if (shouldSuppressForDocInteraction()) {
+      return
+    }
     const now = Date.now()
     if (options?.suppressDuringFind && shouldSuppressForBrowserFind()) {
       return
@@ -323,7 +357,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       },
       { updateSummary: options?.updateSummary }
     )
-  }, [postFocusEvent, shouldSuppressForBrowserFind])
+  }, [postFocusEvent, shouldSuppressForBrowserFind, shouldSuppressForDocInteraction])
 
   const requestExamFullscreen = useCallback(async (
     source: string,
@@ -390,6 +424,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     lastWindowSignalRef.current = null
     findIntentUntilRef.current = 0
     findSuppressionUntilRef.current = 0
+    docsInteractionSuppressionUntilRef.current = 0
     loadQuizzes() // Refresh list to get updated status
   }, [loadQuizzes])
 
@@ -433,6 +468,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     lastWindowSignalRef.current = null
     findIntentUntilRef.current = 0
     findSuppressionUntilRef.current = 0
+    docsInteractionSuppressionUntilRef.current = 0
     void requestExamFullscreen('start_test_confirm')
     if (selectedQuizIdRef.current !== quizId || !selectedQuiz) {
       void handleSelectQuiz(quizId)
@@ -604,6 +640,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const startAway = (source: 'visibility' | 'blur') => {
       if (awayStartedAtRef.current !== null) return
       if (shouldSuppressForBrowserFind()) return
+      if (shouldSuppressForDocInteraction()) return
       awayStartedAtRef.current = Date.now()
       void postFocusEvent('away_start', { source })
     }
@@ -642,7 +679,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
         void postFocusEvent('away_end', { source: 'cleanup' })
       }
     }
-  }, [focusEnabled, postFocusEvent, shouldSuppressForBrowserFind])
+  }, [focusEnabled, postFocusEvent, shouldSuppressForBrowserFind, shouldSuppressForDocInteraction])
 
   useEffect(() => {
     return () => {
@@ -812,7 +849,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
           </div>
         )}
 
-        <PageContent className="flex-1 min-h-0 pt-1">
+        <PageContent className="flex-1 min-h-0 px-0 pt-1">
           <div className="mx-auto h-full w-full max-w-none">
             <div
               data-testid="student-test-split-container"
@@ -859,7 +896,10 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                                 variant="secondary"
                                 size="sm"
                                 className="w-full justify-start"
-                                onClick={() => setActiveDoc(doc)}
+                                onClick={() => {
+                                  markAllowedDocInteraction()
+                                  setActiveDoc(doc)
+                                }}
                                 tabIndex={showDocPanel ? -1 : 0}
                               >
                                 {doc.title}
@@ -889,11 +929,14 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                       </div>
                     </div>
 
-                    <div
-                      aria-hidden={!showDocPanel}
-                      className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
-                        showDocPanel
-                          ? 'pointer-events-auto translate-x-0 opacity-100'
+                      <div
+                        aria-hidden={!showDocPanel}
+                        onPointerDown={markAllowedDocInteraction}
+                        onPointerMove={markAllowedDocInteraction}
+                        onWheel={markAllowedDocInteraction}
+                        className={`absolute inset-0 transition-all duration-300 ease-out motion-reduce:transition-none ${
+                          showDocPanel
+                            ? 'pointer-events-auto translate-x-0 opacity-100'
                           : 'pointer-events-none -translate-x-2 opacity-0'
                       }`}
                     >
@@ -901,7 +944,10 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                         <div className="grid h-10 grid-cols-[auto_minmax(0,1fr)_auto] items-center border-b border-border bg-surface-2 px-3">
                           <button
                             type="button"
-                            onClick={() => setActiveDoc(null)}
+                            onClick={() => {
+                              markAllowedDocInteraction()
+                              setActiveDoc(null)
+                            }}
                             aria-label="Back to documents list"
                             className="inline-flex items-center gap-1 justify-self-start whitespace-nowrap rounded-md bg-info-bg px-2 py-1 text-xs font-semibold text-primary transition-colors hover:bg-info-bg-hover"
                             tabIndex={showDocPanel ? 0 : -1}
@@ -922,13 +968,17 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                         </div>
 
                         {activeDoc?.source === 'text' ? (
-                          <div className="scrollbar-hover min-h-0 flex-1 overflow-auto bg-surface-2 p-3">
+                          <div
+                            className="scrollbar-hover min-h-0 flex-1 overflow-auto bg-surface-2 p-3"
+                            onMouseUp={handleTextDocPointerUp}
+                            onKeyUp={handleTextDocPointerUp}
+                          >
                             <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
                               {activeDoc.content || ''}
                             </pre>
                           </div>
                         ) : iframeDocs.length > 0 ? (
-                          <div className="group relative min-h-0 flex-1 overflow-hidden bg-white">
+                          <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
                             {iframeDocs.map((doc) => {
                               const isVisible = activeDoc?.id === doc.id
                               return (
@@ -936,10 +986,12 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                                   key={doc.id}
                                   src={doc.url}
                                   title={doc.title || 'Documentation'}
-                                  className={`absolute inset-y-0 left-0 h-full transition-[opacity,width] duration-150 motion-reduce:transition-none ${
+                                  onFocus={markAllowedDocInteraction}
+                                  onPointerEnter={markAllowedDocInteraction}
+                                  className={`absolute inset-y-0 left-0 h-full w-[calc(100%+10px)] transition-opacity duration-150 motion-reduce:transition-none ${
                                     isVisible
-                                      ? 'w-[calc(100%+12px)] opacity-100 group-hover:w-full group-focus-within:w-full'
-                                      : 'pointer-events-none w-full opacity-0'
+                                      ? 'opacity-100'
+                                      : 'pointer-events-none opacity-0'
                                   }`}
                                   sandbox="allow-same-origin allow-scripts allow-forms"
                                   loading="eager"

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -27,7 +27,7 @@ import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
-import { normalizeTestDocuments } from '@/lib/test-documents'
+import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import { markdownToTest, testToMarkdown, TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
 import type {
@@ -102,6 +102,7 @@ export function QuizDetailPanel({
   const markdownDirtyRef = useRef(false)
   const savedMarkdownRef = useRef('')
   const documentsRef = useRef(documents)
+  const autoSyncAttemptedRef = useRef<Set<string>>(new Set())
 
   const normalizeQuestionPositions = useCallback((nextQuestions: QuizQuestion[]): QuizQuestion[] => {
     return nextQuestions.map((question, index) => ({ ...question, position: index }))
@@ -219,6 +220,10 @@ export function QuizDetailPanel({
   useEffect(() => {
     setDocuments(normalizeTestDocuments((quiz as { documents?: unknown }).documents))
   }, [quiz])
+
+  useEffect(() => {
+    autoSyncAttemptedRef.current.clear()
+  }, [quiz.id])
 
   useEffect(() => {
     documentsRef.current = documents
@@ -473,6 +478,48 @@ export function QuizDetailPanel({
   useEffect(() => {
     loadQuizDetails()
   }, [loadQuizDetails])
+
+  useEffect(() => {
+    if (!isTestsView) return
+
+    const staleDoc = normalizeTestDocuments(documents).find((doc) => {
+      if (!isLinkDocumentSnapshotStale(doc)) return false
+      const attemptKey = `${doc.id}:${doc.url || ''}:${doc.synced_at || ''}:${doc.snapshot_path || ''}`
+      return !autoSyncAttemptedRef.current.has(attemptKey)
+    })
+
+    if (!staleDoc) return
+
+    const attemptKey = `${staleDoc.id}:${staleDoc.url || ''}:${staleDoc.synced_at || ''}:${staleDoc.snapshot_path || ''}`
+    autoSyncAttemptedRef.current.add(attemptKey)
+
+    let isCancelled = false
+
+    void (async () => {
+      try {
+        const response = await fetch(`${apiBasePath}/${quiz.id}/documents/${staleDoc.id}/sync`, {
+          method: 'POST',
+        })
+        const data = await response.json()
+        if (!response.ok || isCancelled) {
+          if (!response.ok) {
+            console.error(`Auto-sync failed for ${staleDoc.title}:`, data?.error || 'Unknown error')
+          }
+          return
+        }
+
+        setDocuments(normalizeTestDocuments(data?.quiz?.documents))
+      } catch (error) {
+        if (!isCancelled) {
+          console.error(`Auto-sync failed for ${staleDoc.title}:`, error)
+        }
+      }
+    })()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [apiBasePath, documents, isTestsView, quiz.id])
 
   useEffect(() => {
     if (!isTestsView) return

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -330,7 +330,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
             {/* Doc list — always in DOM so switching back is instant */}
             <div
               aria-hidden={showDocPanel}
-              className={`p-3 sm:p-4 overflow-y-auto scrollbar-hover h-full transition-all duration-200 ease-out motion-reduce:transition-none ${
+              className={`p-3 sm:p-4 overflow-x-hidden overflow-y-auto scrollbar-hover h-full transition-all duration-200 ease-out motion-reduce:transition-none ${
                 showDocPanel
                   ? 'pointer-events-none translate-x-2 opacity-0'
                   : 'translate-x-0 opacity-100'
@@ -392,7 +392,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                 </div>
 
                 {activeDoc?.source === 'text' ? (
-                  <div className="scrollbar-hover min-h-0 flex-1 overflow-auto bg-surface-2 p-3">
+                  <div className="scrollbar-hover min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3">
                     <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
                       {activeDoc.content || ''}
                     </pre>

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, Maximize2, X } from 'lucide-react'
 import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
-import { normalizeTestDocuments } from '@/lib/test-documents'
+import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import type { QuizQuestion, TestDocument } from '@/types'
 
 interface Props {
@@ -59,18 +59,24 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [activeDoc, setActiveDoc] = useState<AllowedDocItem | null>(null)
   const fullscreenActiveRef = useRef(false)
+  const autoSyncAttemptedRef = useRef<Set<string>>(new Set())
 
   const allowedDocs = useMemo(() => {
     const teacherManagedDocs = normalizeTestDocuments(documents).map((doc) => ({
       id: doc.id,
       title: doc.title,
       source: doc.source,
-      url: doc.url,
+      url:
+        doc.source === 'link'
+          ? doc.snapshot_path
+            ? `/api/teacher/tests/${testId}/documents/${doc.id}/snapshot`
+            : undefined
+          : doc.url,
       content: doc.content,
     }))
     if (teacherManagedDocs.length > 0) return teacherManagedDocs
     return extractAllowedDocLinks(questions)
-  }, [documents, questions])
+  }, [documents, questions, testId])
 
   useEffect(() => {
     setActiveDoc((previous) => {
@@ -187,6 +193,50 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
       isCancelled = true
     }
   }, [testId])
+
+  useEffect(() => {
+    autoSyncAttemptedRef.current.clear()
+  }, [testId])
+
+  useEffect(() => {
+    const staleDoc = normalizeTestDocuments(documents).find((doc) => {
+      if (!isLinkDocumentSnapshotStale(doc)) return false
+      const attemptKey = `${doc.id}:${doc.url || ''}:${doc.synced_at || ''}:${doc.snapshot_path || ''}`
+      return !autoSyncAttemptedRef.current.has(attemptKey)
+    })
+
+    if (!staleDoc) return
+
+    const attemptKey = `${staleDoc.id}:${staleDoc.url || ''}:${staleDoc.synced_at || ''}:${staleDoc.snapshot_path || ''}`
+    autoSyncAttemptedRef.current.add(attemptKey)
+
+    let isCancelled = false
+
+    void (async () => {
+      try {
+        const response = await fetch(`/api/teacher/tests/${testId}/documents/${staleDoc.id}/sync`, {
+          method: 'POST',
+        })
+        const data = await response.json()
+        if (!response.ok || isCancelled) {
+          if (!response.ok) {
+            console.error(`Auto-sync failed for ${staleDoc.title}:`, data?.error || 'Unknown error')
+          }
+          return
+        }
+
+        setDocuments(normalizeTestDocuments(data?.quiz?.documents))
+      } catch (error) {
+        if (!isCancelled) {
+          console.error(`Auto-sync failed for ${staleDoc.title}:`, error)
+        }
+      }
+    })()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [documents, testId])
 
   function handleClosePreview() {
     window.close()
@@ -348,7 +398,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                     </pre>
                   </div>
                 ) : iframeDocs.length > 0 ? (
-                  <div className="group relative min-h-0 flex-1 overflow-hidden bg-white">
+                  <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
                     {iframeDocs.map((doc) => {
                       const isVisible = activeDoc?.id === doc.id
                       return (
@@ -356,10 +406,10 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                           key={doc.id}
                           src={doc.url}
                           title={doc.title || 'Documentation'}
-                          className={`absolute inset-y-0 left-0 h-full transition-[opacity,width] duration-150 motion-reduce:transition-none ${
+                          className={`absolute inset-y-0 left-0 h-full w-[calc(100%+10px)] transition-opacity duration-150 motion-reduce:transition-none ${
                             isVisible
-                              ? 'w-[calc(100%+12px)] opacity-100 group-hover:w-full group-focus-within:w-full'
-                              : 'pointer-events-none w-full opacity-0'
+                              ? 'opacity-100'
+                              : 'pointer-events-none opacity-0'
                           }`}
                           sandbox="allow-same-origin allow-scripts allow-forms"
                           loading="eager"

--- a/src/components/TestDocumentsEditor.tsx
+++ b/src/components/TestDocumentsEditor.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ExternalLink, FileText, Link2, Pencil, Trash2, Upload } from 'lucide-react'
+import { ChevronDown, ExternalLink, FileText, Link2, Pencil, RefreshCw, Trash2, Upload } from 'lucide-react'
 import { Button, DialogPanel, Input } from '@/ui'
 import {
   MAX_TEST_DOCUMENT_TEXT_LENGTH,
   TEST_DOCUMENT_ACCEPT,
+  clearTestDocumentSnapshot,
+  formatCompactRelativeAge,
   normalizeTestDocuments,
   isValidHttpUrl,
 } from '@/lib/test-documents'
@@ -43,8 +45,10 @@ export function TestDocumentsEditor({
   const [activeModal, setActiveModal] = useState<AddDocumentModal | 'edit'>(null)
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
+  const [syncingDocId, setSyncingDocId] = useState<string | null>(null)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
+  const [nowMs, setNowMs] = useState(() => Date.now())
   const addMenuId = useId()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const addMenuRef = useRef<HTMLDivElement>(null)
@@ -53,6 +57,15 @@ export function TestDocumentsEditor({
     const normalized = normalizeTestDocuments(documents)
     setLocalDocs(normalized)
   }, [documents])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now())
+    }, 30_000)
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [])
 
   const editingDoc = useMemo(
     () => localDocs.find((doc) => doc.id === editingDocId) ?? null,
@@ -149,12 +162,54 @@ export function TestDocumentsEditor({
       setLocalDocs(normalized)
       setSuccess('Documents saved')
       onUpdated()
-      return true
+      return normalized
     } catch (err: any) {
       setError(err.message || 'Failed to save documents')
-      return false
+      return null
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function syncLinkDocument(
+    docId: string,
+    options?: {
+      successMessage?: string
+      failurePrefix?: string
+      silent?: boolean
+    }
+  ) {
+    setSyncingDocId(docId)
+    if (!options?.silent) {
+      setError('')
+      setSuccess('')
+    }
+    try {
+      const res = await fetch(`${apiBasePath}/${testId}/documents/${docId}/sync`, {
+        method: 'POST',
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to sync document')
+      }
+
+      const normalized = normalizeTestDocuments(data.quiz?.documents || localDocs)
+      setLocalDocs(normalized)
+      if (!options?.silent) {
+        setSuccess(options?.successMessage || 'Document synced')
+      }
+      onUpdated()
+      return normalized
+    } catch (err: any) {
+      const prefix = options?.failurePrefix || 'Failed to sync document'
+      if (!options?.silent) {
+        setError(`${prefix}: ${err.message || 'Unknown error'}`)
+      } else {
+        console.error(`${prefix}:`, err)
+      }
+      return null
+    } finally {
+      setSyncingDocId(null)
     }
   }
 
@@ -177,7 +232,9 @@ export function TestDocumentsEditor({
       return
     }
 
-    const nextDocBase: TestDocument = {
+    const urlChanged = editingDoc.source === 'link' && editUrl.trim() !== (editingDoc.url || '')
+
+    let nextDocBase: TestDocument = {
       ...editingDoc,
       title: title.slice(0, 120),
     }
@@ -199,10 +256,20 @@ export function TestDocumentsEditor({
       nextDocBase.content = editContent.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH)
     }
 
+    if (urlChanged) {
+      nextDocBase = clearTestDocumentSnapshot(nextDocBase)
+    }
+
     const nextDocs = localDocs.map((doc) => (doc.id === editingDoc.id ? nextDocBase : doc))
-    const persisted = await persistDocuments(nextDocs)
-    if (persisted) {
+    const persistedDocs = await persistDocuments(nextDocs)
+    if (persistedDocs) {
       closeAddModal()
+      if (urlChanged) {
+        void syncLinkDocument(editingDoc.id, {
+          successMessage: 'Link saved and synced',
+          failurePrefix: 'Link saved, but sync failed',
+        })
+      }
     }
   }
 
@@ -219,19 +286,25 @@ export function TestDocumentsEditor({
       return
     }
 
+    const nextLinkDoc: TestDocument = {
+      id: crypto.randomUUID(),
+      title: title.slice(0, 120),
+      url,
+      source: 'link' as const,
+    }
+
     const nextDocs = [
       ...localDocs,
-      {
-        id: crypto.randomUUID(),
-        title: title.slice(0, 120),
-        url,
-        source: 'link' as const,
-      },
+      nextLinkDoc,
     ]
-    const persisted = await persistDocuments(nextDocs)
-    if (persisted) {
+    const persistedDocs = await persistDocuments(nextDocs)
+    if (persistedDocs) {
       clearModalFields('link')
       closeAddModal()
+      void syncLinkDocument(nextLinkDoc.id, {
+        successMessage: 'Link saved and synced',
+        failurePrefix: 'Link saved, but sync failed',
+      })
     }
   }
 
@@ -257,8 +330,8 @@ export function TestDocumentsEditor({
         content: content.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH),
       },
     ]
-    const persisted = await persistDocuments(nextDocs)
-    if (persisted) {
+    const persistedDocs = await persistDocuments(nextDocs)
+    if (persistedDocs) {
       clearModalFields('text')
       closeAddModal()
     }
@@ -292,8 +365,8 @@ export function TestDocumentsEditor({
         },
       ]
 
-      const persisted = await persistDocuments(nextDocs)
-      if (persisted) {
+      const persistedDocs = await persistDocuments(nextDocs)
+      if (persistedDocs) {
         clearModalFields('upload')
         closeAddModal()
       }
@@ -335,6 +408,28 @@ export function TestDocumentsEditor({
                   <p className="truncate text-sm font-medium text-text-default">{doc.title}</p>
                 </div>
                 <div className="flex items-center gap-2">
+                  {doc.source === 'link' && (
+                    <>
+                      {doc.synced_at ? (
+                        <span className="text-xs text-text-muted" aria-label={`Synced ${formatCompactRelativeAge(doc.synced_at, nowMs)} ago`}>
+                          {formatCompactRelativeAge(doc.synced_at, nowMs)}
+                        </span>
+                      ) : null}
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="px-2"
+                        onClick={() => {
+                          void syncLinkDocument(doc.id)
+                        }}
+                        disabled={!isEditable || saving || uploading || syncingDocId === doc.id}
+                        aria-label={`Refresh ${doc.title}`}
+                      >
+                        <RefreshCw className={`h-4 w-4 ${syncingDocId === doc.id ? 'animate-spin' : ''}`} />
+                      </Button>
+                    </>
+                  )}
                   <Button
                     type="button"
                     variant="secondary"

--- a/src/lib/server/test-document-snapshots.ts
+++ b/src/lib/server/test-document-snapshots.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { ApiError } from '@/lib/api-handler'
+import {
+  normalizeSnapshotContentType,
+  normalizeTestDocuments,
+  isSupportedLinkSnapshotContentType,
+  sanitizeSnapshotHtml,
+  TEST_DOCUMENT_MAX_SIZE,
+} from '@/lib/test-documents'
+import type { TestDocument } from '@/types'
+import type { TestAccessRecord } from '@/lib/server/tests'
+
+const TEST_DOCUMENTS_BUCKET = 'test-documents'
+
+function buildSnapshotStoragePath(teacherId: string, testId: string, docId: string): string {
+  return `link-docs/${teacherId}/${testId}/${docId}/snapshot`
+}
+
+export function findTestDocument(test: Pick<TestAccessRecord, 'documents'>, docId: string): TestDocument | null {
+  return normalizeTestDocuments(test.documents).find((doc) => doc.id === docId) ?? null
+}
+
+export async function syncExternalLinkTestDocument(options: {
+  teacherId: string
+  testId: string
+  doc: TestDocument
+}) {
+  const { teacherId, testId, doc } = options
+  if (doc.source !== 'link' || !doc.url) {
+    throw new ApiError(400, 'Only link documents can be synced')
+  }
+
+  let response: Response
+  try {
+    response = await fetch(doc.url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: AbortSignal.timeout(15_000),
+      headers: {
+        'User-Agent': 'PikaLinkSnapshot/1.0',
+      },
+      cache: 'no-store',
+    })
+  } catch {
+    throw new ApiError(400, 'Failed to fetch source document')
+  }
+
+  if (!response.ok) {
+    throw new ApiError(400, `Source returned ${response.status}`)
+  }
+
+  const contentType = normalizeSnapshotContentType(response.headers.get('content-type'))
+  if (!isSupportedLinkSnapshotContentType(contentType)) {
+    throw new ApiError(400, 'Unsupported document type')
+  }
+
+  const contentLengthHeader = response.headers.get('content-length')
+  if (contentLengthHeader) {
+    const contentLength = Number(contentLengthHeader)
+    if (!Number.isNaN(contentLength) && contentLength > TEST_DOCUMENT_MAX_SIZE) {
+      throw new ApiError(400, 'Document is too large to sync')
+    }
+  }
+
+  let body = Buffer.from(await response.arrayBuffer())
+  if (body.byteLength > TEST_DOCUMENT_MAX_SIZE) {
+    throw new ApiError(400, 'Document is too large to sync')
+  }
+
+  if (contentType === 'text/html') {
+    const html = body.toString('utf8')
+    body = Buffer.from(sanitizeSnapshotHtml(html, doc.url), 'utf8')
+  }
+
+  const supabase = getServiceRoleClient()
+  const snapshotPath = buildSnapshotStoragePath(teacherId, testId, doc.id)
+
+  const { error: uploadError } = await supabase.storage
+    .from(TEST_DOCUMENTS_BUCKET)
+    .upload(snapshotPath, body, {
+      contentType,
+      upsert: true,
+    })
+
+  if (uploadError) {
+    const details = `${uploadError.message || ''} ${(uploadError as { details?: string }).details || ''}`.toLowerCase()
+    if (details.includes('mime type') || details.includes('not supported')) {
+      throw new ApiError(400, 'HTML link snapshots require migration 052 to be applied')
+    }
+    if (details.includes('bucket') || details.includes('not found')) {
+      throw new ApiError(400, 'Test document uploads require migration 042 to be applied')
+    }
+    throw new ApiError(500, 'Failed to store synced document')
+  }
+
+  return {
+    snapshot_path: snapshotPath,
+    snapshot_content_type: contentType,
+    synced_at: new Date().toISOString(),
+  }
+}
+
+export async function buildSnapshotResponse(doc: TestDocument): Promise<NextResponse> {
+  if (!doc.snapshot_path) {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data, error } = await supabase.storage
+    .from(TEST_DOCUMENTS_BUCKET)
+    .download(doc.snapshot_path)
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+  }
+
+  const contentType = normalizeSnapshotContentType(doc.snapshot_content_type) || 'application/octet-stream'
+  const headers = new Headers({
+    'Cache-Control': 'private, no-store',
+    'Content-Disposition': 'inline',
+    'Content-Type': contentType,
+    'X-Frame-Options': 'SAMEORIGIN',
+  })
+
+  if (contentType === 'text/html') {
+    headers.set(
+      'Content-Security-Policy',
+      "default-src 'none'; base-uri 'self'; script-src 'none'; object-src 'none'; connect-src 'none'; form-action 'none'; frame-ancestors 'self'; img-src * data: blob:; style-src 'unsafe-inline' *; font-src * data:; media-src * blob: data:"
+    )
+  }
+
+  if (typeof (data as Blob).arrayBuffer === 'function') {
+    return new NextResponse(await (data as Blob).arrayBuffer(), { headers })
+  }
+
+  if (typeof (data as Blob).stream === 'function') {
+    return new NextResponse((data as Blob).stream(), { headers })
+  }
+
+  if (typeof (data as Blob).text === 'function') {
+    return new NextResponse(await (data as Blob).text(), { headers })
+  }
+
+  return new NextResponse(data as BodyInit, { headers })
+}

--- a/src/lib/test-documents.ts
+++ b/src/lib/test-documents.ts
@@ -16,6 +16,13 @@ export const TEST_DOCUMENT_ACCEPT =
   '.pdf,.txt,.md,.csv,.json,.doc,.docx,application/pdf,text/plain,text/markdown,text/csv,application/json,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 export const MAX_TEST_DOCUMENTS = 20
 export const MAX_TEST_DOCUMENT_TEXT_LENGTH = 20000
+export const LINK_DOCUMENT_AUTO_SYNC_MAX_AGE_MS = 24 * 60 * 60 * 1000
+export const LINK_DOCUMENT_SNAPSHOT_SUPPORTED_TYPES = [
+  'text/html',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+] as const
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -47,6 +54,13 @@ export function normalizeTestDocuments(value: unknown): TestDocument[] {
     const source = normalizeTestDocumentSource(raw.source)
     const url = typeof raw.url === 'string' ? raw.url.trim() : ''
     const content = typeof raw.content === 'string' ? raw.content : ''
+    const snapshotPath = typeof raw.snapshot_path === 'string' ? raw.snapshot_path.trim() : ''
+    const snapshotContentType =
+      typeof raw.snapshot_content_type === 'string' ? raw.snapshot_content_type.trim().toLowerCase() : ''
+    const syncedAt =
+      raw.synced_at === null ? null : typeof raw.synced_at === 'string' && raw.synced_at.trim()
+        ? raw.synced_at.trim()
+        : undefined
     if (!id || !title) continue
 
     if (source === 'text') {
@@ -68,10 +82,91 @@ export function normalizeTestDocuments(value: unknown): TestDocument[] {
       title: title.slice(0, 120),
       url,
       source,
+      ...(snapshotPath ? { snapshot_path: snapshotPath } : {}),
+      ...(snapshotContentType ? { snapshot_content_type: snapshotContentType } : {}),
+      ...(syncedAt !== undefined ? { synced_at: syncedAt } : {}),
     })
   }
 
   return docs.slice(0, MAX_TEST_DOCUMENTS)
+}
+
+export function isSupportedLinkSnapshotContentType(contentType: string): boolean {
+  return LINK_DOCUMENT_SNAPSHOT_SUPPORTED_TYPES.includes(
+    contentType as (typeof LINK_DOCUMENT_SNAPSHOT_SUPPORTED_TYPES)[number]
+  )
+}
+
+export function normalizeSnapshotContentType(contentType: string | null | undefined): string {
+  return contentType?.split(';')[0]?.trim().toLowerCase() || ''
+}
+
+export function clearTestDocumentSnapshot(doc: TestDocument): TestDocument {
+  return {
+    id: doc.id,
+    title: doc.title,
+    source: doc.source,
+    ...(doc.url ? { url: doc.url } : {}),
+    ...(doc.content ? { content: doc.content } : {}),
+  }
+}
+
+export function formatCompactRelativeAge(value: string | null | undefined, nowMs = Date.now()): string {
+  if (!value) return ''
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) return ''
+
+  const diffSeconds = Math.max(0, Math.floor((nowMs - timestamp) / 1000))
+  if (diffSeconds < 60) return `${diffSeconds}s`
+
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  if (diffMinutes < 60) return `${diffMinutes}m`
+
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours}h`
+
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 30) return `${diffDays}d`
+
+  const diffMonths = Math.floor(diffDays / 30)
+  if (diffMonths < 12) return `${diffMonths}mo`
+
+  return `${Math.floor(diffDays / 365)}y`
+}
+
+export function isLinkDocumentSnapshotStale(
+  doc: Pick<TestDocument, 'source' | 'snapshot_path' | 'synced_at'>,
+  nowMs = Date.now(),
+  maxAgeMs = LINK_DOCUMENT_AUTO_SYNC_MAX_AGE_MS
+): boolean {
+  if (doc.source !== 'link') return false
+  if (!doc.snapshot_path || !doc.synced_at) return true
+
+  const timestamp = Date.parse(doc.synced_at)
+  if (Number.isNaN(timestamp)) return true
+
+  return nowMs - timestamp >= maxAgeMs
+}
+
+export function sanitizeSnapshotHtml(html: string, sourceUrl: string): string {
+  const strippedScripts = html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\son[a-z-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/<meta[^>]+http-equiv\s*=\s*["']?refresh["']?[^>]*>/gi, '')
+
+  const baseTag = `<base href="${sourceUrl.replace(/"/g, '&quot;')}">`
+  const referrerTag = '<meta name="referrer" content="no-referrer">'
+  const headMatch = strippedScripts.match(/<head\b[^>]*>/i)
+
+  if (headMatch) {
+    return strippedScripts.replace(headMatch[0], `${headMatch[0]}${baseTag}${referrerTag}`)
+  }
+
+  if (/<html\b[^>]*>/i.test(strippedScripts)) {
+    return strippedScripts.replace(/<html\b[^>]*>/i, (match) => `${match}<head>${baseTag}${referrerTag}</head>`)
+  }
+
+  return `<!doctype html><html><head>${baseTag}${referrerTag}</head><body>${strippedScripts}</body></html>`
 }
 
 export function validateTestDocumentsPayload(value: unknown):

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -440,6 +440,9 @@ export interface TestDocument {
   source: TestDocumentSource
   url?: string
   content?: string
+  snapshot_path?: string
+  snapshot_content_type?: string
+  synced_at?: string | null
 }
 export type TestAiGradingBasis = 'teacher_key' | 'generated_reference'
 

--- a/supabase/migrations/052_allow_html_test_document_snapshots.sql
+++ b/supabase/migrations/052_allow_html_test_document_snapshots.sql
@@ -1,0 +1,8 @@
+-- Allow synced external link snapshots to store sanitized HTML pages.
+
+update storage.buckets
+set allowed_mime_types = (
+  select array_agg(distinct mime_type order by mime_type)
+  from unnest(coalesce(allowed_mime_types, array[]::text[]) || array['text/html']) as mime_type
+)
+where id = 'test-documents';

--- a/tests/api/student/tests-documents-snapshot.test.ts
+++ b/tests/api/student/tests-documents-snapshot.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/student/tests/[id]/documents/[docId]/snapshot/route'
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'student-1',
+    email: 'student1@example.com',
+    role: 'student',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  assertStudentCanAccessTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      id: 'test-1',
+      documents: [
+        {
+          id: 'doc-1',
+          title: 'Node.js API',
+          source: 'link',
+          url: 'https://nodejs.org/api/fs.html',
+          snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+          snapshot_content_type: 'text/html',
+          synced_at: '2026-04-02T12:00:00.000Z',
+        },
+      ],
+    },
+  })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabase),
+}))
+
+const mockDownload = vi.fn()
+const mockSupabase = {
+  storage: {
+    from: vi.fn(() => ({
+      download: mockDownload,
+    })),
+  },
+}
+
+function createMockDownloadBody(content: string, contentType: string) {
+  const bytes = new TextEncoder().encode(content)
+  return {
+    type: contentType,
+    stream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      }),
+    arrayBuffer: async () => bytes.slice().buffer,
+    text: async () => content,
+  }
+}
+
+describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDownload.mockResolvedValue({
+      data: createMockDownloadBody('<html><body>Snapshot</body></html>', 'text/html'),
+      error: null,
+    })
+  })
+
+  it('streams the stored snapshot', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/html')
+    expect(response.headers.get('content-security-policy')).toContain("script-src 'none'")
+    expect(await (await response.blob()).text()).toContain('Snapshot')
+  })
+
+  it('returns 404 when the link doc has no snapshot', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        id: 'test-1',
+        documents: [
+          {
+            id: 'doc-1',
+            title: 'Node.js API',
+            source: 'link',
+            url: 'https://nodejs.org/api/fs.html',
+          },
+        ],
+      } as any,
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Snapshot not found')
+  })
+})

--- a/tests/api/teacher/tests-documents-snapshot.test.ts
+++ b/tests/api/teacher/tests-documents-snapshot.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/teacher/tests/[id]/documents/[docId]/snapshot/route'
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  assertTeacherOwnsTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      id: 'test-1',
+      documents: [
+        {
+          id: 'doc-1',
+          title: 'Node.js API',
+          source: 'link',
+          url: 'https://nodejs.org/api/fs.html',
+          snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+          snapshot_content_type: 'application/pdf',
+          synced_at: '2026-04-02T12:00:00.000Z',
+        },
+      ],
+    },
+  })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabase),
+}))
+
+const mockDownload = vi.fn()
+const mockSupabase = {
+  storage: {
+    from: vi.fn(() => ({
+      download: mockDownload,
+    })),
+  },
+}
+
+function createMockDownloadBody(content: string, contentType: string) {
+  const bytes = new TextEncoder().encode(content)
+  return {
+    type: contentType,
+    stream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      }),
+    arrayBuffer: async () => bytes.slice().buffer,
+    text: async () => content,
+  }
+}
+
+describe('GET /api/teacher/tests/[id]/documents/[docId]/snapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDownload.mockResolvedValue({
+      data: createMockDownloadBody('%PDF-1.4', 'application/pdf'),
+      error: null,
+    })
+  })
+
+  it('streams the stored snapshot for preview mode', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/pdf')
+    expect(await (await response.blob()).text()).toContain('%PDF-1.4')
+  })
+})

--- a/tests/api/teacher/tests-documents-sync.test.ts
+++ b/tests/api/teacher/tests-documents-sync.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/tests/[id]/documents/[docId]/sync/route'
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', () => ({
+  assertTeacherOwnsTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      id: 'test-1',
+      classroom_id: 'classroom-1',
+      title: 'Unit Test',
+      status: 'draft',
+      show_results: false,
+      position: 0,
+      created_at: '2026-04-02T00:00:00.000Z',
+      updated_at: '2026-04-02T00:00:00.000Z',
+      documents: [
+        {
+          id: 'doc-1',
+          title: 'Node.js API',
+          source: 'link',
+          url: 'https://nodejs.org/api/fs.html',
+        },
+      ],
+      classrooms: { archived_at: null },
+    },
+  })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabase),
+}))
+
+const mockUpload = vi.fn()
+const mockUpdate = vi.fn()
+const mockSupabase = {
+  storage: {
+    from: vi.fn(() => ({
+      upload: mockUpload,
+    })),
+  },
+  from: vi.fn((table: string) => {
+    if (table !== 'tests') {
+      throw new Error(`Unexpected table: ${table}`)
+    }
+    return {
+      update: mockUpdate,
+    }
+  }),
+}
+
+describe('POST /api/teacher/tests/[id]/documents/[docId]/sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('<html><head><script>bad()</script></head><body>Docs</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }))
+    )
+    mockUpload.mockResolvedValue({ error: null })
+    mockUpdate.mockImplementation((payload: Record<string, unknown>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'test-1',
+              documents: payload.documents,
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
+  })
+
+  it('syncs a link document and saves snapshot metadata', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/documents/doc-1/sync', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://nodejs.org/api/fs.html',
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(mockUpload).toHaveBeenCalledWith(
+      'link-docs/teacher-1/test-1/doc-1/snapshot',
+      expect.any(Buffer),
+      expect.objectContaining({
+        contentType: 'text/html',
+        upsert: true,
+      })
+    )
+    expect(data.doc.snapshot_path).toBe('link-docs/teacher-1/test-1/doc-1/snapshot')
+    expect(data.doc.snapshot_content_type).toBe('text/html')
+    expect(data.doc.synced_at).toBeTruthy()
+  })
+
+  it('returns 400 for unsupported source types', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('body', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+    )
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/documents/doc-1/sync', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Unsupported document type')
+  })
+})

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -981,59 +981,67 @@ Prompt:
 
     it('adds a link document and sends documents payload to tests PATCH endpoint', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-      fetchMock
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            draft: {
-              version: 1,
-              content: {
-                title: 'Doc Save Test',
-                show_results: true,
-                questions: sampleQuestions,
+      fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (url.includes('/draft')) {
+          return {
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: 1,
+                content: {
+                  title: 'Doc Save Test',
+                  show_results: true,
+                  questions: sampleQuestions,
+                },
               },
-            },
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            quiz: { documents: [] },
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            quiz: {
-              documents: [
-                { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
-              ],
-            },
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            draft: {
-              version: 2,
-              content: {
-                title: 'Doc Save Test',
-                show_results: true,
-                questions: sampleQuestions,
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: { documents: [] },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1' && options?.method === 'PATCH') {
+          const body = JSON.parse(String(options.body))
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: body.documents,
               },
-            },
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            quiz: {
-              documents: [
-                { id: 'doc-1', title: 'Java API', url: 'https://docs.oracle.com', source: 'link' },
-              ],
-            },
-          }),
-        })
+            }),
+          }
+        }
+
+        if (url.match(/\/api\/teacher\/tests\/quiz-1\/documents\/.+\/sync$/) && options?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [
+                  {
+                    id: JSON.parse(String(fetchMock.mock.calls.find((call: any[]) => call[1]?.method === 'PATCH')?.[1]?.body)).documents[0].id,
+                    title: 'Java API',
+                    url: 'https://docs.oracle.com',
+                    source: 'link',
+                    snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                    snapshot_content_type: 'text/html',
+                    synced_at: '2026-04-02T12:00:00.000Z',
+                  },
+                ],
+              },
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`)
+      })
 
       const testQuiz = makeQuizWithStats({
         assessment_type: 'test',
@@ -1051,10 +1059,10 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Documents' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: 'Documents' }))
+      fireEvent.click(screen.getByRole('button', { name: /Documents/ }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
       fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
       fireEvent.change(screen.getByPlaceholderText('Title'), {
@@ -1077,6 +1085,210 @@ Prompt:
             source: 'link',
           },
         ])
+      })
+
+      await waitFor(() => {
+        expect(
+          fetchMock.mock.calls.some(
+            (call: any[]) => String(call[0]).includes('/documents/') && call[1]?.method === 'POST'
+          )
+        ).toBe(true)
+      })
+    })
+
+    it('shows compact sync age and refreshes existing link documents', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (url.includes('/draft')) {
+          return {
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: 1,
+                content: {
+                  title: 'Doc Refresh Test',
+                  show_results: true,
+                  questions: sampleQuestions,
+                },
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [
+                  {
+                    id: 'doc-1',
+                    title: 'Java API',
+                    url: 'https://docs.oracle.com',
+                    source: 'link',
+                    snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                    snapshot_content_type: 'text/html',
+                    synced_at: new Date(Date.now() - 4 * 60 * 1000).toISOString(),
+                  },
+                ],
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && options?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [
+                  {
+                    id: 'doc-1',
+                    title: 'Java API',
+                    url: 'https://docs.oracle.com',
+                    source: 'link',
+                    snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                    snapshot_content_type: 'text/html',
+                    synced_at: '2026-04-02T12:00:00.000Z',
+                  },
+                ],
+              },
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`)
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Doc Refresh Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /Documents/ }))
+
+      await waitFor(() => {
+        expect(screen.getByText('4m')).toBeInTheDocument()
+      })
+
+      expect(
+        fetchMock.mock.calls.some(
+          (call: any[]) => call[0] === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && call[1]?.method === 'POST'
+        )
+      ).toBe(false)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Refresh Java API' }))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/teacher/tests/quiz-1/documents/doc-1/sync',
+          expect.objectContaining({ method: 'POST' })
+        )
+      })
+    })
+
+    it('auto-syncs stale link documents when a teacher opens the test', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (url.includes('/draft')) {
+          return {
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: 1,
+                content: {
+                  title: 'Doc Auto Sync Test',
+                  show_results: true,
+                  questions: sampleQuestions,
+                },
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [
+                  {
+                    id: 'doc-1',
+                    title: 'Java API',
+                    url: 'https://docs.oracle.com',
+                    source: 'link',
+                    snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                    snapshot_content_type: 'text/html',
+                    synced_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+                  },
+                ],
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && options?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [
+                  {
+                    id: 'doc-1',
+                    title: 'Java API',
+                    url: 'https://docs.oracle.com',
+                    source: 'link',
+                    snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                    snapshot_content_type: 'text/html',
+                    synced_at: new Date().toISOString(),
+                  },
+                ],
+              },
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`)
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Doc Auto Sync Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
+      })
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/teacher/tests/quiz-1/documents/doc-1/sync',
+          expect.objectContaining({ method: 'POST' })
+        )
       })
     })
 

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -19,6 +19,25 @@ describe('StudentQuizzesTab exam mode', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 768,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1024,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 768,
+    })
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -581,6 +600,12 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
     })
     expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
+    const activeIframe = container.querySelector('iframe[title="Node.js API"]')
+    expect(activeIframe).toBeInTheDocument()
+    expect(activeIframe?.className || '').toContain('w-[calc(100%+10px)]')
+    expect(activeIframe?.className || '').not.toContain('group-hover:w-full')
+    expect(activeIframe?.className || '').not.toContain('group-focus-within:w-full')
+    expect(container.querySelector('.z-\\[1\\].w-3.bg-white')).not.toBeInTheDocument()
     const splitContainerDocOpen = getSplitContainer(container)
     expect(splitContainerDocOpen.className).toContain('lg:grid-cols-[50%_50%]')
     expect(splitContainerDocOpen.className).not.toContain('lg:grid-cols-[30%_70%]')
@@ -592,6 +617,384 @@ describe('StudentQuizzesTab exam mode', () => {
     })
     const splitContainerBack = getSplitContainer(container)
     expect(splitContainerBack.className).toContain('lg:grid-cols-[30%_70%]')
+  })
+
+  it('suppresses iframe doc-triggered fullscreen and resize exits', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+      }),
+    })
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use documentation for this question.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    const { container } = render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
+    })
+
+    const iframe = container.querySelector('iframe[title="Node.js API"]')
+    expect(iframe).toBeInTheDocument()
+    fireEvent.pointerEnter(iframe!)
+    fullscreenElement = null
+    fireEvent(document, new Event('fullscreenchange'))
+    fireEvent(window, new Event('resize'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(focusBodies).toEqual([])
+  })
+
+  it('suppresses blur and visibility exits after text doc interaction', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let visibilityState: DocumentVisibilityState = 'visible'
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    Object.defineProperty(window, 'getSelection', {
+      configurable: true,
+      value: vi.fn(() => ({
+        toString: () => 'Selected reference text',
+      })),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Formula Sheet',
+                  content: 'Solve using the quadratic formula.',
+                  source: 'text',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use the formula sheet.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Formula Sheet' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Formula Sheet' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
+    })
+
+    fireEvent.mouseUp(screen.getByText('Solve using the quadratic formula.'))
+    fireEvent(window, new Event('blur'))
+    visibilityState = 'hidden'
+    fireEvent(document, new Event('visibilitychange'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(focusBodies).toEqual([])
+  })
+
+  it('does not log exit telemetry when returning from an open doc to the docs list', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use documentation for this question.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to documents list' }))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(focusBodies).toEqual([])
   })
 
   it('uses 30/70 split when student is viewing returned test results', async () => {
@@ -1497,6 +1900,131 @@ describe('StudentQuizzesTab exam mode', () => {
     await waitFor(() => {
       expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
     })
+
+    window.dispatchEvent(
+      new CustomEvent(STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT, {
+        detail: { classroomId: classroom.id, source: 'in_app_navigation' },
+      })
+    )
+    fireEvent(window, new Event('pagehide'))
+
+    await waitFor(() => {
+      expect(focusBodies.filter((body) => body.event_type === 'route_exit_attempt')).toHaveLength(2)
+    })
+  })
+
+  it('logs real route and page exits after the docs suppression window elapses', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use documentation for this question.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        const routeExitAttempts = focusBodies.filter(
+          (body) => body.event_type === 'route_exit_attempt'
+        ).length
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary({
+              exit_count: routeExitAttempts > 0 ? 1 : 0,
+              route_exit_attempts: routeExitAttempts,
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
+    })
+
+    const iframe = document.querySelector('iframe[title="Node.js API"]')
+    expect(iframe).toBeInTheDocument()
+    fireEvent.pointerEnter(iframe!)
+    await new Promise((resolve) => setTimeout(resolve, 1250))
 
     window.dispatchEvent(
       new CustomEvent(STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT, {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -265,6 +265,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,
@@ -380,6 +383,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,
@@ -505,6 +511,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,
@@ -602,6 +611,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
     const activeIframe = container.querySelector('iframe[title="Node.js API"]')
     expect(activeIframe).toBeInTheDocument()
+    expect(activeIframe?.getAttribute('src')).toBe('/api/student/tests/test-1/documents/doc-1/snapshot')
     expect(activeIframe?.className || '').toContain('w-[calc(100%+10px)]')
     expect(activeIframe?.className || '').not.toContain('group-hover:w-full')
     expect(activeIframe?.className || '').not.toContain('group-focus-within:w-full')
@@ -686,6 +696,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,
@@ -925,6 +938,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,
@@ -995,6 +1011,107 @@ describe('StudentQuizzesTab exam mode', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(focusBodies).toEqual([])
+  })
+
+  it('shows an unavailable state for unsynced link docs', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              documents: [
+                {
+                  id: 'doc-1',
+                  title: 'Node.js API',
+                  url: 'https://nodejs.org/api/fs.html',
+                  source: 'link',
+                },
+              ],
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: 'Use documentation for this question.',
+                options: ['A', 'B'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Node.js API' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Node.js API' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('This document is unavailable.')).toBeInTheDocument()
+    })
+
+    expect(document.querySelector('iframe[title="Node.js API"]')).not.toBeInTheDocument()
   })
 
   it('uses 30/70 split when student is viewing returned test results', async () => {
@@ -1950,6 +2067,9 @@ describe('StudentQuizzesTab exam mode', () => {
                   title: 'Node.js API',
                   url: 'https://nodejs.org/api/fs.html',
                   source: 'link',
+                  snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+                  snapshot_content_type: 'text/html',
+                  synced_at: '2026-04-02T12:00:00.000Z',
                 },
               ],
               position: 0,

--- a/tests/unit/test-documents.test.ts
+++ b/tests/unit/test-documents.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it } from 'vitest'
 import {
+  formatCompactRelativeAge,
   getTestDocumentValidationError,
+  isLinkDocumentSnapshotStale,
   normalizeTestDocuments,
+  sanitizeSnapshotHtml,
   validateTestDocumentsPayload,
 } from '@/lib/test-documents'
 
 describe('test-documents', () => {
   it('normalizes valid documents and drops invalid entries', () => {
     const result = normalizeTestDocuments([
-      { id: 'doc-1', title: ' Java API ', url: 'https://docs.oracle.com', source: 'link' },
+      {
+        id: 'doc-1',
+        title: ' Java API ',
+        url: 'https://docs.oracle.com',
+        source: 'link',
+        snapshot_path: 'link-docs/teacher/test/doc-1/snapshot',
+        snapshot_content_type: 'text/html',
+        synced_at: '2026-04-02T10:00:00.000Z',
+      },
       { id: 'doc-2', title: ' Allowed Syntax ', source: 'text', content: 'if, else, switch' },
       { id: 'bad', title: 'Bad', url: 'javascript:alert(1)', source: 'link' },
     ])
@@ -19,6 +30,9 @@ describe('test-documents', () => {
         title: 'Java API',
         url: 'https://docs.oracle.com',
         source: 'link',
+        snapshot_path: 'link-docs/teacher/test/doc-1/snapshot',
+        snapshot_content_type: 'text/html',
+        synced_at: '2026-04-02T10:00:00.000Z',
       },
       {
         id: 'doc-2',
@@ -77,5 +91,64 @@ describe('test-documents', () => {
 
     const invalidType = new File(['{}'], 'data.exe', { type: 'application/x-msdownload' })
     expect(getTestDocumentValidationError(invalidType)).toContain('Invalid file type')
+  })
+
+  it('formats compact relative sync ages', () => {
+    const now = Date.parse('2026-04-02T12:00:00.000Z')
+
+    expect(formatCompactRelativeAge('2026-04-02T11:59:56.000Z', now)).toBe('4s')
+    expect(formatCompactRelativeAge('2026-04-02T11:56:00.000Z', now)).toBe('4m')
+    expect(formatCompactRelativeAge('2026-04-02T08:00:00.000Z', now)).toBe('4h')
+    expect(formatCompactRelativeAge('2026-04-01T12:00:00.000Z', now)).toBe('1d')
+    expect(formatCompactRelativeAge('2026-02-01T12:00:00.000Z', now)).toBe('2mo')
+    expect(formatCompactRelativeAge('2025-04-02T12:00:00.000Z', now)).toBe('1y')
+  })
+
+  it('treats missing or old link snapshots as stale', () => {
+    const now = Date.parse('2026-04-03T12:00:00.000Z')
+
+    expect(
+      isLinkDocumentSnapshotStale({
+        source: 'link',
+        snapshot_path: undefined,
+        synced_at: null,
+      }, now)
+    ).toBe(true)
+
+    expect(
+      isLinkDocumentSnapshotStale({
+        source: 'link',
+        snapshot_path: 'link-docs/teacher/test/doc-1/snapshot',
+        synced_at: '2026-04-02T11:59:59.000Z',
+      }, now)
+    ).toBe(true)
+
+    expect(
+      isLinkDocumentSnapshotStale({
+        source: 'link',
+        snapshot_path: 'link-docs/teacher/test/doc-1/snapshot',
+        synced_at: '2026-04-03T11:00:00.000Z',
+      }, now)
+    ).toBe(false)
+
+    expect(
+      isLinkDocumentSnapshotStale({
+        source: 'text',
+        snapshot_path: undefined,
+        synced_at: null,
+      }, now)
+    ).toBe(false)
+  })
+
+  it('sanitizes synced html snapshots', () => {
+    const sanitized = sanitizeSnapshotHtml(
+      '<html><head><meta http-equiv="refresh" content="0;url=https://evil.test"><script>alert(1)</script></head><body><a onclick="steal()">Go</a></body></html>',
+      'https://docs.example.com/path'
+    )
+
+    expect(sanitized).toContain('<base href="https://docs.example.com/path">')
+    expect(sanitized).not.toContain('<script')
+    expect(sanitized).not.toContain('http-equiv="refresh"')
+    expect(sanitized).not.toContain('onclick=')
   })
 })


### PR DESCRIPTION
## Summary
- suppress false exam-mode exit telemetry while students interact with allowed test documents
- keep real classroom navigation and page-exit signals logging after the suppression window elapses
- clean up the student split layout so the iframe docs pane hides the scrollbar edge cleanly and the outer pane edges sit flush

## Root Cause
Allowed docs-pane interactions in exam mode were still feeding the same blur, visibility, fullscreen, resize, and route-exit paths used for real exam exits. The inline iframe pane also relied on a hover-reveal width trick that exposed an ugly divider-edge interaction.

## What Changed
- added a 1200ms docs-interaction suppression window in the student tests flow
- marked docs-list clicks, iframe focus and pointer entry, text-doc selection, pane pointer and wheel activity, and the in-panel back action as allowed docs interactions
- bypassed suppression for real navigation sources such as classroom switching and tab navigation
- removed the old hover-reveal iframe width behavior and replaced it with a clipped iframe treatment
- removed the outer horizontal padding from the student test split layout so the panes align with the viewport edges
- added regression coverage for the docs interaction cases and the remaining real exit cases

## Validation
- `npm test -- tests/components/StudentQuizzesTab.test.tsx`
- `npm test -- tests/components/TeacherQuizzesTab.test.tsx tests/unit/quizzes.test.ts`
- `npm run lint -- --file 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' --file 'tests/components/StudentQuizzesTab.test.tsx'`
- visual verification:
  - student docs-open: `/tmp/pika-issue-441-seed-doc-open-edges.png`
  - teacher tests list: `/tmp/pika-issue-441-teacher-tests-clean.png`
