### PR TITLE
[codex] streamline AI guidance workflow

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -6,15 +6,14 @@ Read this file at the start of every AI session. It is the compact continuity la
 
 - Product status: core classroom, assignment, quiz/test, and auth flows are live.
 - Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
-- Feature inventory: `.ai/features.json` is the status authority for big epics. All listed epics currently pass.
+- Feature inventory: `.ai/features.json` is the status authority for big epics; check it directly for current pass/fail state.
 
 ## Environment And Workflow Facts
 
 - Main hub checkout: `$HOME/Repos/pika`
 - Feature worktrees: `$HOME/Repos/.worktrees/pika/<branch-name>`
 - Shared env file: `$HOME/Repos/.env/pika/.env.local`
-- Package manager: `pnpm` via Corepack (`packageManager: pnpm@10.25.0`)
-- Node baseline: `24.x`; `.nvmrc` currently points to `v24.12.0`
+- Runtime and package-manager requirements live in `.nvmrc`, `package.json`, and `scripts/verify-env.sh`
 - Worktree and shared-env setup are defined only in `docs/dev-workflow.md`
 
 ## Repo Invariants

--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -1,0 +1,42 @@
+# Pika Current Context
+
+Read this file at the start of every AI session. It is the compact continuity layer for current repo state. Use `.ai/JOURNAL.md` only when you need historical detail.
+
+## Current Focus
+
+- Product status: core classroom, assignment, quiz/test, and auth flows are live.
+- Maintenance focus: coverage expansion, API-route standardization, UI decomposition, and AI-guidance cleanup.
+- Feature inventory: `.ai/features.json` is the status authority for big epics. All listed epics currently pass.
+
+## Environment And Workflow Facts
+
+- Main hub checkout: `$HOME/Repos/pika`
+- Feature worktrees: `$HOME/Repos/.worktrees/pika/<branch-name>`
+- Shared env file: `$HOME/Repos/.env/pika/.env.local`
+- Package manager: `pnpm` via Corepack (`packageManager: pnpm@10.25.0`)
+- Node baseline: `24.x`; `.nvmrc` currently points to `v24.12.0`
+- Worktree and shared-env setup are defined only in `docs/dev-workflow.md`
+
+## Repo Invariants
+
+- All deadline and attendance cutoffs use `America/Toronto`
+- Keep business logic out of UI components; prefer `src/lib/*` and server-side modules
+- API routes use `withErrorHandler` from `@/lib/api-handler`
+- Repeated client-side reads use `fetchJSONWithCache` from `@/lib/request-cache`
+- Tiptap content parsing uses `parseContentField` from `@/lib/tiptap-content`
+- App code uses semantic tokens and `@/ui` primitives, not raw `dark:` classes or `@/components` UI imports
+- AI may create or edit migration files, but humans apply migrations manually
+
+## Known Hazards
+
+- Do not work in the hub checkout for non-trivial changes; bind to a worktree first
+- Do not tail `.ai/JOURNAL.md` by default; it is intentionally large and should be consulted on demand
+- Do not run `supabase db push`, `supabase db reset`, or other migration-application commands as an AI agent
+- `main` accepts linear history only; `production` merges go through the protected PR flow
+
+## Recent Architectural Direction
+
+- Session startup now centers on `.ai/START-HERE.md`, this file, `docs/ai-instructions.md`, and `.ai/features.json`
+- `docs/dev-workflow.md` is the canonical source for worktrees and shared `.env.local` setup
+- The design system expects semantic tokens in app code and `@/ui` imports for primitives
+- Route and content drift hotspots are `withErrorHandler`, `fetchJSONWithCache`, and `parseContentField`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8696,3 +8696,16 @@
 - `pnpm test -- --run tests/unit/ai-startup-docs.test.ts` (resolved to a full Vitest run in this shell; `tests/unit/ai-startup-docs.test.ts` still passed)
 
 **Status:** `.ai/CURRENT.md` is now narrower and less likely to drift away from canonical repo metadata.
+
+## 2026-04-16 [AI - Codex]
+
+**Goal:** Fix the follow-up PR review findings around startup-contract drift in the automated session-start path.
+
+**Completed:**
+- Updated `.codex/skills/pika-session-start/scripts/session_start.sh` to render the full required startup set in order: `.ai/START-HERE.md`, `.ai/CURRENT.md`, `.ai/features.json`, and `docs/ai-instructions.md`.
+- Tightened `tests/unit/ai-startup-docs.test.ts` so the regression suite now asserts that the preferred automated startup paths reference the entire required startup set in the documented order.
+
+**Validation:**
+- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec vitest run tests/unit/ai-startup-docs.test.ts`
+
+**Status:** The automated startup path now matches the documented startup contract, and CI coverage now checks that alignment explicitly.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8683,3 +8683,16 @@
 - `rg -n "tail -40 .*JOURNAL|tail -60 .*JOURNAL|follow its required reading order|Ensure dev server is running|Refresh auth states if needed|Take screenshots for BOTH roles" AGENTS.md docs/issue-worker.md docs/workflow/handle-issue.md .codex/prompts/session-start.md .ai/START-HERE.md`
 
 **Status:** The remaining workflow docs are leaner, and the startup-budget and no-journal-tail rules now have test coverage.
+
+## 2026-04-16 [AI - Codex]
+
+**Goal:** Address PR review drift findings in `.ai/CURRENT.md` without adding more synchronization machinery.
+
+**Completed:**
+- Removed the volatile claim that all feature epics currently pass and replaced it with a direct pointer back to `.ai/features.json` as the status authority.
+- Replaced hardcoded package-manager and Node-version facts with a pointer to `.nvmrc`, `package.json`, and `scripts/verify-env.sh` so startup context stays operational instead of duplicating metadata.
+
+**Validation:**
+- `pnpm test -- --run tests/unit/ai-startup-docs.test.ts` (resolved to a full Vitest run in this shell; `tests/unit/ai-startup-docs.test.ts` still passed)
+
+**Status:** `.ai/CURRENT.md` is now narrower and less likely to drift away from canonical repo metadata.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8645,3 +8645,41 @@
   - student resources split view: `/tmp/pika-resources-padding-student-v4.png`
 
 **Status:** The resources panes now use matching outer gutters, and the empty-state cards line up to the pane walls consistently.
+
+## 2026-04-15 [AI - Codex]
+
+**Goal:** Slim down the AI guidance surface and move session continuity onto a compact current-state summary instead of the full journal.
+
+**Completed:**
+- Added `.ai/CURRENT.md` as the default always-read continuity file and updated `.ai/START-HERE.md`, `AGENTS.md`, and the session-start skill to use it.
+- Rewrote `docs/ai-instructions.md` into a smaller routing document that points agents to task-specific docs instead of requiring the full core stack every session.
+- Reconciled setup and migration guidance in `docs/core/project-context.md`, `docs/dev-workflow.md`, and `docs/semester-plan.md` so worktree/env setup stays canonical and migration application stays human-controlled.
+- Simplified the Codex prompt files so they point back to canonical workflow docs for generic rules while preserving the required UI guidance declaration for UI-affecting work.
+
+**Validation:**
+- Startup context budget:
+  - `.ai/START-HERE.md` + `.ai/CURRENT.md` + `.ai/features.json` + `docs/ai-instructions.md` = `12,653` characters
+- Conflict scan:
+  - `rg -n "supabase db push|run migrations on deploy|Configure \\.env\\.local \\(see README|tail -40 .*JOURNAL|tail -60 .*JOURNAL|read these files \\*\\*in this exact order\\*\\*|Check journal" .ai docs .codex/prompts AGENTS.md --glob '!**/.ai/JOURNAL.md'`
+- Targeted regression:
+  - `corepack pnpm --dir /Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown exec vitest run tests/unit/ui-guidance-docs.test.ts`
+- Full session-start dry run:
+  - `PATH="/opt/homebrew/opt/node@24/bin:$PATH" PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"`
+
+**Status:** The default AI startup path is now under the target budget, journal reads are on-demand, and the bound worktree session-start flow passes end-to-end.
+
+## 2026-04-15 [AI - Codex]
+
+**Goal:** Tighten the remaining workflow-doc overlap and add regression checks for the slimmed AI startup contract.
+
+**Completed:**
+- Reduced `AGENTS.md` by replacing embedded workflow recipes with pointers back to the canonical startup, worktree, and UI verification docs.
+- Reworked `docs/issue-worker.md` and `docs/workflow/handle-issue.md` to follow the new routed doc-loading model and avoid duplicating the full screenshot procedure.
+- Added `tests/unit/ai-startup-docs.test.ts` to lock the startup budget and prevent `.ai/JOURNAL.md` tailing from re-entering the default startup flow.
+
+**Validation:**
+- `corepack pnpm --dir /Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown exec vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
+- `wc -lc AGENTS.md docs/issue-worker.md docs/workflow/handle-issue.md .ai/START-HERE.md .ai/CURRENT.md docs/ai-instructions.md`
+- `rg -n "tail -40 .*JOURNAL|tail -60 .*JOURNAL|follow its required reading order|Ensure dev server is running|Refresh auth states if needed|Take screenshots for BOTH roles" AGENTS.md docs/issue-worker.md docs/workflow/handle-issue.md .codex/prompts/session-start.md .ai/START-HERE.md`
+
+**Status:** The remaining workflow docs are leaner, and the startup-budget and no-journal-tail rules now have test coverage.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8709,3 +8709,16 @@
 - `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec vitest run tests/unit/ai-startup-docs.test.ts`
 
 **Status:** The automated startup path now matches the documented startup contract, and CI coverage now checks that alignment explicitly.
+
+## 2026-04-16 [AI - Codex]
+
+**Goal:** Replace the remaining source-text-only startup regression with a behavior-level check.
+
+**Completed:**
+- Reworked `tests/unit/ai-startup-docs.test.ts` so the script assertion now builds a disposable fixture worktree, initializes a minimal git repo, and executes the real `session_start.sh` script against that fixture.
+- Added runtime assertions that the rendered output includes the required startup docs in order and still emits the feature summary and next-feature sections.
+
+**Validation:**
+- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec vitest run tests/unit/ai-startup-docs.test.ts`
+
+**Status:** The startup regression now checks actual script behavior instead of only checking source text.

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -11,14 +11,16 @@
 ```
 [ ] Verify worktree: echo $PIKA_WORKTREE (must NOT be $HOME/Repos/pika)
 [ ] Run: bash "$PIKA_WORKTREE/scripts/verify-env.sh"
-[ ] Check journal: tail -40 "$PIKA_WORKTREE/.ai/JOURNAL.md"
 [ ] Check status: git -C "$PIKA_WORKTREE" status
-[ ] Read: docs/ai-instructions.md (then follow its reading order)
-[ ] Identify task: GitHub issue, features.json, or ask user
+[ ] Read: .ai/CURRENT.md
+[ ] Read: docs/ai-instructions.md
+[ ] Check features: node "$PIKA_WORKTREE/scripts/features.mjs" next
+[ ] Load task-specific docs routed by docs/ai-instructions.md
 [ ] Plan before coding: state task, propose approach, wait for approval
 ```
 
 Do not start coding if verification fails.
