### PR TITLE
[codex] Preserve student test progress through exam lock overlay

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9071,3 +9071,19 @@
 - `pnpm build`
 - `pnpm run seed`
 - Seeded browser verification on `Test Classroom` → `Personal Narrative Essay` showing the new teacher AI grading note during an active batch run
+
+## 2026-04-21 — Preserve Student Test Progress Through Exam Lock Overlay
+
+- Investigated issue `#483` and confirmed the progress-loss symptom came from same-session remounting during sustained exam-mode non-compliance, not from missing draft persistence on the server.
+- Kept the active student test shell mounted while the maximize-warning overlay is active, hiding it with `visibility: hidden` and `aria-hidden` instead of swapping the pane out for an empty placeholder.
+- Updated exam-mode component coverage so lock-state assertions check that content becomes hidden rather than unmounted, and added a regression test proving an unsaved open-response draft survives the lock/unlock cycle.
+- Visually verified the seeded student test flow in `Test Classroom`, including the active test, maximize-warning overlay, and restored view with the typed response still present.
+
+**Validation:**
+- `pnpm test tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx tests/api/student/tests-id.test.ts tests/api/student/tests-attempt.test.ts`
+- Browser verification on seeded `Test Classroom` tests:
+  - teacher desktop tests tab
+  - student mobile tests tab
+  - student desktop active test
+  - student desktop maximize-warning overlay
+  - student desktop restored test with preserved draft

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -1144,18 +1144,15 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
           </div>
         )}
 
-        {showNotMaximizedWarning ? (
-          <PageContent className={showSplitExamShell ? 'flex-1 min-h-0 px-0 pt-1' : 'flex-1 min-h-0'}>
-            <div aria-hidden="true" className="h-full" />
-          </PageContent>
-        ) : (
-          <PageContent className={showSplitExamShell ? 'flex-1 min-h-0 px-0 pt-1' : 'flex-1 min-h-0'}>
-            <div
-              className={`mx-auto h-full w-full ${
-                showSplitExamShell || !hasSelectedQuiz ? 'max-w-none' : 'max-w-3xl'
-              }`}
-            >
-              {showSplitExamShell ? (
+        <PageContent className={showSplitExamShell ? 'flex-1 min-h-0 px-0 pt-1' : 'flex-1 min-h-0'}>
+          <div
+            aria-hidden={showNotMaximizedWarning}
+            className={`mx-auto h-full w-full ${
+              showSplitExamShell || !hasSelectedQuiz ? 'max-w-none' : 'max-w-3xl'
+            }`}
+            style={showNotMaximizedWarning ? { visibility: 'hidden' } : undefined}
+          >
+            {showSplitExamShell ? (
                 <div
                   data-testid="student-test-split-container"
                   className={`grid grid-cols-1 gap-2 ${
@@ -1420,7 +1417,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                     )}
                   </section>
                 </div>
-              ) : !hasSelectedQuiz ? (
+            ) : !hasSelectedQuiz ? (
                 quizzes.length === 0 ? (
                   <EmptyState
                     title="No tests available."
@@ -1431,11 +1428,11 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                     {renderAssessmentList(false)}
                   </div>
                 )
-              ) : selectedQuizId && loadingQuiz ? (
+            ) : selectedQuizId && loadingQuiz ? (
                 <div className="flex justify-center py-12">
                   <Spinner size="lg" />
                 </div>
-              ) : (
+            ) : (
                 <div className="min-w-0">
                   <button
                     type="button"
@@ -1546,10 +1543,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                     />
                   )}
                 </div>
-              )}
-            </div>
-          </PageContent>
-        )}
+            )}
+          </div>
+        </PageContent>
 
         <ConfirmDialog
           isOpen={showStartTestConfirm}

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -2766,7 +2766,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
 
     expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
-    expect(screen.queryByText('2 + 2 = ?')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3071,7 +3071,7 @@ describe('StudentQuizzesTab exam mode', () => {
     })
 
     expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
-    expect(screen.queryByText('2 + 2 = ?')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3079,5 +3079,223 @@ describe('StudentQuizzesTab exam mode', () => {
           body.metadata?.source === 'window_resize'
       )
     ).toBe(true)
+  })
+
+  it('preserves unsaved in-progress test answers when the maximize lock overlay appears and clears', async () => {
+    let fullscreenElement: Element | null = null
+    let savedResponses: Record<string, unknown> = {}
+    const focusBodies: Array<Record<string, any>> = []
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/session-status')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              status: 'active',
+              assessment_type: 'test',
+              student_status: 'not_started',
+              returned_at: null,
+            },
+            student_status: 'not_started',
+            returned_at: null,
+            can_continue: true,
+            message: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1') && !url.includes('/session-status') && !url.includes('/focus-events') && !url.includes('/attempt')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+              {
+                id: 'q2',
+                quiz_id: 'test-1',
+                question_text: 'Explain one benefit of writing tests before implementation.',
+                options: [],
+                question_type: 'open_response',
+                points: 4,
+                response_max_chars: 5000,
+                position: 1,
+              },
+            ],
+            student_responses: savedResponses,
+            focus_summary: makeFocusSummary({
+              window_unmaximize_attempts: focusBodies.filter(
+                (body) => body.event_type === 'window_unmaximize_attempt'
+              ).length,
+            }),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/attempt') && options?.method === 'PATCH') {
+        const body = JSON.parse(String(options.body || '{}')) as { responses?: Record<string, unknown> }
+        savedResponses = body.responses || {}
+        return {
+          ok: true,
+          json: async () => ({
+            attempt: {
+              id: 'attempt-1',
+              responses: savedResponses,
+              is_submitted: false,
+            },
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary({
+              window_unmaximize_attempts: focusBodies.filter(
+                (body) => body.event_type === 'window_unmaximize_attempt'
+              ).length,
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Explain one benefit of writing tests before implementation.')
+      ).toBeInTheDocument()
+    })
+
+    vi.useFakeTimers()
+
+    const responseBox = screen.getAllByPlaceholderText('Write your response...')[0]
+    fireEvent.change(responseBox, {
+      target: { value: 'TDD clarifies expected behavior before coding.' },
+    })
+
+    expect(savedResponses).toEqual({})
+
+    fullscreenElement = null
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+    fireEvent(document, new Event('fullscreenchange'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(450)
+    })
+
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+    await act(async () => {
+      fireEvent(window, new Event('resize'))
+    })
+
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('TDD clarifies expected behavior before coding.')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- keep the active student test pane mounted while the exam maximize-warning overlay is shown
- hide locked content instead of replacing it with an empty shell so in-memory draft state survives the lock/unlock cycle
- add regression coverage for the hidden lock state and the unsaved open-response preservation path

## Root Cause
Sustained exam-mode non-compliance replaced the active test pane with an empty branch. That unmounted `StudentQuizForm`, so the next mount rehydrated from stale `initialResponses` and made student progress appear lost even when the server draft was still intact.

## Validation
- `pnpm test tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx tests/api/student/tests-id.test.ts tests/api/student/tests-attempt.test.ts`
- Browser verification on seeded `Test Classroom` tests flow:
  - teacher desktop tests tab
  - student mobile tests tab
  - student desktop active test
  - student desktop maximize-warning overlay
  - student desktop restored test with preserved draft

Closes #483
