### PR TITLE
[codex] Highlight incorrect teacher test MC answers

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -7878,3 +7878,24 @@
 **Follow-up:**
 - Removed the assignment-list late badge so overview cards show mailbox count only.
 - Re-verified that late state is still represented inside the assignment drill-down by the status icon logic: late statuses and late-derived downstream statuses append a clock indicator.
+
+## 2026-04-09 [AI - Codex]
+
+**Goal:** Fix issue #444 so the teacher test grading panel highlights incorrect multiple-choice answers and shows the correct answer.
+
+**Completed:**
+- Extended the teacher test grading panel to read `correct_option` for multiple-choice questions.
+- Replaced the plain `Answer: ...` line with separate `Student answer` and `Correct answer` blocks in the teacher grading view.
+- Styled incorrect student multiple-choice answers with warning text to match the student returned-results treatment.
+- Added component coverage for incorrect-answer highlighting, correct-answer display, and the non-highlighted correct-answer case while preserving the existing MC score override coverage.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx`
+- `corepack pnpm exec next lint --file src/components/TestStudentGradingPanel.tsx --file tests/components/TestStudentGradingPanel.test.tsx`
+- `corepack pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx tests/components/StudentQuizResults.test.tsx`
+- Visual verification on local dev server for `/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=tests`:
+  - teacher desktop grading view: `/tmp/pika-issue-444-teacher-desktop.png`
+  - teacher mobile grading table: `/tmp/pika-issue-444-teacher-mobile.png`
+  - student mobile tests tab: `/tmp/pika-issue-444-student-mobile.png`
+
+**Status:** The teacher grading panel now calls out wrong MC answers clearly and shows the correct answer alongside them. Desktop verification confirmed the changed UI on the seeded closed test (`Seed Test - AI Grading Demo`, `Student2 Test`).

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -14,6 +14,7 @@ interface TestQuestionInfo {
   question_text: string
   question_type: 'multiple_choice' | 'open_response'
   options: string[]
+  correct_option: number | null
   points: number
 }
 
@@ -580,10 +581,18 @@ export function TestStudentGradingPanel({
             if (question.question_type === 'multiple_choice') {
               const responseId = answer?.response_id || null
               const isGradeEditable = !!responseId && !answer?.is_draft
+              const selectedOption =
+                typeof answer?.selected_option === 'number' ? answer.selected_option : null
               const selectedText =
-                typeof answer?.selected_option === 'number'
-                  ? question.options[answer.selected_option] || '—'
-                  : 'No response'
+                selectedOption != null ? question.options[selectedOption] || '—' : 'No response'
+              const correctText =
+                typeof question.correct_option === 'number'
+                  ? question.options[question.correct_option] || '—'
+                  : '—'
+              const isIncorrectMultipleChoice =
+                selectedOption != null &&
+                typeof question.correct_option === 'number' &&
+                selectedOption !== question.correct_option
 
               return (
                 <div key={question.id} className="space-y-2 py-1">
@@ -592,9 +601,27 @@ export function TestStudentGradingPanel({
                   </p>
                   <QuestionMarkdown content={question.question_text} />
                   <div className="grid grid-cols-[minmax(0,1fr)_76px] items-start gap-2">
-                    <p className="text-base text-text-muted">
-                      Answer: {selectedText}{answer?.is_draft ? ' (Draft)' : ''}
-                    </p>
+                    <div className="space-y-1 text-sm">
+                      <div className="rounded-md bg-surface-2 px-3 py-2 text-text-default">
+                        <p
+                          className={`text-xs font-semibold uppercase tracking-wide ${
+                            isIncorrectMultipleChoice ? 'text-warning' : ''
+                          }`}
+                        >
+                          Student answer
+                        </p>
+                        <p className={`font-medium ${isIncorrectMultipleChoice ? 'text-warning' : ''}`}>
+                          {selectedText}
+                          {answer?.is_draft ? ' (Draft)' : ''}
+                        </p>
+                      </div>
+                      <div className="rounded-md bg-surface-2 px-3 py-2 text-text-muted">
+                        <p className="text-xs font-semibold uppercase tracking-wide">
+                          Correct answer
+                        </p>
+                        <p className="font-medium">{correctText}</p>
+                      </div>
+                    </div>
                     <SplitScoreInput
                       ariaLabel={`Q${index + 1} score`}
                       maxPoints={points}

--- a/tests/components/TestStudentGradingPanel.test.tsx
+++ b/tests/components/TestStudentGradingPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
@@ -59,7 +59,17 @@ function makeResultsPayload(score: number | null, feedback: string | null) {
   }
 }
 
-function makeMixedResultsPayload(mcScore: number, openScore: number | null, feedback: string | null) {
+function makeMixedResultsPayload(
+  mcScore: number,
+  openScore: number | null,
+  feedback: string | null,
+  options: {
+    selectedOption?: number
+    correctOption?: number | null
+  } = {}
+) {
+  const selectedOption = options.selectedOption ?? 1
+  const correctOption = options.correctOption ?? 1
   return {
     quiz: { id: 'test-1', title: 'Unit Test' },
     questions: [
@@ -68,6 +78,7 @@ function makeMixedResultsPayload(mcScore: number, openScore: number | null, feed
         question_text: 'What is 2 + 2?',
         question_type: 'multiple_choice' as const,
         options: ['3', '4', '5'],
+        correct_option: correctOption,
         points: 2,
       },
       {
@@ -75,6 +86,7 @@ function makeMixedResultsPayload(mcScore: number, openScore: number | null, feed
         question_text: 'Explain osmosis.',
         question_type: 'open_response' as const,
         options: [],
+        correct_option: null,
         points: 5,
       },
     ],
@@ -95,7 +107,7 @@ function makeMixedResultsPayload(mcScore: number, openScore: number | null, feed
           'q-mc-1': {
             response_id: 'response-mc-1',
             question_type: 'multiple_choice' as const,
-            selected_option: 1,
+            selected_option: selectedOption,
             response_text: null,
             score: mcScore,
             feedback: null,
@@ -309,6 +321,81 @@ describe('TestStudentGradingPanel save-all grading', () => {
       url: expect.stringContaining('/responses/response-mc-1'),
       body: { score: 1 },
     })
+  })
+
+  it('highlights incorrect MC answers and shows the correct answer', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/teacher/tests/test-1/results')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeMixedResultsPayload(0, null, null, { correctOption: 2 }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TestStudentGradingPanel
+        testId="test-1"
+        selectedStudentId="student-1"
+      />
+    )
+
+    await screen.findByText('Student answer')
+
+    const studentAnswerLabel = screen.getByText('Student answer')
+    const studentAnswerBlock = studentAnswerLabel.closest('div')
+    const correctAnswerLabel = screen.getByText('Correct answer')
+    const correctAnswerBlock = correctAnswerLabel.closest('div')
+
+    expect(studentAnswerLabel.className).toContain('text-warning')
+    expect(studentAnswerBlock).not.toBeNull()
+    expect(correctAnswerBlock).not.toBeNull()
+    expect(within(studentAnswerBlock!).getByText('4').className).toContain('text-warning')
+    expect(correctAnswerLabel).toBeInTheDocument()
+    expect(within(correctAnswerBlock!).getByText('5')).toBeInTheDocument()
+  })
+
+  it('does not highlight correct MC answers', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/teacher/tests/test-1/results')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeMixedResultsPayload(2, null, null),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TestStudentGradingPanel
+        testId="test-1"
+        selectedStudentId="student-1"
+      />
+    )
+
+    await screen.findByText('Student answer')
+
+    const studentAnswerLabel = screen.getByText('Student answer')
+    const studentAnswerBlock = studentAnswerLabel.closest('div')
+    const correctAnswerLabel = screen.getByText('Correct answer')
+    const correctAnswerBlock = correctAnswerLabel.closest('div')
+
+    expect(studentAnswerLabel.className).not.toContain('text-warning')
+    expect(studentAnswerBlock).not.toBeNull()
+    expect(correctAnswerBlock).not.toBeNull()
+    expect(within(studentAnswerBlock!).getByText('4').className).not.toContain('text-warning')
+    expect(within(correctAnswerBlock!).getByText('4')).toBeInTheDocument()
   })
 
   it('saves cleared score/feedback as clear_grade through save-all handler', async () => {


### PR DESCRIPTION
## Summary
- highlight incorrect multiple-choice answers in the teacher test grading panel
- show the correct answer alongside the selected student answer for teacher review
- add component coverage for incorrect and correct teacher-side MC rendering

## Why
Issue #444 reported that wrong MC answers were already called out in the student returned-results view but not in the teacher's test grading view. The teacher panel was using a separate rendering path that only showed a plain `Answer: ...` line.

## Impact
Teachers can now spot incorrect multiple-choice selections immediately while grading tests, without losing the existing manual score override workflow.

## Validation
- `corepack pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx`
- `corepack pnpm exec next lint --file src/components/TestStudentGradingPanel.tsx --file tests/components/TestStudentGradingPanel.test.tsx`
- `corepack pnpm exec vitest run tests/components/TestStudentGradingPanel.test.tsx tests/components/StudentQuizResults.test.tsx`
- visual verification on local dev server for `/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=tests`

Closes #444