+Use `.ai/JOURNAL.md` only if you need historical detail that is not covered by `.ai/CURRENT.md`.
 
 ---
 
@@ -29,9 +31,9 @@ All agents are bound to exactly ONE worktree via `$PIKA_WORKTREE`.
 - NEVER assume the shell cwd.
 - ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`.
 - ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
-- Never do branch work in `$HOME/Repos/pika/` (the hub). Use worktrees under `$HOME/Repos/.worktrees/pika/`.
+- Never do branch work in `$HOME/Repos/pika/` (the hub).
+- Worktree creation, cleanup, and shared `.env.local` setup live in `docs/dev-workflow.md`.
 - For hub-level git commands (add/remove worktrees): `export PIKA_WORKTREE="$HOME/Repos/pika"`
-- Creating worktrees: see `docs/dev-workflow.md`
 
 ---
 
@@ -57,10 +59,11 @@ All agents are bound to exactly ONE worktree via `$PIKA_WORKTREE`.
 
 Trust in this order:
 1. `.ai/features.json` — status authority
-2. `docs/core/architecture.md` — architecture and invariants
-3. `docs/core/tests.md` — testing requirements
-4. `docs/core/design.md` — UI/UX rules
-5. `docs/core/project-context.md` — setup and commands
-6. `docs/core/roadmap.md` — phase strategy
-7. `docs/core/decision-log.md` — historical rationale
-8. `.ai/JOURNAL.md` — session history
+2. `.ai/CURRENT.md` — compact current-state context
+3. `docs/core/architecture.md` — architecture and invariants
+4. `docs/core/tests.md` — testing requirements
+5. `docs/core/design.md` — UI/UX rules
+6. `docs/core/project-context.md` — setup and commands
+7. `docs/core/roadmap.md` — phase strategy
+8. `docs/core/decision-log.md` — historical rationale
+9. `.ai/JOURNAL.md` — session history (on demand)

--- a/.codex/prompts/add-api-route.md
+++ b/.codex/prompts/add-api-route.md
@@ -1,51 +1,16 @@
-Scaffold a new API route at the given path with best-practice patterns.
+Scaffold a new API route at the path in `$ARGUMENTS`.
 
-Takes the route path as an argument (e.g. `teacher/widgets/[id]`).
+Use `docs/ai-instructions.md` and `docs/core/architecture.md` for the canonical route rules. The critical route-specific requirements are:
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
-
-Rules:
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
-- Follow patterns from `docs/ai-instructions.md` and `docs/core/architecture.md`.
-- Every handler MUST use `withErrorHandler` from `@/lib/api-handler`.
-- Use Zod for request body validation.
-- Use `requireRole` from `@/lib/auth` for authentication/authorization.
-- Import Supabase client from `@/lib/supabase-server` (service role) or `@/lib/supabase-route` (user context).
+- Use `withErrorHandler` from `@/lib/api-handler`
+- Use `requireRole` for access control
+- Use Zod for request validation
+- Keep the happy path only inside the handler
 
 Steps:
-
-1) Parse the target path
-   - Extract the route path from arguments (e.g. `teacher/widgets/[id]`).
-   - Compute full file path: `$PIKA_WORKTREE/src/app/api/<path>/route.ts`.
-   - If the file already exists, stop and report.
-
-2) Determine route characteristics
-   - If path starts with `teacher/` -> use `requireRole('teacher')`.
-   - If path starts with `student/` -> use `requireRole('student')`.
-   - Otherwise -> default to generic auth check.
-   - If path contains `[id]` or similar dynamic segments -> include `context.params` destructuring.
-
-3) Generate the route file using this template:
-
-   ```typescript
-   import { NextRequest, NextResponse } from 'next/server'
-   import { withErrorHandler } from '@/lib/api-handler'
-   import { requireRole } from '@/lib/auth'
-   import { createSupabaseServer } from '@/lib/supabase-server'
-
-   export const GET = withErrorHandler('Get<Resource>', async (request, context) => {
-     const { id } = await context.params
-     const user = await requireRole('teacher')
-     const supabase = createSupabaseServer()
-
-     // TODO: implement
-     return NextResponse.json({ id })
-   })
-   ```
-
-   - Include GET handler by default.
-   - Use PascalCase for the route name in `withErrorHandler`.
-
-4) Create parent directories if needed with `mkdir -p`.
-
-5) Verify with `pnpm tsc --noEmit`.
+1. Resolve the target path to `$PIKA_WORKTREE/src/app/api/<path>/route.ts`.
+2. Stop if the file already exists.
+3. Infer role requirements and whether `context.params` is needed from the path.
+4. Generate a minimal route with a `GET` handler by default.
+5. Use a PascalCase route name for `withErrorHandler`.
+6. Create parent directories if needed, then verify with `pnpm -C "$PIKA_WORKTREE" tsc --noEmit`.

--- a/.codex/prompts/audit.md
+++ b/.codex/prompts/audit.md
@@ -1,25 +1,8 @@
-Pre-commit audit: scan changed files for common violations.
+Run the repo audit for changed files and report every violation found.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
-
-Rules:
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
-- Report ALL violations found, not just the first one.
-
-Steps:
-
-1) Get changed `.ts`/`.tsx` files from `git diff --name-only HEAD`.
-2) Check each file for violations:
-   a) **Manual error handling** (API routes under `src/app/api/`): `catch (error` without `withErrorHandler`
-   b) **Direct dark: classes** (outside `src/ui/`): `dark:` in className strings
-   c) **Duplicated parseContentField**: local function named `parseContentField`
-   d) **Missing withErrorHandler** (API routes): `export async function GET/POST/PATCH/PUT/DELETE` without wrapper
-   e) **Console.log in production** (not test files): `console.log(`
-   f) **Direct Supabase in components**: `createClient(` in `src/components/` or non-api `src/app/`
-3) Report: file path, line number, violation type, suggested fix.
-4) Summary: total violations, pass/fail.
-
-Alternatively, run the audit script directly:
+Preferred path:
 ```bash
 bash "$PIKA_WORKTREE/.codex/skills/pika-audit/scripts/audit.sh"
 ```
+
+Focus on the full result set, not only the first failure. The audit checks the highest-drift patterns: manual API-route error handling, illegal `dark:` classes, duplicated `parseContentField`, `console.log`, and related violations.

--- a/.codex/prompts/commit-and-pr.md
+++ b/.codex/prompts/commit-and-pr.md
@@ -1,40 +1,14 @@
-Commit staged/unstaged changes and create or update a PR.
+Commit the current worktree changes and create or update the PR.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+Use the bound-worktree rules from `docs/dev-workflow.md`. Task-specific safeguards:
 
-Rules:
-- Run all commands directly.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
-- Never commit directly to `main` or `production`. If on these branches, stop and ask me to create a feature branch first.
-- Never force-push.
-- Generate commit message from diff using conventional commits format.
+- Never commit directly to `main` or `production`
+- Never force-push
+- Use a conventional-commit message derived from the diff
 
 Steps:
-
-1) Verify environment
-   - Verify `$PIKA_WORKTREE` is set: `echo $PIKA_WORKTREE`
-   - If not set or equals `$HOME/Repos/pika` (hub), stop and tell me to bind a worktree first (`pika claude <worktree>`).
-   - Run: `git -C "$PIKA_WORKTREE" status -sb`, `git -C "$PIKA_WORKTREE" branch --show-current`
-   - If on `main` or `production`, stop and ask me to create a feature branch.
-   - If no changes (staged or unstaged), stop and tell me.
-
-2) Review changes
-   - Run: `git -C "$PIKA_WORKTREE" diff --stat` and `git -C "$PIKA_WORKTREE" diff` to understand the changes.
-   - Run: `git -C "$PIKA_WORKTREE" log --oneline -5` to understand commit message style.
-
-3) Stage and commit
-   - Stage all changes: `git -C "$PIKA_WORKTREE" add -A`
-   - Generate a commit message from the diff using conventional commits (feat/fix/chore/docs/refactor/test).
-   - Commit with the generated message using `git -C "$PIKA_WORKTREE" commit -m "..."`.
-   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit.
-
-4) Push
-   - If branch has no upstream, push with `git -C "$PIKA_WORKTREE" push -u origin <branch>`.
-   - Otherwise, push with `git -C "$PIKA_WORKTREE" push`.
-
-5) Create or update PR
-   - Check if PR exists: `gh pr view --json url` (auto-detects repo from branch)
-   - If PR exists: just show the PR URL (push already updated it).
-   - If no PR exists: create one with `gh pr create`.
-     - Title: derive from commit message or branch name.
-     - Body: summarize the changes, include test plan checklist.
+1. Confirm the current branch and stop if it is `main` or `production`.
+2. Review `git -C "$PIKA_WORKTREE" diff --stat`, `git -C "$PIKA_WORKTREE" diff`, and recent commit style.
+3. Stage the intended files, generate a conventional-commit message, and commit.
+4. Push the branch, setting upstream if needed.
+5. If a PR already exists, report its URL. Otherwise create one with a concise summary and test plan.

--- a/.codex/prompts/follow-workflow.md
+++ b/.codex/prompts/follow-workflow.md
@@ -1,20 +1,10 @@
-STOP and re-read the workflow docs before continuing.
+Stop and reload the canonical workflow context before continuing.
 
-You may have drifted from the required workflow. Follow these steps:
-
-1) Check environment first: `echo $PIKA_WORKTREE`
-2) Read the workflow docs:
-   - Read `$PIKA_WORKTREE/.ai/START-HERE.md`
-   - Read `$PIKA_WORKTREE/docs/dev-workflow.md`
-   (If $PIKA_WORKTREE is unset, use `$HOME/Repos/pika`)
-
-Key rules to remember:
-
-- NEVER assume the shell cwd
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`
-- Verify `$PIKA_WORKTREE` is set before running commands
-- Hub (`$HOME/Repos/pika`) is for managing worktrees, NOT feature development
+Read these files in order:
+1. `$PIKA_WORKTREE/.ai/START-HERE.md`
+2. `$PIKA_WORKTREE/.ai/CURRENT.md`
+3. `$PIKA_WORKTREE/docs/ai-instructions.md`
+4. `$PIKA_WORKTREE/docs/dev-workflow.md`
 
 After reading, confirm:
 1. What is `$PIKA_WORKTREE` set to?

--- a/.codex/prompts/merge-main-into-production.md
+++ b/.codex/prompts/merge-main-into-production.md
@@ -1,21 +1,14 @@
-Merge `main` into `production` via the protected PR flow.
+Merge `main` into `production` using the protected PR workflow.
 
-Use the repository skill:
+Use the dedicated repo skill and `docs/dev-workflow.md` as the canonical process reference.
 
-- Skill: `.codex/skills/pika-main-to-production-merge`
-- Script: `.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
+Primary command:
+```bash
+bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
+```
 
-Rules:
-- Run commands directly (do not return copy/paste-only guidance).
-- Respect worktree rules (`git -C "$PIKA_WORKTREE"` for repo worktree operations).
-- Expect direct pushes to `production` to be rejected by branch protection (`GH013`).
-- If merge conflicts occur, stop and ask for resolution direction.
-
-Execution steps:
-1. Run preflight + merge branch + PR creation:
-   - `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
-2. Merge the created PR.
-3. Fast-forward local production worktree:
-   - `git -C "$HOME/Repos/.worktrees/pika/production" fetch origin production`
-   - `git -C "$HOME/Repos/.worktrees/pika/production" merge --ff-only origin/production`
-4. Report final `origin/production` commit SHA.
+After the script:
+1. Merge the created PR.
+2. Fast-forward the local production worktree to `origin/production`.
+3. Report the final `origin/production` commit SHA.
+4. Stop and ask for direction if conflicts appear at any stage.

--- a/.codex/prompts/migrate-error-handler.md
+++ b/.codex/prompts/migrate-error-handler.md
@@ -1,54 +1,11 @@
-Migrate an API route from manual try/catch error handling to `withErrorHandler`.
+Migrate the API route in `$ARGUMENTS` from manual `try/catch` handling to `withErrorHandler`.
 
-Takes the file path to migrate as an argument (relative to `$PIKA_WORKTREE` or absolute).
-
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
-
-Rules:
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
-- Preserve all existing business logic exactly.
-- Do NOT change response shapes, status codes, or behavior.
-- Only refactor the error handling wrapper.
-
-Migration pattern:
-
-**Before (manual):**
-```typescript
-export async function GET(request: NextRequest) {
-  try {
-    const user = await requireRole('teacher')
-    // ... business logic ...
-    return NextResponse.json(data)
-  } catch (error: any) {
-    if (error.name === 'AuthenticationError') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-    if (error.name === 'AuthorizationError') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-    console.error('...', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
-  }
-}
-```
-
-**After (withErrorHandler):**
-```typescript
-export const GET = withErrorHandler('GetResource', async (request, context) => {
-  const user = await requireRole('teacher')
-  // ... business logic (unchanged) ...
-  return NextResponse.json(data)
-})
-```
+Preserve business logic and response behavior. Only change the error-handling structure.
 
 Steps:
-1) Read the target file. If it already uses `withErrorHandler`, stop.
-2) For each exported handler (GET, POST, PATCH, PUT, DELETE):
-   - Remove the outer try/catch block.
-   - Keep the happy-path body unchanged.
-   - Change `export async function X(...)` to `export const X = withErrorHandler(...)`.
-   - Ensure handler signature includes `context` param.
-   - Derive route name from file path in PascalCase.
-3) Add `import { withErrorHandler } from '@/lib/api-handler'` if not present.
-4) If catch block has custom error handling beyond auth/500, convert to `ApiError` or `apiErrors` inline.
-5) Verify with `pnpm tsc --noEmit` and run any existing tests.
+1. Read the target file. If it already uses `withErrorHandler`, stop.
+2. For each exported handler, remove the outer `try/catch` and keep the happy path unchanged.
+3. Convert `export async function X(...)` to `export const X = withErrorHandler(...)`.
+4. Add `import { withErrorHandler } from '@/lib/api-handler'` if missing.
+5. If the old `catch` contained custom domain behavior, move it inline with `ApiError` or `apiErrors`.
+6. Verify with `pnpm -C "$PIKA_WORKTREE" tsc --noEmit` and run nearby tests when available.

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -1,28 +1,21 @@
-Start a new AI session: validate environment, load context, identify next task.
+Start a new AI session.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+Canonical startup rules live in `.ai/START-HERE.md`, `.ai/CURRENT.md`, `docs/ai-instructions.md`, and `docs/dev-workflow.md`.
 
