### PR TITLE
Refine assignment and assessment UX guidance

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8894,3 +8894,51 @@
 - Reviewed the resulting diff for `.ai/START-HERE.md` and `docs/dev-workflow.md` to confirm both docs now describe the same cleanup sequence.
 
 **Status:** The cleanup rule now explicitly requires fast-forwarding the hub `main` as part of post-merge cleanup.
+## 2026-04-15 [AI - Codex]
+
+**Goal:** Add assignment-parity UX guidance and a repeatable verification harness for tests/quizzes.
+
+**Completed:**
+- Added `docs/guidance/assignment-ux-language.md` to codify the assignment tabs as the canonical assessment UX system, including required primitives, state-based rules, and explicit anti-drift prohibitions.
+- Added `.codex/prompts/assessment-ux-parity.md` so a fresh AI can restyle assessment surfaces against the assignment system without extra coaching.
+- Added `docs/guides/assessment-ux-evaluation.md` with the blind-run workflow, rubric, hard failures, and iteration rules for tightening docs when parity runs drift.
+- Added `e2e/verify/assessment-ux-parity.ts`, registered it in the verification runner, and extended verification results to include artifact paths.
+- Updated `docs/guides/ai-ui-testing.md` and `docs/core/tests.md` so the new `assessment-ux-parity` scenario is discoverable in the existing UI verification docs.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm e2e:verify --help`
+- `pnpm e2e:verify assessment-ux-parity`
+
+**Notes:**
+- The parity scenario captures reference/target screenshots to `artifacts/assessment-ux-parity/`.
+- Verification used the existing local auth states during execution; the worktree itself does not retain a committed `.auth` directory.
+
+**Status:** The documentation, prompt, rubric, and screenshot harness are in place and the new parity capture scenario runs successfully.
+
+## 2026-04-16 [AI - Codex]
+
+**Goal:** Tighten the blind-run guidance package after fresh-context parity runs stalled before implementation.
+
+**Completed:**
+- Added `scripts/run-teacher-tests-parity-challenge.sh` to run a scoped teacher-tests parity challenge with attached before/reference screenshots, prompt packet capture, and automatic pre/post parity screenshots.
+- Added `.codex/prompts/teacher-tests-ux-parity.md` as a task-scoped execution prompt for the `TeacherQuizzesTab` teacher-tests authoring branch.
+- Added `.codex/prompts/assessment-ux-family-parity.md` for a looser “same product family, slight evolution allowed” mode.
+- Tightened `docs/guidance/assignment-ux-language.md`, `.codex/prompts/assessment-ux-parity.md`, and `docs/guides/assessment-ux-evaluation.md` so blind runs must stay scoped and “never reached implementation” counts as failure.
+- Updated `docs/guides/ai-ui-testing.md` to document the dedicated blind challenge runner and the family-mode prompt.
+
+**Validation:**
+- `bash -n scripts/run-teacher-tests-parity-challenge.sh`
+
+**Notes:**
+- Fresh-context `codex exec` parity runs still defaulted into repo startup/context reacquisition before editing; the new runner is intended to reduce that by attaching the concrete reference and before-state screenshots directly to the task packet.
+- The new family-mode prompt explicitly optimizes for consistent future aesthetic across assignments/tests/quizzes rather than exact cloning.
+
+**Status:** Runner and updated guidance are ready for the next blind run iteration.
+## 2026-04-16 — Teacher Work-Surface Canon + Audit
+
+- Added `docs/guidance/ui/teacher-work-surfaces.md` as the stable canon for the teacher assignments/quizzes/tests family.
+- Added `docs/guidance/ui/audit-teacher-work-surfaces.md` to classify foundations, primitives, composed patterns, feature-local behavior, and legacy drift for that family.
+- Added `.codex/prompts/teacher-work-surface-promotion-review.md` for recurring non-mutating promotion review runs.
+- Updated UI guidance entrypoints and issue workflow docs so teacher assignments/quizzes/tests work routes through the new canon and audit.

--- a/.codex/prompts/assessment-ux-family-parity.md
+++ b/.codex/prompts/assessment-ux-family-parity.md
@@ -1,0 +1,62 @@
+Restyle an assessment surface so it clearly belongs to the same product family as assignments, while allowing slight aesthetic evolution.
+
+Use this mode when you want consistency, not cloning.
+
+## Intent
+
+The result does not need to be a visual duplicate of assignments.
+
+It does need to preserve the same:
+
+- shell discipline
+- spacing rhythm
+- action hierarchy
+- card semantics
+- empty-state calmness
+- content-first behavior
+
+Small aesthetic changes are acceptable if they are reusable across assessment surfaces and still feel like the same system.
+
+## Allowed Evolution
+
+You may slightly evolve:
+
+- card polish
+- status chip treatment
+- typography emphasis
+- spacing density
+- empty-state composition
+
+But only if the result would still make sense as a future design direction for:
+
+- teacher assignments
+- teacher tests
+- teacher quizzes
+- student assignments
+- student tests
+- student quizzes
+
+## Not Allowed
+
+- one-off styling that only exists on the target screen
+- a new shell language that breaks family resemblance
+- controls taking visual priority over content
+- dashboard chrome or placeholder panes that assignments would not use
+
+## Design Test
+
+At a glance, a reviewer should think:
+
+- same product
+- same design system
+- same interaction priorities
+
+They should not think:
+
+- different tool
+- special admin console
+- bespoke screen with unrelated chrome
+
+## Review Standard
+
+If the UI changed aesthetically but the same aesthetic could now be rolled back into assignments without conflict, the evolution is acceptable.

--- a/.codex/prompts/assessment-ux-parity.md
+++ b/.codex/prompts/assessment-ux-parity.md
@@ -1,0 +1,98 @@
+Restyle an assessment surface so it matches the assignments UX system.
+
+Treat assignments as the canonical design source of truth for classroom assessment work in Pika.
+
+## Inspect First
+
+Read these files before editing:
+
+1. `docs/guidance/assignment-ux-language.md`
+2. `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
+3. `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`
+4. `src/components/SortableAssignmentCard.tsx`
+5. `src/components/PageLayout.tsx`
+6. `src/ui/EmptyState.tsx`
+7. The target assessment surface:
+   - `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
+   - `src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`
+   - related assessment components only as needed
+
+If the challenge is teacher tests authoring parity, treat the exact target as:
+
+- `TeacherQuizzesTab`
+- `assessmentType="test"`
+- `testsMode === 'authoring'`
+
+Do not spend the run auditing unrelated tabs once those references are loaded.
+
+## Goal
+
+Make the target surface feel like it belongs to the same product family as assignments.
+
+Preserve assessment-specific behavior:
+- test-taking
+- grading
+- status semantics
+- submission or return behavior
+
+But express that behavior using the assignment shell, spacing, card tone, empty-state tone, and selection flow.
+
+## Must Match
+
+- Use the assignment page shell and spacing rhythm where possible.
+- Keep the page content-first and quiet.
+- Prefer the same list-card language as assignments.
+- Keep empty states as restrained as assignments.
+- Make detail appear because the user selected work, not because the layout reserved a large empty pane in advance.
+- Reuse existing primitives before creating new layout structures:
+  - `PageLayout`
+  - `PageActionBar`
+  - `PageContent`
+  - `PageStack`
+  - `EmptyState`
+
+## Must Preserve
+
+- Existing assessment behavior and data model
+- Existing role semantics
+- Existing API interactions and business logic
+- Test-specific constraints that are actually necessary for active exam mode or grading mode
+
+## Must Not Introduce
+
+- A new shell or layout system when assignments already provide one
+- Default split panes with placeholder detail states unless the analogous assignment state uses them
+- Controls or mode toggles that visually outrank content
+- Louder, denser, or more decorative empty states than assignments
+- One-off card styling that no longer resembles assignment cards
+- Raw `dark:` classes or non-semantic token styling
+
+## Working Rules
+
+- Keep logic out of UI components.
+- Prefer adapting existing assessment components to the assignment shell rather than rewriting behavior.
+- If an assessment-specific mode truly needs a different layout, keep that difference limited to the active mode and do not let it bleed into passive browsing states.
+- For student tests, passive browsing and pre-start detail should still read like student assignments; reserve the split exam shell for active in-progress test work.
+- If you need a split view, justify it with the current state, not with anticipated future selection.
+- In a blind run, stay scoped to the named target branch instead of reloading broad repo context after the required files are read.
+- If the outer harness says the environment is already verified, do not rerun full startup or full-suite validation before implementing the target.
+
+## Finish Checklist
+
+Before stopping:
+
+1. Capture assignment reference screenshots and target screenshots.
+   - `pnpm e2e:verify assessment-ux-parity`
+2. Review the artifacts in `artifacts/assessment-ux-parity/`.
+3. Score the result against `docs/guides/assessment-ux-evaluation.md`.
+4. List the remaining mismatches explicitly.
+5. If the result still drifts from assignments, tighten the implementation before handing off.
+
+## Known First-Pass Drift To Remove
+
+For the current teacher tests surface, eliminate these before considering the run successful:
+
+- the left-list plus right-placeholder passive shell
+- the oversized no-selection pane with “Select a test” copy
+- mode-toggle emphasis that outranks the test cards
+- card styling that reads as tool chrome instead of assignment-family work items

--- a/.codex/prompts/teacher-tests-ux-parity.md
+++ b/.codex/prompts/teacher-tests-ux-parity.md
@@ -1,0 +1,100 @@
+Restyle the teacher tests passive browsing surface so it matches the teacher assignments UX system.
+
+This is a task-scoped parity prompt for the teacher-tests authoring surface. That surface spans the test-authoring branch in `TeacherQuizzesTab` and the surrounding teacher assessment shell in `ClassroomPageClient`.
+
+Aim for the same **product family** as assignments, not a literal visual clone. Small aesthetic refinements are acceptable if they would also make sense as a future shared direction for assignments, tests, and quizzes.
+
+## Target
+
+- Primary file: `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
+- Supporting shell file: `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
+- Supporting layout config: `src/lib/layout-config.ts`
+- Branch: `assessmentType="test"` with `testsMode === 'authoring'`
+
+Do not treat teacher quizzes or grading mode as the primary target for this challenge.
+Do not treat unrelated classroom tabs as in scope.
+
+## Read Only These Files First
+
+1. `docs/guidance/assignment-ux-language.md`
+2. `docs/guides/assessment-ux-evaluation.md`
+3. `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
+4. `src/components/SortableAssignmentCard.tsx`
+5. `src/components/PageLayout.tsx`
+6. `src/ui/EmptyState.tsx`
+7. `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
+8. `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
+9. `src/lib/layout-config.ts`
+10. `src/components/QuizCard.tsx`
+11. `tests/components/TeacherQuizzesTab.test.tsx`
+
+If the surrounding harness says the environment is already verified, do not rerun full repo startup or full-suite validation. Move directly from these files into the implementation.
+
+When reading or editing App Router files from the shell, quote the path exactly because `[` and `]` will be treated as glob syntax by `zsh`. Example:
+
+- `sed -n '1,220p' 'src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx'`
+- `sed -n '1,220p' 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx'`
+- `git diff -- 'src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx'`
+
+## Goal
+
+Make teacher tests authoring feel like teacher assignments summary/list state:
+
+- quiet shell
+- content-first list
+- restrained action bar
+- no reserved right-side placeholder detail pane before selection
+- no reserved blank right-side column after the placeholder pane is removed
+- assignment-family card tone
+
+If the visible placeholder or split-pane treatment comes from the surrounding classroom shell rather than `TeacherQuizzesTab`, fix it there instead of forcing the tab component to work around it.
+If the blank right column is being created by the teacher tests route opening the right sidebar by default, fix that in `src/lib/layout-config.ts` rather than only hiding content inside the open shell.
+
+## Must Match
+
+- The default authoring view should feel complete as a list page, just like teacher assignments.
+- The default authoring view may evolve the shared aesthetic slightly, but it must still read as part of the same assignment-derived system at a glance.
+- The default authoring view must use the available main-content width for the test list. Hiding placeholder copy while leaving an empty right column is still a failure.
+- `New Test` can remain the primary action, but it should not be visually outnumbered by chrome.
+- The authoring/grading toggle may remain, but it must recede behind the content and should not be the first thing the eye lands on.
+- Empty or no-selection states should use `EmptyState` or a comparably quiet single-surface treatment.
+- Cards should read like descendants of `SortableAssignmentCard`, not a separate dashboard component family.
+- The teacher assessment sidebar or detail shell must not stay visually active in authoring mode when nothing is selected.
+
+## Must Preserve
+
+- Existing test data and API behavior
+- Existing grading mode behavior
+- Existing create/open/close actions
+- Existing sidebar and selection wiring that the rest of the classroom page depends on
+- Existing teacher assessment detail behavior once a test is actually selected
+
+## Must Not Introduce
+
+- A split-pane placeholder state in authoring mode before a selection exists
+- A large blank right pane with “Select a test” copy in passive browsing state
+- A large blank right pane or blank right column in passive browsing state even if the placeholder copy is removed
+- Louder controls than the content list
+- A new shell or layout system outside the existing page primitives
+- A workaround that hides the symptom in `TeacherQuizzesTab` while leaving the outer `ClassroomPageClient` shell behavior inconsistent
+
+## Expected Edit Shape
+
+The likely implementation should stay narrow:
+
+- reshape the `PageActionBar` hierarchy for the test authoring state
+- reshape the authoring branch of `TeacherQuizzesTab`
+- adjust the teacher assessment no-selection shell in `ClassroomPageClient` if that is what produces the placeholder pane
+- adjust the `tests-teacher` route config in `src/lib/layout-config.ts` if the route-level default sidebar state is what keeps the blank column alive
+- adapt `QuizCard` only if needed so teacher tests cards feel closer to assignment cards
+- avoid touching grading tables unless required for shared component compatibility
+
+## Finish Checklist
+
+1. Run `pnpm exec vitest run tests/components/TeacherQuizzesTab.test.tsx`
+2. Run `pnpm e2e:verify assessment-ux-parity`
+3. Review:
+   - `artifacts/assessment-ux-parity/teacher-assignments-reference.png`
+   - `artifacts/assessment-ux-parity/teacher-tests-target.png`
+4. Score the result with `docs/guides/assessment-ux-evaluation.md`
+5. Report pass/fail and list any remaining mismatches

