### PR TITLE
feat: add fullscreen toggle to app header

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronLeft, ClockAlert, LogOut, Maximize2 } from 'lucide-react'
+import { ChevronLeft, ClockAlert, LogOut, Maximize } from 'lucide-react'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout } from '@/components/PageLayout'
@@ -849,7 +849,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   void requestExamFullscreen('center_overlay_maximize', { logFailures: true })
                 }}
               >
-                <Maximize2 className="h-5 w-5" />
+                <Maximize className="h-5 w-5" />
                 <span>Maximize Window</span>
               </Button>
             </div>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import { ClockAlert, LogOut, Menu } from 'lucide-react'
+import { ClockAlert, LogOut, Maximize, Menu, Minimize } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ClassroomDropdown } from './ClassroomDropdown'
 import { UserMenu } from './UserMenu'
 import { PikaLogo } from './PikaLogo'
 import { Tooltip } from '@/ui'
+import { useFullscreen } from '@/hooks/use-fullscreen'
+import { useKeyboardShortcutHint } from '@/hooks/use-keyboard-shortcut-hint'
 
 interface AppHeaderProps {
   user?: {
@@ -54,11 +56,31 @@ export function AppHeader({
   examModeHeader,
 }: AppHeaderProps) {
   const [now, setNow] = useState(() => new Date())
+  const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
+  const hints = useKeyboardShortcutHint()
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(new Date()), 60_000)
     return () => window.clearInterval(id)
   }, [])
+
+  const isExamMode = Boolean(examModeHeader)
+
+  useEffect(() => {
+    if (isExamMode) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'f') {
+        const target = e.target as HTMLElement
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+          return
+        }
+        e.preventDefault()
+        void toggleFullscreen()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [toggleFullscreen, isExamMode])
 
   return (
     <header className="sticky top-0 z-50 h-12 bg-surface border-b border-border grid grid-cols-[1fr_minmax(0,1fr)_1fr] items-center px-4">
@@ -128,6 +150,18 @@ export function AppHeader({
 
       {/* Right section */}
       <div className="flex items-center justify-end gap-0">
+        {!isExamMode && (
+          <Tooltip content={`${isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'} (${hints.fullscreen})`}>
+            <button
+              type="button"
+              onClick={() => void toggleFullscreen()}
+              className="p-2 rounded-md text-text-muted hover:text-text-default hover:bg-surface-hover transition-colors"
+              aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            >
+              {isFullscreen ? <Minimize className="w-4 h-4" /> : <Maximize className="w-4 h-4" />}
+            </button>
+          </Tooltip>
+        )}
         <span className="mr-2 whitespace-nowrap text-base font-semibold tabular-nums text-text-default">
           <span>{formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}</span>
           <span className="ml-2">{formatInTimeZone(now, 'America/Toronto', 'h:mm a')}</span>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -69,7 +69,7 @@ export function AppHeader({
   useEffect(() => {
     if (isExamMode) return
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'f') {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'f') {
         const target = e.target as HTMLElement
         if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
           return

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronLeft, Maximize2, X } from 'lucide-react'
+import { ChevronLeft, Maximize, X } from 'lucide-react'
 import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
@@ -301,7 +301,7 @@ export function TeacherTestPreviewPage({ classroomId, testId }: Props) {
                 void requestExamFullscreen()
               }}
             >
-              <Maximize2 className="h-5 w-5" />
+              <Maximize className="h-5 w-5" />
               <span>Maximize Window</span>
             </Button>
           </div>

--- a/src/hooks/use-fullscreen.ts
+++ b/src/hooks/use-fullscreen.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Manages browser fullscreen state via the Fullscreen API.
+ * Syncs with external changes (e.g. Escape key exits fullscreen).
+ */
+export function useFullscreen() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const handleChange = () => setIsFullscreen(Boolean(document.fullscreenElement))
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
+
+  const toggle = useCallback(async () => {
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen().catch(() => {})
+    } else {
+      await document.exitFullscreen().catch(() => {})
+    }
+  }, [])
+
+  return { isFullscreen, toggle }
+}

--- a/src/hooks/use-keyboard-shortcut-hint.ts
+++ b/src/hooks/use-keyboard-shortcut-hint.ts
@@ -21,5 +21,7 @@ export function useKeyboardShortcutHint() {
     leftPanel: `${mod}\\`,
     /** Right sidebar toggle: ⌘⇧\ or Ctrl+Shift+\ */
     rightPanel: isMac ? '⌘⇧\\' : 'Ctrl+Shift+\\',
+    /** Fullscreen toggle: ⌘⇧F or Ctrl+Shift+F */
+    fullscreen: isMac ? '⌘⇧F' : 'Ctrl+Shift+F',
   }
 }


### PR DESCRIPTION
## Summary

- Adds a **Maximize/Minimize button** to the global app header (right section, before the clock) using the `Maximize`/`Minimize` lucide icons
- Adds **`Cmd+Shift+F` / `Ctrl+Shift+F`** keyboard shortcut to toggle fullscreen
- Both the button and shortcut are **hidden/disabled in exam mode** to prevent students from accidentally exiting fullscreen
- Updates the "Maximize Window" button in `StudentQuizzesTab` and `TeacherTestPreviewPage` to use the same `Maximize` icon for consistency

## Test plan

- [ ] Click the fullscreen button in the header — window goes fullscreen, icon switches to Minimize
- [ ] Click again (or press Escape) — exits fullscreen, icon switches back to Maximize
- [ ] Press `Cmd+Shift+F` (Mac) or `Ctrl+Shift+F` (Windows) — toggles fullscreen
- [ ] In exam mode, confirm the fullscreen button is not visible in the header
- [ ] In exam mode, confirm `Cmd+Shift+F` does nothing
- [ ] Confirm the "Maximize Window" overlay button in student exam view uses the same icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)