-Steps:
-1) Verify environment: `echo $PIKA_WORKTREE` — must NOT be `$HOME/Repos/pika`.
-   If unset/hub: STOP — tell user to run `pika codex <worktree>` first.
-2) Run: `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`
-3) Recover context: `git -C "$PIKA_WORKTREE" log --oneline -10` and `tail -60 "$PIKA_WORKTREE/.ai/JOURNAL.md"`
-4) Read docs: `$PIKA_WORKTREE/docs/ai-instructions.md` and `$PIKA_WORKTREE/docs/core/architecture.md`
-5) Check features: `node "$PIKA_WORKTREE/scripts/features.mjs" next`
-6) If $ARGUMENTS is an issue number: `gh issue view $ARGUMENTS --json number,title,body,labels`
-7) If the task affects UI/UX, also read:
-   - `$PIKA_WORKTREE/docs/guidance/ui/README.md`
-   - `$PIKA_WORKTREE/docs/guidance/ui/stable.md`
-8) State task clearly. Propose approach. Wait for approval before coding.
-
-For UI/UX work, include a UI guidance declaration:
-- guidance read
-- stable guidance followed
-- experimental guidance introduced: yes/no
-- experimental draft file created or updated, if any
-- human promotion needed: yes/no
-
-Alternatively, run the session start script:
+Preferred path:
 ```bash
 bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"
 ```
+
+Manual fallback:
+1. Verify `$PIKA_WORKTREE` is set and is not `$HOME/Repos/pika`.
+2. Run `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`.
+3. Review `git -C "$PIKA_WORKTREE" status -sb` and `git -C "$PIKA_WORKTREE" log --oneline -8`.
+4. Read `.ai/START-HERE.md`, `.ai/CURRENT.md`, `.ai/features.json`, and `docs/ai-instructions.md`.
+5. Load only the task-specific docs routed by `docs/ai-instructions.md`.
+   - For UI work, include a UI guidance declaration.
+   - Record: stable guidance followed
+   - Record: experimental guidance introduced: yes/no
+   - Record: human promotion needed: yes/no
+6. If `$ARGUMENTS` is an issue number, run `gh issue view $ARGUMENTS --json number,title,body,labels`.
+7. State the task, propose the approach, and wait for approval before coding.

--- a/.codex/prompts/tdd.md
+++ b/.codex/prompts/tdd.md
@@ -1,13 +1,12 @@
-Guide TDD: write failing tests first, implement to pass, then refactor.
+Use TDD for the feature described in `$ARGUMENTS`.
 
-Takes a feature description as $ARGUMENTS.
+If you have not already loaded it, read `docs/core/tests.md` first.
 
 Steps:
-1) Understand feature scope from $ARGUMENTS
-2) Identify test file: `tests/lib/`, `tests/api/`, `tests/hooks/`, or `tests/components/`
-3) Write test file FIRST (function doesn't exist yet — that's expected)
-4) Run to confirm tests FAIL: `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>`
-5) Write minimal implementation to pass tests
-6) Run again to confirm GREEN: `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>`
-7) Refactor if needed, re-run to confirm still green
-8) Check coverage: `pnpm -C "$PIKA_WORKTREE" test:coverage`
+1. Identify the target test file under `tests/lib/`, `tests/api/`, `tests/hooks/`, or `tests/components/`.
+2. Write the failing test first.
+3. Run `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>` and confirm it fails for the expected reason.
+4. Implement the minimum code needed to pass.
+5. Re-run the focused test, then refactor as needed.
+6. Re-run the focused test and any nearby regression tests.
+7. Check coverage when the change affects shared core logic.

