### PR TITLE
[codex] Refine assignment grading workspace

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -7899,3 +7899,310 @@
   - student mobile tests tab: `/tmp/pika-issue-444-student-mobile.png`
 
 **Status:** The teacher grading panel now calls out wrong MC answers clearly and shows the correct answer alongside them. Desktop verification confirmed the changed UI on the seeded closed test (`Seed Test - AI Grading Demo`, `Student2 Test`).
+
+## 2026-04-09 [AI - Codex]
+
+**Goal:** Implement issue #453 so teacher assignment grading uses a first-class three-pane layout with persisted desktop sizing, collapse controls, and resizable inspector behavior.
+
+**Completed:**
+- Added `assignment-grading-layout` helpers and a dedicated `useAssignmentGradingLayout` hook to manage classroom-scoped cookie persistence, defaults, and width clamping for the roster/workspace and content/inspector splits.
+- Expanded `RightSidebarWidth` to support arbitrary percentage strings, then replaced the assignment-specific hardcoded sidebar widths with layout-driven values in the classroom page shell.
+- Updated the teacher assignments roster to switch into an explicit grading-roster mode based on pane state instead of the old sidebar-width heuristic, including a collapsed roster variant that keeps checkbox, first name, status, and grade visible.
+- Reworked `TeacherStudentWorkPanel` to add roster/inspector collapse controls, reset-layout behavior, resizable desktop separators, and a responsive inspector pane that stays full-width on mobile instead of inheriting desktop percentage widths.
+- Added helper, hook, and component coverage for cookie hydration, layout persistence/reset, arbitrary sidebar percentages, grading-pane toggles, and the mobile inspector-width regression.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/hooks/use-assignment-grading-layout.test.tsx tests/unit/assignment-grading-layout.test.ts tests/unit/layout-config.test.ts`
+- `corepack pnpm exec next lint --file src/lib/assignment-grading-layout.ts --file src/hooks/use-assignment-grading-layout.ts --file src/lib/layout-config.ts --file 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx' --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file src/components/TeacherStudentWorkPanel.tsx --file tests/unit/assignment-grading-layout.test.ts --file tests/unit/layout-config.test.ts --file tests/hooks/use-assignment-grading-layout.test.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on local dev server for `/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop selected grading layout: `/tmp/issue453-teacher-selected-loaded.png`
+  - teacher desktop collapsed roster: `/tmp/issue453-teacher-collapsed-roster.png`
+  - teacher desktop grading hidden/reset states: `/tmp/issue453-teacher-hide-grading.png`, `/tmp/issue453-teacher-reset-layout.png`
+  - teacher mobile grading drawer: `/tmp/issue453-teacher-mobile-fixed.png`
+  - student desktop assignments sanity check: `/tmp/issue453-student-assignments-loaded.png`
+
+**Status:** Assignment grading now uses persistent desktop pane state instead of hardcoded widths, the roster has an explicit collapsed grading mode, and the inspector remains responsive across desktop and mobile without leaking desktop percentage sizing into stacked mobile layouts.
+
+## 2026-04-09 [AI - Codex]
+
+**Goal:** Polish issue #453 so the teacher grading workspace uses a single shared header, stable loading behavior, flush content presentation, and a quick return-to-table action.
+
+**Completed:**
+- Moved teacher assignment grading controls into a shared workspace header inside `TeacherStudentWorkPanel`, including edit, assignment title, previous/next navigation, and icon-only controls for table-only, roster collapse, grading collapse, and layout reset.
+- Removed the layout-shifting top refresh bar from the grading workspace and replaced it with a subtle inline `Updating` status in the shared header while preserving the current content until the new student response arrives.
+- Made the submission content render flush with the pane by adding a `chrome="flush"` viewer mode and removing the boxed wrapper treatment from the grading content area.
+- Extended selected-student assignment context with `onEditAssignment` and `onShowTableOnly` callbacks so the panel can own its header actions while the teacher table remains the source of student selection state.
+- Added request-order guards for student work and history fetches so rapid student navigation cannot paint stale responses into the stable layout.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/hooks/use-assignment-grading-layout.test.tsx tests/unit/assignment-grading-layout.test.ts tests/unit/layout-config.test.ts`
+- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file src/components/editor/RichTextViewer.tsx --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx' --file src/types/index.ts --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on local dev server for `/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop grading workspace: `/tmp/issue453-followup-teacher-desktop.png`
+  - teacher mobile grading workspace: `/tmp/issue453-followup-teacher-mobile.png`
+  - student desktop assignments sanity check: `/tmp/issue453-followup-student-desktop.png`
+
+**Status:** The teacher grading experience now reads as one coordinated workspace instead of nested toolbars, content switches no longer shove the layout downward, and the student table can be restored directly from the grading header without introducing a separate persisted mode.
+
+## 2026-04-10 [AI - Codex]
+
+**Goal:** Rework issue #453 into a single teacher assignment workspace with one top action bar, explicit `Overview` / `Details` modes, and no teacher grading content in the shell right sidebar.
+
+**Completed:**
+- Replaced the old roster/workspace grading layout model with a mode-aware inspector layout in `assignment-grading-layout`, including per-mode width/collapse state and per-assignment remembered student cookies for `Details`.
+- Moved teacher assignment workspace ownership into `TeacherClassroomView`, including the single top action bar, assignment title identity, student-name secondary label in `Details`, `Overview` / `Details` segmented control, batch actions, prev/next navigation, and grading visibility/reset controls.
+- Removed teacher assignment grading from `ClassroomPageClient`’s generic `RightSidebar`, while preserving the summary-mode markdown sidebar behavior for assignment list editing.
+- Refactored `TeacherStudentWorkPanel` so it no longer renders its own header and now supports `overview` inspector-only rendering plus `details` content+inspector rendering with stable loading behavior and flush submission content.
+- Removed the old `Show student table only` and roster-collapse concepts from the active grading UI and test coverage, and dropped the obsolete `SelectedStudentInfo` cross-component contract.
+- Rewrote focused tests for the new layout helper/hook model and the simplified student panel contract.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/hooks/use-assignment-grading-layout.test.tsx tests/unit/assignment-grading-layout.test.ts tests/unit/layout-config.test.ts`
+- `corepack pnpm exec next lint --file src/lib/assignment-grading-layout.ts --file src/hooks/use-assignment-grading-layout.ts --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx' --file src/components/TeacherStudentWorkPanel.tsx --file src/types/index.ts --file tests/unit/assignment-grading-layout.test.ts --file tests/hooks/use-assignment-grading-layout.test.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop overview: `/tmp/issue453-rework-teacher-overview.png`
+  - teacher desktop overview split: `/tmp/issue453-rework-teacher-overview-split.png`
+  - teacher desktop details: `/tmp/issue453-rework-teacher-details.png`
+  - teacher mobile overview: `/tmp/issue453-rework-teacher-mobile-overview.png`
+  - student desktop assignments sanity check: `/tmp/issue453-rework-student-desktop.png`
+
+**Status:** Teacher assignments now open into a main-content workspace that defaults to `Overview`, shifts to `Details` only by explicit mode switch, keeps a single persistent top action bar, and leaves the generic shell inspector out of grading entirely.
+
+## 2026-04-10 [AI - Codex]
+
+**Goal:** Flatten the assignment workspace action bar so the assignment title, optional details-mode student name, mode toggle, and all controls share one inline toolbar, with icon-only action buttons.
+
+**Completed:**
+- Reworked the assignment-mode action bar in `TeacherClassroomView` into a single inline toolbar row instead of the previous stacked identity/action layout.
+- Moved the assignment title and details-mode student name into the same inline flow as the `Overview` / `Details` toggle and the rest of the controls.
+- Converted `Edit`, `Repo analysis`, `Grading`, and `Send` to icon buttons with tooltip/accessible labels while preserving their disabled-state rules and existing batch-action semantics.
+- Kept the existing prev/next, grading visibility, and reset controls as icon actions in the same inline toolbar so the adjustable pane region remains fully below the bar.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop overview: `/tmp/issue453-toolbar-teacher-overview.png`
+  - teacher desktop overview split: `/tmp/issue453-toolbar-teacher-overview-split.png`
+  - teacher desktop details: `/tmp/issue453-toolbar-teacher-details.png`
+  - teacher mobile details: `/tmp/issue453-toolbar-teacher-mobile-details.png`
+  - student desktop sanity: `/tmp/issue453-toolbar-student-desktop.png`
+
+**Status:** The assignment workspace now reads as one compact toolbar-driven surface on desktop, with the title and selected student identity inline where requested and no second action row above the panes.
+
+## 2026-04-10 [AI - Codex]
+
+**Goal:** Apply the follow-up toolbar/content-header refinement for issue #453 by renaming the workspace toggle to `Class` / `Individual`, moving the toggle ahead of the assignment title, and shifting student identity into the details content header.
+
+**Completed:**
+- Updated the assignment workspace top bar in `TeacherClassroomView` so the segmented mode control appears first, renamed the visible labels to `Class` and `Individual`, and removed the selected student name from the global toolbar.
+- Added an always-visible student-first content header in `TeacherStudentWorkPanel` for `details` mode, reusing the old repo metadata strip so the student name appears first and repo metadata follows inline when available.
+- Preserved the `Class` view as table-driven only, with no additional student identity outside the selected row and right pane.
+- Added focused component coverage for the new `individual-content-header` behavior and cleaned out the now-unused top-bar student display value.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file 'src/components/TeacherStudentWorkPanel.tsx' --file 'tests/components/TeacherStudentWorkPanel.test.tsx'`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop class view: `/tmp/issue453-class-toolbar-teacher-overview.png`
+  - teacher desktop class split view: `/tmp/issue453-class-toolbar-teacher-overview-split.png`
+  - teacher desktop individual view: `/tmp/issue453-class-toolbar-teacher-details.png`
+  - teacher mobile individual view: `/tmp/issue453-class-toolbar-teacher-mobile-details.png`
+  - student desktop sanity check: `/tmp/issue453-class-toolbar-student-desktop.png`
+
+**Status:** The assignment workspace now uses the requested `Class` / `Individual` framing, with the top bar focused on assignment scope and controls, and the student identity anchored directly to the individual submission content area.
+
+## 2026-04-10 [AI - Codex]
+
+**Goal:** Remove the assignment workspace `Hide grading` and `Reset layout` toolbar actions now that class-row selection and pane resizing cover the remaining use cases.
+
+**Completed:**
+- Removed the `Hide grading` and `Reset layout` icon buttons from the assignment workspace action bar in `TeacherClassroomView`.
+- Simplified class-mode inspector visibility so selecting a student row always opens the grading pane and deselecting the row remains the way back to a table-only class view.
+- Forced the individual workspace pane to keep the grading inspector visible so older persisted collapsed states cannot strand the user without a way to restore the right pane after the buttons are gone.
+- Kept pane-width resizing intact in `Individual` and preserved the existing prev/next student navigation.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- `corepack pnpm exec tsc --noEmit`
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- Visual verification on the local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher class view: `/tmp/issue453-nohide-teacher-class.png`
+  - teacher class split view: `/tmp/issue453-nohide-teacher-class-split.png`
+  - teacher individual view: `/tmp/issue453-nohide-teacher-individual.png`
+  - teacher mobile individual view: `/tmp/issue453-nohide-teacher-mobile-individual.png`
+  - student desktop sanity check: `/tmp/issue453-nohide-student-desktop.png`
+
+**Status:** The assignment toolbar is now reduced to the essential mode, batch, and navigation actions, while class-row selection and individual-mode resizing carry the remaining layout control.
+
+## 2026-04-10 (issue 453 table compactness follow-up)
+
+**Goal:** Remove the horizontal scrollbar from the teacher assignment student table by tightening the column model instead of relying on overflow.
+
+**Completed:**
+- Removed the `Updated` column from the teacher assignment student table in class mode.
+- Tightened the first-name, last-name, status, and artifacts column widths in `TeacherClassroomView` and stopped enabling horizontal table overflow for the split class workspace.
+- Reworked `AssignmentArtifactsCell` compact mode to show a one-line truncated artifact summary with `+N` overflow count instead of a generic `N items` pill, keeping the modal preview entry point intact.
+- Updated the compact artifacts component test to cover the new ellipsis-style summary rendering.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `corepack pnpm exec vitest run tests/components/AssignmentArtifactsCell.test.tsx`
+- `corepack pnpm exec next lint --file src/components/AssignmentArtifactsCell.tsx --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file tests/components/AssignmentArtifactsCell.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher class split view: `/tmp/issue453-table-compact-teacher-class-split.png`
+  - teacher individual view sanity: `/tmp/issue453-table-compact-teacher-individual.png`
+  - student desktop sanity check: `/tmp/issue453-table-compact-student-desktop.png`
+
+**Status:** The assignment student table now fits within the class split pane without a horizontal scrollbar, using a narrower schema and a truncated artifacts summary instead of a wide overflow column.
+
+## 2026-04-10 (issue 453 folder-tab workspace chrome)
+
+**Goal:** Replace the assignment workspace `Class / Individual` pill toggle with a folder-tab treatment that visually fuses into the entire workspace below it.
+
+**Completed:**
+- Reworked the assignment-mode toolbar in `TeacherClassroomView` so `Class` and `Individual` render as top tabs instead of a pill toggle, with the active tab overlapping the workspace shell by 1px.
+- Added a shared outer assignment workspace shell with `bg-surface` and a single border so the active tab now reads as attached to the whole workspace rather than floating in the toolbar.
+- Reduced the handoff gap between `PageActionBar` and assignment-mode content so the tab strip and shell render as one unit.
+- Normalized the grading pane backgrounds in `TeacherStudentWorkPanel` to `bg-surface` so the shell owns the top-level chrome and the internal panes no longer fight it visually.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file src/components/TeacherStudentWorkPanel.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server at `http://localhost:3003/classrooms/a88c86b5-7d08-4468-ac4b-71f2f5010d56?tab=assignments`:
+  - teacher desktop class view: `/tmp/issue453-foldertab-teacher-class.png`
+  - teacher desktop individual view: `/tmp/issue453-foldertab-teacher-individual.png`
+  - teacher mobile assignment view: `/tmp/issue453-foldertab-teacher-mobile.png`
+  - student desktop sanity check: `/tmp/issue453-foldertab-student-desktop.png`
+
+**Status:** The assignment workspace now uses a true folder-tab treatment with one shared shell across `Class` and `Individual`, while keeping existing workspace behavior unchanged.
+
+## 2026-04-11 (issue 453 class-table shell flattening)
+
+**Goal:** Remove the nested table-card chrome from assignment `Class` mode so the folder tab visually matches the same top-level workspace surface as `Individual`.
+
+**Completed:**
+- Added a `chrome` presentation option to `TableCard` in `DataTable.tsx`, with `default` preserving existing table cards and `flush` removing the outer border/radius/background.
+- Switched the assignment student table in `TeacherClassroomView` to use `TableCard chrome=\"flush\"`, keeping the existing table header tint, row dividers, sorting, selection, and compact column model intact.
+- Added a focused `DataTable` component test covering `TableCard` default vs flush chrome behavior so the new presentation mode stays assignment-only by default.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/DataTable.test.tsx`
+- `corepack pnpm exec next lint --file src/components/DataTable.tsx --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file tests/components/DataTable.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher desktop class view: `/tmp/issue453-flush-teacher-class.png`
+  - teacher desktop class split view: `/tmp/issue453-flush-teacher-class-split.png`
+  - teacher desktop individual view sanity: `/tmp/issue453-flush-teacher-individual.png`
+  - teacher mobile assignment view: `/tmp/issue453-flush-teacher-mobile.png`
+  - student desktop sanity check: `/tmp/issue453-flush-student-desktop.png`
+
+**Status:** The `Class` tab now lands on the same top-level workspace shell as the table beneath it, removing the mismatched nested-card effect without changing assignment behavior or other table screens.
+
+## 2026-04-11 (issue 453 individual header character count)
+
+**Goal:** Move the individual-view character count from the bottom content footer into the content header alongside the student identity, and choose a simple icon for it.
+
+**Completed:**
+- Moved the character count from the bottom of the individual content pane into the `individual-content-header` in `TeacherStudentWorkPanel`.
+- Used the Lucide `Type` icon as the character-count marker and rendered the count as a muted `N chars` badge in the header.
+- Removed the old bottom character-count footer so the content area ends cleanly without a second metadata strip.
+- Updated the panel test to assert the new header count and absence of the old footer copy.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher desktop individual view: `/tmp/issue453-charcount-teacher-individual.png`
+  - teacher mobile individual view: `/tmp/issue453-charcount-teacher-mobile.png`
+  - student desktop sanity check: `/tmp/issue453-charcount-student-desktop.png`
+
+**Status:** Character count now lives in the individual header next to the student identity, using a small `Type` icon and a shorter `chars` label instead of a bottom footer.
+
+## 2026-04-11 (issue 453 character-count text simplification)
+
+**Goal:** Simplify the individual header character count by removing the icon and leaving only the text count.
+
+**Completed:**
+- Removed the Lucide `Type` icon from the individual content header in `TeacherStudentWorkPanel`.
+- Kept the header count as simple muted text in the form `N chars`.
+- Left the header placement and footer removal unchanged.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher desktop individual view: `/tmp/issue453-charcount-noicon-teacher-individual.png`
+  - student desktop sanity check: `/tmp/issue453-charcount-noicon-student-desktop.png`
+
+**Status:** The individual header now shows just `N chars` with no icon, which reads cleaner alongside the student name.
+
+## 2026-04-11 (issue 453 toolbar vertical centering)
+
+**Goal:** Stop the assignment title from feeling bottom-justified in the folder-tab toolbar while keeping the `Class / Individual` tabs attached to the workspace shell.
+
+**Completed:**
+- Reworked the assignment-mode action bar layout in `TeacherClassroomView` so the folder-tab strip stays in a bottom-aligned sub-container while the assignment title, loading state, and action icons sit in a vertically centered sibling row.
+- Added a small minimum toolbar height in assignment mode so the title reads as centered within the toolbar band instead of hanging low with the tabs.
+- Kept the folder-tab overlap and shell attachment unchanged.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher desktop class view: `/tmp/issue453-toolbar-center-teacher-class.png`
+  - teacher desktop individual view: `/tmp/issue453-toolbar-center-teacher-individual.png`
+  - teacher mobile assignment view: `/tmp/issue453-toolbar-center-teacher-mobile.png`
+  - student desktop sanity check: `/tmp/issue453-toolbar-center-student-desktop.png`
+
+**Status:** The assignment title now reads vertically centered in the toolbar band while the folder tabs remain visually attached to the workspace shell.
+
+## 2026-04-11 (issue 453 AI feedback draft merge)
+
+**Goal:** Make AI grading feedback appear directly in the feedback draft textarea instead of a separate suggestion box, while preserving any unsaved teacher comments already typed.
+
+**Completed:**
+- Removed the separate `AI Suggestion` card from the grading pane in `TeacherStudentWorkPanel`.
+- Added draft-merge behavior so `ai_feedback_suggestion` is folded into the feedback draft textarea content instead of living in a separate UI.
+- Appended new AI feedback to any current unsaved teacher comments with a blank-line separator, and avoided duplicate appends when the same suggestion is already present.
+- Kept initial document loads consistent by merging any persisted AI suggestion into the visible draft textarea content.
+- Added focused panel tests for both initial merge behavior and append-after-auto-grade behavior.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher individual grading view: `/tmp/issue453-aifeedback-merged-teacher-individual-grading.png`
+  - student desktop sanity check: `/tmp/issue453-aifeedback-merged-student-desktop.png`
+
+**Status:** AI-generated grading feedback now lands directly in the feedback draft area, appending below existing teacher comments instead of showing up in a separate suggestion box.
+
+## 2026-04-11 (issue 453 AI draft cue in feedback draft)
+
+**Goal:** Keep AI-generated grading feedback merged into the single feedback draft textarea, but make fresh AI content temporarily identifiable until the teacher focuses the draft.
+
+**Completed:**
+- Changed `TeacherStudentWorkPanel` draft merging so `ai_feedback_suggestion` is prepended ahead of any existing unsaved teacher draft text instead of appended after it.
+- Added local `hasFreshAIDraft` state so newly merged AI feedback shows a temporary `AI draft` label and subtle textarea tint inside the existing `Feedback Draft` section.
+- Cleared the temporary AI cue on first textarea focus without changing the merged text content or reintroducing a separate suggestion box.
+- Kept duplicate-prevention behavior so the same AI suggestion is not reinserted multiple times.
+- Updated focused panel tests to cover prepend order, temporary AI styling, and cue dismissal on focus.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
+- `corepack pnpm exec tsc --noEmit`
+- Visual verification on the local dev server:
+  - teacher grading before focus: `/Users/stew/Repos/.worktrees/pika/issue/453-grading-layout/.playwright-cli/page-2026-04-11T20-49-35-491Z.png`
+  - teacher grading after focus: `/Users/stew/Repos/.worktrees/pika/issue/453-grading-layout/.playwright-cli/page-2026-04-11T20-49-50-023Z.png`
+  - student assignments sanity check: `/tmp/issue453-ai-draft-student.png`
+
+**Status:** Fresh AI grading feedback now appears first in the draft, is visibly marked as AI-generated until the teacher clicks into the field, and then becomes a normal draft textarea without altering the text.

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -31,9 +31,7 @@ import {
 } from '@/components/layout'
 import { DESKTOP_BREAKPOINT, getRouteKeyFromTab } from '@/lib/layout-config'
 import { RichTextViewer } from '@/components/editor'