--- a/.codex/prompts/teacher-work-surface-promotion-review.md
+++ b/.codex/prompts/teacher-work-surface-promotion-review.md
@@ -1,0 +1,66 @@
+# Teacher Work-Surface Promotion Review
+
+Review the teacher work-surface family only:
+
+- teacher assignments
+- teacher quizzes
+- teacher tests
+
+Stay out of unrelated teacher tabs, the main classroom shell, and all student-only surfaces unless they materially affect the teacher-side implementation of this family.
+
+## Required Inputs
+
+Read and compare:
+
+- [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
+- [`docs/guidance/ui/teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md)
+- [`docs/guidance/ui/audit-teacher-work-surfaces.md`](/docs/guidance/ui/audit-teacher-work-surfaces.md)
+- relevant files under [`docs/guidance/ui/experimental/`](/docs/guidance/ui/experimental/) only if they materially affect this family
+- current implementation of teacher assignments, teacher quizzes, and teacher tests
+
+## Goal
+
+Produce a concise non-mutating review packet that tells a human:
+
+- which current patterns should remain local
+- which patterns should be recorded as experimental
+- which patterns are ready to promote to stable
+- which patterns are ready for primitive extraction
+- which patterns should be deprecated as legacy drift
+- which guidance docs look stale versus the best current implementation
+
+## Rules
+
+- Do not edit repo-tracked files.
+- Do not silently promote anything to stable.
+- Do not treat assignments as permanent authority. Treat the canon as authority.
+- Prefer structural findings over cosmetic nitpicks.
+- If screenshot capture would materially improve the review, use the existing verification flow, but keep the run non-mutating.
+
+## Extraction Test
+
+Recommend primitive extraction only when all are true:
+
+- the pattern is structural rather than domain-specific
+- it appears in at least two places or clearly needs to
+- it has stabilized
+- the API can remain narrow
+- abstraction would reduce duplication without hiding meaningful differences
+
+## Expected Output
+
+Return one concise review packet with these sections:
+
+1. `Stable Candidates`
+2. `Experimental Candidates`
+3. `Primitive Candidates`
+4. `Legacy Drift`
+5. `Docs To Update`
+6. `Recommended Next Actions`
+
+Each item should name:
+
+- the pattern
+- the current owner files
+- the proposed disposition: keep local / mark experimental / promote stable / extract primitive / deprecate legacy
+- the shortest convincing reason

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -171,6 +171,7 @@ Run predefined verification scenarios:
 pnpm e2e:verify --help                    # List available scenarios
 pnpm e2e:verify add-students-modal        # Verify add students modal
 pnpm e2e:verify create-classroom-wizard   # Verify classroom creation
+pnpm e2e:verify assessment-ux-parity      # Capture assignment parity references/targets
 ```
 
 Scripts output JSON with pass/fail status and can be used to validate UI changes.

--- a/docs/guidance/assignment-ux-language.md
+++ b/docs/guidance/assignment-ux-language.md
@@ -1,0 +1,299 @@
+# Assignment UX Language
+
+This document codifies the current assignments experience as a reusable design language. It is the primary source of truth for the look, feel, structure, and interaction rhythm of assignment-style work in Pika.
+
+The goal is not to freeze every pixel. The goal is to preserve the recognizable system:
+
+- calm page shell
+- content-first browsing
+- restrained controls
+- clear summary-to-detail progression
+- assignment-family cards and surfaces
+
+If another surface borrows from assignments later, it should feel like a descendant of this system rather than a separate tool.
+
+## Canonical Sources
+
+Read these files before reproducing the assignment experience:
+
+- Teacher assignments summary and workspace:
+  - `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
+- Student assignments summary and editor entry:
+  - `src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx`
+- Assignment list card:
+  - `src/components/SortableAssignmentCard.tsx`
+- Shared shell primitives:
+  - `src/components/PageLayout.tsx`
+  - `src/ui/EmptyState.tsx`
+
+These files define the real implementation. This doc explains the design language they express.
+
+## Required Primitives
+
+Assignment-style surfaces should prefer the same primitives already used by assignments:
+
+- `PageLayout`
+- `PageActionBar`
+- `PageContent`
+- `PageStack`
+- `EmptyState`
+- semantic tokens such as `bg-surface`, `bg-surface-panel`, `bg-surface-2`, `border-border`, `border-border-strong`, `text-text-default`, `text-text-muted`
+
+Do not invent a new page shell when the assignment shell already fits the state.
+
+## Core Character
+
+### Quiet shell
+
+Assignments feel calm because the shell stays out of the way:
+
+- one stable action bar
+- broad, readable content area
+- light framing
+- minimal decorative chrome
+
+The eye should land on the work list or the current work item first, not on controls, tabs, or placeholders.
+
+### Content-first hierarchy
+
+Assignments always prioritize the work itself:
+
+- titles and due/status information come first
+- controls are present but visually secondary
+- empty states are simple and direct
+- detail views appear because the user chose a work item, not because the layout pre-allocates inspector space
+
+### Soft, practical polish
+
+Assignments are not flat, but they are restrained:
+
+- soft borders
+- small elevation
+- gentle hover movement
+- compact chips
+- muted secondary copy
+
+The system feels purposeful, not ornamental.
+
+## Teacher Assignments
+
+Teacher assignments have two dominant states: summary and workspace.
+
+### Summary state
+
+The summary state is the default browsing view.
+
+It should feel like:
+
+- a single list surface
+- a sparse top action bar
+- full-width cards with clear scanning rhythm
+- no reserved detail pane before selection
+
+Visual characteristics:
+
+- `PageLayout` fills the available height
+- `PageActionBar` sits at the top without heavy framing
+- `PageContent` uses modest vertical spacing
+- `PageStack` separates cards evenly
+- cards span the available content width
+
+### Workspace state
+
+Once a teacher selects an assignment, the interface can become denser and more tool-like, but it still keeps the same shell.
+
+Important behavior:
+
+- detail appears because selection changed
+- the calm outer shell remains consistent
+- tables, grading panes, and side content are justified by active review work
+
+The assignments system earns complexity only after the user is inside the work.
+
+## Student Assignments
+
+Student assignments have a simpler progression than teacher assignments.
+
+### Summary state
+
+The student summary state is straightforward:
+
+- no extra header chrome when not needed
+- vertically stacked cards
+- strong title, muted due information, compact status chip
+- full-width browsing experience
+
+The list should feel like a clean queue of work.
+
+### Selected state
+
+When a student opens an assignment:
+
+- the list yields to the focused work view
+- the active task becomes the main surface
+- supporting actions stay close to the work
+
+The interaction pattern is summary to focused work, not summary beside an always-present inspector.
+
+### Empty state
+
+Student empty states are especially quiet:
+
+- one `EmptyState`
+- short explanatory copy
+- no extra border maze or placeholder panel
+
+## Card Anatomy
+
+`SortableAssignmentCard` defines the teacher assignment card language.
+
+### Teacher card structure
+
+The card has a clear left-to-right order:
+
+1. drag handle
+2. title and due information
+3. compact status or submission summary
+4. light action icons
+
+What matters:
+
+- title is the strongest text
+- due metadata is muted
+- status is compact
+- actions do not dominate the row
+
+### Student card structure
+
+The student assignment card is simpler:
+
+1. title
+2. due metadata
+3. compact relative timing or supporting copy
+4. status chip
+
+It should scan quickly and feel lighter than a dashboard tile.
+
+## Layout Rules
+
+### Width
+
+Assignment browsing states use the available content width.
+
+- do not artificially narrow the browsing surface unless the assignment implementation already does
+- do not leave a silent empty column beside the list
+- do not reserve future detail space in the default state
+
+### Spacing
+
+Assignments use consistent breathing room:
+
+- modest action-bar spacing
+- clear but not oversized gaps between cards
+- enough padding for readability without feeling loose
+
+### Selection
+
+Selection changes the layout only when necessary.
+
+- summary state should feel complete on its own
+- detail state should appear because the user selected something
+- pre-selection placeholder panes are not part of the assignment language
+
+## Action Hierarchy
+
+Assignments use a very clear action order.
+
+### Primary action
+
+There is usually one obvious primary action:
+
+- `New`
+- `Submit`
+- another single current task action
+
+It is visible, but not oversized.
+
+### Secondary actions
+
+Secondary actions stay quieter:
+
+- icon buttons
+- subtle buttons
+- compact supporting controls
+
+They should read as utilities, not as the focal point of the page.
+
+### Stability
+
+The action bar should not jump between radically different structures across nearby states. Assignment surfaces feel coherent because the shell stays recognizable while content changes.
+
+## Copy Tone
+
+Assignment copy is terse and product-like.
+
+Use:
+
+- short titles
+- direct descriptions
+- muted secondary guidance
+
+Avoid:
+
+- tutorial-like paragraphs
+- redundant labels
+- over-explaining status
+
+The assignments voice is calm, plain, and concise.
+
+## What To Preserve
+
+When reproducing the assignment experience, preserve:
+
+- the quiet shell
+- full-width browsing surfaces
+- restrained card styling
+- short copy
+- selection-driven detail
+- semantic-token usage
+- existing `@/ui` and page-shell primitives
+
+## What Not To Introduce
+
+Do not introduce any of the following into an assignment-style surface:
+
+- default split panes before selection
+- placeholder inspector panels
+- loud toggle bars
+- dashboard chrome
+- bespoke card families unrelated to assignment cards
+- extra framing around empty states
+- raw `dark:` classes in app code
+
+## AI Reproduction Checklist
+
+If an AI needs to reproduce the assignment style, it should verify:
+
+- `PageLayout` is the outer shell
+- `PageActionBar` stays sparse and stable
+- `PageContent` and `PageStack` control the browsing rhythm
+- cards fill the available content width
+- the first visual emphasis is on content, not controls
+- empty states use a single quiet surface
+- detail appears only after selection
+- status chips are compact
+- copy stays short and muted
+
+## Reuse Guidance
+
+If another feature later borrows from assignments, use this rule:
+
+Start from the assignment shell and only add complexity when the task truly requires it.
+
+That means:
+
+- browse like assignments
+- select like assignments
+- only become denser when active work or review genuinely needs it
+
+This keeps future surfaces in the same product family even if the exact domain behavior differs.

--- a/docs/guidance/ui/README.md
+++ b/docs/guidance/ui/README.md
@@ -24,7 +24,8 @@ When a task affects UI, styling, layout, or interaction flow, read in this order
 1. [`docs/core/design.md`](/docs/core/design.md)
 2. [`src/ui/README.md`](/src/ui/README.md)
 3. [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
-4. Relevant experimental, legacy, and open-question docs in this folder only if they materially affect the task
+4. Family-specific canon docs in this folder when the task targets a governed slice
+5. Relevant experimental, legacy, and open-question docs in this folder only if they materially affect the task
 
 The stable file is the default. Experimental and legacy docs are context, not overrides.
 
@@ -38,11 +39,13 @@ The stable file is the default. Experimental and legacy docs are context, not ov
 
 ## V1 Scope
 
-The first governed slice is:
+The current governed slices are:
 
-- Assignments
-- Attendance
-- Shared classroom shell behavior that directly supports those workflows
+- Cross-cutting stable guidance for assignments, attendance, and shared classroom shell behavior that directly supports those workflows
+- A dedicated teacher work-surface canon for:
+  - teacher assignments
+  - teacher quizzes
+  - teacher tests
 
 This is intentionally smaller than the full app.
 
@@ -60,6 +63,8 @@ When a task touches UI/UX, the implementation plan or issue note should declare:
 
 - [`audit-v1.md`](/docs/guidance/ui/audit-v1.md)
 - [`stable.md`](/docs/guidance/ui/stable.md)
+- [`teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md)
+- [`audit-teacher-work-surfaces.md`](/docs/guidance/ui/audit-teacher-work-surfaces.md)
 - [`legacy.md`](/docs/guidance/ui/legacy.md)
 - [`open-questions.md`](/docs/guidance/ui/open-questions.md)
 - [`experimental/README.md`](/docs/guidance/ui/experimental/README.md)

--- a/docs/guidance/ui/audit-teacher-work-surfaces.md
+++ b/docs/guidance/ui/audit-teacher-work-surfaces.md
@@ -1,0 +1,139 @@
+# Audit: Teacher Work Surfaces
+
+This audit classifies the current teacher-side work-surface family:
+
+- teacher assignments
+- teacher quizzes
+- teacher tests
+
+Use it to decide what should become a primitive, what should remain a composed pattern, and what should stay feature-local.
+
+## Scope
+
+Included:
+
+- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+- [`src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`](/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx)
+- supporting layout primitives in [`src/components/PageLayout.tsx`](/src/components/PageLayout.tsx), [`src/components/layout/ThreePanelShell.tsx`](/src/components/layout/ThreePanelShell.tsx), and [`src/components/layout/RightSidebar.tsx`](/src/components/layout/RightSidebar.tsx)
+- card and workspace components used by those surfaces
+
+Excluded:
+
+- the student product
+- the main classroom shell as a whole
+- unrelated teacher tabs
+
+## Foundations
+
+These are already foundational and should stay shared:
+
+| Pattern | Current owners | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- |
+| Semantic tokens for surfaces, borders, and text | `src/ui`, app-wide classroom surfaces | stable | keep as foundation | now |
+| Base controls from `@/ui` | `src/ui`, assignments, quizzes/tests | stable | keep as foundation | now |
+| Shared page shell primitives: `PageLayout`, `PageActionBar`, `PageContent`, `PageStack` | assignments, quizzes/tests | stable | keep as primitives | now |
+| Shared classroom shell: `ThreePanelShell`, `LeftSidebar`, `RightSidebar`, `MainContent` | classroom route layer | stable cross-cutting | keep as shell primitives | now |
+
+## True Primitives
+
+These are the current or proposed structural primitives for the teacher work-surface family.
+
+| Pattern | Current owners | Where else it appears | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- | --- |
+| Page-shell primitives (`PageLayout`, `PageActionBar`, `PageContent`, `PageStack`) | assignments, quizzes/tests | shared already | stable | keep as primitives | now |
+| Calm empty-state container via `EmptyState` | quizzes/tests today, assignments via similar composition | intended family-wide | stable | keep as primitive | now |
+| Teacher workspace split container derived from assignments | assignment viewing/grading + shell sidebar behavior | intended for quizzes/tests later | experimental candidate | extract as new primitive | now |
+| Shared teacher work-item card variant | `SortableAssignmentCard`, `QuizCard` | partial convergence only | experimental | revisit after convergence | later |
+| Generic teacher list/detail container | no single owner yet | conceptually repeated | unstable | do not extract yet | never for now |
+
+## Composed Work-Surface Patterns
+
+These should remain composed feature patterns even if they use shared primitives internally.
+
+| Pattern | Current owners | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- |
+| Teacher assignment summary list and selection flow | `TeacherClassroomView` | stable | keep composed | now |
+| Teacher assignment focused workspace and student inspection | `TeacherClassroomView`, `TeacherStudentWorkPanel` | stable | keep composed, feed split extraction | now |
+| Teacher quiz authoring composition | `TeacherQuizzesTab`, `QuizDetailPanel`, `QuizModal` | experimental | keep composed | now |
+| Teacher test authoring composition | `TeacherQuizzesTab`, `QuizDetailPanel`, `QuizModal` | experimental | keep composed | now |
+| Teacher grading workspace composition | `TeacherQuizzesTab`, `TestStudentGradingPanel` | experimental | keep composed | now |
+
+## Feature-Local Behavior
+
+These should not be extracted into primitives.
+
+| Pattern | Current owners | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- |
+| Assignment grading logic and student work fetching | `TeacherClassroomView`, assignment workspace hooks | stable | keep feature-local | now |
+| Quiz/test authoring rules, question editing, and validation | `TeacherQuizzesTab`, `QuizModal`, question editors | stable per feature | keep feature-local | now |
+| Test grading batch actions, AI grading strategy, and return flows | `TeacherQuizzesTab` | experimental | keep feature-local | now |
+| Right-sidebar open/close decisions tied to route/query behavior | `ClassroomPageClient`, layout hooks | mixed | keep feature-local until split primitive is extracted | later |
+
+## Legacy Drift To Avoid Copying Forward
+
+These are present or recently present patterns that should not be treated as reusable defaults.
+
+| Pattern | Current owners | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- |
+| Passive split shells that reserve empty detail space before selection | tests/quizzes shell paths | legacy drift | mark legacy, avoid copying | now |
+| Mode controls that visually outrank content lists | tests authoring/grading toggle states | legacy drift | reduce or localize | now |
+| Divergent card systems with incompatible metadata density | assignments vs quizzes/tests cards | experimental drift | converge before extracting | later |
+
+## Extraction Roadmap
+
+### Now: teacher workspace split
+
+The first extraction target is a reusable teacher workspace split derived from assignments.
+
+Responsibilities:
+
+- primary pane plus inspector pane layout
+- resize handle
+- width clamping
+- collapsed and expanded inspector state
+- desktop split vs mobile stacked behavior
+
+Required API shape:
+
+- `primary`
+- `inspector`
+- `inspectorWidth`
+- `onInspectorWidthChange`
+- `inspectorCollapsed`
+- `onInspectorCollapsedChange`
+
+Non-goals:
+
+- no assignment, quiz, or test business logic
+- no grading logic
+- no routing/query management beyond what a layout primitive strictly needs
+
+Adoption order:
+
+1. assignments adopt it first
+2. teacher quizzes/tests adopt it only when their workspace state truly matches the pattern
+
+### Later: teacher work-item card convergence
+
+Assignments and quizzes/tests both need compact work-item cards, but they have not converged far enough yet to justify one primitive.
+
+Promotion criteria before extraction:
+
+- shared metadata hierarchy
+- shared action affordances
+- comparable density and status treatment
+- narrow enough API that does not leak assessment-specific logic
+
+### Never for now: full assessment mega-shell
+
+Do not introduce a generic assessment framework that tries to own assignments, quizzes, and tests in one abstraction. The family is aligned at the structural level, not at the business-logic level.
+
+## Review Checklist
+
+When deciding whether a pattern should be promoted or extracted, answer:
+
+1. Is the pattern structural rather than domain-specific?
+2. Does it appear in at least two places or clearly need to?
+3. Is the API narrow enough to stay comprehensible?
+4. Would extraction simplify future work instead of hiding important differences?
+5. Should the pattern be canonized first before code extraction?

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -1,8 +1,15 @@
 # Stable UI Guidance
 
-These are the stable UI rules for the v1 governed slice: assignments, attendance, and the classroom shell that supports them.
+These are the stable cross-cutting UI rules for the current governed slices.
 
 Use these by default for new work.
+
+For teacher assignments, teacher quizzes, and teacher tests, also read:
+
+- [`docs/guidance/ui/teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md)
+- [`docs/guidance/ui/audit-teacher-work-surfaces.md`](/docs/guidance/ui/audit-teacher-work-surfaces.md)
+
+This file handles shared foundation rules. The teacher work-surface canon handles that family’s composition and promotion lifecycle.
 
 ## Stable Rules
 
@@ -84,5 +91,6 @@ Source grounding:
 ## Stable Guidance Limits
 
 - This file is intentionally narrow. It does not try to canonize the entire app.
+- Teacher assignments/quizzes/tests family rules live in [`teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md).
 - If a current pattern exists in code but is not listed here, do not assume it is stable.
 - Use an experimental draft when you want to propose reuse beyond the current stable rules.

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -1,0 +1,171 @@
+# Teacher Work-Surface Canon
+
+This document is the stable canon for the teacher-side work-surface family:
+
+- teacher assignments
+- teacher quizzes
+- teacher tests
+
+It governs how those three tabs should feel, compose, and evolve. It does not govern:
+
+- the main classroom shell
+- unrelated teacher tabs such as attendance, roster, settings, gradebook, or calendar
+- the student product
+
+Assignments are the starting reference implementation for this family because they currently express the clearest summary-to-workspace flow. They are not permanent authority. If quizzes or tests produce a better pattern, this canon should be updated and assignments can then follow.
+
+## Read Order
+
+When a task touches teacher assignments, teacher quizzes, or teacher tests, read in this order:
+
+1. [`docs/core/design.md`](/docs/core/design.md)
+2. [`src/ui/README.md`](/src/ui/README.md)
+3. [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
+4. [`docs/guidance/ui/teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md)
+5. [`docs/guidance/ui/audit-teacher-work-surfaces.md`](/docs/guidance/ui/audit-teacher-work-surfaces.md)
+6. Relevant experimental or legacy guidance only if it materially affects the task
+
+## Authority Model
+
+- `stable.md` remains the source of truth for cross-cutting UI rules.
+- This file is the source of truth for teacher assignments/quizzes/tests composition and taste.
+- Experimental guidance may originate in assignments, quizzes, or tests.
+- Nothing becomes stable for this family until this canon and the audit agree it is stable.
+
+## Stable Rules
+
+### 1. Teacher work surfaces begin in a quiet summary shell
+
+- The default teacher state is a scan-friendly list or summary surface, not a tool-heavy workspace.
+- The first visual emphasis belongs to the content list, not to toggles, segmented controls, or placeholder panels.
+- Empty states should feel calm and singular: one primary surface, one clear action, minimal framing.
+
+Current grounding:
+
+- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+- [`src/components/SortableAssignmentCard.tsx`](/src/components/SortableAssignmentCard.tsx)
+
+### 2. Action bars stay stable, sparse, and subordinate to content
+
+- Use the shared page-shell composition already present in teacher assignments: `PageLayout`, `PageActionBar`, `PageContent`, `PageStack`.
+- The primary create/edit action may be prominent, but surrounding controls should remain restrained.
+- Mode controls are allowed only when they unlock a materially different teacher workflow. They should not visually outrank the list itself.
+
+Current grounding:
+
+- [`src/components/PageLayout.tsx`](/src/components/PageLayout.tsx)
+- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+- [`src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`](/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx)
+
+### 3. Card language stays compact, descriptive, and reusable
+
+- Teacher work-item cards should surface the title, key status, time context, and the minimum metadata needed to decide what to open next.
+- Metadata density should stay restrained. Avoid secondary badges, helper copy, or action clusters that make cards feel like mini dashboards.
+- New shared card variants are acceptable only if assignments, quizzes, and tests converge on the same structure.
+
+Current grounding:
+
+- [`src/components/SortableAssignmentCard.tsx`](/src/components/SortableAssignmentCard.tsx)
+- [`src/components/QuizCard.tsx`](/src/components/QuizCard.tsx)
+
+### 4. Summary-to-detail progression should feel deliberate
+
+- The teacher should move from summary to focused work only after a real selection or workflow transition.
+- Passive browsing states should not reserve large empty detail panes purely to preserve structure.
+- Split or inspector layouts are justified only when the teacher is actively reviewing work, grading, authoring in detail, or comparing primary content with contextual inspection.
+
+Current grounding:
+
+- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
+- [`src/components/TeacherStudentWorkPanel.tsx`](/src/components/TeacherStudentWorkPanel.tsx)
+- [`src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`](/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx)
+
+### 5. Split and resizable layouts are workspace tools, not default chrome
+
+- A split workspace is appropriate when the teacher is actively working in both panes.
+- A split workspace is not appropriate as a passive no-selection scaffold.
+- Width, collapse, and resize behavior should be structural and reusable. Business logic must stay outside the shared layout primitive.
+- The first extraction target for this family is a reusable teacher workspace split derived from assignments.
+
+Current grounding:
+
+- [`src/components/layout/ThreePanelShell.tsx`](/src/components/layout/ThreePanelShell.tsx)
+- [`src/components/layout/RightSidebar.tsx`](/src/components/layout/RightSidebar.tsx)
+- [`src/lib/layout-config.ts`](/src/lib/layout-config.ts)
+
+### 6. Tone and copy stay plain, product-like, and low-drama
+
+- Prefer short labels and direct status language over decorative copy.
+- Empty and no-selection states should explain the next action without sounding instructional for the sake of it.
+- Reuse Toronto-aware date language and existing status terms where possible.
+
+Current grounding:
+
+- [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
+- [`docs/core/design.md`](/docs/core/design.md)
+
+## Componentization Rules
+
+Not every recurring UI idea should become a primitive.
+
+A pattern becomes a primitive only when all of the following are true:
+
+- it is structural rather than domain-specific
+- it appears in at least two places or is clearly intended to
+- it has stabilized
+- it can expose a narrow API
+- extracting it removes duplication without hiding meaningful differences
+
+For this teacher work-surface family:
+
+- should become primitives:
+  - shared page-shell pieces already in use
+  - stable empty/list/detail containers where structure truly matches
+  - the teacher resizable split workspace container derived from assignments
+  - shared teacher work-item card variants only if assignments/quizzes/tests converge
+- should remain composed patterns:
+  - teacher assignment summary
+  - teacher assignment workspace
+  - teacher quiz authoring composition
+  - teacher test authoring composition
+  - grading workspace composition
+- should remain feature-local:
+  - grading behavior
+  - quiz/test state machines
+  - assessment-specific domain controls
+  - authoring rules and validation logic
+
+## Lifecycle
+
+Every teacher work-surface pattern should be classified as one of:
+
+- `local`: a one-off implementation detail, not proposed for reuse
+- `experimental`: a promising reusable pattern under review
+- `stable`: the approved default that AI and engineers should reuse
+- `legacy`: still present in code but not appropriate for new work
+
+Promotion flow:
+
+1. a pattern changes in assignments, quizzes, or tests
+2. it is recorded as local or experimental
+3. if it proves better or reusable, this canon and the audit are updated
+4. only then does it become stable or a primitive candidate
+
+The weekly promotion-review automation should be used to surface promotion candidates and stale guidance, but it must remain non-mutating. Human review is still required before stable guidance changes.
+
+## Change Protocol
+
+Any meaningful teacher assignments/quizzes/tests UX change should update this canon when it changes:
+
+- shell structure
+- action hierarchy
+- card anatomy
+- empty-state treatment
+- focused workspace behavior
+- rules around when split panes are justified
+
+When updating this file, explicitly note whether the pattern is:
+
+- assignment-led and already stable
+- experimental and under review
+- promoted from quizzes/tests because it is now the better family pattern

--- a/docs/guides/ai-ui-testing.md
+++ b/docs/guides/ai-ui-testing.md
@@ -86,6 +86,7 @@ pnpm e2e:verify --help
 # Run specific scenario
 pnpm e2e:verify create-classroom-wizard
 pnpm e2e:verify add-students-modal
+pnpm e2e:verify assessment-ux-parity
 ```
 
 ### Output Format
@@ -106,6 +107,50 @@ Scripts output JSON to stdout:
 ```
 
 Exit code is 0 for pass, 1 for fail.
+
+### Assignment-Parity Capture
+
+Use the `assessment-ux-parity` scenario when you need a reference/target screenshot set for assignment-style assessment work:
+
+```bash
+pnpm e2e:verify assessment-ux-parity
+```
+
+Artifacts are written to:
+
+```bash
+artifacts/assessment-ux-parity/
+```
+
+This scenario captures teacher/student assignment reference screens plus teacher/student assessment target screens for rubric-based review.
+
+### Blind Challenge Runner
+
+Use the dedicated teacher-tests blind runner when you want a fresh AI to attempt the parity change with attached screenshot references:
+
+```bash
+bash scripts/run-teacher-tests-parity-challenge.sh --refresh-auth
+```
+
+Artifacts written by the runner:
+
+- current assignment reference screenshot
+- teacher tests screenshot before the run
+- teacher tests screenshot after the run
+- exact prompt packet used for the run
+- the fresh AI's final summary
+
+The runner uses the scoped prompt at:
+
+```bash
+.codex/prompts/teacher-tests-ux-parity.md
+```
+
+If you want a looser “same family, not exact clone” direction for future work, use:
+
+```bash
+.codex/prompts/assessment-ux-family-parity.md
+```
 
 ## Iteration Workflow
 

--- a/docs/guides/assessment-ux-evaluation.md
+++ b/docs/guides/assessment-ux-evaluation.md
@@ -1,0 +1,178 @@
+# Assessment UX Evaluation
+
+Use this guide to verify that the new assignment-parity docs actually cause a fresh AI to produce assessment screens that match the existing assignments system.
+
+This is a **rubric-and-screenshot** evaluation flow, not a pixel diff.
+
+## Goal
+
+A fresh AI should be able to restyle tests or quizzes so they feel like assignment-family screens without extra coaching.
+
+Passing means:
+
+- the resulting screen reads as the same product family as assignments at a glance
+- the code reuses the expected page primitives
+- the evaluator can explain parity using the rubric instead of relying on vague taste
+
+Minor aesthetic evolution is acceptable. The pass condition is family consistency, not pixel identity.
+
+## Reference and Target Artifacts
+
+Capture screenshots with:
+
+```bash
+pnpm e2e:verify assessment-ux-parity
+```
+
+The scenario writes screenshots to:
+
+```bash
+artifacts/assessment-ux-parity/
+```
+
+Expected artifacts:
+
+- `teacher-assignments-reference.png`
+- `teacher-tests-target.png`
+- `teacher-quizzes-target.png`
+- `student-assignments-reference.png`
+- `student-tests-target.png`
+- `student-quizzes-target.png`
+
+Use the assignment images as the reference set. Use the assessment images as the targets to score.
+
+If you are intentionally testing a “same family, slightly evolved” direction, use the same rubric. The question is still whether the target reads as a descendant of assignments rather than a separate tool.
+
+## Blind-Run Validation Workflow
+
+Run the docs in a fresh AI session with only:
+
+- `docs/guidance/assignment-ux-language.md`
+- `.codex/prompts/assessment-ux-parity.md`
+- the target task request
+
+Do not provide prior design discussion or hidden context.
+
+For the teacher-tests blind run, prefer the dedicated wrapper:
+
+```bash
+bash scripts/run-teacher-tests-parity-challenge.sh --refresh-auth
+```
+
+This attaches the assignment reference screenshot and the current teacher-tests screenshot to the fresh run so the evaluator tests implementation quality instead of the agent's ability to imagine the baseline from text alone.
+
+### Required challenge set
+
+Run at least these three tasks:
+
+1. teacher tests authoring/list parity
+2. student tests list/detail parity
+3. student quizzes list/detail parity
+
+Teacher quizzes are optional for v1, but should be included when time allows.
+
+### Test loop
+
+For each challenge:
+
+1. Start a fresh AI session.
+2. Give it one concrete restyle task.
+3. Let it implement without extra verbal guidance.
+4. Capture screenshots with `pnpm e2e:verify assessment-ux-parity`.
+5. Score the resulting screen against the assignment references.
+6. Record failures against the docs and prompt.
+7. Tighten the docs or prompt.
+8. Rerun the same challenge until it passes.
+
+If the fresh AI never reaches implementation and spends the run reacquiring unrelated context instead, count that as a failed blind run. The guidance package must be specific enough to get a task-scoped change started, not just to describe the desired end state.
+
+Also count it as a prompt-scoping failure if the fresh AI only inspects the local tab component while the visible no-selection shell actually lives in a surrounding container such as `ClassroomPageClient`.
+Also count it as a prompt-scoping failure if the persistent blank column is owned by route-level layout configuration such as `tests-teacher` in `src/lib/layout-config.ts` and the challenge packet never points the fresh AI there.
+
+Also count it as an execution-packet failure if the prompt names App Router files with bracketed path segments but does not tell the fresh AI to quote those paths in shell commands. In this repo, that causes `zsh` glob failures before implementation even starts.
+
+## Rubric
+
+Score each category from 0 to 2.
+
+| Category | 0 | 1 | 2 |
+| --- | --- | --- | --- |
+| Shell/Layout Parity | Different structural language from assignments | Partially similar, but still noticeably bespoke | Clearly uses the same shell language as assignments |
+| Spacing/Density Parity | Much denser or noisier than assignments | Close in places, but inconsistent | Matches assignment rhythm and breathing room |
+| Empty-State Parity | Extra framing, chrome, or noise | Same intent but heavier than assignments | Same quiet tone as assignments |
+| List-Card Parity | Cards feel unrelated to assignments | Mixed parity | Clearly reads as assignment-family cards |
+| Detail-State Parity | Detail layout appears unrelated or premature | Partially aligned | Detail emerges in the same way assignments do |
+| Action Hierarchy Parity | Controls dominate the page | Action hierarchy is improved but still busy | Same restraint and emphasis as assignments |
+| Status/Copy Parity | Copy or status treatment feels like a different product | Some alignment, some drift | Same terse, product-like tone |
+| Chrome Restraint | New panes, toggles, or placeholders overpower content | Reduced, but still visible drift | Chrome stays subordinate to content |
+
+Maximum score: `16`
+
+### Pass threshold
+
+Pass only if:
+
+- total score is `12` or higher
+- no `0` appears in:
+  - Shell/Layout Parity
+  - Empty-State Parity
+  - List-Card Parity
+  - Action Hierarchy Parity
+
+## Hard Failures
+
+The run fails immediately if any of these appear:
+
+- A default split-pane placeholder state appears before selection without a strong functional reason.
+- A passive browsing state still reserves a visibly empty right column or pane after placeholder content is removed.
+- A student browsing state uses an exam-style split shell before active test-taking has actually started.
+- The empty state is materially noisier than assignments.
+- Controls or mode toggles visually dominate the screen before content.
+- The layout introduces a structural pattern that does not exist in assignments for the analogous state.
+
+## Required Code Review Checks
+
+Before approving a blind-run result, confirm the implementation reuses expected primitives where appropriate:
+
+- `PageLayout`
+- `PageActionBar`
+- `PageContent`
+- `PageStack`
+- `EmptyState`
+- semantic tokens instead of bespoke raw-theme styling
+
+If the screenshots look close but the code invented a new shell or component family, treat that as drift and update the docs/prompt.
+
+## Failure Logging
+
+Every failed run should produce a short note with:
+
+- challenge name
+- screenshot pair reviewed
+- rubric scores
+- hard failures, if any
+- whether the AI actually reached implementation
+- exact drift observed
+- whether the wrong owning component was targeted
+- where the docs were insufficient:
+  - UX system rule missing
+  - prompt instruction missing
+  - primitive checklist missing
+
+## Iteration Rules
+
+Update the **UX spec** when the failure is system-level:
+
+- state progression is unclear
+- split-pane rules are underspecified
+- empty-state tone is underspecified
+- card or shell language is underspecified
+
+Update the **parity prompt** when the failure is execution-level:
+
+- the AI used the wrong files as references
+- the AI invented a new layout even though the spec was clear
+- the AI ignored primitive reuse
+- the AI needed stronger “must not introduce” constraints
+
+Do not call the guidance “working” after one success. Require repeatable passes across the full challenge set.

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -13,6 +13,7 @@ gh issue view <number> --json number,title,body,labels,comments
 3. Read `docs/ai-instructions.md` and load only the task-specific docs it routes you to.
 3. Check `.ai/features.json` for any referenced feature IDs.
 4. If the issue affects UI/UX, read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`.
+5. If the issue affects teacher assignments, teacher quizzes, or teacher tests, also read `docs/guidance/ui/teacher-work-surfaces.md` and `docs/guidance/ui/audit-teacher-work-surfaces.md`.
 
 ## 3) Branch & PR Setup
 - Create or bind a dedicated worktree using `docs/dev-workflow.md`.
@@ -27,6 +28,7 @@ Produce a short plan:
 If the issue affects UI/UX, add a **UI guidance declaration**:
 - guidance read
 - stable guidance followed
+- teacher work-surface canon followed: yes/no/not-applicable
 - experimental guidance introduced: yes/no
 - experimental draft file created or updated, if any
 - human promotion needed: yes/no

--- a/docs/workflow/handle-issue.md
+++ b/docs/workflow/handle-issue.md
@@ -9,17 +9,19 @@ Use the automated command for the full workflow:
 1. `gh issue view <N> --json number,title,body,labels`
 2. Read `.ai/START-HERE.md`, `.ai/CURRENT.md`, and `docs/ai-instructions.md`
 3. If the issue touches UI/UX, also read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`
-4. Draft plan: branch name, files to change, tests to write first, migration needed?
-5. For UI/UX work, include a UI guidance declaration:
+4. If the issue touches teacher assignments, teacher quizzes, or teacher tests, also read `docs/guidance/ui/teacher-work-surfaces.md` and `docs/guidance/ui/audit-teacher-work-surfaces.md`
+5. Draft plan: branch name, files to change, tests to write first, migration needed?
+6. For UI/UX work, include a UI guidance declaration:
    - guidance read
    - stable guidance followed
+   - teacher work-surface canon followed: yes/no/not-applicable
    - experimental guidance introduced: yes/no
    - experimental draft file created/updated, if any
    - human promotion needed: yes/no
-6. **Wait for user approval** before writing any code
-7. Create worktree: `issue/<N>-<slug>` (see `docs/dev-workflow.md`)
-8. Follow TDD: tests first → implement → refactor
-9. Create PR with "Closes #N"
+7. **Wait for user approval** before writing any code
+8. Create worktree: `issue/<N>-<slug>` (see `docs/dev-workflow.md`)
+9. Follow TDD: tests first → implement → refactor
+10. Create PR with "Closes #N"
 
 ## Critical Rules
 

--- a/e2e/verify/assessment-ux-parity.ts
+++ b/e2e/verify/assessment-ux-parity.ts
@@ -1,0 +1,313 @@
+/**
+ * Verification: Assessment UX parity capture
+ *
+ * Captures assignment reference screens and assessment target screens for both
+ * teacher and student roles using a shared classroom. This is a screenshot
+ * collection harness for rubric-driven review, not a visual diff test.
+ */
+import fs from 'fs'
+import path from 'path'
+
+import type { Page } from '@playwright/test'
+
+import type { VerificationCheck, VerificationResult, VerificationScript } from './types'
+
+type ClassroomRecord = {
+  id: string
+  title?: string
+}
+
+type CaptureRoute = {
+  role: 'teacher' | 'student'
+  name: string
+  tab: 'assignments' | 'tests' | 'quizzes'
+  readyTexts: readonly string[]
+  readyButtons?: readonly string[]
+  readySelectors?: readonly string[]
+  readySelector?: string
+}
+
+const ARTIFACT_DIR = path.join(process.cwd(), 'artifacts', 'assessment-ux-parity')
+
+const ROUTES: readonly CaptureRoute[] = [
+  {
+    role: 'teacher' as const,
+    name: 'teacher-assignments-reference',
+    tab: 'assignments',
+    readyTexts: ['No assignments yet', 'Due:', 'Draft', 'Scheduled'],
+    readyButtons: ['New'],
+    readySelectors: ['main h3'],
+  },
+  {
+    role: 'teacher' as const,
+    name: 'teacher-tests-target',
+    tab: 'tests',
+    readyTexts: ['No tests yet'],
+    readyButtons: ['New Test', 'Authoring', 'Grading'],
+    readySelectors: ['main h3'],
+  },
+  {
+    role: 'teacher' as const,
+    name: 'teacher-quizzes-target',
+    tab: 'quizzes',
+    readyTexts: ['No quizzes yet'],
+    readyButtons: ['New Quiz'],
+    readySelectors: ['main h3'],
+  },
+  {
+    role: 'student' as const,
+    name: 'student-assignments-reference',
+    tab: 'assignments',
+    readyTexts: ['No assignments yet', 'When your teacher posts work', 'Unsubmit', 'Returned', 'Graded'],
+    readySelectors: ['[data-testid="assignment-card"]'],
+    readySelector: '[data-testid=\"assignment-card\"]',
+  },
+  {
+    role: 'student' as const,
+    name: 'student-tests-target',
+    tab: 'tests',
+    readyTexts: ['Select a test from the list to view and complete it.', 'No tests available.', 'This test is closed', 'Returned'],
+    readyButtons: ['Start the Test'],
+    readySelectors: ['[data-testid="student-test-split-container"]', 'main button h3'],
+  },
+  {
+    role: 'student' as const,
+    name: 'student-quizzes-target',
+    tab: 'quizzes',
+    readyTexts: ['No quizzes available.', 'View Results', 'Submitted'],
+    readySelectors: ['main button h3'],
+  },
+] as const
+
+async function loadClassrooms(page: Page, apiPath: string): Promise<ClassroomRecord[]> {
+  return page.evaluate(async (pathName) => {
+    const response = await fetch(pathName)
+    if (!response.ok) {
+      throw new Error(`Failed to load ${pathName}: ${response.status}`)
+    }
+    const data = await response.json()
+    return Array.isArray(data.classrooms) ? data.classrooms : []
+  }, apiPath)
+}
+
+function chooseSharedClassroom(
+  teacherClassrooms: ClassroomRecord[],
+  studentClassrooms: ClassroomRecord[],
+): ClassroomRecord | null {
+  const studentIds = new Set(studentClassrooms.map((classroom) => classroom.id))
+  const shared = teacherClassrooms.filter((classroom) => studentIds.has(classroom.id))
+
+  if (shared.length === 0) return null
+
+  const preferred = shared.find((classroom) => classroom.title?.toLowerCase().includes('test classroom'))
+  return preferred || shared[0]
+}
+
+async function waitForReadyState(
+  page: Page,
+  opts: {
+    readyTexts: readonly string[]
+    readyButtons?: readonly string[]
+    readySelectors?: readonly string[]
+  },
+) {
+  const { readyTexts, readyButtons = [], readySelectors = [] } = opts
+
+  await page.waitForFunction(
+    ({ texts, buttons, selectors }) => {
+      for (const selector of selectors) {
+        const elements = Array.from(document.querySelectorAll(selector))
+        for (const element of elements) {
+          if (!(element instanceof HTMLElement)) continue
+          const style = window.getComputedStyle(element)
+          if (style.visibility === 'hidden' || style.display === 'none') continue
+          if (element.getClientRects().length > 0) {
+            return true
+          }
+        }
+      }
+
+      const buttonsOnPage = Array.from(document.querySelectorAll('button'))
+      for (const label of buttons) {
+        for (const button of buttonsOnPage) {
+          if (!(button instanceof HTMLElement)) continue
+          const style = window.getComputedStyle(button)
+          if (style.visibility === 'hidden' || style.display === 'none') continue
+          if (button.getClientRects().length === 0) continue
+          const text = button.textContent?.trim() || ''
+          if (text.includes(label)) {
+            return true
+          }
+        }
+      }
+
+      const bodyText = document.body?.innerText || ''
+      return texts.some((text) => bodyText.includes(text))
+    },
+    {
+      texts: readyTexts,
+      buttons: readyButtons,
+      selectors: readySelectors,
+    },
+    { timeout: 30_000 },
+  )
+}
+
+async function captureScreen(opts: {
+  page: Page
+  baseUrl: string
+  classroomId: string
+  tab: string
+  readyTexts: readonly string[]
+  readyButtons?: readonly string[]
+  readySelectors?: readonly string[]
+  readySelector?: string
+  outputPath: string
+}) {
+  const {
+    page,
+    baseUrl,
+    classroomId,
+    tab,
+    readyTexts,
+    readyButtons,
+    readySelectors,
+    readySelector,
+    outputPath,
+  } = opts
+
+  await page.goto(`${baseUrl}/classrooms/${classroomId}?tab=${tab}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  await page.waitForTimeout(2500)
+  if (readySelector) {
+    const selectorVisible = await page.locator(readySelector).first()
+      .waitFor({ state: 'visible', timeout: 30_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (!selectorVisible) {
+      await waitForReadyState(page, opts)
+    }
+  } else {
+    await waitForReadyState(page, { readyTexts, readyButtons, readySelectors })
+  }
+  await page.screenshot({ path: outputPath, fullPage: true })
+}
+
+export const assessmentUxParity: VerificationScript = {
+  name: 'assessment-ux-parity',
+  description: 'Capture assignment references and assessment targets for teacher/student parity review',
+  role: 'teacher',
+
+  async run(page, baseUrl): Promise<VerificationResult> {
+    const checks: VerificationCheck[] = []
+    const artifacts: string[] = []
+
+    fs.mkdirSync(ARTIFACT_DIR, { recursive: true })
+
+    await page.goto(`${baseUrl}/classrooms`, { waitUntil: 'domcontentloaded' })
+    const browser = page.context().browser()
+    if (!browser) {
+      return {
+        scenario: 'assessment-ux-parity',
+        passed: false,
+        checks,
+        error: 'Browser instance unavailable from verification context.',
+      }
+    }
+
+    const studentAuthPath = path.join(process.cwd(), '.auth', 'student.json')
+    if (!fs.existsSync(studentAuthPath)) {
+      return {
+        scenario: 'assessment-ux-parity',
+        passed: false,
+        checks,
+        error: `Auth state not found: ${studentAuthPath}. Run "pnpm e2e:auth" first.`,
+      }
+    }
+    const studentContext = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      storageState: studentAuthPath,
+    })
+    const studentPage = await studentContext.newPage()
+
+    try {
+      await studentPage.goto(`${baseUrl}/classrooms`, { waitUntil: 'domcontentloaded' })
+
+      const [teacherClassrooms, studentClassrooms] = await Promise.all([
+        loadClassrooms(page, '/api/teacher/classrooms'),
+        loadClassrooms(studentPage, '/api/student/classrooms'),
+      ])
+
+      const sharedClassroom = chooseSharedClassroom(teacherClassrooms, studentClassrooms)
+
+      if (!sharedClassroom) {
+        checks.push({
+          name: 'Shared classroom available',
+          passed: false,
+          message: 'No classroom is visible to both teacher and student. Seed a shared classroom before running parity capture.',
+        })
+        return {
+          scenario: 'assessment-ux-parity',
+          passed: false,
+          checks,
+          artifacts,
+        }
+      }
+
+      checks.push({
+        name: 'Shared classroom available',
+        passed: true,
+        message: `${sharedClassroom.title || 'Shared classroom'} (${sharedClassroom.id})`,
+      })
+
+      for (const route of ROUTES) {
+        const outputPath = path.join(ARTIFACT_DIR, `${route.name}.png`)
+        const targetPage = route.role === 'teacher' ? page : studentPage
+
+        try {
+          await captureScreen({
+            page: targetPage,
+            baseUrl,
+            classroomId: sharedClassroom.id,
+            tab: route.tab,
+            readyTexts: route.readyTexts,
+            readyButtons: route.readyButtons,
+            readySelectors: route.readySelectors,
+            readySelector: route.readySelector,
+            outputPath,
+          })
+        } catch (error) {
+          checks.push({
+            name: `Capture ${route.name}`,
+            passed: false,
+            message: error instanceof Error ? error.message : String(error),
+          })
+          return {
+            scenario: 'assessment-ux-parity',
+            passed: false,
+            checks,
+            artifacts,
+            error: `Failed while capturing ${route.name}.`,
+          }
+        }
+
+        artifacts.push(outputPath)
+        checks.push({
+          name: `Capture ${route.name}`,
+          passed: true,
+          message: outputPath,
+        })
+      }
+
+      return {
+        scenario: 'assessment-ux-parity',
+        passed: checks.every((check) => check.passed),
+        checks,
+        artifacts,
+      }
+    } finally {
+      await studentContext.close()
+    }
+  },
+}

--- a/e2e/verify/run.ts
+++ b/e2e/verify/run.ts
@@ -15,10 +15,12 @@ import type { VerificationResult, VerificationScript } from './types'
 
 // Import scenarios
 import { addStudentsModal } from './add-students-modal'
+import { assessmentUxParity } from './assessment-ux-parity'
 import { createClassroomWizard } from './create-classroom-wizard'
 
 const scenarios: Record<string, VerificationScript> = {
   'add-students-modal': addStudentsModal,
+  'assessment-ux-parity': assessmentUxParity,
   'create-classroom-wizard': createClassroomWizard,
 }
 

--- a/e2e/verify/types.ts
+++ b/e2e/verify/types.ts
@@ -22,6 +22,7 @@ export interface VerificationResult {
   passed: boolean
   checks: VerificationCheck[]
   error?: string
+  artifacts?: string[]
 }
 
 export interface VerificationScript {

--- a/scripts/run-teacher-tests-parity-challenge.sh
+++ b/scripts/run-teacher-tests-parity-challenge.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKTREE="${PIKA_WORKTREE:-$(pwd)}"
+HUB="${HOME}/Repos/pika"
+MODEL="gpt-5.4"
+REFRESH_AUTH=0
+SKIP_PRECAPTURE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)
+      MODEL="${2:?missing value for --model}"
+      shift 2
+      ;;
+    --refresh-auth)
+      REFRESH_AUTH=1
+      shift
+      ;;
+    --skip-precapture)
+      SKIP_PRECAPTURE=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--model <model>] [--refresh-auth] [--skip-precapture]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$WORKTREE" ]]; then
+  echo "Worktree does not exist: $WORKTREE" >&2
+  exit 1
+fi
+
+if [[ "$WORKTREE" == "$HUB" ]]; then
+  echo "Refusing to run in the hub checkout: $HUB" >&2
+  exit 1
+fi
+
+if ! git -C "$WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a git worktree: $WORKTREE" >&2
+  exit 1
+fi
+
+ARTIFACT_DIR="$WORKTREE/artifacts/assessment-ux-parity"
+PROMPT_PATH="$WORKTREE/.codex/prompts/teacher-tests-ux-parity.md"
+REFERENCE_IMAGE="$ARTIFACT_DIR/teacher-assignments-reference.png"
+TARGET_IMAGE="$ARTIFACT_DIR/teacher-tests-target.png"
+BEFORE_IMAGE="$ARTIFACT_DIR/teacher-tests-target-before-challenge.png"
+PROMPT_COPY="$ARTIFACT_DIR/teacher-tests-challenge-prompt.txt"
+LAST_MESSAGE="$ARTIFACT_DIR/teacher-tests-challenge-last.txt"
+
+mkdir -p "$ARTIFACT_DIR"
+
+if [[ $REFRESH_AUTH -eq 1 ]]; then
+  echo "Refreshing Playwright auth state..."
+  (
+    cd "$WORKTREE"
+    pnpm e2e:auth
+  )
+fi
+
+if [[ $SKIP_PRECAPTURE -eq 0 ]]; then
+  echo "Capturing current parity references and targets..."
+  (
+    cd "$WORKTREE"
+    pnpm e2e:verify assessment-ux-parity
+  )
+fi
+
+if [[ ! -f "$REFERENCE_IMAGE" ]]; then
+  echo "Missing reference image: $REFERENCE_IMAGE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TARGET_IMAGE" ]]; then
+  echo "Missing target image: $TARGET_IMAGE" >&2
+  exit 1
+fi
+
+cp "$TARGET_IMAGE" "$BEFORE_IMAGE"
+
+cat >"$PROMPT_COPY" <<EOF
+Fresh-context parity rerun.
+
+The environment is already verified and the dev server is already running.
+This is a task-scoped blind run. Do not widen the task into a repo audit or startup ritual beyond what the prompt itself requires.
+If you use shell commands on App Router files with \`[classroomId]\` in the path, quote the path exactly so \`zsh\` does not treat it as a glob.
+
+Use the attached screenshots as visual references:
+- attached image 1: current teacher assignments reference
+- attached image 2: current teacher tests target before your changes
+
+Read and follow this prompt exactly:
+
+$(<"$PROMPT_PATH")
+EOF
+
+echo "Running scoped teacher-tests parity challenge with model $MODEL..."
+(
+  cd "$WORKTREE"
+  env PIKA_WORKTREE="$WORKTREE" codex exec \
+    --ephemeral \
+    --full-auto \
+    -m "$MODEL" \
+    -C "$WORKTREE" \
+    -i "$REFERENCE_IMAGE" \
+    -i "$BEFORE_IMAGE" \
+    -o "$LAST_MESSAGE" \
+    - <"$PROMPT_COPY"
+)
+
+echo "Re-capturing parity screenshots after the challenge..."
+(
+  cd "$WORKTREE"
+  pnpm e2e:verify assessment-ux-parity
+)
+
+printf '\nArtifacts:\n'
+printf '  Reference: %s\n' "$REFERENCE_IMAGE"
+printf '  Before:    %s\n' "$BEFORE_IMAGE"
+printf '  After:     %s\n' "$TARGET_IMAGE"
+printf '  Prompt:    %s\n' "$PROMPT_COPY"
+printf '  Summary:   %s\n' "$LAST_MESSAGE"

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -689,6 +689,21 @@ function ClassroomPageContent({
   ])
 
   useEffect(() => {
+    if (!isTeacher || activeTab !== 'tests') return
+    if (testGradingContext.mode === 'grading') return
+    if (selectedQuiz) return
+    setRightSidebarOpen(false)
+    closeMobileDrawer()
+  }, [
+    activeTab,
+    closeMobileDrawer,
+    isTeacher,
+    selectedQuiz,
+    setRightSidebarOpen,
+    testGradingContext.mode,
+  ])
+
+  useEffect(() => {
     if (activeTab === 'roster') {
       setRightSidebarOpen(false)
     }
@@ -1327,7 +1342,9 @@ function ClassroomPageContent({
                   : undefined
               }
             />
-          ) : isTeacher && isAssessmentTab ? (
+          ) : isTeacher &&
+            activeTab === 'tests' &&
+            testGradingContext.mode === 'authoring' ? null : isTeacher && isAssessmentTab ? (
             <div className="flex h-full min-h-0 items-center p-4">
               <EmptyState
                 title={`Select a ${assessmentLabel}`}

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronLeft, ClockAlert, LogOut, Maximize } from 'lucide-react'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import { Spinner } from '@/components/Spinner'
-import { PageContent, PageLayout } from '@/components/PageLayout'
+import { PageContent, PageLayout, PageStack } from '@/components/PageLayout'
 import {
   getQuizExitCount,
   getQuizStatusBadgeClass,
@@ -12,7 +12,7 @@ import {
 } from '@/lib/quizzes'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
 import { StudentQuizResults } from '@/components/StudentQuizResults'
-import { Button, ConfirmDialog } from '@/ui'
+import { Button, ConfirmDialog, EmptyState } from '@/ui'
 import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
@@ -717,7 +717,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     }
 
     return (
-      <div className="space-y-3">
+      <PageStack>
         {quizzes.map((quiz) => {
           const isSelected = selectedQuizId === quiz.id
 
@@ -728,30 +728,37 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
               onClick={() => {
                 void handleSelectQuiz(quiz.id)
               }}
-              className={`w-full rounded-lg border p-4 text-left transition-colors ${
+              className={`block w-full rounded-card border px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] ${
                 showSelectionState && isSelected
-                  ? 'border-primary ring-1 ring-primary/40'
-                  : 'border-border bg-surface hover:bg-surface-hover'
+                  ? 'border-primary bg-surface-accent ring-1 ring-primary/25 shadow-panel'
+                  : 'border-border bg-surface-panel hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel'
               }`}
             >
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium text-text-default">{quiz.title}</h3>
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <h3 className="truncate text-base font-semibold text-text-default">{quiz.title}</h3>
+                  {quiz.status === 'closed' && (
+                    <p className="mt-1 text-sm text-text-muted">
+                      This {isTestsView ? 'test' : 'quiz'} is closed
+                    </p>
+                  )}
+                </div>
                 {isTestsView ? (
                   <>
                     {quiz.student_status === 'can_view_results' ? (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
+                      <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-info">
                         Returned
                       </span>
                     ) : quiz.status === 'closed' ? (
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('closed')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('closed')}`}>
                         Closed
                       </span>
                     ) : quiz.student_status === 'responded' ? (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                      <span className="rounded-badge bg-surface-2 px-2.5 py-1 text-xs font-semibold text-text-muted">
                         Submitted
                       </span>
                     ) : (
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('active')}`}>
                         New
                       </span>
                     )}
@@ -759,32 +766,27 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                 ) : (
                   <>
                     {quiz.student_status === 'not_started' && (
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${getQuizStatusBadgeClass('active')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('active')}`}>
                         New
                       </span>
                     )}
                     {quiz.student_status === 'responded' && (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                      <span className="rounded-badge bg-surface-2 px-2.5 py-1 text-xs font-semibold text-text-muted">
                         Submitted
                       </span>
                     )}
                     {quiz.student_status === 'can_view_results' && (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-info-bg text-info">
+                      <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-info">
                         View Results
                       </span>
                     )}
                   </>
                 )}
               </div>
-              {quiz.status === 'closed' && (
-                <p className="text-xs text-text-muted mt-1">
-                  This {isTestsView ? 'test' : 'quiz'} is closed
-                </p>
-              )}
             </button>
           )
         })}
-      </div>
+      </PageStack>
     )
   }
 
@@ -806,12 +808,17 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const awayCount = focusSummary?.away_count ?? 0
     const routeExitAttempts = focusSummary?.route_exit_attempts ?? 0
     const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
-    const showNotMaximizedWarning = hasSelectedQuiz && focusEnabled && !isFullscreen
+    const showNotMaximizedWarning = showCurrentTestInfoPanel && !isFullscreen
     const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
     const selectedTestTitle = hasSelectedQuiz ? selectedQuiz.quiz.title : ''
     const selectedTestPanelTitle = isViewingResults
       ? `${selectedTestTitle} Results`
       : selectedTestTitle
+    const showSplitExamShell =
+      hasSelectedQuiz &&
+      !requiresStart &&
+      !hasResponded &&
+      showCurrentTestInfoPanel
 
     return (
       <PageLayout className="relative h-full flex flex-col">
@@ -856,18 +863,19 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
           </div>
         )}
 
-        <PageContent className="flex-1 min-h-0 px-0 pt-1">
-          <div className="mx-auto h-full w-full max-w-none">
-            <div
-              data-testid="student-test-split-container"
-              className={`grid grid-cols-1 gap-2 ${
-                showDocPanel
-                  ? 'lg:grid-cols-[50%_50%]'
-                  : showCurrentTestInfoPanel || isViewingResults
-                    ? 'lg:grid-cols-[30%_70%]'
-                    : 'lg:grid-cols-[50%_50%]'
-              } lg:h-full lg:min-h-0 lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
-            >
+        <PageContent className={showSplitExamShell ? 'flex-1 min-h-0 px-0 pt-1' : 'flex-1 min-h-0'}>
+          <div
+            className={`mx-auto h-full w-full ${
+              showSplitExamShell || !hasSelectedQuiz ? 'max-w-none' : 'max-w-3xl'
+            }`}
+          >
+            {showSplitExamShell ? (
+              <div
+                data-testid="student-test-split-container"
+                className={`grid grid-cols-1 gap-2 ${
+                  showDocPanel ? 'lg:grid-cols-[50%_50%]' : 'lg:grid-cols-[30%_70%]'
+                } lg:h-full lg:min-h-0 lg:transition-[grid-template-columns] lg:duration-500 lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:[will-change:grid-template-columns] motion-reduce:transition-none`}
+              >
               <section
                 className={`rounded-xl border border-border bg-surface ${
                   showCurrentTestInfoPanel
@@ -1108,7 +1116,116 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                   </div>
                 )}
               </section>
-            </div>
+              </div>
+            ) : !hasSelectedQuiz ? (
+              quizzes.length === 0 ? (
+                <EmptyState
+                  title="No tests available."
+                  description="When your teacher publishes a test, it will show up here."
+                />
+              ) : (
+                <div className="min-w-0 h-full flex flex-col max-w-none">
+                  {renderAssessmentList(false)}
+                </div>
+              )
+            ) : selectedQuizId && loadingQuiz ? (
+              <div className="flex justify-center py-12">
+                <Spinner size="lg" />
+              </div>
+            ) : (
+              <div className="min-w-0">
+                <button
+                  type="button"
+                  onClick={handleBack}
+                  className="mb-4 flex items-center gap-1 text-sm text-text-muted hover:text-text-default"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Back to tests
+                </button>
+
+                <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 className="truncate text-xl font-bold text-text-default">
+                      {selectedTestPanelTitle}
+                    </h2>
+                    {allowedDocs.length > 0 && requiresStart ? (
+                      <p className="mt-1 text-sm text-text-muted">
+                        {allowedDocs.length} reference document{allowedDocs.length === 1 ? '' : 's'} will be available during the test.
+                      </p>
+                    ) : null}
+                  </div>
+                  <span
+                    className={[
+                      'rounded-badge px-2.5 py-1 text-xs font-semibold',
+                      selectedQuiz?.quiz.student_status === 'can_view_results'
+                        ? 'bg-info-bg text-info'
+                        : selectedQuiz?.quiz.student_status === 'responded'
+                          ? 'bg-surface-2 text-text-muted'
+                          : selectedQuiz?.quiz.status === 'closed'
+                            ? getQuizStatusBadgeClass('closed')
+                            : getQuizStatusBadgeClass('active'),
+                    ].join(' ')}
+                  >
+                    {selectedQuiz?.quiz.student_status === 'can_view_results'
+                      ? 'Returned'
+                      : selectedQuiz?.quiz.student_status === 'responded'
+                        ? 'Submitted'
+                        : selectedQuiz?.quiz.status === 'closed'
+                          ? 'Closed'
+                          : 'New'}
+                  </span>
+                </div>
+
+                {requiresStart ? (
+                  <div className="rounded-card border border-border bg-surface-panel p-5 shadow-elevated">
+                    <p className="text-sm text-text-muted">
+                      Review the test details, then start when you are ready.
+                    </p>
+                    <div className="mt-4">
+                      <Button
+                        type="button"
+                        className="w-full sm:w-auto"
+                        onClick={() => handleRequestStartTest(selectedQuiz.quiz.id)}
+                      >
+                        Start the Test
+                      </Button>
+                    </div>
+                  </div>
+                ) : hasResponded && selectedQuiz.quiz.student_status === 'can_view_results' ? (
+                  <StudentQuizResults
+                    quizId={selectedQuizId!}
+                    myResponses={selectedQuiz.studentResponses}
+                    assessmentType={assessmentType}
+                    apiBasePath={apiBasePath}
+                    showSubmissionBanner={false}
+                  />
+                ) : hasResponded ? (
+                  <div className="rounded-card border border-success bg-success-bg p-5 text-center shadow-elevated">
+                    <p className="font-medium text-success">Response Submitted</p>
+                    {selectedQuiz.quiz.status !== 'closed' ? (
+                      <p className="mt-1 text-sm text-text-muted">
+                        Results will be available after this test is closed and returned by your teacher.
+                      </p>
+                    ) : (
+                      <p className="mt-1 text-sm text-text-muted">
+                        Results will be available after your teacher returns this test.
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <StudentQuizForm
+                    quizId={selectedQuizId!}
+                    questions={selectedQuiz.questions}
+                    initialResponses={selectedQuiz.studentResponses}
+                    enableDraftAutosave
+                    isInteractionLocked={showNotMaximizedWarning}
+                    assessmentType={assessmentType}
+                    apiBasePath={apiBasePath}
+                    onSubmitted={handleQuizSubmitted}
+                  />
+                )}
+              </div>
+            )}
           </div>
         </PageContent>
 

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1166,14 +1166,14 @@ export function TeacherClassroomView({
       </button>
     ) : (
       <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
-        <div className="inline-flex items-center rounded-lg border border-border bg-surface-2 p-0.5">
+        <div className="mb-[-1px] flex items-end gap-1 self-end">
           <button
             type="button"
             className={[
               assignmentWorkspaceMode === 'overview'
-                ? 'bg-surface text-text-default shadow-sm'
-                : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
-              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+                : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+              'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('overview')}
             aria-pressed={assignmentWorkspaceMode === 'overview'}
@@ -1184,10 +1184,10 @@ export function TeacherClassroomView({
             type="button"
             className={[
               assignmentWorkspaceMode === 'details'
-                ? 'bg-surface text-text-default shadow-sm'
-                : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
-              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-text-muted' : '',
-              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+                : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-surface-2 hover:text-text-muted' : '',
+              'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('details')}
             aria-pressed={assignmentWorkspaceMode === 'details'}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -38,6 +38,7 @@ import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import {
+  ACTIONBAR_ICON_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
   ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
   PageActionBar,
@@ -222,6 +223,12 @@ function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLat
   return baseLabel
 }
 
+function getStudentDisplayName(row: StudentSubmissionRow | null): string | null {
+  if (!row) return null
+  const fullName = [row.student_first_name, row.student_last_name].filter(Boolean).join(' ').trim()
+  return fullName || row.student_email || null
+}
+
 export function TeacherClassroomView({
   classroom,
   onSelectAssignment,
@@ -266,6 +273,10 @@ export function TeacherClassroomView({
   const [pendingDelete, setPendingDelete] = useState<{ id: string; title: string } | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const [individualHeaderMeta, setIndividualHeaderMeta] = useState<{
+    studentName: string
+    characterCount: number
+  } | null>(null)
   const [assignmentWorkspaceMode, setAssignmentWorkspaceMode] =
     useState<AssignmentWorkspaceMode>('overview')
   const [editAssignment, setEditAssignment] = useState<Assignment | null>(null)
@@ -791,9 +802,11 @@ export function TeacherClassroomView({
 
     if (nextMode === 'details') {
       const nextStudentId = resolveDetailsStudentId()
-      if (nextStudentId) {
-        setSelectedStudentId(nextStudentId)
-      }
+      if (!nextStudentId) return
+      setIndividualHeaderMeta(null)
+      setSelectedStudentId(nextStudentId)
+    } else {
+      setIndividualHeaderMeta(null)
     }
 
     updateModeLayout(nextMode, assignmentGradingLayout[assignmentWorkspaceMode])
@@ -844,6 +857,16 @@ export function TeacherClassroomView({
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [assignmentWorkspaceMode, selectedStudentId])
+
+  useEffect(() => {
+    if (selection.mode !== 'assignment') {
+      setIndividualHeaderMeta(null)
+    }
+  }, [selection.mode])
+
+  useEffect(() => {
+    setIndividualHeaderMeta(null)
+  }, [selectedAssignmentKey])
 
   // Apply sidebar grade saves to the current row without forcing a table reload.
   useEffect(() => {
@@ -915,6 +938,14 @@ export function TeacherClassroomView({
     activeSelectedAssignmentData?.assignment.title ??
     selectedAssignmentSummary?.title ??
     'Assignment'
+  const selectedStudentDisplayName =
+    individualHeaderMeta?.studentName ?? getStudentDisplayName(selectedStudentRow)
+  const individualCharacterCountLabel =
+    selectedStudentDisplayName
+      ? individualHeaderMeta
+        ? `${individualHeaderMeta.characterCount} chars`
+        : 'Loading…'
+      : null
   const activeWorkspaceLayout = assignmentGradingLayout[assignmentWorkspaceMode]
   const showOverviewInspector =
     assignmentWorkspaceMode === 'overview' &&
@@ -960,65 +991,6 @@ export function TeacherClassroomView({
 
   const studentTable = (
     <div className="flex h-full min-h-0 flex-col">
-      {assignmentWorkspaceMode === 'overview' && (
-        <div className="border-b border-border bg-surface px-3 py-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
-              <SplitButton
-                label={
-                  <span className="inline-flex items-center gap-2">
-                    <Check className="h-4 w-4" aria-hidden="true" />
-                    <span>AI Grade</span>
-                  </span>
-                }
-                onPrimaryClick={() => {
-                  void handleBatchAutoGrade()
-                }}
-                options={[
-                  {
-                    id: 'repo-analysis',
-                    label: (
-                      <span className="inline-flex items-center gap-2">
-                        <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                        <span>Repo analysis</span>
-                      </span>
-                    ),
-                    onSelect: () => {
-                      void handleBatchArtifactRepoAnalyze()
-                    },
-                    disabled: isArtifactRepoAnalyzing || isReadOnly || batchSelectedCount === 0,
-                  },
-                ]}
-                disabled={isAutoGrading || isReadOnly || batchSelectedCount === 0}
-                className="inline-flex"
-                toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
-                menuPlacement="down"
-                primaryButtonProps={{
-                  'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-                }}
-              />
-            </Tooltip>
-
-            <Tooltip content={`Send${workspaceActionLabelSuffix}`}>
-              <Button
-                type="button"
-                variant="subtle"
-                size="sm"
-                className="px-4"
-                onClick={() => {
-                  setShowReturnConfirm(true)
-                }}
-                disabled={isReturning || isReadOnly || batchSelectedCount === 0}
-                aria-label={`Send${workspaceActionLabelSuffix}`}
-              >
-                <Send className="h-4 w-4" aria-hidden="true" />
-                <span>Send</span>
-              </Button>
-            </Tooltip>
-          </div>
-        </div>
-      )}
-
       <KeyboardNavigableTable
         ref={tableContainerRef}
         rowKeys={currentStudentRows.map((student) => student.student_id)}
@@ -1115,8 +1087,10 @@ export function TeacherClassroomView({
                         key={student.student_id}
                         className={getRowClassName(isSelected)}
                         onClick={() => {
-                          setSelectedStudentId(isSelected ? null : student.student_id)
-                          setAssignmentWorkspaceMode('overview')
+                          if (assignmentWorkspaceMode === 'details') {
+                            setIndividualHeaderMeta(null)
+                          }
+                          setSelectedStudentId(student.student_id)
                         }}
                       >
                         <DataTableCell>
@@ -1191,15 +1165,15 @@ export function TeacherClassroomView({
         <span>New</span>
       </button>
     ) : (
-      <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2 sm:min-h-[2.75rem]">
-        <div className="mb-[-1px] flex border-b border-border self-end">
+      <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
+        <div className="inline-flex items-center rounded-lg border border-border bg-surface-2 p-0.5">
           <button
             type="button"
             className={[
               assignmentWorkspaceMode === 'overview'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:border-border hover:text-text-default',
-              'border-b-2 -mb-px px-4 py-2 text-sm font-medium transition-colors',
+                ? 'bg-surface text-text-default shadow-sm'
+                : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('overview')}
             aria-pressed={assignmentWorkspaceMode === 'overview'}
@@ -1210,10 +1184,10 @@ export function TeacherClassroomView({
             type="button"
             className={[
               assignmentWorkspaceMode === 'details'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:border-border hover:text-text-default',
-              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:border-transparent hover:text-text-muted' : '',
-              'border-b-2 -mb-px px-4 py-2 text-sm font-medium transition-colors',
+                ? 'bg-surface text-text-default shadow-sm'
+                : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
+              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-text-muted' : '',
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
             ].join(' ')}
             onClick={() => handleSwitchWorkspaceMode('details')}
             aria-pressed={assignmentWorkspaceMode === 'details'}
@@ -1223,13 +1197,106 @@ export function TeacherClassroomView({
           </button>
         </div>
 
-        <div className="flex min-w-0 flex-1 items-center gap-3 self-center">
-          {workspaceLoading && (
-            <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
-              <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-              <span>Updating</span>
-            </div>
-          )}
+        <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
+          <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
+            {assignmentWorkspaceMode === 'overview' ? (
+              <>
+                <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
+                  <SplitButton
+                    label={
+                      <span className="inline-flex items-center gap-2">
+                        <Check className="h-4 w-4" aria-hidden="true" />
+                        <span>AI Grade</span>
+                      </span>
+                    }
+                    onPrimaryClick={() => {
+                      void handleBatchAutoGrade()
+                    }}
+                    options={[
+                      {
+                        id: 'repo-analysis',
+                        label: (
+                          <span className="inline-flex items-center gap-2">
+                            <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                            <span>Repo analysis</span>
+                          </span>
+                        ),
+                        onSelect: () => {
+                          void handleBatchArtifactRepoAnalyze()
+                        },
+                        disabled: isArtifactRepoAnalyzing || isReadOnly || batchSelectedCount === 0,
+                      },
+                    ]}
+                    disabled={isAutoGrading || isReadOnly || batchSelectedCount === 0}
+                    className="inline-flex"
+                    toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+                    menuPlacement="down"
+                    primaryButtonProps={{
+                      'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+                    }}
+                  />
+                </Tooltip>
+
+                <Tooltip content={`Send${workspaceActionLabelSuffix}`}>
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    className="px-4"
+                    onClick={() => {
+                      setShowReturnConfirm(true)
+                    }}
+                    disabled={isReturning || isReadOnly || batchSelectedCount === 0}
+                    aria-label={`Send${workspaceActionLabelSuffix}`}
+                  >
+                    <Send className="h-4 w-4" aria-hidden="true" />
+                    <span>Send</span>
+                  </Button>
+                </Tooltip>
+              </>
+            ) : (
+              <>
+                <div
+                  className="min-w-0 max-w-[18rem] truncate text-center text-sm font-medium text-text-default"
+                  title={selectedStudentDisplayName ?? undefined}
+                >
+                  {selectedStudentDisplayName ?? 'No student selected'}
+                </div>
+                {individualCharacterCountLabel && (
+                  <div className="shrink-0 text-xs text-text-muted" aria-label={individualCharacterCountLabel}>
+                    {individualCharacterCountLabel}
+                  </div>
+                )}
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                    onClick={handleGoPrevStudent}
+                    disabled={!canGoPrevStudent}
+                    aria-label="Previous student"
+                  >
+                    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+                    onClick={handleGoNextStudent}
+                    disabled={!canGoNextStudent}
+                    aria-label="Next student"
+                  >
+                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </div>
+              </>
+            )}
+
+            {workspaceLoading && (
+              <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
+                <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                <span>Updating</span>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-1 sm:ml-auto sm:gap-2">
@@ -1348,6 +1415,7 @@ export function TeacherClassroomView({
                     onGoNextStudent={handleGoNextStudent}
                     canGoPrevStudent={canGoPrevStudent}
                     canGoNextStudent={canGoNextStudent}
+                    onDetailsMetaChange={setIndividualHeaderMeta}
                   />
                 ) : selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError) ? (
                   <div className="flex flex-1 items-center justify-center py-12">

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Check, Circle, ClockAlert, LogOut, Plus, Send } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
-import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
-import { Button, ConfirmDialog, DialogPanel, FormField, Select, Tooltip } from '@/ui'
+import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
 import { useRightSidebar } from '@/components/layout'
 import {
   TEACHER_QUIZZES_UPDATED_EVENT,
@@ -641,120 +641,127 @@ export function TeacherQuizzesTab({
     }
   }
   const batchGradeDescription = batchGradeDescriptionParts.join(' ')
+  const testsModeToggle = isTestsView ? (
+    <div className="inline-flex items-center rounded-md border border-border bg-surface p-0.5 shadow-sm">
+      <button
+        type="button"
+        onClick={() => {
+          setTestsMode('authoring')
+          setSelectedQuizId(null)
+          setRightSidebarOpen(false)
+        }}
+        className={[
+          'rounded px-2.5 py-1 text-xs font-medium transition-colors sm:px-3 sm:py-1.5 sm:text-sm',
+          testsMode === 'authoring'
+            ? 'bg-surface-panel text-text-default shadow-sm'
+            : 'text-text-muted hover:text-text-default',
+        ].join(' ')}
+        aria-pressed={testsMode === 'authoring'}
+      >
+        Authoring
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setTestsMode('grading')
+          setRightSidebarOpen(true)
+        }}
+        className={[
+          'rounded px-2.5 py-1 text-xs font-medium transition-colors sm:px-3 sm:py-1.5 sm:text-sm',
+          testsMode === 'grading'
+            ? 'bg-surface-panel text-text-default shadow-sm'
+            : 'text-text-muted hover:text-text-default',
+        ].join(' ')}
+        aria-pressed={testsMode === 'grading'}
+      >
+        Grading
+      </button>
+    </div>
+  ) : null
 
   return (
-    <PageLayout>
+    <PageLayout className="flex h-full min-h-0 flex-col">
       <PageActionBar
         primary={
-          <div className="w-full flex flex-wrap items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              {!isReadOnly && (!isTestsView || testsMode === 'authoring') && (
-                <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5">
-                  <Plus className="h-4 w-4" />
-                  {isTestsView ? 'New Test' : 'New Quiz'}
-                </Button>
-              )}
-              {isTestsView && testsMode === 'grading' ? (
-                <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm">
-                  <span className="font-medium text-text-default">{selectedTestTitle}</span>
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            {isTestsView && testsMode === 'grading' ? (
+              <>
+                <div className="min-w-0 rounded-md border border-border bg-surface px-3 py-2 text-sm">
+                  <span className="block truncate font-medium text-text-default">{selectedTestTitle}</span>
                 </div>
-              ) : null}
-              {isTestsView && testsMode === 'grading' && !isReadOnly ? (
-                <>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      if (batchSelectedCount === 0) {
-                        setGradingWarning('Select students to grade')
-                        return
-                      }
-                      setShowBatchGradeModal(true)
-                    }}
-                    className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
-                    aria-label={batchSelectedCount > 0 ? `Grade ${batchSelectedCount} selected` : 'Grade selected students'}
-                    disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-                  >
-                    <Check className="h-4 w-4 text-primary" />
-                  </Button>
-                  <Tooltip
-                    content={
-                      batchSelectedCount > 0
-                        ? `Return (${batchSelectedCount})`
-                        : 'Select students to return'
-                    }
-                  >
+                {!isReadOnly ? (
+                  <>
                     <Button
                       type="button"
                       variant="secondary"
                       size="sm"
-                      className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
-                      aria-label={batchSelectedCount > 0 ? `Return ${batchSelectedCount} selected tests` : 'Return selected tests'}
-                      disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
                       onClick={() => {
                         if (batchSelectedCount === 0) {
-                          setGradingWarning('Select students to return')
+                          setGradingWarning('Select students to grade')
                           return
                         }
-                        setShowReturnConfirm(true)
+                        setShowBatchGradeModal(true)
                       }}
+                      className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
+                      aria-label={batchSelectedCount > 0 ? `Grade ${batchSelectedCount} selected` : 'Grade selected students'}
+                      disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
                     >
-                      <Send className="h-4 w-4 text-primary" />
+                      <Check className="h-4 w-4 text-primary" />
                     </Button>
-                  </Tooltip>
-                </>
-              ) : null}
-            </div>
-
-            {isTestsView ? (
-              <div className="inline-flex rounded-md border border-border bg-surface p-0.5 ml-auto">
-                <button
-                  type="button"
-                  onClick={() => setTestsMode('authoring')}
-                  className={[
-                    'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-                    testsMode === 'authoring'
-                      ? 'bg-primary text-text-inverse'
-                      : 'text-text-muted hover:text-text-default',
-                  ].join(' ')}
-                >
-                  Authoring
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setTestsMode('grading')
-                    setRightSidebarOpen(true)
-                  }}
-                  className={[
-                    'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-                    testsMode === 'grading'
-                      ? 'bg-primary text-text-inverse'
-                      : 'text-text-muted hover:text-text-default',
-                  ].join(' ')}
-                >
-                  Grading
-                </button>
-              </div>
-            ) : null}
+                    <Tooltip
+                      content={
+                        batchSelectedCount > 0
+                          ? `Return (${batchSelectedCount})`
+                          : 'Select students to return'
+                      }
+                    >
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
+                        aria-label={batchSelectedCount > 0 ? `Return ${batchSelectedCount} selected tests` : 'Return selected tests'}
+                        disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
+                        onClick={() => {
+                          if (batchSelectedCount === 0) {
+                            setGradingWarning('Select students to return')
+                            return
+                          }
+                          setShowReturnConfirm(true)
+                        }}
+                      >
+                        <Send className="h-4 w-4 text-primary" />
+                      </Button>
+                    </Tooltip>
+                  </>
+                ) : null}
+              </>
+            ) : (
+              !isReadOnly && (!isTestsView || testsMode === 'authoring') && (
+                <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5 shadow-sm">
+                  <Plus className="h-4 w-4" />
+                  {isTestsView ? 'New Test' : 'New Quiz'}
+                </Button>
+              )
+            )}
           </div>
         }
+        trailing={testsModeToggle}
       />
 
-      <PageContent>
+      <PageContent className="flex min-h-0 flex-1 flex-col gap-3">
         {gradingError && isTestsView && testsMode === 'grading' && (
-          <div className="mb-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {gradingError}
           </div>
         )}
         {gradingWarning && isTestsView && testsMode === 'grading' && (
-          <div className="mb-3 rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
             {gradingWarning}
           </div>
         )}
         {gradingInfo && isTestsView && testsMode === 'grading' && (
-          <div className="mb-3 rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
+          <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
             {gradingInfo}
           </div>
         )}
@@ -764,9 +771,12 @@ export function TeacherQuizzesTab({
             <Spinner size="lg" />
           </div>
         ) : quizzes.length === 0 ? (
-          <p className="text-text-muted text-center py-8">
-            No {assessmentLabelPlural.toLowerCase()} yet. Create one to get started.
-          </p>
+          <EmptyState
+            title={`No ${assessmentLabelPlural.toLowerCase()} yet`}
+            description={`Create a ${isTestsView ? 'test' : 'quiz'} to get started.`}
+            tone="muted"
+            className="mx-auto w-full max-w-3xl"
+          />
         ) : isTestsView && testsMode === 'grading' ? (
           <div className="space-y-3">
             {gradingLoading ? (
@@ -953,7 +963,7 @@ export function TeacherQuizzesTab({
             )}
           </div>
         ) : (
-          <div className="space-y-3">
+          <PageStack className="mx-auto w-full max-w-6xl">
             {quizzes.map((quiz) => (
               <QuizCard
                 key={quiz.id}
@@ -965,7 +975,7 @@ export function TeacherQuizzesTab({
                 onQuizUpdate={loadQuizzes}
               />
             ))}
-          </div>
+          </PageStack>
         )}
       </PageContent>
 

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -227,8 +227,7 @@ export function QuizCard({
                 : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
         ].join(' ')}
       >
-        <div className="grid grid-cols-[1fr_auto] items-center gap-3">
-          {/* Left: Title, response stats, status badge */}
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
           <button
             type="button"
             onClick={onSelect}
@@ -240,16 +239,11 @@ export function QuizCard({
             ].join(' ')}>
               {quiz.title}
             </h3>
-            <div className="mt-0.5 flex items-center gap-2 text-xs text-text-muted">
-              <span>{quiz.stats.responded}/{quiz.stats.total_students} responded</span>
-              <span
-                className={`inline-flex shrink-0 items-center rounded-badge px-2.5 py-1 text-xs font-semibold ${statusBadgeClass}`}
-              >
-                {statusLabel}
-              </span>
-            </div>
-            {isScheduled && quiz.opens_at && (
-              <p className="text-xs text-warning mt-0.5">
+            <p className="mt-0.5 text-xs text-text-muted">
+              {quiz.stats.responded}/{quiz.stats.total_students} responded
+            </p>
+            {isScheduled && quiz.opens_at ? (
+              <p className="mt-0.5 text-xs text-warning">
                 Opens {new Date(quiz.opens_at).toLocaleString('en-US', {
                   timeZone: 'America/Toronto',
                   month: 'short',
@@ -258,17 +252,28 @@ export function QuizCard({
                   minute: '2-digit',
                 })}
               </p>
-            )}
-            {actionError && (
+            ) : null}
+            {actionError ? (
               <p className="mt-1 text-xs text-danger" role="alert">
                 {actionError}
               </p>
-            )}
+            ) : null}
           </button>
 
-          {/* Right: Action buttons */}
-          <div className="relative flex items-center gap-1">
-            {/* Status action */}
+          <div className="flex items-center gap-2 sm:flex-col sm:items-center sm:justify-center sm:px-4 sm:text-center">
+            <span
+              className={`inline-flex shrink-0 items-center rounded-badge px-2.5 py-1 text-xs font-semibold ${statusBadgeClass}`}
+            >
+              {statusLabel}
+            </span>
+            {!isDraft && !isScheduled ? (
+              <span className="text-sm text-text-muted">
+                {quiz.stats.responded}/{quiz.stats.total_students}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="relative col-span-2 flex items-center justify-end gap-1 sm:col-span-1">
             {quiz.status === 'draft' && (
               <Tooltip
                 content={
@@ -280,9 +285,9 @@ export function QuizCard({
                 }
               >
                 <Button
-                  variant="success"
+                  variant="ghost"
                   size="sm"
-                  className="h-9 w-9 p-0"
+                  className="p-1.5 text-success hover:bg-success-bg-muted"
                   aria-label={
                     supportsScheduling
                       ? `Open ${assessmentLabel} now`
@@ -298,9 +303,9 @@ export function QuizCard({
             {quiz.status === 'active' && !isScheduled && (
               <Tooltip content={`Close ${assessmentLabel}`}>
                 <Button
-                  variant="danger"
+                  variant="ghost"
                   size="sm"
-                  className="h-9 w-9 p-0"
+                  className="p-1.5 text-danger hover:bg-danger-bg"
                   aria-label={`Close ${assessmentLabel}`}
                   disabled={isReadOnly || updating}
                   onClick={(e) => {
@@ -349,9 +354,9 @@ export function QuizCard({
             {quiz.status === 'closed' && (
               <Tooltip content={`Reopen ${assessmentLabel}`}>
                 <Button
-                  variant="success"
+                  variant="ghost"
                   size="sm"
-                  className="h-9 w-9 p-0"
+                  className="p-1.5 text-success hover:bg-success-bg-muted"
                   aria-label={`Reopen ${assessmentLabel}`}
                   disabled={isReadOnly || updating}
                   onClick={(e) => {

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,13 +1,11 @@
 'use client'
 
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
-import { ACTIONBAR_ICON_BUTTON_CLASSNAME } from '@/components/PageLayout'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -36,6 +34,7 @@ interface TeacherStudentWorkPanelProps {
   onGoNextStudent?: () => void
   canGoPrevStudent?: boolean
   canGoNextStudent?: boolean
+  onDetailsMetaChange?: (meta: { studentName: string; characterCount: number } | null) => void
 }
 
 export function TeacherStudentWorkPanel({
@@ -52,6 +51,7 @@ export function TeacherStudentWorkPanel({
   onGoNextStudent,
   canGoPrevStudent = false,
   canGoNextStudent = false,
+  onDetailsMetaChange,
 }: TeacherStudentWorkPanelProps) {
   const workspaceRef = useRef<HTMLDivElement | null>(null)
   const {
@@ -160,6 +160,25 @@ export function TeacherStudentWorkPanel({
     }))
   }, [updateLayout])
 
+  useEffect(() => {
+    if (mode !== 'details' || showInitialSpinner || error || !data) {
+      onDetailsMetaChange?.(null)
+      return
+    }
+
+    const nextDisplayContent = previewContent || data.doc?.content
+    const nextCharacterCount =
+      nextDisplayContent && !isEmpty(nextDisplayContent)
+        ? countCharacters(nextDisplayContent)
+        : 0
+    const nextStudentDisplayName = data.student.name?.trim() || data.student.email
+
+    onDetailsMetaChange?.({
+      studentName: nextStudentDisplayName,
+      characterCount: nextCharacterCount,
+    })
+  }, [data, error, mode, onDetailsMetaChange, previewContent, showInitialSpinner])
+
   if (showInitialSpinner) {
     return (
       <div className="flex justify-center py-12">
@@ -177,16 +196,6 @@ export function TeacherStudentWorkPanel({
   }
 
   const displayContent = previewContent || data.doc?.content
-  const repoDisplayUrl =
-    data.repo_target.submittedRepoUrl ||
-    data.repo_target.effectiveRepoUrl ||
-    data.repo_target.target?.selected_repo_url ||
-    ''
-  const repoDisplayGitHubUsername =
-    data.repo_target.submittedGitHubUsername ||
-    data.repo_target.effectiveGitHubUsername ||
-    repoReviewResult?.github_login ||
-    ''
   const studentDisplayName = data.student.name?.trim() || data.student.email
   const characterCount =
     displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
@@ -249,81 +258,12 @@ export function TeacherStudentWorkPanel({
           previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
         }`}
       >
-        <div
-          data-testid="individual-content-header"
-          className="border-b border-border bg-surface px-4 py-2 text-sm"
-        >
-          <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center">
-            <div
-              className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
-            >
-              <div
-                className="min-w-0 truncate font-medium text-text-default"
-                title={studentDisplayName}
-              >
-                {studentDisplayName}
-              </div>
-              {(repoDisplayUrl || repoDisplayGitHubUsername) && (
-                <>
-                  <span className="text-text-muted" aria-hidden="true">
-                    /
-                  </span>
-                  <div className="min-w-0 truncate text-text-muted">
-                    <span className="text-text-muted">Repo </span>
-                    {repoDisplayUrl ? (
-                      <a
-                        href={repoDisplayUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-primary hover:underline"
-                      >
-                        {repoDisplayUrl}
-                      </a>
-                    ) : (
-                      '—'
-                    )}
-                  </div>
-                  {repoDisplayGitHubUsername && (
-                    <div className="truncate text-text-muted">
-                      <span className="font-medium text-text-default">
-                        @{repoDisplayGitHubUsername}
-                      </span>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-            <div
-              className="inline-flex shrink-0 items-center justify-center text-xs text-text-muted sm:justify-self-center"
-              aria-label={`${characterCount} characters`}
-            >
-              <span>{characterCount} chars</span>
-            </div>
-            {(onGoPrevStudent || onGoNextStudent) && (
-              <div className="flex items-center gap-1 sm:justify-self-end">
-                <button
-                  type="button"
-                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                  onClick={onGoPrevStudent}
-                  disabled={!onGoPrevStudent || !canGoPrevStudent}
-                  aria-label="Previous student"
-                >
-                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                  onClick={onGoNextStudent}
-                  disabled={!onGoNextStudent || !canGoNextStudent}
-                  aria-label="Next student"
-                >
-                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </div>
-            )}
-          </div>
-          {previewEntry && (
-            <div className="mt-1 text-xs font-medium text-primary">
+        {previewEntry && (
+          <div
+            data-testid="individual-content-header"
+            className="border-b border-border bg-surface px-4 py-2 text-sm"
+          >
+            <div className="text-xs font-medium text-primary">
               Previewing save from{' '}
               {formatInTimeZone(
                 new Date(previewEntry.created_at),
@@ -331,8 +271,8 @@ export function TeacherStudentWorkPanel({
                 'MMM d, h:mm a',
               )}
             </div>
-          )}
-        </div>
+          </div>
+        )}
         {displayContent && !isEmpty(displayContent) ? (
           <div className="min-h-0 flex-1 overflow-auto">
             <RichTextViewer content={displayContent} fillHeight chrome="flush" />

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -129,7 +129,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'reading' },
   },
   'tests-teacher': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '60%' },
+    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '60%' },
     mainContent: { maxWidth: 'full' },
   },
   'tests-student': {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -102,6 +102,13 @@ describe('StudentQuizzesTab exam mode', () => {
     return splitContainer
   }
 
+  function querySplitContainer(container: HTMLElement): HTMLDivElement | null {
+    const splitContainer = container.querySelector(
+      '[data-testid="student-test-split-container"]'
+    )
+    return splitContainer instanceof HTMLDivElement ? splitContainer : null
+  }
+
   function makeFocusSummary(overrides: Partial<QuizFocusSummary> = {}): QuizFocusSummary {
     return {
       exit_count: 0,
@@ -348,7 +355,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(screen.queryByText(/Browser minimization attempts/i)).not.toBeInTheDocument()
   })
 
-  it('uses 50/50 split before start and 30/70 exam mode split after start', async () => {
+  it('uses centered detail before start and 30/70 exam mode split after start', async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/api/student/tests?classroom_id=')) {
         return {
@@ -441,16 +448,14 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByText('Midterm Test')).toBeInTheDocument()
     })
 
-    const splitContainerBeforeStart = getSplitContainer(container)
-    expect(splitContainerBeforeStart.className).toContain('lg:grid-cols-[50%_50%]')
-    expect(splitContainerBeforeStart.className).not.toContain('lg:grid-cols-[30%_70%]')
-    expect(screen.getByRole('heading', { name: 'Tests' })).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: 'Exam Mode' })).not.toBeInTheDocument()
-
     fireEvent.click(screen.getByText('Midterm Test'))
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
     })
+    expect(querySplitContainer(container)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Back to tests' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Tests' })).not.toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
     await waitFor(() => {
       expect(screen.getByText('Start this test?')).toBeInTheDocument()
@@ -1114,7 +1119,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(document.querySelector('iframe[title="Node.js API"]')).not.toBeInTheDocument()
   })
 
-  it('uses 30/70 split when student is viewing returned test results', async () => {
+  it('uses centered detail when student is viewing returned test results', async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/api/student/tests?classroom_id=')) {
         return {
@@ -1226,9 +1231,8 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(screen.getByText('Returned')).toBeInTheDocument()
     expect(screen.queryByText('View Results')).not.toBeInTheDocument()
 
-    const splitContainer = getSplitContainer(container)
-    expect(splitContainer.className).toContain('lg:grid-cols-[30%_70%]')
-    expect(splitContainer.className).not.toContain('lg:grid-cols-[50%_50%]')
+    expect(querySplitContainer(container)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Back to tests' })).toBeInTheDocument()
   })
 
   it('shows Closed, Submitted, and Returned status pills for tests', async () => {
@@ -1441,7 +1445,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(screen.queryByRole('button', { name: 'Open in new tab' })).not.toBeInTheDocument()
   })
 
-  it('keeps the test list visible and refreshes statuses after submit', async () => {
+  it('refreshes list statuses after submit when returning from detail', async () => {
     let listCallCount = 0
     let detailCallCount = 0
 
@@ -1565,7 +1569,14 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByText('Response Submitted')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Final Test')).toBeInTheDocument()
+    expect(querySplitContainer(document.body)).toBeNull()
+    expect(screen.queryByText('Final Test')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to tests' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Final Test')).toBeInTheDocument()
+    })
     expect(screen.getByText('Submitted')).toBeInTheDocument()
   })
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1,5 +1,5 @@
-import { forwardRef } from 'react'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { forwardRef, useEffect } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
@@ -78,12 +78,21 @@ vi.mock('@/components/AssignmentArtifactsCell', () => ({
 }))
 
 vi.mock('@/components/TeacherStudentWorkPanel', () => ({
-  TeacherStudentWorkPanel: ({ assignmentId, studentId, mode }: any) => (
-    <div data-testid="teacher-work-panel">{`${mode}:${assignmentId}:${studentId}`}</div>
-  ),
+  TeacherStudentWorkPanel: ({ assignmentId, studentId, mode, onDetailsMetaChange }: any) => {
+    useEffect(() => {
+      onDetailsMetaChange?.(
+        mode === 'details'
+          ? { studentName: `${studentId} Student`, characterCount: 17 }
+          : null,
+      )
+    }, [mode, onDetailsMetaChange, studentId])
+
+    return <div data-testid="teacher-work-panel">{`${mode}:${assignmentId}:${studentId}`}</div>
+  },
 }))
 
 vi.mock('@/components/PageLayout', () => ({
+  ACTIONBAR_ICON_BUTTON_CLASSNAME: 'icon-button',
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME: 'primary-button',
   ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME: 'wide-button',
   PageLayout: ({ children }: any) => <div>{children}</div>,
@@ -321,5 +330,159 @@ describe('TeacherClassroomView', () => {
     await waitFor(() => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-2:student-2')
     })
+  })
+
+  it('renders class-mode actions in the selected-assignment action bar without duplicating them in the table', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    expect(screen.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
+    expect(screen.getByRole('button', { name: /Send/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
+  })
+
+  it('switches to individual mode with student controls in the action bar', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Individual' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('details:assignment-1:student-1')
+    })
+
+    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByRole('button', { name: /AI Grade/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()
+    expect(screen.getByText('student-1 Student')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('17 chars')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Previous student' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next student' })).toBeInTheDocument()
+  })
+
+  it('keeps class mode active when clicking a student row', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1').assignment,
+            students: [
+              ...makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1').students,
+              {
+                student_id: 'student-2',
+                student_email: 'student-2@example.com',
+                student_first_name: 'student-2',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  submitted_at: '2026-04-10T12:00:00Z',
+                  updated_at: '2026-04-10T12:00:00Z',
+                  score_completion: null,
+                  score_thinking: null,
+                  score_workflow: null,
+                  graded_at: null,
+                  returned_at: null,
+                  feedback_returned_at: null,
+                },
+              },
+            ],
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getAllByText('student-2')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-2')
+    })
+
+    expect(screen.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
-import { countCharacters } from '@/lib/tiptap-content'
 
 vi.mock('@/components/Spinner', () => ({
   Spinner: () => <div data-testid="spinner" />,
@@ -970,22 +969,10 @@ describe('TeacherStudentWorkPanel', () => {
     expect(await screen.findByTestId('rich-text-viewer')).toHaveAttribute('data-chrome', 'flush')
     expect(screen.queryByTestId('grading-workspace-header')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /show student table only/i })).not.toBeInTheDocument()
-    expect(screen.getByTestId('individual-content-header')).toHaveTextContent('student-1')
-    const expectedCharacters = countCharacters({
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [{ type: 'text', text: 'Work for student-1' }],
-        },
-      ],
-    })
-    expect(screen.getByLabelText(`${expectedCharacters} characters`)).toHaveTextContent(
-      `${expectedCharacters} chars`,
-    )
+    expect(screen.queryByTestId('individual-content-header')).not.toBeInTheDocument()
   })
 
-  it('renders the individual content header with student name first and repo metadata after it', async () => {
+  it('removes student identity and repo metadata from the top content header in details mode', async () => {
     mockFetchByStudent({
       'student-1': {
         graded: false,
@@ -1006,14 +993,8 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const header = await screen.findByTestId('individual-content-header')
-    expect(header).toHaveTextContent('student-1')
-    expect(header).toHaveTextContent('Repo')
-    expect(within(header).getByRole('link')).toHaveAttribute(
-      'href',
-      'https://github.com/example/student-1-repo',
-    )
-    expect(header).toHaveTextContent('@student1')
+    await screen.findByTestId('rich-text-viewer')
+    expect(screen.queryByTestId('individual-content-header')).not.toBeInTheDocument()
   })
 
   it('resets the individual pane split to 50/50 on separator double click', async () => {
@@ -1036,7 +1017,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await screen.findByTestId('individual-content-header')
+    await screen.findByTestId('rich-text-viewer')
 
     fireEvent.doubleClick(screen.getByRole('separator', { name: 'Resize content and grading panes' }))
 


### PR DESCRIPTION
## Summary
- add assignment-parity guidance, prompts, and screenshot-based evaluation docs for assessment UX iteration
- add the assessment parity verification harness and challenge runner for repeatable screenshot capture and blind-run checks
- refine the teacher assignments selected-state action bar with a centered context-aware control lane and move individual header metadata into the action bar
- tighten teacher and student assessment surfaces and supporting tests around the new assignment-family UX direction

## Testing
- git diff --check
- pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx
- pnpm exec tsc --noEmit

## Visual Verification
- verified the teacher assignments action bar live in class mode and individual mode from the worktree dev server
