### PR TITLE
Polish assignment workspace defaults and spacing

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8206,3 +8206,168 @@
   - student assignments sanity check: `/tmp/issue453-ai-draft-student.png`
 
 **Status:** Fresh AI grading feedback now appears first in the draft, is visibly marked as AI-generated until the teacher clicks into the field, and then becomes a normal draft textarea without altering the text.
+
+## 2026-04-14 (assignment grading panes default to 50/50)
+
+**Goal:** Make the assignment workspace left/right panes open at an even 50/50 split in both Class and Individual grading modes.
+
+**Completed:**
+- Updated the shared assignment grading layout default so both overview (`Class`) and details (`Individual`) modes start with a `50%` inspector width instead of `40%`.
+- Left the existing persisted-cookie behavior and separator double-click reset behavior intact.
+- Updated the layout helper and hook tests to reflect the new default split.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/unit/assignment-grading-layout.test.ts tests/hooks/use-assignment-grading-layout.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- Visual verification on the local dev server:
+  - teacher class grading view: `/tmp/pika-assignment-class-mode.png`
+  - teacher individual grading view: `/tmp/pika-assignment-individual-mode.png`
+  - student mobile classroom sanity check: `/tmp/pika-student-classrooms.png`
+
+**Status:** Assignment grading now defaults to a 50/50 workspace split in both class and individual modes, while saved user-resized layouts still persist as before.
+
+## 2026-04-14 (assignment grading divider gutter removed)
+
+**Goal:** Remove the small gutter before the right-hand grading cards in assignment Class and Individual modes without losing resize behavior.
+
+**Completed:**
+- Changed both assignment resize separators to use an overlay hit target instead of reserving visible layout width.
+- Kept the draggable divider and double-click reset behavior intact while letting the right panel start flush against the divider line.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/hooks/use-assignment-grading-layout.test.tsx tests/unit/assignment-grading-layout.test.ts`
+- Visual verification on the local dev server:
+  - teacher class grading view: `/tmp/pika-assignment-class-mode-tight-divider.png`
+  - teacher individual grading view: `/tmp/pika-assignment-individual-mode-tight-divider.png`
+  - student mobile classroom sanity check: `/tmp/pika-student-classrooms-tight-divider.png`
+
+**Status:** Assignment right-panel cards now sit flush against the divider in both class and individual grading modes, with the resize handle still available as an invisible overlay.
+
+## 2026-04-14 (individual assignment header compacted)
+
+**Goal:** Make the individual-mode left-pane header more vertically compact without removing the student name, character count, or navigation controls.
+
+**Completed:**
+- Reduced the individual work header top/bottom padding from `py-3` to `py-2`.
+- Tightened the internal row gap from `gap-2` to `gap-1` so the student name row and controls sit closer together.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherStudentWorkPanel.test.tsx`
+- Visual verification on the local dev server:
+  - teacher individual grading view: `/tmp/pika-assignment-individual-header-compact.png`
+
+**Status:** The individual-mode header is more vertically compact while preserving the same content and controls.
+
+## 2026-04-14 (classrooms landing title enlarged)
+
+**Goal:** Make the `Classrooms` title on the landing classrooms page feel larger and more prominent.
+
+**Completed:**
+- Increased the student landing page `Classrooms` heading from `text-2xl` to `text-3xl`.
+- Added a classrooms-only title size bump in the shared app header so the teacher landing page title renders larger without affecting other page titles.
+
+**Validation:**
+- Visual verification on the local dev server:
+  - teacher classrooms landing page: `/tmp/pika-classrooms-title-teacher.png`
+  - student classrooms landing page: `/tmp/pika-classrooms-title-student.png`
+
+**Status:** The landing `Classrooms` title is now more prominent for both teacher and student views.
+
+## 2026-04-14 (assignment summary gutters removed)
+
+**Goal:** Remove the extra left/right gutter around assignment summary lists while keeping the cards themselves readable.
+
+**Completed:**
+- Removed the generic `PageContent` horizontal padding from the teacher assignment summary view.
+- Removed the generic `PageContent` horizontal padding from the student assignment summary view only, leaving the edit/detail view spacing unchanged.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx' --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- `corepack pnpm exec vitest run tests/components/StudentAssignmentsTab.test.tsx`
+- Visual verification on the local dev server:
+  - teacher assignments summary: `/tmp/pika-assignments-teacher-summary-gutterless.png`
+  - student assignments summary: `/tmp/pika-assignments-student-summary-gutterless.png`
+
+**Status:** Assignment summary lists now sit flush to the available width in both teacher and student views, without changing the internal card padding.
+
+## 2026-04-14 (assignment gutter correction for class and individual modes)
+
+**Goal:** Revert the accidental assignment summary gutter removal and apply the gutter reduction only to the teacher assignment workspace modes.
+
+**Completed:**
+- Restored the original assignment summary padding for teacher and student summary views.
+- Moved the horizontal gutter reduction to the non-summary teacher assignment workspace wrapper, so it applies only in `Class` and `Individual` modes.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx' --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- `corepack pnpm exec vitest run tests/components/StudentAssignmentsTab.test.tsx`
+- Visual verification on the local dev server:
+  - teacher class workspace: `/tmp/pika-assignments-teacher-class-workspace-gutterless.png`
+  - teacher individual workspace: `/tmp/pika-assignments-teacher-individual-workspace-gutterless.png`
+  - student assignment summary sanity check: `/tmp/pika-assignments-student-summary-restored.png`
+
+**Status:** Assignment summary gutters are restored, and the reduced outer gutter now applies only to the teacher `Class` and `Individual` assignment workspaces.
+
+## 2026-04-14 (header fullscreen-to-datetime spacing)
+
+**Goal:** Add a bit more breathing room between the fullscreen toggle and the date/time in the app header.
+
+**Completed:**
+- Added a small right margin to the fullscreen toggle button in the shared app header.
+- Left the date/time and user menu spacing unchanged.
+
+**Validation:**
+- `corepack pnpm exec next lint --file src/components/AppHeader.tsx`
+- Visual verification on the local dev server:
+  - teacher header: `/tmp/pika-header-gap-teacher.png`
+  - student header: `/tmp/pika-header-gap-student.png`
+
+**Status:** The fullscreen button now has a small visual gap before the date/time in the shared app header.
+
+## 2026-04-14 (assignment workspace action bar gutter removed)
+
+**Goal:** Remove the action bar gutter in the teacher assignment workspace so it aligns with the gutterless `Class` and `Individual` panes.
+
+**Completed:**
+- Overrode the shared `PageActionBar` horizontal padding only for non-summary assignment workspace mode in `TeacherClassroomView`.
+- Left summary-mode action bars and other pages unchanged.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- Visual verification on the local dev server:
+  - teacher class workspace action bar: `/tmp/pika-assignments-class-actionbar-gutterless.png`
+  - teacher individual workspace action bar: `/tmp/pika-assignments-individual-actionbar-gutterless.png`
+
+**Status:** The teacher assignment workspace action bar is now flush with the `Class` and `Individual` workspace content.
+
+## 2026-04-14 (assignment workspace action bar right padding)
+
+**Goal:** Keep the teacher assignment workspace action bar flush on the left while adding a small amount of right padding.
+
+**Completed:**
+- Adjusted the non-summary assignment action bar override from full `px-0` to `pl-0 pr-2`.
+- Kept the `Class` and `Individual` workspace content alignment intact while giving the right-edge assignment title control a bit of breathing room.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- Visual verification on the local dev server:
+  - teacher class workspace action bar: `/tmp/pika-assignments-class-actionbar-rightpad.png`
+  - teacher individual workspace action bar: `/tmp/pika-assignments-individual-actionbar-rightpad.png`
+
+**Status:** The teacher assignment workspace action bar is flush on the left with a small right-edge inset.
+
+## 2026-04-14 (assignment class mode defaults to split workspace)
+
+**Goal:** Make teacher assignment `Class` mode open in the split-pane workspace by default instead of showing only the table pane.
+
+**Completed:**
+- Updated `TeacherClassroomView` to auto-select the first available student once when entering an assignment workspace, regardless of whether the active mode is `Class` or `Individual`.
+- Added a workspace-key guard so the default selection happens on entry, but manual deselection is not immediately overridden during the same workspace session.
+- Reset that guard when leaving assignment mode so reopening an assignment still defaults back to the split layout.
+
+**Validation:**
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx'`
+- Visual verification on the local dev server:
+  - teacher class workspace defaults split: `/tmp/pika-assignment-class-default-split.png`
+  - teacher individual workspace still split: `/tmp/pika-assignment-individual-still-split.png`
+
+**Status:** Teacher assignment `Class` mode now opens with the split workspace active by default.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8371,3 +8371,18 @@
   - teacher individual workspace still split: `/tmp/pika-assignment-individual-still-split.png`
 
 **Status:** Teacher assignment `Class` mode now opens with the split workspace active by default.
