### PR TITLE
[codex] Fix assignment AI grading artifact detection

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8954,3 +8954,15 @@
 **Notes:**
 - Left `src/lib/repo-review.ts` handling of `package-lock.json` intact because it is generic generated-file detection, not active package-manager configuration.
 - Did not run installs/tests in this session.
+## 2026-04-20 — Assignment AI Grading Artifact Detection
+
+- Fixed assignment AI grading so attached artifacts are included in the grader prompt instead of relying on extracted plain text alone.
+- Added prompt guidance telling the grader to treat attached links, repositories, and images as part of the submission rather than marking them missing.
+- Allowed artifact-only submissions, such as image-only site evidence, to be graded instead of failing as empty work.
+- Added regression coverage for link-mark artifacts and image-only submissions.
+
+**Validation:**
+- `pnpm test -- tests/unit/ai-grading.test.ts tests/lib/assignment-artifacts.test.ts tests/api/teacher/assignments-id.test.ts`
+
+**Notes:**
+- The targeted command expanded to the full Vitest suite in this worktree; all 194 files / 1708 tests passed.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -8960,6 +8960,8 @@
 - Added prompt guidance telling the grader to treat attached links, repositories, and images as part of the submission rather than marking them missing.
 - Allowed artifact-only submissions, such as image-only site evidence, to be graded instead of failing as empty work.
 - Added regression coverage for link-mark artifacts and image-only submissions.
+- Normalized legacy stringified `assignment_docs.content` in the assignment auto-grade route before invoking the shared grading helper.
+- Added API-level regression coverage so assignment auto-grading now proves both parsed legacy content and legacy empty submissions are handled correctly at the route boundary.
 
 **Validation:**
 - `pnpm test -- tests/unit/ai-grading.test.ts tests/lib/assignment-artifacts.test.ts tests/api/teacher/assignments-id.test.ts`

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -6,6 +6,7 @@ import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { withErrorHandler } from '@/lib/api-handler'
 import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
