### PR TITLE
[codex] Add UI guidance loop v1

### DIFF
--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -10,7 +10,17 @@ Steps:
 4) Read docs: `$PIKA_WORKTREE/docs/ai-instructions.md` and `$PIKA_WORKTREE/docs/core/architecture.md`
 5) Check features: `node "$PIKA_WORKTREE/scripts/features.mjs" next`
 6) If $ARGUMENTS is an issue number: `gh issue view $ARGUMENTS --json number,title,body,labels`
-7) State task clearly. Propose approach. Wait for approval before coding.
+7) If the task affects UI/UX, also read:
+   - `$PIKA_WORKTREE/docs/guidance/ui/README.md`
+   - `$PIKA_WORKTREE/docs/guidance/ui/stable.md`
+8) State task clearly. Propose approach. Wait for approval before coding.
+
+For UI/UX work, include a UI guidance declaration:
+- guidance read
+- stable guidance followed
+- experimental guidance introduced: yes/no
+- experimental draft file created or updated, if any
+- human promotion needed: yes/no
 
 Alternatively, run the session start script:
 ```bash

--- a/.codex/prompts/work-on-issue.md
+++ b/.codex/prompts/work-on-issue.md
@@ -5,13 +5,26 @@ Takes the issue number as $ARGUMENTS.
 Steps:
 1) `gh issue view $ARGUMENTS --json number,title,body,labels,assignees`
 2) Read docs: `docs/ai-instructions.md`, relevant sections of `docs/core/architecture.md`
-3) Explore affected files (read only, no changes yet)
-4) Draft plan: branch name, files to change, tests to write first, migration needed?
-5) Present plan and wait for approval
-6) After approval: set up worktree from hub (`export PIKA_WORKTREE="$HOME/Repos/pika"`)
+3) If the issue affects UI/UX, also read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`
+4) Explore affected files (read only, no changes yet)
+5) Draft plan: branch name, files to change, tests to write first, migration needed?
+6) For UI/UX work, include a UI guidance declaration:
+   - guidance read
+   - stable guidance followed
+   - experimental guidance introduced: yes/no
+   - experimental draft file created or updated, if any
+   - human promotion needed: yes/no
+7) Present plan and wait for approval
+8) After approval: set up worktree from hub (`export PIKA_WORKTREE="$HOME/Repos/pika"`)
    ```bash
    git -C "$HOME/Repos/pika" fetch origin
    git -C "$HOME/Repos/pika" worktree add "$HOME/Repos/.worktrees/pika/issue-$ARGUMENTS-<slug>" \
      -b "issue/$ARGUMENTS-<slug>" origin/main
    ```
    Then tell user: `pika codex issue-$ARGUMENTS-<slug>`
+
+Default rule for UI/UX work:
+- stable guidance is the default
+- AI may create or update experimental guidance
+- AI may add to legacy or open-question guidance when justified
+- AI must not silently edit stable guidance during feature work

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -28,6 +28,10 @@ When working on any task, read these files **in this exact order** to prevent ar
 6. **[/docs/core/tests.md](/docs/core/tests.md)** — TDD requirements
 7. **[/docs/core/roadmap.md](/docs/core/roadmap.md)** — Current status
 