--- a/.codex/prompts/ui-verify.md
+++ b/.codex/prompts/ui-verify.md
@@ -1,18 +1,13 @@
-Visual verification of UI changes using Playwright screenshots.
+Visually verify UI changes for the page path in `$ARGUMENTS`.
 
-Takes the page path as $ARGUMENTS (e.g. `classrooms/abc123`).
+Use the repo guide for expectations: `docs/guides/ai-ui-testing.md`.
 
-Steps:
-1) Verify dev server: `curl -s http://localhost:3000 > /dev/null`
-2) Verify auth: `ls "$PIKA_WORKTREE/.auth/"` — need teacher.json, student.json
-3) Teacher screenshot (1440x900):
-   `npx playwright screenshot "http://localhost:3000/$ARGUMENTS" /tmp/pika-teacher.png --load-storage "$PIKA_WORKTREE/.auth/teacher.json" --viewport-size 1440,900`
-4) Student screenshot (390x844):
-   `npx playwright screenshot "http://localhost:3000/$ARGUMENTS" /tmp/pika-student.png --load-storage "$PIKA_WORKTREE/.auth/student.json" --viewport-size 390,844`
-5) View screenshots, describe what you see, flag any issues.
-6) If issues found: fix code and repeat.
-
-Alternatively:
+Preferred path:
 ```bash
 bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" "$ARGUMENTS"
 ```
+
+After screenshots are captured:
+1. Review the teacher and student views.
+2. Check layout, spacing, typography, responsiveness, and missing states.
+3. If anything looks off, fix the code and repeat the verification.

--- a/.codex/prompts/work-on-issue.md
+++ b/.codex/prompts/work-on-issue.md
@@ -1,30 +1,15 @@
-Load a GitHub issue, explore affected code, and draft a plan before coding.
+Load a GitHub issue, inspect affected code, and draft a plan before coding.
 
-Takes the issue number as $ARGUMENTS.
+Assume the startup context from `.ai/START-HERE.md` is already loaded. If not, run `/session-start` first.
 
 Steps:
-1) `gh issue view $ARGUMENTS --json number,title,body,labels,assignees`
-2) Read docs: `docs/ai-instructions.md`, relevant sections of `docs/core/architecture.md`
-3) If the issue affects UI/UX, also read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`
-4) Explore affected files (read only, no changes yet)
-5) Draft plan: branch name, files to change, tests to write first, migration needed?
-6) For UI/UX work, include a UI guidance declaration:
-   - guidance read
-   - stable guidance followed
-   - experimental guidance introduced: yes/no
-   - experimental draft file created or updated, if any
-   - human promotion needed: yes/no
-7) Present plan and wait for approval
-8) After approval: set up worktree from hub (`export PIKA_WORKTREE="$HOME/Repos/pika"`)
-   ```bash
-   git -C "$HOME/Repos/pika" fetch origin
-   git -C "$HOME/Repos/pika" worktree add "$HOME/Repos/.worktrees/pika/issue-$ARGUMENTS-<slug>" \
-     -b "issue/$ARGUMENTS-<slug>" origin/main
-   ```
-   Then tell user: `pika codex issue-$ARGUMENTS-<slug>`
-
-Default rule for UI/UX work:
-- stable guidance is the default
-- AI may create or update experimental guidance
-- AI may add to legacy or open-question guidance when justified
-- AI must not silently edit stable guidance during feature work
+1. Run `gh issue view $ARGUMENTS --json number,title,body,labels,assignees`.
+2. Read `docs/workflow/handle-issue.md` plus the task-specific docs selected by `docs/ai-instructions.md`.
+   - For UI work, include a UI guidance declaration.
+   - Record: stable guidance followed
+   - Record: experimental guidance introduced: yes/no
+   - Record: human promotion needed: yes/no
+3. Inspect the affected files and the nearest tests without editing anything yet.
+4. Draft the plan: worktree or branch name, files to change, tests to write first, and whether a migration file is needed.
+5. Present the plan and wait for approval.
+6. After approval, create or bind the worktree using `docs/dev-workflow.md`, then continue the work from that bound worktree.

--- a/.codex/skills/pika-session-start/SKILL.md
+++ b/.codex/skills/pika-session-start/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: pika-session-start
-description: Start a new Pika AI session. Validates worktree environment, runs verify-env.sh, loads recent journal and git context, checks feature inventory, and identifies the next task. Run at the beginning of every coding session.
+description: Start a new Pika AI session. Validates worktree environment, runs verify-env.sh, loads compact current context and git state, checks feature inventory, and identifies the next task. Run at the beginning of every coding session.
 ---
 
 # Pika Session Start
 
 ## Overview
 
-Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with validated environment and correct context.
+Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with validated environment and compact current context.
 
 ## Workflow
 
@@ -15,7 +15,7 @@ Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with 
    ```bash
    bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"
    ```
-2. Review the output — confirm worktree, branch, and task.
+2. Review the output — confirm worktree, branch, `.ai/CURRENT.md`, and feature status.
 3. If an issue number is provided, load it with `gh issue view <number>`.
 4. Propose implementation plan before writing any code.
 

--- a/.codex/skills/pika-session-start/scripts/session_start.sh
+++ b/.codex/skills/pika-session-start/scripts/session_start.sh
@@ -49,14 +49,14 @@ git -C "$PIKA_WORKTREE" log --oneline -8
 echo ""
 git -C "$PIKA_WORKTREE" status -sb
 
-# ── 4. Recent journal ───────────────────────────────
+# ── 4. Current context ──────────────────────────────
 echo ""
-echo "── 4. Recent journal (last 40 lines)"
-JOURNAL="$PIKA_WORKTREE/.ai/JOURNAL.md"
-if [[ -f "$JOURNAL" ]]; then
-  tail -40 "$JOURNAL"
+echo "── 4. Current context"
+CURRENT="$PIKA_WORKTREE/.ai/CURRENT.md"
+if [[ -f "$CURRENT" ]]; then
+  sed -n '1,220p' "$CURRENT"
 else
-  echo -e "${INFO} No journal found at $JOURNAL"
+  echo -e "${INFO} No current context found at $CURRENT"
 fi
 
 # ── 5. Feature inventory ────────────────────────────
@@ -71,6 +71,11 @@ if [[ -f "$FEATURES_SCRIPT" ]]; then
 else
   echo -e "${INFO} features.mjs not found"
 fi
+
+echo ""
+echo "── 6. Reminder"
+echo -e "${INFO} Read docs/ai-instructions.md next, then load only the task-specific docs it routes you to."
+echo -e "${INFO} Use .ai/JOURNAL.md only for historical investigation."
 
 echo ""
 echo "╔══════════════════════════════════════════════╗"

--- a/.codex/skills/pika-session-start/scripts/session_start.sh
+++ b/.codex/skills/pika-session-start/scripts/session_start.sh
@@ -6,6 +6,20 @@ PASS="\033[0;32m✅\033[0m"
 FAIL="\033[0;31m❌\033[0m"
 INFO="\033[0;34mℹ️ \033[0m"
 
+print_required_doc() {
+  local label="$1"
+  local file="$2"
+  local range="$3"
+
+  echo ""
+  echo "── $label"
+  if [[ -f "$file" ]]; then
+    sed -n "$range" "$file"
+  else
+    echo -e "${INFO} Missing required startup doc: $file"
+  fi
+}
+
 echo "╔══════════════════════════════════════════════╗"
 echo "║         Pika Session Start Ritual            ║"
 echo "╚══════════════════════════════════════════════╝"
@@ -49,19 +63,20 @@ git -C "$PIKA_WORKTREE" log --oneline -8
 echo ""
 git -C "$PIKA_WORKTREE" status -sb
 
-# ── 4. Current context ──────────────────────────────
-echo ""
-echo "── 4. Current context"
+# ── 4. Required startup docs ────────────────────────
+START_HERE="$PIKA_WORKTREE/.ai/START-HERE.md"
 CURRENT="$PIKA_WORKTREE/.ai/CURRENT.md"
-if [[ -f "$CURRENT" ]]; then
-  sed -n '1,220p' "$CURRENT"
-else
-  echo -e "${INFO} No current context found at $CURRENT"
-fi
+FEATURES_FILE="$PIKA_WORKTREE/.ai/features.json"
+AI_INSTRUCTIONS="$PIKA_WORKTREE/docs/ai-instructions.md"
 
-# ── 5. Feature inventory ────────────────────────────
+print_required_doc "4. Startup contract (.ai/START-HERE.md)" "$START_HERE" '1,200p'
+print_required_doc "5. Current context (.ai/CURRENT.md)" "$CURRENT" '1,220p'
+print_required_doc "6. Feature inventory (.ai/features.json)" "$FEATURES_FILE" '1,220p'
+print_required_doc "7. AI routing (docs/ai-instructions.md)" "$AI_INSTRUCTIONS" '1,260p'
+
+# ── 8. Feature summary ──────────────────────────────
 echo ""
-echo "── 5. Feature inventory"
+echo "── 8. Feature summary"
 FEATURES_SCRIPT="$PIKA_WORKTREE/scripts/features.mjs"
 if [[ -f "$FEATURES_SCRIPT" ]]; then
   node "$FEATURES_SCRIPT" summary 2>/dev/null || echo "(features.mjs summary unavailable)"
@@ -73,8 +88,9 @@ else
 fi
 
 echo ""
-echo "── 6. Reminder"
-echo -e "${INFO} Read docs/ai-instructions.md next, then load only the task-specific docs it routes you to."
+echo "── 9. Reminder"
+echo -e "${INFO} The required startup docs were rendered above."
+echo -e "${INFO} Load only the task-specific docs routed by docs/ai-instructions.md before coding."
 echo -e "${INFO} Use .ai/JOURNAL.md only for historical investigation."
 
 echo ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,98 +2,32 @@
 
 ## Start Here (MANDATORY)
 - Read `.ai/START-HERE.md` at the start of every session.
-- **`docs/ai-instructions.md` is the authoritative source** for repository layout, worktree usage, and environment file handling.
-- Follow the required reading order in `docs/ai-instructions.md` before modifying code.
+- Read `.ai/CURRENT.md` as the default continuity file.
+- **`docs/ai-instructions.md` is the authoritative source** for AI routing, task-based doc loading, and top-level coding invariants.
+- **`docs/dev-workflow.md` is the authoritative source** for worktree usage and shared `.env.local` setup.
+- Follow the startup contract in `.ai/START-HERE.md` before modifying code.
 
 ## UI/UX Changes: MUST Verify Visually (MANDATORY)
 
-**After ANY UI/UX change, you MUST:**
+After any UI/UX change, you must:
+1. Take screenshots and visually verify the result
+2. Check both teacher and student views when both roles are affected
+3. Iterate until the styling and layout are acceptable
 
-1. Take a screenshot and visually verify the change
-2. Check BOTH teacher AND student views (if applicable)
-3. Iterate on aesthetics/styling until it looks good
-
-```bash
-# 1. Ensure dev server is running
-pnpm dev
-
-# 2. Refresh auth if needed (uses teacher@example.com / student1@example.com)
-pnpm e2e:auth
-
-# 3. Take screenshot as teacher
-npx playwright screenshot http://localhost:3000/classrooms /tmp/teacher-view.png \
-  --load-storage .auth/teacher.json --viewport-size 1440,900
-
-# 4. Take screenshot as student
-npx playwright screenshot http://localhost:3000/classrooms /tmp/student-view.png \
-  --load-storage .auth/student.json --viewport-size 1440,900
-
-# 5. View the screenshot (use Read tool on the image file)
-```
-
-**Iterate until satisfied:** If something looks off, fix the code and take another screenshot.
-
-See: `docs/guides/ai-ui-testing.md` for detailed usage.
+Use `docs/guides/ai-ui-testing.md` and `.codex/prompts/ui-verify.md` for the actual procedure.
 
 ## Git Worktrees (Required Workflow)
 
-**Core Principle:** Never switch branches in an existing working directory. For any non-trivial task, ALWAYS create a git worktree.
-
-**Rules:**
-- One worktree == one branch
-- Treat branch switching as directory switching
-- Main repo lives at: `$HOME/Repos/pika` (hub checkout, stays on `main`)
-- Worktrees live under: `$HOME/Repos/.worktrees/pika/<branch-name>`
-
-**Quick start (existing worktree):**
-```bash
-pika ls
-pika claude <worktree>
-# or
-pika codex <worktree>
-```
-
-**Creating a new worktree:**
-- Follow `docs/dev-workflow.md` (authoritative)
-
-**Cleanup:**
-- After PR is merged, remove the worktree and delete the local branch.
-- Use the safe patterns in `docs/dev-workflow.md` (all git commands via `git -C "$PIKA_WORKTREE"`).
-
-**Legacy Helper Script (avoid):**
-- `bash scripts/wt-add.sh <branch-name>` (superseded by `docs/dev-workflow.md`)
+- Never switch branches inside an existing feature checkout.
+- Use one worktree per branch.
+- Use `docs/dev-workflow.md` for creation, cleanup, and the `pika` command workflow.
+- Avoid the legacy `scripts/wt-add.sh` helper.
 
 ## Environment Files (.env.local)
 
-**Core Principle:** All worktrees share a single canonical `.env.local` file to avoid duplication and drift.
-
-**Canonical Location:**
-```
-$HOME/Repos/.env/pika/.env.local
-```
-
-**Symlink Setup:**
-Each worktree must symlink `.env.local` to the canonical file:
-```bash
-ln -sf $HOME/Repos/.env/pika/.env.local <worktree>/.env.local
-```
-
-**Why Symlinks:**
-- Worktrees do not share gitignored files
-- Symlinks avoid duplication and drift across branches
-- `-s` = symbolic link, `-f` = force/replace existing file
-
-**Workflow Reference:**
-- See `docs/dev-workflow.md` for the recommended setup flow
-
-### When Branch-Specific Envs Are Allowed (Exceptions Only)
-
-Use separate `.env.local` files ONLY in these cases:
-- Running multiple Supabase/backend instances in parallel
-- Destructive DB schema or migration experiments
-- Different external API keys, models, or cost profiles
-
-**Otherwise, shared `.env.local` is mandatory.**
+- Shared `.env.local` setup is defined in `docs/dev-workflow.md`.
+- Default policy: worktrees share the canonical env file via symlink.
+- Only use branch-specific env files when intentionally isolating backend state or secrets.
 
 ## Project Overview
 - Next.js 14+ (App Router) + TypeScript
@@ -104,11 +38,12 @@ Use separate `.env.local` files ONLY in these cases:
 
 ## Core Commands
 - Verify: `bash scripts/verify-env.sh` (optional: `--full`)
-- Tests: `npm test` (watch: `npm run test:watch`)
-- Lint: `npm run lint`
-- Build: `npm run build`
+- Tests: `pnpm test` (watch: `pnpm test:watch`)
+- Lint: `pnpm lint`
+- Build: `pnpm build`
 
 ## AI Continuity Rules
+- `.ai/CURRENT.md` is the default always-read AI context file.
 - `.ai/JOURNAL.md` is append-only. Log meaningful work each session.
 - `.ai/features.json` is append-only. Track **big epics only** and update status with `node scripts/features.mjs`.
 
@@ -120,8 +55,9 @@ Use separate `.env.local` files ONLY in these cases:
 
 ## When Docs Conflict
 1. `.ai/features.json` (status authority)
-2. `docs/core/architecture.md` (architecture invariants)
-3. `docs/core/tests.md` (testing requirements)
-4. `docs/core/design.md` (UI/UX rules)
-5. `docs/core/project-context.md` (setup and commands)
-6. `.ai/JOURNAL.md` + `docs/core/decision-log.md` (history/rationale)
+2. `.ai/CURRENT.md` (current-state summary)
+3. `docs/core/architecture.md` (architecture invariants)
+4. `docs/core/tests.md` (testing requirements)
+5. `docs/core/design.md` (UI/UX rules)
+6. `docs/core/project-context.md` (setup and commands)
+7. `.ai/JOURNAL.md` + `docs/core/decision-log.md` (history/rationale)

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -1,309 +1,73 @@
 # AI Instructions for Pika
 
-This is your **primary entry point** for working on the Pika project.
+This file is the AI routing layer for the repo. Use it after `.ai/START-HERE.md`.
 
-If you are starting a new session, **first read** `.ai/START-HERE.md` (environment check + journal + workflow), then come back here.
+For worktree creation, cleanup, and shared `.env.local` setup, use [`docs/dev-workflow.md`](./dev-workflow.md). Do not duplicate those setup steps elsewhere.
 
----
+## Default Startup Context
 
-## Overview
+Read these files at the start of every session:
 
-**Pika** is a comprehensive online classroom management application for a Canadian high school course (GLD2O). Teachers manage classrooms with ~19 feature tabs: attendance, assignments, quizzes, tests, gradebook, announcements, resources, lesson plans, and more. Students submit journal entries, complete assignments, and take quizzes/tests.
+1. [`.ai/START-HERE.md`](../.ai/START-HERE.md)
+2. [`.ai/CURRENT.md`](../.ai/CURRENT.md)
+3. [`.ai/features.json`](../.ai/features.json)
+4. [`docs/ai-instructions.md`](./ai-instructions.md)
 
-**Tech**: Next.js 14 App Router + Supabase + Tailwind CSS + Vitest. Deployed on Vercel.
+Do not tail `.ai/JOURNAL.md` by default. Use it only for historical investigation.
 
-**Status**: Feature-rich application with AI-assisted grading (OpenAI `gpt-5-nano`), Tiptap-based rich text editing, assessment draft system (JSON Patch), and scheduled content release. Ongoing: test coverage expansion, component decomposition, and API route standardization.
+## Load Only The Docs You Need
 
----
+After the startup set above, load task-specific docs:
 
-## Required Reading Order
+| Task | Read next |
+|---|---|
+| Any non-trivial code change | [`docs/core/architecture.md`](./core/architecture.md) |
+| UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
+| TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
+| Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |
+| Multi-agent delegation | [`docs/core/agents.md`](./core/agents.md) |
+| Product status or phase questions | [`docs/core/roadmap.md`](./core/roadmap.md) |
+| GitHub issue work | [`docs/workflow/handle-issue.md`](./workflow/handle-issue.md) |
+| Feature-specific behavior | `docs/guidance/*.md` or the closest focused spec |
 
-When working on any task, read these files **in this exact order** to prevent architectural drift:
+Inspect or modify source only after the startup set and the docs required by your task are loaded.
 
-1. **[/docs/ai-instructions.md](/docs/ai-instructions.md)** (this file) — AI orchestrator
-2. **[/docs/core/architecture.md](/docs/core/architecture.md)** — System architecture & patterns
-3. **[/docs/core/design.md](/docs/core/design.md)** — UI/UX guidelines
-4. **[/docs/core/project-context.md](/docs/core/project-context.md)** — Tech stack & setup
-5. **[/docs/core/agents.md](/docs/core/agents.md)** — Multi-agent collaboration
-6. **[/docs/core/tests.md](/docs/core/tests.md)** — TDD requirements
-7. **[/docs/core/roadmap.md](/docs/core/roadmap.md)** — Current status
+## Repo Invariants
 
-For **UI-affecting work**, immediately continue with:
-- **[/docs/guidance/ui/README.md](/docs/guidance/ui/README.md)** — UI canon entrypoint
-- **[/docs/guidance/ui/stable.md](/docs/guidance/ui/stable.md)** — Stable UI guidance for current governed workflows
+- Platform: Next.js App Router, Supabase, Tailwind CSS, Vitest, Vercel
+- Timezone: all deadline and attendance logic uses `America/Toronto`
+- Auth: email verification codes plus password login; no OAuth providers
+- Architecture: keep business logic out of UI components; prefer `src/lib/*` and server-side modules
+- API routes: use `withErrorHandler` from `@/lib/api-handler`
+- Repeated client-side reads: use `fetchJSONWithCache` from `@/lib/request-cache`
+- Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
+- UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
+- Migrations: AI may create or edit migration files, but humans apply them manually
+- Workflow: do non-trivial work in a bound worktree, plan before coding, and keep `.ai/JOURNAL.md` append-only
 
-Then consult:
-- **[/docs/guidance/*.md](/docs/guidance/)** — Feature specifications (as needed)
-- **[/docs/workflow/handle-issue.md](/docs/workflow/handle-issue.md)** — Issue workflow (when working on issues)
-
-**Only after reading these** should you inspect or modify source code.
-
----
-
-## Core Loop
-
-1. **Load Context** — Read required docs in order (above)
-2. **Understand Requirements** — Read issue or user prompt
-3. **Write Tests FIRST** — For core logic (utilities, business rules)
-4. **Implement Minimal Code** — Pass the tests
-5. **Refactor** — Keep code simple
-6. **Keep UI Thin** — Logic in utilities, not components
-
----
-
-## Critical Constraints
-
-### Platform Requirements (MANDATORY)
-
-✅ **MUST USE**:
-- Next.js App Router (NOT Pages Router)
-- Supabase for database and storage
-- America/Toronto timezone for all deadlines
-- Email verification codes (signup/reset) + password login (NO OAuth providers)
-- Tailwind CSS for styling
-- Vitest + React Testing Library for tests
-
-### API Route Rules (MANDATORY)
-
-🔌 **ALL API routes MUST use `withErrorHandler`** from `@/lib/api-handler`:
-```ts
-export const GET = withErrorHandler('GetResource', async (request, context) => {
-  const user = await requireRole('teacher')
-  // ... happy path only — errors auto-mapped to 401/403/400/500
-})
-```
-- **Never** write `export async function GET(...)` with a manual `try/catch` in new routes.
-- Use `/migrate-error-handler` slash command to convert existing routes.
-- Use `ApiError` / `apiErrors` from `@/lib/api-handler` for domain errors.
-
-### Client-Side Fetch Rules (MANDATORY)
-
-📡 **Use `fetchJSONWithCache`** from `@/lib/request-cache` for repeated client-side API calls:
-```ts
-const data = await fetchJSONWithCache(
-  `resource:${id}`,  // cache key
-  () => fetch(`/api/.../resource`).then(r => r.json()),
-  20_000  // TTL in ms
-)
-```
-- Never make raw `fetch()` calls in components for data that is fetched repeatedly.
-- Exception: one-off mutations (POST/PATCH/DELETE) do NOT need the cache wrapper.
-
-### Tiptap Content Rule (MANDATORY)
-
-📝 **Never define a local `parseContentField`** in route files. Import from `@/lib/tiptap-content`:
-```ts
-import { parseContentField } from '@/lib/tiptap-content'
-const content = parseContentField(doc.content)  // handles string or object
-```
-
-### Architecture Rules (PROHIBITED)
-
-❌ **DO NOT**:
-- Mix business logic with UI components
-- Store plaintext login codes (always hash with bcrypt)
-- Skip TDD workflow for core utilities
-- Modify architecture without reading design docs first
-- Use component libraries (Tailwind only)
-- Implement features without tests for core logic
-- Make changes to unrelated files
-- Over-engineer or add unnecessary abstractions
-- **Use `dark:` classes in app code** (use semantic tokens instead)
-- **Import UI primitives from `@/components`** (use `@/ui`)
-- **Run or apply database migrations** (human applies migrations manually)
-- **Write manual try/catch error handling in API routes** (use `withErrorHandler`)
-- **Define `parseContentField` locally** (import from `@/lib/tiptap-content`)
-- **Make raw `fetch()` calls in components for repeated data** (use `fetchJSONWithCache`)
-
-### Database Migrations (MANDATORY)
-
-🗄️ **AI may**:
-- Create new migration files in `supabase/migrations/`
-- Modify existing migration files (if not yet applied)
-- Rename migration files to fix numbering conflicts
-
-🗄️ **AI must NEVER**:
-- Run `supabase db push`, `supabase db reset`, or any migration commands
-- Apply migrations to any database (local or remote)
-- Assume migrations have been applied
-
-**The human will apply all migrations manually.** After creating/modifying migration files, inform the user that migrations need to be applied.
-
-### Design System Rules (MANDATORY)
-
-🎨 **UI Components**:
-- Import `Button`, `Input`, `Select`, `FormField`, `AlertDialog`, `ConfirmDialog`, `Card`, `Tooltip` from `@/ui`
-- Wrap all form controls with `<FormField>` for consistent label/error styling
-- ESLint and CI enforce these import patterns
-
-🎨 **Semantic Tokens** (instead of `dark:` classes):
-```tsx
-// CORRECT - semantic tokens
-<div className="bg-surface text-text-default border-border">
-<p className="text-text-muted">Secondary text</p>
-
-// WRONG - dark: classes in app code
-<div className="bg-white dark:bg-gray-900">  // ❌ Blocked by CI
-```
-
-Common tokens: `bg-page`, `bg-surface`, `bg-surface-2`, `text-text-default`, `text-text-muted`, `border-border`, `text-primary`, `text-danger`, `text-success`
-
-See `/src/ui/README.md` for the full token reference.
-
-### Security Requirements (MANDATORY)
-
-🔒 **MUST IMPLEMENT**:
-- Hash all login codes with bcrypt before storing
-- Use HTTP-only, secure, SameSite cookies for sessions
-- Validate email domains (check ALLOWED_EMAIL_DOMAIN)
-- Rate limit auth endpoints (code requests and verifications)
-- Protect routes by role (student vs teacher)
-- Never expose session secrets or internal tokens
-
-### Testing Requirements (MANDATORY)
-
-🧪 **MUST TEST**:
-- Core utilities: 100% coverage (attendance, timezone, auth, crypto)
-- Data layer: 90%+ coverage (API routes with mocked Supabase)
-- Pure functions: Test all edge cases
-- Timezone handling: Test DST transitions
-- Authentication: Code generation, hashing, verification
-
----
-
-## Workflows — Use Slash Commands
+## Prompt And Command Map
 
 | Task | Claude Code | Codex |
 |---|---|---|
 | Start a session | `/session-start` | `.codex/prompts/session-start.md` |
 | Work on a GitHub issue | `/work-on-issue <N>` | `.codex/prompts/work-on-issue.md` |
 | TDD implementation | `/tdd <feature>` | `.codex/prompts/tdd.md` |
-| Verify UI changes (MANDATORY) | `/ui-verify <page>` | `.codex/prompts/ui-verify.md` |
+| Verify UI changes | `/ui-verify <page>` | `.codex/prompts/ui-verify.md` |
 | Pre-commit audit | `/audit` | `.codex/prompts/audit.md` |
 | Migrate error handler | `/migrate-error-handler <file>` | `.codex/prompts/migrate-error-handler.md` |
 | Scaffold API route | `/add-api-route` | `.codex/prompts/add-api-route.md` |
+| Merge `main` into `production` | `/merge-main-into-production` | `.codex/prompts/merge-main-into-production.md` |
 
-UI changes **must** be visually verified before committing. See `docs/guides/ai-ui-testing.md` for patterns.
+UI changes must be visually verified before commit. Use [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) for the verification workflow.
 
----
+## Source Of Truth Order
 
-## Git & Worktrees
-
-Worktree rules are in `.ai/START-HERE.md`. Key points:
-- All git commands: `git -C "$PIKA_WORKTREE"`
-- All file paths: absolute or `$PIKA_WORKTREE`-prefixed
-- Setup details: `docs/dev-workflow.md`
-
-### Merge Policies (MANDATORY)
-
-- **`main`**: No merge commits. Use PR **Squash and merge** (preferred) or linear rebase/cherry-pick.
-- **`production`**: Direct push blocked. Use `/merge-main-into-production` command.
-
-### Environment (.env.local)
-
-- Never commit `.env.local` — it's symlinked from `$HOME/Repos/.env/pika/.env.local`
-- Each worktree needs: `ln -sf $HOME/Repos/.env/pika/.env.local <worktree>/.env.local`
-- See `docs/dev-workflow.md` for setup
-
----
-
-## Specialized Agents
-
-See [/docs/core/agents.md](/docs/core/agents.md) for details. For complex features, use agents in sequence: Architect → Testing/QA → Implementation → UI/UX.
-
-| Task | Agent |
-|---|---|
-| System design | Architect |
-| Tests / TDD | Testing/QA |
-| Feature implementation | Implementation |
-| Database / migrations | Data/Storage |
-| Refactoring | Refactor |
-| UI / visual design | UI/UX |
-
----
-
-## Common AI Mistakes (Avoid These)
-
-**Don't:**
-- Work in `$HOME/Repos/pika` (the hub) — always use a worktree
-- Manually edit `.ai/features.json` — use `node scripts/features.mjs pass/fail <id>`
-- Commit `.env.local` or secrets — it's symlinked, not a real file
-- Skip the reading order — architectural drift happens fast
-- Start coding without a plan — state task, wait for approval
-- Write `export async function GET(...)` with manual try/catch — use `withErrorHandler`
-- Define `parseContentField` locally — import from `@/lib/tiptap-content`
-- Make raw `fetch()` in components — use `fetchJSONWithCache` for repeated reads
-- Use `dark:` Tailwind classes in app code — use semantic tokens (`bg-surface`, etc.)
-- Import from `@/components` for UI primitives — use `@/ui`
-
-**Recovery:**
-- Worked in hub by mistake? `git stash`, create worktree, `git stash pop` in worktree
-- Committed to wrong branch? `git reset --soft HEAD~1`, switch branches, recommit
-- Need to update features.json? Use the script, not manual edits
-- Added manual try/catch to a route? Run `/migrate-error-handler` on that file
-
----
-
-## Anti-Drift Rules
-
-These are the patterns that **most commonly drift** when AI agents add code. Check each one before committing.
-
-| What to check | Required pattern | Violation flag |
-|---|---|---|
-| New API route handler | `export const X = withErrorHandler(...)` | `export async function X(...)` with try/catch |
-| New client-side fetch in component | `fetchJSONWithCache(key, fetcher, ttl)` | raw `fetch()` in component body |
-| Content field parsing | `import { parseContentField } from '@/lib/tiptap-content'` | local function definition |
-| UI colors/themes | `bg-surface`, `text-text-default`, etc. | `bg-white dark:bg-gray-900` or raw colors |
-| UI primitives | `import { Button } from '@/ui'` | `import { Button } from '@/components'` |
-| New Supabase column check | `isMissing<Table>Error` guard + `TODO(cleanup-0XX)` | silent failure or permanent guard |
-
-Run `/audit` before every commit to catch violations automatically.
-
----
-
-## Quick Reference
-
-### Key Files — Core
-- **Error handling**: `src/lib/api-handler.ts` — `withErrorHandler`, `ApiError`, `apiErrors`
-- **Client cache**: `src/lib/request-cache.ts` — `fetchJSONWithCache(key, fetcher, ttlMs)`
-- **Auth**: `src/lib/auth.ts` — `requireRole('teacher' | 'student')`, session management
-- **Design system**: `src/ui/` — UI primitives (import from `@/ui`)
-- **Token definitions**: `src/styles/tokens.css` — CSS variables for theming
-- **Types**: `src/types/index.ts` — centralized TypeScript types (no duplication)
-
-### Key Files — Assessments
-- **Tiptap utils**: `src/lib/tiptap-content.ts` — `parseContentField`, `extractPlainText`, etc.
-- **Draft system**: `src/lib/server/assessment-drafts.ts` — unified quiz/test draft with JSON Patch
-- **Scheduling**: `src/lib/scheduling.ts` — `combineScheduleDateTimeToIso`, `isScheduleIsoInFuture`
-- **Quiz logic**: `src/lib/quizzes.ts` — `getStudentQuizStatus`, `getStudentTestStatus`
-- **Test responses**: `src/lib/test-responses.ts` — `hasMeaningfulTestResponse`
-- **AI grading**: `src/lib/ai-grading.ts` (assignments), `src/lib/ai-test-grading.ts` (tests)
-
-### Key Files — Infrastructure
-- **Attendance**: `src/lib/attendance.ts` — pure function, fully testable
-- **Timezone**: `src/lib/timezone.ts` — America/Toronto handling
-- **Crypto**: `src/lib/crypto.ts` — code generation and hashing
-
-### Key Concepts
-- **Assessment discrimination**: `assessment_type: 'quiz' | 'test'` on both quiz and test records
-- **Tab mounting**: tabs mount once on first visit, then stay in DOM (persistent mounting)
-- **Prefetching**: assignments + resources prefetched at idle; others on demand
-- **Gradebook**: fetches on every student selection change (no caching currently — being fixed)
-- **Migration shims**: `isMissing<Table>Error` guards removed after migration confirmed applied
-- **ClassDay**: a day when attendance is expected
-- **Entry**: a student's journal submission for a day
-
-### Common Commands
-```bash
-pnpm dev                 # Start dev server
-pnpm test:watch          # TDD mode
-pnpm test:coverage       # Check coverage
-gh issue view X          # View issue details
-/audit                   # Pre-commit violation check
-/migrate-error-handler   # Convert manual try/catch route to withErrorHandler
-/add-api-route           # Scaffold new route with best practices
-/session-start           # Validate environment + load context
-/work-on-issue <N>       # Load issue N, explore, plan
-/tdd <feature>           # Write tests first, then implement
-/ui-verify <page>        # Take Playwright screenshots to verify UI
-```
+1. `.ai/features.json`
+2. `.ai/CURRENT.md`
+3. `docs/core/architecture.md`
+4. `docs/core/tests.md`
+5. `docs/core/design.md`
+6. `docs/core/project-context.md`
+7. `docs/core/roadmap.md`
+8. `docs/core/decision-log.md`
+9. `.ai/JOURNAL.md` on demand

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -42,7 +42,7 @@ Overview of **Pika**: daily journals, attendance, classrooms, and assignments fo
 
 ## Prerequisites
 
-Node: 24.x (see `package.json#engines` and `.nvmrc`)
+Node: 24.x (`.nvmrc` currently pins the recommended local version)
 
 Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
 
@@ -50,8 +50,11 @@ Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
 1. Install dependencies:
    - `corepack enable`
    - `pnpm install`
-2. Configure `.env.local` (see README for template).
-3. Apply all database migrations via Supabase dashboard or `supabase db push`.
+2. Set up `.env.local` using the shared-worktree flow in [`docs/dev-workflow.md`](../dev-workflow.md).
+   - Default: symlink the worktree’s `.env.local` to `$HOME/Repos/.env/pika/.env.local`
+   - Exception-only: use a branch-specific env file when intentionally isolating backend state
+3. Ensure pending migrations have been applied by a human before runtime work that depends on them.
+   - AI agents may create or edit migration files, but must not run `supabase db push`, `supabase db reset`, or similar migration commands
 4. `pnpm dev` and open http://localhost:3000
 5. Optional: `pnpm seed`
    - To wipe + reseed against a specific env file: `ENV_FILE=.env.staging.local ALLOW_DB_WIPE=true pnpm seed:fresh`
@@ -106,7 +109,7 @@ Legacy anon/service keys are supported but publishable/secret are preferred.
 ## Deployment
 
 - Host on Vercel; configure env vars in dashboard; set `ENABLE_MOCK_EMAIL=false` and add real email provider before production.
-- Supabase Cloud for DB; enable connection pooling; run migrations on deploy.
+- Supabase Cloud for DB; enable connection pooling; treat migrations as a separate human-controlled deploy step.
 - If using cron, configure schedules in the Vercel dashboard (production recommended). Current recommended schedule: `0 6 * * *` (06:00 UTC).
 
 ---

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -3,6 +3,9 @@
 This document describes the internal development workflow for the Pika project,
 with a focus on agentic (Claude / Codex) development using git worktrees.
 
+This is the canonical source for worktree usage and shared `.env.local` setup.
+Other AI guidance docs should point here instead of restating the same setup steps.
+
 This is **developer infrastructure**, not a product feature.
 
 ---

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -9,14 +9,14 @@ gh issue view <number> --json number,title,body,labels,comments
 
 ## 2) Load Context (MANDATORY)
 1. Read `.ai/START-HERE.md`
-2. Read `docs/ai-instructions.md` and follow its required reading order.
+2. Read `.ai/CURRENT.md`
+3. Read `docs/ai-instructions.md` and load only the task-specific docs it routes you to.
 3. Check `.ai/features.json` for any referenced feature IDs.
 4. If the issue affects UI/UX, read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`.
 
 ## 3) Branch & PR Setup
-- Branch name pattern: `<issue-number>-<short-slug>` (example: `8-ai-effectiveness-layer`)
-- If a matching branch already exists, use it.
-- Prefer creating a **Draft PR** early; include `Closes #<number>` in the body.
+- Create or bind a dedicated worktree using `docs/dev-workflow.md`.
+- Prefer a draft PR early; include `Closes #<number>` in the body.
 
 ## 4) Plan Before Coding (MANDATORY)
 Produce a short plan:
@@ -45,36 +45,9 @@ Do not proceed until the user approves the plan.
 - AI must not silently edit stable UI guidance as part of ordinary feature work.
 
 ## 6) AI UI Verification (MANDATORY for UI Changes)
-
-After implementing UI changes, you MUST verify them visually:
-
-```bash
-# 1. Ensure dev server is running
-pnpm dev
-
-# 2. Refresh auth states if needed
-pnpm e2e:auth
-
-# 3. Take screenshots for BOTH roles
-npx playwright screenshot http://localhost:3000/<page> /tmp/teacher.png \
-  --load-storage .auth/teacher.json --viewport-size 1440,900
-
-npx playwright screenshot http://localhost:3000/<page> /tmp/student.png \
-  --load-storage .auth/student.json --viewport-size 1440,900
-
-# 4. View screenshot with Read tool, iterate until satisfied
-
-# 5. Run verification scripts if applicable
-pnpm e2e:verify <scenario>
-```
-
-**This is mandatory for:**
-- Any UI component changes
-- Any styling/CSS changes
-- New UI features
-- Layout changes
-
-See `docs/guides/ai-ui-testing.md` for detailed patterns.
+- Use `docs/guides/ai-ui-testing.md` or `.codex/prompts/ui-verify.md`.
+- Check the affected teacher and student views when both roles are impacted.
+- Iterate on the UI until the verified screenshots are acceptable.
 
 ## 7) Update AI Continuity Layer
 Before ending a session:

--- a/docs/semester-plan.md
+++ b/docs/semester-plan.md
@@ -106,8 +106,7 @@ esac
                       │
 ┌─────────────────────▼───────────────────────────────────┐
 │ 4. APPLY                                                │
-│    - Supabase Dashboard → SQL Editor → Run migration    │
-│    - Or: supabase db push --db-url $PROD_DB_URL         │
+│    - Human applies migration via Supabase Dashboard     │
 │    - Verify via quick smoke test                        │
 └─────────────────────┬───────────────────────────────────┘
                       │

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -7,7 +7,7 @@ Use the automated command for the full workflow:
 ## Quick Reference (if running manually)
 
 1. `gh issue view <N> --json number,title,body,labels`
-2. Read `docs/ai-instructions.md` + relevant core docs
+2. Read `.ai/START-HERE.md`, `.ai/CURRENT.md`, and `docs/ai-instructions.md`
 3. If the issue touches UI/UX, also read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`
 4. Draft plan: branch name, files to change, tests to write first, migration needed?
 5. For UI/UX work, include a UI guidance declaration:
@@ -25,7 +25,7 @@ Use the automated command for the full workflow:
 
 - Write tests BEFORE implementation for core logic
 - Make minimal, focused changes — do not modify unrelated files
-- Follow the reading order to prevent drift
+- Follow the routed doc-loading flow in `docs/ai-instructions.md`
 - Preserve existing patterns unless explicitly asked to change them
 - Stable UI guidance is the default for new UI work
 - AI may draft experimental UI guidance, but may not silently edit stable UI guidance during feature work

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+function readRepoFile(relativePath: string) {
+  return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
+}
+
+describe('AI startup docs', () => {
+  it('keeps the default startup set under the budget', () => {
+    const files = [
+      '.ai/START-HERE.md',
+      '.ai/CURRENT.md',
+      '.ai/features.json',
+      'docs/ai-instructions.md',
+    ]
+
+    const totalChars = files.reduce((sum, file) => sum + readRepoFile(file).length, 0)
+
+    expect(totalChars).toBeLessThanOrEqual(15_000)
+  })
+
+  it('keeps journal reads out of the default startup flow', () => {
+    const files = [
+      '.ai/START-HERE.md',
+      '.codex/prompts/session-start.md',
+      '.codex/skills/pika-session-start/scripts/session_start.sh',
+    ]
+
+    for (const file of files) {
+      const content = readRepoFile(file)
+      expect(content).not.toContain('tail -40 "$PIKA_WORKTREE/.ai/JOURNAL.md"')
+      expect(content).not.toContain('tail -60 "$PIKA_WORKTREE/.ai/JOURNAL.md"')
+    }
+
+    expect(readRepoFile('.ai/START-HERE.md')).toContain('.ai/CURRENT.md')
+    expect(readRepoFile('.codex/prompts/session-start.md')).toContain('.ai/CURRENT.md')
+    expect(readRepoFile('.codex/skills/pika-session-start/scripts/session_start.sh')).toContain('.ai/CURRENT.md')
+  })
+})

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -9,16 +9,16 @@ function readRepoFile(relativePath: string) {
   return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
 }
 
+const requiredStartupFiles = [
+  '.ai/START-HERE.md',
+  '.ai/CURRENT.md',
+  '.ai/features.json',
+  'docs/ai-instructions.md',
+]
+
 describe('AI startup docs', () => {
   it('keeps the default startup set under the budget', () => {
-    const files = [
-      '.ai/START-HERE.md',
-      '.ai/CURRENT.md',
-      '.ai/features.json',
-      'docs/ai-instructions.md',
-    ]
-
-    const totalChars = files.reduce((sum, file) => sum + readRepoFile(file).length, 0)
+    const totalChars = requiredStartupFiles.reduce((sum, file) => sum + readRepoFile(file).length, 0)
 
     expect(totalChars).toBeLessThanOrEqual(15_000)
   })
@@ -35,9 +35,19 @@ describe('AI startup docs', () => {
       expect(content).not.toContain('tail -40 "$PIKA_WORKTREE/.ai/JOURNAL.md"')
       expect(content).not.toContain('tail -60 "$PIKA_WORKTREE/.ai/JOURNAL.md"')
     }
+  })
 
-    expect(readRepoFile('.ai/START-HERE.md')).toContain('.ai/CURRENT.md')
-    expect(readRepoFile('.codex/prompts/session-start.md')).toContain('.ai/CURRENT.md')
-    expect(readRepoFile('.codex/skills/pika-session-start/scripts/session_start.sh')).toContain('.ai/CURRENT.md')
+  it('keeps the preferred startup paths aligned with the required startup set', () => {
+    const prompt = readRepoFile('.codex/prompts/session-start.md')
+    const script = readRepoFile('.codex/skills/pika-session-start/scripts/session_start.sh')
+
+    for (const file of requiredStartupFiles) {
+      expect(prompt).toContain(file)
+      expect(script).toContain(file)
+    }
+
+    expect(script.indexOf('.ai/START-HERE.md')).toBeLessThan(script.indexOf('.ai/CURRENT.md'))
+    expect(script.indexOf('.ai/CURRENT.md')).toBeLessThan(script.indexOf('.ai/features.json'))
+    expect(script.indexOf('.ai/features.json')).toBeLessThan(script.indexOf('docs/ai-instructions.md'))
   })
 })

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -1,5 +1,7 @@
-import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
@@ -7,6 +9,43 @@ const testDir = dirname(fileURLToPath(import.meta.url))
 
 function readRepoFile(relativePath: string) {
   return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
+}
+
+function makeFixtureWorktree() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-start-'))
+
+  mkdirSync(join(repoRoot, '.ai'), { recursive: true })
+  mkdirSync(join(repoRoot, 'docs'), { recursive: true })
+  mkdirSync(join(repoRoot, 'scripts'), { recursive: true })
+
+  writeFileSync(join(repoRoot, '.ai/START-HERE.md'), '# Fixture Start Here\nSTART HERE MARKER\n')
+  writeFileSync(join(repoRoot, '.ai/CURRENT.md'), '# Fixture Current\nCURRENT MARKER\n')
+  writeFileSync(
+    join(repoRoot, '.ai/features.json'),
+    '{\n  "marker": "FEATURES MARKER",\n  "features": []\n}\n',
+  )
+  writeFileSync(join(repoRoot, 'docs/ai-instructions.md'), '# Fixture AI Instructions\nAI INSTRUCTIONS MARKER\n')
+  writeFileSync(join(repoRoot, 'scripts/verify-env.sh'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 })
+  writeFileSync(
+    join(repoRoot, 'scripts/features.mjs'),
+    [
+      '#!/usr/bin/env node',
+      "if (process.argv[2] === 'summary') console.log('FEATURE SUMMARY MARKER')",
+      "if (process.argv[2] === 'next') console.log('FEATURE NEXT MARKER')",
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  )
+  writeFileSync(join(repoRoot, 'README.md'), 'fixture\n')
+
+  execFileSync('git', ['init'], { cwd: repoRoot })
+  execFileSync('git', ['config', 'user.name', 'Codex Test'], { cwd: repoRoot })
+  execFileSync('git', ['config', 'user.email', 'codex@example.com'], { cwd: repoRoot })
+  execFileSync('git', ['checkout', '-b', 'fixture/session-start'], { cwd: repoRoot })
+  execFileSync('git', ['add', '.'], { cwd: repoRoot })
+  execFileSync('git', ['commit', '-m', 'fixture'], { cwd: repoRoot })
+
+  return repoRoot
 }
 
 const requiredStartupFiles = [
@@ -37,17 +76,43 @@ describe('AI startup docs', () => {
     }
   })
 
-  it('keeps the preferred startup paths aligned with the required startup set', () => {
+  it('keeps the manual startup prompt aligned with the required startup set', () => {
     const prompt = readRepoFile('.codex/prompts/session-start.md')
-    const script = readRepoFile('.codex/skills/pika-session-start/scripts/session_start.sh')
 
     for (const file of requiredStartupFiles) {
       expect(prompt).toContain(file)
-      expect(script).toContain(file)
     }
+  })
 
-    expect(script.indexOf('.ai/START-HERE.md')).toBeLessThan(script.indexOf('.ai/CURRENT.md'))
-    expect(script.indexOf('.ai/CURRENT.md')).toBeLessThan(script.indexOf('.ai/features.json'))
-    expect(script.indexOf('.ai/features.json')).toBeLessThan(script.indexOf('docs/ai-instructions.md'))
+  it('renders the required startup docs in order in the automated session-start path', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
+
+    try {
+      const output = execFileSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: repoRoot,
+          PIKA_WORKTREE: repoRoot,
+        },
+        encoding: 'utf8',
+      })
+
+      const startHereIndex = output.indexOf('START HERE MARKER')
+      const currentIndex = output.indexOf('CURRENT MARKER')
+      const featuresIndex = output.indexOf('FEATURES MARKER')
+      const instructionsIndex = output.indexOf('AI INSTRUCTIONS MARKER')
+
+      expect(startHereIndex).toBeGreaterThanOrEqual(0)
+      expect(currentIndex).toBeGreaterThan(startHereIndex)
+      expect(featuresIndex).toBeGreaterThan(currentIndex)
+      expect(instructionsIndex).toBeGreaterThan(featuresIndex)
+
+      expect(output).toContain('FEATURE SUMMARY MARKER')
+      expect(output).toContain('FEATURE NEXT MARKER')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add `.ai/CURRENT.md` as the compact always-read continuity file for AI sessions
- slim the startup and workflow guidance so core docs are routed on demand instead of always loaded
- align issue/workflow docs with the new startup contract and add a regression test for startup budget and no journal tailing

## Why
The AI guidance layer had grown large and repetitive, with `.ai/JOURNAL.md` still treated as normal startup context and several workflow docs repeating the same policy blocks. This change reduces default context size, keeps canonical rules in one place, and adds regression coverage so the startup contract does not drift back.

## Impact
AI startup now reads `.ai/START-HERE.md`, `.ai/CURRENT.md`, `.ai/features.json`, and `docs/ai-instructions.md` by default. Journal reads are on-demand, prompt files are thinner, and core workflow/setup docs remain the source of truth.

## Validation
- full `session_start.sh` dry run in the bound worktree with Node 24 and passing full Vitest suite
- `corepack pnpm --dir /Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown exec vitest run tests/unit/ui-guidance-docs.test.ts`
- `corepack pnpm --dir /Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown exec vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
- startup budget and conflict scans recorded in `.ai/JOURNAL.md`