+
+## 2026-04-14 (review fix: assignment switch stale split pane)
+
+**Goal:** Address review feedback that switching between assignments could briefly bind the new class workspace to a stale student selection from the previous assignment.
+
+**Completed:**
+- Updated `TeacherClassroomView` so only assignment data whose `assignment.id` matches the current selection is treated as active for student rows, header/sidebar state, and split-pane rendering.
+- Tightened the default student auto-selection effect so it only treats a student as already selected if that student still exists in the current assignment roster.
+- Added a focused `TeacherClassroomView` regression test that switches from one assignment to another while the second roster fetch is still pending and verifies the old right pane disappears until the new assignment data arrives.
+
+**Validation:**
+- `corepack pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/hooks/use-assignment-grading-layout.test.tsx tests/unit/assignment-grading-layout.test.ts`
+- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file tests/components/TeacherClassroomView.test.tsx`
+
+**Status:** Assignment-to-assignment switching no longer reuses a stale student selection while the next roster is loading, and the regression is covered by an automated component test.

--- a/src/app/classrooms/StudentClassroomsIndex.tsx
+++ b/src/app/classrooms/StudentClassroomsIndex.tsx
@@ -22,7 +22,7 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
     <PageLayout className="mx-auto max-w-6xl">
       <PageActionBar
         primary={
-          <h1 className="text-2xl font-bold text-text-default">Classrooms</h1>
+          <h1 className="text-3xl font-bold text-text-default">Classrooms</h1>
         }
         actions={
           [

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -273,6 +273,7 @@ export function TeacherClassroomView({
   const [info, setInfo] = useState('')
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const workspaceContainerRef = useRef<HTMLDivElement | null>(null)
+  const defaultedWorkspaceKeyRef = useRef<string | null>(null)
   const [workspaceWidth, setWorkspaceWidth] = useState(0)
 
   // Batch grading state
@@ -744,6 +745,11 @@ export function TeacherClassroomView({
     setSelectedStudentId(null)
   }, [currentStudentRows, selectedStudentId])
 
+  useEffect(() => {
+    if (selection.mode === 'assignment') return
+    defaultedWorkspaceKeyRef.current = null
+  }, [selection.mode])
+
   const resolveDetailsStudentId = useCallback(() => {
     if (selection.mode !== 'assignment') return null
 
@@ -785,14 +791,20 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
-    if (assignmentWorkspaceMode !== 'details') return
-    if (selectedStudentId) return
+    const workspaceKey = `${selection.assignmentId}:${assignmentWorkspaceMode}`
+    if (defaultedWorkspaceKeyRef.current === workspaceKey) return
+
+    if (selectedStudentId) {
+      defaultedWorkspaceKeyRef.current = workspaceKey
+      return
+    }
 
     const nextStudentId = resolveDetailsStudentId()
     if (nextStudentId) {
+      defaultedWorkspaceKeyRef.current = workspaceKey
       setSelectedStudentId(nextStudentId)
     }
-  }, [assignmentWorkspaceMode, resolveDetailsStudentId, selectedStudentId, selection.mode])
+  }, [assignmentWorkspaceMode, resolveDetailsStudentId, selectedStudentId, selection])
 
   // Escape key to deselect student
   useEffect(() => {
@@ -1226,13 +1238,14 @@ export function TeacherClassroomView({
         primary={primaryButtons}
         actions={[]}
         trailing={showMobileToggle ? <RightSidebarToggle /> : undefined}
+        className={selection.mode === 'summary' ? '' : 'pl-0 pr-2'}
       />
 
       <PageContent
         className={
           selection.mode === 'summary'
             ? 'flex flex-col gap-3'
-            : 'flex min-h-0 flex-1 flex-col gap-3 pt-0'
+            : 'px-0 flex min-h-0 flex-1 flex-col gap-3 pt-0'
         }
       >
         {error && (
@@ -1331,15 +1344,17 @@ export function TeacherClassroomView({
                     {studentTable}
                   </div>
                   {isDesktop && (
-                    <div
-                      role="separator"
-                      aria-orientation="vertical"
-                      aria-label="Resize table and grading panes"
-                      className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
-                      onPointerDown={handleOverviewInspectorResizeStart}
-                      onDoubleClick={handleOverviewInspectorResizeReset}
-                    >
-                      <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+                    <div className="relative hidden w-0 shrink-0 lg:block">
+                      <div
+                        role="separator"
+                        aria-orientation="vertical"
+                        aria-label="Resize table and grading panes"
+                        className="absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent"
+                        onPointerDown={handleOverviewInspectorResizeStart}
+                        onDoubleClick={handleOverviewInspectorResizeReset}
+                      >
+                        <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+                      </div>
                     </div>
                   )}
                   <div

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -486,18 +486,27 @@ export function TeacherClassroomView({
     }
   }, [selection])
 
+  const activeSelectedAssignmentData = useMemo(() => {
+    if (selection.mode !== 'assignment' || !selectedAssignmentData) return null
+    return selectedAssignmentData.assignment.id === selection.assignmentId
+      ? selectedAssignmentData
+      : null
+  }, [selectedAssignmentData, selection])
+
   // Notify parent about selected assignment for sidebar
   useEffect(() => {
     if (selection.mode === 'summary') {
       onSelectAssignment?.(null)
-    } else if (selectedAssignmentData) {
-      const { assignment } = selectedAssignmentData
+    } else if (activeSelectedAssignmentData) {
+      const { assignment } = activeSelectedAssignmentData
       onSelectAssignment?.({
         title: assignment.title,
         instructions: assignment.instructions_markdown || assignment.rich_instructions || assignment.description,
       })
+    } else {
+      onSelectAssignment?.(null)
     }
-  }, [selection.mode, selectedAssignmentData, onSelectAssignment])
+  }, [activeSelectedAssignmentData, onSelectAssignment, selection.mode])
 
   // Notify parent of view mode changes
   useEffect(() => {
@@ -569,10 +578,16 @@ export function TeacherClassroomView({
     return rows
   }, [selectedAssignmentData, sortColumn, sortDirection])
 
-  const currentStudentRows = sortedStudents
+  const currentStudentRows = useMemo(
+    () => (activeSelectedAssignmentData ? sortedStudents : []),
+    [activeSelectedAssignmentData, sortedStudents],
+  )
 
   const studentRowIds = useMemo(() => currentStudentRows.map((s) => s.student_id), [currentStudentRows])
-  const dueAtMs = useMemo(() => selectedAssignmentData ? new Date(selectedAssignmentData.assignment.due_at).getTime() : 0, [selectedAssignmentData])
+  const dueAtMs = useMemo(
+    () => (activeSelectedAssignmentData ? new Date(activeSelectedAssignmentData.assignment.due_at).getTime() : 0),
+    [activeSelectedAssignmentData],
+  )
   const selectedAssignmentKey =
     selection.mode === 'assignment' ? selection.assignmentId : null
   const {
@@ -720,6 +735,7 @@ export function TeacherClassroomView({
     if (!selectedStudentId) return null
     return currentStudentRows.find((student) => student.student_id === selectedStudentId) ?? null
   }, [currentStudentRows, selectedStudentId])
+  const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
 
   const handleGoPrevStudent = useCallback(() => {
     if (selectedStudentIndex <= 0) return
@@ -732,12 +748,12 @@ export function TeacherClassroomView({
   }, [currentStudentRows, selectedStudentIndex])
 
   useEffect(() => {
-    if (selection.mode !== 'assignment' || !selectedStudentId) return
+    if (selection.mode !== 'assignment' || !activeSelectedStudentId) return
     writeCookie(
       getAssignmentWorkspaceStudentCookieName(classroom.id, selection.assignmentId),
-      selectedStudentId,
+      activeSelectedStudentId,
     )
-  }, [classroom.id, selectedStudentId, selection])
+  }, [activeSelectedStudentId, classroom.id, selection])
 
   useEffect(() => {
     if (!selectedStudentId) return
@@ -791,10 +807,11 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
+    if (!activeSelectedAssignmentData || selectedAssignmentLoading) return
     const workspaceKey = `${selection.assignmentId}:${assignmentWorkspaceMode}`
     if (defaultedWorkspaceKeyRef.current === workspaceKey) return
 
-    if (selectedStudentId) {
+    if (activeSelectedStudentId) {
       defaultedWorkspaceKeyRef.current = workspaceKey
       return
     }
@@ -804,7 +821,14 @@ export function TeacherClassroomView({
       defaultedWorkspaceKeyRef.current = workspaceKey
       setSelectedStudentId(nextStudentId)
     }
-  }, [assignmentWorkspaceMode, resolveDetailsStudentId, selectedStudentId, selection])
+  }, [
+    activeSelectedAssignmentData,
+    activeSelectedStudentId,
+    assignmentWorkspaceMode,
+    resolveDetailsStudentId,
+    selectedAssignmentLoading,
+    selection,
+  ])
 
   // Escape key to deselect student
   useEffect(() => {
@@ -883,18 +907,18 @@ export function TeacherClassroomView({
   }
 
   const canEditAssignment =
-    selection.mode === 'assignment' && !!selectedAssignmentData && !selectedAssignmentLoading && !isReadOnly
+    selection.mode === 'assignment' && !!activeSelectedAssignmentData && !selectedAssignmentLoading && !isReadOnly
   const selectedAssignmentSummary = selection.mode === 'assignment'
     ? assignments.find((item) => item.id === selection.assignmentId) ?? null
     : null
   const selectedAssignmentTitle =
-    selectedAssignmentData?.assignment.title ??
+    activeSelectedAssignmentData?.assignment.title ??
     selectedAssignmentSummary?.title ??
     'Assignment'
   const activeWorkspaceLayout = assignmentGradingLayout[assignmentWorkspaceMode]
   const showOverviewInspector =
     assignmentWorkspaceMode === 'overview' &&
-    !!selectedStudentId
+    !!activeSelectedStudentId
   const canOpenDetails =
     selection.mode === 'assignment' &&
     !selectedAssignmentLoading &&
@@ -998,18 +1022,18 @@ export function TeacherClassroomView({
       <KeyboardNavigableTable
         ref={tableContainerRef}
         rowKeys={currentStudentRows.map((student) => student.student_id)}
-        selectedKey={selectedStudentId}
+        selectedKey={activeSelectedStudentId}
         onSelectKey={setSelectedStudentId}
         onDeselect={() => setSelectedStudentId(null)}
       >
         <TableCard chrome="flush">
-          {selectedAssignmentLoading ? (
+          {selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError) ? (
             <div className="flex justify-center py-10">
               <Spinner />
             </div>
-          ) : selectedAssignmentError || !selectedAssignmentData ? (
+          ) : selectedAssignmentError ? (
             <div className="p-4 text-sm text-danger">
-              {selectedAssignmentError || 'Failed to load assignment'}
+              {selectedAssignmentError}
             </div>
           ) : (
             <div className="relative">
@@ -1066,8 +1090,8 @@ export function TeacherClassroomView({
                   </DataTableRow>
                 </DataTableHead>
                 <DataTableBody>
-                  {sortedStudents.map((student) => {
-                    const isSelected = selectedStudentId === student.student_id
+                  {currentStudentRows.map((student) => {
+                    const isSelected = activeSelectedStudentId === student.student_id
                     const totalScore =
                       student.doc?.score_completion != null &&
                       student.doc?.score_thinking != null &&
@@ -1214,8 +1238,8 @@ export function TeacherClassroomView({
               type="button"
               className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex max-w-[22rem] items-center gap-2`}
               onClick={() => {
-                if (selectedAssignmentData) {
-                  setEditAssignment(selectedAssignmentData.assignment)
+                if (activeSelectedAssignmentData) {
+                  setEditAssignment(activeSelectedAssignmentData.assignment)
                 }
               }}
               disabled={!canEditAssignment}
@@ -1309,11 +1333,11 @@ export function TeacherClassroomView({
               className="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
             >
               {assignmentWorkspaceMode === 'details' ? (
-                selectedStudentId ? (
+                activeSelectedStudentId ? (
                   <TeacherStudentWorkPanel
                     classroomId={classroom.id}
                     assignmentId={selection.assignmentId}
-                    studentId={selectedStudentId}
+                    studentId={activeSelectedStudentId}
                     mode="details"
                     inspectorCollapsed={false}
                     inspectorWidth={activeWorkspaceLayout.inspectorWidth}
@@ -1325,13 +1349,13 @@ export function TeacherClassroomView({
                     canGoPrevStudent={canGoPrevStudent}
                     canGoNextStudent={canGoNextStudent}
                   />
-                ) : selectedAssignmentLoading ? (
+                ) : selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError) ? (
                   <div className="flex flex-1 items-center justify-center py-12">
                     <Spinner />
                   </div>
-                ) : selectedAssignmentError || !selectedAssignmentData ? (
+                ) : selectedAssignmentError ? (
                   <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
-                    {selectedAssignmentError || 'Failed to load assignment'}
+                    {selectedAssignmentError}
                   </div>
                 ) : (
                   <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
@@ -1371,7 +1395,7 @@ export function TeacherClassroomView({
                     <TeacherStudentWorkPanel
                       classroomId={classroom.id}
                       assignmentId={selection.assignmentId}
-                      studentId={selectedStudentId}
+                      studentId={activeSelectedStudentId}
                       mode="overview"
                       inspectorCollapsed={false}
                       inspectorWidth={activeWorkspaceLayout.inspectorWidth}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -67,6 +67,10 @@ export function AppHeader({
   }, [])
 
   const isExamMode = Boolean(examModeHeader)
+  const pageTitleClassName =
+    pageTitle === 'Classrooms'
+      ? 'text-base sm:text-lg'
+      : 'text-sm'
 
   useEffect(() => {
     if (isExamMode) return
@@ -148,7 +152,7 @@ export function AppHeader({
             </div>
           </div>
         ) : pageTitle ? (
-          <h1 className="truncate text-sm font-semibold text-text-default">{pageTitle}</h1>
+          <h1 className={`truncate font-semibold text-text-default ${pageTitleClassName}`}>{pageTitle}</h1>
         ) : null}
       </div>
 
@@ -159,7 +163,7 @@ export function AppHeader({
             <button
               type="button"
               onClick={() => void toggleFullscreen()}
-              className="p-2 rounded-md text-text-muted hover:text-text-default hover:bg-surface-hover transition-colors"
+              className="mr-1 p-2 rounded-md text-text-muted hover:text-text-default hover:bg-surface-hover transition-colors"
               aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             >
               {isFullscreen ? <Minimize className="w-4 h-4" /> : <Maximize className="w-4 h-4" />}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -251,9 +251,9 @@ export function TeacherStudentWorkPanel({
       >
         <div
           data-testid="individual-content-header"
-          className="border-b border-border bg-surface px-4 py-3 text-sm"
+          className="border-b border-border bg-surface px-4 py-2 text-sm"
         >
-          <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center">
+          <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center">
             <div
               className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
             >
@@ -345,15 +345,17 @@ export function TeacherStudentWorkPanel({
       </div>
 
       {!layout.inspectorCollapsed && (
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize content and grading panes"
-          className="relative hidden w-3 shrink-0 cursor-col-resize bg-transparent lg:block"
-          onPointerDown={handleInspectorResizeStart}
-          onDoubleClick={handleInspectorResizeReset}
-        >
-          <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+        <div className="relative hidden w-0 shrink-0 lg:block">
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize content and grading panes"
+            className="absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent"
+            onPointerDown={handleInspectorResizeStart}
+            onDoubleClick={handleInspectorResizeReset}
+          >
+            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+          </div>
         </div>
       )}
 

--- a/src/lib/assignment-grading-layout.ts
+++ b/src/lib/assignment-grading-layout.ts
@@ -15,7 +15,7 @@ export interface AssignmentGradingLayoutMetrics {
 }
 
 export const ASSIGNMENT_GRADING_LAYOUT = {
-  defaultInspectorWidth: 40,
+  defaultInspectorWidth: 50,
   inspectorMinPx: 320,
   overviewPrimaryMinPx: 420,
   detailsPrimaryMinPx: 360,

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1,0 +1,325 @@
+import { forwardRef } from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
+import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
+import type { Classroom } from '@/types'
+
+const mockFetchJSONWithCache = vi.fn()
+const mockToggleSelect = vi.fn()
+const mockToggleSelectAll = vi.fn()
+const mockClearSelection = vi.fn()
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: any) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: class {},
+  PointerSensor: class {},
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  arrayMove: vi.fn((items) => items),
+  SortableContext: ({ children }: any) => <div>{children}</div>,
+  sortableKeyboardCoordinates: vi.fn(),
+  verticalListSortingStrategy: vi.fn(),
+}))
+
+vi.mock('@/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  ConfirmDialog: () => null,
+  SplitButton: ({ label, onPrimaryClick, disabled, primaryButtonProps }: any) => (
+    <button
+      type="button"
+      onClick={onPrimaryClick}
+      disabled={disabled}
+      {...primaryButtonProps}
+    >
+      {label}
+    </button>
+  ),
+  Tooltip: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('@/hooks/useDelayedBusy', () => ({
+  useDelayedBusy: (value: boolean) => value,
+}))
+
+vi.mock('@/hooks/useStudentSelection', () => ({
+  useStudentSelection: () => ({
+    selectedIds: new Set<string>(),
+    toggleSelect: mockToggleSelect,
+    toggleSelectAll: mockToggleSelectAll,
+    allSelected: false,
+    clearSelection: mockClearSelection,
+    selectedCount: 0,
+  }),
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}))
+
+vi.mock('@/components/AssignmentModal', () => ({
+  AssignmentModal: () => null,
+}))
+
+vi.mock('@/components/SortableAssignmentCard', () => ({
+  SortableAssignmentCard: ({ assignment, onSelect }: any) => (
+    <button type="button" onClick={onSelect}>
+      {assignment.title}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/AssignmentArtifactsCell', () => ({
+  AssignmentArtifactsCell: () => <div>Artifacts</div>,
+}))
+
+vi.mock('@/components/TeacherStudentWorkPanel', () => ({
+  TeacherStudentWorkPanel: ({ assignmentId, studentId, mode }: any) => (
+    <div data-testid="teacher-work-panel">{`${mode}:${assignmentId}:${studentId}`}</div>
+  ),
+}))
+
+vi.mock('@/components/PageLayout', () => ({
+  ACTIONBAR_BUTTON_PRIMARY_CLASSNAME: 'primary-button',
+  ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME: 'wide-button',
+  PageLayout: ({ children }: any) => <div>{children}</div>,
+  PageActionBar: ({ primary, trailing }: any) => (
+    <div>
+      {primary}
+      {trailing}
+    </div>
+  ),
+  PageContent: ({ children }: any) => <div>{children}</div>,
+  PageStack: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layout', () => ({
+  RightSidebarToggle: () => null,
+}))
+
+vi.mock('@/lib/assignments', () => ({
+  calculateAssignmentStatus: vi.fn(() => 'submitted_on_time'),
+  getAssignmentStatusIconClass: vi.fn(() => ''),
+  getAssignmentStatusLabel: vi.fn(() => 'Submitted'),
+  hasDraftSavedGrade: vi.fn(() => false),
+}))
+
+vi.mock('@/hooks/use-assignment-grading-layout', () => ({
+  useAssignmentGradingLayout: () => ({
+    layout: {
+      overview: { inspectorCollapsed: false, inspectorWidth: 50 },
+      details: { inspectorCollapsed: false, inspectorWidth: 50 },
+    },
+    updateModeLayout: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/scheduling', () => ({
+  isVisibleAtNow: () => true,
+}))
+
+vi.mock('@/components/DataTable', () => ({
+  DataTable: ({ children }: any) => <table><tbody>{children}</tbody></table>,
+  DataTableBody: ({ children }: any) => <>{children}</>,
+  DataTableCell: ({ children }: any) => <td>{children}</td>,
+  DataTableHead: ({ children }: any) => <>{children}</>,
+  DataTableHeaderCell: ({ children }: any) => <th>{children}</th>,
+  DataTableRow: ({ children, ...props }: any) => <tr {...props}>{children}</tr>,
+  EmptyStateRow: ({ message }: any) => <tr><td>{message}</td></tr>,
+  KeyboardNavigableTable: forwardRef<HTMLDivElement, any>(function KeyboardNavigableTableMock(
+    { children },
+    ref,
+  ) {
+    return <div ref={ref}>{children}</div>
+  }),
+  SortableHeaderCell: ({ label, onClick }: any) => <button type="button" onClick={onClick}>{label}</button>,
+  TableCard: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: (...args: any[]) => mockFetchJSONWithCache(...args),
+  invalidateCachedJSON: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-window-size', () => ({
+  useWindowSize: () => ({ width: 1440, height: 900 }),
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const classroom: Classroom = {
+  id: 'classroom-1',
+  teacher_id: 'teacher-1',
+  title: 'Physics',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'hidden',
+  archived_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function makeAssignmentSummary(id: string, title: string) {
+  return {
+    id,
+    classroom_id: classroom.id,
+    title,
+    description: `${title} description`,
+    instructions_markdown: `${title} instructions`,
+    rich_instructions: null,
+    due_at: '2026-04-20T12:00:00Z',
+    position: 0,
+    is_draft: false,
+    released_at: '2026-04-10T12:00:00Z',
+    created_by: 'teacher-1',
+    created_at: '2026-04-01T12:00:00Z',
+    updated_at: '2026-04-01T12:00:00Z',
+    stats: { total_students: 1, submitted: 1, late: 0 },
+  }
+}
+
+function makeAssignmentDetails(assignmentId: string, title: string, studentId: string) {
+  return {
+    assignment: {
+      id: assignmentId,
+      classroom_id: classroom.id,
+      title,
+      description: `${title} description`,
+      instructions_markdown: `${title} instructions`,
+      rich_instructions: null,
+      due_at: '2026-04-20T12:00:00Z',
+      position: 0,
+      is_draft: false,
+      released_at: '2026-04-10T12:00:00Z',
+      created_by: 'teacher-1',
+      created_at: '2026-04-01T12:00:00Z',
+      updated_at: '2026-04-01T12:00:00Z',
+    },
+    students: [
+      {
+        student_id: studentId,
+        student_email: `${studentId}@example.com`,
+        student_first_name: studentId,
+        student_last_name: 'Student',
+        status: 'submitted_on_time',
+        student_updated_at: '2026-04-10T12:00:00Z',
+        artifacts: [],
+        doc: {
+          submitted_at: '2026-04-10T12:00:00Z',
+          updated_at: '2026-04-10T12:00:00Z',
+          score_completion: null,
+          score_thinking: null,
+          score_workflow: null,
+          graded_at: null,
+          returned_at: null,
+          feedback_returned_at: null,
+        },
+      },
+    ],
+  }
+}
+
+function clearSelectionCookie() {
+  document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=; Path=/; Max-Age=0; SameSite=Lax`
+}
+
+describe('TeacherClassroomView', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      disconnect() {}
+    })
+    mockToggleSelect.mockReset()
+    mockToggleSelectAll.mockReset()
+    mockClearSelection.mockReset()
+    clearSelectionCookie()
+    mockFetchJSONWithCache.mockResolvedValue({
+      assignments: [
+        makeAssignmentSummary('assignment-1', 'Assignment One'),
+        makeAssignmentSummary('assignment-2', 'Assignment Two'),
+      ],
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    clearSelectionCookie()
+  })
+
+  it('clears the old split pane while the next assignment roster is still loading', async () => {
+    const assignmentTwoDeferred = createDeferred<any>()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-2') {
+        return assignmentTwoDeferred.promise
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_ASSIGNMENTS_SELECTION_EVENT, {
+          detail: { classroomId: classroom.id, value: 'assignment-2' },
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+    })
+
+    await act(async () => {
+      assignmentTwoDeferred.resolve({
+        ok: true,
+        json: async () => makeAssignmentDetails('assignment-2', 'Assignment Two', 'student-2'),
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-2:student-2')
+    })
+  })
+})

--- a/tests/hooks/use-assignment-grading-layout.test.tsx
+++ b/tests/hooks/use-assignment-grading-layout.test.tsx
@@ -62,7 +62,7 @@ describe('useAssignmentGradingLayout', () => {
       expect(document.cookie).toContain(savedValue)
     })
 
-    expect(document.cookie).not.toContain(encodeURIComponent('"inspectorWidth":40'))
+    expect(document.cookie).not.toContain(encodeURIComponent('"inspectorWidth":50'))
   })
 
   it('persists mode-specific layout updates and resets to defaults', async () => {
@@ -90,11 +90,11 @@ describe('useAssignmentGradingLayout', () => {
       expect(result.current.layout).toEqual({
         overview: {
           inspectorCollapsed: false,
-          inspectorWidth: 40,
+          inspectorWidth: 50,
         },
         details: {
           inspectorCollapsed: false,
-          inspectorWidth: 40,
+          inspectorWidth: 50,
         },
       })
     })

--- a/tests/unit/assignment-grading-layout.test.ts
+++ b/tests/unit/assignment-grading-layout.test.ts
@@ -17,11 +17,11 @@ describe('assignment grading layout helpers', () => {
     expect(getDefaultAssignmentGradingLayout()).toEqual({
       overview: {
         inspectorCollapsed: false,
-        inspectorWidth: 40,
+        inspectorWidth: 50,
       },
       details: {
         inspectorCollapsed: false,
-        inspectorWidth: 40,
+        inspectorWidth: 50,
       },
     })
   })
@@ -90,7 +90,7 @@ describe('assignment grading layout helpers', () => {
       ...layout,
       overview: {
         inspectorCollapsed: true,
-        inspectorWidth: 40,
+        inspectorWidth: 50,
       },
     })
   })


### PR DESCRIPTION
## Summary
- default assignment class and individual workspaces to a 50/50 split and open class mode in split view by default
- remove workspace gutters around the assignment panes/action bar while keeping a small right inset on the action bar
- tighten the individual-mode header and slightly increase the classrooms/header title spacing polish

## Validation
- `corepack pnpm exec next lint --file 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' --file src/components/AppHeader.tsx --file src/components/TeacherStudentWorkPanel.tsx --file src/app/classrooms/StudentClassroomsIndex.tsx`
- `corepack pnpm exec vitest run tests/unit/assignment-grading-layout.test.ts tests/hooks/use-assignment-grading-layout.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
- visual verification on local teacher/student screenshots for classrooms and assignment workspace states