### PR TITLE
[codex] Filter transient exam-mode fullscreen loss

### DIFF
--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -87,12 +87,62 @@ function isFullscreenActive(): boolean {
   return typeof document !== 'undefined' && Boolean(document.fullscreenElement)
 }
 
+const EXAM_WINDOW_COMPLIANCE_GRACE_MS = 400
+const EXAM_WINDOW_MIN_WIDTH_RATIO = 0.92
+const EXAM_WINDOW_MIN_HEIGHT_RATIO = 0.88
 const DOCS_EXIT_SUPPRESSION_WINDOW_MS = 1200
 const UNSUPPRESSED_ROUTE_EXIT_SOURCES = new Set([
   'tab_navigation',
   'home_navigation',
   'classroom_switch',
 ])
+
+type ExamWindowComplianceSnapshot = {
+  isFullscreen: boolean
+  isCompliant: boolean
+  widthRatio: number
+  heightRatio: number
+  innerWidth: number
+  innerHeight: number
+  availWidth: number
+  availHeight: number
+}
+
+function getExamWindowComplianceSnapshot(): ExamWindowComplianceSnapshot {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return {
+      isFullscreen: false,
+      isCompliant: true,
+      widthRatio: 1,
+      heightRatio: 1,
+      innerWidth: 0,
+      innerHeight: 0,
+      availWidth: 0,
+      availHeight: 0,
+    }
+  }
+
+  const isFullscreen = isFullscreenActive()
+  const innerWidth = window.innerWidth
+  const innerHeight = window.innerHeight
+  const availWidth = window.screen?.availWidth || innerWidth
+  const availHeight = window.screen?.availHeight || innerHeight
+  const widthRatio = availWidth > 0 ? innerWidth / availWidth : 1
+  const heightRatio = availHeight > 0 ? innerHeight / availHeight : 1
+
+  return {
+    isFullscreen,
+    isCompliant:
+      isFullscreen ||
+      (widthRatio >= EXAM_WINDOW_MIN_WIDTH_RATIO && heightRatio >= EXAM_WINDOW_MIN_HEIGHT_RATIO),
+    widthRatio,
+    heightRatio,
+    innerWidth,
+    innerHeight,
+    availWidth,
+    availHeight,
+  }
+}
 
 function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
   const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
@@ -149,6 +199,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const [showStartTestConfirm, setShowStartTestConfirm] = useState(false)
   const [pendingStartTestId, setPendingStartTestId] = useState<string | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [isWindowCompliantNow, setIsWindowCompliantNow] = useState(true)
+  const [isWindowCompliantStable, setIsWindowCompliantStable] = useState(true)
   const [activeDoc, setActiveDoc] = useState<AllowedDocItem | null>(null)
   const [remoteClosureNotice, setRemoteClosureNotice] = useState<RemoteClosureNotice | null>(null)
   const selectedQuizIdRef = useRef<string | null>(null)
@@ -156,6 +208,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const awayStartedAtRef = useRef<number | null>(null)
   const focusEnabledRef = useRef(false)
   const fullscreenActiveRef = useRef(false)
+  const isWindowCompliantStableRef = useRef(true)
+  const pendingNonCompliantTimeoutRef = useRef<number | null>(null)
+  const pendingNonCompliantSourceRef = useRef<'fullscreen_exit' | 'window_resize' | null>(null)
   const lastRouteExitRef = useRef<{ source: string; loggedAtMs: number } | null>(null)
   const lastWindowSignalRef = useRef<{ source: string; loggedAtMs: number } | null>(null)
   const findIntentUntilRef = useRef(0)
@@ -202,21 +257,42 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   }, [selectedQuizId])
 
   useEffect(() => {
+    isWindowCompliantStableRef.current = isWindowCompliantStable
+  }, [isWindowCompliantStable])
+
+  const clearPendingNonCompliantTimeout = useCallback(() => {
+    if (pendingNonCompliantTimeoutRef.current !== null) {
+      window.clearTimeout(pendingNonCompliantTimeoutRef.current)
+      pendingNonCompliantTimeoutRef.current = null
+    }
+    pendingNonCompliantSourceRef.current = null
+  }, [])
+
+  useEffect(() => {
     focusEnabledRef.current = focusEnabled
     if (!focusEnabled) {
+      clearPendingNonCompliantTimeout()
       lastRouteExitRef.current = null
       lastWindowSignalRef.current = null
       findIntentUntilRef.current = 0
       findSuppressionUntilRef.current = 0
       docsInteractionSuppressionUntilRef.current = 0
     }
-  }, [focusEnabled])
+  }, [clearPendingNonCompliantTimeout, focusEnabled])
 
   useEffect(() => {
-    const fullscreenNow = isFullscreenActive()
-    fullscreenActiveRef.current = fullscreenNow
-    setIsFullscreen(fullscreenNow)
+    const snapshot = getExamWindowComplianceSnapshot()
+    fullscreenActiveRef.current = snapshot.isFullscreen
+    setIsFullscreen(snapshot.isFullscreen)
+    setIsWindowCompliantNow(snapshot.isCompliant)
+    setIsWindowCompliantStable(snapshot.isCompliant)
   }, [])
