### PR TITLE
[codex] Refine assignment modal scheduling

### DIFF
--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useRef } from 'react'
-import type { FormEvent, KeyboardEvent, ReactNode, RefObject } from 'react'
-import { Input, Button, FormField } from '@/ui'
+import { useId, useRef } from 'react'
+import type { KeyboardEvent, ReactNode, RefObject } from 'react'
+import { Input, Button } from '@/ui'
 import { DateActionBar } from '@/components/DateActionBar'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
@@ -12,58 +12,8 @@ import { LinkIcon } from '@/components/tiptap-icons/link-icon'
 import { ListIcon } from '@/components/tiptap-icons/list-icon'
 import { Redo2Icon } from '@/components/tiptap-icons/redo2-icon'
 import { Undo2Icon } from '@/components/tiptap-icons/undo2-icon'
-import { getTodayInToronto } from '@/lib/timezone'
+import { getRelativeDueDate } from '@/lib/assignment-relative-date'
 import type { ClassDay } from '@/types'
-
-function countClassDaysBetween(classDays: ClassDay[], fromDate: string, toDate: string): number {
-  // Count class days between two dates (exclusive of fromDate, inclusive of toDate)
-  const start = fromDate < toDate ? fromDate : toDate
-  const end = fromDate < toDate ? toDate : fromDate
-  const count = classDays.filter(day =>
-    day.is_class_day && day.date > start && day.date <= end
-  ).length
-  return fromDate < toDate ? count : -count
-}
-
-function getRelativeDays(dueAt: string, classDays?: ClassDay[]): { text: string; isPast: boolean } | null {
-  if (!dueAt) return null
-  const today = getTodayInToronto()
-
-  // If we have class days, count class days instead of calendar days
-  if (classDays && classDays.length > 0) {
-    const classCount = countClassDaysBetween(classDays, today, dueAt)
-    const isPast = classCount < 0
-    const absCount = Math.abs(classCount)
-
-    if (dueAt === today) return { text: 'today', isPast: false }
-    if (absCount === 0) {
-      // No classes between, but not today - show as next/last class
-      return isPast
-        ? { text: 'last class', isPast: true }
-        : { text: 'next class', isPast: false }
-    }
-    if (absCount === 1) {
-      return isPast
-        ? { text: 'last class', isPast: true }
-        : { text: 'next class', isPast: false }
-    }
-    return isPast
-      ? { text: `${absCount} classes ago`, isPast: true }
-      : { text: `in ${absCount} classes`, isPast: false }
-  }
-
-  // Fallback to calendar days if no class days provided
-  const due = new Date(dueAt + 'T00:00:00')
-  const todayDate = new Date(today + 'T00:00:00')
-  const diffTime = due.getTime() - todayDate.getTime()
-  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24))
-
-  if (diffDays === 0) return { text: 'today', isPast: false }
-  if (diffDays === 1) return { text: 'tomorrow', isPast: false }
-  if (diffDays === -1) return { text: 'yesterday', isPast: true }
-  if (diffDays > 0) return { text: `in ${diffDays} days`, isPast: false }
-  return { text: `${Math.abs(diffDays)} days ago`, isPast: true }
-}
 
 interface AssignmentFormProps {
   title: string
@@ -78,25 +28,15 @@ interface AssignmentFormProps {
   onDueAtChange: (next: string) => void
   onPrevDate: () => void
   onNextDate: () => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
-  onCancel?: () => void
-  submitLabel: string
-  cancelLabel?: string
   disabled?: boolean
-  submitDisabled?: boolean
   error?: string
   titleInputRef?: RefObject<HTMLInputElement>
   onBlur?: () => void
-  footerContent?: ReactNode
+  topRowActions?: ReactNode
+  statusContent?: ReactNode
   markdownWarning?: string | null
   canUndoInstructions?: boolean
   canRedoInstructions?: boolean
-  // Optional extra action button (e.g., Release for drafts)
-  extraAction?: {
-    label: ReactNode
-    onClick: () => void
-    variant?: 'primary' | 'success'
-  }
 }
 
 export function AssignmentForm({
@@ -112,23 +52,18 @@ export function AssignmentForm({
   onDueAtChange,
   onPrevDate,
   onNextDate,
-  onSubmit,
-  onCancel,
-  submitLabel,
-  cancelLabel = 'Cancel',
   disabled = false,
-  submitDisabled = false,
   error,
   titleInputRef,
   onBlur,
-  footerContent,
+  topRowActions,
+  statusContent,
   markdownWarning,
   canUndoInstructions = false,
   canRedoInstructions = false,
-  extraAction,
 }: AssignmentFormProps) {
-  const isSubmitDisabled = disabled || submitDisabled || !title || !dueAt
   const instructionsRef = useRef<HTMLTextAreaElement>(null)
+  const titleFieldId = useId()
 
   function applyWrapFormatting(prefix: string, suffix = prefix) {
     const textarea = instructionsRef.current
@@ -215,28 +150,77 @@ export function AssignmentForm({
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3 w-full">
-      <FormField label="Title" required>
-        <Input
-          ref={titleInputRef}
-          type="text"
-          value={title}
-          onChange={(e) => onTitleChange(e.target.value)}
-          onBlur={onBlur}
-          required
-          disabled={disabled}
-          placeholder="Add a title"
-        />
-      </FormField>
+    <div className="space-y-3 w-full">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_auto] lg:items-end lg:gap-x-8">
+        <div className="min-w-0 space-y-1">
+          <label htmlFor={titleFieldId} className="block text-sm font-medium text-text-default">
+            Title
+            <span className="ml-1 text-danger">*</span>
+          </label>
+          <Input
+            id={titleFieldId}
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => onTitleChange(e.target.value)}
+            onBlur={onBlur}
+            required
+            disabled={disabled}
+            placeholder="Add a title"
+            className="flex-1"
+          />
+        </div>
 
-      <FormField label="Instructions">
+        <div className="space-y-1">
+          {(() => {
+            const relative = getRelativeDueDate(dueAt, classDays)
+            const labelText = relative ? `Due ${relative.text}` : 'Due Date'
+            const colorClass = relative
+              ? relative.isPast
+                ? 'text-warning'
+                : 'text-primary'
+              : 'text-text-muted'
+            return (
+              <div className={`text-sm font-medium ${colorClass}`}>
+                {labelText}
+              </div>
+            )
+          })()}
+          <div className="flex">
+            <DateActionBar
+              value={dueAt}
+              onChange={onDueAtChange}
+              onPrev={onPrevDate}
+              onNext={onNextDate}
+              layout="compact"
+            />
+          </div>
+        </div>
+
+        {topRowActions && (
+          <div className="space-y-1 lg:justify-self-end lg:pl-2">
+            {topRowActions}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+          <label className="block text-sm font-medium text-text-default">
+            Instructions
+          </label>
+          <div className="justify-self-center">
+            {statusContent}
+          </div>
+          <div aria-hidden="true" />
+        </div>
         <div className="rounded-lg border border-border-strong overflow-hidden">
           {markdownWarning && (
             <div className="border-b border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
               {markdownWarning}
             </div>
           )}
-          <div className="grid min-h-[260px] gap-0 md:grid-cols-2">
+          <div className="grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]">
             <div className="flex h-full min-h-0 flex-col border-b border-border md:border-b-0 md:border-r md:border-border">
               <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
                 <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
@@ -273,14 +257,14 @@ export function AssignmentForm({
                 placeholder="Assignment instructions"
                 disabled={disabled}
                 spellCheck={false}
-                className="h-full min-h-[220px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0"
+                className="h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]"
               />
             </div>
             <div className="bg-page">
               <div className="px-3 py-2 text-xs font-medium uppercase tracking-wide text-text-muted">
                 Preview
               </div>
-              <div className="min-h-[220px] px-3 pb-3">
+              <div className="min-h-[360px] px-3 pb-3 lg:min-h-[420px]">
                 <LimitedMarkdown
                   content={instructionsMarkdown}
                   emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
@@ -289,55 +273,11 @@ export function AssignmentForm({
             </div>
           </div>
         </div>
-      </FormField>
+      </div>
 
       {extraFields}
 
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-        <div className="min-w-0 flex-1">
-          {(() => {
-            const relative = getRelativeDays(dueAt, classDays)
-            const labelText = relative ? `Due ${relative.text}` : 'Due Date'
-            const colorClass = relative
-              ? relative.isPast
-                ? 'text-warning'
-                : 'text-primary'
-              : 'text-text-muted'
-            return (
-              <label className={`block text-sm font-medium mb-1 ${colorClass}`}>
-                {labelText}
-              </label>
-            )
-          })()}
-          <DateActionBar value={dueAt} onChange={onDueAtChange} onPrev={onPrevDate} onNext={onNextDate} />
-        </div>
-
-        {footerContent ?? (
-          <div className="flex gap-2 justify-end lg:flex-shrink-0">
-            <Button type="submit" disabled={isSubmitDisabled} className="min-w-[5.5rem]">
-              {submitLabel}
-            </Button>
-            {onCancel && (
-              <Button type="button" variant="secondary" onClick={onCancel} disabled={disabled} className="min-w-[5.5rem]">
-                {cancelLabel}
-              </Button>
-            )}
-            {extraAction && (
-              <Button
-                type="button"
-                variant={extraAction.variant === 'success' ? 'success' : 'secondary'}
-                onClick={extraAction.onClick}
-                disabled={disabled}
-                className="min-w-[5.5rem]"
-              >
-                {extraAction.label}
-              </Button>
-            )}
-          </div>
-        )}
-      </div>
-
       {error && <p className="text-sm text-warning">{error}</p>}
-    </form>
+    </div>
   )
 }

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -1,17 +1,17 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback, type FormEvent } from 'react'
-import { X } from 'lucide-react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import type { Assignment, ClassDay } from '@/types'
 import { AssignmentForm } from '@/components/AssignmentForm'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
+import { getRelativeDueDate } from '@/lib/assignment-relative-date'
 import { ConfirmDialog, DialogPanel, SplitButton } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
 import { format } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
 import { useAssignmentDateValidation } from '@/hooks/useAssignmentDateValidation'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
-import { DEFAULT_SCHEDULE_TIME, getTodayInSchedulingTimezone, isVisibleAtNow, parseScheduleIsoToParts } from '@/lib/scheduling'
+import { DEFAULT_SCHEDULE_TIME, getDefaultScheduleDateInSchedulingTimezone, getTodayInSchedulingTimezone, isVisibleAtNow, parseScheduleIsoToParts } from '@/lib/scheduling'
 import { useAssignmentScheduling, type CreateSubmitAction } from '@/hooks/useAssignmentScheduling'
 
 const AUTOSAVE_DEBOUNCE_MS = 3000
@@ -155,7 +155,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         setScheduleTime(scheduled.time)
         setPrimaryAction('schedule')
       } else {
-        setScheduleDate(getTodayInSchedulingTimezone())
+        setScheduleDate(getDefaultScheduleDateInSchedulingTimezone())
         setScheduleTime(DEFAULT_SCHEDULE_TIME)
         setPrimaryAction('post')
       }
@@ -173,7 +173,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       resetInstructionsHistory('')
       setMarkdownWarning(null)
       setDueAt(defaultDueAt)
-      setScheduleDate(getTodayInSchedulingTimezone())
+      setScheduleDate(getDefaultScheduleDateInSchedulingTimezone())
       setScheduleTime(DEFAULT_SCHEDULE_TIME)
       setPrimaryAction('post')
       lastSavedValuesRef.current = null
@@ -532,27 +532,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     }
   }
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    if (isCreateMode && currentAssignment) {
-      await handleTriggerPrimaryAction()
-      return
-    }
-
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current)
-      saveTimeoutRef.current = null
-    }
-    if (throttledSaveTimeoutRef.current) {
-      clearTimeout(throttledSaveTimeoutRef.current)
-      throttledSaveTimeoutRef.current = null
-    }
-    pendingValuesRef.current = null
-    setSaving(true)
-    await saveChanges({ title, instructionsMarkdown, dueAt }, { closeAfter: true })
-    setSaving(false)
-  }
-
   async function saveDraftAndClose() {
     if (saving || releasing) return
     if (saveTimeoutRef.current) {
@@ -630,31 +609,26 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
         : isScheduled
           ? 'Edit Scheduled Assignment'
           : 'Edit Assignment'
+  const relativeDueDate = getRelativeDueDate(dueAt, classDays)
+  const scheduleContextLabel = relativeDueDate ? `Due ${relativeDueDate.text}` : null
+  const scheduleContextTone = relativeDueDate
+    ? relativeDueDate.isPast
+      ? 'warning'
+      : 'primary'
+    : 'muted'
+
   return (
     <>
       <DialogPanel
         isOpen={isOpen}
         onClose={handleClose}
         maxWidth="w-[min(90vw,56rem)]"
-        className="p-6"
+        className="max-h-[92vh] p-6"
         ariaLabelledBy="assignment-modal-title"
       >
-        <div className="flex items-center justify-between mb-4 flex-shrink-0">
-          <h2 id="assignment-modal-title" className="text-xl font-bold text-text-default">
-            {modalTitle}
-          </h2>
-          <span
-            className={`text-xs ${
-              saveStatus === 'saved'
-                ? 'text-success'
-                : saveStatus === 'saving'
-                  ? 'text-text-muted'
-                  : 'text-warning'
-            }`}
-          >
-            {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
-          </span>
-        </div>
+        <h2 id="assignment-modal-title" className="sr-only">
+          {modalTitle}
+        </h2>
 
         <div className="flex-1 min-h-0 overflow-y-auto">
           <AssignmentForm
@@ -669,8 +643,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             onDueAtChange={handleDueAtChange}
             onPrevDate={handlePrevDate}
             onNextDate={handleNextDate}
-            onSubmit={handleSubmit}
-            submitLabel={saving ? 'Saving...' : saveStatus === 'saved' ? 'Done' : 'Save'}
             disabled={saving || releasing || creating}
             error={error}
             titleInputRef={titleInputRef}
@@ -678,54 +650,49 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             markdownWarning={markdownWarning}
             canUndoInstructions={instructionsHistoryIndexRef.current > 0}
             canRedoInstructions={instructionsHistoryIndexRef.current < instructionsHistoryRef.current.length - 1}
-            footerContent={
+            statusContent={(
+              <span
+                className={`text-xs ${
+                  saveStatus === 'saved'
+                    ? 'text-success'
+                    : saveStatus === 'saving'
+                      ? 'text-text-muted'
+                      : 'text-warning'
+                }`}
+              >
+                {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
+              </span>
+            )}
+            topRowActions={
               currentAssignment
                 ? (
-                    <div className="flex items-center justify-end gap-2">
+                    <div className="flex flex-col items-start gap-2">
                       {isScheduled && currentAssignment.released_at && (
-                        <div className="inline-flex items-stretch rounded-md border border-warning bg-warning-bg text-warning">
-                          <button
-                            type="button"
-                            onClick={() => {
-                              if (!ensureTitleBeforeRelease()) return
-                              void openScheduleModalWithSave()
-                            }}
-                            disabled={creating || releasing || saving}
-                            className="px-2.5 py-1.5 text-xs font-medium hover:bg-warning-bg disabled:cursor-not-allowed"
-                          >
-                            {`Scheduled for ${formatReleaseDate(currentAssignment.released_at)}`}
-                          </button>
-                          <button
-                            type="button"
-                            aria-label="Clear scheduled release"
-                            onClick={() => {
-                              void clearScheduledRelease()
-                            }}
-                            disabled={creating || releasing || saving}
-                            className="border-l border-warning px-2 hover:bg-warning-bg disabled:cursor-not-allowed"
-                          >
-                            <X className="h-3.5 w-3.5" aria-hidden="true" />
-                          </button>
+                        <div className="text-xs font-medium text-warning">
+                          {formatReleaseDate(currentAssignment.released_at)}
                         </div>
                       )}
-                      <SplitButton
-                        label={primaryLabel}
-                        onPrimaryClick={() => {
-                          void handleTriggerPrimaryAction()
-                        }}
-                        variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
-                        size="md"
-                        disabled={creating || releasing || saving || !currentAssignment}
+                      <div className="flex">
+                        <SplitButton
+                          label={primaryLabel}
+                          onPrimaryClick={() => {
+                            void handleTriggerPrimaryAction()
+                          }}
+                          variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
+                          size="md"
+                          disabled={creating || releasing || saving || !currentAssignment}
                         className="shadow-sm"
                         toggleAriaLabel="Choose assignment action"
+                        menuPlacement="down"
                         primaryButtonProps={{
                           className: 'w-[9rem] justify-center font-semibold',
                         }}
-                        options={splitOptions.map((option) => ({
-                          ...option,
-                          onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
-                        }))}
-                      />
+                          options={splitOptions.map((option) => ({
+                            ...option,
+                            onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
+                          }))}
+                        />
+                      </div>
                     </div>
                   )
                 : undefined
@@ -754,16 +721,26 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           isFutureValid={isScheduleValid}
           onDateChange={setScheduleDate}
           onTimeChange={setScheduleTime}
-          onCancel={() => setShowCreateScheduleModal(false)}
+          onCancel={
+            isScheduled
+              ? () => {
+                  void clearScheduledRelease()
+                }
+              : undefined
+          }
           onConfirm={() => {
             if (!ensureTitleBeforeRelease()) return
             void scheduleAssignmentRelease({ closeAfter: isScheduled })
           }}
           confirmLabel={releasing ? 'Scheduling...' : isScheduled ? 'Save schedule' : 'Schedule'}
+          cancelLabel="Cancel schedule"
+          cancelVariant="danger"
           dateLabel="Date"
           timeLabel="Time"
           showHeader={false}
           showTimezoneLabel={false}
+          contextLabel={scheduleContextLabel}
+          contextTone={scheduleContextTone}
           className="border-0 bg-transparent p-0 shadow-none"
         />
       </DialogPanel>

--- a/src/components/DateActionBar.tsx
+++ b/src/components/DateActionBar.tsx
@@ -12,14 +12,27 @@ interface DateActionBarProps {
   onNext: () => void
   rightActions?: React.ReactNode
   className?: string
+  layout?: 'default' | 'compact'
 }
 
-export function DateActionBar({ value, onChange, onPrev, onNext, rightActions, className = '' }: DateActionBarProps) {
+export function DateActionBar({
+  value,
+  onChange,
+  onPrev,
+  onNext,
+  rightActions,
+  className = '',
+  layout = 'default',
+}: DateActionBarProps) {
   const dateInputRef = useRef<HTMLInputElement>(null)
   const formattedDate = value ? format(parseISO(value), 'EEE MMM d') : ''
+  const isCompact = layout === 'compact'
+  const containerClassName = isCompact
+    ? 'flex items-center gap-2'
+    : 'flex w-full flex-wrap items-center justify-between gap-4'
 
   return (
-    <div className={['flex w-full flex-wrap items-center justify-between gap-4', className].join(' ')}>
+    <div className={[containerClassName, className].join(' ')}>
       <div className="flex flex-wrap items-center gap-2">
         <button type="button" className={ACTIONBAR_ICON_BUTTON_CLASSNAME} onClick={onPrev} aria-label="Previous day">
           <ChevronLeft className="h-5 w-5" aria-hidden="true" />

--- a/src/components/ScheduleDateTimePicker.tsx
+++ b/src/components/ScheduleDateTimePicker.tsx
@@ -14,12 +14,16 @@ interface ScheduleDateTimePickerProps {
   onConfirm: () => void
   onCancel?: () => void
   confirmLabel?: string
+  cancelLabel?: string
+  cancelVariant?: 'secondary' | 'danger'
   title?: string
   dateLabel?: string
   timeLabel?: string
   showHeader?: boolean
   showTimezoneLabel?: boolean
   className?: string
+  contextLabel?: string | null
+  contextTone?: 'primary' | 'warning' | 'muted'
 }
 
 export function ScheduleDateTimePicker({
@@ -32,15 +36,25 @@ export function ScheduleDateTimePicker({
   onConfirm,
   onCancel,
   confirmLabel = 'Done',
+  cancelLabel = 'Cancel',
+  cancelVariant = 'secondary',
   title = 'Schedule',
   dateLabel = 'Date (Toronto)',
   timeLabel = 'Time (Toronto)',
   showHeader = true,
   showTimezoneLabel = true,
   className = '',
+  contextLabel,
+  contextTone = 'muted',
 }: ScheduleDateTimePickerProps) {
   const dateInputId = useId()
   const timeInputId = useId()
+  const contextToneClass =
+    contextTone === 'warning'
+      ? 'text-warning'
+      : contextTone === 'primary'
+        ? 'text-primary'
+        : 'text-text-muted'
 
   return (
     <div className={`bg-surface rounded-lg shadow-lg border border-border p-3 ${className}`.trim()}>
@@ -49,6 +63,12 @@ export function ScheduleDateTimePicker({
           <Calendar className="h-4 w-4 text-text-muted" />
           <span className="text-sm font-medium text-text-default">{title}</span>
         </div>
+      )}
+
+      {contextLabel && (
+        <p className={`mb-3 text-sm font-medium ${contextToneClass}`}>
+          {contextLabel}
+        </p>
       )}
 
       <div className="space-y-3">
@@ -86,8 +106,8 @@ export function ScheduleDateTimePicker({
 
       <div className="mt-3 flex items-center gap-2">
         {onCancel && (
-          <Button variant="secondary" size="sm" className="flex-1" onClick={onCancel}>
-            Cancel
+          <Button variant={cancelVariant} size="sm" className="flex-1" onClick={onCancel}>
+            {cancelLabel}
           </Button>
         )}
         <Button

--- a/src/hooks/useAssignmentScheduling.ts
+++ b/src/hooks/useAssignmentScheduling.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 import {
   combineScheduleDateTimeToIso,
   DEFAULT_SCHEDULE_TIME,
-  getTodayInSchedulingTimezone,
+  getDefaultScheduleDateInSchedulingTimezone,
   isScheduleIsoInFuture,
   isVisibleAtNow,
   parseScheduleIsoToParts,
@@ -102,7 +102,7 @@ export function useAssignmentScheduling({
   onClose,
   onError,
 }: UseAssignmentSchedulingOptions): UseAssignmentSchedulingReturn {
-  const [scheduleDate, setScheduleDate] = useState(getTodayInSchedulingTimezone())
+  const [scheduleDate, setScheduleDate] = useState(getDefaultScheduleDateInSchedulingTimezone())
   const [scheduleTime, setScheduleTime] = useState(DEFAULT_SCHEDULE_TIME)
   const [primaryAction, setPrimaryAction] = useState<CreateSubmitAction>('post')
   const [showPostNowConfirm, setShowPostNowConfirm] = useState(false)
@@ -154,7 +154,7 @@ export function useAssignmentScheduling({
       setScheduleTime(scheduled.time)
       setPrimaryAction('schedule')
     } else {
-      setScheduleDate(getTodayInSchedulingTimezone())
+      setScheduleDate(getDefaultScheduleDateInSchedulingTimezone())
       setScheduleTime(DEFAULT_SCHEDULE_TIME)
       setPrimaryAction('post')
     }
@@ -179,7 +179,7 @@ export function useAssignmentScheduling({
       setScheduleDate(parsed.date)
       setScheduleTime(parsed.time)
     } else {
-      setScheduleDate(getTodayInSchedulingTimezone())
+      setScheduleDate(getDefaultScheduleDateInSchedulingTimezone())
       setScheduleTime(DEFAULT_SCHEDULE_TIME)
     }
   }

--- a/src/lib/assignment-relative-date.ts
+++ b/src/lib/assignment-relative-date.ts
@@ -1,0 +1,49 @@
+import { getTodayInToronto } from '@/lib/timezone'
+import type { ClassDay } from '@/types'
+
+function countClassDaysBetween(classDays: ClassDay[], fromDate: string, toDate: string): number {
+  const start = fromDate < toDate ? fromDate : toDate
+  const end = fromDate < toDate ? toDate : fromDate
+  const count = classDays.filter((day) =>
+    day.is_class_day && day.date > start && day.date <= end
+  ).length
+  return fromDate < toDate ? count : -count
+}
+
+export interface RelativeDueDate {
+  text: string
+  isPast: boolean
+}
+
+export function getRelativeDueDate(dueAt: string, classDays?: ClassDay[]): RelativeDueDate | null {
+  if (!dueAt) return null
+
+  const today = getTodayInToronto()
+
+  if (classDays && classDays.length > 0) {
+    const classCount = countClassDaysBetween(classDays, today, dueAt)
+    const isPast = classCount < 0
+    const absCount = Math.abs(classCount)
+
+    if (dueAt === today) return { text: 'today', isPast: false }
+    if (absCount === 0 || absCount === 1) {
+      return isPast
+        ? { text: 'last class', isPast: true }
+        : { text: 'next class', isPast: false }
+    }
+    return isPast
+      ? { text: `${absCount} classes ago`, isPast: true }
+      : { text: `in ${absCount} classes`, isPast: false }
+  }
+
+  const due = new Date(`${dueAt}T00:00:00`)
+  const todayDate = new Date(`${today}T00:00:00`)
+  const diffTime = due.getTime() - todayDate.getTime()
+  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return { text: 'today', isPast: false }
+  if (diffDays === 1) return { text: 'tomorrow', isPast: false }
+  if (diffDays === -1) return { text: 'yesterday', isPast: true }
+  if (diffDays > 0) return { text: `in ${diffDays} days`, isPast: false }
+  return { text: `${Math.abs(diffDays)} days ago`, isPast: true }
+}

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -1,4 +1,5 @@
 import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
+import { addDaysToDateString } from '@/lib/date-string'
 
 export const SCHEDULING_TIMEZONE = 'America/Toronto'
 export const DEFAULT_SCHEDULE_TIME = '07:00'
@@ -10,6 +11,10 @@ export interface ScheduleDateTimeParts {
 
 export function getTodayInSchedulingTimezone(): string {
   return formatInTimeZone(new Date(), SCHEDULING_TIMEZONE, 'yyyy-MM-dd')
+}
+
+export function getDefaultScheduleDateInSchedulingTimezone(): string {
+  return addDaysToDateString(getTodayInSchedulingTimezone(), 1)
 }
 
 export function combineScheduleDateTimeToIso(date: string, time?: string): string {
@@ -38,4 +43,3 @@ export function normalizeScheduleTime(time?: string): string {
   if (!time) return DEFAULT_SCHEDULE_TIME
   return time
 }
-

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -73,6 +73,11 @@ export function SplitButton({
     }
   }, [isOpen])
 
+  function handleOptionSelect(onSelect: () => void) {
+    setIsOpen(false)
+    onSelect()
+  }
+
   return (
     <div ref={containerRef} className={cn('relative inline-flex', className)}>
       <Button
@@ -94,7 +99,10 @@ export function SplitButton({
         aria-controls={menuId}
         aria-expanded={isOpen}
         aria-label={toggleAriaLabel}
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={(event) => {
+          event.stopPropagation()
+          setIsOpen((prev) => !prev)
+        }}
         disabled={disabled || options.length === 0}
         className="rounded-l-none border-l border-black/15 px-3"
       >
@@ -105,8 +113,9 @@ export function SplitButton({
         <div
           id={menuId}
           role="menu"
+          onClick={(event) => event.stopPropagation()}
           className={cn(
-            'absolute right-0 z-20 min-w-[9rem] rounded-md border border-border-strong bg-surface p-1 shadow-xl',
+            'absolute right-0 z-50 min-w-[9rem] rounded-md border border-border-strong bg-surface p-1 shadow-xl',
             menuPlacement === 'down' ? 'top-full mt-1' : 'bottom-full mb-1'
           )}
         >
@@ -116,9 +125,9 @@ export function SplitButton({
               type="button"
               role="menuitem"
               disabled={option.disabled}
-              onClick={() => {
-                option.onSelect()
-                setIsOpen(false)
+              onClick={(event) => {
+                event.stopPropagation()
+                handleOptionSelect(option.onSelect)
               }}
               className="w-full rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
             >

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { toTorontoEndOfDayIso } from '@/lib/timezone'
 import type { Assignment } from '@/types'
@@ -31,6 +31,7 @@ describe('AssignmentModal', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   describe('edit mode', () => {
@@ -61,6 +62,7 @@ describe('AssignmentModal', () => {
 
       expect(screen.getByLabelText(/Title/)).toHaveValue('Original title')
       expect(screen.getByDisplayValue('2025-01-15')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Wed Jan 15' })).toBeInTheDocument()
     })
 
     it('renders a markdown-only instructions editor with formatting buttons', () => {
@@ -132,6 +134,7 @@ describe('AssignmentModal', () => {
 
       expect(screen.getByRole('button', { name: 'Post' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Choose assignment action' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
       fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
       expect(screen.queryByRole('menuitem', { name: 'Post' })).not.toBeInTheDocument()
       expect(screen.getByRole('menuitem', { name: 'Schedule' })).toBeInTheDocument()
@@ -180,6 +183,35 @@ describe('AssignmentModal', () => {
       expect(options.method).toBe('POST')
       const payload = JSON.parse(options.body)
       expect(payload.release_at).toBeDefined()
+    })
+
+    it('defaults the schedule dialog date to the next day for draft assignments', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={{ ...baseAssignment, due_at: toTorontoEndOfDayIso('2026-03-02') }}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Schedule' }))
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      const scheduleDialog = screen.getByRole('dialog', { name: 'Schedule Release' })
+      const scheduleScope = within(scheduleDialog)
+
+      expect(scheduleScope.getByText('Due tomorrow')).toBeInTheDocument()
+      expect(scheduleScope.getByLabelText('Date')).toHaveValue('2026-03-02')
+      expect(scheduleScope.getByLabelText('Time')).toHaveValue('07:00')
     })
 
     it('manual save sends only changed fields and closes modal', async () => {
@@ -306,7 +338,7 @@ describe('AssignmentModal', () => {
       )
 
       expect(screen.getByRole('button', { name: 'Schedule' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /Scheduled for/ })).toBeInTheDocument()
+      expect(screen.getByText(/Mar 1, 9:00 AM/)).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Choose assignment action' })).toBeDisabled()
       fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
       expect(screen.queryByRole('menuitem', { name: 'Post' })).not.toBeInTheDocument()
@@ -318,7 +350,7 @@ describe('AssignmentModal', () => {
       await waitFor(() => {
         expect(screen.getByText('Schedule Release')).toBeInTheDocument()
       })
-      expect(screen.queryByRole('button', { name: 'Clear schedule' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Cancel schedule' })).toBeInTheDocument()
       expect(onSuccess).not.toHaveBeenCalled()
     })
 
@@ -372,7 +404,7 @@ describe('AssignmentModal', () => {
       })
     })
 
-    it('clears scheduled release from attached scheduled chip cancel button', async () => {
+    it('clears scheduled release from the schedule modal cancel action', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
         is_draft: false,
@@ -396,7 +428,11 @@ describe('AssignmentModal', () => {
         />
       )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Clear scheduled release' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Schedule' }))
+      await waitFor(() => {
+        expect(screen.getByText('Schedule Release')).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel schedule' }))
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -419,7 +455,7 @@ describe('AssignmentModal', () => {
       expect(screen.queryByRole('menuitem', { name: 'Schedule' })).not.toBeInTheDocument()
     })
 
-    it('saves pending form edits before opening schedule modal from release info', async () => {
+    it('saves pending form edits before opening schedule modal from schedule action', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
         is_draft: false,
@@ -442,7 +478,7 @@ describe('AssignmentModal', () => {
       )
 
       fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'Updated title' } })
-      fireEvent.click(screen.getByRole('button', { name: /Scheduled for/ }))
+      fireEvent.click(screen.getByRole('button', { name: 'Schedule' }))
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -652,7 +688,7 @@ describe('AssignmentModal', () => {
       expect(payload.release_at).toBeDefined()
 
       await waitFor(() => {
-        expect(screen.getByText(/Scheduled for/)).toBeInTheDocument()
+        expect(screen.getByText(/Mar 1, 9:00 AM/)).toBeInTheDocument()
       })
     })
 

--- a/tests/unit/assignment-relative-date.test.ts
+++ b/tests/unit/assignment-relative-date.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getRelativeDueDate } from '@/lib/assignment-relative-date'
+
+describe('getRelativeDueDate', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns tomorrow for the next calendar day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+    expect(getRelativeDueDate('2026-03-02')).toEqual({ text: 'tomorrow', isPast: false })
+  })
+
+  it('returns next class when class-day logic applies', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+    expect(
+      getRelativeDueDate('2026-03-03', [
+        { date: '2026-03-02', is_class_day: false },
+        { date: '2026-03-03', is_class_day: true },
+      ])
+    ).toEqual({ text: 'next class', isPast: false })
+  })
+})

--- a/tests/unit/scheduling.test.ts
+++ b/tests/unit/scheduling.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import {
   combineScheduleDateTimeToIso,
+  getDefaultScheduleDateInSchedulingTimezone,
   getTodayInSchedulingTimezone,
   isScheduleIsoInFuture,
   isVisibleAtNow,
@@ -40,5 +41,10 @@ describe('scheduling utilities', () => {
     vi.setSystemTime(new Date('2026-03-01T04:30:00.000Z')) // 2026-02-28 23:30 Toronto
     expect(getTodayInSchedulingTimezone()).toBe('2026-02-28')
   })
-})
 
+  it('returns next Toronto day for default schedule helper', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T04:30:00.000Z')) // 2026-02-28 23:30 Toronto
+    expect(getDefaultScheduleDateInSchedulingTimezone()).toBe('2026-03-01')
+  })
+})


### PR DESCRIPTION
## What changed
- reworked the assignment modal header/top row so title, due date controls, and publish actions use the reclaimed vertical space more efficiently
- moved schedule-related state defaults to open on the next Toronto day and restored the split-button schedule flow
- added shared relative due-date logic so the inline due label and the schedule dialog stay consistent

## Why
The assignment creation flow was too vertically cramped, the schedule dropdown had regressed, and the scheduling UI needed clearer due-date context.

## User impact
- teachers can see more instructions/editor content at once
- the post/schedule controls are easier to reach and the schedule dialog now defaults to tomorrow at 7:00 AM
- scheduled assignments show cleaner status text and the schedule dialog shows the same relative due context as the main form

## Root cause
The modal layout still dedicated too much space to header/footer chrome, and a split-button interaction hardening change had broken synchronous schedule option selection.

## Validation
- `./node_modules/.bin/vitest run tests/components/AssignmentModal.test.tsx tests/hooks/useAssignmentScheduling.test.ts tests/unit/scheduling.test.ts tests/unit/assignment-relative-date.test.ts tests/ui/SplitButton.test.tsx`
- browser verification of the teacher assignment modal layout and scheduling flows on `http://localhost:3002`