+import { parseContentField } from '@/lib/tiptap-content'
 import type { AssignmentDocHistoryEntry } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -70,9 +71,10 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
   async function processOne() {
     while (queue.length > 0) {
       const doc = queue.shift()!
+      const studentWork = parseContentField(doc.content)
 
       // Skip docs with no content (empty work)
-      if (!doc.content || (typeof doc.content === 'object' && (!doc.content.content || doc.content.content.length === 0))) {
+      if (!studentWork.content || studentWork.content.length === 0) {
         skippedCount++
         continue
       }
@@ -81,7 +83,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
         const result = await gradeStudentWork({
           assignmentTitle: assignment.title,
           instructions: instructionsText,
-          studentWork: doc.content,
+          studentWork,
           previousFeedback: doc.feedback,
         })
 

--- a/src/lib/ai-grading.ts
+++ b/src/lib/ai-grading.ts
@@ -1,3 +1,7 @@
+import {
+  extractAssignmentArtifacts,
+  type AssignmentArtifact,
+} from '@/lib/assignment-artifacts'
 import { extractPlainText } from '@/lib/tiptap-content'
 import type { TiptapContent } from '@/types'
 
@@ -30,6 +34,44 @@ function extractResponseOutputText(payload: any): string | null {
   return null
 }
 
+function formatArtifactLabel(artifact: AssignmentArtifact): string {
+  switch (artifact.type) {
+    case 'image':
+      return 'Image'
+    case 'repo':
+      return 'Repository'
+    default:
+      return 'Link'
+  }
+}
+
+function buildStudentSubmissionText(studentWork: TiptapContent): string {
+  const studentText = extractPlainText(studentWork).trim()
+  const artifacts = extractAssignmentArtifacts(studentWork)
+  const sections: string[] = []
+
+  if (studentText) {
+    sections.push(studentText)
+  }
+
+  if (artifacts.length > 0) {
+    const artifactLines = artifacts.map((artifact) => {
+      const repoSummary =
+        artifact.type === 'repo' && artifact.repo_owner && artifact.repo_name
+          ? ` (${artifact.repo_owner}/${artifact.repo_name})`
+          : ''
+      return `- ${formatArtifactLabel(artifact)}: ${artifact.url}${repoSummary}`
+    })
+    sections.push(`Attached Artifacts:\n${artifactLines.join('\n')}`)
+  }
+
+  if (sections.length === 0) {
+    throw new Error('Student work is empty')
+  }
+
+  return sections.join('\n\n')
+}
+
 export interface GradeResult {
   score_completion: number
   score_thinking: number
@@ -50,17 +92,14 @@ export async function gradeStudentWork(opts: {
   }
 
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
-  const studentText = extractPlainText(opts.studentWork)
-
-  if (!studentText.trim()) {
-    throw new Error('Student work is empty')
-  }
+  const studentSubmission = buildStudentSubmissionText(opts.studentWork)
 
   const systemPrompt = `You are an assignment grader. Grade the student's work using this rubric:
 
 - **Completion** (0–10): Did the student complete all parts of the assignment?
 - **Thinking** (0–10): Does the work show depth of thought, analysis, or understanding?
 - **Workflow** (0–10): Is the work organized, clear, and well-presented?
+- Treat attached artifacts (links, repositories, images) as part of the student's submission. Do not say a required site or artifact is missing if it appears in the "Attached Artifacts" section.
 
 Respond with ONLY valid JSON in this format:
 {"score_completion":N,"score_thinking":N,"score_workflow":N,"feedback":"..."}
@@ -75,7 +114,7 @@ Feedback rules:
 Instructions: ${opts.instructions}
 
 Student Work:
-${studentText}`
+${studentSubmission}`
 
   const res = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',

--- a/tests/api/teacher/assignments-auto-grade.test.ts
+++ b/tests/api/teacher/assignments-auto-grade.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { gradeStudentWork } = vi.hoisted(() => ({
+  gradeStudentWork: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/ai-grading', () => ({
+  gradeStudentWork,
+}))
+
+import { POST } from '@/app/api/teacher/assignments/[id]/auto-grade/route'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    gradeStudentWork.mockResolvedValue({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      feedback: 'Strength: Complete submission. Next Step: Add a short reflection.',
+      model: 'gpt-5-nano',
+    })
+  })
+
+  it('parses legacy stringified assignment doc content before grading', async () => {
+    const legacyContent = JSON.stringify({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'My portfolio is attached here.',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'https://student.example.com/portfolio' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const updateCalls: Array<Record<string, unknown>> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  title: 'Portfolio Site',
+                  instructions_markdown: 'Build and submit your portfolio site.',
+                  rich_instructions: null,
+                  description: 'Build and submit your portfolio site.',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: legacyContent,
+                    feedback: 'Earlier feedback',
+                    authenticity_score: 42,
+                  },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            updateCalls.push(payload)
+            return {
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      graded_count: 1,
+      skipped_count: 0,
+      errors: undefined,
+    })
+    expect(gradeStudentWork).toHaveBeenCalledTimes(1)
+    expect(gradeStudentWork).toHaveBeenCalledWith({
+      assignmentTitle: 'Portfolio Site',
+      instructions: 'Build and submit your portfolio site.',
+      studentWork: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'My portfolio is attached here.',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://student.example.com/portfolio' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      previousFeedback: 'Earlier feedback',
+    })
+    expect(updateCalls).toEqual([
+      expect.objectContaining({
+        score_completion: 8,
+        score_thinking: 7,
+        score_workflow: 9,
+        ai_feedback_suggestion: 'Strength: Complete submission. Next Step: Add a short reflection.',
+        ai_feedback_model: 'gpt-5-nano',
+        graded_at: null,
+        graded_by: null,
+      }),
+    ])
+  })
+
+  it('skips legacy stringified empty docs without calling the grader', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  title: 'Portfolio Site',
+                  instructions_markdown: 'Build and submit your portfolio site.',
+                  rich_instructions: null,
+                  description: 'Build and submit your portfolio site.',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: JSON.stringify({ type: 'doc', content: [] }),
+                    feedback: null,
+                    authenticity_score: 42,
+                  },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      graded_count: 0,
+      skipped_count: 1,
+      errors: undefined,
+    })
+    expect(gradeStudentWork).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/ai-grading.test.ts
+++ b/tests/unit/ai-grading.test.ts
@@ -53,4 +53,84 @@ describe('gradeStudentWork prompt rules', () => {
     expect(systemPrompt).toContain('sentence starting with "Next Step:"')
     expect(systemPrompt).toContain('total score is less than 30')
   })
+
+  it('includes extracted artifacts in the grading prompt', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"score_completion":9,"score_thinking":8,"score_workflow":8,"feedback":"Strength: You included the required project site. Next Step: add a brief note explaining your design choices. Improve: Add one concrete example showing how the site meets the assignment goals."}',
+      }),
+    })
+
+    await gradeStudentWork({
+      assignmentTitle: 'Portfolio Site',
+      instructions: 'Build and submit your portfolio site.',
+      studentWork: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'My final portfolio is linked here.',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://student.example.com/portfolio' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const systemPrompt = gradingBody.input?.[0]?.content?.[0]?.text as string
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(systemPrompt).toContain('Treat attached artifacts')
+    expect(userPrompt).toContain('Attached Artifacts:')
+    expect(userPrompt).toContain('- Link: https://student.example.com/portfolio')
+  })
+
+  it('accepts artifact-only submissions when building the grading prompt', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"score_completion":8,"score_thinking":7,"score_workflow":8,"feedback":"Strength: You submitted the required artifact. Next Step: add a short written explanation alongside it. Improve: Add one sentence that explains how the artifact meets the prompt."}',
+      }),
+    })
+
+    const result = await gradeStudentWork({
+      assignmentTitle: 'Screenshot Submission',
+      instructions: 'Attach a screenshot of your completed site.',
+      studentWork: {
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: {
+              src: 'https://cdn.example.com/submission-images/final-site.png',
+            },
+          },
+        ],
+      },
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(result.score_completion).toBe(8)
+    expect(userPrompt).toContain('Attached Artifacts:')
+    expect(userPrompt).toContain('- Image: https://cdn.example.com/submission-images/final-site.png')
+  })
 })


### PR DESCRIPTION
## Summary
- include extracted assignment artifacts in the AI grading prompt so attached sites, repos, and images are visible to the model
- treat artifact-only submissions as valid work instead of failing them as empty submissions
- add regression coverage for link-mark artifacts and image-only submissions

## Root Cause
Assignment auto-grading passed only plain extracted text to the model. Links stored as Tiptap marks and image-only submissions were not represented in the prompt, so the grader could incorrectly report missing attached work.

## Impact
- AI grading should stop claiming required sites or artifacts are missing when they are actually attached in the submission editor
- artifact-only evidence such as screenshots can now be graded

## Validation
- `pnpm test -- tests/unit/ai-grading.test.ts tests/lib/assignment-artifacts.test.ts tests/api/teacher/assignments-id.test.ts` (expanded to full Vitest suite in this worktree: 194 files / 1708 tests passed)
