### PR TITLE
[codex] Refactor assignment grading inspector

### DIFF
--- a/src/app/api/teacher/assignments/[id]/grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/grade/route.ts
@@ -6,6 +6,13 @@ import { withErrorHandler } from '@/lib/api-handler'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+function parseDraftScore(value: unknown): number | null | typeof Number.NaN {
+  if (value === '' || value === null || value === undefined) return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 10) return Number.NaN
+  return parsed
+}
+
 // POST /api/teacher/assignments/[id]/grade - Save grade for a student
 export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (request, context) => {
   const user = await requireRole('teacher')
@@ -24,14 +31,6 @@ export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (reques
     return NextResponse.json({ error: 'student_id is required' }, { status: 400 })
   }
 
-  // Validate scores
-  for (const [name, val] of Object.entries({ score_completion, score_thinking, score_workflow })) {
-    const n = Number(val)
-    if (!Number.isInteger(n) || n < 0 || n > 10) {
-      return NextResponse.json({ error: `${name} must be an integer 0–10` }, { status: 400 })
-    }
-  }
-
   if (typeof feedback !== 'string') {
     return NextResponse.json({ error: 'feedback must be a string' }, { status: 400 })
   }
@@ -41,6 +40,24 @@ export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (reques
   }
 
   const shouldMarkGraded = save_mode === 'graded' || save_mode === undefined
+  const parsedScores = {
+    score_completion: shouldMarkGraded ? Number(score_completion) : parseDraftScore(score_completion),
+    score_thinking: shouldMarkGraded ? Number(score_thinking) : parseDraftScore(score_thinking),
+    score_workflow: shouldMarkGraded ? Number(score_workflow) : parseDraftScore(score_workflow),
+  }
+
+  for (const [name, value] of Object.entries(parsedScores)) {
+    if (shouldMarkGraded) {
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
+        return NextResponse.json({ error: `${name} must be an integer 0–10` }, { status: 400 })
+      }
+      continue
+    }
+
+    if (Number.isNaN(value)) {
+      return NextResponse.json({ error: `${name} must be blank or an integer 0–10` }, { status: 400 })
+    }
+  }
 
   const supabase = getServiceRoleClient()
 