+For **UI-affecting work**, immediately continue with:
+- **[/docs/guidance/ui/README.md](/docs/guidance/ui/README.md)** — UI canon entrypoint
+- **[/docs/guidance/ui/stable.md](/docs/guidance/ui/stable.md)** — Stable UI guidance for current governed workflows
+
 Then consult:
 - **[/docs/guidance/*.md](/docs/guidance/)** — Feature specifications (as needed)
 - **[/docs/workflow/handle-issue.md](/docs/workflow/handle-issue.md)** — Issue workflow (when working on issues)
@@ -303,4 +307,3 @@ gh issue view X          # View issue details
 /tdd <feature>           # Write tests first, then implement
 /ui-verify <page>        # Take Playwright screenshots to verify UI
 ```
-

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -2,6 +2,8 @@
 
 This document defines UI/UX patterns, visual design standards, and component guidelines for **Pika**.
 
+For workflow-specific UI guidance and governed reuse decisions, use the UI canon in [`docs/guidance/ui/README.md`](/docs/guidance/ui/README.md). This file remains the high-level invariant layer; the UI canon handles stable, experimental, legacy, and open-question guidance for active workflows.
+
 ---
 
 ## Design Principles

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2,6 +2,13 @@
 
 Design tokens and component guidelines for consistent, compact UI.
 
+> Historical reference only. This file is no longer a co-equal source of truth for new UI work.
+>
+> For active guidance, read:
+> - [`docs/core/design.md`](/docs/core/design.md)
+> - [`src/ui/README.md`](/src/ui/README.md)
+> - [`docs/guidance/ui/README.md`](/docs/guidance/ui/README.md)
+
 ---
 
 ## 🎨 Design Principles

--- a/docs/guidance/ui/README.md
+++ b/docs/guidance/ui/README.md
@@ -1,0 +1,65 @@
+# Pika UI Canon
+
+This directory is the governed UI/UX canon for Pika.
+
+Use it to keep AI-driven UI work grounded in the current product instead of inventing new patterns on the fly.
+
+## Operating Model
+
+Pika uses four UI guidance buckets:
+
+1. **Stable guidance**
+   Default rules for new UI work. These are the preferred patterns and should be treated as truth for AI implementation.
+2. **Experimental guidance**
+   Candidate patterns observed in recent work or proposed for controlled reuse. AI may draft or update these, but they are not truth yet.
+3. **Legacy guidance**
+   Older or still-present patterns that should not be copied into new work unless a human explicitly chooses them.
+4. **Open questions**
+   Unresolved UX tensions where the product still needs human judgment or additional iteration.
+
+## Read Order For UI Work
+
+When a task affects UI, styling, layout, or interaction flow, read in this order:
+
+1. [`docs/core/design.md`](/docs/core/design.md)
+2. [`src/ui/README.md`](/src/ui/README.md)
+3. [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
+4. Relevant experimental, legacy, and open-question docs in this folder only if they materially affect the task
+
+The stable file is the default. Experimental and legacy docs are context, not overrides.
+
+## Promotion Rules
+
+- Humans promote guidance into `stable.md`.
+- AI may create or update experimental drafts.
+- AI may add legacy entries when older patterns still exist in code and need to be called out as non-default.
+- AI may add open questions when a UX tradeoff is real and unresolved.
+- AI must not silently edit stable guidance as part of ordinary feature work.
+
+## V1 Scope
+
+The first governed slice is:
+
+- Assignments
+- Attendance
+- Shared classroom shell behavior that directly supports those workflows
+
+This is intentionally smaller than the full app.
+
+## Workflow Contract
+
+When a task touches UI/UX, the implementation plan or issue note should declare:
+
+- guidance read
+- stable guidance followed
+- experimental guidance introduced: yes/no
+- experimental draft file updated or created, if any
+- human promotion needed: yes/no
+
+## Related Files
+
+- [`audit-v1.md`](/docs/guidance/ui/audit-v1.md)
+- [`stable.md`](/docs/guidance/ui/stable.md)
+- [`legacy.md`](/docs/guidance/ui/legacy.md)
+- [`open-questions.md`](/docs/guidance/ui/open-questions.md)
+- [`experimental/README.md`](/docs/guidance/ui/experimental/README.md)

--- a/docs/guidance/ui/audit-v1.md
+++ b/docs/guidance/ui/audit-v1.md
@@ -1,0 +1,48 @@
+# UI Guidance Audit v1
+
+This audit records which existing sources already govern Pika UI work and which current screens were used to seed the first governed canon.
+
+## Existing Governing Docs
+
+- [`docs/ai-instructions.md`](/docs/ai-instructions.md)
+  Defines the global read order, mandatory constraints, and AI workflow rules.
+- [`docs/core/design.md`](/docs/core/design.md)
+  Holds the durable UI invariants: mobile-first, accessibility, dark-mode support via semantic tokens, and classroom-route layout expectations.
+- [`src/ui/README.md`](/src/ui/README.md)
+  Documents the canonical primitive layer: `@/ui` imports, semantic tokens, `FormField`, `Card`, dialogs, and token usage.
+- [`docs/workflow/handle-issue.md`](/docs/workflow/handle-issue.md) and [`docs/issue-worker.md`](/docs/issue-worker.md)
+  Govern how issue work is planned and executed, including the UI verification requirement after actual UI changes.
+
+## Current Seed Surfaces
+
+The v1 canon is grounded in these current code surfaces:
+
+- Shared shell:
+  - [`src/components/AppShell.tsx`](/src/components/AppShell.tsx)
+  - [`src/components/layout/ThreePanelShell.tsx`](/src/components/layout/ThreePanelShell.tsx)
+  - [`src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`](/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx)
+- Attendance:
+  - [`src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx`](/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx)
+- Assignments:
+  - [`src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`](/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx)
+  - [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+  - [`src/components/AssignmentModal.tsx`](/src/components/AssignmentModal.tsx)
+  - [`src/components/AssignmentForm.tsx`](/src/components/AssignmentForm.tsx)
+
+## What Was Already Strong
+
+- Semantic color tokens and theme handling are already explicit in docs and widely used in app code.
+- `@/ui` is already the canonical primitive layer for buttons, inputs, dialogs, cards, tooltips, and field chrome.
+- The classroom experience already has a shared shell model with left navigation, main content, and optional right-side inspection.
+- Attendance and assignments already encode several strong product behaviors, such as presence-only attendance status and visible assignment autosave/submission states.
+
+## What Was Missing
+
+- No single UI canon separated stable patterns from candidate patterns.
+- No explicit place for legacy patterns that still exist in code or docs.
+- No workflow requirement for AI to declare whether it is following stable guidance or introducing a new candidate pattern.
+- No lightweight script to generate reviewable experimental guidance from changed files or a diff base.
+
+## Conclusion
+
+The repo already had solid UI rules, but they were split across architecture, design, primitive docs, and live code. This v1 canon adds governance and a promotion path without replacing those foundations.

--- a/docs/guidance/ui/experimental/2026-04-v1-assignments-attendance.md
+++ b/docs/guidance/ui/experimental/2026-04-v1-assignments-attendance.md
@@ -1,0 +1,61 @@
+---
+status: experimental
+scope:
+  - assignments
+  - attendance
+  - shared-shell
+source_files:
+  - src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+  - src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+  - src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+  - src/components/AssignmentModal.tsx
+  - src/components/PageLayout.tsx
+  - src/components/DataTable.tsx
+human_review_required: true
+generated_at: 2026-04-14
+---
+
+# v1 Candidate Guidance: Assignments + Attendance
+
+## Summary
+
+These patterns are visible in the current assignments and attendance workflows and look reusable, but they are not stable enough yet to bless as defaults across the whole app.
+
+## Affected Screens / Files
+
+- Student assignment summary and editor flow
+- Teacher assignment list and grading/work inspection flow
+- Teacher attendance table and date navigation flow
+- Shared action-bar and table scaffolding used by those routes
+
+## Observed Pattern
+
+- Feature-level pages use `PageLayout`, `PageActionBar`, and `PageContent` to keep controls and content aligned inside the classroom shell.
+- Dense, interactive list or table surfaces use feature-owned components such as `DataTable` and `TableCard` rather than a primitive from `@/ui`.
+- Student assignments use large pressable cards with title, due date, relative due text, and a compact status badge.
+- Teacher assignment and attendance views favor side-by-side inspection rather than modal-heavy drill-down once the user is already inside the workflow.
+
+## Proposed Guidance
+
+- Consider `PageLayout` and the matching action/content structure the preferred page-level composition for classroom tabs until a better shared shell abstraction emerges.
+- Consider dense feature-owned tables and list cards acceptable for high-information classroom workflows, but treat them as workflow-level patterns rather than primitive-level truth.
+- Prefer visible status cues and adjacent detail inspection over hidden state or multi-step reveal in attendance and assignments.
+
+## Why This Is Experimental
+
+- These patterns are strong inside assignments and attendance, but they have not yet been validated across enough other classroom tabs.
+- Some of the supporting components still live in `src/components/` as feature-owned building blocks instead of the canonized `@/ui` layer.
+- The repo has not yet decided whether these should remain workflow-specific or become broader defaults.
+
+## Human Review Required
+
+- Decide whether `PageLayout` and `DataTable` should remain feature-owned composition helpers or become promoted shared guidance.
+- Decide whether the pressable assignment-card pattern should become a wider classroom-list standard.
+- Confirm that these dense layouts remain strong on smaller screens before promotion.
+
+## Promotion Criteria
+
+- Reused successfully in additional classroom workflows
+- No major usability regressions in teacher or student views
+- Consistent with stable token and `@/ui` usage
+- Explicit human approval to move the pattern into `stable.md`

--- a/docs/guidance/ui/experimental/README.md
+++ b/docs/guidance/ui/experimental/README.md
@@ -1,0 +1,44 @@
+# Experimental UI Guidance
+
+Experimental guidance holds candidate UI patterns that are reviewable and reusable, but not yet promoted to stable guidance.
+
+## Rules
+
+- Experimental guidance must be clearly marked as experimental.
+- AI may draft or update experimental entries.
+- Experimental entries do not override stable guidance.
+- Promotion into stable guidance requires human review.
+
+## When To Create An Experimental Entry
+
+Create or update an experimental entry when:
+
+- a task introduces a new UI pattern that is likely to be reused
+- a current feature-level pattern looks promising but is not yet broad enough to canonize
+- a change needs a human review point before the pattern should spread further
+
+Quick draft command:
+
+```bash
+node scripts/ui-guidance-candidate.mjs --scope assignments --files src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx src/components/AssignmentModal.tsx
+```
+
+## Required Frontmatter
+
+Every experimental entry should include:
+
+- `status: experimental`
+- `scope`
+- `source_files`
+- `human_review_required: true`
+
+## Promotion Criteria
+
+Promote an experimental pattern only when a human agrees that it:
+
+- has been used across multiple screens or flows
+- survived iteration without obvious regressions
+- improves clarity, usability, or implementation consistency
+- is ready to become a default rather than a local exception
+
+Use `legacy.md` when an experimental direction fails or when an older pattern remains in code but should not be reused.

--- a/docs/guidance/ui/legacy.md
+++ b/docs/guidance/ui/legacy.md
@@ -1,0 +1,31 @@
+# Legacy UI Guidance
+
+These patterns still exist in the repo, but they should not be treated as defaults for new work.
+
+## Legacy Patterns
+
+### 1. `docs/design-system.md` as a co-equal source of truth
+
+- The file still contains older raw-color and pre-token examples such as `bg-white`, `text-gray-900`, and hard-coded blue/gray styling guidance.
+- Keep it as historical context only.
+- New UI work should use `docs/core/design.md`, `src/ui/README.md`, and this UI canon instead.
+
+### 2. Feature-local surface styling that bypasses canonized primitives
+
+- Some targeted workflow surfaces still style interactive containers directly instead of using a canonized shared primitive.
+- Example: the student assignment summary cards in [`src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`](/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx) are locally styled `button` cards.
+- This is acceptable to preserve current behavior, but it should not automatically become a new default pattern.
+
+### 3. Shared classroom composition that lives outside `@/ui`
+
+- Attendance and teacher-assignment workflows rely on `PageLayout`, `PageActionBar`, `DataTable`, and related helpers in `src/components/`.
+- Those building blocks are useful, but they are not yet canonized at the same level as `@/ui`.
+- Preserve them when working inside those workflows, but do not assume they are promoted shared truth.
+
+## Legacy Guidance Rule
+
+If a pattern is listed here:
+
+- preserve it when necessary to avoid churn
+- avoid spreading it into unrelated screens
+- promote it only after a human intentionally moves it into stable guidance

--- a/docs/guidance/ui/open-questions.md
+++ b/docs/guidance/ui/open-questions.md
@@ -1,0 +1,25 @@
+# Open UI Questions
+
+These are active UX questions for the first governed slice. They are here so AI work can name the uncertainty instead of guessing silently.
+
+## Open Questions
+
+### 1. Should classroom-level page scaffolding be promoted?
+
+The assignments and attendance tabs both rely on `PageLayout` and `PageActionBar`, but the repo has not decided whether those are permanent shared page primitives or just current implementation helpers.
+
+### 2. Should dense data tables remain workflow-specific?
+
+Attendance and teacher-assignment views use dense table patterns. The repo still needs a human decision on whether those tables are a stable classroom-wide pattern or a local fit for high-information teacher flows only.
+
+### 3. How reusable is the student assignment summary card?
+
+The current pressable card pattern works for assignments, but it is still unclear whether other student tab summaries should follow the same structure or whether it is too workflow-specific.
+
+### 4. When should details live in a right sidebar versus inline content?
+
+The classroom shell supports secondary inspection, but the product has not yet settled a universal rule for when information should move to the inspector versus remain inline, especially on smaller screens.
+
+### 5. Which save-state language should become standard?
+
+Assignments already communicate autosave and submission state clearly, but the repo has not yet chosen a stable cross-feature vocabulary for draft, saving, saved, submitted, graded, and returned states.

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -1,0 +1,88 @@
+# Stable UI Guidance
+
+These are the stable UI rules for the v1 governed slice: assignments, attendance, and the classroom shell that supports them.
+
+Use these by default for new work.
+
+## Stable Rules
+
+### 1. App code uses semantic tokens, not raw theme switching
+
+- Use semantic surface, border, and text tokens in app code.
+- Keep `dark:` classes inside `src/ui/` or other documented exceptions only.
+- Favor tokens such as `bg-page`, `bg-surface`, `bg-surface-panel`, `border-border`, `border-border-strong`, `text-text-default`, and `text-text-muted`.
+
+Source grounding:
+
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`src/ui/README.md`](/src/ui/README.md)
+- Current classroom surfaces use these tokens heavily.
+
+### 2. Base controls come from `@/ui`
+
+- Import primitives from `@/ui`, not from feature-local component paths.
+- Wrap labeled form controls in `FormField`.
+- Reuse `Button`, `Card`, dialogs, and other primitives before inventing feature-local base controls.
+
+Source grounding:
+
+- [`src/ui/README.md`](/src/ui/README.md)
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`src/components/AssignmentForm.tsx`](/src/components/AssignmentForm.tsx)
+
+### 3. Classroom pages preserve the shared shell
+
+- Classroom work stays inside the shared classroom shell rather than inventing standalone page layouts.
+- Keep left navigation for tab switching, main content for the active workflow, and right-side inspection/detail behavior where the route already supports it.
+- On desktop, the shell remains a three-panel grid. On mobile, side panels collapse into drawer behavior rather than creating a separate information architecture.
+
+Source grounding:
+
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`src/components/layout/ThreePanelShell.tsx`](/src/components/layout/ThreePanelShell.tsx)
+- [`src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`](/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx)
+
+### 4. Attendance stays presence-first and scan-friendly
+
+- Attendance UI is optimized for quick scanning and teacher drill-down, not extra status taxonomy.
+- Present and absent remain the primary user-facing states.
+- Use a sortable teacher matrix/table view with clear date movement and lightweight summary counts.
+- Detailed log content belongs in secondary inspection, not inside each row.
+
+Source grounding:
+
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`docs/core/architecture.md`](/docs/core/architecture.md)
+- [`src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx`](/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx)
+
+### 5. Assignment surfaces expose status, due date, and save state clearly
+
+- Assignment list items should surface title, due date, and concise status without requiring expansion first.
+- Student editing surfaces must make autosave and submit state obvious.
+- Submission controls remain explicit primary actions rather than hidden behind menus.
+- Teacher assignment views keep student status and work inspection adjacent to the assignment context.
+
+Source grounding:
+
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`](/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx)
+- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+- [`src/components/AssignmentModal.tsx`](/src/components/AssignmentModal.tsx)
+
+### 6. Toronto date language stays consistent across classroom workflows
+
+- Use the existing Toronto-aware date helpers and the established app language for dates.
+- Prefer predictable classroom-facing date labels instead of one-off formatting.
+- Date presentation should feel consistent across attendance navigation, assignment due labels, and classroom-level scheduling affordances.
+
+Source grounding:
+
+- [`docs/core/design.md`](/docs/core/design.md)
+- [`docs/core/architecture.md`](/docs/core/architecture.md)
+- Current attendance and assignment surfaces already rely on Toronto-aware helpers.
+
+## Stable Guidance Limits
+
+- This file is intentionally narrow. It does not try to canonize the entire app.
+- If a current pattern exists in code but is not listed here, do not assume it is stable.
+- Use an experimental draft when you want to propose reuse beyond the current stable rules.

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -11,6 +11,7 @@ gh issue view <number> --json number,title,body,labels,comments
 1. Read `.ai/START-HERE.md`
 2. Read `docs/ai-instructions.md` and follow its required reading order.
 3. Check `.ai/features.json` for any referenced feature IDs.
+4. If the issue affects UI/UX, read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`.
 
 ## 3) Branch & PR Setup
 - Branch name pattern: `<issue-number>-<short-slug>` (example: `8-ai-effectiveness-layer`)
@@ -23,6 +24,13 @@ Produce a short plan:
 - Approach and edge cases
 - Testing plan (`pnpm test` + targeted tests)
 
+If the issue affects UI/UX, add a **UI guidance declaration**:
+- guidance read
+- stable guidance followed
+- experimental guidance introduced: yes/no
+- experimental draft file created or updated, if any
+- human promotion needed: yes/no
+
 Do not proceed until the user approves the plan.
 
 ## 5) Execute With Constraints
@@ -31,6 +39,10 @@ Do not proceed until the user approves the plan.
 - Preserve security patterns (sessions, role checks, Supabase usage).
 - Keep business logic out of UI components.
 - Do not add dependencies without explicit approval.
+- Stable UI guidance is the default for new UI work.
+- AI may create or update experimental UI guidance entries when a new pattern is introduced.
+- AI may add to legacy or open-question guidance when clearly justified.
+- AI must not silently edit stable UI guidance as part of ordinary feature work.
 
 ## 6) AI UI Verification (MANDATORY for UI Changes)
 

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -8,11 +8,18 @@ Use the automated command for the full workflow:
 
 1. `gh issue view <N> --json number,title,body,labels`
 2. Read `docs/ai-instructions.md` + relevant core docs
-3. Draft plan: branch name, files to change, tests to write first, migration needed?
-4. **Wait for user approval** before writing any code
-5. Create worktree: `issue/<N>-<slug>` (see `docs/dev-workflow.md`)
-6. Follow TDD: tests first → implement → refactor
-7. Create PR with "Closes #N"
+3. If the issue touches UI/UX, also read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`
+4. Draft plan: branch name, files to change, tests to write first, migration needed?
+5. For UI/UX work, include a UI guidance declaration:
+   - guidance read
+   - stable guidance followed
+   - experimental guidance introduced: yes/no
+   - experimental draft file created/updated, if any
+   - human promotion needed: yes/no
+6. **Wait for user approval** before writing any code
+7. Create worktree: `issue/<N>-<slug>` (see `docs/dev-workflow.md`)
+8. Follow TDD: tests first → implement → refactor
+9. Create PR with "Closes #N"
 
 ## Critical Rules
 
@@ -20,3 +27,5 @@ Use the automated command for the full workflow:
 - Make minimal, focused changes — do not modify unrelated files
 - Follow the reading order to prevent drift
 - Preserve existing patterns unless explicitly asked to change them
+- Stable UI guidance is the default for new UI work
+- AI may draft experimental UI guidance, but may not silently edit stable UI guidance during feature work

--- a/scripts/ui-guidance-candidate.mjs
+++ b/scripts/ui-guidance-candidate.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const VALID_SCOPES = new Set(['assignments', 'attendance', 'shared-shell'])
+const EXPERIMENTAL_DIR = 'docs/guidance/ui/experimental'
+const STABLE_PATH = 'docs/guidance/ui/stable.md'
+
+function todayIsoDate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function parseArgs(argv) {
+  const args = {
+    scope: '',
+    files: [],
+    diffBase: '',
+    title: '',
+    out: '',
+    stdout: false,
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+
+    switch (token) {
+      case '--scope':
+        args.scope = argv[index + 1] || ''
+        index += 1
+        break
+      case '--files': {
+        let cursor = index + 1
+        while (cursor < argv.length && !argv[cursor].startsWith('--')) {
+          args.files.push(argv[cursor])
+          cursor += 1
+        }
+        index = cursor - 1
+        break
+      }
+      case '--diff-base':
+        args.diffBase = argv[index + 1] || ''
+        index += 1
+        break
+      case '--title':
+        args.title = argv[index + 1] || ''
+        index += 1
+        break
+      case '--out':
+        args.out = argv[index + 1] || ''
+        index += 1
+        break
+      case '--stdout':
+        args.stdout = true
+        break
+      case '--help':
+      case '-h':
+        args.help = true
+        break
+      default:
+        throw new Error(`Unknown argument: ${token}`)
+    }
+  }
+
+  return args
+}
+
+export function validateArgs(args) {
+  if (args.help) return
+
+  if (!VALID_SCOPES.has(args.scope)) {
+    throw new Error(`--scope must be one of: ${Array.from(VALID_SCOPES).join(', ')}`)
+  }
+
+  const hasFiles = args.files.length > 0
+  const hasDiffBase = Boolean(args.diffBase)
+
+  if (hasFiles === hasDiffBase) {
+    throw new Error('Provide exactly one of --files or --diff-base')
+  }
+}
+
+function normalizeRelativeFile(filePath) {
+  return filePath.replace(/\\/g, '/').replace(/^\.\/+/, '')
+}
+
+export function resolveSourceFiles({ cwd, files, diffBase }) {
+  let resolvedFiles = files
+
+  if (diffBase) {
+    const diffOutput = execFileSync(
+      'git',
+      ['diff', '--name-only', `${diffBase}...HEAD`],
+      { cwd, encoding: 'utf8' },
+    )
+    resolvedFiles = diffOutput
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  }
+
+  const uniqueFiles = Array.from(new Set(resolvedFiles.map(normalizeRelativeFile))).sort()
+
+  if (uniqueFiles.length === 0) {
+    throw new Error('No source files found for candidate guidance draft')
+  }
+
+  return uniqueFiles
+}
+
+export function resolveOutputPath({ cwd, out, scope, title }) {
+  const defaultFilename = `${todayIsoDate()}-${slugify(title || `candidate-${scope}-guidance`)}.md`
+  const rawOutputPath = out || `${EXPERIMENTAL_DIR}/${defaultFilename}`
+  const absoluteOutputPath = resolve(cwd, rawOutputPath)
+  const relativeOutputPath = normalizeRelativeFile(relative(cwd, absoluteOutputPath))
+
+  if (relativeOutputPath === STABLE_PATH) {
+    throw new Error('Stable guidance is human-promoted only; refusing to write to docs/guidance/ui/stable.md')
+  }
+
+  if (
+    relativeOutputPath.startsWith('../') ||
+    !relativeOutputPath.startsWith(`${EXPERIMENTAL_DIR}/`)
+  ) {
+    throw new Error('Candidate guidance drafts may only be written under docs/guidance/ui/experimental/')
+  }
+
+  return absoluteOutputPath
+}
+
+function scopeHeading(scope) {
+  switch (scope) {
+    case 'assignments':
+      return 'Assignments'
+    case 'attendance':
+      return 'Attendance'
+    case 'shared-shell':
+      return 'Shared Shell'
+    default:
+      return scope
+  }
+}
+
+export function buildCandidateMarkdown({ scope, sourceFiles, title }) {
+  const heading = title || `${scopeHeading(scope)} Candidate Guidance`
+  const summaryScope = scopeHeading(scope).toLowerCase()
+  const sourceFileLines = sourceFiles.map((file) => `  - ${file}`).join('\n')
+  const affectedFileLines = sourceFiles.map((file) => `- \`${file}\``).join('\n')
+
+  return `---
+status: experimental
+scope:
+  - ${scope}
+source_files:
+${sourceFileLines}
+human_review_required: true
+generated_at: ${todayIsoDate()}
+---
+
+# ${heading}
+
+## Summary
+
+Candidate UI guidance draft for the ${summaryScope} workflow. This draft was generated from the listed source files and requires human review before promotion.
+
+## Affected Screens / Files
+
+${affectedFileLines}
+
+## Observed Pattern
+
+- Review the listed files and capture the concrete interaction, layout, or visual pattern that looks reusable.
+- Note whether the pattern already appears in multiple places within the selected workflow.
+
+## Proposed Guidance
+
+- Describe the default behavior that future work should follow if this pattern is reused.
+- Call out any required tokens, primitives, or layout constraints.
+- State the scope limits so the pattern does not spread accidentally.
+
+## Why This Is Experimental
+
+- Explain what is promising about this pattern.
+- Explain what is still unproven, local, or in need of iteration.
+
+## Human Review Required
+
+- Confirm whether the pattern should remain local, stay experimental, or be promoted later.
+- Call out any regressions, mobile concerns, or accessibility risks that must be checked first.
+
+## Promotion Criteria
+
+- Used successfully in more than one screen or flow
+- No significant usability regressions
+- Consistent with stable token and primitive guidance
+- Explicit human approval before promotion to stable guidance
+`
+}
+
+export function printHelp(stdout = process.stdout) {
+  stdout.write(`Usage: node scripts/ui-guidance-candidate.mjs --scope <assignments|attendance|shared-shell> (--files <path...> | --diff-base <git-ref>) [--title <title>] [--out <path>] [--stdout]
+
+Examples:
+  node scripts/ui-guidance-candidate.mjs --scope assignments --files src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx src/components/AssignmentModal.tsx
+  node scripts/ui-guidance-candidate.mjs --scope attendance --diff-base origin/main --stdout
+`)
+}
+
+export function runUiGuidanceCandidateCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  stdout = process.stdout,
+} = {}) {
+  const args = parseArgs(argv)
+  validateArgs(args)
+
+  if (args.help) {
+    printHelp(stdout)
+    return { markdown: '', outputPath: null }
+  }
+
+  const sourceFiles = resolveSourceFiles({
+    cwd,
+    files: args.files,
+    diffBase: args.diffBase,
+  })
+
+  const markdown = buildCandidateMarkdown({
+    scope: args.scope,
+    sourceFiles,
+    title: args.title,
+  })
+
+  if (args.stdout) {
+    stdout.write(markdown)
+    return { markdown, outputPath: null }
+  }
+
+  const outputPath = resolveOutputPath({
+    cwd,
+    out: args.out,
+    scope: args.scope,
+    title: args.title,
+  })
+
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, markdown, 'utf8')
+  stdout.write(`${normalizeRelativeFile(relative(cwd, outputPath))}\n`)
+
+  return { markdown, outputPath }
+}
+
+function isDirectExecution() {
+  if (!process.argv[1]) return false
+  return import.meta.url === pathToFileURL(process.argv[1]).href
+}
+
+if (isDirectExecution()) {
+  try {
+    runUiGuidanceCandidateCli()
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
+}

--- a/tests/unit/ui-guidance-candidate-script.test.ts
+++ b/tests/unit/ui-guidance-candidate-script.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const scriptPath = resolve(testDir, '../../scripts/ui-guidance-candidate.mjs')
+
+const tempDirs: string[] = []
+
+function makeTempWorkspace() {
+  const workspace = mkdtempSync(resolve(tmpdir(), 'pika-ui-guidance-'))
+  tempDirs.push(workspace)
+  mkdirSync(resolve(workspace, 'docs/guidance/ui/experimental'), { recursive: true })
+  return workspace
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('ui-guidance-candidate script', () => {
+  it('writes a draft under the experimental guidance directory with the required sections', () => {
+    const workspace = makeTempWorkspace()
+
+    execFileSync('node', [
+      scriptPath,
+      '--scope',
+      'assignments',
+      '--files',
+      'src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx',
+      'src/components/AssignmentModal.tsx',
+      '--title',
+      'Assignments candidate guidance',
+    ], { cwd: workspace, encoding: 'utf8' })
+
+    const generatedFiles = readdirSync(resolve(workspace, 'docs/guidance/ui/experimental'))
+    expect(generatedFiles).toHaveLength(1)
+
+    const generatedPath = resolve(workspace, 'docs/guidance/ui/experimental', generatedFiles[0])
+    const markdown = readFileSync(generatedPath, 'utf8')
+
+    expect(markdown).toContain('status: experimental')
+    expect(markdown).toContain('human_review_required: true')
+    expect(markdown).toContain('## Summary')
+    expect(markdown).toContain('## Affected Screens / Files')
+    expect(markdown).toContain('## Observed Pattern')
+    expect(markdown).toContain('## Proposed Guidance')
+    expect(markdown).toContain('## Why This Is Experimental')
+    expect(markdown).toContain('## Human Review Required')
+    expect(markdown).toContain('## Promotion Criteria')
+  })
+
+  it('refuses to write to stable guidance', () => {
+    const workspace = makeTempWorkspace()
+
+    expect(() => execFileSync('node', [
+      scriptPath,
+      '--scope',
+      'attendance',
+      '--files',
+      'src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx',
+      '--out',
+      'docs/guidance/ui/stable.md',
+    ], { cwd: workspace, encoding: 'utf8', stdio: 'pipe' })).toThrow(/Stable guidance is human-promoted only/)
+
+    expect(existsSync(resolve(workspace, 'docs/guidance/ui/stable.md'))).toBe(false)
+  })
+
+  it('supports stdout mode without writing a file', () => {
+    const workspace = makeTempWorkspace()
+
+    const output = execFileSync('node', [
+      scriptPath,
+      '--scope',
+      'shared-shell',
+      '--files',
+      'src/components/AppShell.tsx',
+      '--stdout',
+    ], { cwd: workspace, encoding: 'utf8' })
+
+    expect(output).toContain('# Shared Shell Candidate Guidance')
+    expect(readdirSync(resolve(workspace, 'docs/guidance/ui/experimental'))).toHaveLength(0)
+  })
+})

--- a/tests/unit/ui-guidance-docs.test.ts
+++ b/tests/unit/ui-guidance-docs.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+function readRepoFile(relativePath: string) {
+  return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
+}
+
+describe('ui guidance docs and prompts', () => {
+  it('points UI work to the canon entrypoint and stable guidance', () => {
+    const aiInstructions = readRepoFile('docs/ai-instructions.md')
+    const coreDesign = readRepoFile('docs/core/design.md')
+    const designSystem = readRepoFile('docs/design-system.md')
+
+    expect(aiInstructions).toContain('docs/guidance/ui/README.md')
+    expect(aiInstructions).toContain('docs/guidance/ui/stable.md')
+    expect(coreDesign).toContain('UI canon')
+    expect(designSystem).toContain('Historical reference only')
+  })
+
+  it('requires the UI guidance declaration in issue and Codex workflows', () => {
+    const files = [
+      'docs/workflow/handle-issue.md',
+      'docs/issue-worker.md',
+      '.codex/prompts/session-start.md',
+      '.codex/prompts/work-on-issue.md',
+    ]
+
+    for (const file of files) {
+      const content = readRepoFile(file)
+      expect(content).toContain('UI guidance declaration')
+      expect(content).toContain('stable guidance followed')
+      expect(content).toContain('experimental guidance introduced: yes/no')
+      expect(content).toContain('human promotion needed: yes/no')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a governed UI canon under `docs/guidance/ui/` for the v1 assignments + attendance slice
- require a UI guidance declaration in issue/session workflows and Codex prompts
- add `scripts/ui-guidance-candidate.mjs` plus tests to draft experimental guidance without allowing writes to stable guidance

## Why
Issue #464 asks for a practical first version of a self-improving UI/UX guidance loop that is grounded in the current app, reviewable by humans, and reversible. This PR adds the minimum documentation and tooling needed to make future AI work follow stable guidance by default while capturing candidate patterns safely.

## Validation
- `pnpm test`
- `pnpm exec vitest run tests/unit/ui-guidance-candidate-script.test.ts tests/unit/ui-guidance-docs.test.ts`
- manual smoke of `node scripts/ui-guidance-candidate.mjs --scope assignments --files 'src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx' 'src/components/AssignmentModal.tsx' --stdout`
- manual smoke of `node scripts/ui-guidance-candidate.mjs --scope attendance --files 'src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx' --stdout`

Closes #464