+
+  useEffect(() => {
+    return () => {
+      clearPendingNonCompliantTimeout()
+    }
+  }, [clearPendingNonCompliantTimeout])
 
   const loadQuizzes = useCallback(async () => {
     setLoading(true)
@@ -240,6 +316,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     studentStatus?: StudentQuizStatus
     message?: string | null
   }) => {
+    clearPendingNonCompliantTimeout()
     const nextStudentStatus = options?.studentStatus ?? 'responded'
     setSelectedQuiz((current) => {
       if (!current) return current
@@ -264,7 +341,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     awayStartedAtRef.current = null
     lastRouteExitRef.current = null
     lastWindowSignalRef.current = null
-  }, [])
+  }, [clearPendingNonCompliantTimeout])
 
   async function handleSelectQuiz(quizId: string) {
     setSelectedQuizId(quizId)
@@ -473,6 +550,85 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     )
   }, [postFocusEvent, shouldSuppressForBrowserFind, shouldSuppressForDocInteraction])
 
+  const applyWindowComplianceSnapshot = useCallback((snapshot: ExamWindowComplianceSnapshot) => {
+    fullscreenActiveRef.current = snapshot.isFullscreen
+    setIsFullscreen(snapshot.isFullscreen)
+    setIsWindowCompliantNow(snapshot.isCompliant)
+  }, [])
+
+  const confirmNonCompliantWindow = useCallback((
+    source: 'fullscreen_exit' | 'window_resize',
+    snapshot: ExamWindowComplianceSnapshot
+  ) => {
+    setIsWindowCompliantStable(false)
+    if (!isWindowCompliantStableRef.current) return
+
+    const baseMetadata = {
+      width_ratio: Number(snapshot.widthRatio.toFixed(3)),
+      height_ratio: Number(snapshot.heightRatio.toFixed(3)),
+      inner_width: snapshot.innerWidth,
+      inner_height: snapshot.innerHeight,
+      avail_width: snapshot.availWidth,
+      avail_height: snapshot.availHeight,
+    }
+
+    if (source === 'window_resize') {
+      logWindowUnmaximizeAttempt(
+        'window_resize',
+        baseMetadata,
+        { dedupe: true, dedupeWindowMs: 3000, suppressDuringFind: true, updateSummary: true }
+      )
+      return
+    }
+
+    logWindowUnmaximizeAttempt(
+      'fullscreen_exit',
+      {
+        trigger: 'fullscreenchange',
+        ...baseMetadata,
+      },
+      { dedupe: true, suppressDuringFind: true, updateSummary: true }
+    )
+  }, [logWindowUnmaximizeAttempt])
+
+  const updateWindowCompliance = useCallback((
+    source: 'fullscreen_exit' | 'window_resize'
+  ) => {
+    const snapshot = getExamWindowComplianceSnapshot()
+    applyWindowComplianceSnapshot(snapshot)
+
+    if (snapshot.isCompliant) {
+      clearPendingNonCompliantTimeout()
+      setIsWindowCompliantStable(true)
+      return snapshot
+    }
+
+    clearPendingNonCompliantTimeout()
+    pendingNonCompliantSourceRef.current = source
+    pendingNonCompliantTimeoutRef.current = window.setTimeout(() => {
+      pendingNonCompliantTimeoutRef.current = null
+      const confirmedSource = pendingNonCompliantSourceRef.current
+      pendingNonCompliantSourceRef.current = null
+      const confirmedSnapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(confirmedSnapshot)
+
+      if (confirmedSnapshot.isCompliant) {
+        setIsWindowCompliantStable(true)
+        return
+      }
+
+      if (confirmedSource) {
+        confirmNonCompliantWindow(confirmedSource, confirmedSnapshot)
+      }
+    }, EXAM_WINDOW_COMPLIANCE_GRACE_MS)
+
+    return snapshot
+  }, [
+    applyWindowComplianceSnapshot,
+    clearPendingNonCompliantTimeout,
+    confirmNonCompliantWindow,
+  ])
+
   const requestExamFullscreen = useCallback(async (
     source: string,
     options?: { logFailures?: boolean }
@@ -480,9 +636,12 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     if (!isTestsView) return
     const fullscreenElement = document.documentElement as FullscreenCapableElement
     if (!fullscreenElement?.requestFullscreen) {
-      const fullscreenNow = isFullscreenActive()
-      fullscreenActiveRef.current = fullscreenNow
-      setIsFullscreen(fullscreenNow)
+      const snapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(snapshot)
+      if (snapshot.isCompliant) {
+        clearPendingNonCompliantTimeout()
+        setIsWindowCompliantStable(true)
+      }
       if (options?.logFailures) {
         logWindowUnmaximizeAttempt(
           'fullscreen_not_supported',
@@ -494,20 +653,26 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     }
 
     if (isFullscreenActive()) {
-      fullscreenActiveRef.current = true
-      setIsFullscreen(true)
+      const snapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(snapshot)
+      clearPendingNonCompliantTimeout()
+      setIsWindowCompliantStable(true)
       return
     }
 
     try {
       await fullscreenElement.requestFullscreen()
-      const fullscreenNow = isFullscreenActive()
-      fullscreenActiveRef.current = fullscreenNow
-      setIsFullscreen(fullscreenNow)
+      const snapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(snapshot)
+      clearPendingNonCompliantTimeout()
+      setIsWindowCompliantStable(snapshot.isCompliant)
     } catch (error) {
-      const fullscreenNow = isFullscreenActive()
-      fullscreenActiveRef.current = fullscreenNow
-      setIsFullscreen(fullscreenNow)
+      const snapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(snapshot)
+      if (snapshot.isCompliant) {
+        clearPendingNonCompliantTimeout()
+        setIsWindowCompliantStable(true)
+      }
       if (options?.logFailures) {
         logWindowUnmaximizeAttempt(
           'fullscreen_request_failed',
@@ -519,9 +684,15 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
         )
       }
     }
-  }, [isTestsView, logWindowUnmaximizeAttempt])
+  }, [
+    applyWindowComplianceSnapshot,
+    clearPendingNonCompliantTimeout,
+    isTestsView,
+    logWindowUnmaximizeAttempt,
+  ])
 
   const performBackToAssessmentList = useCallback(() => {
+    clearPendingNonCompliantTimeout()
     setSelectedQuizId(null)
     setSelectedQuiz(null)
     setStartedTestId(null)
@@ -530,9 +701,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     setPendingStartTestId(null)
     setActiveDoc(null)
     setRemoteClosureNotice(null)
-    const fullscreenNow = isFullscreenActive()
-    fullscreenActiveRef.current = fullscreenNow
-    setIsFullscreen(fullscreenNow)
+    const snapshot = getExamWindowComplianceSnapshot()
+    applyWindowComplianceSnapshot(snapshot)
+    setIsWindowCompliantStable(snapshot.isCompliant)
     focusSessionIdRef.current = null
     awayStartedAtRef.current = null
     lastRouteExitRef.current = null
@@ -541,7 +712,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     findSuppressionUntilRef.current = 0
     docsInteractionSuppressionUntilRef.current = 0
     loadQuizzes() // Refresh list to get updated status
-  }, [loadQuizzes])
+  }, [applyWindowComplianceSnapshot, clearPendingNonCompliantTimeout, loadQuizzes])
 
   function handleBack() {
     performBackToAssessmentList()
@@ -695,63 +866,45 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
 
   useEffect(() => {
     if (!focusEnabled) {
-      const fullscreenNow = isFullscreenActive()
-      fullscreenActiveRef.current = fullscreenNow
-      setIsFullscreen(fullscreenNow)
+      clearPendingNonCompliantTimeout()
+      const snapshot = getExamWindowComplianceSnapshot()
+      applyWindowComplianceSnapshot(snapshot)
+      setIsWindowCompliantStable(snapshot.isCompliant)
       return
     }
 
-    const fullscreenNow = isFullscreenActive()
-    fullscreenActiveRef.current = fullscreenNow
-    setIsFullscreen(fullscreenNow)
-    if (!fullscreenNow) {
+    const initialSnapshot = getExamWindowComplianceSnapshot()
+    applyWindowComplianceSnapshot(initialSnapshot)
+    setIsWindowCompliantStable(true)
+    if (!initialSnapshot.isFullscreen) {
       void requestExamFullscreen('exam_mode_start')
+    }
+    if (!initialSnapshot.isCompliant) {
+      updateWindowCompliance('window_resize')
     }
 
     const handleFullscreenChange = () => {
-      const currentlyFullscreen = isFullscreenActive()
-      const wasFullscreen = fullscreenActiveRef.current
-      fullscreenActiveRef.current = currentlyFullscreen
-      setIsFullscreen(currentlyFullscreen)
-      if (wasFullscreen && !currentlyFullscreen) {
-        logWindowUnmaximizeAttempt(
-          'fullscreen_exit',
-          { trigger: 'fullscreenchange' },
-          { dedupe: true, suppressDuringFind: true, updateSummary: true }
-        )
-      }
+      void updateWindowCompliance('fullscreen_exit')
     }
 
     const handleResize = () => {
-      if (isFullscreenActive()) return
-      const availWidth = window.screen?.availWidth || window.innerWidth
-      const availHeight = window.screen?.availHeight || window.innerHeight
-      const widthRatio = availWidth > 0 ? window.innerWidth / availWidth : 1
-      const heightRatio = availHeight > 0 ? window.innerHeight / availHeight : 1
-      const looksUnmaximized = widthRatio < 0.92 || heightRatio < 0.88
-      if (!looksUnmaximized) return
-
-      logWindowUnmaximizeAttempt(
-        'window_resize',
-        {
-          width_ratio: Number(widthRatio.toFixed(3)),
-          height_ratio: Number(heightRatio.toFixed(3)),
-          inner_width: window.innerWidth,
-          inner_height: window.innerHeight,
-          avail_width: availWidth,
-          avail_height: availHeight,
-        },
-        { dedupe: true, dedupeWindowMs: 3000, suppressDuringFind: true, updateSummary: true }
-      )
+      void updateWindowCompliance('window_resize')
     }
 
     document.addEventListener('fullscreenchange', handleFullscreenChange)
     window.addEventListener('resize', handleResize)
     return () => {
+      clearPendingNonCompliantTimeout()
       document.removeEventListener('fullscreenchange', handleFullscreenChange)
       window.removeEventListener('resize', handleResize)
     }
-  }, [focusEnabled, logWindowUnmaximizeAttempt, requestExamFullscreen])
+  }, [
+    applyWindowComplianceSnapshot,
+    clearPendingNonCompliantTimeout,
+    focusEnabled,
+    requestExamFullscreen,
+    updateWindowCompliance,
+  ])
 
   useEffect(() => {
     if (!focusEnabled) return
@@ -936,7 +1089,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const awayCount = focusSummary?.away_count ?? 0
     const routeExitAttempts = focusSummary?.route_exit_attempts ?? 0
     const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
-    const showNotMaximizedWarning = showCurrentTestInfoPanel && !isFullscreen
+    const showNotMaximizedWarning = showCurrentTestInfoPanel && !isWindowCompliantStable
     const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
     const selectedTestTitle = hasSelectedQuiz ? selectedQuiz.quiz.title : ''
     const selectedTestPanelTitle = isViewingResults

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -168,14 +168,14 @@ describe('StudentQuizzesTab exam mode', () => {
     fireEvent.click(screen.getByText('Start test'))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Maximize Window/i })).toBeInTheDocument()
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
     })
 