@@ -81,9 +98,9 @@ export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (reques
     .upsert({
       assignment_id: id,
       student_id,
-      score_completion: Number(score_completion),
-      score_thinking: Number(score_thinking),
-      score_workflow: Number(score_workflow),
+      score_completion: parsedScores.score_completion,
+      score_thinking: parsedScores.score_thinking,
+      score_workflow: parsedScores.score_workflow,
       teacher_feedback_draft: feedback,
       teacher_feedback_draft_updated_at: new Date().toISOString(),
       graded_at: shouldMarkGraded ? new Date().toISOString() : null,

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -280,6 +280,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const dialogVariant = pendingAction?.mode === 'delete' ? 'danger' : 'default'
 
   const hasActiveClassrooms = activeClassrooms.length > 0
+  const showBottomCreateButton = hasActiveClassrooms || view === 'archived'
 
   return (
     <PageLayout className="mx-auto max-w-2xl">
@@ -435,7 +436,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
               onClick={() => setShowCreate(true)}
               className={[
                 'rounded-control bg-primary px-4 py-1.5 text-sm font-semibold text-text-inverse shadow-sm transition-colors hover:bg-primary-hover',
-                hasActiveClassrooms ? 'inline-flex items-center' : 'hidden',
+                showBottomCreateButton ? 'inline-flex items-center' : 'hidden',
               ].join(' ')}
             >
               + New

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -398,45 +398,47 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         )}
       </PageContent>
 
-      {/* Fixed bottom bar: + New button (when classrooms exist) + Active/Archive toggle */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center gap-2 border-t border-border bg-page/90 pb-4 pt-3 backdrop-blur-sm">
-        {hasActiveClassrooms && (
-          <div className="w-full max-w-2xl px-4">
+      {/* Fixed bottom bar: Active/Archived toggle with inline create CTA */}
+      <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-page/90 pb-4 pt-3 backdrop-blur-sm">
+        <div className="mx-auto flex w-full max-w-2xl items-center justify-center px-4">
+          <div className="flex items-center gap-2">
+            <div className="inline-flex items-stretch rounded-control border border-border bg-surface shadow-sm">
+              <button
+                type="button"
+                onClick={() => setView('active')}
+                className={[
+                  'rounded-l-control px-4 py-1.5 text-sm font-medium transition-colors',
+                  view === 'active'
+                    ? 'bg-surface-selected text-text-default'
+                    : 'text-text-muted hover:bg-surface-accent',
+                ].join(' ')}
+              >
+                Active
+              </button>
+              <button
+                type="button"
+                onClick={() => setView('archived')}
+                className={[
+                  'rounded-r-control px-4 py-1.5 text-sm font-medium transition-colors',
+                  view === 'archived'
+                    ? 'bg-surface-selected text-text-default'
+                    : 'text-text-muted hover:bg-surface-accent',
+                ].join(' ')}
+              >
+                Archived
+              </button>
+            </div>
             <button
               type="button"
               onClick={() => setShowCreate(true)}
-              className="flex w-full items-center justify-center gap-2 rounded-control bg-primary py-3 text-sm font-semibold text-text-inverse shadow-sm transition-colors hover:bg-primary-hover"
+              className={[
+                'rounded-control bg-primary px-4 py-1.5 text-sm font-semibold text-text-inverse shadow-sm transition-colors hover:bg-primary-hover',
+                hasActiveClassrooms ? 'inline-flex items-center' : 'hidden',
+              ].join(' ')}
             >
-              <Plus className="h-5 w-5" aria-hidden="true" />
-              New classroom
+              + New
             </button>
           </div>
-        )}
-        <div className="inline-flex rounded-control border border-border bg-surface shadow-sm">
-          <button
-            type="button"
-            onClick={() => setView('active')}
-            className={[
-              'rounded-l-control px-4 py-1.5 text-sm font-medium transition-colors',
-              view === 'active'
-                ? 'bg-surface-selected text-text-default'
-                : 'text-text-muted hover:bg-surface-accent',
-            ].join(' ')}
-          >
-            Active
-          </button>
-          <button
-            type="button"
-            onClick={() => setView('archived')}
-            className={[
-              'rounded-r-control px-4 py-1.5 text-sm font-medium transition-colors',
-              view === 'archived'
-                ? 'bg-surface-selected text-text-default'
-                : 'text-text-muted hover:bg-surface-accent',
-            ].join(' ')}
-          >
-            Archived
-          </button>
         </div>
       </div>
 

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -19,7 +19,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useRouter, usePathname } from 'next/navigation'
-import { Plus } from 'lucide-react'
+import { Archive, CircleDot, Plus } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
 import { Button, ConfirmDialog } from '@/ui'
 import { Spinner } from '@/components/Spinner'
@@ -402,29 +402,31 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
       <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-page/90 pb-4 pt-3 backdrop-blur-sm">
         <div className="mx-auto flex w-full max-w-2xl items-center justify-center px-4">
           <div className="flex items-center gap-2">
-            <div className="inline-flex items-stretch rounded-control border border-border bg-surface shadow-sm">
+            <div className="inline-flex items-stretch rounded-full border border-border bg-surface-2 p-0.5 shadow-sm">
               <button
                 type="button"
                 onClick={() => setView('active')}
                 className={[
-                  'rounded-l-control px-4 py-1.5 text-sm font-medium transition-colors',
+                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
                   view === 'active'
-                    ? 'bg-surface-selected text-text-default'
+                    ? 'bg-surface text-text-default shadow-sm'
                     : 'text-text-muted hover:bg-surface-accent',
                 ].join(' ')}
               >
+                <CircleDot className="h-3.5 w-3.5" aria-hidden="true" />
                 Active
               </button>
               <button
                 type="button"
                 onClick={() => setView('archived')}
                 className={[
-                  'rounded-r-control px-4 py-1.5 text-sm font-medium transition-colors',
+                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
                   view === 'archived'
-                    ? 'bg-surface-selected text-text-default'
+                    ? 'bg-surface text-text-default shadow-sm'
                     : 'text-text-muted hover:bg-surface-accent',
                 ].join(' ')}
               >
+                <Archive className="h-3.5 w-3.5" aria-hidden="true" />
                 Archived
               </button>
             </div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -29,7 +29,7 @@ import {
   RotateCcw,
   Send,
 } from 'lucide-react'
-import { ConfirmDialog, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, SplitButton, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -39,7 +39,7 @@ import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import {
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
-  ACTIONBAR_ICON_BUTTON_CLASSNAME,
+  ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
   PageActionBar,
   PageContent,
   PageLayout,
@@ -141,7 +141,6 @@ function getRowClassName(isSelected: boolean): string {
 
 const STATUS_ICON_CLASS = 'h-4 w-4'
 const LATE_CLOCK_CLASS = 'h-3 w-3'
-const WORKSPACE_TAB_BASE_CLASSNAME = 'rounded-t-lg border px-3 py-1.5 text-sm font-medium transition-colors'
 
 function MetricBar({ value }: { value: number }) {
   const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
@@ -915,163 +914,232 @@ export function TeacherClassroomView({
     window.addEventListener('pointerup', handlePointerUp)
   }
 
-  const studentTable = (
-    <KeyboardNavigableTable
-      ref={tableContainerRef}
-      rowKeys={currentStudentRows.map((student) => student.student_id)}
-      selectedKey={selectedStudentId}
-      onSelectKey={setSelectedStudentId}
-      onDeselect={() => setSelectedStudentId(null)}
-    >
-      <TableCard chrome="flush">
-        {selectedAssignmentLoading ? (
-          <div className="flex justify-center py-10">
-            <Spinner />
-          </div>
-        ) : selectedAssignmentError || !selectedAssignmentData ? (
-          <div className="p-4 text-sm text-danger">
-            {selectedAssignmentError || 'Failed to load assignment'}
-          </div>
-        ) : (
-          <div className="relative">
-            {(isAutoGrading || isArtifactRepoAnalyzing || isReturning) && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface/70">
-                <div className="flex items-center gap-2 text-sm text-text-muted">
-                  <Spinner />
-                  <span>
-                    {isAutoGrading
-                      ? `Grading ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                      : isArtifactRepoAnalyzing
-                        ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                        : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
-                  </span>
-                </div>
-              </div>
-            )}
-            <DataTable density={showOverviewInspector ? 'tight' : 'compact'}>
-              <DataTableHead>
-                <DataTableRow>
-                  <DataTableHeaderCell className="w-10">
-                    <input
-                      type="checkbox"
-                      checked={batchAllSelected}
-                      onChange={batchToggleSelectAll}
-                      onClick={(e) => e.stopPropagation()}
-                      className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                      aria-label="Select all students"
-                    />
-                  </DataTableHeaderCell>
-                  <SortableHeaderCell
-                    label="First Name"
-                    isActive={sortColumn === 'first'}
-                    direction={sortDirection}
-                    onClick={() => toggleSort('first')}
-                    className="w-[7rem]"
-                  />
-                  <SortableHeaderCell
-                    label="Last Name"
-                    isActive={sortColumn === 'last'}
-                    direction={sortDirection}
-                    onClick={() => toggleSort('last')}
-                    className="w-[7rem]"
-                  />
-                  <SortableHeaderCell
-                    label="Status"
-                    isActive={sortColumn === 'status'}
-                    direction={sortDirection}
-                    onClick={() => toggleSort('status')}
-                    className="w-[4.5rem]"
-                  />
-                  <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
-                  <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
-                </DataTableRow>
-              </DataTableHead>
-              <DataTableBody>
-                {sortedStudents.map((student) => {
-                  const isSelected = selectedStudentId === student.student_id
-                  const totalScore =
-                    student.doc?.score_completion != null &&
-                    student.doc?.score_thinking != null &&
-                    student.doc?.score_workflow != null
-                      ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
-                      : null
-                  const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
-                    graded_at: student.doc.graded_at ?? null,
-                    score_completion: student.doc.score_completion ?? null,
-                    score_thinking: student.doc.score_thinking ?? null,
-                    score_workflow: student.doc.score_workflow ?? null,
-                  } : null)
-                  const wasLate = !!(
-                    student.doc?.submitted_at &&
-                    dueAtMs &&
-                    new Date(student.doc.submitted_at).getTime() > dueAtMs
-                  )
+  function handleOverviewInspectorResizeReset() {
+    updateModeLayout('overview', (current) => ({
+      ...current,
+      inspectorCollapsed: false,
+      inspectorWidth: 50,
+    }))
+  }
 
-                  return (
-                    <DataTableRow
-                      key={student.student_id}
-                      className={getRowClassName(isSelected)}
-                      onClick={() => {
-                        setSelectedStudentId(isSelected ? null : student.student_id)
-                        setAssignmentWorkspaceMode('overview')
-                      }}
-                    >
-                      <DataTableCell>
-                        <input
-                          type="checkbox"
-                          checked={batchSelectedIds.has(student.student_id)}
-                          onChange={() => batchToggleSelect(student.student_id)}
-                          onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                          aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
-                        />
-                      </DataTableCell>
-                      <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
-                        {student.student_first_name ? (
-                          <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
-                            <span>{student.student_first_name}</span>
-                          </Tooltip>
-                        ) : '—'}
-                      </DataTableCell>
-                      <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
-                        {student.student_last_name ? (
-                          <Tooltip content={student.student_last_name}>
-                            <span>{student.student_last_name}</span>
-                          </Tooltip>
-                        ) : '—'}
-                      </DataTableCell>
-                      <DataTableCell className="w-[4.5rem]">
-                        <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                          <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                            <StatusIcon
-                              status={student.status}
-                              wasLate={wasLate}
-                              hasDraftGrade={hasDraftGrade}
-                            />
-                          </span>
-                        </Tooltip>
-                      </DataTableCell>
-                      <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
-                        {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
-                      </DataTableCell>
-                      <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
-                        <AssignmentArtifactsCell
-                          artifacts={student.artifacts || []}
-                          isCompact={showOverviewInspector}
-                        />
-                      </DataTableCell>
-                    </DataTableRow>
-                  )
-                })}
-                {sortedStudents.length === 0 && (
-                  <EmptyStateRow colSpan={6} message="No students enrolled" />
-                )}
-              </DataTableBody>
-            </DataTable>
+  const studentTable = (
+    <div className="flex h-full min-h-0 flex-col">
+      {assignmentWorkspaceMode === 'overview' && (
+        <div className="border-b border-border bg-surface px-3 py-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
+              <SplitButton
+                label={
+                  <span className="inline-flex items-center gap-2">
+                    <Check className="h-4 w-4" aria-hidden="true" />
+                    <span>AI Grade</span>
+                  </span>
+                }
+                onPrimaryClick={() => {
+                  void handleBatchAutoGrade()
+                }}
+                options={[
+                  {
+                    id: 'repo-analysis',
+                    label: (
+                      <span className="inline-flex items-center gap-2">
+                        <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                        <span>Repo analysis</span>
+                      </span>
+                    ),
+                    onSelect: () => {
+                      void handleBatchArtifactRepoAnalyze()
+                    },
+                    disabled: isArtifactRepoAnalyzing || isReadOnly || batchSelectedCount === 0,
+                  },
+                ]}
+                disabled={isAutoGrading || isReadOnly || batchSelectedCount === 0}
+                className="inline-flex"
+                toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+                menuPlacement="down"
+                primaryButtonProps={{
+                  'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+                }}
+              />
+            </Tooltip>
+
+            <Tooltip content={`Send${workspaceActionLabelSuffix}`}>
+              <Button
+                type="button"
+                variant="subtle"
+                size="sm"
+                className="px-4"
+                onClick={() => {
+                  setShowReturnConfirm(true)
+                }}
+                disabled={isReturning || isReadOnly || batchSelectedCount === 0}
+                aria-label={`Send${workspaceActionLabelSuffix}`}
+              >
+                <Send className="h-4 w-4" aria-hidden="true" />
+                <span>Send</span>
+              </Button>
+            </Tooltip>
           </div>
-        )}
-      </TableCard>
-    </KeyboardNavigableTable>
+        </div>
+      )}
+
+      <KeyboardNavigableTable
+        ref={tableContainerRef}
+        rowKeys={currentStudentRows.map((student) => student.student_id)}
+        selectedKey={selectedStudentId}
+        onSelectKey={setSelectedStudentId}
+        onDeselect={() => setSelectedStudentId(null)}
+      >
+        <TableCard chrome="flush">
+          {selectedAssignmentLoading ? (
+            <div className="flex justify-center py-10">
+              <Spinner />
+            </div>
+          ) : selectedAssignmentError || !selectedAssignmentData ? (
+            <div className="p-4 text-sm text-danger">
+              {selectedAssignmentError || 'Failed to load assignment'}
+            </div>
+          ) : (
+            <div className="relative">
+              {(isAutoGrading || isArtifactRepoAnalyzing || isReturning) && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface/70">
+                  <div className="flex items-center gap-2 text-sm text-text-muted">
+                    <Spinner />
+                    <span>
+                      {isAutoGrading
+                        ? `Grading ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+                        : isArtifactRepoAnalyzing
+                          ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+                          : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
+                    </span>
+                  </div>
+                </div>
+              )}
+              <DataTable density={showOverviewInspector ? 'tight' : 'compact'}>
+                <DataTableHead>
+                  <DataTableRow>
+                    <DataTableHeaderCell className="w-10">
+                      <input
+                        type="checkbox"
+                        checked={batchAllSelected}
+                        onChange={batchToggleSelectAll}
+                        onClick={(e) => e.stopPropagation()}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                        aria-label="Select all students"
+                      />
+                    </DataTableHeaderCell>
+                    <SortableHeaderCell
+                      label="First Name"
+                      isActive={sortColumn === 'first'}
+                      direction={sortDirection}
+                      onClick={() => toggleSort('first')}
+                      className="w-[7rem]"
+                    />
+                    <SortableHeaderCell
+                      label="Last Name"
+                      isActive={sortColumn === 'last'}
+                      direction={sortDirection}
+                      onClick={() => toggleSort('last')}
+                      className="w-[7rem]"
+                    />
+                    <SortableHeaderCell
+                      label="Status"
+                      isActive={sortColumn === 'status'}
+                      direction={sortDirection}
+                      onClick={() => toggleSort('status')}
+                      className="w-[4.5rem]"
+                    />
+                    <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
+                    <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {sortedStudents.map((student) => {
+                    const isSelected = selectedStudentId === student.student_id
+                    const totalScore =
+                      student.doc?.score_completion != null &&
+                      student.doc?.score_thinking != null &&
+                      student.doc?.score_workflow != null
+                        ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
+                        : null
+                    const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
+                      graded_at: student.doc.graded_at ?? null,
+                      score_completion: student.doc.score_completion ?? null,
+                      score_thinking: student.doc.score_thinking ?? null,
+                      score_workflow: student.doc.score_workflow ?? null,
+                    } : null)
+                    const wasLate = !!(
+                      student.doc?.submitted_at &&
+                      dueAtMs &&
+                      new Date(student.doc.submitted_at).getTime() > dueAtMs
+                    )
+
+                    return (
+                      <DataTableRow
+                        key={student.student_id}
+                        className={getRowClassName(isSelected)}
+                        onClick={() => {
+                          setSelectedStudentId(isSelected ? null : student.student_id)
+                          setAssignmentWorkspaceMode('overview')
+                        }}
+                      >
+                        <DataTableCell>
+                          <input
+                            type="checkbox"
+                            checked={batchSelectedIds.has(student.student_id)}
+                            onChange={() => batchToggleSelect(student.student_id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
+                          />
+                        </DataTableCell>
+                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                          {student.student_first_name ? (
+                            <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
+                              <span>{student.student_first_name}</span>
+                            </Tooltip>
+                          ) : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                          {student.student_last_name ? (
+                            <Tooltip content={student.student_last_name}>
+                              <span>{student.student_last_name}</span>
+                            </Tooltip>
+                          ) : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[4.5rem]">
+                          <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                            <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                              <StatusIcon
+                                status={student.status}
+                                wasLate={wasLate}
+                                hasDraftGrade={hasDraftGrade}
+                              />
+                            </span>
+                          </Tooltip>
+                        </DataTableCell>
+                        <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
+                          {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
+                          <AssignmentArtifactsCell
+                            artifacts={student.artifacts || []}
+                            isCompact={showOverviewInspector}
+                          />
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
+                  {sortedStudents.length === 0 && (
+                    <EmptyStateRow colSpan={6} message="No students enrolled" />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </div>
+          )}
+        </TableCard>
+      </KeyboardNavigableTable>
+    </div>
   )
 
   const primaryButtons =
@@ -1088,14 +1156,14 @@ export function TeacherClassroomView({
       </button>
     ) : (
       <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2 sm:min-h-[2.75rem]">
-        <div className="relative z-10 inline-flex items-end gap-1 self-end">
+        <div className="mb-[-1px] flex border-b border-border self-end">
           <button
             type="button"
             className={[
-              WORKSPACE_TAB_BASE_CLASSNAME,
               assignmentWorkspaceMode === 'overview'
-                ? '-mb-px border-border border-b-transparent bg-surface text-text-default shadow-sm'
-                : 'border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:border-border hover:text-text-default',
+              'border-b-2 -mb-px px-4 py-2 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('overview')}
             aria-pressed={assignmentWorkspaceMode === 'overview'}
@@ -1105,11 +1173,11 @@ export function TeacherClassroomView({
           <button
             type="button"
             className={[
-              WORKSPACE_TAB_BASE_CLASSNAME,
               assignmentWorkspaceMode === 'details'
-                ? '-mb-px border-border border-b-transparent bg-surface text-text-default shadow-sm'
-                : 'border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-surface-2 hover:text-text-muted' : '',
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:border-border hover:text-text-default',
+              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:border-transparent hover:text-text-muted' : '',
+              'border-b-2 -mb-px px-4 py-2 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('details')}
             aria-pressed={assignmentWorkspaceMode === 'details'}
@@ -1120,15 +1188,6 @@ export function TeacherClassroomView({
         </div>
 
         <div className="flex min-w-0 flex-1 items-center gap-3 self-center">
-          <div className="flex min-w-0 shrink items-center gap-2 sm:max-w-[28rem]">
-            <span
-              className="truncate text-sm font-semibold text-text-default"
-              title={selectedAssignmentTitle}
-            >
-              {selectedAssignmentTitle}
-            </span>
-          </div>
-
           {workspaceLoading && (
             <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
               <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
@@ -1141,7 +1200,7 @@ export function TeacherClassroomView({
           <Tooltip content="Edit assignment">
             <button
               type="button"
-              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+              className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex max-w-[22rem] items-center gap-2`}
               onClick={() => {
                 if (selectedAssignmentData) {
                   setEditAssignment(selectedAssignmentData.assignment)
@@ -1149,79 +1208,12 @@ export function TeacherClassroomView({
               }}
               disabled={!canEditAssignment}
               aria-label="Edit assignment"
+              title={selectedAssignmentTitle}
             >
-              <Pencil className="h-4 w-4" aria-hidden="true" />
+              <span className="truncate">{selectedAssignmentTitle}</span>
+              <Pencil className="h-4 w-4 shrink-0" aria-hidden="true" />
             </button>
           </Tooltip>
-
-          <Tooltip content={`Repo analysis${workspaceActionLabelSuffix}`}>
-            <button
-              type="button"
-              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-              onClick={() => {
-                void handleBatchArtifactRepoAnalyze()
-              }}
-              disabled={isArtifactRepoAnalyzing || isReadOnly || batchSelectedCount === 0}
-              aria-label={`Repo analysis${workspaceActionLabelSuffix}`}
-            >
-              <BarChart3 className="h-4 w-4" aria-hidden="true" />
-            </button>
-          </Tooltip>
-
-          <Tooltip content={`Grading${workspaceActionLabelSuffix}`}>
-            <button
-              type="button"
-              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-              onClick={() => {
-                void handleBatchAutoGrade()
-              }}
-              disabled={isAutoGrading || isReadOnly || batchSelectedCount === 0}
-              aria-label={`Grading${workspaceActionLabelSuffix}`}
-            >
-              <Check className="h-4 w-4" aria-hidden="true" />
-            </button>
-          </Tooltip>
-
-          <Tooltip content={`Send${workspaceActionLabelSuffix}`}>
-            <button
-              type="button"
-              className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-              onClick={() => {
-                setShowReturnConfirm(true)
-              }}
-              disabled={isReturning || isReadOnly || batchSelectedCount === 0}
-              aria-label={`Send${workspaceActionLabelSuffix}`}
-            >
-              <Send className="h-4 w-4" aria-hidden="true" />
-            </button>
-          </Tooltip>
-
-          {selectedStudentId && (
-            <>
-              <Tooltip content="Previous student">
-                <button
-                  type="button"
-                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                  onClick={handleGoPrevStudent}
-                  disabled={!canGoPrevStudent}
-                  aria-label="Previous student"
-                >
-                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </Tooltip>
-              <Tooltip content="Next student">
-                <button
-                  type="button"
-                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                  onClick={handleGoNextStudent}
-                  disabled={!canGoNextStudent}
-                  aria-label="Next student"
-                >
-                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </Tooltip>
-            </>
-          )}
         </div>
       </div>
     )
@@ -1315,6 +1307,10 @@ export function TeacherClassroomView({
                     totalWidth={workspaceWidth}
                     onLayoutChange={(next) => updateModeLayout('details', next)}
                     onLoadingStateChange={setWorkspaceLoading}
+                    onGoPrevStudent={handleGoPrevStudent}
+                    onGoNextStudent={handleGoNextStudent}
+                    canGoPrevStudent={canGoPrevStudent}
+                    canGoNextStudent={canGoNextStudent}
                   />
                 ) : selectedAssignmentLoading ? (
                   <div className="flex flex-1 items-center justify-center py-12">
@@ -1341,6 +1337,7 @@ export function TeacherClassroomView({
                       aria-label="Resize table and grading panes"
                       className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
                       onPointerDown={handleOverviewInspectorResizeStart}
+                      onDoubleClick={handleOverviewInspectorResizeReset}
                     >
                       <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
                     </div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -766,6 +766,8 @@ export function TeacherClassroomView({
   }, [classroom.id, currentStudentRows, selectedStudentId, selection])
 
   const handleSwitchWorkspaceMode = useCallback((nextMode: AssignmentWorkspaceMode) => {
+    if (nextMode === assignmentWorkspaceMode) return
+
     if (nextMode === 'details') {
       const nextStudentId = resolveDetailsStudentId()
       if (nextStudentId) {
@@ -773,8 +775,14 @@ export function TeacherClassroomView({
       }
     }
 
+    updateModeLayout(nextMode, assignmentGradingLayout[assignmentWorkspaceMode])
     setAssignmentWorkspaceMode(nextMode)
-  }, [resolveDetailsStudentId])
+  }, [
+    assignmentGradingLayout,
+    assignmentWorkspaceMode,
+    resolveDetailsStudentId,
+    updateModeLayout,
+  ])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
@@ -1221,14 +1229,20 @@ export function TeacherClassroomView({
   const showMobileToggle = selection.mode === 'summary'
 
   return (
-    <PageLayout>
+    <PageLayout className="flex h-full min-h-0 flex-col">
       <PageActionBar
         primary={primaryButtons}
         actions={[]}
         trailing={showMobileToggle ? <RightSidebarToggle /> : undefined}
       />
 
-      <PageContent className={selection.mode === 'summary' ? 'space-y-3' : 'space-y-3 pt-0'}>
+      <PageContent
+        className={
+          selection.mode === 'summary'
+            ? 'flex flex-col gap-3'
+            : 'flex min-h-0 flex-1 flex-col gap-3 pt-0'
+        }
+      >
         {error && (
           <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {error}
@@ -1284,8 +1298,11 @@ export function TeacherClassroomView({
             )}
           </div>
         ) : (
-          <div className="overflow-hidden rounded-b-lg border border-border bg-surface">
-            <div ref={workspaceContainerRef} className="flex min-h-[65vh] flex-col overflow-hidden">
+          <div className="flex min-h-0 flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
+            <div
+              ref={workspaceContainerRef}
+              className="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+            >
               {assignmentWorkspaceMode === 'details' ? (
                 selectedStudentId ? (
                   <TeacherStudentWorkPanel
@@ -1313,7 +1330,7 @@ export function TeacherClassroomView({
                   </div>
                 )
               ) : showOverviewInspector ? (
-                <div className="flex min-h-[65vh] flex-col lg:flex-row">
+                <div className="flex h-full min-h-0 flex-col lg:flex-row">
                   <div className="min-h-0 flex-1 overflow-hidden">
                     {studentTable}
                   </div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -134,7 +134,7 @@ function isScheduledAssignment(assignment: Assignment): boolean {
 
 function getRowClassName(isSelected: boolean): string {
   if (isSelected) {
-    return 'cursor-pointer bg-info-bg border-l-2 border-l-blue-500'
+    return 'cursor-pointer border-l-2 border-l-primary bg-surface-selected shadow-sm'
   }
   return 'cursor-pointer hover:bg-surface-hover'
 }
@@ -1339,9 +1339,11 @@ export function TeacherClassroomView({
                       role="separator"
                       aria-orientation="vertical"
                       aria-label="Resize table and grading panes"
-                      className="hidden w-2 shrink-0 cursor-col-resize border-l border-r border-border bg-surface-2 lg:block"
+                      className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
                       onPointerDown={handleOverviewInspectorResizeStart}
-                    />
+                    >
+                      <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+                    </div>
                   )}
                   <div
                     className="min-h-0 border-t border-border bg-surface lg:border-t-0"

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -270,7 +270,7 @@ export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable
       ref={ref}
       tabIndex={0}
       onKeyDown={handleKeyDown}
-      className="rounded-card outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      className="rounded-card outline-none"
     >
       {children}
     </div>

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useRef } from 'react'
+import { formatInTimeZone } from 'date-fns-tz'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
@@ -279,6 +280,16 @@ export function TeacherStudentWorkPanel({
               <span>{characterCount} chars</span>
             </div>
           </div>
+          {previewEntry && (
+            <div className="mt-1 text-xs font-medium text-primary">
+              Previewing save from{' '}
+              {formatInTimeZone(
+                new Date(previewEntry.created_at),
+                'America/Toronto',
+                'MMM d, h:mm a',
+              )}
+            </div>
+          )}
         </div>
         {displayContent && !isEmpty(displayContent) ? (
           <div className="min-h-0 flex-1 overflow-auto">
@@ -296,9 +307,11 @@ export function TeacherStudentWorkPanel({
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize content and grading panes"
-          className="hidden w-2 shrink-0 cursor-col-resize border-l border-r border-border bg-surface-2 lg:block"
+          className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
           onPointerDown={handleInspectorResizeStart}
-        />
+        >
+          <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+        </div>
       )}
 
       {!layout.inspectorCollapsed && (

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
-import { HistoryList } from '@/components/HistoryList'
-import { Button, SplitButton, Tooltip } from '@/ui'
+import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
+import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -12,162 +12,8 @@ import {
   type AssignmentWorkspacePaneLayout,
 } from '@/lib/assignment-grading-layout'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
-import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
-import { formatInTimeZone } from 'date-fns-tz'
-import { TEACHER_GRADE_UPDATED_EVENT, type TeacherGradeUpdatedEventDetail } from '@/lib/events'
-import type {
-  Assignment,
-  AssignmentDoc,
-  AssignmentDocHistoryEntry,
-  AssignmentFeedbackEntry,
-  AssignmentRepoReviewResult,
-  AssignmentRepoTarget,
-  AssignmentRepoTargetSelectionMode,
-  AssignmentRepoTargetValidationStatus,
-  AssignmentStatus,
-  AuthenticityFlag,
-  TiptapContent,
-} from '@/types'
-import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useWindowSize } from '@/hooks/use-window-size'
-import { readCookie, writeCookie } from '@/lib/cookies'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
-
-function AuthenticityGauge({ score, flags }: { score: number | null; flags: AuthenticityFlag[] }) {
-  const hasScore = score !== null
-  const displayScore = score ?? 0
-  const color = !hasScore ? 'bg-gray-300' : displayScore >= 70 ? 'bg-green-500' : displayScore >= 40 ? 'bg-yellow-500' : 'bg-red-500'
-  const textColor = !hasScore ? 'text-text-muted' : displayScore >= 70 ? 'text-green-700' : displayScore >= 40 ? 'text-yellow-700' : 'text-red-700'
-
-  const bar = (
-    <div className="relative h-5 overflow-hidden rounded-full bg-gray-200">
-      {hasScore && (
-        <div className={`h-full rounded-full ${color}`} style={{ width: `${displayScore}%` }} />
-      )}
-      <span className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${hasScore ? textColor : 'text-text-muted'}`}>
-        Authenticity {hasScore ? `${displayScore}%` : '—'}
-      </span>
-    </div>
-  )
-
-  if (flags.length === 0) return bar
-
-  return (
-    <Tooltip
-      content={
-        <div className="space-y-1 py-0.5">
-          {flags.map((flag, i) => (
-            <div key={i}>
-              {flag.reason === 'paste'
-                ? `${flag.wordDelta} words pasted`
-                : `${flag.wordDelta} words in ${flag.seconds}s (${Math.round(flag.wps * 60)} wpm)`}
-            </div>
-          ))}
-        </div>
-      }
-    >
-      <div>{bar}</div>
-    </Tooltip>
-  )
-}
-
-function RepoMetricBar({ label, value }: { label: string; value: number }) {
-  const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
-
-  return (
-    <div className="relative h-6 overflow-hidden rounded-full border border-border bg-surface-2">
-      <div className="absolute inset-y-0 left-0 rounded-full bg-primary transition-[width]" style={{ width: `${percentage}%` }} />
-      <div className="absolute inset-0 z-10 flex items-center justify-between px-3 text-[10px] font-semibold leading-none">
-        <span className="text-text-default">{label}</span>
-        <span className="text-text-default">{percentage}%</span>
-      </div>
-    </div>
-  )
-}
-
-function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: string | null | undefined) {
-  const base = (baseDraft ?? '').trim()
-  const suggestion = (aiSuggestion ?? '').trim()
-
-  if (!suggestion) return { value: baseDraft ?? '', hasFreshAI: false }
-  if (!base) return { value: suggestion, hasFreshAI: true }
-  if (base.includes(suggestion)) return { value: baseDraft ?? base, hasFreshAI: false }
-
-  return { value: `${suggestion}\n\n${base}`, hasFreshAI: true }
-}
-
-function ScoreInput({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
-  const quickScores = Array.from({ length: 11 }, (_, i) => i)
-  const n = Number(value)
-  const selected = Number.isInteger(n) && n >= 0 && n <= 10 ? n : null
-
-  return (
-    <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_2.25rem] items-center gap-x-1.5">
-      <label
-        className={[
-          'whitespace-nowrap text-[11px] font-medium text-text-muted',
-          label === 'Completion' ? 'pr-2' : 'pr-1',
-        ].join(' ')}
-      >
-        {label}
-      </label>
-      <div className="flex min-w-0 items-center justify-start gap-0">
-        {quickScores.map((score) => {
-          const isActive = selected === score
-          return (
-            <Tooltip key={score} content={score} delayDuration={0} side="top">
-              <button
-                type="button"
-                onClick={() => onChange(String(score))}
-                className={[
-                  'inline-flex h-6 w-[clamp(0.5rem,calc(100%/11),1.5rem)] flex-none items-center justify-center rounded border px-0 text-[10px] font-semibold leading-none transition-colors',
-                  isActive
-                    ? 'border-primary bg-primary text-text-inverse'
-                    : 'border-border bg-surface text-text-default hover:bg-surface-hover',
-                ].join(' ')}
-                aria-label={`Set ${label} score to ${score}`}
-                aria-pressed={isActive}
-              >
-                {''}
-              </button>
-            </Tooltip>
-          )
-        })}
-      </div>
-      <input
-        type="number"
-        min={0}
-        max={10}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="h-6 w-9 justify-self-end rounded border border-border bg-surface px-1 py-0.5 text-center text-xs font-medium text-text-default [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        aria-label={`${label} score`}
-      />
-    </div>
-  )
-}
-
-interface StudentWorkData {
-  assignment: Assignment
-  classroom: { id: string; title: string }
-  student: { id: string; email: string; name: string | null }
-  doc: AssignmentDoc | null
-  status: AssignmentStatus
-  feedback_entries: AssignmentFeedbackEntry[]
-  repo_target: {
-    target: AssignmentRepoTarget | null
-    submittedRepoUrl: string | null
-    submittedGitHubUsername: string | null
-    effectiveRepoUrl: string | null
-    effectiveGitHubUsername: string | null
-    repoOwner: string | null
-    repoName: string | null
-    selectionMode: AssignmentRepoTargetSelectionMode
-    validationStatus: AssignmentRepoTargetValidationStatus
-    validationMessage: string | null
-    latest_result: AssignmentRepoReviewResult | null
-  }
-}
 
 interface TeacherStudentWorkPanelProps {
   classroomId: string
@@ -185,322 +31,6 @@ interface TeacherStudentWorkPanelProps {
   onLoadingStateChange?: (loading: boolean) => void
 }
 
-type RightTab = 'history' | 'grading'
-type GradeSaveMode = 'draft' | 'graded'
-const RIGHT_TAB_COOKIE_PREFIX = 'pika_teacher_student_work_tab'
-
-function getRightTabCookieName(classroomId: string) {
-  return `${RIGHT_TAB_COOKIE_PREFIX}:${classroomId}`
-}
-
-function WorkspaceInspector({
-  historyEntries,
-  historyLoading,
-  historyError,
-  previewEntry,
-  onEntryClick,
-  onEntryHover,
-  onMouseLeave,
-  isPreviewLocked,
-  onExitPreview,
-  rightTab,
-  onRightTabChange,
-  data,
-  gradeError,
-  repoReviewResult,
-  scoreCompletion,
-  setScoreCompletion,
-  scoreThinking,
-  setScoreThinking,
-  scoreWorkflow,
-  setScoreWorkflow,
-  totalPercent,
-  totalScore,
-  feedbackEntries,
-  feedbackDraft,
-  hasFreshAIDraft,
-  setFeedbackDraft,
-  onAIDraftAcknowledge,
-  autoGrading,
-  feedbackReturning,
-  gradeSaving,
-  repoAnalyzing,
-  handleAutoGrade,
-  handleReturnFeedback,
-  handleSaveGrade,
-  handleAnalyzeRepo,
-}: {
-  historyEntries: AssignmentDocHistoryEntry[]
-  historyLoading: boolean
-  historyError: string
-  previewEntry: AssignmentDocHistoryEntry | null
-  onEntryClick: (entry: AssignmentDocHistoryEntry) => void
-  onEntryHover: (entry: AssignmentDocHistoryEntry) => void
-  onMouseLeave: () => void
-  isPreviewLocked: boolean
-  onExitPreview: () => void
-  rightTab: RightTab
-  onRightTabChange: (tab: RightTab) => void
-  data: StudentWorkData
-  gradeError: string
-  repoReviewResult: AssignmentRepoReviewResult | null
-  scoreCompletion: string
-  setScoreCompletion: (value: string) => void
-  scoreThinking: string
-  setScoreThinking: (value: string) => void
-  scoreWorkflow: string
-  setScoreWorkflow: (value: string) => void
-  totalPercent: number
-  totalScore: number
-  feedbackEntries: AssignmentFeedbackEntry[]
-  feedbackDraft: string
-  hasFreshAIDraft: boolean
-  setFeedbackDraft: (value: string) => void
-  onAIDraftAcknowledge: () => void
-  autoGrading: boolean
-  feedbackReturning: boolean
-  gradeSaving: boolean
-  repoAnalyzing: boolean
-  handleAutoGrade: () => Promise<void>
-  handleReturnFeedback: () => Promise<void>
-  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
-  handleAnalyzeRepo: () => Promise<void>
-}) {
-  return (
-    <div
-      data-testid="grading-inspector-pane"
-      className="flex min-h-0 flex-col border-border bg-surface lg:border-l"
-    >
-      <div className="flex border-b border-border">
-        <button
-          type="button"
-          className={`flex-1 px-3 py-2 text-xs font-medium ${
-            rightTab === 'history'
-              ? 'border-b-2 border-primary text-primary'
-              : 'text-text-muted hover:text-text-default'
-          }`}
-          onClick={() => onRightTabChange('history')}
-        >
-          History
-        </button>
-        <button
-          type="button"
-          className={`flex-1 px-3 py-2 text-xs font-medium ${
-            rightTab === 'grading'
-              ? 'border-b-2 border-primary text-primary'
-              : 'text-text-muted hover:text-text-default'
-          }`}
-          onClick={() => onRightTabChange('grading')}
-        >
-          Grading
-        </button>
-      </div>
-
-      {rightTab === 'history' ? (
-        <>
-          <div className="flex-1 min-h-0 overflow-y-auto" onMouseLeave={onMouseLeave}>
-            {historyLoading && historyEntries.length === 0 ? (
-              <div className="p-4 text-center">
-                <Spinner size="sm" />
-              </div>
-            ) : historyError ? (
-              <div className="p-3">
-                <p className="text-xs text-danger">{historyError}</p>
-              </div>
-            ) : historyEntries.length === 0 ? (
-              <div className="p-3">
-                <p className="text-xs text-text-muted">No saves yet</p>
-              </div>
-            ) : (
-              <HistoryList
-                entries={historyEntries}
-                activeEntryId={previewEntry?.id ?? null}
-                onEntryClick={onEntryClick}
-                onEntryHover={onEntryHover}
-              />
-            )}
-          </div>
-          {isPreviewLocked && previewEntry && (
-            <div className="border-t border-border px-3 py-2">
-              <Button onClick={onExitPreview} variant="secondary" size="sm" className="w-full">
-                Exit preview
-              </Button>
-            </div>
-          )}
-        </>
-      ) : (
-        <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3">
-          <AuthenticityGauge
-            score={data.doc?.authenticity_score ?? null}
-            flags={data.doc?.authenticity_flags ?? []}
-          />
-
-          {gradeError && (
-            <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
-              {gradeError}
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Repo Analysis</div>
-              <Button
-                size="sm"
-                onClick={() => {
-                  void handleAnalyzeRepo()
-                }}
-                disabled={
-                  repoAnalyzing ||
-                  !data.repo_target.effectiveRepoUrl ||
-                  !data.repo_target.effectiveGitHubUsername
-                }
-              >
-                {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
-              </Button>
-            </div>
-
-            {repoReviewResult && (
-              <div className="space-y-2">
-                <RepoMetricBar
-                  label="Contribution"
-                  value={repoReviewResult.relative_contribution_share || 0}
-                />
-                <RepoMetricBar
-                  label="Consistency"
-                  value={repoReviewResult.spread_score || 0}
-                />
-                <RepoMetricBar
-                  label="Iteration"
-                  value={repoReviewResult.iteration_score || 0}
-                />
-              </div>
-            )}
-          </div>
-
-          <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
-          <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
-          <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
-
-          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-1">
-            <span aria-hidden="true" />
-            <span
-              className={[
-                'inline-flex h-8 w-12 items-center justify-center justify-self-end rounded border text-sm font-medium',
-                totalPercent >= 80
-                  ? 'border-green-200 bg-green-100 text-green-700'
-                  : totalPercent >= 60
-                    ? 'border-yellow-200 bg-yellow-100 text-yellow-700'
-                    : totalPercent >= 50
-                      ? 'border-orange-200 bg-orange-100 text-orange-700'
-                      : 'border-red-200 bg-red-100 text-red-700',
-              ].join(' ')}
-            >
-              {totalPercent}%
-            </span>
-            <div className="flex items-center justify-self-end gap-1">
-              <span className="text-xs text-text-muted">30</span>
-              <span className="inline-flex h-8 w-12 items-center justify-center rounded border border-border bg-surface text-sm font-medium text-text-default">
-                {totalScore}
-              </span>
-            </div>
-          </div>
-
-          {feedbackEntries.length > 0 && (
-            <div className="space-y-2">
-              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Returned Feedback</div>
-              <div className="rounded border border-border bg-surface p-3">
-                <div className="space-y-3">
-                  {feedbackEntries.map((entry, index) => (
-                    <div key={entry.id} className={index > 0 ? 'border-t border-border pt-3' : ''}>
-                      <div className="mb-1 text-[11px] font-medium text-text-muted">
-                        {formatInTimeZone(new Date(entry.returned_at), 'America/Toronto', 'MMM d, h:mm a')}
-                      </div>
-                      <div className="whitespace-pre-wrap text-sm text-text-default">{entry.body}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-1">
-            <div className="flex items-center gap-2">
-              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">Feedback Draft</div>
-              {hasFreshAIDraft && (
-                <span className="rounded-full border border-primary/40 bg-info-bg px-2 py-0.5 text-[11px] font-medium text-primary">
-                  AI draft
-                </span>
-              )}
-            </div>
-            <textarea
-              value={feedbackDraft}
-              onChange={(e) => setFeedbackDraft(e.target.value)}
-              onFocus={onAIDraftAcknowledge}
-              className={[
-                'min-h-[10rem] w-full resize-y rounded border px-2 py-1 text-sm text-text-default',
-                hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
-              ].join(' ')}
-              placeholder="Teacher feedback draft"
-            />
-          </div>
-
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              className="flex-1"
-              onClick={() => {
-                void handleAutoGrade()
-              }}
-              disabled={autoGrading}
-            >
-              {autoGrading ? 'Grading...' : 'AI grade'}
-            </Button>
-            <Button
-              size="sm"
-              variant="secondary"
-              className="flex-1"
-              onClick={() => {
-                void handleReturnFeedback()
-              }}
-              disabled={feedbackReturning || !feedbackDraft.trim()}
-            >
-              {feedbackReturning ? 'Returning...' : 'Return Feedback'}
-            </Button>
-            <SplitButton
-              label={gradeSaving ? 'Saving...' : 'Save'}
-              onPrimaryClick={() => {
-                void handleSaveGrade('graded')
-              }}
-              options={[
-                {
-                  id: 'draft',
-                  label: 'Draft',
-                  onSelect: () => {
-                    void handleSaveGrade('draft')
-                  },
-                },
-              ]}
-              size="sm"
-              className="flex-1"
-              disabled={gradeSaving}
-              toggleAriaLabel="Choose save mode"
-              primaryButtonProps={{ className: 'flex-1 justify-center' }}
-            />
-          </div>
-
-          {data.doc?.graded_at && (
-            <div className="shrink-0 text-xs text-text-muted">
-              Graded {formatInTimeZone(new Date(data.doc.graded_at), 'America/Toronto', 'MMM d, h:mm a')}
-              {data.doc.graded_by && ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
 export function TeacherStudentWorkPanel({
   classroomId,
   assignmentId,
@@ -513,34 +43,51 @@ export function TeacherStudentWorkPanel({
   onLoadingStateChange,
 }: TeacherStudentWorkPanelProps) {
   const workspaceRef = useRef<HTMLDivElement | null>(null)
-  const studentLoadRequestIdRef = useRef(0)
-  const historyLoadRequestIdRef = useRef(0)
-  const [data, setData] = useState<StudentWorkData | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-
-  const [historyEntries, setHistoryEntries] = useState<AssignmentDocHistoryEntry[]>([])
-  const [historyLoading, setHistoryLoading] = useState(false)
-  const [historyError, setHistoryError] = useState('')
-  const [previewEntry, setPreviewEntry] = useState<AssignmentDocHistoryEntry | null>(null)
-  const [previewContent, setPreviewContent] = useState<TiptapContent | null>(null)
-  const [lockedEntryId, setLockedEntryId] = useState<string | null>(null)
-  const rightTabCookieName = getRightTabCookieName(classroomId)
-
-  const [rightTab, setRightTab] = useState<RightTab>(() => (
-    readCookie(getRightTabCookieName(classroomId)) === 'grading' ? 'grading' : 'history'
-  ))
-  const [scoreCompletion, setScoreCompletion] = useState<string>('')
-  const [scoreThinking, setScoreThinking] = useState<string>('')
-  const [scoreWorkflow, setScoreWorkflow] = useState<string>('')
-  const [feedbackDraft, setFeedbackDraft] = useState<string>('')
-  const [hasFreshAIDraft, setHasFreshAIDraft] = useState(false)
-  const [gradeSaving, setGradeSaving] = useState(false)
-  const [gradeError, setGradeError] = useState('')
-  const [autoGrading, setAutoGrading] = useState(false)
-  const [feedbackReturning, setFeedbackReturning] = useState(false)
-  const [repoAnalyzing, setRepoAnalyzing] = useState(false)
-  const showInitialSpinner = useDelayedBusy(loading && !data)
+  const {
+    data,
+    error,
+    showInitialSpinner,
+    historyEntries,
+    historyLoading,
+    historyError,
+    previewEntry,
+    previewContent,
+    isPreviewLocked,
+    scoreCompletion,
+    scoreThinking,
+    scoreWorkflow,
+    feedbackDraft,
+    hasFreshAIDraft,
+    gradeSaving,
+    gradeError,
+    autoGrading,
+    feedbackReturning,
+    repoAnalyzing,
+    feedbackEntries,
+    repoReviewResult,
+    totalScore,
+    totalPercent,
+    expandedSections,
+    setScoreCompletion,
+    setScoreThinking,
+    setScoreWorkflow,
+    setFeedbackDraft,
+    handlePreviewHover,
+    handlePreviewLock,
+    handleExitPreview,
+    handleHistoryMouseLeave,
+    handleAIDraftAcknowledge,
+    toggleSection,
+    handleAutoGrade,
+    handleReturnFeedback,
+    handleSaveGrade,
+    handleAnalyzeRepo,
+  } = useTeacherStudentWorkController({
+    classroomId,
+    assignmentId,
+    studentId,
+    onLoadingStateChange,
+  })
   const { width: viewportWidth } = useWindowSize()
   const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
   const layout = useMemo(
@@ -567,355 +114,33 @@ export function TeacherStudentWorkPanel({
     [onLayoutChange],
   )
 
-  function dispatchGradeUpdated(doc: AssignmentDoc | null) {
-    const detail: TeacherGradeUpdatedEventDetail = {
-      assignmentId,
-      studentId,
-      doc,
-    }
-    window.dispatchEvent(new CustomEvent<TeacherGradeUpdatedEventDetail>(TEACHER_GRADE_UPDATED_EVENT, { detail }))
-  }
+  const handleInspectorResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!workspaceRef.current) return
 
-  function handleRightTabChange(nextTab: RightTab) {
-    setRightTab(nextTab)
-    writeCookie(rightTabCookieName, nextTab)
-  }
+      event.preventDefault()
+      const { right, width } = workspaceRef.current.getBoundingClientRect()
+      if (width <= 0) return
 
-  function updatePreview(entry: AssignmentDocHistoryEntry): boolean {
-    const oldestFirst = [...historyEntries].reverse()
-    const reconstructed = reconstructAssignmentDocContent(oldestFirst, entry.id)
-
-    if (reconstructed) {
-      setPreviewEntry(entry)
-      setPreviewContent(reconstructed)
-      return true
-    }
-
-    return false
-  }
-
-  function handlePreviewHover(entry: AssignmentDocHistoryEntry) {
-    if (lockedEntryId) return
-    updatePreview(entry)
-  }
-
-  function handlePreviewLock(entry: AssignmentDocHistoryEntry) {
-    const success = updatePreview(entry)
-    if (success) {
-      setLockedEntryId(entry.id)
-    }
-  }
-
-  function handleExitPreview() {
-    setPreviewEntry(null)
-    setPreviewContent(null)
-    setLockedEntryId(null)
-  }
-
-  function handleHistoryMouseLeave() {
-    if (lockedEntryId) return
-    handleExitPreview()
-  }
-
-  function handleInspectorResizeStart(event: React.PointerEvent<HTMLDivElement>) {
-    if (!workspaceRef.current) return
-
-    event.preventDefault()
-    const { right, width } = workspaceRef.current.getBoundingClientRect()
-    if (width <= 0) return
-
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
-      updateLayout((current) => ({
-        ...current,
-        inspectorCollapsed: false,
-        inspectorWidth: nextInspectorWidth,
-      }))
-    }
-
-    const handlePointerUp = () => {
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
-    }
-
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-  }
-
-  function populateGradeForm(doc: AssignmentDoc | null, mergeBaseDraft?: string | null) {
-    if (doc) {
-      setScoreCompletion(doc.score_completion?.toString() ?? '')
-      setScoreThinking(doc.score_thinking?.toString() ?? '')
-      setScoreWorkflow(doc.score_workflow?.toString() ?? '')
-      const baseDraft =
-        mergeBaseDraft ?? doc.teacher_feedback_draft ?? doc.feedback ?? ''
-      const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion)
-      setFeedbackDraft(mergedDraft.value)
-      setHasFreshAIDraft(mergedDraft.hasFreshAI)
-    } else {
-      setScoreCompletion('')
-      setScoreThinking('')
-      setScoreWorkflow('')
-      setFeedbackDraft('')
-      setHasFreshAIDraft(false)
-    }
-  }
-
-  const loadStudentWork = useCallback(async (options?: { mergeFeedbackIntoDraftFrom?: string | null }): Promise<StudentWorkData | null> => {
-    const requestId = ++studentLoadRequestIdRef.current
-    setLoading(true)
-    setError('')
-    setGradeError('')
-    handleExitPreview()
-
-    try {
-      const response = await fetch(`/api/teacher/assignments/${assignmentId}/students/${studentId}`)
-      const result = await response.json()
-      if (!response.ok) {
-        throw new Error(result.error || 'Failed to load student work')
-      }
-      if (requestId !== studentLoadRequestIdRef.current) {
-        return null
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
+        updateLayout((current) => ({
+          ...current,
+          inspectorCollapsed: false,
+          inspectorWidth: nextInspectorWidth,
+        }))
       }
 
-      setData(result)
-      populateGradeForm(result.doc, options?.mergeFeedbackIntoDraftFrom)
-      return result
-    } catch (err: any) {
-      if (requestId !== studentLoadRequestIdRef.current) {
-        return null
+      const handlePointerUp = () => {
+        window.removeEventListener('pointermove', handlePointerMove)
+        window.removeEventListener('pointerup', handlePointerUp)
       }
-      setError(err.message || 'Failed to load student work')
-      return null
-    } finally {
-      if (requestId === studentLoadRequestIdRef.current) {
-        setLoading(false)
-      }
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assignmentId, studentId])
 
-  useEffect(() => {
-    void loadStudentWork()
-  }, [loadStudentWork])
-
-  useEffect(() => {
-    const requestId = ++historyLoadRequestIdRef.current
-    setHistoryLoading(true)
-    setHistoryError('')
-
-    async function loadHistory() {
-      try {
-        const response = await fetch(
-          `/api/assignment-docs/${assignmentId}/history?student_id=${studentId}`,
-        )
-        const result = await response.json()
-        if (!response.ok) {
-          throw new Error(result.error || 'Failed to load history')
-        }
-        if (requestId !== historyLoadRequestIdRef.current) return
-        setHistoryEntries(result.history || [])
-      } catch (err: any) {
-        if (requestId !== historyLoadRequestIdRef.current) return
-        setHistoryError(err.message || 'Failed to load history')
-      } finally {
-        if (requestId === historyLoadRequestIdRef.current) {
-          setHistoryLoading(false)
-        }
-      }
-    }
-
-    void loadHistory()
-  }, [assignmentId, studentId])
-
-  useEffect(() => {
-    onLoadingStateChange?.(loading && !!data)
-  }, [data, loading, onLoadingStateChange])
-
-  useEffect(() => {
-    return () => {
-      onLoadingStateChange?.(false)
-    }
-  }, [onLoadingStateChange])
-
-  async function handleSaveGrade(selectedSaveMode: GradeSaveMode) {
-    if (!data) return
-    const sc = Number(scoreCompletion)
-    const st = Number(scoreThinking)
-    const sw = Number(scoreWorkflow)
-
-    if ([sc, st, sw].some((n) => !Number.isInteger(n) || n < 0 || n > 10)) {
-      setGradeError('Scores must be integers 0–10')
-      return
-    }
-
-    setGradeSaving(true)
-    setGradeError('')
-    const previousDoc = data.doc
-    const optimisticDoc: AssignmentDoc = {
-      ...(previousDoc || {
-        id: '',
-        assignment_id: assignmentId,
-        student_id: studentId,
-        content: { type: 'doc', content: [] },
-        repo_url: null,
-        github_username: null,
-        is_submitted: false,
-        submitted_at: null,
-        viewed_at: null,
-        score_completion: null,
-        score_thinking: null,
-        score_workflow: null,
-        feedback: null,
-        teacher_feedback_draft: null,
-        teacher_feedback_draft_updated_at: null,
-        feedback_returned_at: null,
-        ai_feedback_suggestion: null,
-        ai_feedback_suggested_at: null,
-        ai_feedback_model: null,
-        teacher_cleared_at: null,
-        graded_at: null,
-        graded_by: null,
-        returned_at: null,
-        authenticity_score: null,
-        authenticity_flags: null,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }),
-      score_completion: sc,
-      score_thinking: st,
-      score_workflow: sw,
-      teacher_feedback_draft: feedbackDraft,
-      teacher_feedback_draft_updated_at: new Date().toISOString(),
-      graded_at: selectedSaveMode === 'graded'
-        ? (previousDoc?.graded_at || new Date().toISOString())
-        : null,
-      graded_by: selectedSaveMode === 'graded'
-        ? (previousDoc?.graded_by || 'teacher')
-        : null,
-      updated_at: new Date().toISOString(),
-    }
-    setData((prev) => (prev ? { ...prev, doc: optimisticDoc } : prev))
-
-    try {
-      const res = await fetch(`/api/teacher/assignments/${assignmentId}/grade`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          student_id: studentId,
-          score_completion: sc,
-          score_thinking: st,
-          score_workflow: sw,
-          feedback: feedbackDraft,
-          save_mode: selectedSaveMode,
-        }),
-      })
-      const result = await res.json()
-      if (!res.ok) throw new Error(result.error || 'Failed to save grade')
-      setData((prev) => (prev ? { ...prev, doc: result.doc } : prev))
-      dispatchGradeUpdated(result.doc)
-    } catch (err: any) {
-      setData((prev) => (prev ? { ...prev, doc: previousDoc } : prev))
-      setGradeError(err.message || 'Failed to save grade')
-    } finally {
-      setGradeSaving(false)
-    }
-  }
-
-  async function handleAutoGrade() {
-    if (!data) return
-    setAutoGrading(true)
-    setGradeError('')
-    try {
-      const res = await fetch(`/api/teacher/assignments/${assignmentId}/auto-grade`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: [studentId] }),
-      })
-      const result = await res.json()
-      if (!res.ok) throw new Error(result.error || 'Auto-grade failed')
-      if (result.errors?.length) {
-        setGradeError(result.errors.join(', '))
-        return
-      }
-      if (result.graded_count === 0) {
-        setGradeError('No gradable content found — the submission may be empty')
-        return
-      }
-      const refreshed = await loadStudentWork({ mergeFeedbackIntoDraftFrom: feedbackDraft })
-      handleRightTabChange('grading')
-      dispatchGradeUpdated(refreshed?.doc ?? null)
-    } catch (err: any) {
-      setGradeError(err.message || 'Auto-grade failed')
-    } finally {
-      setAutoGrading(false)
-    }
-  }
-
-  async function handleReturnFeedback() {
-    if (!data) return
-    const trimmed = feedbackDraft.trim()
-    if (!trimmed) {
-      setGradeError('Feedback draft is required before returning feedback')
-      return
-    }
-
-    setFeedbackReturning(true)
-    setGradeError('')
-    try {
-      const res = await fetch(`/api/teacher/assignments/${assignmentId}/feedback-return`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          student_id: studentId,
-          feedback: trimmed,
-        }),
-      })
-      const result = await res.json()
-      if (!res.ok) throw new Error(result.error || 'Failed to return feedback')
-
-      setData((prev) => prev ? {
-        ...prev,
-        doc: result.doc,
-        feedback_entries: [...prev.feedback_entries, result.entry],
-      } : prev)
-      populateGradeForm(result.doc)
-      dispatchGradeUpdated(result.doc)
-    } catch (err: any) {
-      setGradeError(err.message || 'Failed to return feedback')
-    } finally {
-      setFeedbackReturning(false)
-    }
-  }
-
-  async function handleAnalyzeRepo() {
-    if (!data) return
-    setRepoAnalyzing(true)
-    setGradeError('')
-    try {
-      const res = await fetch(`/api/teacher/assignments/${assignmentId}/artifact-repo/run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: [studentId] }),
-      })
-      const result = await res.json()
-      if (!res.ok) throw new Error(result.error || 'Repo analysis failed')
-      const refreshed = await loadStudentWork()
-      dispatchGradeUpdated(refreshed?.doc ?? null)
-      if ((result.analyzed_students ?? 0) === 0 && result.skipped_reasons) {
-        const message = Object.entries(result.skipped_reasons as Record<string, number>)
-          .map(([reason, count]) => `${count} ${reason}`)
-          .join(' ')
-        if (message) {
-          setGradeError(message)
-        }
-      }
-    } catch (err: any) {
-      setGradeError(err.message || 'Repo analysis failed')
-    } finally {
-      setRepoAnalyzing(false)
-    }
-  }
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+    },
+    [updateLayout],
+  )
 
   if (showInitialSpinner) {
     return (
@@ -933,10 +158,7 @@ export function TeacherStudentWorkPanel({
     return <div className="p-4 text-sm text-text-muted">No data</div>
   }
 
-  const isPreviewLocked = lockedEntryId !== null
   const displayContent = previewContent || data.doc?.content
-  const repoReviewResult = data.repo_target?.latest_result || null
-  const feedbackEntries = data.feedback_entries || []
   const repoDisplayUrl =
     data.repo_target.submittedRepoUrl ||
     data.repo_target.effectiveRepoUrl ||
@@ -948,13 +170,8 @@ export function TeacherStudentWorkPanel({
     repoReviewResult?.github_login ||
     ''
   const studentDisplayName = data.student.name?.trim() || data.student.email
-  const characterCount = displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
-
-  const sc = Number(scoreCompletion) || 0
-  const st = Number(scoreThinking) || 0
-  const sw = Number(scoreWorkflow) || 0
-  const totalScore = sc + st + sw
-  const totalPercent = Math.round((totalScore / 30) * 100)
+  const characterCount =
+    displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
   const inspectorPaneStyle = layout.inspectorCollapsed
     ? undefined
     : isDesktop
@@ -964,46 +181,48 @@ export function TeacherStudentWorkPanel({
         } as const)
       : undefined
 
+  const inspector = (
+    <TeacherWorkInspector
+      data={data}
+      historyEntries={historyEntries}
+      historyLoading={historyLoading}
+      historyError={historyError}
+      previewEntry={previewEntry}
+      onEntryClick={handlePreviewLock}
+      onEntryHover={handlePreviewHover}
+      onHistoryMouseLeave={handleHistoryMouseLeave}
+      isPreviewLocked={isPreviewLocked}
+      onExitPreview={handleExitPreview}
+      repoReviewResult={repoReviewResult}
+      scoreCompletion={scoreCompletion}
+      setScoreCompletion={setScoreCompletion}
+      scoreThinking={scoreThinking}
+      setScoreThinking={setScoreThinking}
+      scoreWorkflow={scoreWorkflow}
+      setScoreWorkflow={setScoreWorkflow}
+      totalPercent={totalPercent}
+      totalScore={totalScore}
+      feedbackEntries={feedbackEntries}
+      feedbackDraft={feedbackDraft}
+      hasFreshAIDraft={hasFreshAIDraft}
+      setFeedbackDraft={setFeedbackDraft}
+      onAIDraftAcknowledge={handleAIDraftAcknowledge}
+      gradeError={gradeError}
+      autoGrading={autoGrading}
+      feedbackReturning={feedbackReturning}
+      gradeSaving={gradeSaving}
+      repoAnalyzing={repoAnalyzing}
+      expandedSections={expandedSections}
+      onToggleSection={toggleSection}
+      handleAutoGrade={handleAutoGrade}
+      handleReturnFeedback={handleReturnFeedback}
+      handleSaveGrade={handleSaveGrade}
+      handleAnalyzeRepo={handleAnalyzeRepo}
+    />
+  )
+
   if (mode === 'overview') {
-    return (
-      <WorkspaceInspector
-        historyEntries={historyEntries}
-        historyLoading={historyLoading}
-        historyError={historyError}
-        previewEntry={previewEntry}
-        onEntryClick={handlePreviewLock}
-        onEntryHover={handlePreviewHover}
-        onMouseLeave={handleHistoryMouseLeave}
-        isPreviewLocked={isPreviewLocked}
-        onExitPreview={handleExitPreview}
-        rightTab={rightTab}
-        onRightTabChange={handleRightTabChange}
-        data={data}
-        gradeError={gradeError}
-        repoReviewResult={repoReviewResult}
-        scoreCompletion={scoreCompletion}
-        setScoreCompletion={setScoreCompletion}
-        scoreThinking={scoreThinking}
-        setScoreThinking={setScoreThinking}
-        scoreWorkflow={scoreWorkflow}
-        setScoreWorkflow={setScoreWorkflow}
-        totalPercent={totalPercent}
-        totalScore={totalScore}
-        feedbackEntries={feedbackEntries}
-        feedbackDraft={feedbackDraft}
-        hasFreshAIDraft={hasFreshAIDraft}
-        setFeedbackDraft={setFeedbackDraft}
-        onAIDraftAcknowledge={() => setHasFreshAIDraft(false)}
-        autoGrading={autoGrading}
-        feedbackReturning={feedbackReturning}
-        gradeSaving={gradeSaving}
-        repoAnalyzing={repoAnalyzing}
-        handleAutoGrade={handleAutoGrade}
-        handleReturnFeedback={handleReturnFeedback}
-        handleSaveGrade={handleSaveGrade}
-        handleAnalyzeRepo={handleAnalyzeRepo}
-      />
-    )
+    return inspector
   }
 
   return (
@@ -1062,11 +281,9 @@ export function TeacherStudentWorkPanel({
           </div>
         </div>
         {displayContent && !isEmpty(displayContent) ? (
-          <>
-            <div className="min-h-0 flex-1 overflow-auto">
-              <RichTextViewer content={displayContent} fillHeight chrome="flush" />
-            </div>
-          </>
+          <div className="min-h-0 flex-1 overflow-auto">
+            <RichTextViewer content={displayContent} fillHeight chrome="flush" />
+          </div>
         ) : (
           <div className="flex h-32 items-center justify-center text-text-muted">
             No work submitted yet
@@ -1085,44 +302,11 @@ export function TeacherStudentWorkPanel({
       )}
 
       {!layout.inspectorCollapsed && (
-        <div className="flex min-h-0 flex-col border-t border-border bg-surface lg:border-t-0" style={inspectorPaneStyle}>
-          <WorkspaceInspector
-            historyEntries={historyEntries}
-            historyLoading={historyLoading}
-            historyError={historyError}
-            previewEntry={previewEntry}
-            onEntryClick={handlePreviewLock}
-            onEntryHover={handlePreviewHover}
-            onMouseLeave={handleHistoryMouseLeave}
-            isPreviewLocked={isPreviewLocked}
-            onExitPreview={handleExitPreview}
-            rightTab={rightTab}
-            onRightTabChange={handleRightTabChange}
-            data={data}
-            gradeError={gradeError}
-            repoReviewResult={repoReviewResult}
-            scoreCompletion={scoreCompletion}
-            setScoreCompletion={setScoreCompletion}
-            scoreThinking={scoreThinking}
-            setScoreThinking={setScoreThinking}
-            scoreWorkflow={scoreWorkflow}
-            setScoreWorkflow={setScoreWorkflow}
-            totalPercent={totalPercent}
-            totalScore={totalScore}
-            feedbackEntries={feedbackEntries}
-            feedbackDraft={feedbackDraft}
-            hasFreshAIDraft={hasFreshAIDraft}
-            setFeedbackDraft={setFeedbackDraft}
-            onAIDraftAcknowledge={() => setHasFreshAIDraft(false)}
-            autoGrading={autoGrading}
-            feedbackReturning={feedbackReturning}
-            gradeSaving={gradeSaving}
-            repoAnalyzing={repoAnalyzing}
-            handleAutoGrade={handleAutoGrade}
-            handleReturnFeedback={handleReturnFeedback}
-            handleSaveGrade={handleSaveGrade}
-            handleAnalyzeRepo={handleAnalyzeRepo}
-          />
+        <div
+          className="flex min-h-0 flex-col overflow-hidden border-t border-border bg-surface lg:border-t-0"
+          style={inspectorPaneStyle}
+        >
+          {inspector}
         </div>
       )}
     </div>

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -2,10 +2,12 @@
 
 import { useCallback, useMemo, useRef } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
+import { ACTIONBAR_ICON_BUTTON_CLASSNAME } from '@/components/PageLayout'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -30,6 +32,10 @@ interface TeacherStudentWorkPanelProps {
       | ((current: AssignmentWorkspacePaneLayout) => AssignmentWorkspacePaneLayout),
   ) => void
   onLoadingStateChange?: (loading: boolean) => void
+  onGoPrevStudent?: () => void
+  onGoNextStudent?: () => void
+  canGoPrevStudent?: boolean
+  canGoNextStudent?: boolean
 }
 
 export function TeacherStudentWorkPanel({
@@ -42,6 +48,10 @@ export function TeacherStudentWorkPanel({
   totalWidth = 0,
   onLayoutChange,
   onLoadingStateChange,
+  onGoPrevStudent,
+  onGoNextStudent,
+  canGoPrevStudent = false,
+  canGoNextStudent = false,
 }: TeacherStudentWorkPanelProps) {
   const workspaceRef = useRef<HTMLDivElement | null>(null)
   const {
@@ -59,9 +69,9 @@ export function TeacherStudentWorkPanel({
     scoreWorkflow,
     feedbackDraft,
     hasFreshAIDraft,
+    gradeMode,
     gradeSaving,
     gradeError,
-    autoGrading,
     feedbackReturning,
     repoAnalyzing,
     feedbackEntries,
@@ -79,9 +89,8 @@ export function TeacherStudentWorkPanel({
     handleHistoryMouseLeave,
     handleAIDraftAcknowledge,
     toggleSection,
-    handleAutoGrade,
     handleReturnFeedback,
-    handleSaveGrade,
+    handleSetGradeMode,
     handleAnalyzeRepo,
   } = useTeacherStudentWorkController({
     classroomId,
@@ -142,6 +151,14 @@ export function TeacherStudentWorkPanel({
     },
     [updateLayout],
   )
+
+  const handleInspectorResizeReset = useCallback(() => {
+    updateLayout((current) => ({
+      ...current,
+      inspectorCollapsed: false,
+      inspectorWidth: 50,
+    }))
+  }, [updateLayout])
 
   if (showInitialSpinner) {
     return (
@@ -208,16 +225,15 @@ export function TeacherStudentWorkPanel({
       hasFreshAIDraft={hasFreshAIDraft}
       setFeedbackDraft={setFeedbackDraft}
       onAIDraftAcknowledge={handleAIDraftAcknowledge}
+      gradeMode={gradeMode}
       gradeError={gradeError}
-      autoGrading={autoGrading}
       feedbackReturning={feedbackReturning}
       gradeSaving={gradeSaving}
       repoAnalyzing={repoAnalyzing}
       expandedSections={expandedSections}
       onToggleSection={toggleSection}
-      handleAutoGrade={handleAutoGrade}
       handleReturnFeedback={handleReturnFeedback}
-      handleSaveGrade={handleSaveGrade}
+      handleSetGradeMode={handleSetGradeMode}
       handleAnalyzeRepo={handleAnalyzeRepo}
     />
   )
@@ -237,48 +253,74 @@ export function TeacherStudentWorkPanel({
           data-testid="individual-content-header"
           className="border-b border-border bg-surface px-4 py-3 text-sm"
         >
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center">
             <div
-              className="min-w-0 truncate font-medium text-text-default"
-              title={studentDisplayName}
+              className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
             >
-              {studentDisplayName}
-            </div>
-            {(repoDisplayUrl || repoDisplayGitHubUsername) && (
-              <>
-                <span className="text-text-muted" aria-hidden="true">
-                  /
-                </span>
-                <div className="min-w-0 truncate text-text-muted">
-                  <span className="text-text-muted">Repo </span>
-                  {repoDisplayUrl ? (
-                    <a
-                      href={repoDisplayUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-primary hover:underline"
-                    >
-                      {repoDisplayUrl}
-                    </a>
-                  ) : (
-                    '—'
-                  )}
-                </div>
-                {repoDisplayGitHubUsername && (
-                  <div className="truncate text-text-muted">
-                    <span className="font-medium text-text-default">
-                      @{repoDisplayGitHubUsername}
-                    </span>
+              <div
+                className="min-w-0 truncate font-medium text-text-default"
+                title={studentDisplayName}
+              >
+                {studentDisplayName}
+              </div>
+              {(repoDisplayUrl || repoDisplayGitHubUsername) && (
+                <>
+                  <span className="text-text-muted" aria-hidden="true">
+                    /
+                  </span>
+                  <div className="min-w-0 truncate text-text-muted">
+                    <span className="text-text-muted">Repo </span>
+                    {repoDisplayUrl ? (
+                      <a
+                        href={repoDisplayUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        {repoDisplayUrl}
+                      </a>
+                    ) : (
+                      '—'
+                    )}
                   </div>
-                )}
-              </>
-            )}
+                  {repoDisplayGitHubUsername && (
+                    <div className="truncate text-text-muted">
+                      <span className="font-medium text-text-default">
+                        @{repoDisplayGitHubUsername}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
             <div
-              className="inline-flex shrink-0 items-center text-xs text-text-muted sm:ml-auto"
+              className="inline-flex shrink-0 items-center justify-center text-xs text-text-muted sm:justify-self-center"
               aria-label={`${characterCount} characters`}
             >
               <span>{characterCount} chars</span>
             </div>
+            {(onGoPrevStudent || onGoNextStudent) && (
+              <div className="flex items-center gap-1 sm:justify-self-end">
+                <button
+                  type="button"
+                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                  onClick={onGoPrevStudent}
+                  disabled={!onGoPrevStudent || !canGoPrevStudent}
+                  aria-label="Previous student"
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                  onClick={onGoNextStudent}
+                  disabled={!onGoNextStudent || !canGoNextStudent}
+                  aria-label="Next student"
+                >
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            )}
           </div>
           {previewEntry && (
             <div className="mt-1 text-xs font-medium text-primary">
@@ -309,6 +351,7 @@ export function TeacherStudentWorkPanel({
           aria-label="Resize content and grading panes"
           className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
           onPointerDown={handleInspectorResizeStart}
+          onDoubleClick={handleInspectorResizeReset}
         >
           <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
         </div>

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -110,7 +110,7 @@ function ScoreInput({
     : null
 
   return (
-    <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_2.25rem] items-center gap-x-1.5">
+    <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_4.75rem] items-center gap-x-2">
       <label
         className={[
           'whitespace-nowrap text-[11px] font-medium text-text-muted',
@@ -140,15 +140,20 @@ function ScoreInput({
           )
         })}
       </div>
-      <input
-        type="number"
-        min={0}
-        max={10}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="h-6 w-9 justify-self-end rounded border border-border bg-surface px-1 py-0.5 text-center text-xs font-medium text-text-default [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        aria-label={`${label} score`}
-      />
+      <div className="grid h-8 grid-cols-[1fr_auto] overflow-hidden rounded border border-border bg-surface">
+        <input
+          type="number"
+          min={0}
+          max={10}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="min-w-0 border-0 bg-transparent px-2 text-center text-sm font-semibold text-text-default [appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          aria-label={`${label} score`}
+        />
+        <div className="flex min-w-[2rem] items-center justify-center border-l border-border bg-surface-2 px-1.5 text-xs font-medium text-text-muted">
+          10
+        </div>
+      </div>
     </div>
   )
 }
@@ -165,7 +170,7 @@ function InspectorSection({
   id: InspectorSectionId
   title: string
   expanded: boolean
-  summary: ReactNode
+  summary?: ReactNode
   onToggle: () => void
   action?: ReactNode
   children?: ReactNode
@@ -186,20 +191,20 @@ function InspectorSection({
           aria-controls={contentId}
           onClick={onToggle}
         >
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             {expanded ? (
               <ChevronDown className="h-4 w-4 text-text-muted" aria-hidden="true" />
             ) : (
               <ChevronRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
             )}
-            <span className="text-sm font-semibold text-text-default">{title}</span>
+            <span className="shrink-0 text-sm font-semibold text-text-default">{title}</span>
+            {summary ? <div className="min-w-0 flex-1">{summary}</div> : null}
           </div>
-          <div className="mt-2 min-w-0">{summary}</div>
         </button>
-        {action && <div className="shrink-0">{action}</div>}
+        {expanded && action ? <div className="shrink-0">{action}</div> : null}
       </div>
       {expanded && (
-        <div id={contentId} className="border-t border-border px-3 py-3">
+        <div id={contentId} className="px-3 pb-3">
           {children}
         </div>
       )}
@@ -215,15 +220,11 @@ function RepoSummary({
   hasRepoConnection: boolean
 }) {
   if (!hasRepoConnection) {
-    return (
-      <RepoMetricBar label="No repo linked" value={0} tone="muted" />
-    )
+    return <RepoMetricBar label="No repo linked" value={0} tone="muted" />
   }
 
   if (!repoReviewResult) {
-    return (
-      <RepoMetricBar label="Analysis not run" value={0} tone="muted" />
-    )
+    return <RepoMetricBar label="Analysis not run" value={0} tone="muted" />
   }
 
   const compositeScore =
@@ -235,7 +236,20 @@ function RepoSummary({
   return <RepoMetricBar label="Repo analysis" value={compositeScore} />
 }
 
-function GradeSummary({ totalPercent, totalScore }: { totalPercent: number; totalScore: number }) {
+function ScoreTotalBox({ value, total }: { value: number; total: number }) {
+  return (
+    <div className="grid h-8 grid-cols-[1fr_auto] overflow-hidden rounded border border-border bg-surface">
+      <div className="flex min-w-[2.75rem] items-center justify-center px-2 text-sm font-semibold text-text-default">
+        {value}
+      </div>
+      <div className="flex min-w-[2rem] items-center justify-center border-l border-border bg-surface-2 px-1.5 text-xs font-medium text-text-muted">
+        {total}
+      </div>
+    </div>
+  )
+}
+
+function GradeSummary({ totalPercent }: { totalPercent: number }) {
   const tone =
     totalPercent >= 80
       ? 'border-green-200 bg-green-100 text-green-700'
@@ -249,37 +263,11 @@ function GradeSummary({ totalPercent, totalScore }: { totalPercent: number; tota
     <div className="flex flex-wrap items-center gap-2">
       <span
         className={[
-          'inline-flex items-center justify-center rounded border px-2.5 py-1 text-sm font-medium',
+          'inline-flex h-8 items-center justify-center rounded border px-2.5 text-sm font-medium',
           tone,
         ].join(' ')}
       >
         {totalPercent}%
-      </span>
-      <span className="inline-flex items-center justify-center rounded border border-border bg-surface-2 px-2.5 py-1 text-sm font-medium text-text-default">
-        {totalScore} / 30
-      </span>
-    </div>
-  )
-}
-
-function CommentsSummary({
-  feedbackEntries,
-  feedbackDraft,
-}: {
-  feedbackEntries: AssignmentFeedbackEntry[]
-  feedbackDraft: string
-}) {
-  const hasDraft = feedbackDraft.trim().length > 0
-
-  return (
-    <div className="flex flex-wrap items-center gap-2 text-xs">
-      <span className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-text-muted">
-        {feedbackEntries.length > 0
-          ? `${feedbackEntries.length} returned`
-          : 'No returned feedback'}
-      </span>
-      <span className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-text-muted">
-        {hasDraft ? 'Draft present' : 'No draft'}
       </span>
     </div>
   )
@@ -458,25 +446,56 @@ export function TeacherWorkInspector({
     },
     {
       id: 'grades',
-      title: 'Grades',
-      summary: <GradeSummary totalPercent={totalPercent} totalScore={totalScore} />,
+      title: 'Grade',
+      summary: <GradeSummary totalPercent={totalPercent} />,
+      action: (
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              void handleAutoGrade()
+            }}
+            disabled={autoGrading}
+          >
+            {autoGrading ? 'Grading...' : 'AI grade'}
+          </Button>
+          <SplitButton
+            label={gradeSaving ? 'Saving...' : 'Save'}
+            onPrimaryClick={() => {
+              void handleSaveGrade('graded')
+            }}
+            options={[
+              {
+                id: 'draft',
+                label: 'Draft',
+                onSelect: () => {
+                  void handleSaveGrade('draft')
+                },
+              },
+            ]}
+            size="sm"
+            disabled={gradeSaving}
+            toggleAriaLabel="Choose save mode"
+          />
+        </div>
+      ),
       content: (
         <div className="space-y-3">
           <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
           <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
           <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
+          <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_4.75rem] items-center gap-x-2">
+            <div className="whitespace-nowrap text-[11px] font-medium text-text-muted">Total</div>
+            <div />
+            <ScoreTotalBox value={totalScore} total={30} />
+          </div>
         </div>
       ),
     },
     {
       id: 'comments',
-      title: 'Comments',
-      summary: (
-        <CommentsSummary
-          feedbackEntries={feedbackEntries}
-          feedbackDraft={feedbackDraft}
-        />
-      ),
+      title: 'Feedback',
       content: (
         <div className="space-y-3">
           <div className="space-y-1">
@@ -500,6 +519,18 @@ export function TeacherWorkInspector({
               ].join(' ')}
               placeholder="Teacher feedback draft"
             />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  void handleReturnFeedback()
+                }}
+                disabled={feedbackReturning || !feedbackDraft.trim()}
+              >
+                {feedbackReturning ? 'Returning...' : 'Return Feedback'}
+              </Button>
+            </div>
           </div>
 
           <div className="space-y-2">
@@ -509,11 +540,8 @@ export function TeacherWorkInspector({
             {feedbackEntries.length > 0 ? (
               <div className="rounded border border-border bg-surface p-3">
                 <div className="space-y-3">
-                  {feedbackEntries.map((entry, index) => (
-                    <div
-                      key={entry.id}
-                      className={index > 0 ? 'border-t border-border pt-3' : ''}
-                    >
+                  {feedbackEntries.map((entry) => (
+                    <div key={entry.id}>
                       <div className="mb-1 text-[11px] font-medium text-text-muted">
                         {formatInTimeZone(
                           new Date(entry.returned_at),
@@ -540,10 +568,10 @@ export function TeacherWorkInspector({
   return (
     <div
       data-testid="grading-inspector-pane"
-      className="flex h-full min-h-0 flex-col border-border bg-surface lg:border-l"
+      className="flex h-full min-h-0 flex-col bg-surface"
     >
-      <div className="flex-1 overflow-y-auto p-3">
-        <div className="space-y-3">
+      <div className="flex-1 overflow-y-auto">
+        <div>
           {sections.map((section) => (
             <InspectorSection
               key={section.id}
@@ -560,73 +588,30 @@ export function TeacherWorkInspector({
         </div>
       </div>
 
-      <div className="border-t border-border bg-surface px-3 py-3">
-        <div className="space-y-3">
-          {gradeError && (
-            <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
-              {gradeError}
-            </div>
-          )}
+      {(gradeError || data.doc?.graded_at) && (
+        <div className="border-t border-border bg-surface px-3 py-3">
+          <div className="space-y-3">
+            {gradeError && (
+              <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
+                {gradeError}
+              </div>
+            )}
 
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              className="flex-1"
-              onClick={() => {
-                void handleAutoGrade()
-              }}
-              disabled={autoGrading}
-            >
-              {autoGrading ? 'Grading...' : 'AI grade'}
-            </Button>
-            <Button
-              size="sm"
-              variant="secondary"
-              className="flex-1"
-              onClick={() => {
-                void handleReturnFeedback()
-              }}
-              disabled={feedbackReturning || !feedbackDraft.trim()}
-            >
-              {feedbackReturning ? 'Returning...' : 'Return Feedback'}
-            </Button>
-            <SplitButton
-              label={gradeSaving ? 'Saving...' : 'Save'}
-              onPrimaryClick={() => {
-                void handleSaveGrade('graded')
-              }}
-              options={[
-                {
-                  id: 'draft',
-                  label: 'Draft',
-                  onSelect: () => {
-                    void handleSaveGrade('draft')
-                  },
-                },
-              ]}
-              size="sm"
-              className="flex-1"
-              disabled={gradeSaving}
-              toggleAriaLabel="Choose save mode"
-              primaryButtonProps={{ className: 'flex-1 justify-center' }}
-            />
+            {data.doc?.graded_at && (
+              <div className="text-xs text-text-muted">
+                Graded{' '}
+                {formatInTimeZone(
+                  new Date(data.doc.graded_at),
+                  'America/Toronto',
+                  'MMM d, h:mm a',
+                )}
+                {data.doc.graded_by &&
+                  ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
+              </div>
+            )}
           </div>
-
-          {data.doc?.graded_at && (
-            <div className="text-xs text-text-muted">
-              Graded{' '}
-              {formatInTimeZone(
-                new Date(data.doc.graded_at),
-                'America/Toronto',
-                'MMM d, h:mm a',
-              )}
-              {data.doc.graded_by &&
-                ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
-            </div>
-          )}
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -1,0 +1,632 @@
+'use client'
+
+import { Fragment, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { formatInTimeZone } from 'date-fns-tz'
+import { HistoryList } from '@/components/HistoryList'
+import { Spinner } from '@/components/Spinner'
+import { Button, SplitButton, Tooltip } from '@/ui'
+import type {
+  AssignmentDocHistoryEntry,
+  AssignmentFeedbackEntry,
+  AssignmentRepoReviewResult,
+  AuthenticityFlag,
+} from '@/types'
+import type { InspectorSectionId, StudentWorkData } from './types'
+
+type GradeSaveMode = 'draft' | 'graded'
+
+function AuthenticityGauge({ score, flags }: { score: number | null; flags: AuthenticityFlag[] }) {
+  const hasScore = score !== null
+  const displayScore = score ?? 0
+  const color = !hasScore
+    ? 'bg-surface-2'
+    : displayScore >= 70
+      ? 'bg-green-500'
+      : displayScore >= 40
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+  const textColor = !hasScore
+    ? 'text-text-muted'
+    : displayScore >= 70
+      ? 'text-green-700'
+      : displayScore >= 40
+        ? 'text-yellow-700'
+        : 'text-red-700'
+
+  const bar = (
+    <div className="relative h-5 overflow-hidden rounded-full bg-surface-2">
+      {hasScore && (
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${displayScore}%` }} />
+      )}
+      <span
+        className={`absolute inset-0 flex items-center justify-center text-[10px] font-bold ${textColor}`}
+      >
+        Authenticity {hasScore ? `${displayScore}%` : '—'}
+      </span>
+    </div>
+  )
+
+  if (flags.length === 0) return bar
+
+  return (
+    <Tooltip
+      content={
+        <div className="space-y-1 py-0.5">
+          {flags.map((flag, index) => (
+            <div key={index}>
+              {flag.reason === 'paste'
+                ? `${flag.wordDelta} words pasted`
+                : `${flag.wordDelta} words in ${flag.seconds}s (${Math.round(flag.wps * 60)} wpm)`}
+            </div>
+          ))}
+        </div>
+      }
+    >
+      <div>{bar}</div>
+    </Tooltip>
+  )
+}
+
+function RepoMetricBar({
+  label,
+  value,
+  tone = 'primary',
+}: {
+  label: string
+  value: number
+  tone?: 'primary' | 'muted'
+}) {
+  const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
+  const fillClass = tone === 'primary' ? 'bg-primary' : 'bg-surface-hover'
+
+  return (
+    <div className="relative h-6 overflow-hidden rounded-full border border-border bg-surface">
+      <div
+        className={`absolute inset-y-0 left-0 rounded-full transition-[width] ${fillClass}`}
+        style={{ width: `${percentage}%` }}
+      />
+      <div className="absolute inset-0 z-10 flex items-center justify-between px-3 text-[10px] font-semibold leading-none">
+        <span className="text-text-default">{label}</span>
+        <span className="text-text-default">{percentage}%</span>
+      </div>
+    </div>
+  )
+}
+
+function ScoreInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  const quickScores = Array.from({ length: 11 }, (_, index) => index)
+  const numericValue = Number(value)
+  const selected = Number.isInteger(numericValue) && numericValue >= 0 && numericValue <= 10
+    ? numericValue
+    : null
+
+  return (
+    <div className="grid grid-cols-[4.75rem_minmax(0,1fr)_2.25rem] items-center gap-x-1.5">
+      <label
+        className={[
+          'whitespace-nowrap text-[11px] font-medium text-text-muted',
+          label === 'Completion' ? 'pr-2' : 'pr-1',
+        ].join(' ')}
+      >
+        {label}
+      </label>
+      <div className="flex min-w-0 items-center justify-start gap-0">
+        {quickScores.map((score) => {
+          const isActive = selected === score
+          return (
+            <Tooltip key={score} content={score} delayDuration={0} side="top">
+              <button
+                type="button"
+                onClick={() => onChange(String(score))}
+                className={[
+                  'inline-flex h-6 w-[clamp(0.5rem,calc(100%/11),1.5rem)] flex-none items-center justify-center rounded border px-0 text-[10px] font-semibold leading-none transition-colors',
+                  isActive
+                    ? 'border-primary bg-primary text-text-inverse'
+                    : 'border-border bg-surface text-text-default hover:bg-surface-hover',
+                ].join(' ')}
+                aria-label={`Set ${label} score to ${score}`}
+                aria-pressed={isActive}
+              />
+            </Tooltip>
+          )
+        })}
+      </div>
+      <input
+        type="number"
+        min={0}
+        max={10}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-6 w-9 justify-self-end rounded border border-border bg-surface px-1 py-0.5 text-center text-xs font-medium text-text-default [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        aria-label={`${label} score`}
+      />
+    </div>
+  )
+}
+
+function InspectorSection({
+  id,
+  title,
+  expanded,
+  summary,
+  onToggle,
+  action,
+  children,
+}: {
+  id: InspectorSectionId
+  title: string
+  expanded: boolean
+  summary: ReactNode
+  onToggle: () => void
+  action?: ReactNode
+  children?: ReactNode
+}) {
+  const contentId = `assignment-inspector-section-${id}`
+
+  return (
+    <section
+      data-testid={`inspector-section-${id}`}
+      className="overflow-hidden rounded-lg border border-border bg-surface"
+    >
+      <div className="flex items-start gap-3 p-3">
+        <button
+          type="button"
+          className="min-w-0 flex-1 text-left"
+          aria-label={title}
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          onClick={onToggle}
+        >
+          <div className="flex items-center gap-2">
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 text-text-muted" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
+            )}
+            <span className="text-sm font-semibold text-text-default">{title}</span>
+          </div>
+          <div className="mt-2 min-w-0">{summary}</div>
+        </button>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      {expanded && (
+        <div id={contentId} className="border-t border-border px-3 py-3">
+          {children}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function RepoSummary({
+  repoReviewResult,
+  hasRepoConnection,
+}: {
+  repoReviewResult: AssignmentRepoReviewResult | null
+  hasRepoConnection: boolean
+}) {
+  if (!hasRepoConnection) {
+    return (
+      <RepoMetricBar label="No repo linked" value={0} tone="muted" />
+    )
+  }
+
+  if (!repoReviewResult) {
+    return (
+      <RepoMetricBar label="Analysis not run" value={0} tone="muted" />
+    )
+  }
+
+  const compositeScore =
+    ((repoReviewResult.relative_contribution_share || 0) +
+      (repoReviewResult.spread_score || 0) +
+      (repoReviewResult.iteration_score || 0)) /
+    3
+
+  return <RepoMetricBar label="Repo analysis" value={compositeScore} />
+}
+
+function GradeSummary({ totalPercent, totalScore }: { totalPercent: number; totalScore: number }) {
+  const tone =
+    totalPercent >= 80
+      ? 'border-green-200 bg-green-100 text-green-700'
+      : totalPercent >= 60
+        ? 'border-yellow-200 bg-yellow-100 text-yellow-700'
+        : totalPercent >= 50
+          ? 'border-orange-200 bg-orange-100 text-orange-700'
+          : 'border-red-200 bg-red-100 text-red-700'
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span
+        className={[
+          'inline-flex items-center justify-center rounded border px-2.5 py-1 text-sm font-medium',
+          tone,
+        ].join(' ')}
+      >
+        {totalPercent}%
+      </span>
+      <span className="inline-flex items-center justify-center rounded border border-border bg-surface-2 px-2.5 py-1 text-sm font-medium text-text-default">
+        {totalScore} / 30
+      </span>
+    </div>
+  )
+}
+
+function CommentsSummary({
+  feedbackEntries,
+  feedbackDraft,
+}: {
+  feedbackEntries: AssignmentFeedbackEntry[]
+  feedbackDraft: string
+}) {
+  const hasDraft = feedbackDraft.trim().length > 0
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      <span className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-text-muted">
+        {feedbackEntries.length > 0
+          ? `${feedbackEntries.length} returned`
+          : 'No returned feedback'}
+      </span>
+      <span className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-text-muted">
+        {hasDraft ? 'Draft present' : 'No draft'}
+      </span>
+    </div>
+  )
+}
+
+export function TeacherWorkInspector({
+  data,
+  historyEntries,
+  historyLoading,
+  historyError,
+  previewEntry,
+  onEntryClick,
+  onEntryHover,
+  onHistoryMouseLeave,
+  isPreviewLocked,
+  onExitPreview,
+  repoReviewResult,
+  scoreCompletion,
+  setScoreCompletion,
+  scoreThinking,
+  setScoreThinking,
+  scoreWorkflow,
+  setScoreWorkflow,
+  totalPercent,
+  totalScore,
+  feedbackEntries,
+  feedbackDraft,
+  hasFreshAIDraft,
+  setFeedbackDraft,
+  onAIDraftAcknowledge,
+  gradeError,
+  autoGrading,
+  feedbackReturning,
+  gradeSaving,
+  repoAnalyzing,
+  expandedSections,
+  onToggleSection,
+  handleAutoGrade,
+  handleReturnFeedback,
+  handleSaveGrade,
+  handleAnalyzeRepo,
+}: {
+  data: StudentWorkData
+  historyEntries: AssignmentDocHistoryEntry[]
+  historyLoading: boolean
+  historyError: string
+  previewEntry: AssignmentDocHistoryEntry | null
+  onEntryClick: (entry: AssignmentDocHistoryEntry) => void
+  onEntryHover: (entry: AssignmentDocHistoryEntry) => void
+  onHistoryMouseLeave: () => void
+  isPreviewLocked: boolean
+  onExitPreview: () => void
+  repoReviewResult: AssignmentRepoReviewResult | null
+  scoreCompletion: string
+  setScoreCompletion: (value: string) => void
+  scoreThinking: string
+  setScoreThinking: (value: string) => void
+  scoreWorkflow: string
+  setScoreWorkflow: (value: string) => void
+  totalPercent: number
+  totalScore: number
+  feedbackEntries: AssignmentFeedbackEntry[]
+  feedbackDraft: string
+  hasFreshAIDraft: boolean
+  setFeedbackDraft: (value: string) => void
+  onAIDraftAcknowledge: () => void
+  gradeError: string
+  autoGrading: boolean
+  feedbackReturning: boolean
+  gradeSaving: boolean
+  repoAnalyzing: boolean
+  expandedSections: InspectorSectionId[]
+  onToggleSection: (section: InspectorSectionId) => void
+  handleAutoGrade: () => Promise<void>
+  handleReturnFeedback: () => Promise<void>
+  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
+  handleAnalyzeRepo: () => Promise<void>
+}) {
+  const hasRepoConnection = !!(
+    data.repo_target.effectiveRepoUrl || data.repo_target.effectiveGitHubUsername
+  )
+
+  const sections: Array<{
+    id: InspectorSectionId
+    title: string
+    summary: ReactNode
+    action?: ReactNode
+    content: ReactNode
+  }> = [
+    {
+      id: 'history',
+      title: 'History',
+      summary: (
+        <AuthenticityGauge
+          score={data.doc?.authenticity_score ?? null}
+          flags={data.doc?.authenticity_flags ?? []}
+        />
+      ),
+      content: (
+        <Fragment>
+          <div className="max-h-[18rem] overflow-y-auto" onMouseLeave={onHistoryMouseLeave}>
+            {historyLoading && historyEntries.length === 0 ? (
+              <div className="p-4 text-center">
+                <Spinner size="sm" />
+              </div>
+            ) : historyError ? (
+              <p className="text-xs text-danger">{historyError}</p>
+            ) : historyEntries.length === 0 ? (
+              <p className="text-xs text-text-muted">No saves yet</p>
+            ) : (
+              <HistoryList
+                entries={historyEntries}
+                activeEntryId={previewEntry?.id ?? null}
+                onEntryClick={onEntryClick}
+                onEntryHover={onEntryHover}
+              />
+            )}
+          </div>
+          {isPreviewLocked && previewEntry && (
+            <div className="mt-3">
+              <Button onClick={onExitPreview} variant="secondary" size="sm" className="w-full">
+                Exit preview
+              </Button>
+            </div>
+          )}
+        </Fragment>
+      ),
+    },
+    {
+      id: 'repo',
+      title: 'Repo',
+      summary: (
+        <RepoSummary
+          repoReviewResult={repoReviewResult}
+          hasRepoConnection={hasRepoConnection}
+        />
+      ),
+      action: (
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            void handleAnalyzeRepo()
+          }}
+          disabled={
+            repoAnalyzing ||
+            !data.repo_target.effectiveRepoUrl ||
+            !data.repo_target.effectiveGitHubUsername
+          }
+        >
+          {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
+        </Button>
+      ),
+      content: repoReviewResult ? (
+        <div className="space-y-2">
+          <RepoMetricBar
+            label="Contribution"
+            value={repoReviewResult.relative_contribution_share || 0}
+          />
+          <RepoMetricBar
+            label="Consistency"
+            value={repoReviewResult.spread_score || 0}
+          />
+          <RepoMetricBar
+            label="Iteration"
+            value={repoReviewResult.iteration_score || 0}
+          />
+        </div>
+      ) : (
+        <p className="text-sm text-text-muted">
+          {hasRepoConnection
+            ? 'Run repo analysis to see contribution, consistency, and iteration details.'
+            : 'No repository metadata is available for this submission yet.'}
+        </p>
+      ),
+    },
+    {
+      id: 'grades',
+      title: 'Grades',
+      summary: <GradeSummary totalPercent={totalPercent} totalScore={totalScore} />,
+      content: (
+        <div className="space-y-3">
+          <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
+          <ScoreInput label="Thinking" value={scoreThinking} onChange={setScoreThinking} />
+          <ScoreInput label="Workflow" value={scoreWorkflow} onChange={setScoreWorkflow} />
+        </div>
+      ),
+    },
+    {
+      id: 'comments',
+      title: 'Comments',
+      summary: (
+        <CommentsSummary
+          feedbackEntries={feedbackEntries}
+          feedbackDraft={feedbackDraft}
+        />
+      ),
+      content: (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                Feedback Draft
+              </div>
+              {hasFreshAIDraft && (
+                <span className="rounded-full border border-primary/40 bg-info-bg px-2 py-0.5 text-[11px] font-medium text-primary">
+                  AI draft
+                </span>
+              )}
+            </div>
+            <textarea
+              value={feedbackDraft}
+              onChange={(event) => setFeedbackDraft(event.target.value)}
+              onFocus={onAIDraftAcknowledge}
+              className={[
+                'min-h-[10rem] w-full resize-y rounded border px-2 py-1 text-sm text-text-default',
+                hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
+              ].join(' ')}
+              placeholder="Teacher feedback draft"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
+              Returned Feedback
+            </div>
+            {feedbackEntries.length > 0 ? (
+              <div className="rounded border border-border bg-surface p-3">
+                <div className="space-y-3">
+                  {feedbackEntries.map((entry, index) => (
+                    <div
+                      key={entry.id}
+                      className={index > 0 ? 'border-t border-border pt-3' : ''}
+                    >
+                      <div className="mb-1 text-[11px] font-medium text-text-muted">
+                        {formatInTimeZone(
+                          new Date(entry.returned_at),
+                          'America/Toronto',
+                          'MMM d, h:mm a',
+                        )}
+                      </div>
+                      <div className="whitespace-pre-wrap text-sm text-text-default">
+                        {entry.body}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-text-muted">No returned feedback yet.</p>
+            )}
+          </div>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div
+      data-testid="grading-inspector-pane"
+      className="flex h-full min-h-0 flex-col border-border bg-surface lg:border-l"
+    >
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="space-y-3">
+          {sections.map((section) => (
+            <InspectorSection
+              key={section.id}
+              id={section.id}
+              title={section.title}
+              expanded={expandedSections.includes(section.id)}
+              summary={section.summary}
+              action={section.action}
+              onToggle={() => onToggleSection(section.id)}
+            >
+              {section.content}
+            </InspectorSection>
+          ))}
+        </div>
+      </div>
+
+      <div className="border-t border-border bg-surface px-3 py-3">
+        <div className="space-y-3">
+          {gradeError && (
+            <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
+              {gradeError}
+            </div>
+          )}
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="flex-1"
+              onClick={() => {
+                void handleAutoGrade()
+              }}
+              disabled={autoGrading}
+            >
+              {autoGrading ? 'Grading...' : 'AI grade'}
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="flex-1"
+              onClick={() => {
+                void handleReturnFeedback()
+              }}
+              disabled={feedbackReturning || !feedbackDraft.trim()}
+            >
+              {feedbackReturning ? 'Returning...' : 'Return Feedback'}
+            </Button>
+            <SplitButton
+              label={gradeSaving ? 'Saving...' : 'Save'}
+              onPrimaryClick={() => {
+                void handleSaveGrade('graded')
+              }}
+              options={[
+                {
+                  id: 'draft',
+                  label: 'Draft',
+                  onSelect: () => {
+                    void handleSaveGrade('draft')
+                  },
+                },
+              ]}
+              size="sm"
+              className="flex-1"
+              disabled={gradeSaving}
+              toggleAriaLabel="Choose save mode"
+              primaryButtonProps={{ className: 'flex-1 justify-center' }}
+            />
+          </div>
+
+          {data.doc?.graded_at && (
+            <div className="text-xs text-text-muted">
+              Graded{' '}
+              {formatInTimeZone(
+                new Date(data.doc.graded_at),
+                'America/Toronto',
+                'MMM d, h:mm a',
+              )}
+              {data.doc.graded_by &&
+                ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { Fragment, type ReactNode } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight, Send } from 'lucide-react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { HistoryList } from '@/components/HistoryList'
 import { Spinner } from '@/components/Spinner'
-import { Button, SplitButton, Tooltip } from '@/ui'
+import { Button, Tooltip } from '@/ui'
 import type {
   AssignmentDocHistoryEntry,
   AssignmentFeedbackEntry,
@@ -15,6 +15,15 @@ import type {
 import type { InspectorSectionId, StudentWorkData } from './types'
 
 type GradeSaveMode = 'draft' | 'graded'
+const INSPECTOR_SECTION_TRANSITION_MS = 180
+
+function autoResizeTextarea(textarea: HTMLTextAreaElement | null, minHeightPx: number) {
+  if (!textarea) return
+  textarea.style.height = `${minHeightPx}px`
+  const measuredHeight = textarea.scrollHeight
+  const nextHeight = measuredHeight > minHeightPx + 2 ? measuredHeight : minHeightPx
+  textarea.style.height = `${nextHeight}px`
+}
 
 function AuthenticityGauge({ score, flags }: { score: number | null; flags: AuthenticityFlag[] }) {
   const hasScore = score !== null
@@ -182,10 +191,10 @@ function InspectorSection({
       data-testid={`inspector-section-${id}`}
       className="overflow-hidden rounded-lg border border-border bg-surface"
     >
-      <div className="flex items-start gap-3 p-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,19rem)] items-center gap-3 p-3">
         <button
           type="button"
-          className="min-w-0 flex-1 text-left"
+          className="min-w-0 text-left"
           aria-label={title}
           aria-expanded={expanded}
           aria-controls={contentId}
@@ -198,17 +207,105 @@ function InspectorSection({
               <ChevronRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
             )}
             <span className="shrink-0 text-sm font-semibold text-text-default">{title}</span>
-            {summary ? <div className="min-w-0 flex-1">{summary}</div> : null}
           </div>
         </button>
-        {expanded && action ? <div className="shrink-0">{action}</div> : null}
-      </div>
-      {expanded && (
-        <div id={contentId} className="px-3 pb-3">
-          {children}
+        <div className="min-w-0">
+          {(summary || (expanded && action)) ? (
+            <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+              <div className="min-w-0">{summary}</div>
+              {expanded && action ? <div className="shrink-0">{action}</div> : null}
+            </div>
+          ) : null}
         </div>
-      )}
+      </div>
+      <AnimatedSectionContent id={contentId} expanded={expanded}>
+        {children}
+      </AnimatedSectionContent>
     </section>
+  )
+}
+
+function AnimatedSectionContent({
+  id,
+  expanded,
+  children,
+}: {
+  id: string
+  expanded: boolean
+  children?: ReactNode
+}) {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [shouldRender, setShouldRender] = useState(expanded)
+  const [maxHeight, setMaxHeight] = useState(expanded ? 'none' : '0px')
+  const [opacity, setOpacity] = useState(expanded ? 1 : 0)
+  const [translateY, setTranslateY] = useState(expanded ? 0 : -6)
+
+  useEffect(() => {
+    let frameId = 0
+    let frameIdTwo = 0
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+    if (expanded) {
+      setShouldRender(true)
+      setMaxHeight('0px')
+      setOpacity(0)
+      setTranslateY(-6)
+
+      frameId = window.requestAnimationFrame(() => {
+        const nextHeight = contentRef.current?.scrollHeight ?? 0
+        setMaxHeight(`${nextHeight}px`)
+        setOpacity(1)
+        setTranslateY(0)
+
+        timeoutId = window.setTimeout(() => {
+          setMaxHeight('none')
+        }, INSPECTOR_SECTION_TRANSITION_MS)
+      })
+    } else if (shouldRender) {
+      const currentHeight = contentRef.current?.scrollHeight ?? 0
+      setMaxHeight(`${currentHeight}px`)
+      setOpacity(1)
+      setTranslateY(0)
+
+      frameId = window.requestAnimationFrame(() => {
+        frameIdTwo = window.requestAnimationFrame(() => {
+          setMaxHeight('0px')
+          setOpacity(0)
+          setTranslateY(-6)
+        })
+      })
+
+      timeoutId = window.setTimeout(() => {
+        setShouldRender(false)
+      }, INSPECTOR_SECTION_TRANSITION_MS)
+    }
+
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId)
+      if (frameIdTwo) window.cancelAnimationFrame(frameIdTwo)
+      if (timeoutId) window.clearTimeout(timeoutId)
+    }
+  }, [expanded, shouldRender])
+
+  if (!shouldRender) return null
+
+  return (
+    <div
+      id={id}
+      aria-hidden={!expanded}
+      className={expanded ? '' : 'pointer-events-none'}
+      style={{
+        maxHeight,
+        opacity,
+        overflow: 'hidden',
+        transform: `translateY(${translateY}px)`,
+        transition: `max-height ${INSPECTOR_SECTION_TRANSITION_MS}ms ease, opacity ${INSPECTOR_SECTION_TRANSITION_MS}ms ease, transform ${INSPECTOR_SECTION_TRANSITION_MS}ms ease`,
+      }}
+    >
+      <div ref={contentRef} className="px-3 pb-3">
+        {children}
+      </div>
+    </div>
   )
 }
 
@@ -238,14 +335,46 @@ function RepoSummary({
 
 function ScoreTotalBox({ value, total }: { value: number; total: number }) {
   return (
-    <div className="grid h-8 grid-cols-[1fr_auto] overflow-hidden rounded border border-border bg-surface">
-      <div className="flex min-w-[2.75rem] items-center justify-center px-2 text-sm font-semibold text-text-default">
+    <div className="grid h-8 grid-cols-[1fr_auto] overflow-hidden rounded border border-border bg-surface-2">
+      <div className="flex min-w-[2.75rem] items-center justify-center px-2 text-sm font-semibold tabular-nums text-text-muted">
         {value}
       </div>
-      <div className="flex min-w-[2rem] items-center justify-center border-l border-border bg-surface-2 px-1.5 text-xs font-medium text-text-muted">
+      <div className="flex min-w-[2rem] items-center justify-center border-l border-border bg-surface-hover px-1.5 text-xs font-medium tabular-nums text-text-muted">
         {total}
       </div>
     </div>
+  )
+}
+
+function AutoGrowFeedbackTextarea({
+  value,
+  onChange,
+  onFocus,
+  hasFreshAIDraft,
+}: {
+  value: string
+  onChange: (value: string) => void
+  onFocus: () => void
+  hasFreshAIDraft: boolean
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    autoResizeTextarea(textareaRef.current, 160)
+  }, [value])
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onFocus={onFocus}
+      className={[
+        'min-h-[10rem] w-full overflow-hidden rounded border px-2 py-1 text-sm text-text-default',
+        hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
+      ].join(' ')}
+      placeholder="Teacher feedback draft"
+    />
   )
 }
 
@@ -298,16 +427,15 @@ export function TeacherWorkInspector({
   hasFreshAIDraft,
   setFeedbackDraft,
   onAIDraftAcknowledge,
+  gradeMode,
   gradeError,
-  autoGrading,
   feedbackReturning,
   gradeSaving,
   repoAnalyzing,
   expandedSections,
   onToggleSection,
-  handleAutoGrade,
   handleReturnFeedback,
-  handleSaveGrade,
+  handleSetGradeMode,
   handleAnalyzeRepo,
 }: {
   data: StudentWorkData
@@ -334,21 +462,37 @@ export function TeacherWorkInspector({
   hasFreshAIDraft: boolean
   setFeedbackDraft: (value: string) => void
   onAIDraftAcknowledge: () => void
+  gradeMode: GradeSaveMode
   gradeError: string
-  autoGrading: boolean
   feedbackReturning: boolean
   gradeSaving: boolean
   repoAnalyzing: boolean
   expandedSections: InspectorSectionId[]
   onToggleSection: (section: InspectorSectionId) => void
-  handleAutoGrade: () => Promise<void>
   handleReturnFeedback: () => Promise<void>
-  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
+  handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
   handleAnalyzeRepo: () => Promise<void>
 }) {
   const hasRepoConnection = !!(
     data.repo_target.effectiveRepoUrl || data.repo_target.effectiveGitHubUsername
   )
+  const hasSavedDraftContent = !!(
+    data.doc?.teacher_feedback_draft?.trim()
+    || data.doc?.score_completion !== null
+    || data.doc?.score_thinking !== null
+    || data.doc?.score_workflow !== null
+  )
+  const gradeStatusLabel = gradeSaving
+    ? `Saving ${gradeMode === 'graded' ? 'graded' : 'draft'}...`
+    : data.doc?.graded_at
+      ? `Graded ${formatInTimeZone(
+          new Date(data.doc.graded_at),
+          'America/Toronto',
+          'MMM d, h:mm a',
+        )}`
+      : hasSavedDraftContent
+        ? 'Draft autosaved'
+        : null
 
   const sections: Array<{
     id: InspectorSectionId
@@ -405,24 +549,24 @@ export function TeacherWorkInspector({
           hasRepoConnection={hasRepoConnection}
         />
       ),
-      action: (
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={() => {
-            void handleAnalyzeRepo()
-          }}
-          disabled={
-            repoAnalyzing ||
-            !data.repo_target.effectiveRepoUrl ||
-            !data.repo_target.effectiveGitHubUsername
-          }
-        >
-          {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
-        </Button>
-      ),
       content: repoReviewResult ? (
-        <div className="space-y-2">
+        <div className="space-y-3">
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                void handleAnalyzeRepo()
+              }}
+              disabled={
+                repoAnalyzing ||
+                !data.repo_target.effectiveRepoUrl ||
+                !data.repo_target.effectiveGitHubUsername
+              }
+            >
+              {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
+            </Button>
+          </div>
           <RepoMetricBar
             label="Contribution"
             value={repoReviewResult.relative_contribution_share || 0}
@@ -437,49 +581,35 @@ export function TeacherWorkInspector({
           />
         </div>
       ) : (
-        <p className="text-sm text-text-muted">
-          {hasRepoConnection
-            ? 'Run repo analysis to see contribution, consistency, and iteration details.'
-            : 'No repository metadata is available for this submission yet.'}
-        </p>
+        <div className="space-y-3">
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                void handleAnalyzeRepo()
+              }}
+              disabled={
+                repoAnalyzing ||
+                !data.repo_target.effectiveRepoUrl ||
+                !data.repo_target.effectiveGitHubUsername
+              }
+            >
+              {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
+            </Button>
+          </div>
+          <p className="text-sm text-text-muted">
+            {hasRepoConnection
+              ? 'Run repo analysis to see contribution, consistency, and iteration details.'
+              : 'No repository metadata is available for this submission yet.'}
+          </p>
+        </div>
       ),
     },
     {
       id: 'grades',
       title: 'Grade',
       summary: <GradeSummary totalPercent={totalPercent} />,
-      action: (
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={() => {
-              void handleAutoGrade()
-            }}
-            disabled={autoGrading}
-          >
-            {autoGrading ? 'Grading...' : 'AI grade'}
-          </Button>
-          <SplitButton
-            label={gradeSaving ? 'Saving...' : 'Save'}
-            onPrimaryClick={() => {
-              void handleSaveGrade('graded')
-            }}
-            options={[
-              {
-                id: 'draft',
-                label: 'Draft',
-                onSelect: () => {
-                  void handleSaveGrade('draft')
-                },
-              },
-            ]}
-            size="sm"
-            disabled={gradeSaving}
-            toggleAriaLabel="Choose save mode"
-          />
-        </div>
-      ),
       content: (
         <div className="space-y-3">
           <ScoreInput label="Completion" value={scoreCompletion} onChange={setScoreCompletion} />
@@ -490,6 +620,46 @@ export function TeacherWorkInspector({
             <div />
             <ScoreTotalBox value={totalScore} total={30} />
           </div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 text-xs text-text-muted">{gradeStatusLabel ?? ''}</div>
+            <div
+              data-testid="grade-mode-toggle"
+              className="inline-flex rounded-full border border-border bg-surface-2 p-0.5"
+            >
+              <button
+                type="button"
+                className={[
+                  'inline-flex h-8 items-center justify-center rounded-full px-3 text-xs font-medium transition-colors',
+                  gradeMode === 'draft'
+                    ? 'bg-surface text-text-default shadow-sm'
+                    : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text-default',
+                ].join(' ')}
+                aria-pressed={gradeMode === 'draft'}
+                onClick={() => {
+                  void handleSetGradeMode('draft')
+                }}
+                disabled={gradeSaving}
+              >
+                Draft
+              </button>
+              <button
+                type="button"
+                className={[
+                  'inline-flex h-8 items-center justify-center rounded-full px-3 text-xs font-medium transition-colors',
+                  gradeMode === 'graded'
+                    ? 'bg-surface text-text-default shadow-sm'
+                    : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text-default',
+                ].join(' ')}
+                aria-pressed={gradeMode === 'graded'}
+                onClick={() => {
+                  void handleSetGradeMode('graded')
+                }}
+                disabled={gradeSaving}
+              >
+                Final
+              </button>
+            </div>
+          </div>
         </div>
       ),
     },
@@ -499,26 +669,19 @@ export function TeacherWorkInspector({
       content: (
         <div className="space-y-3">
           <div className="space-y-1">
-            <div className="flex items-center gap-2">
-              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                Feedback Draft
-              </div>
-              {hasFreshAIDraft && (
+            <AutoGrowFeedbackTextarea
+              value={feedbackDraft}
+              onChange={setFeedbackDraft}
+              onFocus={onAIDraftAcknowledge}
+              hasFreshAIDraft={hasFreshAIDraft}
+            />
+            {hasFreshAIDraft && (
+              <div className="flex justify-start">
                 <span className="rounded-full border border-primary/40 bg-info-bg px-2 py-0.5 text-[11px] font-medium text-primary">
                   AI draft
                 </span>
-              )}
-            </div>
-            <textarea
-              value={feedbackDraft}
-              onChange={(event) => setFeedbackDraft(event.target.value)}
-              onFocus={onAIDraftAcknowledge}
-              className={[
-                'min-h-[10rem] w-full resize-y rounded border px-2 py-1 text-sm text-text-default',
-                hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
-              ].join(' ')}
-              placeholder="Teacher feedback draft"
-            />
+              </div>
+            )}
             <div className="flex justify-end">
               <Button
                 size="sm"
@@ -528,16 +691,23 @@ export function TeacherWorkInspector({
                 }}
                 disabled={feedbackReturning || !feedbackDraft.trim()}
               >
-                {feedbackReturning ? 'Returning...' : 'Return Feedback'}
+                {feedbackReturning ? (
+                  'Sending...'
+                ) : (
+                  <>
+                    <Send className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>Send feedback</span>
+                  </>
+                )}
               </Button>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
-              Returned Feedback
-            </div>
-            {feedbackEntries.length > 0 ? (
+          {feedbackEntries.length > 0 ? (
+            <div className="space-y-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                Feedback Sent
+              </div>
               <div className="rounded border border-border bg-surface p-3">
                 <div className="space-y-3">
                   {feedbackEntries.map((entry) => (
@@ -556,10 +726,8 @@ export function TeacherWorkInspector({
                   ))}
                 </div>
               </div>
-            ) : (
-              <p className="text-sm text-text-muted">No returned feedback yet.</p>
-            )}
-          </div>
+            </div>
+          ) : null}
         </div>
       ),
     },
@@ -588,27 +756,10 @@ export function TeacherWorkInspector({
         </div>
       </div>
 
-      {(gradeError || data.doc?.graded_at) && (
+      {gradeError && (
         <div className="border-t border-border bg-surface px-3 py-3">
-          <div className="space-y-3">
-            {gradeError && (
-              <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
-                {gradeError}
-              </div>
-            )}
-
-            {data.doc?.graded_at && (
-              <div className="text-xs text-text-muted">
-                Graded{' '}
-                {formatInTimeZone(
-                  new Date(data.doc.graded_at),
-                  'America/Toronto',
-                  'MMM d, h:mm a',
-                )}
-                {data.doc.graded_by &&
-                  ` by ${data.doc.graded_by.startsWith('ai:') ? 'AI' : data.doc.graded_by}`}
-              </div>
-            )}
+          <div className="rounded border border-danger bg-danger-bg px-2 py-1.5 text-xs text-danger">
+            {gradeError}
           </div>
         </div>
       )}

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -243,7 +243,7 @@ function AnimatedSectionContent({
   useEffect(() => {
     let frameId = 0
     let frameIdTwo = 0
-    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let timeoutId: number | undefined
 
     if (expanded) {
       setShouldRender(true)
@@ -666,6 +666,7 @@ export function TeacherWorkInspector({
     {
       id: 'comments',
       title: 'Feedback',
+      summary: null,
       content: (
         <div className="space-y-3">
           <div className="space-y-1">

--- a/src/components/assignment-workspace/types.ts
+++ b/src/components/assignment-workspace/types.ts
@@ -1,0 +1,34 @@
+import type {
+  Assignment,
+  AssignmentDoc,
+  AssignmentFeedbackEntry,
+  AssignmentRepoReviewResult,
+  AssignmentRepoTarget,
+  AssignmentRepoTargetSelectionMode,
+  AssignmentRepoTargetValidationStatus,
+  AssignmentStatus,
+} from '@/types'
+
+export type InspectorSectionId = 'history' | 'repo' | 'grades' | 'comments'
+
+export interface StudentWorkData {
+  assignment: Assignment
+  classroom: { id: string; title: string }
+  student: { id: string; email: string; name: string | null }
+  doc: AssignmentDoc | null
+  status: AssignmentStatus
+  feedback_entries: AssignmentFeedbackEntry[]
+  repo_target: {
+    target: AssignmentRepoTarget | null
+    submittedRepoUrl: string | null
+    submittedGitHubUsername: string | null
+    effectiveRepoUrl: string | null
+    effectiveGitHubUsername: string | null
+    repoOwner: string | null
+    repoName: string | null
+    selectionMode: AssignmentRepoTargetSelectionMode
+    validationStatus: AssignmentRepoTargetValidationStatus
+    validationMessage: string | null
+    latest_result: AssignmentRepoReviewResult | null
+  }
+}

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -114,6 +114,29 @@ function parseGradeInputs({
   }
 }
 
+function serializeDraftGradeInputs({
+  scoreCompletion,
+  scoreThinking,
+  scoreWorkflow,
+}: {
+  scoreCompletion: string
+  scoreThinking: string
+  scoreWorkflow: string
+}) {
+  const normalize = (value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = Number(trimmed)
+    return Number.isInteger(parsed) && parsed >= 0 && parsed <= 10 ? parsed : null
+  }
+
+  return {
+    scoreCompletion: normalize(scoreCompletion),
+    scoreThinking: normalize(scoreThinking),
+    scoreWorkflow: normalize(scoreWorkflow),
+  }
+}
+
 export interface TeacherStudentWorkController {
   data: StudentWorkData | null
   error: string
@@ -406,17 +429,26 @@ export function useTeacherStudentWorkController({
         scoreThinking,
         scoreWorkflow,
       })
+      const serializedDraftScores = serializeDraftGradeInputs({
+        scoreCompletion,
+        scoreThinking,
+        scoreWorkflow,
+      })
+      const isValidForSelectedMode =
+        selectedSaveMode === 'draft'
+          ? true
+          : parsedScores.isValid
 
-      if (!parsedScores.isValid) {
+      if (!isValidForSelectedMode) {
         if (options?.source !== 'autosave') {
           setGradeError('Scores must be integers 0–10')
         }
         return
       }
 
-      const sc = parsedScores.scoreCompletion
-      const st = parsedScores.scoreThinking
-      const sw = parsedScores.scoreWorkflow
+      const sc = selectedSaveMode === 'draft' ? serializedDraftScores.scoreCompletion : parsedScores.scoreCompletion
+      const st = selectedSaveMode === 'draft' ? serializedDraftScores.scoreThinking : parsedScores.scoreThinking
+      const sw = selectedSaveMode === 'draft' ? serializedDraftScores.scoreWorkflow : parsedScores.scoreWorkflow
       const nextSnapshot = buildGradeSnapshot({
         scoreCompletion,
         scoreThinking,
@@ -481,9 +513,9 @@ export function useTeacherStudentWorkController({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            student_id: studentId,
-            score_completion: sc,
-            score_thinking: st,
+              student_id: studentId,
+              score_completion: sc,
+              score_thinking: st,
             score_workflow: sw,
             feedback: feedbackDraft,
             save_mode: selectedSaveMode,
@@ -530,13 +562,14 @@ export function useTeacherStudentWorkController({
       return
     }
 
-    const parsedScores = parseGradeInputs({
-      scoreCompletion,
-      scoreThinking,
-      scoreWorkflow,
-    })
-
-    if (!parsedScores.isValid) {
+    if (
+      selectedSaveMode === 'graded'
+      && !parseGradeInputs({
+        scoreCompletion,
+        scoreThinking,
+        scoreWorkflow,
+      }).isValid
+    ) {
       return
     }
 

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -1,0 +1,592 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
+import { readCookie, writeCookie } from '@/lib/cookies'
+import { TEACHER_GRADE_UPDATED_EVENT, type TeacherGradeUpdatedEventDetail } from '@/lib/events'
+import { useDelayedBusy } from '@/hooks/useDelayedBusy'
+import type {
+  AssignmentDoc,
+  AssignmentDocHistoryEntry,
+  AssignmentFeedbackEntry,
+  AssignmentRepoReviewResult,
+  TiptapContent,
+} from '@/types'
+import type { InspectorSectionId, StudentWorkData } from './types'
+
+type GradeSaveMode = 'draft' | 'graded'
+
+const SECTION_ORDER: InspectorSectionId[] = ['history', 'repo', 'grades', 'comments']
+const DEFAULT_EXPANDED_SECTIONS: InspectorSectionId[] = ['grades', 'comments']
+const INSPECTOR_SECTIONS_COOKIE_PREFIX = 'pika_teacher_student_work_sections'
+
+function getInspectorSectionsCookieName(classroomId: string) {
+  return `${INSPECTOR_SECTIONS_COOKIE_PREFIX}:${classroomId}`
+}
+
+function parseExpandedSections(rawValue: string | null | undefined): InspectorSectionId[] {
+  if (!rawValue) return DEFAULT_EXPANDED_SECTIONS
+
+  const parts = rawValue
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  if (parts.length === 0) return DEFAULT_EXPANDED_SECTIONS
+
+  const valid = new Set<InspectorSectionId>(SECTION_ORDER)
+  const nextSections: InspectorSectionId[] = []
+
+  for (const part of parts) {
+    if (!valid.has(part as InspectorSectionId)) {
+      return DEFAULT_EXPANDED_SECTIONS
+    }
+    const section = part as InspectorSectionId
+    if (!nextSections.includes(section)) {
+      nextSections.push(section)
+    }
+  }
+
+  return SECTION_ORDER.filter((section) => nextSections.includes(section))
+}
+
+function serializeExpandedSections(sections: InspectorSectionId[]): string {
+  return SECTION_ORDER.filter((section) => sections.includes(section)).join(',')
+}
+
+function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: string | null | undefined) {
+  const base = (baseDraft ?? '').trim()
+  const suggestion = (aiSuggestion ?? '').trim()
+
+  if (!suggestion) return { value: baseDraft ?? '', hasFreshAI: false }
+  if (!base) return { value: suggestion, hasFreshAI: true }
+  if (base.includes(suggestion)) return { value: baseDraft ?? base, hasFreshAI: false }
+
+  return { value: `${suggestion}\n\n${base}`, hasFreshAI: true }
+}
+
+export interface TeacherStudentWorkController {
+  data: StudentWorkData | null
+  error: string
+  loading: boolean
+  showInitialSpinner: boolean
+  historyEntries: AssignmentDocHistoryEntry[]
+  historyLoading: boolean
+  historyError: string
+  previewEntry: AssignmentDocHistoryEntry | null
+  previewContent: TiptapContent | null
+  isPreviewLocked: boolean
+  scoreCompletion: string
+  scoreThinking: string
+  scoreWorkflow: string
+  feedbackDraft: string
+  hasFreshAIDraft: boolean
+  gradeSaving: boolean
+  gradeError: string
+  autoGrading: boolean
+  feedbackReturning: boolean
+  repoAnalyzing: boolean
+  feedbackEntries: AssignmentFeedbackEntry[]
+  repoReviewResult: AssignmentRepoReviewResult | null
+  totalScore: number
+  totalPercent: number
+  expandedSections: InspectorSectionId[]
+  setScoreCompletion: (value: string) => void
+  setScoreThinking: (value: string) => void
+  setScoreWorkflow: (value: string) => void
+  setFeedbackDraft: (value: string) => void
+  handlePreviewHover: (entry: AssignmentDocHistoryEntry) => void
+  handlePreviewLock: (entry: AssignmentDocHistoryEntry) => void
+  handleExitPreview: () => void
+  handleHistoryMouseLeave: () => void
+  handleAIDraftAcknowledge: () => void
+  toggleSection: (section: InspectorSectionId) => void
+  handleAutoGrade: () => Promise<void>
+  handleReturnFeedback: () => Promise<void>
+  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
+  handleAnalyzeRepo: () => Promise<void>
+}
+
+export function useTeacherStudentWorkController({
+  classroomId,
+  assignmentId,
+  studentId,
+  onLoadingStateChange,
+}: {
+  classroomId: string
+  assignmentId: string
+  studentId: string
+  onLoadingStateChange?: (loading: boolean) => void
+}): TeacherStudentWorkController {
+  const studentLoadRequestIdRef = useRef(0)
+  const historyLoadRequestIdRef = useRef(0)
+  const [data, setData] = useState<StudentWorkData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const [historyEntries, setHistoryEntries] = useState<AssignmentDocHistoryEntry[]>([])
+  const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState('')
+  const [previewEntry, setPreviewEntry] = useState<AssignmentDocHistoryEntry | null>(null)
+  const [previewContent, setPreviewContent] = useState<TiptapContent | null>(null)
+  const [lockedEntryId, setLockedEntryId] = useState<string | null>(null)
+
+  const [scoreCompletion, setScoreCompletion] = useState('')
+  const [scoreThinking, setScoreThinking] = useState('')
+  const [scoreWorkflow, setScoreWorkflow] = useState('')
+  const [feedbackDraft, setFeedbackDraft] = useState('')
+  const [hasFreshAIDraft, setHasFreshAIDraft] = useState(false)
+  const [gradeSaving, setGradeSaving] = useState(false)
+  const [gradeError, setGradeError] = useState('')
+  const [autoGrading, setAutoGrading] = useState(false)
+  const [feedbackReturning, setFeedbackReturning] = useState(false)
+  const [repoAnalyzing, setRepoAnalyzing] = useState(false)
+  const [expandedSections, setExpandedSections] = useState<InspectorSectionId[]>(() =>
+    parseExpandedSections(readCookie(getInspectorSectionsCookieName(classroomId))),
+  )
+  const showInitialSpinner = useDelayedBusy(loading && !data)
+
+  useEffect(() => {
+    setExpandedSections(parseExpandedSections(readCookie(getInspectorSectionsCookieName(classroomId))))
+  }, [classroomId])
+
+  const persistExpandedSections = useCallback(
+    (sections: InspectorSectionId[]) => {
+      writeCookie(
+        getInspectorSectionsCookieName(classroomId),
+        serializeExpandedSections(sections),
+      )
+    },
+    [classroomId],
+  )
+
+  const toggleSection = useCallback(
+    (section: InspectorSectionId) => {
+      setExpandedSections((current) => {
+        const next = current.includes(section)
+          ? current.filter((value) => value !== section)
+          : SECTION_ORDER.filter((value) => value === section || current.includes(value))
+        persistExpandedSections(next)
+        return next
+      })
+    },
+    [persistExpandedSections],
+  )
+
+  const dispatchGradeUpdated = useCallback(
+    (doc: AssignmentDoc | null) => {
+      const detail: TeacherGradeUpdatedEventDetail = {
+        assignmentId,
+        studentId,
+        doc,
+      }
+      window.dispatchEvent(
+        new CustomEvent<TeacherGradeUpdatedEventDetail>(TEACHER_GRADE_UPDATED_EVENT, { detail }),
+      )
+    },
+    [assignmentId, studentId],
+  )
+
+  const updatePreview = useCallback(
+    (entry: AssignmentDocHistoryEntry): boolean => {
+      const oldestFirst = [...historyEntries].reverse()
+      const reconstructed = reconstructAssignmentDocContent(oldestFirst, entry.id)
+
+      if (!reconstructed) return false
+
+      setPreviewEntry(entry)
+      setPreviewContent(reconstructed)
+      return true
+    },
+    [historyEntries],
+  )
+
+  const handlePreviewHover = useCallback(
+    (entry: AssignmentDocHistoryEntry) => {
+      if (lockedEntryId) return
+      updatePreview(entry)
+    },
+    [lockedEntryId, updatePreview],
+  )
+
+  const handlePreviewLock = useCallback(
+    (entry: AssignmentDocHistoryEntry) => {
+      const success = updatePreview(entry)
+      if (success) {
+        setLockedEntryId(entry.id)
+      }
+    },
+    [updatePreview],
+  )
+
+  const handleExitPreview = useCallback(() => {
+    setPreviewEntry(null)
+    setPreviewContent(null)
+    setLockedEntryId(null)
+  }, [])
+
+  const handleHistoryMouseLeave = useCallback(() => {
+    if (lockedEntryId) return
+    handleExitPreview()
+  }, [handleExitPreview, lockedEntryId])
+
+  const populateGradeForm = useCallback((doc: AssignmentDoc | null, mergeBaseDraft?: string | null) => {
+    if (!doc) {
+      setScoreCompletion('')
+      setScoreThinking('')
+      setScoreWorkflow('')
+      setFeedbackDraft('')
+      setHasFreshAIDraft(false)
+      return
+    }
+
+    setScoreCompletion(doc.score_completion?.toString() ?? '')
+    setScoreThinking(doc.score_thinking?.toString() ?? '')
+    setScoreWorkflow(doc.score_workflow?.toString() ?? '')
+
+    const baseDraft = mergeBaseDraft ?? doc.teacher_feedback_draft ?? doc.feedback ?? ''
+    const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion)
+    setFeedbackDraft(mergedDraft.value)
+    setHasFreshAIDraft(mergedDraft.hasFreshAI)
+  }, [])
+
+  const loadStudentWork = useCallback(
+    async (options?: { mergeFeedbackIntoDraftFrom?: string | null }): Promise<StudentWorkData | null> => {
+      const requestId = ++studentLoadRequestIdRef.current
+      setLoading(true)
+      setError('')
+      setGradeError('')
+      handleExitPreview()
+
+      try {
+        const response = await fetch(`/api/teacher/assignments/${assignmentId}/students/${studentId}`)
+        const result = await response.json()
+        if (!response.ok) {
+          throw new Error(result.error || 'Failed to load student work')
+        }
+        if (requestId !== studentLoadRequestIdRef.current) {
+          return null
+        }
+
+        setData(result)
+        populateGradeForm(result.doc, options?.mergeFeedbackIntoDraftFrom)
+        return result
+      } catch (err: any) {
+        if (requestId !== studentLoadRequestIdRef.current) {
+          return null
+        }
+        setError(err.message || 'Failed to load student work')
+        return null
+      } finally {
+        if (requestId === studentLoadRequestIdRef.current) {
+          setLoading(false)
+        }
+      }
+    },
+    [assignmentId, handleExitPreview, populateGradeForm, studentId],
+  )
+
+  useEffect(() => {
+    void loadStudentWork()
+  }, [loadStudentWork])
+
+  useEffect(() => {
+    const requestId = ++historyLoadRequestIdRef.current
+    setHistoryLoading(true)
+    setHistoryError('')
+
+    async function loadHistory() {
+      try {
+        const response = await fetch(
+          `/api/assignment-docs/${assignmentId}/history?student_id=${studentId}`,
+        )
+        const result = await response.json()
+        if (!response.ok) {
+          throw new Error(result.error || 'Failed to load history')
+        }
+        if (requestId !== historyLoadRequestIdRef.current) return
+        setHistoryEntries(result.history || [])
+      } catch (err: any) {
+        if (requestId !== historyLoadRequestIdRef.current) return
+        setHistoryError(err.message || 'Failed to load history')
+      } finally {
+        if (requestId === historyLoadRequestIdRef.current) {
+          setHistoryLoading(false)
+        }
+      }
+    }
+
+    void loadHistory()
+  }, [assignmentId, studentId])
+
+  useEffect(() => {
+    onLoadingStateChange?.(loading && !!data)
+  }, [data, loading, onLoadingStateChange])
+
+  useEffect(() => {
+    return () => {
+      onLoadingStateChange?.(false)
+    }
+  }, [onLoadingStateChange])
+
+  const handleSaveGrade = useCallback(
+    async (selectedSaveMode: GradeSaveMode) => {
+      if (!data) return
+
+      const sc = Number(scoreCompletion)
+      const st = Number(scoreThinking)
+      const sw = Number(scoreWorkflow)
+
+      if ([sc, st, sw].some((value) => !Number.isInteger(value) || value < 0 || value > 10)) {
+        setGradeError('Scores must be integers 0–10')
+        return
+      }
+
+      setGradeSaving(true)
+      setGradeError('')
+      const previousDoc = data.doc
+      const optimisticDoc: AssignmentDoc = {
+        ...(previousDoc || {
+          id: '',
+          assignment_id: assignmentId,
+          student_id: studentId,
+          content: { type: 'doc', content: [] },
+          repo_url: null,
+          github_username: null,
+          is_submitted: false,
+          submitted_at: null,
+          viewed_at: null,
+          score_completion: null,
+          score_thinking: null,
+          score_workflow: null,
+          feedback: null,
+          teacher_feedback_draft: null,
+          teacher_feedback_draft_updated_at: null,
+          feedback_returned_at: null,
+          ai_feedback_suggestion: null,
+          ai_feedback_suggested_at: null,
+          ai_feedback_model: null,
+          teacher_cleared_at: null,
+          graded_at: null,
+          graded_by: null,
+          returned_at: null,
+          authenticity_score: null,
+          authenticity_flags: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+        score_completion: sc,
+        score_thinking: st,
+        score_workflow: sw,
+        teacher_feedback_draft: feedbackDraft,
+        teacher_feedback_draft_updated_at: new Date().toISOString(),
+        graded_at:
+          selectedSaveMode === 'graded'
+            ? previousDoc?.graded_at || new Date().toISOString()
+            : null,
+        graded_by:
+          selectedSaveMode === 'graded'
+            ? previousDoc?.graded_by || 'teacher'
+            : null,
+        updated_at: new Date().toISOString(),
+      }
+      setData((current) => (current ? { ...current, doc: optimisticDoc } : current))
+
+      try {
+        const response = await fetch(`/api/teacher/assignments/${assignmentId}/grade`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            student_id: studentId,
+            score_completion: sc,
+            score_thinking: st,
+            score_workflow: sw,
+            feedback: feedbackDraft,
+            save_mode: selectedSaveMode,
+          }),
+        })
+        const result = await response.json()
+        if (!response.ok) throw new Error(result.error || 'Failed to save grade')
+        setData((current) => (current ? { ...current, doc: result.doc } : current))
+        dispatchGradeUpdated(result.doc)
+      } catch (err: any) {
+        setData((current) => (current ? { ...current, doc: previousDoc } : current))
+        setGradeError(err.message || 'Failed to save grade')
+      } finally {
+        setGradeSaving(false)
+      }
+    },
+    [
+      assignmentId,
+      data,
+      dispatchGradeUpdated,
+      feedbackDraft,
+      scoreCompletion,
+      scoreThinking,
+      scoreWorkflow,
+      studentId,
+    ],
+  )
+
+  const handleAutoGrade = useCallback(async () => {
+    if (!data) return
+
+    setAutoGrading(true)
+    setGradeError('')
+    try {
+      const response = await fetch(`/api/teacher/assignments/${assignmentId}/auto-grade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student_ids: [studentId] }),
+      })
+      const result = await response.json()
+      if (!response.ok) throw new Error(result.error || 'Auto-grade failed')
+      if (result.errors?.length) {
+        setGradeError(result.errors.join(', '))
+        return
+      }
+      if (result.graded_count === 0) {
+        setGradeError('No gradable content found — the submission may be empty')
+        return
+      }
+      const refreshed = await loadStudentWork({ mergeFeedbackIntoDraftFrom: feedbackDraft })
+      dispatchGradeUpdated(refreshed?.doc ?? null)
+    } catch (err: any) {
+      setGradeError(err.message || 'Auto-grade failed')
+    } finally {
+      setAutoGrading(false)
+    }
+  }, [assignmentId, data, dispatchGradeUpdated, feedbackDraft, loadStudentWork, studentId])
+
+  const handleReturnFeedback = useCallback(async () => {
+    if (!data) return
+
+    const trimmed = feedbackDraft.trim()
+    if (!trimmed) {
+      setGradeError('Feedback draft is required before returning feedback')
+      return
+    }
+
+    setFeedbackReturning(true)
+    setGradeError('')
+    try {
+      const response = await fetch(`/api/teacher/assignments/${assignmentId}/feedback-return`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          student_id: studentId,
+          feedback: trimmed,
+        }),
+      })
+      const result = await response.json()
+      if (!response.ok) throw new Error(result.error || 'Failed to return feedback')
+
+      setData((current) =>
+        current
+          ? {
+              ...current,
+              doc: result.doc,
+              feedback_entries: [...current.feedback_entries, result.entry],
+            }
+          : current,
+      )
+      populateGradeForm(result.doc)
+      dispatchGradeUpdated(result.doc)
+    } catch (err: any) {
+      setGradeError(err.message || 'Failed to return feedback')
+    } finally {
+      setFeedbackReturning(false)
+    }
+  }, [
+    assignmentId,
+    data,
+    dispatchGradeUpdated,
+    feedbackDraft,
+    populateGradeForm,
+    studentId,
+  ])
+
+  const handleAnalyzeRepo = useCallback(async () => {
+    if (!data) return
+
+    setRepoAnalyzing(true)
+    setGradeError('')
+    try {
+      const response = await fetch(`/api/teacher/assignments/${assignmentId}/artifact-repo/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student_ids: [studentId] }),
+      })
+      const result = await response.json()
+      if (!response.ok) throw new Error(result.error || 'Repo analysis failed')
+      const refreshed = await loadStudentWork()
+      dispatchGradeUpdated(refreshed?.doc ?? null)
+      if ((result.analyzed_students ?? 0) === 0 && result.skipped_reasons) {
+        const message = Object.entries(result.skipped_reasons as Record<string, number>)
+          .map(([reason, count]) => `${count} ${reason}`)
+          .join(' ')
+        if (message) {
+          setGradeError(message)
+        }
+      }
+    } catch (err: any) {
+      setGradeError(err.message || 'Repo analysis failed')
+    } finally {
+      setRepoAnalyzing(false)
+    }
+  }, [assignmentId, data, dispatchGradeUpdated, loadStudentWork, studentId])
+
+  const feedbackEntries = data?.feedback_entries || []
+  const repoReviewResult = data?.repo_target.latest_result || null
+
+  const totalScore = useMemo(() => {
+    const sc = Number(scoreCompletion) || 0
+    const st = Number(scoreThinking) || 0
+    const sw = Number(scoreWorkflow) || 0
+    return sc + st + sw
+  }, [scoreCompletion, scoreThinking, scoreWorkflow])
+
+  const totalPercent = useMemo(() => Math.round((totalScore / 30) * 100), [totalScore])
+
+  return {
+    data,
+    error,
+    loading,
+    showInitialSpinner,
+    historyEntries,
+    historyLoading,
+    historyError,
+    previewEntry,
+    previewContent,
+    isPreviewLocked: lockedEntryId !== null,
+    scoreCompletion,
+    scoreThinking,
+    scoreWorkflow,
+    feedbackDraft,
+    hasFreshAIDraft,
+    gradeSaving,
+    gradeError,
+    autoGrading,
+    feedbackReturning,
+    repoAnalyzing,
+    feedbackEntries,
+    repoReviewResult,
+    totalScore,
+    totalPercent,
+    expandedSections,
+    setScoreCompletion,
+    setScoreThinking,
+    setScoreWorkflow,
+    setFeedbackDraft,
+    handlePreviewHover,
+    handlePreviewLock,
+    handleExitPreview,
+    handleHistoryMouseLeave,
+    handleAIDraftAcknowledge: () => setHasFreshAIDraft(false),
+    toggleSection,
+    handleAutoGrade,
+    handleReturnFeedback,
+    handleSaveGrade,
+    handleAnalyzeRepo,
+  }
+}

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -19,6 +19,7 @@ type GradeSaveMode = 'draft' | 'graded'
 const SECTION_ORDER: InspectorSectionId[] = ['history', 'repo', 'grades', 'comments']
 const DEFAULT_EXPANDED_SECTIONS: InspectorSectionId[] = ['grades', 'comments']
 const INSPECTOR_SECTIONS_COOKIE_PREFIX = 'pika_teacher_student_work_sections'
+const GRADE_AUTOSAVE_DELAY_MS = 900
 
 function getInspectorSectionsCookieName(classroomId: string) {
   return `${INSPECTOR_SECTIONS_COOKIE_PREFIX}:${classroomId}`
@@ -65,6 +66,54 @@ function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: 
   return { value: `${suggestion}\n\n${base}`, hasFreshAI: true }
 }
 
+function getGradeSaveMode(doc: AssignmentDoc | null | undefined): GradeSaveMode {
+  return doc?.graded_at ? 'graded' : 'draft'
+}
+
+function buildGradeSnapshot({
+  scoreCompletion,
+  scoreThinking,
+  scoreWorkflow,
+  feedbackDraft,
+  mode,
+}: {
+  scoreCompletion: string
+  scoreThinking: string
+  scoreWorkflow: string
+  feedbackDraft: string
+  mode: GradeSaveMode
+}) {
+  return JSON.stringify({
+    scoreCompletion,
+    scoreThinking,
+    scoreWorkflow,
+    feedbackDraft,
+    mode,
+  })
+}
+
+function parseGradeInputs({
+  scoreCompletion,
+  scoreThinking,
+  scoreWorkflow,
+}: {
+  scoreCompletion: string
+  scoreThinking: string
+  scoreWorkflow: string
+}) {
+  const sc = Number(scoreCompletion)
+  const st = Number(scoreThinking)
+  const sw = Number(scoreWorkflow)
+  const values = [sc, st, sw]
+
+  return {
+    isValid: values.every((value) => Number.isInteger(value) && value >= 0 && value <= 10),
+    scoreCompletion: sc,
+    scoreThinking: st,
+    scoreWorkflow: sw,
+  }
+}
+
 export interface TeacherStudentWorkController {
   data: StudentWorkData | null
   error: string
@@ -81,6 +130,7 @@ export interface TeacherStudentWorkController {
   scoreWorkflow: string
   feedbackDraft: string
   hasFreshAIDraft: boolean
+  gradeMode: GradeSaveMode
   gradeSaving: boolean
   gradeError: string
   autoGrading: boolean
@@ -103,7 +153,7 @@ export interface TeacherStudentWorkController {
   toggleSection: (section: InspectorSectionId) => void
   handleAutoGrade: () => Promise<void>
   handleReturnFeedback: () => Promise<void>
-  handleSaveGrade: (mode: GradeSaveMode) => Promise<void>
+  handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
   handleAnalyzeRepo: () => Promise<void>
 }
 
@@ -120,6 +170,7 @@ export function useTeacherStudentWorkController({
 }): TeacherStudentWorkController {
   const studentLoadRequestIdRef = useRef(0)
   const historyLoadRequestIdRef = useRef(0)
+  const lastSavedGradeSnapshotRef = useRef('')
   const [data, setData] = useState<StudentWorkData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -237,17 +288,34 @@ export function useTeacherStudentWorkController({
       setScoreWorkflow('')
       setFeedbackDraft('')
       setHasFreshAIDraft(false)
+      lastSavedGradeSnapshotRef.current = buildGradeSnapshot({
+        scoreCompletion: '',
+        scoreThinking: '',
+        scoreWorkflow: '',
+        feedbackDraft: '',
+        mode: 'draft',
+      })
       return
     }
 
-    setScoreCompletion(doc.score_completion?.toString() ?? '')
-    setScoreThinking(doc.score_thinking?.toString() ?? '')
-    setScoreWorkflow(doc.score_workflow?.toString() ?? '')
-
+    const nextScoreCompletion = doc.score_completion?.toString() ?? ''
+    const nextScoreThinking = doc.score_thinking?.toString() ?? ''
+    const nextScoreWorkflow = doc.score_workflow?.toString() ?? ''
     const baseDraft = mergeBaseDraft ?? doc.teacher_feedback_draft ?? doc.feedback ?? ''
     const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion)
+
+    setScoreCompletion(nextScoreCompletion)
+    setScoreThinking(nextScoreThinking)
+    setScoreWorkflow(nextScoreWorkflow)
     setFeedbackDraft(mergedDraft.value)
     setHasFreshAIDraft(mergedDraft.hasFreshAI)
+    lastSavedGradeSnapshotRef.current = buildGradeSnapshot({
+      scoreCompletion: nextScoreCompletion,
+      scoreThinking: nextScoreThinking,
+      scoreWorkflow: nextScoreWorkflow,
+      feedbackDraft: mergedDraft.value,
+      mode: getGradeSaveMode(doc),
+    })
   }, [])
 
   const loadStudentWork = useCallback(
@@ -329,18 +397,34 @@ export function useTeacherStudentWorkController({
     }
   }, [onLoadingStateChange])
 
-  const handleSaveGrade = useCallback(
-    async (selectedSaveMode: GradeSaveMode) => {
+  const persistGrade = useCallback(
+    async (selectedSaveMode: GradeSaveMode, options?: { source?: 'autosave' | 'manual' }) => {
       if (!data) return
 
-      const sc = Number(scoreCompletion)
-      const st = Number(scoreThinking)
-      const sw = Number(scoreWorkflow)
+      const parsedScores = parseGradeInputs({
+        scoreCompletion,
+        scoreThinking,
+        scoreWorkflow,
+      })
 
-      if ([sc, st, sw].some((value) => !Number.isInteger(value) || value < 0 || value > 10)) {
-        setGradeError('Scores must be integers 0–10')
+      if (!parsedScores.isValid) {
+        if (options?.source !== 'autosave') {
+          setGradeError('Scores must be integers 0–10')
+        }
         return
       }
+
+      const sc = parsedScores.scoreCompletion
+      const st = parsedScores.scoreThinking
+      const sw = parsedScores.scoreWorkflow
+      const nextSnapshot = buildGradeSnapshot({
+        scoreCompletion,
+        scoreThinking,
+        scoreWorkflow,
+        feedbackDraft,
+        mode: selectedSaveMode,
+      })
+      const previousSavedSnapshot = lastSavedGradeSnapshotRef.current
 
       setGradeSaving(true)
       setGradeError('')
@@ -407,9 +491,11 @@ export function useTeacherStudentWorkController({
         })
         const result = await response.json()
         if (!response.ok) throw new Error(result.error || 'Failed to save grade')
+        lastSavedGradeSnapshotRef.current = nextSnapshot
         setData((current) => (current ? { ...current, doc: result.doc } : current))
         dispatchGradeUpdated(result.doc)
       } catch (err: any) {
+        lastSavedGradeSnapshotRef.current = previousSavedSnapshot
         setData((current) => (current ? { ...current, doc: previousDoc } : current))
         setGradeError(err.message || 'Failed to save grade')
       } finally {
@@ -426,6 +512,68 @@ export function useTeacherStudentWorkController({
       scoreWorkflow,
       studentId,
     ],
+  )
+
+  useEffect(() => {
+    if (!data || gradeSaving) return
+
+    const selectedSaveMode = getGradeSaveMode(data.doc)
+    const nextSnapshot = buildGradeSnapshot({
+      scoreCompletion,
+      scoreThinking,
+      scoreWorkflow,
+      feedbackDraft,
+      mode: selectedSaveMode,
+    })
+
+    if (nextSnapshot === lastSavedGradeSnapshotRef.current) {
+      return
+    }
+
+    const parsedScores = parseGradeInputs({
+      scoreCompletion,
+      scoreThinking,
+      scoreWorkflow,
+    })
+
+    if (!parsedScores.isValid) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void persistGrade(selectedSaveMode, { source: 'autosave' })
+    }, GRADE_AUTOSAVE_DELAY_MS)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [data, feedbackDraft, gradeSaving, persistGrade, scoreCompletion, scoreThinking, scoreWorkflow])
+
+  const updateScoreCompletion = useCallback((value: string) => {
+    setGradeError('')
+    setScoreCompletion(value)
+  }, [])
+
+  const updateScoreThinking = useCallback((value: string) => {
+    setGradeError('')
+    setScoreThinking(value)
+  }, [])
+
+  const updateScoreWorkflow = useCallback((value: string) => {
+    setGradeError('')
+    setScoreWorkflow(value)
+  }, [])
+
+  const updateFeedbackDraft = useCallback((value: string) => {
+    setGradeError('')
+    setFeedbackDraft(value)
+  }, [])
+
+  const handleSetGradeMode = useCallback(
+    async (selectedSaveMode: GradeSaveMode) => {
+      await persistGrade(selectedSaveMode, { source: 'manual' })
+    },
+    [persistGrade],
   )
 
   const handleAutoGrade = useCallback(async () => {
@@ -547,6 +695,7 @@ export function useTeacherStudentWorkController({
   }, [scoreCompletion, scoreThinking, scoreWorkflow])
 
   const totalPercent = useMemo(() => Math.round((totalScore / 30) * 100), [totalScore])
+  const gradeMode = getGradeSaveMode(data?.doc)
 
   return {
     data,
@@ -564,6 +713,7 @@ export function useTeacherStudentWorkController({
     scoreWorkflow,
     feedbackDraft,
     hasFreshAIDraft,
+    gradeMode,
     gradeSaving,
     gradeError,
     autoGrading,
@@ -574,10 +724,10 @@ export function useTeacherStudentWorkController({
     totalScore,
     totalPercent,
     expandedSections,
-    setScoreCompletion,
-    setScoreThinking,
-    setScoreWorkflow,
-    setFeedbackDraft,
+    setScoreCompletion: updateScoreCompletion,
+    setScoreThinking: updateScoreThinking,
+    setScoreWorkflow: updateScoreWorkflow,
+    setFeedbackDraft: updateFeedbackDraft,
     handlePreviewHover,
     handlePreviewLock,
     handleExitPreview,
@@ -586,7 +736,7 @@ export function useTeacherStudentWorkController({
     toggleSection,
     handleAutoGrade,
     handleReturnFeedback,
-    handleSaveGrade,
+    handleSetGradeMode,
     handleAnalyzeRepo,
   }
 }

--- a/tests/api/teacher/assignments-id-grade.test.ts
+++ b/tests/api/teacher/assignments-id-grade.test.ts
@@ -224,6 +224,97 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
     expect(body.doc.graded_at).toBeNull()
   })
 
+  it('allows partial draft saves with blank scores', async () => {
+    let capturedUpsertPayload: Record<string, unknown> | null = null
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'enroll-1' }, error: null }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          upsert: vi.fn((payload: Record<string, unknown>) => {
+            capturedUpsertPayload = payload
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    assignment_id: 'assignment-1',
+                    student_id: 'student-1',
+                    score_completion: 6,
+                    score_thinking: null,
+                    score_workflow: null,
+                    teacher_feedback_draft: 'Draft only',
+                    graded_at: null,
+                    graded_by: null,
+                  },
+                  error: null,
+                }),
+              })),
+            }
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_id: 'student-1',
+        score_completion: 6,
+        score_thinking: '',
+        score_workflow: null,
+        feedback: 'Draft only',
+        save_mode: 'draft',
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(capturedUpsertPayload).toMatchObject({
+      score_completion: 6,
+      score_thinking: null,
+      score_workflow: null,
+      teacher_feedback_draft: 'Draft only',
+      graded_at: null,
+      graded_by: null,
+    })
+    expect(body.doc.teacher_feedback_draft).toBe('Draft only')
+  })
+
   it('returns 400 for invalid save_mode', async () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade', {
       method: 'POST',

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TeacherClassroomsIndex } from '@/app/classrooms/TeacherClassroomsIndex'
 import { createMockClassroom } from '../helpers/mocks'
 
@@ -35,5 +35,21 @@ describe('TeacherClassroomsIndex', () => {
       ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/classrooms'
     )
     expect(classroomFetchCalls).toHaveLength(0)
+  })
+
+  it('keeps the bottom create button available in archived view when there are no active classrooms', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        classrooms: [createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' })],
+      }),
+    })
+
+    render(<TeacherClassroomsIndex initialClassrooms={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
+
+    expect(await screen.findByText('Archived')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -17,8 +17,19 @@ vi.mock('@/components/editor', () => ({
 }))
 
 vi.mock('@/components/HistoryList', () => ({
-  HistoryList: ({ entries }: any) => (
-    <div data-testid="history-list">{entries.map((entry: any) => entry.id).join(',')}</div>
+  HistoryList: ({ entries, onEntryClick, onEntryHover }: any) => (
+    <div data-testid="history-list">
+      {entries.map((entry: any) => (
+        <button
+          key={entry.id}
+          type="button"
+          onMouseEnter={() => onEntryHover?.(entry)}
+          onClick={() => onEntryClick(entry)}
+        >
+          {entry.id}
+        </button>
+      ))}
+    </div>
   ),
 }))
 
@@ -157,6 +168,7 @@ function mockFetchByStudent(
       feedbackEntries?: Array<{ id: string; body: string; returned_at: string }>
       repoReviewResult?: Record<string, any> | null
       authenticityScore?: number | null
+      historyEntries?: Array<Record<string, any>>
     }
   >,
 ) {
@@ -181,9 +193,12 @@ function mockFetchByStudent(
     }
 
     if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+      const match = url.match(/student_id=([^&]+)/)
+      const studentId = match?.[1] || ''
+      const config = studentMap[studentId]
       return Promise.resolve({
         ok: true,
-        json: async () => ({ history: [{ id: 'history-1' }] }),
+        json: async () => ({ history: config?.historyEntries || [{ id: 'history-1' }] }),
       })
     }
 
@@ -264,18 +279,21 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.getByText('Authenticity 64%')).toBeInTheDocument()
     expect(screen.getByText('No repo linked')).toBeInTheDocument()
     expect(within(gradesSection).getByText('0%')).toBeInTheDocument()
-    expect(within(gradesSection).getByText('0 / 30')).toBeInTheDocument()
-    expect(screen.getByText('No returned feedback')).toBeInTheDocument()
-    expect(screen.getByText('No draft')).toBeInTheDocument()
+    expect(within(gradesSection).getByText('Total')).toBeInTheDocument()
+    expect(within(gradesSection).getByText('30')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Feedback' })).toBeInTheDocument()
+    expect(screen.queryByText('No draft')).not.toBeInTheDocument()
 
     expect(screen.getByLabelText('Completion score')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
 
-    expect(screen.getByRole('button', { name: 'AI grade' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Return Feedback' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(within(gradesSection).getByRole('button', { name: 'AI grade' })).toBeInTheDocument()
+    expect(within(gradesSection).getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    const feedbackSection = screen.getByTestId('inspector-section-comments')
+    expect(within(feedbackSection).getByRole('button', { name: 'Return Feedback' })).toBeInTheDocument()
   })
 
   it('persists expanded and collapsed sections per classroom when switching students', async () => {
@@ -298,7 +316,7 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     await user.click(await screen.findByRole('button', { name: 'History' }))
-    await user.click(screen.getByRole('button', { name: 'Grades' }))
+    await user.click(screen.getByRole('button', { name: 'Grade' }))
 
     expect(await screen.findByTestId('history-list')).toBeInTheDocument()
     expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
@@ -399,17 +417,90 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     const repoSection = await screen.findByTestId('inspector-section-repo')
-    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
+    expect(within(repoSection).queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Repo' }))
 
+    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
     expect(within(repoSection).getByText('Contribution')).toBeInTheDocument()
     expect(within(repoSection).getByText('Consistency')).toBeInTheDocument()
     expect(within(repoSection).getByText('Iteration')).toBeInTheDocument()
   })
 
-  it('shows collapsed comments status and expanded returned feedback details', async () => {
+  it('updates the individual-mode preview when hovering a history entry', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        historyEntries: [
+          {
+            id: 'history-older',
+            assignment_doc_id: 'doc-student-1',
+            patch: null,
+            snapshot: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Older saved work' }],
+                },
+              ],
+            },
+            word_count: 3,
+            char_count: 16,
+            paste_word_count: 0,
+            keystroke_count: 10,
+            trigger: 'save',
+            created_at: '2026-02-20T11:00:00Z',
+          },
+          {
+            id: 'history-newer',
+            assignment_doc_id: 'doc-student-1',
+            patch: null,
+            snapshot: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Newer saved work' }],
+                },
+              ],
+            },
+            word_count: 3,
+            char_count: 16,
+            paste_word_count: 0,
+            keystroke_count: 10,
+            trigger: 'save',
+            created_at: '2026-02-20T12:00:00Z',
+          },
+        ],
+      },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'History' }))
+
+    expect(screen.getByTestId('rich-text-viewer')).toHaveTextContent('Work for student-1')
+
+    await user.hover(screen.getByRole('button', { name: 'history-older' }))
+
+    expect(screen.getByTestId('rich-text-viewer')).toHaveTextContent('Older saved work')
+    expect(screen.getByText('Previewing save from Feb 20, 6:00 AM')).toBeInTheDocument()
+  })
+
+  it('shows no comments summary pills when collapsed and keeps expanded returned feedback details', async () => {
     mockFetchByStudent({
       'student-1': {
         graded: false,
@@ -437,15 +528,14 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    expect(await screen.findByText('Draft present')).toBeInTheDocument()
-    expect(screen.getByText('1 returned')).toBeInTheDocument()
+    expect(await screen.findByText('Returned feedback body')).toBeInTheDocument()
     expect(screen.getByText('Returned feedback body')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Comments' }))
+    await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
     expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
-    expect(screen.getByText('Draft present')).toBeInTheDocument()
-    expect(screen.getByText('1 returned')).toBeInTheDocument()
+    expect(screen.queryByText('Draft present')).not.toBeInTheDocument()
+    expect(screen.queryByText('1 returned')).not.toBeInTheDocument()
   })
 
   it('prepends AI feedback suggestion into the feedback draft and marks it as an AI draft until focus', async () => {

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import { countCharacters } from '@/lib/tiptap-content'
@@ -35,21 +35,6 @@ vi.mock('@/components/HistoryList', () => ({
 
 vi.mock('@/ui', () => ({
   Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-  SplitButton: ({ label, onPrimaryClick, options, toggleAriaLabel, ...props }: any) => (
-    <div {...props}>
-      <button type="button" onClick={onPrimaryClick}>
-        {label}
-      </button>
-      <button type="button" aria-label={toggleAriaLabel || 'More actions'}>
-        Toggle
-      </button>
-      {options.map((option: { id: string; label: string; onSelect: () => void }) => (
-        <button key={option.id} type="button" onClick={option.onSelect}>
-          {option.label}
-        </button>
-      ))}
-    </div>
-  ),
   Tooltip: ({ children }: any) => <>{children}</>,
 }))
 
@@ -172,7 +157,7 @@ function mockFetchByStudent(
     }
   >,
 ) {
-  ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+  ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
 
     if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
@@ -199,6 +184,35 @@ function mockFetchByStudent(
       return Promise.resolve({
         ok: true,
         json: async () => ({ history: config?.historyEntries || [{ id: 'history-1' }] }),
+      })
+    }
+
+    if (url.includes('/api/teacher/assignments/') && url.endsWith('/grade')) {
+      const body = JSON.parse(String(init?.body || '{}')) as {
+        student_id: string
+        score_completion: number
+        score_thinking: number
+        score_workflow: number
+        feedback: string
+        save_mode?: 'draft' | 'graded'
+      }
+      const config = studentMap[body.student_id]
+      const baseDoc = makeStudentWork(body.student_id, config || { graded: false }).doc
+
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          doc: {
+            ...baseDoc,
+            score_completion: body.score_completion,
+            score_thinking: body.score_thinking,
+            score_workflow: body.score_workflow,
+            teacher_feedback_draft: body.feedback,
+            teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
+            graded_at: body.save_mode === 'graded' ? '2026-02-20T13:05:00Z' : null,
+            graded_by: body.save_mode === 'graded' ? 'teacher@example.com' : null,
+          },
+        }),
       })
     }
 
@@ -246,7 +260,7 @@ describe('TeacherStudentWorkPanel', () => {
     clearInspectorSectionsCookies()
   })
 
-  it('renders the new inspector sections in order with sticky footer actions', async () => {
+  it('renders the new inspector sections in order with grade mode actions', async () => {
     mockFetchByStudent({
       'student-1': { graded: false, authenticityScore: 64 },
     })
@@ -290,10 +304,171 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
 
-    expect(within(gradesSection).getByRole('button', { name: 'AI grade' })).toBeInTheDocument()
-    expect(within(gradesSection).getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(within(gradesSection).queryByRole('button', { name: 'AI grade' })).not.toBeInTheDocument()
+    const gradeModeToggle = within(gradesSection).getByTestId('grade-mode-toggle')
+    expect(within(gradeModeToggle).getByRole('button', { name: 'Draft' })).toBeInTheDocument()
+    expect(within(gradeModeToggle).getByRole('button', { name: 'Final' })).toBeInTheDocument()
+    expect(within(gradesSection).queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
     const feedbackSection = screen.getByTestId('inspector-section-comments')
-    expect(within(feedbackSection).getByRole('button', { name: 'Return Feedback' })).toBeInTheDocument()
+    expect(within(feedbackSection).getByRole('button', { name: 'Send feedback' })).toBeInTheDocument()
+  })
+
+  it('autosaves valid grading edits as draft without a save button', async () => {
+    const gradeBodies: Array<Record<string, unknown>> = []
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeStudentWork('student-1', { graded: false }),
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/') && url.endsWith('/grade')) {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        gradeBodies.push(body)
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeStudentWork('student-1', { graded: false }).doc,
+              score_completion: 6,
+              score_thinking: 7,
+              score_workflow: 8,
+              teacher_feedback_draft: 'Teacher note',
+              teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
+              graded_at: null,
+              graded_by: null,
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await screen.findByLabelText('Completion score')
+
+    await user.click(screen.getByRole('button', { name: 'Set Completion score to 6' }))
+    await user.click(screen.getByRole('button', { name: 'Set Thinking score to 7' }))
+    await user.click(screen.getByRole('button', { name: 'Set Workflow score to 8' }))
+    fireEvent.change(screen.getByPlaceholderText('Teacher feedback draft'), {
+      target: { value: 'Teacher note' },
+    })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+    })
+
+    await waitFor(() => {
+      expect(gradeBodies).toHaveLength(1)
+    })
+    expect(gradeBodies[0]).toMatchObject({
+      student_id: 'student-1',
+      score_completion: 6,
+      score_thinking: 7,
+      score_workflow: 8,
+      feedback: 'Teacher note',
+      save_mode: 'draft',
+    })
+    expect(screen.getByText('Draft autosaved')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+  })
+
+  it('marks the current grade as graded on demand', async () => {
+    const gradeBodies: Array<Record<string, unknown>> = []
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeStudentWork('student-1', { graded: false }),
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/') && url.endsWith('/grade')) {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        gradeBodies.push(body)
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeStudentWork('student-1', { graded: true }).doc,
+              score_completion: 7,
+              score_thinking: 8,
+              score_workflow: 9,
+              teacher_feedback_draft: 'Nice work',
+              teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
+              graded_at: '2026-02-20T13:05:00Z',
+              graded_by: 'teacher@example.com',
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await screen.findByLabelText('Completion score')
+    await user.click(screen.getByRole('button', { name: 'Set Completion score to 7' }))
+    await user.click(screen.getByRole('button', { name: 'Set Thinking score to 8' }))
+    await user.click(screen.getByRole('button', { name: 'Set Workflow score to 9' }))
+    await user.click(screen.getByRole('button', { name: 'Final' }))
+
+    await waitFor(() => {
+      expect(gradeBodies.at(-1)).toMatchObject({ save_mode: 'graded' })
+    })
+    expect(screen.getByText('Graded Feb 20, 8:05 AM')).toBeInTheDocument()
   })
 
   it('persists expanded and collapsed sections per classroom when switching students', async () => {
@@ -319,7 +494,9 @@ describe('TeacherStudentWorkPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Grade' }))
 
     expect(await screen.findByTestId('history-list')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+    })
 
     rerender(
       <TeacherStudentWorkPanel
@@ -338,7 +515,9 @@ describe('TeacherStudentWorkPanel', () => {
     })
 
     expect(await screen.findByTestId('history-list')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+    })
   })
 
   it('falls back to the default expanded sections when the cookie is invalid', async () => {
@@ -533,7 +712,9 @@ describe('TeacherStudentWorkPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
-    expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
+    })
     expect(screen.queryByText('Draft present')).not.toBeInTheDocument()
     expect(screen.queryByText('1 returned')).not.toBeInTheDocument()
   })
@@ -591,75 +772,6 @@ describe('TeacherStudentWorkPanel', () => {
     expect(draft).not.toHaveClass('border-primary')
     expect(draft).not.toHaveClass('bg-info-bg')
     expect(screen.queryByText('AI draft')).not.toBeInTheDocument()
-  })
-
-  it('prepends new AI feedback to the current unsaved draft after auto-grade', async () => {
-    const user = userEvent.setup()
-    let studentFetchCount = 0
-
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input)
-
-      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
-        studentFetchCount += 1
-
-        return Promise.resolve({
-          ok: true,
-          json: async () =>
-            makeStudentWork('student-1', {
-              graded: false,
-              teacherFeedbackDraft: studentFetchCount > 1 ? null : '',
-              aiFeedbackSuggestion: studentFetchCount > 1 ? 'AI feedback suggestion' : null,
-            }),
-        })
-      }
-
-      if (url.includes('/api/teacher/assignments/') && url.includes('/auto-grade')) {
-        expect(init?.method).toBe('POST')
-
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ graded_count: 1 }),
-        })
-      }
-
-      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ history: [] }),
-        })
-      }
-
-      return Promise.resolve({
-        ok: false,
-        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
-      })
-    })
-
-    render(
-      <TeacherStudentWorkPanel
-        classroomId="classroom-1"
-        assignmentId="assignment-1"
-        studentId="student-1"
-        mode="details"
-        inspectorCollapsed={false}
-        inspectorWidth={40}
-        totalWidth={1200}
-      />,
-    )
-
-    const draft = await screen.findByPlaceholderText('Teacher feedback draft')
-    await user.clear(draft)
-    await user.type(draft, 'Teacher note')
-    await user.click(screen.getByRole('button', { name: 'AI grade' }))
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Teacher feedback draft')).toHaveValue(
-        'AI feedback suggestion\n\nTeacher note',
-      )
-    })
-
-    expect(screen.getByText('AI draft')).toBeInTheDocument()
   })
 
   it('renders overview mode as inspector-only without submission content', async () => {
@@ -821,5 +933,40 @@ describe('TeacherStudentWorkPanel', () => {
       'https://github.com/example/student-1-repo',
     )
     expect(header).toHaveTextContent('@student1')
+  })
+
+  it('resets the individual pane split to 50/50 on separator double click', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    const onLayoutChange = vi.fn()
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+        onLayoutChange={onLayoutChange}
+      />,
+    )
+
+    await screen.findByTestId('individual-content-header')
+
+    fireEvent.doubleClick(screen.getByRole('separator', { name: 'Resize content and grading panes' }))
+
+    expect(onLayoutChange).toHaveBeenCalledTimes(1)
+    expect(onLayoutChange.mock.calls[0]?.[0]).toEqual(expect.any(Function))
+    expect(onLayoutChange.mock.calls[0][0]({
+      inspectorCollapsed: false,
+      inspectorWidth: 40,
+    })).toEqual({
+      inspectorCollapsed: false,
+      inspectorWidth: 50,
+    })
   })
 })

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -400,6 +400,87 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
   })
 
+  it('autosaves feedback-only draft edits before scores are complete', async () => {
+    const gradeBodies: Array<Record<string, unknown>> = []
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/') && url.includes('/students/')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeStudentWork('student-1', { graded: false }),
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/') && url.endsWith('/grade')) {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        gradeBodies.push(body)
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            doc: {
+              ...makeStudentWork('student-1', { graded: false }).doc,
+              score_completion: null,
+              score_thinking: null,
+              score_workflow: null,
+              teacher_feedback_draft: 'Teacher note',
+              teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
+              graded_at: null,
+              graded_by: null,
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await screen.findByPlaceholderText('Teacher feedback draft')
+
+    await user.type(screen.getByPlaceholderText('Teacher feedback draft'), 'Teacher note')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+    })
+
+    await waitFor(() => {
+      expect(gradeBodies).toHaveLength(1)
+    })
+    expect(gradeBodies[0]).toMatchObject({
+      student_id: 'student-1',
+      score_completion: null,
+      score_thinking: null,
+      score_workflow: null,
+      feedback: 'Teacher note',
+      save_mode: 'draft',
+    })
+    expect(screen.getByText('Draft autosaved')).toBeInTheDocument()
+  })
+
   it('marks the current grade as graded on demand', async () => {
     const gradeBodies: Array<Record<string, unknown>> = []
 

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import { countCharacters } from '@/lib/tiptap-content'
@@ -17,7 +17,9 @@ vi.mock('@/components/editor', () => ({
 }))
 
 vi.mock('@/components/HistoryList', () => ({
-  HistoryList: () => <div data-testid="history-list" />,
+  HistoryList: ({ entries }: any) => (
+    <div data-testid="history-list">{entries.map((entry: any) => entry.id).join(',')}</div>
+  ),
 }))
 
 vi.mock('@/ui', () => ({
@@ -42,7 +44,16 @@ vi.mock('@/ui', () => ({
 
 function makeStudentWork(
   studentId: string,
-  opts: { graded: boolean; repoUrl?: string | null; githubUsername?: string | null; aiFeedbackSuggestion?: string | null; teacherFeedbackDraft?: string | null },
+  opts: {
+    graded: boolean
+    repoUrl?: string | null
+    githubUsername?: string | null
+    aiFeedbackSuggestion?: string | null
+    teacherFeedbackDraft?: string | null
+    feedbackEntries?: Array<{ id: string; body: string; returned_at: string }>
+    repoReviewResult?: Record<string, any> | null
+    authenticityScore?: number | null
+  },
 ) {
   const doc = {
     id: `doc-${studentId}`,
@@ -83,7 +94,7 @@ function makeStudentWork(
     graded_at: opts.graded ? '2026-02-20T13:00:00Z' : null,
     graded_by: opts.graded ? 'teacher@example.com' : null,
     returned_at: null,
-    authenticity_score: null,
+    authenticity_score: opts.authenticityScore ?? null,
     authenticity_flags: [],
     created_at: '2026-02-20T12:00:00Z',
     updated_at: '2026-02-20T12:00:00Z',
@@ -109,7 +120,7 @@ function makeStudentWork(
     student: { id: studentId, email: `${studentId}@example.com`, name: studentId },
     doc,
     status: 'submitted_on_time',
-    feedback_entries: [],
+    feedback_entries: opts.feedbackEntries || [],
     repo_target: {
       target: null,
       submittedRepoUrl: opts.repoUrl ?? null,
@@ -121,7 +132,7 @@ function makeStudentWork(
       selectionMode: 'auto',
       validationStatus: 'missing',
       validationMessage: 'No GitHub repo link detected in the submission.',
-      latest_result: null,
+      latest_result: opts.repoReviewResult ?? null,
     },
   }
 }
@@ -134,7 +145,21 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
-function mockFetchByStudent(studentMap: Record<string, { graded: boolean }>) {
+function mockFetchByStudent(
+  studentMap: Record<
+    string,
+    {
+      graded: boolean
+      repoUrl?: string | null
+      githubUsername?: string | null
+      aiFeedbackSuggestion?: string | null
+      teacherFeedbackDraft?: string | null
+      feedbackEntries?: Array<{ id: string; body: string; returned_at: string }>
+      repoReviewResult?: Record<string, any> | null
+      authenticityScore?: number | null
+    }
+  >,
+) {
   ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
     const url = String(input)
 
@@ -158,7 +183,7 @@ function mockFetchByStudent(studentMap: Record<string, { graded: boolean }>) {
     if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
       return Promise.resolve({
         ok: true,
-        json: async () => ({ history: [] }),
+        json: async () => ({ history: [{ id: 'history-1' }] }),
       })
     }
 
@@ -169,8 +194,13 @@ function mockFetchByStudent(studentMap: Record<string, { graded: boolean }>) {
   })
 }
 
-function clearRightTabCookie() {
-  document.cookie = 'pika_teacher_student_work_tab%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
+function clearInspectorSectionsCookies() {
+  document.cookie = 'pika_teacher_student_work_sections%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
+  document.cookie = 'pika_teacher_student_work_sections%3Aclassroom-2=; Path=/; Max-Age=0; SameSite=Lax'
+}
+
+function writeInspectorSectionsCookie(classroomId: string, value: string) {
+  document.cookie = `pika_teacher_student_work_sections%3A${encodeURIComponent(classroomId)}=${encodeURIComponent(value)}; Path=/; SameSite=Lax`
 }
 
 function mockVisualViewport(width: number, height = 900) {
@@ -191,17 +221,64 @@ function mockVisualViewport(width: number, height = 900) {
 describe('TeacherStudentWorkPanel', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
-    clearRightTabCookie()
+    clearInspectorSectionsCookies()
     mockVisualViewport(1440)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
-    clearRightTabCookie()
+    clearInspectorSectionsCookies()
   })
 
-  it('keeps grading tab selected when switching students in details mode', async () => {
+  it('renders the new inspector sections in order with sticky footer actions', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false, authenticityScore: 64 },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    await screen.findByTestId('grading-inspector-pane')
+
+    const sectionIds = Array.from(
+      document.querySelectorAll('[data-testid^="inspector-section-"]'),
+    ).map((element) => element.getAttribute('data-testid'))
+    expect(sectionIds).toEqual([
+      'inspector-section-history',
+      'inspector-section-repo',
+      'inspector-section-grades',
+      'inspector-section-comments',
+    ])
+
+    const gradesSection = screen.getByTestId('inspector-section-grades')
+    expect(screen.getByText('Authenticity 64%')).toBeInTheDocument()
+    expect(screen.getByText('No repo linked')).toBeInTheDocument()
+    expect(within(gradesSection).getByText('0%')).toBeInTheDocument()
+    expect(within(gradesSection).getByText('0 / 30')).toBeInTheDocument()
+    expect(screen.getByText('No returned feedback')).toBeInTheDocument()
+    expect(screen.getByText('No draft')).toBeInTheDocument()
+
+    expect(screen.getByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
+    expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
+
+    expect(screen.getByRole('button', { name: 'AI grade' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Return Feedback' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('persists expanded and collapsed sections per classroom when switching students', async () => {
     mockFetchByStudent({
       'student-1': { graded: false },
       'student-2': { graded: false },
@@ -220,8 +297,11 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
-    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    await user.click(await screen.findByRole('button', { name: 'History' }))
+    await user.click(screen.getByRole('button', { name: 'Grades' }))
+
+    expect(await screen.findByTestId('history-list')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
 
     rerender(
       <TeacherStudentWorkPanel
@@ -239,10 +319,12 @@ describe('TeacherStudentWorkPanel', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/teacher/assignments/assignment-1/students/student-2')
     })
 
-    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(await screen.findByTestId('history-list')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
   })
 
-  it('renders details mode without the old shared header and keeps content flush', async () => {
+  it('falls back to the default expanded sections when the cookie is invalid', async () => {
+    writeInspectorSectionsCookie('classroom-1', 'nope,grades')
     mockFetchByStudent({
       'student-1': { graded: false },
     })
@@ -259,21 +341,111 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    expect(await screen.findByTestId('rich-text-viewer')).toHaveAttribute('data-chrome', 'flush')
-    expect(screen.queryByTestId('grading-workspace-header')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /show student table only/i })).not.toBeInTheDocument()
-    expect(screen.getByTestId('individual-content-header')).toHaveTextContent('student-1')
-    const expectedCharacters = countCharacters({
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [{ type: 'text', text: 'Work for student-1' }],
-        },
-      ],
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
+    expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
+  })
+
+  it('keeps classroom-specific section state isolated', async () => {
+    writeInspectorSectionsCookie('classroom-2', 'history,repo')
+    mockFetchByStudent({
+      'student-1': { graded: false },
     })
-    expect(screen.getByLabelText(`${expectedCharacters} characters`)).toHaveTextContent(`${expectedCharacters} chars`)
-    expect(screen.queryByText(new RegExp(`${expectedCharacters} characters$`))).not.toBeInTheDocument()
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
+  })
+
+  it('reveals repo metrics only when the repo section is expanded and keeps Analyze Repo there', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        repoUrl: 'https://github.com/example/student-1-repo',
+        githubUsername: 'student1',
+        repoReviewResult: {
+          github_login: 'student1',
+          relative_contribution_share: 0.8,
+          spread_score: 0.7,
+          iteration_score: 0.6,
+        },
+      },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    const repoSection = await screen.findByTestId('inspector-section-repo')
+    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
+    expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Repo' }))
+
+    expect(within(repoSection).getByText('Contribution')).toBeInTheDocument()
+    expect(within(repoSection).getByText('Consistency')).toBeInTheDocument()
+    expect(within(repoSection).getByText('Iteration')).toBeInTheDocument()
+  })
+
+  it('shows collapsed comments status and expanded returned feedback details', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        teacherFeedbackDraft: 'Teacher draft',
+        feedbackEntries: [
+          {
+            id: 'feedback-1',
+            body: 'Returned feedback body',
+            returned_at: '2026-02-20T14:00:00Z',
+          },
+        ],
+      },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByText('Draft present')).toBeInTheDocument()
+    expect(screen.getByText('1 returned')).toBeInTheDocument()
+    expect(screen.getByText('Returned feedback body')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Comments' }))
+
+    expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
+    expect(screen.getByText('Draft present')).toBeInTheDocument()
+    expect(screen.getByText('1 returned')).toBeInTheDocument()
   })
 
   it('prepends AI feedback suggestion into the feedback draft and marks it as an AI draft until focus', async () => {
@@ -317,14 +489,11 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await userEvent.setup().click(await screen.findByRole('button', { name: 'Grading' }))
     const draft = await screen.findByPlaceholderText('Teacher feedback draft')
     expect(draft).toHaveValue('AI feedback suggestion\n\nTeacher note')
     expect(draft).toHaveClass('border-primary')
     expect(draft).toHaveClass('bg-info-bg')
     expect(screen.getByText('AI draft')).toBeInTheDocument()
-    expect(screen.queryByText('AI Suggestion')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Use' })).not.toBeInTheDocument()
 
     await userEvent.setup().click(draft)
 
@@ -389,7 +558,6 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Grading' }))
     const draft = await screen.findByPlaceholderText('Teacher feedback draft')
     await user.clear(draft)
     await user.type(draft, 'Teacher note')
@@ -421,7 +589,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    expect(await screen.findByText('History')).toBeInTheDocument()
+    expect(await screen.findByTestId('grading-inspector-pane')).toBeInTheDocument()
     expect(screen.queryByTestId('rich-text-viewer')).not.toBeInTheDocument()
   })
 
@@ -492,12 +660,46 @@ describe('TeacherStudentWorkPanel', () => {
     })
 
     expect(screen.getByText(/Work for student-1/)).toBeInTheDocument()
-    expect(screen.queryByText('Refreshing history...')).not.toBeInTheDocument()
     expect(loadingStateSpy).toHaveBeenCalledWith(true)
 
     deferredStudent2.resolve(makeStudentWork('student-2', { graded: false }))
 
     expect(await screen.findByText(/Work for student-2/)).toBeInTheDocument()
+  })
+
+  it('renders details mode without the old shared header and keeps content flush', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByTestId('rich-text-viewer')).toHaveAttribute('data-chrome', 'flush')
+    expect(screen.queryByTestId('grading-workspace-header')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /show student table only/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('individual-content-header')).toHaveTextContent('student-1')
+    const expectedCharacters = countCharacters({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Work for student-1' }],
+        },
+      ],
+    })
+    expect(screen.getByLabelText(`${expectedCharacters} characters`)).toHaveTextContent(
+      `${expectedCharacters} chars`,
+    )
   })
 
   it('renders the individual content header with student name first and repo metadata after it', async () => {
@@ -523,7 +725,11 @@ describe('TeacherStudentWorkPanel', () => {
 
     const header = await screen.findByTestId('individual-content-header')
     expect(header).toHaveTextContent('student-1')
-    expect(header).toHaveTextContent('https://github.com/example/student-1-repo')
+    expect(header).toHaveTextContent('Repo')
+    expect(within(header).getByRole('link')).toHaveAttribute(
+      'href',
+      'https://github.com/example/student-1-repo',
+    )
     expect(header).toHaveTextContent('@student1')
   })
 })


### PR DESCRIPTION
## What changed
- refactored the teacher assignment grading inspector into an extracted controller hook and inspector component
- replaced the old history/grading tab switcher with collapsible `History`, `Repo`, `Grade`, and `Feedback` sections
- persisted expanded section state per classroom and kept class/individual pane sizing behavior aligned
- polished the assignment workspace UI after implementation, including section header summaries, score split boxes, button placement, row selection styling, pane dividers, and history preview feedback

## Why
Issue #460 moves the grading inspector away from tabs and toward an always-visible inspection workflow that better fits the assignment workspace sidebar. The follow-up polish fixes interaction regressions and clarifies the visual hierarchy inside the right pane.

## Impact
- teachers can scan history, repo analysis, grading, and feedback in a single inspector without switching tabs
- grade and feedback actions now live closer to the content they affect
- class and individual assignment modes now share the same pane-resize behavior more consistently
- history hover preview is explicit again in individual mode

## Root cause
The original sidebar was organized around a tab model that hid too much context at once. During the refactor, a few layout and interaction regressions surfaced around pane sizing, action placement, divider rendering, and preview affordances; those are included in this branch.

## Validation
- `pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm exec eslint src/components/assignment-workspace/TeacherWorkInspector.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
- targeted eslint checks on touched layout files during iteration
- Playwright screenshots during the earlier UI verification passes for the assignment workspace and classrooms index
