### PR TITLE
Align Node 24 policy and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/docs/core/pilot-mvp.md
+++ b/docs/core/pilot-mvp.md
@@ -90,7 +90,7 @@ To support automated history analysis, MVP should treat **Pika as the primary dr
 - Summaries apply to **assignments only** (not daily logs).
 - Summaries should run **on-demand** and as a nightly batch job at **1:00am America/Toronto**.
 - On-demand summaries are allowed for **drafts** and **submitted** docs.
-- AI model: **OpenAI `gpt-5-mini`** (configurable).
+- AI model: **OpenAI `gpt-5-nano`** by default (override with `OPENAI_GRADING_MODEL`).
 - On-demand summarization should return cached results unless the assignment doc has changed since the last summary.
 - Nightly batch recomputes summaries only for **submitted** assignment docs changed since last summary.
 - Scheduled execution: Vercel Cron (configured in Vercel dashboard; production recommended) at `0 6 * * *` (06:00 UTC; 1:00am Toronto in winter, 2:00am in summer) → `GET /api/cron/nightly-assignment-summaries` (protected via `CRON_SECRET`).

--- a/docs/core/pilot-mvp.md
+++ b/docs/core/pilot-mvp.md
@@ -90,7 +90,7 @@ To support automated history analysis, MVP should treat **Pika as the primary dr
 - Summaries apply to **assignments only** (not daily logs).
 - Summaries should run **on-demand** and as a nightly batch job at **1:00am America/Toronto**.
 - On-demand summaries are allowed for **drafts** and **submitted** docs.
-- AI model: **OpenAI `gpt-5-nano`** by default (override with `OPENAI_GRADING_MODEL`).
+- AI model: **OpenAI `gpt-5-nano`** by default (override with `OPENAI_SUMMARY_MODEL`).
 - On-demand summarization should return cached results unless the assignment doc has changed since the last summary.
 - Nightly batch recomputes summaries only for **submitted** assignment docs changed since last summary.
 - Scheduled execution: Vercel Cron (configured in Vercel dashboard; production recommended) at `0 6 * * *` (06:00 UTC; 1:00am Toronto in winter, 2:00am in summer) → `GET /api/cron/nightly-assignment-summaries` (protected via `CRON_SECRET`).

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -122,7 +122,7 @@ Legacy anon/service keys are supported but publishable/secret are preferred.
 ## Troubleshooting
 
 - **Server won’t start**: check Node 24.x, `.env.local`, clear `.next`.
-- **pnpm thinks you’re on Node 22**: your `pnpm` binary is being executed by a different `node` than your shell (common when an older global pnpm is earlier in `PATH`). Fix with Corepack:
+- **pnpm thinks you’re on the wrong Node version**: your `pnpm` binary is being executed by a different `node` than your shell (common when an older global pnpm is earlier in `PATH`). Fix with Corepack:
   - `corepack enable`
   - `corepack prepare pnpm@10.25.0 --activate`
   - Re-open the terminal and re-check: `node -v`, `pnpm -v`, `pnpm exec node -v`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.25.0",
   "engines": {
-    "node": ">=22"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/scripts/verify-env.sh
+++ b/scripts/verify-env.sh
@@ -15,14 +15,14 @@ echo "🔍 Verifying Pika development environment..."
 
 if ! command -v node >/dev/null 2>&1; then
   echo "❌ node not found"
-  echo "   Install Node.js 22.x or newer"
+  echo "   Install Node.js 24.x"
   exit 1
 fi
 
 NODE_VERSION="$(node -p 'process.versions.node')"
 NODE_MAJOR="${NODE_VERSION%%.*}"
-if [[ "$NODE_MAJOR" -lt 22 ]]; then
-  echo "❌ Node.js 22.x or newer required (found $NODE_VERSION)"
+if [[ "$NODE_MAJOR" -ne 24 ]]; then
+  echo "❌ Node.js 24.x required (found $NODE_VERSION)"
   exit 1
 fi
 echo "✅ Node.js $NODE_VERSION"

--- a/tests/api/student/tests-documents-snapshot.test.ts
+++ b/tests/api/student/tests-documents-snapshot.test.ts
@@ -59,6 +59,10 @@ function createMockDownloadBody(content: string, contentType: string) {
   }
 }
 
+async function readResponseText(response: Response) {
+  return Buffer.from(await response.arrayBuffer()).toString('utf8')
+}
+
 describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -77,7 +81,7 @@ describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toBe('text/html')
     expect(response.headers.get('content-security-policy')).toContain("script-src 'none'")
-    expect(await (await response.blob()).text()).toContain('Snapshot')
+    expect(await readResponseText(response)).toContain('Snapshot')
   })
 
   it('returns 404 when the link doc has no snapshot', async () => {

--- a/tests/api/teacher/tests-documents-snapshot.test.ts
+++ b/tests/api/teacher/tests-documents-snapshot.test.ts
@@ -59,6 +59,10 @@ function createMockDownloadBody(content: string, contentType: string) {
   }
 }
 
+async function readResponseText(response: Response) {
+  return Buffer.from(await response.arrayBuffer()).toString('utf8')
+}
+
 describe('GET /api/teacher/tests/[id]/documents/[docId]/snapshot', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -76,6 +80,6 @@ describe('GET /api/teacher/tests/[id]/documents/[docId]/snapshot', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toBe('application/pdf')
-    expect(await (await response.blob()).text()).toContain('%PDF-1.4')
+    expect(await readResponseText(response)).toContain('%PDF-1.4')
   })
 })


### PR DESCRIPTION
## Summary
- standardize the repo runtime contract on Node 24
- align CI, verify-env messaging, and docs with the Node 24 target
- update snapshot route tests for the Node 24 response body behavior
- correct the stale AI model doc to `gpt-5-nano` and document `OPENAI_GRADING_MODEL`

## Validation
- `mise exec node@24 -- corepack pnpm exec vitest run tests/api/student/tests-documents-snapshot.test.ts tests/api/teacher/tests-documents-snapshot.test.ts`
- `mise exec node@24 -- corepack pnpm run lint`
- validation of the full stacked state was completed before the split with `test:coverage`, `tsc --noEmit`, `build`, and `bash scripts/verify-env.sh` on Node 24