-    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
-    expect(screen.queryByText('2 + 2 = ?')).not.toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: '3' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: '4' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument()
     expect(screen.queryByText('Exit Test')).not.toBeInTheDocument()
     expect(screen.queryByText('Leave this test?')).not.toBeInTheDocument()
   })
@@ -2170,7 +2170,7 @@ describe('StudentQuizzesTab exam mode', () => {
 
     await waitFor(() => {
       expect(focusBodies.filter((body) => body.event_type === 'away_start')).toHaveLength(1)
-      expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(1)
+      expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
       expect(focusBodies.filter((body) => body.event_type === 'away_end')).toHaveLength(1)
     })
   })
@@ -2518,8 +2518,437 @@ describe('StudentQuizzesTab exam mode', () => {
     })
   })
 
-  it('logs window unmaximize telemetry on resize when exam mode window is reduced', async () => {
+  it('keeps the question visible on transient fullscreen loss when the window still looks maximized', async () => {
     const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    vi.useFakeTimers()
+    fullscreenElement = null
+    fireEvent(document, new Event('fullscreenchange'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(450)
+    })
+
+    expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
+  })
+
+  it('locks after sustained fullscreen loss when the window remains non-compliant', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary({
+              window_unmaximize_attempts: focusBodies.filter(
+                (body) => body.event_type === 'window_unmaximize_attempt'
+              ).length,
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    vi.useFakeTimers()
+    fullscreenElement = null
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+    fireEvent(document, new Event('fullscreenchange'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(450)
+    })
+
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.queryByText('2 + 2 = ?')).not.toBeInTheDocument()
+    expect(
+      focusBodies.some(
+        (body) =>
+          body.event_type === 'window_unmaximize_attempt' &&
+          body.metadata?.source === 'fullscreen_exit'
+      )
+    ).toBe(true)
+  })
+
+  it('cancels the pending lock when compliance returns before the grace window expires', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    vi.useFakeTimers()
+    fullscreenElement = null
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+    fireEvent(document, new Event('fullscreenchange'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 768,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1024,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 768,
+    })
+    fireEvent(window, new Event('resize'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
+  })
+
+  it('locks after the grace window when exam mode window is reduced', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
     fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
       if (url.includes('/api/student/tests?classroom_id=')) {
         return {
@@ -2594,12 +3023,29 @@ describe('StudentQuizzesTab exam mode', () => {
       throw new Error(`Unexpected fetch call: ${url}`)
     })
 
-    let fullscreenElement: Element | null = null
-    Object.defineProperty(document, 'fullscreenElement', {
-      configurable: true,
-      get: () => fullscreenElement,
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
     })
 
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    vi.useFakeTimers()
+    fullscreenElement = null
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       writable: true,
@@ -2618,37 +3064,20 @@ describe('StudentQuizzesTab exam mode', () => {
       configurable: true,
       value: 900,
     })
-
-    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByText('Midterm Test'))
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
-    await waitFor(() => {
-      expect(screen.getByText('Start this test?')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByText('Start test'))
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Maximize Window/i })).toBeInTheDocument()
-    })
-
     fireEvent(window, new Event('resize'))
 
-    await waitFor(() => {
-      expect(
-        focusBodies.some(
-          (body) =>
-            body.event_type === 'window_unmaximize_attempt' &&
-            body.metadata?.source === 'window_resize'
-        )
-      ).toBe(true)
+    await act(async () => {
+      vi.advanceTimersByTime(450)
     })
+
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.queryByText('2 + 2 = ?')).not.toBeInTheDocument()
+    expect(
+      focusBodies.some(
+        (body) =>
+          body.event_type === 'window_unmaximize_attempt' &&
+          body.metadata?.source === 'window_resize'
+      )
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add a stabilized exam-window compliance check for student test exam mode
- wait 400ms before showing the opaque lock screen when fullscreen or resize events report non-compliance
- confirm the behavior with focused component coverage and a seeded browser verification run

## Root Cause
Student exam mode treated a raw `fullscreenchange` loss as an immediate lock condition. On some student machines, a transient fullscreen-loss signal during MC interaction could blank the Pika content area even when the window still effectively looked maximized.

## What Changed
- derive exam-mode lock state from a compliance snapshot instead of raw fullscreen status alone
- treat either active fullscreen or a still-maximized window as compliant
- defer lock-screen activation until non-compliance is still present after the grace window
- only log `window_unmaximize_attempt` after sustained non-compliance is confirmed
- add tests for transient loss, sustained loss, restored compliance, and reduced-window resize

## Validation
- `pnpm test tests/components/StudentQuizzesTab.test.tsx`
- `pnpm exec eslint 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' 'tests/components/StudentQuizzesTab.test.tsx'`
- `pnpm run seed`
- `E2E_BASE_URL=http://localhost:3005 pnpm e2e:auth`
- seeded browser check on the active student test confirmed the question stayed visible and no obscurer appeared after a transient fullscreen-loss event

## Impact
This keeps the existing exam-mode lock behavior for true fullscreen or maximize violations, but filters out false positives that were blanking the student exam pane during normal MC interaction.