-import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import { Spinner } from '@/components/Spinner'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
@@ -53,7 +51,6 @@ import type {
   Entry,
   LessonPlan,
   TiptapContent,
-  SelectedStudentInfo,
   Assignment,
   QuizWithStats,
   GradebookStudentSummary,
@@ -402,9 +399,6 @@ function ClassroomPageContent({
   // State for selected assignment instructions (assignments tab)
   const [selectedAssignment, setSelectedAssignment] = useState<SelectedAssignmentInstructions | null>(null)
 
-  // State for selected student (teacher assignments tab - viewing student work)
-  const [selectedStudent, setSelectedStudent] = useState<SelectedStudentInfo | null>(null)
-
   // State for today's lesson plan (student today tab)
   const [todayLessonPlan, setTodayLessonPlan] = useState<LessonPlan | null>(null)
 
@@ -506,10 +500,6 @@ function ClassroomPageContent({
 
   const handleSelectAssignment = useCallback((assignment: SelectedAssignmentInstructions | null) => {
     setSelectedAssignment(assignment)
-  }, [])
-
-  const handleSelectStudent = useCallback((student: SelectedStudentInfo | null) => {
-    setSelectedStudent(student)
   }, [])
 
   const handleSetLessonPlan = useCallback((plan: LessonPlan | null) => {
@@ -666,9 +656,7 @@ function ClassroomPageContent({
   }, [])
 
   useEffect(() => {
-    if (isTeacher && activeTab === 'assignments' && selectedStudent) {
-      setRightSidebarWidth('75%')
-    } else if (isTeacher && activeTab === 'assignments') {
+    if (isTeacher && activeTab === 'assignments') {
       setRightSidebarWidth('50%')
     } else if (isTeacher && activeTab === 'quizzes') {
       setRightSidebarWidth('50%')
@@ -677,19 +665,21 @@ function ClassroomPageContent({
     } else if (isTeacher && activeTab === 'gradebook') {
       setRightSidebarWidth(420)
     }
-  }, [isTeacher, activeTab, selectedStudent, setRightSidebarWidth])
+  }, [
+    isTeacher,
+    activeTab,
+    setRightSidebarWidth,
+  ])
 
   useEffect(() => {
     if (!isTeacher || activeTab !== 'assignments') return
     if (assignmentViewMode !== 'assignment') return
-    if (selectedStudent) return
     setRightSidebarOpen(false)
     closeMobileDrawer()
   }, [
     isTeacher,
     activeTab,
     assignmentViewMode,
-    selectedStudent,
     setRightSidebarOpen,
     closeMobileDrawer,
   ])
@@ -1045,7 +1035,6 @@ function ClassroomPageContent({
                       <TeacherClassroomView
                         classroom={classroom}
                         onSelectAssignment={handleSelectAssignment}
-                        onSelectStudent={handleSelectStudent}
                         onViewModeChange={handleViewModeChange}
                         isActive={activeTab === 'assignments'}
                       />
@@ -1223,8 +1212,6 @@ function ClassroomPageContent({
               )
               : isTeacher && isAssessmentTab
               ? ''
-              : isTeacher && activeTab === 'assignments' && selectedStudent
-              ? selectedStudent.assignmentTitle
               : isTeacher && activeTab === 'assignments'
               ? ''
               : activeTab === 'assignments'
@@ -1300,27 +1287,6 @@ function ClassroomPageContent({
               >
                 Delete
               </button>
-            ) : isTeacher && activeTab === 'assignments' && selectedStudent ? (
-              <>
-                <button
-                  type="button"
-                  onClick={selectedStudent.onGoPrev}
-                  disabled={!selectedStudent.canGoPrev}
-                  className="p-1.5 rounded-md border border-border text-text-muted hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed"
-                  aria-label="Previous student"
-                >
-                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  onClick={selectedStudent.onGoNext}
-                  disabled={!selectedStudent.canGoNext}
-                  className="p-1.5 rounded-md border border-border text-text-muted hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed"
-                  aria-label="Next student"
-                >
-                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </>
             ) : undefined
           }
         >
@@ -1542,17 +1508,9 @@ function ClassroomPageContent({
             <LogSummary classroomId={classroom.id} date={attendanceDate} onStudentClick={handleSummaryStudentClick} />
           ) : isTeacher && activeTab === 'attendance' ? (
             null
-          ) : isTeacher && activeTab === 'assignments' && selectedStudent ? (
-            <TeacherStudentWorkPanel
-              classroomId={classroom.id}
-              assignmentId={selectedStudent.assignmentId}
-              studentId={selectedStudent.studentId}
-            />
           ) : isTeacher && activeTab === 'assignments' ? (
             <div className="p-4">
-              <p className="text-sm text-text-muted">
-                Select a student to view work.
-              </p>
+              <p className="text-sm text-text-muted">Use the assignment workspace to review student work.</p>
             </div>
           ) : activeTab === 'assignments' ? (
             <div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -19,36 +19,45 @@ import {
 import {
   BarChart3,
   Check,
+  ChevronLeft,
+  ChevronRight,
   Circle,
   Clock,
+  LoaderCircle,
   Pencil,
   Plus,
   RotateCcw,
   Send,
 } from 'lucide-react'
-import { Button, ConfirmDialog, RefreshingIndicator, Tooltip } from '@/ui'
+import { ConfirmDialog, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
+import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import {
-  ACTIONBAR_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
-  ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
+  ACTIONBAR_ICON_BUTTON_CLASSNAME,
   PageActionBar,
   PageContent,
   PageLayout,
   PageStack,
 } from '@/components/PageLayout'
-import { useRightSidebar, useMobileDrawer, useLeftSidebar, RightSidebarToggle } from '@/components/layout'
+import { RightSidebarToggle } from '@/components/layout'
 import {
   calculateAssignmentStatus,
   getAssignmentStatusIconClass,
   getAssignmentStatusLabel,
   hasDraftSavedGrade,
 } from '@/lib/assignments'
+import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
+import {
+  getAssignmentWorkspaceStudentCookieName,
+  parseAssignmentWorkspaceStudentId,
+  type AssignmentWorkspaceMode,
+} from '@/lib/assignment-grading-layout'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import type {
@@ -58,7 +67,6 @@ import type {
   AssignmentStatus,
   ClassDay,
   TiptapContent,
-  SelectedStudentInfo,
 } from '@/types'
 import {
   DataTable,
@@ -82,6 +90,8 @@ import { applyDirection, compareByNameFields, toggleSort as toggleSortState } fr
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
+import { readCookie, writeCookie } from '@/lib/cookies'
+import { useWindowSize } from '@/hooks/use-window-size'
 
 interface AssignmentWithStats extends Assignment {
   stats: AssignmentStats
@@ -114,45 +124,8 @@ export type AssignmentViewMode = 'summary' | 'assignment'
 interface Props {
   classroom: Classroom
   onSelectAssignment?: (assignment: { title: string; instructions: TiptapContent | string | null } | null) => void
-  onSelectStudent?: (student: SelectedStudentInfo | null) => void
   onViewModeChange?: (mode: AssignmentViewMode) => void
   isActive?: boolean
-}
-
-function getCookieValue(name: string) {
-  if (typeof document === 'undefined') return null
-  const match = document.cookie
-    .split(';')
-    .map((c) => c.trim())
-    .find((c) => c.startsWith(`${encodeURIComponent(name)}=`))
-  if (!match) return null
-  const value = match.split('=').slice(1).join('=')
-  return decodeURIComponent(value)
-}
-
-function setCookieValue(name: string, value: string) {
-  if (typeof document === 'undefined') return
-  const maxAgeSeconds = 60 * 60 * 24 * 365
-  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; SameSite=Lax`
-}
-
-function formatTorontoDateTime(iso: string) {
-  return new Date(iso).toLocaleString('en-US', {
-    timeZone: 'America/Toronto',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  }).replace(' AM', ' am').replace(' PM', ' pm')
-}
-
-function formatTorontoDateShort(iso: string) {
-  return new Date(iso).toLocaleDateString('en-US', {
-    timeZone: 'America/Toronto',
-    month: 'short',
-    day: 'numeric',
-  })
 }
 
 function isScheduledAssignment(assignment: Assignment): boolean {
@@ -168,6 +141,7 @@ function getRowClassName(isSelected: boolean): string {
 
 const STATUS_ICON_CLASS = 'h-4 w-4'
 const LATE_CLOCK_CLASS = 'h-3 w-3'
+const WORKSPACE_TAB_BASE_CLASSNAME = 'rounded-t-lg border px-3 py-1.5 text-sm font-medium transition-colors'
 
 function MetricBar({ value }: { value: number }) {
   const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
@@ -252,19 +226,16 @@ function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLat
 export function TeacherClassroomView({
   classroom,
   onSelectAssignment,
-  onSelectStudent,
   onViewModeChange,
   isActive = true,
 }: Props) {
   const isReadOnly = !!classroom.archived_at
-  const { setOpen: setSidebarOpen, width: sidebarWidth } = useRightSidebar()
-  const { openRight: openMobileSidebar, close: closeMobileSidebar } = useMobileDrawer()
-  const { setExpanded: setLeftSidebarExpanded } = useLeftSidebar()
+  const { width: viewportWidth } = useWindowSize()
+  const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
 
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([])
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [selection, setSelection] = useState<TeacherAssignmentSelection>({ mode: 'summary' })
@@ -296,11 +267,14 @@ export function TeacherClassroomView({
   const [pendingDelete, setPendingDelete] = useState<{ id: string; title: string } | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const [assignmentWorkspaceMode, setAssignmentWorkspaceMode] =
+    useState<AssignmentWorkspaceMode>('overview')
   const [editAssignment, setEditAssignment] = useState<Assignment | null>(null)
-  const [isSelectorOpen, setIsSelectorOpen] = useState(false)
   const [error, setError] = useState('')
-  const [warning, setWarning] = useState('')
   const [info, setInfo] = useState('')
+  const [workspaceLoading, setWorkspaceLoading] = useState(false)
+  const workspaceContainerRef = useRef<HTMLDivElement | null>(null)
+  const [workspaceWidth, setWorkspaceWidth] = useState(0)
 
   // Batch grading state
   const [isAutoGrading, setIsAutoGrading] = useState(false)
@@ -312,15 +286,14 @@ export function TeacherClassroomView({
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const wasActiveRef = useRef(isActive)
   const showSummarySpinner = useDelayedBusy(loading && assignments.length === 0)
-
-  // Compact table when sidebar is wide or a student is selected (sidebar opens)
-  const isCompactTable = sidebarWidth === '70%' || sidebarWidth === '75%' || selectedStudentId !== null
+  const {
+    layout: assignmentGradingLayout,
+    updateModeLayout,
+  } = useAssignmentGradingLayout(classroom.id, workspaceWidth)
 
   const loadAssignments = useCallback(async (options?: { preserveContent?: boolean }) => {
     const preserveContent = options?.preserveContent ?? false
-    if (preserveContent) {
-      setRefreshing(true)
-    } else {
+    if (!preserveContent) {
       setLoading(true)
     }
     try {
@@ -349,7 +322,6 @@ export function TeacherClassroomView({
       console.error('Error loading assignments:', err)
     } finally {
       setLoading(false)
-      setRefreshing(false)
     }
   }, [classroom.id])
 
@@ -363,6 +335,19 @@ export function TeacherClassroomView({
     }
     wasActiveRef.current = isActive
   }, [hasLoadedOnce, isActive, loadAssignments])
+
+  useEffect(() => {
+    const node = workspaceContainerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver((entries) => {
+      const nextWidth = entries[0]?.contentRect.width ?? 0
+      setWorkspaceWidth((current) => (Math.abs(current - nextWidth) < 1 ? current : nextWidth))
+    })
+
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [selection.mode, assignmentWorkspaceMode, selectedStudentId])
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
@@ -409,7 +394,7 @@ export function TeacherClassroomView({
   useEffect(() => {
     if (loading) return
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
-    const value = getCookieValue(cookieName)
+    const value = readCookie(cookieName)
     if (!value || value === 'summary') {
       setSelection({ mode: 'summary' })
       return
@@ -466,7 +451,6 @@ export function TeacherClassroomView({
     }
 
     const assignmentId = selection.assignmentId
-    const assignmentMeta = assignments.find((item) => item.id === assignmentId)
 
     async function loadSelectedAssignment() {
       setSelectedAssignmentLoading(true)
@@ -493,6 +477,15 @@ export function TeacherClassroomView({
     loadSelectedAssignment()
   }, [assignments, refreshCounter, selection])
 
+  useEffect(() => {
+    if (selection.mode !== 'assignment') {
+      setAssignmentWorkspaceMode('overview')
+      setSelectedStudentId(null)
+      setWorkspaceLoading(false)
+      return
+    }
+  }, [selection])
+
   // Notify parent about selected assignment for sidebar
   useEffect(() => {
     if (selection.mode === 'summary') {
@@ -510,16 +503,6 @@ export function TeacherClassroomView({
   useEffect(() => {
     onViewModeChange?.(selection.mode)
   }, [selection.mode, onViewModeChange])
-
-  // Keep inspector closed for assignment list view (work now lives in-table).
-  useEffect(() => {
-    if (selection.mode !== 'assignment' || selectedStudentId) return
-    if (window.innerWidth < DESKTOP_BREAKPOINT) {
-      closeMobileSidebar()
-    } else {
-      setSidebarOpen(false)
-    }
-  }, [selection.mode, selectedStudentId, closeMobileSidebar, setSidebarOpen])
 
   function handleCreateSuccess(created: Assignment) {
     // Optimistically add the new assignment to the list
@@ -549,9 +532,8 @@ export function TeacherClassroomView({
   function setSelectionAndPersist(next: TeacherAssignmentSelection) {
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     const cookieValue = next.mode === 'summary' ? 'summary' : next.assignmentId
-    setCookieValue(cookieName, cookieValue)
+    writeCookie(cookieName, cookieValue)
     setSelection(next)
-    setIsSelectorOpen(false)
   }
 
   const sortedStudents = useMemo(() => {
@@ -591,6 +573,8 @@ export function TeacherClassroomView({
 
   const studentRowIds = useMemo(() => currentStudentRows.map((s) => s.student_id), [currentStudentRows])
   const dueAtMs = useMemo(() => selectedAssignmentData ? new Date(selectedAssignmentData.assignment.due_at).getTime() : 0, [selectedAssignmentData])
+  const selectedAssignmentKey =
+    selection.mode === 'assignment' ? selection.assignmentId : null
   const {
     selectedIds: batchSelectedIds,
     toggleSelect: batchToggleSelect,
@@ -599,6 +583,15 @@ export function TeacherClassroomView({
     clearSelection: batchClearSelection,
     selectedCount: batchSelectedCount,
   } = useStudentSelection(studentRowIds)
+
+  useEffect(() => {
+    if (selection.mode !== 'assignment') return
+    setAssignmentWorkspaceMode('overview')
+    setSelectedStudentId(null)
+    setWorkspaceLoading(false)
+    batchClearSelection()
+  }, [batchClearSelection, selectedAssignmentKey, selection.mode])
+
   const batchSelectedGradedCount = useMemo(() => {
     if (currentStudentRows.length === 0) return 0
     let graded = 0
@@ -618,16 +611,6 @@ export function TeacherClassroomView({
   }, [batchSelectedIds, currentStudentRows])
   const batchSelectedUngradedCount = batchSelectedCount - batchSelectedGradedCount
 
-  // Auto-dismiss warning after 3 seconds, or immediately when students are selected
-  useEffect(() => {
-    if (!warning) return
-    if (batchSelectedCount > 0) {
-      setWarning('')
-      return
-    }
-    const timer = setTimeout(() => setWarning(''), 3000)
-    return () => clearTimeout(timer)
-  }, [warning, batchSelectedCount])
   useEffect(() => {
     if (!info) return
     const timer = setTimeout(() => setInfo(''), 4000)
@@ -748,44 +731,65 @@ export function TeacherClassroomView({
     setSelectedStudentId(currentStudentRows[selectedStudentIndex + 1].student_id)
   }, [currentStudentRows, selectedStudentIndex])
 
-  // Notify parent when student selection changes
   useEffect(() => {
-    const activeAssignment = selectedAssignmentData?.assignment || null
-    if (selectedStudentId && selection.mode === 'assignment' && activeAssignment?.id) {
-      const studentName = `${selectedStudentRow?.student_first_name || ''} ${selectedStudentRow?.student_last_name || ''}`.trim()
-      onSelectStudent?.({
-        assignmentId: activeAssignment.id,
-        assignmentTitle: activeAssignment.title,
-        studentId: selectedStudentId,
-        studentName: studentName || selectedStudentRow?.student_email || 'Student',
-        canGoPrev: canGoPrevStudent,
-        canGoNext: canGoNextStudent,
-        onGoPrev: handleGoPrevStudent,
-        onGoNext: handleGoNextStudent,
-      })
-    } else {
-      onSelectStudent?.(null)
-    }
-  }, [selectedAssignmentData?.assignment, selectedStudentId, selection.mode, selectedStudentRow, canGoPrevStudent, canGoNextStudent, handleGoPrevStudent, handleGoNextStudent, onSelectStudent])
+    if (selection.mode !== 'assignment' || !selectedStudentId) return
+    writeCookie(
+      getAssignmentWorkspaceStudentCookieName(classroom.id, selection.assignmentId),
+      selectedStudentId,
+    )
+  }, [classroom.id, selectedStudentId, selection])
 
-  // Auto-open right sidebar and collapse left sidebar when student is selected
-  const prevSelectedStudentIdRef = useRef<string | null>(null)
   useEffect(() => {
-    // Only act when transitioning from no selection to a selection
-    if (selectedStudentId && !prevSelectedStudentIdRef.current) {
-      if (window.innerWidth < DESKTOP_BREAKPOINT) {
-        openMobileSidebar()
-      } else {
-        setSidebarOpen(true)
-        // Collapse left sidebar to make room for the right sidebar content
-        setLeftSidebarExpanded(false)
+    if (!selectedStudentId) return
+    if (currentStudentRows.some((student) => student.student_id === selectedStudentId)) return
+    setSelectedStudentId(null)
+  }, [currentStudentRows, selectedStudentId])
+
+  const resolveDetailsStudentId = useCallback(() => {
+    if (selection.mode !== 'assignment') return null
+
+    if (selectedStudentId && currentStudentRows.some((student) => student.student_id === selectedStudentId)) {
+      return selectedStudentId
+    }
+
+    const remembered = parseAssignmentWorkspaceStudentId(
+      readCookie(
+        getAssignmentWorkspaceStudentCookieName(classroom.id, selection.assignmentId),
+      ),
+    )
+
+    if (remembered && currentStudentRows.some((student) => student.student_id === remembered)) {
+      return remembered
+    }
+
+    return currentStudentRows[0]?.student_id ?? null
+  }, [classroom.id, currentStudentRows, selectedStudentId, selection])
+
+  const handleSwitchWorkspaceMode = useCallback((nextMode: AssignmentWorkspaceMode) => {
+    if (nextMode === 'details') {
+      const nextStudentId = resolveDetailsStudentId()
+      if (nextStudentId) {
+        setSelectedStudentId(nextStudentId)
       }
     }
-    prevSelectedStudentIdRef.current = selectedStudentId
-  }, [selectedStudentId, setSidebarOpen, openMobileSidebar, setLeftSidebarExpanded])
+
+    setAssignmentWorkspaceMode(nextMode)
+  }, [resolveDetailsStudentId])
+
+  useEffect(() => {
+    if (selection.mode !== 'assignment') return
+    if (assignmentWorkspaceMode !== 'details') return
+    if (selectedStudentId) return
+
+    const nextStudentId = resolveDetailsStudentId()
+    if (nextStudentId) {
+      setSelectedStudentId(nextStudentId)
+    }
+  }, [assignmentWorkspaceMode, resolveDetailsStudentId, selectedStudentId, selection.mode])
 
   // Escape key to deselect student
   useEffect(() => {
+    if (assignmentWorkspaceMode !== 'overview') return
     if (!selectedStudentId) return
 
     function handleKeyDown(e: KeyboardEvent) {
@@ -796,7 +800,7 @@ export function TeacherClassroomView({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [selectedStudentId])
+  }, [assignmentWorkspaceMode, selectedStudentId])
 
   // Apply sidebar grade saves to the current row without forcing a table reload.
   useEffect(() => {
@@ -832,22 +836,6 @@ export function TeacherClassroomView({
     return () => window.removeEventListener(TEACHER_GRADE_UPDATED_EVENT, onGradeUpdated)
   }, [])
 
-  // Click outside student table to deselect, but not when clicking
-  // the right sidebar (aside) or mobile drawer (fixed overlay).
-  useEffect(() => {
-    if (!selectedStudentId) return
-
-    function handleMouseDown(e: MouseEvent) {
-      const target = e.target as HTMLElement
-      if (tableContainerRef.current?.contains(target)) return
-      if (target.closest('aside') || target.closest('[role="dialog"]')) return
-      setSelectedStudentId(null)
-    }
-
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [selectedStudentId])
-
   function toggleSort(column: 'first' | 'last' | 'status') {
     setSortState((prev) => toggleSortState(prev, column))
   }
@@ -877,6 +865,206 @@ export function TeacherClassroomView({
 
   const canEditAssignment =
     selection.mode === 'assignment' && !!selectedAssignmentData && !selectedAssignmentLoading && !isReadOnly
+  const selectedAssignmentSummary = selection.mode === 'assignment'
+    ? assignments.find((item) => item.id === selection.assignmentId) ?? null
+    : null
+  const selectedAssignmentTitle =
+    selectedAssignmentData?.assignment.title ??
+    selectedAssignmentSummary?.title ??
+    'Assignment'
+  const activeWorkspaceLayout = assignmentGradingLayout[assignmentWorkspaceMode]
+  const showOverviewInspector =
+    assignmentWorkspaceMode === 'overview' &&
+    !!selectedStudentId
+  const canOpenDetails =
+    selection.mode === 'assignment' &&
+    !selectedAssignmentLoading &&
+    currentStudentRows.length > 0
+  const workspaceActionLabelSuffix = batchSelectedCount > 0 ? ` (${batchSelectedCount})` : ''
+
+  function handleOverviewInspectorResizeStart(event: React.PointerEvent<HTMLDivElement>) {
+    if (!workspaceContainerRef.current) return
+
+    event.preventDefault()
+    const { right, width } = workspaceContainerRef.current.getBoundingClientRect()
+    if (width <= 0) return
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
+      updateModeLayout('overview', (current) => ({
+        ...current,
+        inspectorCollapsed: false,
+        inspectorWidth: nextInspectorWidth,
+      }))
+    }
+
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+  }
+
+  const studentTable = (
+    <KeyboardNavigableTable
+      ref={tableContainerRef}
+      rowKeys={currentStudentRows.map((student) => student.student_id)}
+      selectedKey={selectedStudentId}
+      onSelectKey={setSelectedStudentId}
+      onDeselect={() => setSelectedStudentId(null)}
+    >
+      <TableCard chrome="flush">
+        {selectedAssignmentLoading ? (
+          <div className="flex justify-center py-10">
+            <Spinner />
+          </div>
+        ) : selectedAssignmentError || !selectedAssignmentData ? (
+          <div className="p-4 text-sm text-danger">
+            {selectedAssignmentError || 'Failed to load assignment'}
+          </div>
+        ) : (
+          <div className="relative">
+            {(isAutoGrading || isArtifactRepoAnalyzing || isReturning) && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface/70">
+                <div className="flex items-center gap-2 text-sm text-text-muted">
+                  <Spinner />
+                  <span>
+                    {isAutoGrading
+                      ? `Grading ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+                      : isArtifactRepoAnalyzing
+                        ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+                        : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
+                  </span>
+                </div>
+              </div>
+            )}
+            <DataTable density={showOverviewInspector ? 'tight' : 'compact'}>
+              <DataTableHead>
+                <DataTableRow>
+                  <DataTableHeaderCell className="w-10">
+                    <input
+                      type="checkbox"
+                      checked={batchAllSelected}
+                      onChange={batchToggleSelectAll}
+                      onClick={(e) => e.stopPropagation()}
+                      className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                      aria-label="Select all students"
+                    />
+                  </DataTableHeaderCell>
+                  <SortableHeaderCell
+                    label="First Name"
+                    isActive={sortColumn === 'first'}
+                    direction={sortDirection}
+                    onClick={() => toggleSort('first')}
+                    className="w-[7rem]"
+                  />
+                  <SortableHeaderCell
+                    label="Last Name"
+                    isActive={sortColumn === 'last'}
+                    direction={sortDirection}
+                    onClick={() => toggleSort('last')}
+                    className="w-[7rem]"
+                  />
+                  <SortableHeaderCell
+                    label="Status"
+                    isActive={sortColumn === 'status'}
+                    direction={sortDirection}
+                    onClick={() => toggleSort('status')}
+                    className="w-[4.5rem]"
+                  />
+                  <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
+                  <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
+                </DataTableRow>
+              </DataTableHead>
+              <DataTableBody>
+                {sortedStudents.map((student) => {
+                  const isSelected = selectedStudentId === student.student_id
+                  const totalScore =
+                    student.doc?.score_completion != null &&
+                    student.doc?.score_thinking != null &&
+                    student.doc?.score_workflow != null
+                      ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
+                      : null
+                  const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
+                    graded_at: student.doc.graded_at ?? null,
+                    score_completion: student.doc.score_completion ?? null,
+                    score_thinking: student.doc.score_thinking ?? null,
+                    score_workflow: student.doc.score_workflow ?? null,
+                  } : null)
+                  const wasLate = !!(
+                    student.doc?.submitted_at &&
+                    dueAtMs &&
+                    new Date(student.doc.submitted_at).getTime() > dueAtMs
+                  )
+
+                  return (
+                    <DataTableRow
+                      key={student.student_id}
+                      className={getRowClassName(isSelected)}
+                      onClick={() => {
+                        setSelectedStudentId(isSelected ? null : student.student_id)
+                        setAssignmentWorkspaceMode('overview')
+                      }}
+                    >
+                      <DataTableCell>
+                        <input
+                          type="checkbox"
+                          checked={batchSelectedIds.has(student.student_id)}
+                          onChange={() => batchToggleSelect(student.student_id)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                          aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
+                        />
+                      </DataTableCell>
+                      <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                        {student.student_first_name ? (
+                          <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
+                            <span>{student.student_first_name}</span>
+                          </Tooltip>
+                        ) : '—'}
+                      </DataTableCell>
+                      <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                        {student.student_last_name ? (
+                          <Tooltip content={student.student_last_name}>
+                            <span>{student.student_last_name}</span>
+                          </Tooltip>
+                        ) : '—'}
+                      </DataTableCell>
+                      <DataTableCell className="w-[4.5rem]">
+                        <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                          <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                            <StatusIcon
+                              status={student.status}
+                              wasLate={wasLate}
+                              hasDraftGrade={hasDraftGrade}
+                            />
+                          </span>
+                        </Tooltip>
+                      </DataTableCell>
+                      <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
+                        {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
+                      </DataTableCell>
+                      <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
+                        <AssignmentArtifactsCell
+                          artifacts={student.artifacts || []}
+                          isCompact={showOverviewInspector}
+                        />
+                      </DataTableCell>
+                    </DataTableRow>
+                  )
+                })}
+                {sortedStudents.length === 0 && (
+                  <EmptyStateRow colSpan={6} message="No students enrolled" />
+                )}
+              </DataTableBody>
+            </DataTable>
+          </div>
+        )}
+      </TableCard>
+    </KeyboardNavigableTable>
+  )
 
   const primaryButtons =
     selection.mode === 'summary' ? (
@@ -891,99 +1079,159 @@ export function TeacherClassroomView({
         <span>New</span>
       </button>
     ) : (
-      <div className="flex gap-2 flex-wrap items-center">
-        <button
-          type="button"
-          className={`${ACTIONBAR_BUTTON_CLASSNAME} flex items-center gap-1`}
-          onClick={() => {
-            if (selectedAssignmentData) {
-              setEditAssignment(selectedAssignmentData.assignment)
-            }
-          }}
-          disabled={!canEditAssignment}
-          aria-label="Edit assignment"
-        >
-          <Pencil className="h-5 w-5" aria-hidden="true" />
-          <span>Edit</span>
-        </button>
-        {selectedAssignmentData && (
-          <>
-            <Tooltip content={batchSelectedCount > 0 ? `Analyze repo (${batchSelectedCount})` : 'Select students to analyze repos'}>
-              <button
-                type="button"
-                className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} ${batchSelectedCount === 0 ? 'opacity-50' : ''}`}
-                onClick={() => {
-                  if (batchSelectedCount === 0) {
-                    setWarning('Select students to analyze repos')
-                    return
-                  }
-                  void handleBatchArtifactRepoAnalyze()
-                }}
-                disabled={isArtifactRepoAnalyzing || isReadOnly}
-                aria-label={batchSelectedCount > 0 ? `Analyze repos for ${batchSelectedCount} students` : 'Select students to analyze repos'}
-              >
-                <BarChart3 className={`h-5 w-5 ${batchSelectedCount > 0 ? 'text-primary' : ''}`} aria-hidden="true" />
-              </button>
-            </Tooltip>
-            <Tooltip content={batchSelectedCount > 0 ? `AI grade (${batchSelectedCount})` : 'Select students to grade'}>
-              <button
-                type="button"
-                className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} ${batchSelectedCount === 0 ? 'opacity-50' : ''}`}
-                onClick={() => {
-                  if (batchSelectedCount === 0) {
-                    setWarning('Select students to grade')
-                    return
-                  }
-                  handleBatchAutoGrade()
-                }}
-                disabled={isAutoGrading || isReadOnly}
-                aria-label={batchSelectedCount > 0 ? `AI grade ${batchSelectedCount} students` : 'Select students to grade'}
-              >
-                <Check className={`h-5 w-5 ${batchSelectedCount > 0 ? 'text-purple-500' : ''}`} aria-hidden="true" />
-              </button>
-            </Tooltip>
-            <Tooltip content={batchSelectedCount > 0 ? `Return (${batchSelectedCount})` : 'Select students to return'}>
-              <button
-                type="button"
-                className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} ${batchSelectedCount === 0 ? 'opacity-50' : ''}`}
-                onClick={() => {
-                  if (batchSelectedCount === 0) {
-                    setWarning('Select students to return')
-                    return
-                  }
-                  setShowReturnConfirm(true)
-                }}
-                disabled={isReturning || isReadOnly}
-                aria-label={batchSelectedCount > 0 ? `Return to ${batchSelectedCount} students` : 'Select students to return'}
-              >
-                <Send className={`h-5 w-5 ${batchSelectedCount > 0 ? 'text-blue-500' : ''}`} aria-hidden="true" />
-              </button>
-            </Tooltip>
-          </>
-        )}
+      <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2 sm:min-h-[2.75rem]">
+        <div className="relative z-10 inline-flex items-end gap-1 self-end">
+          <button
+            type="button"
+            className={[
+              WORKSPACE_TAB_BASE_CLASSNAME,
+              assignmentWorkspaceMode === 'overview'
+                ? '-mb-px border-border border-b-transparent bg-surface text-text-default shadow-sm'
+                : 'border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+            ].join(' ')}
+            onClick={() => handleSwitchWorkspaceMode('overview')}
+            aria-pressed={assignmentWorkspaceMode === 'overview'}
+          >
+            Class
+          </button>
+          <button
+            type="button"
+            className={[
+              WORKSPACE_TAB_BASE_CLASSNAME,
+              assignmentWorkspaceMode === 'details'
+                ? '-mb-px border-border border-b-transparent bg-surface text-text-default shadow-sm'
+                : 'border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-surface-2 hover:text-text-muted' : '',
+            ].join(' ')}
+            onClick={() => handleSwitchWorkspaceMode('details')}
+            aria-pressed={assignmentWorkspaceMode === 'details'}
+            disabled={!canOpenDetails}
+          >
+            Individual
+          </button>
+        </div>
+
+        <div className="flex min-w-0 flex-1 items-center gap-3 self-center">
+          <div className="flex min-w-0 shrink items-center gap-2 sm:max-w-[28rem]">
+            <span
+              className="truncate text-sm font-semibold text-text-default"
+              title={selectedAssignmentTitle}
+            >
+              {selectedAssignmentTitle}
+            </span>
+          </div>
+
+          {workspaceLoading && (
+            <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
+              <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              <span>Updating</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1 sm:ml-auto sm:gap-2">
+          <Tooltip content="Edit assignment">
+            <button
+              type="button"
+              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+              onClick={() => {
+                if (selectedAssignmentData) {
+                  setEditAssignment(selectedAssignmentData.assignment)
+                }
+              }}
+              disabled={!canEditAssignment}
+              aria-label="Edit assignment"
+            >
+              <Pencil className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </Tooltip>
+
+          <Tooltip content={`Repo analysis${workspaceActionLabelSuffix}`}>
+            <button
+              type="button"
+              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+              onClick={() => {
+                void handleBatchArtifactRepoAnalyze()
+              }}
+              disabled={isArtifactRepoAnalyzing || isReadOnly || batchSelectedCount === 0}
+              aria-label={`Repo analysis${workspaceActionLabelSuffix}`}
+            >
+              <BarChart3 className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </Tooltip>
+
+          <Tooltip content={`Grading${workspaceActionLabelSuffix}`}>
+            <button
+              type="button"
+              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+              onClick={() => {
+                void handleBatchAutoGrade()
+              }}
+              disabled={isAutoGrading || isReadOnly || batchSelectedCount === 0}
+              aria-label={`Grading${workspaceActionLabelSuffix}`}
+            >
+              <Check className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </Tooltip>
+
+          <Tooltip content={`Send${workspaceActionLabelSuffix}`}>
+            <button
+              type="button"
+              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+              onClick={() => {
+                setShowReturnConfirm(true)
+              }}
+              disabled={isReturning || isReadOnly || batchSelectedCount === 0}
+              aria-label={`Send${workspaceActionLabelSuffix}`}
+            >
+              <Send className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </Tooltip>
+
+          {selectedStudentId && (
+            <>
+              <Tooltip content="Previous student">
+                <button
+                  type="button"
+                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                  onClick={handleGoPrevStudent}
+                  disabled={!canGoPrevStudent}
+                  aria-label="Previous student"
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </Tooltip>
+              <Tooltip content="Next student">
+                <button
+                  type="button"
+                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                  onClick={handleGoNextStudent}
+                  disabled={!canGoNextStudent}
+                  aria-label="Next student"
+                >
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </Tooltip>
+            </>
+          )}
+        </div>
       </div>
     )
 
-  // Keep the panel toggle only in summary mode (markdown view).
-  // Assignment mode now shows work artifacts in-table instead of instructions.
   const showMobileToggle = selection.mode === 'summary'
 
   return (
     <PageLayout>
-      <PageActionBar primary={primaryButtons} actions={[]} trailing={showMobileToggle ? <RightSidebarToggle /> : undefined} />
+      <PageActionBar
+        primary={primaryButtons}
+        actions={[]}
+        trailing={showMobileToggle ? <RightSidebarToggle /> : undefined}
+      />
 
-      <PageContent className="space-y-3">
-        {refreshing && (
-          <RefreshingIndicator className="px-0 py-0" />
-        )}
+      <PageContent className={selection.mode === 'summary' ? 'space-y-3' : 'space-y-3 pt-0'}>
         {error && (
           <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {error}
-          </div>
-        )}
-        {warning && (
-          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-            {warning}
           </div>
         )}
         {info && (
@@ -993,216 +1241,120 @@ export function TeacherClassroomView({
         )}
 
         {selection.mode === 'summary' ? (
-        <div>
-          {showSummarySpinner ? (
-            <div className="flex justify-center py-8">
-              <Spinner />
-            </div>
-          ) : assignments.length === 0 ? (
-            <div className="text-center py-6 text-sm text-text-muted">
-              No assignments yet
-            </div>
-          ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={assignments.map((a) => a.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                <PageStack>
-                  {assignments.map((assignment) => (
-                    <SortableAssignmentCard
-                      key={assignment.id}
-                      assignment={assignment}
-                      isReadOnly={isReadOnly}
-                      isDragDisabled={isReordering}
-                      onSelect={() => {
-                        // Draft/scheduled assignments open edit modal instead of detail view
-                        if (assignment.is_draft || isScheduledAssignment(assignment)) {
-                          setEditAssignment(assignment)
-                        } else {
-                          setSelectionAndPersist({ mode: 'assignment', assignmentId: assignment.id })
-                        }
-                      }}
-                      onEdit={() => setEditAssignment(assignment)}
-                      onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
-                    />
-                  ))}
-                </PageStack>
-              </SortableContext>
-            </DndContext>
-          )}
-        </div>
-      ) : (
-        <KeyboardNavigableTable
-          ref={tableContainerRef}
-          rowKeys={currentStudentRows.map((s) => s.student_id)}
-          selectedKey={selectedStudentId}
-          onSelectKey={setSelectedStudentId}
-        >
-          <TableCard>
-            {selectedAssignmentLoading ? (
-              <div className="flex justify-center py-10">
+          <div>
+            {showSummarySpinner ? (
+              <div className="flex justify-center py-8">
                 <Spinner />
               </div>
-            ) : selectedAssignmentError || !selectedAssignmentData ? (
-              <div className="p-4 text-sm text-danger">
-                {selectedAssignmentError || 'Failed to load assignment'}
+            ) : assignments.length === 0 ? (
+              <div className="py-6 text-center text-sm text-text-muted">
+                No assignments yet
               </div>
             ) : (
-              <div className="relative">
-              {(isAutoGrading || isArtifactRepoAnalyzing || isReturning) && (
-                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface/70">
-                  <div className="flex items-center gap-2 text-sm text-text-muted">
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={assignments.map((assignment) => assignment.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <PageStack>
+                    {assignments.map((assignment) => (
+                      <SortableAssignmentCard
+                        key={assignment.id}
+                        assignment={assignment}
+                        isReadOnly={isReadOnly}
+                        isDragDisabled={isReordering}
+                        onSelect={() => {
+                          if (assignment.is_draft || isScheduledAssignment(assignment)) {
+                            setEditAssignment(assignment)
+                          } else {
+                            setSelectionAndPersist({ mode: 'assignment', assignmentId: assignment.id })
+                          }
+                        }}
+                        onEdit={() => setEditAssignment(assignment)}
+                        onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
+                      />
+                    ))}
+                  </PageStack>
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-b-lg border border-border bg-surface">
+            <div ref={workspaceContainerRef} className="flex min-h-[65vh] flex-col overflow-hidden">
+              {assignmentWorkspaceMode === 'details' ? (
+                selectedStudentId ? (
+                  <TeacherStudentWorkPanel
+                    classroomId={classroom.id}
+                    assignmentId={selection.assignmentId}
+                    studentId={selectedStudentId}
+                    mode="details"
+                    inspectorCollapsed={false}
+                    inspectorWidth={activeWorkspaceLayout.inspectorWidth}
+                    totalWidth={workspaceWidth}
+                    onLayoutChange={(next) => updateModeLayout('details', next)}
+                    onLoadingStateChange={setWorkspaceLoading}
+                  />
+                ) : selectedAssignmentLoading ? (
+                  <div className="flex flex-1 items-center justify-center py-12">
                     <Spinner />
-                    <span>
-                      {isAutoGrading
-                        ? `Grading ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                        : isArtifactRepoAnalyzing
-                          ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                          : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
-                    </span>
+                  </div>
+                ) : selectedAssignmentError || !selectedAssignmentData ? (
+                  <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
+                    {selectedAssignmentError || 'Failed to load assignment'}
+                  </div>
+                ) : (
+                  <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
+                    No student submissions yet.
+                  </div>
+                )
+              ) : showOverviewInspector ? (
+                <div className="flex min-h-[65vh] flex-col lg:flex-row">
+                  <div className="min-h-0 flex-1 overflow-hidden">
+                    {studentTable}
+                  </div>
+                  {isDesktop && (
+                    <div
+                      role="separator"
+                      aria-orientation="vertical"
+                      aria-label="Resize table and grading panes"
+                      className="hidden w-2 shrink-0 cursor-col-resize border-l border-r border-border bg-surface-2 lg:block"
+                      onPointerDown={handleOverviewInspectorResizeStart}
+                    />
+                  )}
+                  <div
+                    className="min-h-0 border-t border-border bg-surface lg:border-t-0"
+                    style={
+                      isDesktop
+                        ? ({
+                            width: `${activeWorkspaceLayout.inspectorWidth}%`,
+                            flexBasis: `${activeWorkspaceLayout.inspectorWidth}%`,
+                          } as const)
+                        : undefined
+                    }
+                  >
+                    <TeacherStudentWorkPanel
+                      classroomId={classroom.id}
+                      assignmentId={selection.assignmentId}
+                      studentId={selectedStudentId}
+                      mode="overview"
+                      inspectorCollapsed={false}
+                      inspectorWidth={activeWorkspaceLayout.inspectorWidth}
+                      totalWidth={workspaceWidth}
+                      onLoadingStateChange={setWorkspaceLoading}
+                    />
                   </div>
                 </div>
+              ) : (
+                studentTable
               )}
-              <DataTable density={isCompactTable ? 'tight' : 'compact'}>
-                <DataTableHead>
-                  <DataTableRow>
-                    <DataTableHeaderCell className="w-10">
-                      <input
-                        type="checkbox"
-                        checked={batchAllSelected}
-                        onChange={batchToggleSelectAll}
-                        onClick={(e) => e.stopPropagation()}
-                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                        aria-label="Select all students"
-                      />
-                    </DataTableHeaderCell>
-                    <SortableHeaderCell
-                      label={isCompactTable ? 'First' : 'First Name'}
-                      isActive={sortColumn === 'first'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('first')}
-                      className={isCompactTable ? 'w-[5.5rem]' : 'w-[8rem]'}
-                    />
-                    <SortableHeaderCell
-                      label={isCompactTable ? 'L.' : 'Last Name'}
-                      isActive={sortColumn === 'last'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('last')}
-                      className={isCompactTable ? 'w-[4.5rem]' : 'w-[8rem]'}
-                    />
-                    <SortableHeaderCell
-                      label={isCompactTable ? '' : 'Status'}
-                      isActive={sortColumn === 'status'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('status')}
-                      className="w-[5.75rem]"
-                    />
-                    <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
-                    {!isCompactTable && <DataTableHeaderCell className="w-[5.5rem]">Updated</DataTableHeaderCell>}
-                    <DataTableHeaderCell className={isCompactTable ? 'w-[6.5rem]' : 'w-[38%] min-w-[24rem]'}>
-                      {isCompactTable ? 'Work' : 'Artifacts'}
-                    </DataTableHeaderCell>
-                  </DataTableRow>
-                </DataTableHead>
-                <DataTableBody>
-                  {sortedStudents.map((student) => {
-                    const isSelected = selectedStudentId === student.student_id
-                    const totalScore =
-                      student.doc?.score_completion != null &&
-                      student.doc?.score_thinking != null &&
-                      student.doc?.score_workflow != null
-                        ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
-                        : null
-                    const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
-                      graded_at: student.doc.graded_at ?? null,
-                      score_completion: student.doc.score_completion ?? null,
-                      score_thinking: student.doc.score_thinking ?? null,
-                      score_workflow: student.doc.score_workflow ?? null,
-                    } : null)
-                    const wasLate = !!(student.doc?.submitted_at && dueAtMs && new Date(student.doc.submitted_at).getTime() > dueAtMs)
-                    return (
-                    <DataTableRow
-                      key={student.student_id}
-                      className={getRowClassName(isSelected)}
-                      onClick={() => setSelectedStudentId(isSelected ? null : student.student_id)}
-                    >
-                      <DataTableCell>
-                        <input
-                          type="checkbox"
-                          checked={batchSelectedIds.has(student.student_id)}
-                          onChange={() => batchToggleSelect(student.student_id)}
-                          onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                          aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
-                        />
-                      </DataTableCell>
-                      <DataTableCell className={isCompactTable ? 'w-[5.5rem] max-w-[5.5rem] truncate' : 'w-[8rem] max-w-[8rem] truncate'}>
-                        {student.student_first_name ? (
-                          <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
-                            <span>{student.student_first_name}</span>
-                          </Tooltip>
-                        ) : '—'}
-                      </DataTableCell>
-                      <DataTableCell className={isCompactTable ? 'w-[4.5rem] max-w-[4.5rem] truncate' : 'w-[8rem] max-w-[8rem] truncate'}>
-                        {student.student_last_name ? (
-                          isCompactTable ? (
-                            <Tooltip content={student.student_last_name}>
-                              <span>{student.student_last_name[0]}.</span>
-                            </Tooltip>
-                          ) : (
-                            <Tooltip content={student.student_last_name}>
-                              <span>{student.student_last_name}</span>
-                            </Tooltip>
-                          )
-                        ) : '—'}
-                      </DataTableCell>
-                      <DataTableCell className="w-[5.75rem]">
-                        <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                          <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                            <StatusIcon
-                              status={student.status}
-                              wasLate={wasLate}
-                              hasDraftGrade={hasDraftGrade}
-                            />
-                          </span>
-                        </Tooltip>
-                      </DataTableCell>
-                      <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
-                        {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
-                      </DataTableCell>
-                      {!isCompactTable && (
-                        <DataTableCell className="w-[5.5rem] whitespace-nowrap text-text-muted">
-                          {student.student_updated_at ? (
-                            <Tooltip content={formatTorontoDateTime(student.student_updated_at)}>
-                              <span>{formatTorontoDateShort(student.student_updated_at)}</span>
-                            </Tooltip>
-                          ) : '—'}
-                        </DataTableCell>
-                      )}
-                      <DataTableCell className={isCompactTable ? 'w-[6.5rem]' : 'w-[38%] min-w-[24rem] align-top'}>
-                        <AssignmentArtifactsCell
-                          artifacts={student.artifacts || []}
-                          isCompact={isCompactTable}
-                        />
-                      </DataTableCell>
-                    </DataTableRow>
-                    )
-                  })}
-                  {sortedStudents.length === 0 && (
-                    <EmptyStateRow colSpan={isCompactTable ? 6 : 7} message="No students enrolled" />
-                  )}
-                </DataTableBody>
-              </DataTable>
-              </div>
-            )}
-          </TableCard>
-        </KeyboardNavigableTable>
-      )}
+            </div>
+          </div>
+        )}
 
       <ConfirmDialog
         isOpen={!!pendingDelete}

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -69,6 +69,8 @@ export function AssignmentArtifactsCell({
   const selectedArtifact = modalIndex !== null ? artifacts[modalIndex] : null
 
   const visibleArtifacts = useMemo(() => (isCompact ? [] : artifacts), [artifacts, isCompact])
+  const compactArtifact = artifacts[0] ?? null
+  const compactRemainingCount = Math.max(artifacts.length - 1, 0)
 
   if (artifacts.length === 0) {
     return <span className="text-text-muted">-</span>
@@ -83,10 +85,20 @@ export function AssignmentArtifactsCell({
             event.stopPropagation()
             setModalIndex(0)
           }}
-          className="inline-flex max-w-[7.5rem] items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
+          className="inline-flex w-full max-w-full items-center gap-1.5 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
           aria-label={`View ${artifacts.length} work item${artifacts.length === 1 ? '' : 's'}`}
         >
-          {artifacts.length} items
+          {compactArtifact && (
+            <>
+              <ArtifactTypeIcon artifact={compactArtifact} />
+              <span className="min-w-0 flex-1 truncate text-left">
+                {getArtifactSummary(compactArtifact)}
+              </span>
+            </>
+          )}
+          {compactRemainingCount > 0 && (
+            <span className="shrink-0 text-text-muted">+{compactRemainingCount}</span>
+          )}
         </button>
       ) : (
         <div className="flex w-full max-w-[32rem] flex-wrap gap-1">

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -22,12 +22,20 @@ function densityPadding(density: DataTableDensity) {
 export function TableCard({
   children,
   overflowX = false,
+  chrome = 'default',
 }: {
   children: ReactNode
   overflowX?: boolean
+  chrome?: 'default' | 'flush'
 }) {
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-surface">
+    <div
+      className={
+        chrome === 'flush'
+          ? 'overflow-hidden'
+          : 'overflow-hidden rounded-lg border border-border bg-surface'
+      }
+    >
       <div className={overflowX ? 'overflow-x-auto' : undefined}>{children}</div>
     </div>
   )

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,10 +1,16 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { Button, RefreshingIndicator, SplitButton, Tooltip } from '@/ui'
 import { RichTextViewer } from '@/components/editor'
 import { HistoryList } from '@/components/HistoryList'
+import { Button, SplitButton, Tooltip } from '@/ui'
+import {
+  ASSIGNMENT_GRADING_LAYOUT,
+  clampAssignmentWorkspacePaneLayout,
+  type AssignmentWorkspaceMode,
+  type AssignmentWorkspacePaneLayout,
+} from '@/lib/assignment-grading-layout'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
 import { formatInTimeZone } from 'date-fns-tz'
@@ -23,7 +29,9 @@ import type {
   TiptapContent,
 } from '@/types'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
+import { useWindowSize } from '@/hooks/use-window-size'
 import { readCookie, writeCookie } from '@/lib/cookies'
+import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 
 function AuthenticityGauge({ score, flags }: { score: number | null; flags: AuthenticityFlag[] }) {
   const hasScore = score !== null
@@ -32,7 +40,7 @@ function AuthenticityGauge({ score, flags }: { score: number | null; flags: Auth
   const textColor = !hasScore ? 'text-text-muted' : displayScore >= 70 ? 'text-green-700' : displayScore >= 40 ? 'text-yellow-700' : 'text-red-700'
 
   const bar = (
-    <div className="relative h-5 rounded-full bg-gray-200 overflow-hidden">
+    <div className="relative h-5 overflow-hidden rounded-full bg-gray-200">
       {hasScore && (
         <div className={`h-full rounded-full ${color}`} style={{ width: `${displayScore}%` }} />
       )}
@@ -77,14 +85,21 @@ function RepoMetricBar({ label, value }: { label: string; value: number }) {
   )
 }
 
+function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: string | null | undefined) {
+  const base = (baseDraft ?? '').trim()
+  const suggestion = (aiSuggestion ?? '').trim()
+
+  if (!suggestion) return { value: baseDraft ?? '', hasFreshAI: false }
+  if (!base) return { value: suggestion, hasFreshAI: true }
+  if (base.includes(suggestion)) return { value: baseDraft ?? base, hasFreshAI: false }
+
+  return { value: `${suggestion}\n\n${base}`, hasFreshAI: true }
+}
+
 function ScoreInput({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
   const quickScores = Array.from({ length: 11 }, (_, i) => i)
   const n = Number(value)
   const selected = Number.isInteger(n) && n >= 0 && n <= 10 ? n : null
-
-  function handleInputChange(next: string) {
-    onChange(next)
-  }
 
   return (
     <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_2.25rem] items-center gap-x-1.5">
@@ -124,8 +139,8 @@ function ScoreInput({ label, value, onChange }: { label: string; value: string; 
         min={0}
         max={10}
         value={value}
-        onChange={(e) => handleInputChange(e.target.value)}
-        className="h-6 w-9 justify-self-end rounded border border-border bg-surface px-1 py-0.5 text-xs font-medium text-text-default text-center [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        onChange={(e) => onChange(e.target.value)}
+        className="h-6 w-9 justify-self-end rounded border border-border bg-surface px-1 py-0.5 text-center text-xs font-medium text-text-default [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         aria-label={`${label} score`}
       />
     </div>
@@ -158,6 +173,16 @@ interface TeacherStudentWorkPanelProps {
   classroomId: string
   assignmentId: string
   studentId: string
+  mode?: AssignmentWorkspaceMode
+  inspectorCollapsed?: boolean
+  inspectorWidth?: number
+  totalWidth?: number
+  onLayoutChange?: (
+    next:
+      | AssignmentWorkspacePaneLayout
+      | ((current: AssignmentWorkspacePaneLayout) => AssignmentWorkspacePaneLayout),
+  ) => void
+  onLoadingStateChange?: (loading: boolean) => void
 }
 
 type RightTab = 'history' | 'grading'
@@ -168,16 +193,332 @@ function getRightTabCookieName(classroomId: string) {
   return `${RIGHT_TAB_COOKIE_PREFIX}:${classroomId}`
 }
 
+function WorkspaceInspector({
+  historyEntries,
+  historyLoading,
+  historyError,
+  previewEntry,
+  onEntryClick,
+  onEntryHover,
+  onMouseLeave,
+  isPreviewLocked,
+  onExitPreview,
+  rightTab,
+  onRightTabChange,
+  data,
+  gradeError,
+  repoReviewResult,
+  scoreCompletion,
+  setScoreCompletion,
+  scoreThinking,
+  setScoreThinking,
+  scoreWorkflow,
+  setScoreWorkflow,
+  totalPercent,
+  totalScore,
+  feedbackEntries,
+  feedbackDraft,
+  hasFreshAIDraft,
+  setFeedbackDraft,
+  onAIDraftAcknowledge,
+  autoGrading,
+  feedbackReturning,
+  gradeSaving,
+  repoAnalyzing,
+  handleAutoGrade,
+  handleReturnFeedback,
+  handleSaveGrade,
+  handleAnalyzeRepo,
+}: {
+  historyEntries: AssignmentDocHistoryEntry[]
+  historyLoading: boolean
+  historyError: string
+  previewEntry: AssignmentDocHistoryEntry | null
+  onEntryClick: (entry: AssignmentDocHistoryEntry) => void
+  onEntryHover: (entry: AssignmentDocHistoryEntry) => void
+  onMouseLeave: () => void
+  isPreviewLocked: boolean
+  onExitPreview: () => void
+  rightTab: RightTab
+  onRightTabChange: (tab: RightTab) => void
+  data: StudentWorkData
+  gradeError: string
+  repoReviewResult: AssignmentRepoReviewResult | null
+  scoreCompletion: string
+  setScoreCompletion: (value: string) => void
+  scoreThinking: string
+  setScoreThinking: (value: string) => void
+  scoreWorkflow: string
+  setScoreWorkflow: (value: string) => void
+  totalPercent: number
+  totalScore: number
+  feedbackEntries: AssignmentFeedbackEntry[]
+  feedbackDraft: string
+  hasFreshAIDraft: boolean
+  setFeedbackDraft: (value: string) => void
+  onAIDraftAcknowledge: () => void
+  autoGrading: boolean
+  feedbackReturning: boolean
+  gradeSaving: boolean
+  repoAnalyzing: boolean
+  handleAutoGrade: () => Promise<void>
+  handleReturnFeedback: () => Promise<void>
+  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
+  handleAnalyzeRepo: () => Promise<void>
+}) {
+  return (
+    <div
+      data-testid="grading-inspector-pane"
+      className="flex min-h-0 flex-col border-border bg-surface lg:border-l"
+    >
+      <div className="flex border-b border-border">
+        <button
+          type="button"
+          className={`flex-1 px-3 py-2 text-xs font-medium ${
+            rightTab === 'history'
+              ? 'border-b-2 border-primary text-primary'
+              : 'text-text-muted hover:text-text-default'
+          }`}
+          onClick={() => onRightTabChange('history')}
+        >
+          History
+        </button>
+        <button
+          type="button"
+          className={`flex-1 px-3 py-2 text-xs font-medium ${
+            rightTab === 'grading'
+              ? 'border-b-2 border-primary text-primary'
+              : 'text-text-muted hover:text-text-default'
+          }`}
+          onClick={() => onRightTabChange('grading')}
+        >
+          Grading
+        </button>
+      </div>
+
+      {rightTab === 'history' ? (
+        <>
+          <div className="flex-1 min-h-0 overflow-y-auto" onMouseLeave={onMouseLeave}>
+            {historyLoading && historyEntries.length === 0 ? (
+              <div className="p-4 text-center">
+                <Spinner size="sm" />
+              </div>
+            ) : historyError ? (
+              <div className="p-3">
+                <p className="text-xs text-danger">{historyError}</p>
+              </div>
+            ) : historyEntries.length === 0 ? (
+              <div className="p-3">
+                <p className="text-xs text-text-muted">No saves yet</p>
+              </div>
+            ) : (
+              <HistoryList
+                entries={historyEntries}
+                activeEntryId={previewEntry?.id ?? null}
+                onEntryClick={onEntryClick}
+                onEntryHover={onEntryHover}
+              />
+            )}
+          </div>
+          {isPreviewLocked && previewEntry && (
+            <div className="border-t border-border px-3 py-2">
+              <Button onClick={onExitPreview} variant="secondary" size="sm" className="w-full">
+                Exit preview
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3">
+          <AuthenticityGauge
+            score={data.doc?.authenticity_score ?? null}
+            flags={data.doc?.authenticity_flags ?? []}
+          />
+
+          {gradeError && (
+            <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
+              {gradeError}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Repo Analysis</div>
+              <Button
+                size="sm"
+                onClick={() => {
+                  void handleAnalyzeRepo()
+                }}
+                disabled={
+                  repoAnalyzing ||
+                  !data.repo_target.effectiveRepoUrl ||
+                  !data.repo_target.effectiveGitHubUsername
+                }
+              >
+                {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
+              </Button>
+            </div>
+
+            {repoReviewResult && (
+              <div className="space-y-2">
+                <RepoMetricBar
+                  label="Contribution"
+                  value={repoReviewResult.relative_contribution_share || 0}
+                />
+                <RepoMetricBar
+                  label="Consistency"
+                  value={repoReviewResult.spread_score || 0}
+                />
+                <RepoMetricBar
+                  label="Iteration"
+                  value={repoReviewResult.iteration_score || 0}
+                />
+              </div>
+            )}
+          </div>
+
+          <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
+          <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
+          <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
+
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1">
+            <span aria-hidden="true" />
+            <span
+              className={[
+                'inline-flex h-8 w-12 items-center justify-center justify-self-end rounded border text-sm font-medium',
+                totalPercent >= 80
+                  ? 'border-green-200 bg-green-100 text-green-700'
+                  : totalPercent >= 60
+                    ? 'border-yellow-200 bg-yellow-100 text-yellow-700'
+                    : totalPercent >= 50
+                      ? 'border-orange-200 bg-orange-100 text-orange-700'
+                      : 'border-red-200 bg-red-100 text-red-700',
+              ].join(' ')}
+            >
+              {totalPercent}%
+            </span>
+            <div className="flex items-center justify-self-end gap-1">
+              <span className="text-xs text-text-muted">30</span>
+              <span className="inline-flex h-8 w-12 items-center justify-center rounded border border-border bg-surface text-sm font-medium text-text-default">
+                {totalScore}
+              </span>
+            </div>
+          </div>
+
+          {feedbackEntries.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Returned Feedback</div>
+              <div className="rounded border border-border bg-surface p-3">
+                <div className="space-y-3">
+                  {feedbackEntries.map((entry, index) => (
+                    <div key={entry.id} className={index > 0 ? 'border-t border-border pt-3' : ''}>
+                      <div className="mb-1 text-[11px] font-medium text-text-muted">
+                        {formatInTimeZone(new Date(entry.returned_at), 'America/Toronto', 'MMM d, h:mm a')}
+                      </div>
+                      <div className="whitespace-pre-wrap text-sm text-text-default">{entry.body}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Feedback Draft</div>
+              {hasFreshAIDraft && (
+                <span className="rounded-full border border-primary/40 bg-info-bg px-2 py-0.5 text-[11px] font-medium text-primary">
+                  AI draft
+                </span>
+              )}
+            </div>
+            <textarea
+              value={feedbackDraft}
+              onChange={(e) => setFeedbackDraft(e.target.value)}
+              onFocus={onAIDraftAcknowledge}
+              className={[
+                'min-h-[10rem] w-full resize-y rounded border px-2 py-1 text-sm text-text-default',
+                hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
+              ].join(' ')}
+              placeholder="Teacher feedback draft"
+            />
+          </div>
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="flex-1"
+              onClick={() => {
+                void handleAutoGrade()
+              }}
+              disabled={autoGrading}
+            >
+              {autoGrading ? 'Grading...' : 'AI grade'}
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="flex-1"
+              onClick={() => {
+                void handleReturnFeedback()
+              }}
+              disabled={feedbackReturning || !feedbackDraft.trim()}
+            >
+              {feedbackReturning ? 'Returning...' : 'Return Feedback'}
+            </Button>
+            <SplitButton
+              label={gradeSaving ? 'Saving...' : 'Save'}
+              onPrimaryClick={() => {
+                void handleSaveGrade('graded')
+              }}
+              options={[
+                {
+                  id: 'draft',
+                  label: 'Draft',
+                  onSelect: () => {
+                    void handleSaveGrade('draft')
+                  },
+                },
+              ]}
+              size="sm"
+              className="flex-1"
+              disabled={gradeSaving}
+              toggleAriaLabel="Choose save mode"
+              primaryButtonProps={{ className: 'flex-1 justify-center' }}
+            />
+          </div>
+
+          {data.doc?.graded_at && (
+            <div className="shrink-0 text-xs text-text-muted">
+              Graded {formatInTimeZone(new Date(data.doc.graded_at), 'America/Toronto', 'MMM d, h:mm a')}
+              {data.doc.graded_by && ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function TeacherStudentWorkPanel({
   classroomId,
   assignmentId,
   studentId,
+  mode = 'details',
+  inspectorCollapsed = false,
+  inspectorWidth = ASSIGNMENT_GRADING_LAYOUT.defaultInspectorWidth,
+  totalWidth = 0,
+  onLayoutChange,
+  onLoadingStateChange,
 }: TeacherStudentWorkPanelProps) {
+  const workspaceRef = useRef<HTMLDivElement | null>(null)
+  const studentLoadRequestIdRef = useRef(0)
+  const historyLoadRequestIdRef = useRef(0)
   const [data, setData] = useState<StudentWorkData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  // History state
   const [historyEntries, setHistoryEntries] = useState<AssignmentDocHistoryEntry[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
   const [historyError, setHistoryError] = useState('')
@@ -186,7 +527,6 @@ export function TeacherStudentWorkPanel({
   const [lockedEntryId, setLockedEntryId] = useState<string | null>(null)
   const rightTabCookieName = getRightTabCookieName(classroomId)
 
-  // Grading state
   const [rightTab, setRightTab] = useState<RightTab>(() => (
     readCookie(getRightTabCookieName(classroomId)) === 'grading' ? 'grading' : 'history'
   ))
@@ -194,12 +534,38 @@ export function TeacherStudentWorkPanel({
   const [scoreThinking, setScoreThinking] = useState<string>('')
   const [scoreWorkflow, setScoreWorkflow] = useState<string>('')
   const [feedbackDraft, setFeedbackDraft] = useState<string>('')
+  const [hasFreshAIDraft, setHasFreshAIDraft] = useState(false)
   const [gradeSaving, setGradeSaving] = useState(false)
   const [gradeError, setGradeError] = useState('')
   const [autoGrading, setAutoGrading] = useState(false)
   const [feedbackReturning, setFeedbackReturning] = useState(false)
   const [repoAnalyzing, setRepoAnalyzing] = useState(false)
   const showInitialSpinner = useDelayedBusy(loading && !data)
+  const { width: viewportWidth } = useWindowSize()
+  const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
+  const layout = useMemo(
+    () =>
+      clampAssignmentWorkspacePaneLayout(
+        {
+          inspectorCollapsed,
+          inspectorWidth,
+        },
+        mode,
+        { totalWidth },
+      ),
+    [inspectorCollapsed, inspectorWidth, mode, totalWidth],
+  )
+
+  const updateLayout = useCallback(
+    (
+      next:
+        | AssignmentWorkspacePaneLayout
+        | ((current: AssignmentWorkspacePaneLayout) => AssignmentWorkspacePaneLayout),
+    ) => {
+      onLayoutChange?.(next)
+    },
+    [onLayoutChange],
+  )
 
   function dispatchGradeUpdated(doc: AssignmentDoc | null) {
     const detail: TeacherGradeUpdatedEventDetail = {
@@ -224,6 +590,7 @@ export function TeacherStudentWorkPanel({
       setPreviewContent(reconstructed)
       return true
     }
+
     return false
   }
 
@@ -250,77 +617,126 @@ export function TeacherStudentWorkPanel({
     handleExitPreview()
   }
 
-  function populateGradeForm(doc: AssignmentDoc | null) {
+  function handleInspectorResizeStart(event: React.PointerEvent<HTMLDivElement>) {
+    if (!workspaceRef.current) return
+
+    event.preventDefault()
+    const { right, width } = workspaceRef.current.getBoundingClientRect()
+    if (width <= 0) return
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
+      updateLayout((current) => ({
+        ...current,
+        inspectorCollapsed: false,
+        inspectorWidth: nextInspectorWidth,
+      }))
+    }
+
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+  }
+
+  function populateGradeForm(doc: AssignmentDoc | null, mergeBaseDraft?: string | null) {
     if (doc) {
       setScoreCompletion(doc.score_completion?.toString() ?? '')
       setScoreThinking(doc.score_thinking?.toString() ?? '')
       setScoreWorkflow(doc.score_workflow?.toString() ?? '')
-      setFeedbackDraft(doc.teacher_feedback_draft ?? doc.feedback ?? '')
+      const baseDraft =
+        mergeBaseDraft ?? doc.teacher_feedback_draft ?? doc.feedback ?? ''
+      const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion)
+      setFeedbackDraft(mergedDraft.value)
+      setHasFreshAIDraft(mergedDraft.hasFreshAI)
     } else {
       setScoreCompletion('')
       setScoreThinking('')
       setScoreWorkflow('')
       setFeedbackDraft('')
+      setHasFreshAIDraft(false)
     }
   }
 
-  function populateRepoForm(nextData: StudentWorkData) {
-    void nextData
-  }
-
-  const loadStudentWork = useCallback(async (): Promise<StudentWorkData | null> => {
+  const loadStudentWork = useCallback(async (options?: { mergeFeedbackIntoDraftFrom?: string | null }): Promise<StudentWorkData | null> => {
+    const requestId = ++studentLoadRequestIdRef.current
     setLoading(true)
     setError('')
     setGradeError('')
     handleExitPreview()
+
     try {
       const response = await fetch(`/api/teacher/assignments/${assignmentId}/students/${studentId}`)
       const result = await response.json()
       if (!response.ok) {
         throw new Error(result.error || 'Failed to load student work')
       }
+      if (requestId !== studentLoadRequestIdRef.current) {
+        return null
+      }
+
       setData(result)
-      populateGradeForm(result.doc)
-      populateRepoForm(result)
+      populateGradeForm(result.doc, options?.mergeFeedbackIntoDraftFrom)
       return result
     } catch (err: any) {
+      if (requestId !== studentLoadRequestIdRef.current) {
+        return null
+      }
       setError(err.message || 'Failed to load student work')
       return null
     } finally {
-      setLoading(false)
+      if (requestId === studentLoadRequestIdRef.current) {
+        setLoading(false)
+      }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assignmentId, studentId])
 
-  // Load student work
   useEffect(() => {
     void loadStudentWork()
   }, [loadStudentWork])
 
-  // Load history
   useEffect(() => {
+    const requestId = ++historyLoadRequestIdRef.current
     setHistoryLoading(true)
     setHistoryError('')
 
     async function loadHistory() {
       try {
         const response = await fetch(
-          `/api/assignment-docs/${assignmentId}/history?student_id=${studentId}`
+          `/api/assignment-docs/${assignmentId}/history?student_id=${studentId}`,
         )
         const result = await response.json()
         if (!response.ok) {
           throw new Error(result.error || 'Failed to load history')
         }
+        if (requestId !== historyLoadRequestIdRef.current) return
         setHistoryEntries(result.history || [])
       } catch (err: any) {
+        if (requestId !== historyLoadRequestIdRef.current) return
         setHistoryError(err.message || 'Failed to load history')
       } finally {
-        setHistoryLoading(false)
+        if (requestId === historyLoadRequestIdRef.current) {
+          setHistoryLoading(false)
+        }
       }
     }
 
-    loadHistory()
+    void loadHistory()
   }, [assignmentId, studentId])
+
+  useEffect(() => {
+    onLoadingStateChange?.(loading && !!data)
+  }, [data, loading, onLoadingStateChange])
+
+  useEffect(() => {
+    return () => {
+      onLoadingStateChange?.(false)
+    }
+  }, [onLoadingStateChange])
 
   async function handleSaveGrade(selectedSaveMode: GradeSaveMode) {
     if (!data) return
@@ -380,6 +796,7 @@ export function TeacherStudentWorkPanel({
       updated_at: new Date().toISOString(),
     }
     setData((prev) => (prev ? { ...prev, doc: optimisticDoc } : prev))
+
     try {
       const res = await fetch(`/api/teacher/assignments/${assignmentId}/grade`, {
         method: 'POST',
@@ -395,8 +812,7 @@ export function TeacherStudentWorkPanel({
       })
       const result = await res.json()
       if (!res.ok) throw new Error(result.error || 'Failed to save grade')
-      // Update local state
-      setData((prev) => prev ? { ...prev, doc: result.doc } : prev)
+      setData((prev) => (prev ? { ...prev, doc: result.doc } : prev))
       dispatchGradeUpdated(result.doc)
     } catch (err: any) {
       setData((prev) => (prev ? { ...prev, doc: previousDoc } : prev))
@@ -420,13 +836,13 @@ export function TeacherStudentWorkPanel({
       if (!res.ok) throw new Error(result.error || 'Auto-grade failed')
       if (result.errors?.length) {
         setGradeError(result.errors.join(', '))
-        return // Don't reload — grading failed
+        return
       }
       if (result.graded_count === 0) {
         setGradeError('No gradable content found — the submission may be empty')
         return
       }
-      const refreshed = await loadStudentWork()
+      const refreshed = await loadStudentWork({ mergeFeedbackIntoDraftFrom: feedbackDraft })
       handleRightTabChange('grading')
       dispatchGradeUpdated(refreshed?.doc ?? null)
     } catch (err: any) {
@@ -510,15 +926,11 @@ export function TeacherStudentWorkPanel({
   }
 
   if (error) {
-    return (
-      <div className="p-4 text-sm text-danger">{error}</div>
-    )
+    return <div className="p-4 text-sm text-danger">{error}</div>
   }
 
   if (!data) {
-    return (
-      <div className="p-4 text-sm text-text-muted">No data</div>
-    )
+    return <div className="p-4 text-sm text-text-muted">No data</div>
   }
 
   const isPreviewLocked = lockedEntryId !== null
@@ -535,32 +947,89 @@ export function TeacherStudentWorkPanel({
     data.repo_target.effectiveGitHubUsername ||
     repoReviewResult?.github_login ||
     ''
+  const studentDisplayName = data.student.name?.trim() || data.student.email
+  const characterCount = displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
 
   const sc = Number(scoreCompletion) || 0
   const st = Number(scoreThinking) || 0
   const sw = Number(scoreWorkflow) || 0
   const totalScore = sc + st + sw
   const totalPercent = Math.round((totalScore / 30) * 100)
+  const inspectorPaneStyle = layout.inspectorCollapsed
+    ? undefined
+    : isDesktop
+      ? ({
+          width: `${layout.inspectorWidth}%`,
+          flexBasis: `${layout.inspectorWidth}%`,
+        } as const)
+      : undefined
+
+  if (mode === 'overview') {
+    return (
+      <WorkspaceInspector
+        historyEntries={historyEntries}
+        historyLoading={historyLoading}
+        historyError={historyError}
+        previewEntry={previewEntry}
+        onEntryClick={handlePreviewLock}
+        onEntryHover={handlePreviewHover}
+        onMouseLeave={handleHistoryMouseLeave}
+        isPreviewLocked={isPreviewLocked}
+        onExitPreview={handleExitPreview}
+        rightTab={rightTab}
+        onRightTabChange={handleRightTabChange}
+        data={data}
+        gradeError={gradeError}
+        repoReviewResult={repoReviewResult}
+        scoreCompletion={scoreCompletion}
+        setScoreCompletion={setScoreCompletion}
+        scoreThinking={scoreThinking}
+        setScoreThinking={setScoreThinking}
+        scoreWorkflow={scoreWorkflow}
+        setScoreWorkflow={setScoreWorkflow}
+        totalPercent={totalPercent}
+        totalScore={totalScore}
+        feedbackEntries={feedbackEntries}
+        feedbackDraft={feedbackDraft}
+        hasFreshAIDraft={hasFreshAIDraft}
+        setFeedbackDraft={setFeedbackDraft}
+        onAIDraftAcknowledge={() => setHasFreshAIDraft(false)}
+        autoGrading={autoGrading}
+        feedbackReturning={feedbackReturning}
+        gradeSaving={gradeSaving}
+        repoAnalyzing={repoAnalyzing}
+        handleAutoGrade={handleAutoGrade}
+        handleReturnFeedback={handleReturnFeedback}
+        handleSaveGrade={handleSaveGrade}
+        handleAnalyzeRepo={handleAnalyzeRepo}
+      />
+    )
+  }
 
   return (
-    <div className="flex flex-col h-full">
-      {loading && (
-        <RefreshingIndicator />
-      )}
-      {/* Main content area: Student work + Right panel side by side */}
-      <div className="flex-1 min-h-0 flex">
-        {/* Student work content */}
+    <div ref={workspaceRef} className="relative flex h-full min-h-0 flex-col lg:flex-row">
+      <div
+        className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+          previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
+        }`}
+      >
         <div
-          className={`flex-1 min-h-0 overflow-auto ${
-            previewEntry
-              ? 'outline outline-2 outline-primary outline-offset-[-2px]'
-              : ''
-          }`}
+          data-testid="individual-content-header"
+          className="border-b border-border bg-surface px-4 py-3 text-sm"
         >
-          {(repoDisplayUrl || repoDisplayGitHubUsername) && (
-            <div className="border-b border-border bg-surface px-4 py-3">
-              <div className="min-w-0 space-y-1">
-                <div className="truncate text-sm font-medium text-text-default">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <div
+              className="min-w-0 truncate font-medium text-text-default"
+              title={studentDisplayName}
+            >
+              {studentDisplayName}
+            </div>
+            {(repoDisplayUrl || repoDisplayGitHubUsername) && (
+              <>
+                <span className="text-text-muted" aria-hidden="true">
+                  /
+                </span>
+                <div className="min-w-0 truncate text-text-muted">
                   <span className="text-text-muted">Repo </span>
                   {repoDisplayUrl ? (
                     <a
@@ -575,254 +1044,87 @@ export function TeacherStudentWorkPanel({
                     '—'
                   )}
                 </div>
-                <div className="truncate text-sm text-text-muted">
-                  <span className="font-medium text-text-default">
-                    {repoDisplayGitHubUsername ? `@${repoDisplayGitHubUsername}` : '—'}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-          {displayContent && !isEmpty(displayContent) ? (
-            <div className="p-4">
-              <RichTextViewer content={displayContent} fillHeight />
-              <div className="mt-4 text-center text-xs text-text-muted">
-                {countCharacters(displayContent)} characters
-              </div>
-            </div>
-          ) : (
-            <div className="flex items-center justify-center h-32 text-text-muted">
-              No work submitted yet
-            </div>
-          )}
-        </div>
-
-        {/* Right panel with tabs */}
-        <div className="w-80 border-l border-border bg-page flex flex-col min-h-0">
-          {/* Tab switcher */}
-          <div className="flex border-b border-border">
-            <button
-              type="button"
-              className={`flex-1 px-3 py-2 text-xs font-medium ${
-                rightTab === 'history'
-                  ? 'text-primary border-b-2 border-primary'
-                  : 'text-text-muted hover:text-text-default'
-              }`}
-              onClick={() => handleRightTabChange('history')}
+                {repoDisplayGitHubUsername && (
+                  <div className="truncate text-text-muted">
+                    <span className="font-medium text-text-default">
+                      @{repoDisplayGitHubUsername}
+                    </span>
+                  </div>
+                )}
+              </>
+            )}
+            <div
+              className="inline-flex shrink-0 items-center text-xs text-text-muted sm:ml-auto"
+              aria-label={`${characterCount} characters`}
             >
-              History
-            </button>
-            <button
-              type="button"
-              className={`flex-1 px-3 py-2 text-xs font-medium ${
-                rightTab === 'grading'
-                  ? 'text-primary border-b-2 border-primary'
-                  : 'text-text-muted hover:text-text-default'
-              }`}
-              onClick={() => handleRightTabChange('grading')}
-            >
-              Grading
-            </button>
+              <span>{characterCount} chars</span>
+            </div>
           </div>
-
-          {rightTab === 'history' ? (
-            <>
-              <div
-                className="flex-1 min-h-0 overflow-y-auto"
-                onMouseLeave={handleHistoryMouseLeave}
-              >
-                {historyLoading && historyEntries.length === 0 ? (
-                  <div className="p-4 text-center">
-                    <Spinner size="sm" />
-                  </div>
-                ) : historyError ? (
-                  <div className="p-3">
-                    <p className="text-xs text-danger">{historyError}</p>
-                  </div>
-                ) : historyEntries.length === 0 ? (
-                  <div className="p-3">
-                    <p className="text-xs text-text-muted">No saves yet</p>
-                  </div>
-                ) : (
-                  <HistoryList
-                    entries={historyEntries}
-                    activeEntryId={previewEntry?.id ?? null}
-                    onEntryClick={handlePreviewLock}
-                    onEntryHover={handlePreviewHover}
-                  />
-                )}
-                {historyLoading && historyEntries.length > 0 && (
-                  <RefreshingIndicator label="Refreshing history..." className="px-3 pb-2 pt-0" />
-                )}
-              </div>
-              {isPreviewLocked && previewEntry && (
-                <div className="px-3 py-2 border-t border-border">
-                  <Button onClick={handleExitPreview} variant="secondary" size="sm" className="w-full">
-                    Exit preview
-                  </Button>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3">
-              <AuthenticityGauge
-                score={data.doc?.authenticity_score ?? null}
-                flags={data.doc?.authenticity_flags ?? []}
-              />
-
-              {gradeError && (
-                <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">{gradeError}</div>
-              )}
-
-              {data.doc?.ai_feedback_suggestion?.trim() && (
-                <div className="rounded border border-border bg-surface p-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="text-xs font-medium uppercase tracking-wide text-text-muted">AI Suggestion</div>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => setFeedbackDraft(data.doc?.ai_feedback_suggestion || '')}
-                    >
-                      Use
-                    </Button>
-                  </div>
-                  <div className="mt-2 whitespace-pre-wrap text-sm text-text-default">
-                    {data.doc.ai_feedback_suggestion}
-                  </div>
-                </div>
-              )}
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Repo Analysis</div>
-                  <Button
-                    size="sm"
-                    onClick={() => { void handleAnalyzeRepo() }}
-                    disabled={repoAnalyzing || !data.repo_target.effectiveRepoUrl || !data.repo_target.effectiveGitHubUsername}
-                  >
-                    {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
-                  </Button>
-                </div>
-
-                {repoReviewResult && (
-                  <div className="space-y-2">
-                    <RepoMetricBar
-                      label="Contribution"
-                      value={repoReviewResult.relative_contribution_share || 0}
-                    />
-                    <RepoMetricBar
-                      label="Consistency"
-                      value={repoReviewResult.spread_score || 0}
-                    />
-                    <RepoMetricBar
-                      label="Iteration"
-                      value={repoReviewResult.iteration_score || 0}
-                    />
-                  </div>
-                )}
-              </div>
-
-              <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
-              <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
-              <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
-
-              <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1">
-                <span aria-hidden="true" />
-                <span
-                  className={[
-                    'inline-flex h-8 w-12 items-center justify-center justify-self-end rounded border text-sm font-medium',
-                    totalPercent >= 80
-                      ? 'border-green-200 bg-green-100 text-green-700'
-                      : totalPercent >= 60
-                        ? 'border-yellow-200 bg-yellow-100 text-yellow-700'
-                        : totalPercent >= 50
-                          ? 'border-orange-200 bg-orange-100 text-orange-700'
-                          : 'border-red-200 bg-red-100 text-red-700',
-                  ].join(' ')}
-                >
-                  {totalPercent}%
-                </span>
-                <div className="flex items-center justify-self-end gap-1">
-                  <span className="text-xs text-text-muted">30</span>
-                  <span className="inline-flex h-8 w-12 items-center justify-center rounded border border-border bg-surface text-sm font-medium text-text-default">
-                    {totalScore}
-                  </span>
-                </div>
-              </div>
-
-              {feedbackEntries.length > 0 && (
-                <div className="space-y-2">
-                  <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Returned Feedback</div>
-                  <div className="rounded border border-border bg-surface p-3">
-                    <div className="space-y-3">
-                      {feedbackEntries.map((entry, index) => (
-                        <div key={entry.id} className={index > 0 ? 'border-t border-border pt-3' : ''}>
-                          <div className="mb-1 text-[11px] font-medium text-text-muted">
-                            {formatInTimeZone(new Date(entry.returned_at), 'America/Toronto', 'MMM d, h:mm a')}
-                          </div>
-                          <div className="whitespace-pre-wrap text-sm text-text-default">{entry.body}</div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              <div className="space-y-1">
-                <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Feedback Draft</div>
-                <textarea
-                  value={feedbackDraft}
-                  onChange={(e) => setFeedbackDraft(e.target.value)}
-                  className="min-h-[10rem] w-full rounded border border-border bg-surface px-2 py-1 text-sm text-text-default resize-y"
-                  placeholder="Teacher feedback draft"
-                />
-              </div>
-
-              <div className="flex shrink-0 flex-wrap items-center gap-2">
-                <Button size="sm" variant="secondary" className="flex-1" onClick={handleAutoGrade} disabled={autoGrading}>
-                  {autoGrading ? 'Grading...' : 'AI grade'}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="flex-1"
-                  onClick={() => { void handleReturnFeedback() }}
-                  disabled={feedbackReturning || !feedbackDraft.trim()}
-                >
-                  {feedbackReturning ? 'Returning...' : 'Return Feedback'}
-                </Button>
-                <SplitButton
-                  label={gradeSaving ? 'Saving...' : 'Save'}
-                  onPrimaryClick={() => {
-                    void handleSaveGrade('graded')
-                  }}
-                  options={[
-                    {
-                      id: 'draft',
-                      label: 'Draft',
-                      onSelect: () => {
-                        void handleSaveGrade('draft')
-                      },
-                    },
-                  ]}
-                  size="sm"
-                  className="flex-1"
-                  disabled={gradeSaving}
-                  toggleAriaLabel="Choose save mode"
-                  primaryButtonProps={{ className: 'flex-1 justify-center' }}
-                />
-              </div>
-
-              {data.doc?.graded_at && (
-                <div className="shrink-0 text-xs text-text-muted">
-                  Graded {formatInTimeZone(new Date(data.doc.graded_at), 'America/Toronto', 'MMM d, h:mm a')}
-                  {data.doc.graded_by && ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
-                </div>
-              )}
-            </div>
-          )}
         </div>
+        {displayContent && !isEmpty(displayContent) ? (
+          <>
+            <div className="min-h-0 flex-1 overflow-auto">
+              <RichTextViewer content={displayContent} fillHeight chrome="flush" />
+            </div>
+          </>
+        ) : (
+          <div className="flex h-32 items-center justify-center text-text-muted">
+            No work submitted yet
+          </div>
+        )}
       </div>
+
+      {!layout.inspectorCollapsed && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize content and grading panes"
+          className="hidden w-2 shrink-0 cursor-col-resize border-l border-r border-border bg-surface-2 lg:block"
+          onPointerDown={handleInspectorResizeStart}
+        />
+      )}
+
+      {!layout.inspectorCollapsed && (
+        <div className="flex min-h-0 flex-col border-t border-border bg-surface lg:border-t-0" style={inspectorPaneStyle}>
+          <WorkspaceInspector
+            historyEntries={historyEntries}
+            historyLoading={historyLoading}
+            historyError={historyError}
+            previewEntry={previewEntry}
+            onEntryClick={handlePreviewLock}
+            onEntryHover={handlePreviewHover}
+            onMouseLeave={handleHistoryMouseLeave}
+            isPreviewLocked={isPreviewLocked}
+            onExitPreview={handleExitPreview}
+            rightTab={rightTab}
+            onRightTabChange={handleRightTabChange}
+            data={data}
+            gradeError={gradeError}
+            repoReviewResult={repoReviewResult}
+            scoreCompletion={scoreCompletion}
+            setScoreCompletion={setScoreCompletion}
+            scoreThinking={scoreThinking}
+            setScoreThinking={setScoreThinking}
+            scoreWorkflow={scoreWorkflow}
+            setScoreWorkflow={setScoreWorkflow}
+            totalPercent={totalPercent}
+            totalScore={totalScore}
+            feedbackEntries={feedbackEntries}
+            feedbackDraft={feedbackDraft}
+            hasFreshAIDraft={hasFreshAIDraft}
+            setFeedbackDraft={setFeedbackDraft}
+            onAIDraftAcknowledge={() => setHasFreshAIDraft(false)}
+            autoGrading={autoGrading}
+            feedbackReturning={feedbackReturning}
+            gradeSaving={gradeSaving}
+            repoAnalyzing={repoAnalyzing}
+            handleAutoGrade={handleAutoGrade}
+            handleReturnFeedback={handleReturnFeedback}
+            handleSaveGrade={handleSaveGrade}
+            handleAnalyzeRepo={handleAnalyzeRepo}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/editor/RichTextViewer.tsx
+++ b/src/components/editor/RichTextViewer.tsx
@@ -29,12 +29,14 @@ export interface RichTextViewerProps {
   content: TiptapContent
   showPlainText?: boolean
   fillHeight?: boolean
+  chrome?: 'default' | 'flush'
 }
 
 export function RichTextViewer({
   content,
   showPlainText = false,
   fillHeight = false,
+  chrome = 'default',
 }: RichTextViewerProps) {
   const editor = useEditor({
     immediatelyRender: false,
@@ -107,7 +109,9 @@ export function RichTextViewer({
     <div
       className={[
         fillHeight ? 'simple-editor-wrapper simple-editor-wrapper--fill-height' : 'simple-viewer-wrapper',
-        'bg-surface-2 rounded-none border border-border',
+        chrome === 'flush'
+          ? 'bg-transparent border-transparent rounded-none'
+          : 'bg-surface-2 rounded-none border border-border',
       ].join(' ')}
     >
       <EditorContent

--- a/src/hooks/use-assignment-grading-layout.ts
+++ b/src/hooks/use-assignment-grading-layout.ts
@@ -1,0 +1,80 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { readCookie, writeCookie } from '@/lib/cookies'
+import {
+  clampAssignmentGradingLayout,
+  getAssignmentGradingLayoutCookieName,
+  getDefaultAssignmentGradingLayout,
+  parseAssignmentGradingLayout,
+  serializeAssignmentGradingLayout,
+  type AssignmentGradingLayoutState,
+  type AssignmentWorkspaceMode,
+  type AssignmentWorkspacePaneLayout,
+} from '@/lib/assignment-grading-layout'
+
+export function useAssignmentGradingLayout(
+  classroomId: string,
+  totalWidth: number,
+) {
+  const [layout, setLayoutState] = useState<AssignmentGradingLayoutState>(
+    getDefaultAssignmentGradingLayout(),
+  )
+  const [hasHydratedCookie, setHasHydratedCookie] = useState(false)
+  const cookieName = getAssignmentGradingLayoutCookieName(classroomId)
+
+  useEffect(() => {
+    setLayoutState(parseAssignmentGradingLayout(readCookie(cookieName)))
+    setHasHydratedCookie(true)
+  }, [cookieName])
+
+  const clampedLayout = useMemo(
+    () => clampAssignmentGradingLayout(layout, { totalWidth }),
+    [layout, totalWidth],
+  )
+
+  useEffect(() => {
+    if (!hasHydratedCookie) return
+    writeCookie(cookieName, serializeAssignmentGradingLayout(clampedLayout))
+  }, [clampedLayout, cookieName, hasHydratedCookie])
+
+  const setLayout = useCallback(
+    (
+      next:
+        | AssignmentGradingLayoutState
+        | ((current: AssignmentGradingLayoutState) => AssignmentGradingLayoutState),
+    ) => {
+      setLayoutState((current) => {
+        const candidate = typeof next === 'function' ? next(current) : next
+        return clampAssignmentGradingLayout(candidate, { totalWidth })
+      })
+    },
+    [totalWidth],
+  )
+
+  const updateModeLayout = useCallback(
+    (
+      mode: AssignmentWorkspaceMode,
+      next:
+        | AssignmentWorkspacePaneLayout
+        | ((current: AssignmentWorkspacePaneLayout) => AssignmentWorkspacePaneLayout),
+    ) => {
+      setLayout((current) => ({
+        ...current,
+        [mode]: typeof next === 'function' ? next(current[mode]) : next,
+      }))
+    },
+    [setLayout],
+  )
+
+  const resetLayout = useCallback(() => {
+    setLayoutState(getDefaultAssignmentGradingLayout())
+  }, [])
+
+  return {
+    layout: clampedLayout,
+    setLayout,
+    updateModeLayout,
+    resetLayout,
+  }
+}

--- a/src/lib/assignment-grading-layout.ts
+++ b/src/lib/assignment-grading-layout.ts
@@ -1,0 +1,198 @@
+export type AssignmentWorkspaceMode = 'overview' | 'details'
+
+export interface AssignmentWorkspacePaneLayout {
+  inspectorCollapsed: boolean
+  inspectorWidth: number
+}
+
+export interface AssignmentGradingLayoutState {
+  overview: AssignmentWorkspacePaneLayout
+  details: AssignmentWorkspacePaneLayout
+}
+
+export interface AssignmentGradingLayoutMetrics {
+  totalWidth: number
+}
+
+export const ASSIGNMENT_GRADING_LAYOUT = {
+  defaultInspectorWidth: 40,
+  inspectorMinPx: 320,
+  overviewPrimaryMinPx: 420,
+  detailsPrimaryMinPx: 360,
+} as const
+
+const DEFAULT_PANE_LAYOUT: AssignmentWorkspacePaneLayout = {
+  inspectorCollapsed: false,
+  inspectorWidth: ASSIGNMENT_GRADING_LAYOUT.defaultInspectorWidth,
+}
+
+const DEFAULT_LAYOUT: AssignmentGradingLayoutState = {
+  overview: { ...DEFAULT_PANE_LAYOUT },
+  details: { ...DEFAULT_PANE_LAYOUT },
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (max <= min) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+function isPercentNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function getPrimaryMinPx(mode: AssignmentWorkspaceMode): number {
+  return mode === 'overview'
+    ? ASSIGNMENT_GRADING_LAYOUT.overviewPrimaryMinPx
+    : ASSIGNMENT_GRADING_LAYOUT.detailsPrimaryMinPx
+}
+
+function parsePaneLayout(
+  value: unknown,
+  fallback: AssignmentWorkspacePaneLayout,
+): AssignmentWorkspacePaneLayout {
+  if (!value || typeof value !== 'object') return { ...fallback }
+
+  const pane = value as Partial<AssignmentWorkspacePaneLayout>
+  return {
+    inspectorCollapsed: pane.inspectorCollapsed === true,
+    inspectorWidth: isPercentNumber(pane.inspectorWidth)
+      ? pane.inspectorWidth
+      : fallback.inspectorWidth,
+  }
+}
+
+export function getDefaultAssignmentGradingLayout(): AssignmentGradingLayoutState {
+  return {
+    overview: { ...DEFAULT_LAYOUT.overview },
+    details: { ...DEFAULT_LAYOUT.details },
+  }
+}
+
+export function getAssignmentGradingLayoutCookieName(classroomId: string): string {
+  return `pika_assignment_grading_layout:${classroomId}`
+}
+
+export function getAssignmentWorkspaceStudentCookieName(
+  classroomId: string,
+  assignmentId: string,
+): string {
+  return `pika_assignment_workspace_student:${classroomId}:${assignmentId}`
+}
+
+export function serializeAssignmentGradingLayout(
+  layout: AssignmentGradingLayoutState,
+): string {
+  return JSON.stringify(layout)
+}
+
+export function parseAssignmentGradingLayout(
+  value: string | null | undefined,
+): AssignmentGradingLayoutState {
+  if (!value) return getDefaultAssignmentGradingLayout()
+
+  try {
+    const parsed = JSON.parse(value) as Partial<AssignmentGradingLayoutState>
+    return {
+      overview: parsePaneLayout(parsed.overview, DEFAULT_LAYOUT.overview),
+      details: parsePaneLayout(parsed.details, DEFAULT_LAYOUT.details),
+    }
+  } catch {
+    return getDefaultAssignmentGradingLayout()
+  }
+}
+
+export function parseAssignmentWorkspaceStudentId(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function clampAssignmentWorkspacePaneLayout(
+  layout: AssignmentWorkspacePaneLayout,
+  mode: AssignmentWorkspaceMode,
+  { totalWidth }: AssignmentGradingLayoutMetrics,
+): AssignmentWorkspacePaneLayout {
+  const base = {
+    ...DEFAULT_PANE_LAYOUT,
+    ...layout,
+  }
+
+  if (!Number.isFinite(totalWidth) || totalWidth <= 0) {
+    return {
+      inspectorCollapsed: base.inspectorCollapsed,
+      inspectorWidth: roundPercent(base.inspectorWidth),
+    }
+  }
+
+  if (base.inspectorCollapsed) {
+    return {
+      inspectorCollapsed: true,
+      inspectorWidth: roundPercent(base.inspectorWidth),
+    }
+  }
+
+  const minInspectorPercent =
+    (ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx / totalWidth) * 100
+  const maxInspectorPercent = Math.max(
+    minInspectorPercent,
+    ((totalWidth - getPrimaryMinPx(mode)) / totalWidth) * 100,
+  )
+
+  return {
+    inspectorCollapsed: false,
+    inspectorWidth: roundPercent(
+      clampNumber(base.inspectorWidth, minInspectorPercent, maxInspectorPercent),
+    ),
+  }
+}
+
+export function clampAssignmentGradingLayout(
+  layout: AssignmentGradingLayoutState,
+  metrics: AssignmentGradingLayoutMetrics,
+): AssignmentGradingLayoutState {
+  const base = getDefaultAssignmentGradingLayout()
+  const candidate = {
+    overview: {
+      ...base.overview,
+      ...layout.overview,
+    },
+    details: {
+      ...base.details,
+      ...layout.details,
+    },
+  }
+
+  return {
+    overview: clampAssignmentWorkspacePaneLayout(candidate.overview, 'overview', metrics),
+    details: clampAssignmentWorkspacePaneLayout(candidate.details, 'details', metrics),
+  }
+}
+
+export function getEffectiveInspectorWidthPercent(
+  layout: AssignmentGradingLayoutState,
+  mode: AssignmentWorkspaceMode,
+  metrics: AssignmentGradingLayoutMetrics,
+): number {
+  const pane = clampAssignmentGradingLayout(layout, metrics)[mode]
+  return pane.inspectorCollapsed ? 0 : pane.inspectorWidth
+}
+
+export function setModeInspectorCollapsed(
+  layout: AssignmentGradingLayoutState,
+  mode: AssignmentWorkspaceMode,
+  inspectorCollapsed: boolean,
+): AssignmentGradingLayoutState {
+  return {
+    ...layout,
+    [mode]: {
+      ...layout[mode],
+      inspectorCollapsed,
+    },
+  }
+}

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -9,7 +9,7 @@
 // Types
 // ============================================================================
 
-export type RightSidebarWidth = 320 | 360 | 420 | '40%' | '50%' | '60%' | '70%' | '75%'
+export type RightSidebarWidth = 320 | 360 | 420 | `${number}%`
 
 export type MainContentMaxWidth = 'reading' | 'standard' | 'wide' | 'full'
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -401,21 +401,6 @@ export interface AssignmentRepoReviewResult {
   created_at: string
 }
 
-/**
- * Info about a selected student in teacher assignments view.
- * Used to display student work in the right sidebar.
- */
-export interface SelectedStudentInfo {
-  assignmentId: string
-  assignmentTitle: string
-  studentId: string
-  studentName: string
-  canGoPrev: boolean
-  canGoNext: boolean
-  onGoPrev: () => void
-  onGoNext: () => void
-}
-
 export interface ClassroomResources {
   id: string
   classroom_id: string

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -35,7 +35,9 @@ describe('AssignmentArtifactsCell', () => {
     ]
 
     renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
-    expect(screen.getByRole('button', { name: /view 2 work items/i })).toHaveTextContent('2 items')
+    const button = screen.getByRole('button', { name: /view 2 work items/i })
+    expect(button).toHaveTextContent('example.com/a')
+    expect(button).toHaveTextContent('+1')
   })
 
   it('opens a link preview modal when a pill is clicked', () => {

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TableCard } from '@/components/DataTable'
+
+describe('TableCard', () => {
+  it('renders default chrome for standard tables', () => {
+    const { container } = render(
+      <TableCard>
+        <div>Rows</div>
+      </TableCard>,
+    )
+
+    expect(screen.getByText('Rows')).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('rounded-lg', 'border', 'border-border', 'bg-surface')
+  })
+
+  it('renders flush chrome when table lives inside an outer shell', () => {
+    const { container } = render(
+      <TableCard chrome="flush">
+        <div>Rows</div>
+      </TableCard>,
+    )
+
+    expect(screen.getByText('Rows')).toBeInTheDocument()
+    expect(container.firstChild).not.toHaveClass('rounded-lg')
+    expect(container.firstChild).not.toHaveClass('border')
+    expect(container.firstChild).not.toHaveClass('bg-surface')
+    expect(container.firstChild).toHaveClass('overflow-hidden')
+  })
+})

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -2,15 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
-import { readCookie, writeCookie } from '@/lib/cookies'
-import { TEACHER_GRADE_UPDATED_EVENT } from '@/lib/events'
+import { countCharacters } from '@/lib/tiptap-content'
 
 vi.mock('@/components/Spinner', () => ({
   Spinner: () => <div data-testid="spinner" />,
 }))
 
 vi.mock('@/components/editor', () => ({
-  RichTextViewer: () => <div data-testid="rich-text-viewer" />,
+  RichTextViewer: ({ chrome, content }: any) => (
+    <div data-testid="rich-text-viewer" data-chrome={chrome || 'default'}>
+      {JSON.stringify(content)}
+    </div>
+  ),
 }))
 
 vi.mock('@/components/HistoryList', () => ({
@@ -35,15 +38,25 @@ vi.mock('@/ui', () => ({
     </div>
   ),
   Tooltip: ({ children }: any) => <>{children}</>,
-  RefreshingIndicator: ({ label = 'Refreshing...' }: { label?: string }) => <div>{label}</div>,
 }))
 
-function makeStudentWork(studentId: string, opts: { graded: boolean }) {
+function makeStudentWork(
+  studentId: string,
+  opts: { graded: boolean; repoUrl?: string | null; githubUsername?: string | null; aiFeedbackSuggestion?: string | null; teacherFeedbackDraft?: string | null },
+) {
   const doc = {
     id: `doc-${studentId}`,
     assignment_id: 'assignment-1',
     student_id: studentId,
-    content: { type: 'doc', content: [] },
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: `Work for ${studentId}` }],
+        },
+      ],
+    },
     repo_url: null,
     github_username: null,
     is_submitted: true,
@@ -53,10 +66,18 @@ function makeStudentWork(studentId: string, opts: { graded: boolean }) {
     score_thinking: opts.graded ? 8 : null,
     score_workflow: opts.graded ? 9 : null,
     feedback: opts.graded ? 'Nice work' : null,
-    teacher_feedback_draft: opts.graded ? 'Nice work' : null,
-    teacher_feedback_draft_updated_at: opts.graded ? '2026-02-20T13:00:00Z' : null,
+    teacher_feedback_draft:
+      opts.teacherFeedbackDraft !== undefined
+        ? opts.teacherFeedbackDraft
+        : opts.graded
+          ? 'Nice work'
+          : null,
+    teacher_feedback_draft_updated_at:
+      opts.teacherFeedbackDraft !== undefined || opts.graded
+        ? '2026-02-20T13:00:00Z'
+        : null,
     feedback_returned_at: null,
-    ai_feedback_suggestion: null,
+    ai_feedback_suggestion: opts.aiFeedbackSuggestion ?? null,
     ai_feedback_suggested_at: null,
     ai_feedback_model: null,
     graded_at: opts.graded ? '2026-02-20T13:00:00Z' : null,
@@ -91,10 +112,10 @@ function makeStudentWork(studentId: string, opts: { graded: boolean }) {
     feedback_entries: [],
     repo_target: {
       target: null,
-      submittedRepoUrl: null,
-      submittedGitHubUsername: null,
-      effectiveRepoUrl: null,
-      effectiveGitHubUsername: null,
+      submittedRepoUrl: opts.repoUrl ?? null,
+      submittedGitHubUsername: opts.githubUsername ?? null,
+      effectiveRepoUrl: opts.repoUrl ?? null,
+      effectiveGitHubUsername: opts.githubUsername ?? null,
       repoOwner: null,
       repoName: null,
       selectionMode: 'auto',
@@ -105,11 +126,16 @@ function makeStudentWork(studentId: string, opts: { graded: boolean }) {
   }
 }
 
-function mockFetchByStudent(
-  studentMap: Record<string, { graded: boolean }>,
-  options?: { onGradeSave?: (body: Record<string, unknown>) => void }
-) {
-  ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function mockFetchByStudent(studentMap: Record<string, { graded: boolean }>) {
+  ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
     const url = String(input)
 
     if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
@@ -129,26 +155,6 @@ function mockFetchByStudent(
       })
     }
 
-    if (url.includes('/api/teacher/assignments/') && url.includes('/grade') && init?.method === 'POST') {
-      const body = JSON.parse(String(init.body || '{}')) as Record<string, unknown>
-      options?.onGradeSave?.(body)
-      const isGraded = body.save_mode === 'graded'
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          doc: {
-            ...makeStudentWork('student-1', { graded: isGraded }).doc,
-            score_completion: Number(body.score_completion ?? 0),
-            score_thinking: Number(body.score_thinking ?? 0),
-            score_workflow: Number(body.score_workflow ?? 0),
-            teacher_feedback_draft: String(body.feedback ?? ''),
-            graded_at: isGraded ? '2026-02-20T13:00:00Z' : null,
-            graded_by: isGraded ? 'teacher' : null,
-          },
-        }),
-      })
-    }
-
     if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
       return Promise.resolve({
         ok: true,
@@ -165,13 +171,28 @@ function mockFetchByStudent(
 
 function clearRightTabCookie() {
   document.cookie = 'pika_teacher_student_work_tab%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
-  document.cookie = 'pika_teacher_student_work_tab%3Aclassroom-2=; Path=/; Max-Age=0; SameSite=Lax'
 }
 
-describe('TeacherStudentWorkPanel right-tab persistence', () => {
+function mockVisualViewport(width: number, height = 900) {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: {
+      width,
+      height,
+      offsetTop: 0,
+      offsetLeft: 0,
+      scale: 1,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    },
+  })
+}
+
+describe('TeacherStudentWorkPanel', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
     clearRightTabCookie()
+    mockVisualViewport(1440)
   })
 
   afterEach(() => {
@@ -180,7 +201,7 @@ describe('TeacherStudentWorkPanel right-tab persistence', () => {
     clearRightTabCookie()
   })
 
-  it('keeps grading tab selected when switching students', async () => {
+  it('keeps grading tab selected when switching students in details mode', async () => {
     mockFetchByStudent({
       'student-1': { graded: false },
       'student-2': { graded: false },
@@ -188,148 +209,321 @@ describe('TeacherStudentWorkPanel right-tab persistence', () => {
 
     const user = userEvent.setup()
     const { rerender } = render(
-      <TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
     )
 
     await user.click(await screen.findByRole('button', { name: 'Grading' }))
     expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
 
     rerender(
-      <TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-2" />
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-2"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
     )
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/teacher/assignments/assignment-1/students/student-2')
     })
+
     expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.queryByText('No saves yet')).not.toBeInTheDocument()
   })
 
-  it('keeps history tab selected when switching students', async () => {
+  it('renders details mode without the old shared header and keeps content flush', async () => {
     mockFetchByStudent({
-      'student-1': { graded: true },
-      'student-2': { graded: true },
+      'student-1': { graded: false },
     })
 
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByTestId('rich-text-viewer')).toHaveAttribute('data-chrome', 'flush')
+    expect(screen.queryByTestId('grading-workspace-header')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /show student table only/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('individual-content-header')).toHaveTextContent('student-1')
+    const expectedCharacters = countCharacters({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Work for student-1' }],
+        },
+      ],
+    })
+    expect(screen.getByLabelText(`${expectedCharacters} characters`)).toHaveTextContent(`${expectedCharacters} chars`)
+    expect(screen.queryByText(new RegExp(`${expectedCharacters} characters$`))).not.toBeInTheDocument()
+  })
+
+  it('prepends AI feedback suggestion into the feedback draft and marks it as an AI draft until focus', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            makeStudentWork('student-1', {
+              graded: false,
+              teacherFeedbackDraft: 'Teacher note',
+              aiFeedbackSuggestion: 'AI feedback suggestion',
+            }),
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await userEvent.setup().click(await screen.findByRole('button', { name: 'Grading' }))
+    const draft = await screen.findByPlaceholderText('Teacher feedback draft')
+    expect(draft).toHaveValue('AI feedback suggestion\n\nTeacher note')
+    expect(draft).toHaveClass('border-primary')
+    expect(draft).toHaveClass('bg-info-bg')
+    expect(screen.getByText('AI draft')).toBeInTheDocument()
+    expect(screen.queryByText('AI Suggestion')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Use' })).not.toBeInTheDocument()
+
+    await userEvent.setup().click(draft)
+
+    expect(draft).toHaveValue('AI feedback suggestion\n\nTeacher note')
+    expect(draft).not.toHaveClass('border-primary')
+    expect(draft).not.toHaveClass('bg-info-bg')
+    expect(screen.queryByText('AI draft')).not.toBeInTheDocument()
+  })
+
+  it('prepends new AI feedback to the current unsaved draft after auto-grade', async () => {
     const user = userEvent.setup()
+    let studentFetchCount = 0
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+        studentFetchCount += 1
+
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            makeStudentWork('student-1', {
+              graded: false,
+              teacherFeedbackDraft: studentFetchCount > 1 ? null : '',
+              aiFeedbackSuggestion: studentFetchCount > 1 ? 'AI feedback suggestion' : null,
+            }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/auto-grade')) {
+        expect(init?.method).toBe('POST')
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ graded_count: 1 }),
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'Grading' }))
+    const draft = await screen.findByPlaceholderText('Teacher feedback draft')
+    await user.clear(draft)
+    await user.type(draft, 'Teacher note')
+    await user.click(screen.getByRole('button', { name: 'AI grade' }))
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Teacher feedback draft')).toHaveValue(
+        'AI feedback suggestion\n\nTeacher note',
+      )
+    })
+
+    expect(screen.getByText('AI draft')).toBeInTheDocument()
+  })
+
+  it('renders overview mode as inspector-only without submission content', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="overview"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByText('History')).toBeInTheDocument()
+    expect(screen.queryByTestId('rich-text-viewer')).not.toBeInTheDocument()
+  })
+
+  it('keeps prior content visible while the next student loads', async () => {
+    const deferredStudent2 = createDeferred<any>()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/assignment-1/students/student-1')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeStudentWork('student-1', { graded: false }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/assignment-1/students/student-2')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => deferredStudent2.promise,
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    const loadingStateSpy = vi.fn()
     const { rerender } = render(
-      <TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+        onLoadingStateChange={loadingStateSpy}
+      />,
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'History' }))
-    expect(await screen.findByText('No saves yet')).toBeInTheDocument()
+    expect(await screen.findByText(/Work for student-1/)).toBeInTheDocument()
 
     rerender(
-      <TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-2" />
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-2"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+        onLoadingStateChange={loadingStateSpy}
+      />,
     )
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/teacher/assignments/assignment-1/students/student-2')
     })
-    expect(await screen.findByText('No saves yet')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+
+    expect(screen.getByText(/Work for student-1/)).toBeInTheDocument()
+    expect(screen.queryByText('Refreshing history...')).not.toBeInTheDocument()
+    expect(loadingStateSpy).toHaveBeenCalledWith(true)
+
+    deferredStudent2.resolve(makeStudentWork('student-2', { graded: false }))
+
+    expect(await screen.findByText(/Work for student-2/)).toBeInTheDocument()
   })
 
-  it('restores grading tab from cookie on initial load', async () => {
-    writeCookie('pika_teacher_student_work_tab:classroom-1', 'grading')
+  it('renders the individual content header with student name first and repo metadata after it', async () => {
     mockFetchByStudent({
-      'student-1': { graded: false },
-    })
-
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.queryByText('No saves yet')).not.toBeInTheDocument()
-  })
-
-  it('writes selected right-tab to cookie when toggled', async () => {
-    mockFetchByStudent({
-      'student-1': { graded: false },
-    })
-
-    const user = userEvent.setup()
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    expect(readCookie('pika_teacher_student_work_tab:classroom-1')).toBe('grading')
-
-    await user.click(screen.getByRole('button', { name: 'History' }))
-    expect(readCookie('pika_teacher_student_work_tab:classroom-1')).toBe('history')
-  })
-
-  it('scopes right-tab preference per classroom', async () => {
-    writeCookie('pika_teacher_student_work_tab:classroom-2', 'grading')
-    mockFetchByStudent({
-      'student-1': { graded: false },
-    })
-
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    expect(await screen.findByText('No saves yet')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
-  })
-
-  it('saves as graded with the primary save action', async () => {
-    const savedBodies: Array<Record<string, unknown>> = []
-    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
-    mockFetchByStudent(
-      {
-        'student-1': { graded: false },
+      'student-1': {
+        graded: false,
+        repoUrl: 'https://github.com/example/student-1-repo',
+        githubUsername: 'student1',
       },
-      {
-        onGradeSave: (body) => savedBodies.push(body),
-      }
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
     )
 
-    const user = userEvent.setup()
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-
-    await waitFor(() => {
-      expect(savedBodies).toHaveLength(1)
-    })
-    expect(savedBodies[0].save_mode).toBe('graded')
-    const gradeEvent = dispatchSpy.mock.calls
-      .map(([event]) => event)
-      .find((event) => event.type === TEACHER_GRADE_UPDATED_EVENT) as CustomEvent | undefined
-    expect(gradeEvent).toBeDefined()
-    expect(gradeEvent?.detail).toMatchObject({
-      assignmentId: 'assignment-1',
-      studentId: 'student-1',
-      doc: expect.objectContaining({
-        student_id: 'student-1',
-        graded_at: '2026-02-20T13:00:00Z',
-      }),
-    })
-    expect(await screen.findByText(/^Graded /)).toBeInTheDocument()
-  })
-
-  it('saves as draft from split-button menu action', async () => {
-    const savedBodies: Array<Record<string, unknown>> = []
-    mockFetchByStudent(
-      {
-        'student-1': { graded: false },
-      },
-      {
-        onGradeSave: (body) => savedBodies.push(body),
-      }
-    )
-
-    const user = userEvent.setup()
-    render(<TeacherStudentWorkPanel classroomId="classroom-1" assignmentId="assignment-1" studentId="student-1" />)
-
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    await user.click(screen.getByRole('button', { name: 'Choose save mode' }))
-    await user.click(screen.getByRole('button', { name: 'Draft' }))
-
-    await waitFor(() => {
-      expect(savedBodies).toHaveLength(1)
-    })
-    expect(savedBodies[0].save_mode).toBe('draft')
-    expect(screen.queryByText(/^Graded /)).not.toBeInTheDocument()
+    const header = await screen.findByTestId('individual-content-header')
+    expect(header).toHaveTextContent('student-1')
+    expect(header).toHaveTextContent('https://github.com/example/student-1-repo')
+    expect(header).toHaveTextContent('@student1')
   })
 })

--- a/tests/hooks/use-assignment-grading-layout.test.tsx
+++ b/tests/hooks/use-assignment-grading-layout.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
+
+function clearLayoutCookie() {
+  document.cookie = 'pika_assignment_grading_layout%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
+}
+
+describe('useAssignmentGradingLayout', () => {
+  beforeEach(() => {
+    clearLayoutCookie()
+  })
+
+  afterEach(() => {
+    clearLayoutCookie()
+  })
+
+  it('restores a saved layout from cookie', async () => {
+    document.cookie = `${encodeURIComponent('pika_assignment_grading_layout:classroom-1')}=${encodeURIComponent(
+      JSON.stringify({
+        overview: {
+          inspectorCollapsed: true,
+          inspectorWidth: 44,
+        },
+        details: {
+          inspectorCollapsed: false,
+          inspectorWidth: 36,
+        },
+      }),
+    )}; Path=/; SameSite=Lax`
+
+    const { result } = renderHook(() => useAssignmentGradingLayout('classroom-1', 1000))
+
+    await waitFor(() => {
+      expect(result.current.layout.overview.inspectorCollapsed).toBe(true)
+    })
+
+    expect(result.current.layout.overview.inspectorWidth).toBe(44)
+    expect(result.current.layout.details.inspectorWidth).toBe(36)
+  })
+
+  it('does not overwrite a saved layout cookie before hydration completes', async () => {
+    const cookieName = encodeURIComponent('pika_assignment_grading_layout:classroom-1')
+    const savedValue = encodeURIComponent(
+      JSON.stringify({
+        overview: {
+          inspectorCollapsed: true,
+          inspectorWidth: 44,
+        },
+        details: {
+          inspectorCollapsed: false,
+          inspectorWidth: 36,
+        },
+      }),
+    )
+
+    document.cookie = `${cookieName}=${savedValue}; Path=/; SameSite=Lax`
+
+    renderHook(() => useAssignmentGradingLayout('classroom-1', 1000))
+
+    await waitFor(() => {
+      expect(document.cookie).toContain(savedValue)
+    })
+
+    expect(document.cookie).not.toContain(encodeURIComponent('"inspectorWidth":40'))
+  })
+
+  it('persists mode-specific layout updates and resets to defaults', async () => {
+    const { result } = renderHook(() => useAssignmentGradingLayout('classroom-1', 1000))
+
+    act(() => {
+      result.current.updateModeLayout('overview', (current) => ({
+        ...current,
+        inspectorCollapsed: true,
+        inspectorWidth: 44,
+      }))
+    })
+
+    await waitFor(() => {
+      expect(document.cookie).toContain('pika_assignment_grading_layout%3Aclassroom-1=')
+    })
+
+    expect(document.cookie).toContain(encodeURIComponent('"overview":{"inspectorCollapsed":true,"inspectorWidth":44}'))
+
+    act(() => {
+      result.current.resetLayout()
+    })
+
+    await waitFor(() => {
+      expect(result.current.layout).toEqual({
+        overview: {
+          inspectorCollapsed: false,
+          inspectorWidth: 40,
+        },
+        details: {
+          inspectorCollapsed: false,
+          inspectorWidth: 40,
+        },
+      })
+    })
+  })
+})

--- a/tests/unit/assignment-grading-layout.test.ts
+++ b/tests/unit/assignment-grading-layout.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ASSIGNMENT_GRADING_LAYOUT,
+  clampAssignmentGradingLayout,
+  getAssignmentGradingLayoutCookieName,
+  getAssignmentWorkspaceStudentCookieName,
+  getDefaultAssignmentGradingLayout,
+  getEffectiveInspectorWidthPercent,
+  parseAssignmentGradingLayout,
+  parseAssignmentWorkspaceStudentId,
+  serializeAssignmentGradingLayout,
+  setModeInspectorCollapsed,
+} from '@/lib/assignment-grading-layout'
+
+describe('assignment grading layout helpers', () => {
+  it('returns the expected default layout', () => {
+    expect(getDefaultAssignmentGradingLayout()).toEqual({
+      overview: {
+        inspectorCollapsed: false,
+        inspectorWidth: 40,
+      },
+      details: {
+        inspectorCollapsed: false,
+        inspectorWidth: 40,
+      },
+    })
+  })
+
+  it('round-trips layout through cookie serialization', () => {
+    const layout = {
+      overview: {
+        inspectorCollapsed: true,
+        inspectorWidth: 44,
+      },
+      details: {
+        inspectorCollapsed: false,
+        inspectorWidth: 36,
+      },
+    }
+
+    expect(parseAssignmentGradingLayout(serializeAssignmentGradingLayout(layout))).toEqual(layout)
+  })
+
+  it('falls back to defaults for invalid cookie state', () => {
+    expect(parseAssignmentGradingLayout('not-json')).toEqual(getDefaultAssignmentGradingLayout())
+    expect(parseAssignmentGradingLayout('{"overview":{"inspectorWidth":"bad"}}')).toEqual(
+      getDefaultAssignmentGradingLayout(),
+    )
+  })
+
+  it('clamps overview and details inspector widths to minimum readable sizes', () => {
+    const clamped = clampAssignmentGradingLayout(
+      {
+        overview: {
+          inspectorCollapsed: false,
+          inspectorWidth: 95,
+        },
+        details: {
+          inspectorCollapsed: false,
+          inspectorWidth: 95,
+        },
+      },
+      { totalWidth: 1000 },
+    )
+
+    expect(clamped.overview.inspectorWidth).toBe(58)
+    expect(clamped.details.inspectorWidth).toBe(64)
+  })
+
+  it('returns zero effective width when a mode inspector is collapsed', () => {
+    const layout = {
+      overview: {
+        inspectorCollapsed: true,
+        inspectorWidth: 44,
+      },
+      details: {
+        inspectorCollapsed: false,
+        inspectorWidth: 36,
+      },
+    }
+
+    expect(getEffectiveInspectorWidthPercent(layout, 'overview', { totalWidth: 1000 })).toBe(0)
+    expect(getEffectiveInspectorWidthPercent(layout, 'details', { totalWidth: 1000 })).toBe(36)
+  })
+
+  it('supports explicit collapse transitions without discarding saved widths', () => {
+    const layout = getDefaultAssignmentGradingLayout()
+
+    expect(setModeInspectorCollapsed(layout, 'overview', true)).toEqual({
+      ...layout,
+      overview: {
+        inspectorCollapsed: true,
+        inspectorWidth: 40,
+      },
+    })
+  })
+
+  it('builds classroom-scoped cookie names for layout and selected student memory', () => {
+    expect(getAssignmentGradingLayoutCookieName('classroom-1')).toBe(
+      'pika_assignment_grading_layout:classroom-1',
+    )
+    expect(getAssignmentWorkspaceStudentCookieName('classroom-1', 'assignment-9')).toBe(
+      'pika_assignment_workspace_student:classroom-1:assignment-9',
+    )
+  })
+
+  it('parses remembered student ids defensively', () => {
+    expect(parseAssignmentWorkspaceStudentId(' student-1 ')).toBe('student-1')
+    expect(parseAssignmentWorkspaceStudentId('')).toBeNull()
+    expect(parseAssignmentWorkspaceStudentId(null)).toBeNull()
+  })
+
+  it('keeps the declared minimum widths in sync with the default proportions', () => {
+    const totalWidth = 1000
+    const layout = getDefaultAssignmentGradingLayout()
+    const overviewInspectorPx =
+      (getEffectiveInspectorWidthPercent(layout, 'overview', { totalWidth }) / 100) * totalWidth
+    const detailsInspectorPx =
+      (getEffectiveInspectorWidthPercent(layout, 'details', { totalWidth }) / 100) * totalWidth
+
+    expect(overviewInspectorPx).toBeGreaterThanOrEqual(ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx)
+    expect(detailsInspectorPx).toBeGreaterThanOrEqual(ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx)
+  })
+})

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -117,6 +117,10 @@ describe('getRightSidebarCssWidth', () => {
   it('should return percentage for 60%', () => {
     expect(getRightSidebarCssWidth('60%')).toBe('60%')
   })
+
+  it('should return arbitrary percentage widths', () => {
+    expect(getRightSidebarCssWidth('76.4%')).toBe('76.4%')
+  })
 })
 
 describe('getRouteKeyFromTab', () => {


### PR DESCRIPTION
## Summary
- replace the old teacher assignment sidebar flow with a single assignment workspace that uses `Class` and `Individual` modes
- add persisted grading-pane layout state, resizable desktop panes, folder-tab workspace chrome, and compact class-table rendering
- merge AI grading suggestions directly into the feedback draft with a temporary `AI draft` cue until the teacher focuses the textarea

## Why
Issue #453 needed the assignment grading flow to feel like one coordinated workspace instead of a hard-coded sidebar. This branch moves grading into the main assignment workspace, preserves layout state per classroom, and tightens the teacher grading UI so content, roster, and inspector behavior are explicit instead of width-heuristic-driven.

## User impact
- teachers grade assignments from a dedicated `Class` / `Individual` workspace rather than the generic right sidebar
- desktop grading panes are resizable and persisted per classroom
- the class table fits split view without horizontal scrolling
- AI-generated grading feedback lands in the draft textarea itself and is visibly marked until acknowledged

## Validation
- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
- `corepack pnpm exec next lint --file src/components/TeacherStudentWorkPanel.tsx --file tests/components/TeacherStudentWorkPanel.test.tsx`
- `corepack pnpm exec tsc --noEmit`
- `bash scripts/verify-env.sh`
- visual verification on the local dev server for teacher desktop/mobile and student sanity views during the issue-453 workflow

## Follow-up
- issue #460 tracks the next grading-pane cleanup to replace the remaining `History` / `Grading` tabs with collapsible `History`, `Repo`, `Grades`, and `Comments` sections.
