### PR TITLE
[codex] Fix assignment grading defaults

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9117,3 +9117,12 @@
 **Validation:**
 - `pnpm exec vitest run tests/api/teacher/assignments-id-return.test.ts tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'tests/api/teacher/assignments-id-return.test.ts'`
+
+## 2026-04-21 — Validate Enrollment Before Assignment Auto-Grade
+
+- Updated teacher assignment auto-grade to verify every requested `student_id` is enrolled in the assignment classroom before creating missing grades or batch grading runs.
+- Added route-level regression coverage for rejecting non-enrolled single-student and batch auto-grade requests, and confirmed the missing-grade path is not called for invalid IDs.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments-auto-grade.test.ts`
+- `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/auto-grade/route.ts' 'tests/api/teacher/assignments-auto-grade.test.ts'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9135,3 +9135,13 @@
 **Validation:**
 - `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
 - `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`
+
+## 2026-04-21 — Make Assignment AI Batch Creation Atomic
+
+- Added migration `055_assignment_ai_grading_run_atomic_rpc.sql` with `create_assignment_ai_grading_run_atomic(...)` so run creation, run-item inserts, and skipped-student `Missing` grade upserts happen in one database transaction.
+- Updated `createOrResumeAssignmentAiGradingRun()` to call the atomic RPC instead of issuing separate writes from TypeScript, added explicit migration guidance when the new RPC is unavailable, and mapped active-run unique-key races back to the intended resume/conflict response.
+- Replaced the service regression tests to assert the RPC payload, matching-run resume behavior, the race-recovery path, and the migration-055 error path.
+
+**Validation:**
+- `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts`
+- `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9087,3 +9087,13 @@
   - student desktop active test
   - student desktop maximize-warning overlay
   - student desktop restored test with preserved draft
+## 2026-04-21 — Finalize Default Assignment Grading State
+
+- Changed assignment AI grading to save successful grades as final by default, while preserving draft only when a teacher explicitly chooses draft during manual grading.
+- Auto-finalized missing or empty submissions with `Missing` feedback, zero scores, and graded metadata so batch and single-student grading flows no longer leave these students ungraded.
+- Collapsed repeated AI grading failure text into concise grouped summaries in the teacher classroom header and kept the updated grading workspace stable across desktop and mobile verification.
+
+**Validation:**
+- `pnpm exec vitest run tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec eslint 'src/lib/ai-grading.ts' 'src/lib/server/assignment-ai-grading-runs.ts' 'src/app/api/teacher/assignments/[id]/auto-grade/route.ts' 'src/components/assignment-workspace/useTeacherStudentWorkController.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'tests/api/teacher/assignments-auto-grade.test.ts' 'tests/unit/ai-grading.test.ts' 'tests/components/TeacherStudentWorkPanel.test.tsx' 'tests/components/TeacherClassroomView.test.tsx'`
+- Visual verification screenshots: `/tmp/pika-teacher-grading.png`, `/tmp/pika-teacher-grading-mobile.png`, `/tmp/pika-student-assignments.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9126,3 +9126,12 @@
 **Validation:**
 - `pnpm exec vitest run tests/api/teacher/assignments-auto-grade.test.ts`
 - `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/auto-grade/route.ts' 'tests/api/teacher/assignments-auto-grade.test.ts'`
+
+## 2026-04-21 — Reorder Batch Missing-Grade Writes
+
+- Changed assignment AI grading batch setup to create the grading run and run items before writing `Missing` zero-point grades for skipped students.
+- Added direct service-level regression coverage to ensure missing-grade upserts do not happen when run creation or run-item creation fails, and to lock in the new successful ordering.
+
+**Validation:**
+- `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
+- `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9155,3 +9155,11 @@
 **Validation:**
 - `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts`
 - `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`
+
+## 2026-04-22 — Reshape Migration 055 For Supabase CLI Parsing
+
+- Rewrote `055_assignment_ai_grading_run_atomic_rpc.sql` as a single top-level `DO` block that dynamically creates the RPC and applies the `revoke`/`grant`, avoiding the CLI prepared-statement failure when it tries to apply the whole file at once.
+- Preserved the same RPC body and service-role-only execute permissions; this change is migration-shape only.
+
+**Validation:**
+- Manual migration diff review for semantic parity of the function body and permission changes.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9145,3 +9145,13 @@
 **Validation:**
 - `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts`
 - `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`
+
+## 2026-04-22 — Tighten Atomic RPC Access And Item Failure Handling
+
+- Restricted `create_assignment_ai_grading_run_atomic(...)` execution to `service_role` so the new security-definer RPC cannot be called directly by ordinary authenticated users.
+- Updated batch item processing so failed `Missing` grade writes on `missing_doc` or `empty_doc` items become item-level `failed` states with explicit error metadata instead of crashing the whole grading run.
+- Added regression coverage for both skipped-item failure paths to confirm the run completes with item errors rather than top-level failure.
+
+**Validation:**
+- `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts`
+- `pnpm exec eslint 'src/lib/server/assignment-ai-grading-runs.ts' 'tests/lib/assignment-ai-grading-runs.test.ts'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9097,3 +9097,14 @@
 - `pnpm exec vitest run tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec eslint 'src/lib/ai-grading.ts' 'src/lib/server/assignment-ai-grading-runs.ts' 'src/app/api/teacher/assignments/[id]/auto-grade/route.ts' 'src/components/assignment-workspace/useTeacherStudentWorkController.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'tests/api/teacher/assignments-auto-grade.test.ts' 'tests/unit/ai-grading.test.ts' 'tests/components/TeacherStudentWorkPanel.test.tsx' 'tests/components/TeacherClassroomView.test.tsx'`
 - Visual verification screenshots: `/tmp/pika-teacher-grading.png`, `/tmp/pika-teacher-grading-mobile.png`, `/tmp/pika-student-assignments.png`
+
+## 2026-04-21 — Return Missing Assignment Grades and Simplify Run Errors
+
+- Updated assignment return handling so fully graded work can be returned even when the student never submitted, which allows `Missing` zero-point grades to reach students through the normal return flow.
+- Standardized classroom AI grading summaries to treat empty work as `missing` and show only unique true error messages instead of sampled per-student counts.
+- Added regression coverage for returning unsubmitted `Missing` grades and for the revised teacher header summary wording.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'tests/api/teacher/assignments-id-return.test.ts' 'tests/components/TeacherClassroomView.test.tsx'`
+- Visual verification screenshots: `/tmp/pika-teacher-classroom-header-desktop.png`, `/tmp/pika-teacher-classroom-header-mobile.png`, `/tmp/pika-student-classroom-mobile.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9108,3 +9108,12 @@
 - `pnpm exec vitest run tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id-return.test.ts tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'tests/api/teacher/assignments-id-return.test.ts' 'tests/components/TeacherClassroomView.test.tsx'`
 - Visual verification screenshots: `/tmp/pika-teacher-classroom-header-desktop.png`, `/tmp/pika-teacher-classroom-header-mobile.png`, `/tmp/pika-student-classroom-mobile.png`
+
+## 2026-04-21 — Prevent Duplicate Assignment Re-Returns
+
+- Tightened the assignment return filter so already returned work is not re-returned unless the student has submitted again, while still allowing unsubmitted `Missing` grades to be returned once.
+- Added regression coverage to ensure the return route skips already returned docs instead of duplicating feedback entries or restamping return timestamps.
+
+**Validation:**
+- `pnpm exec vitest run tests/api/teacher/assignments-id-return.test.ts tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'tests/api/teacher/assignments-id-return.test.ts'`

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { hasGradableAssignmentSubmission } from '@/lib/ai-grading'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -6,6 +7,7 @@ import { parseContentField } from '@/lib/tiptap-content'
 import {
   createOrResumeAssignmentAiGradingRun,
   gradeAssignmentDocWithAi,
+  markAssignmentDocMissingGrade,
 } from '@/lib/server/assignment-ai-grading-runs'
 import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
 
@@ -74,18 +76,30 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
   }
 
   if (!doc) {
+    await markAssignmentDocMissingGrade({
+      supabase,
+      assignmentId: id,
+      studentId,
+      gradedBy: user.id,
+    })
     return NextResponse.json({
-      graded_count: 0,
-      skipped_count: 1,
+      graded_count: 1,
+      skipped_count: 0,
       errors: undefined,
     })
   }
 
   const studentWork = parseContentField(doc.content)
-  if (!studentWork.content || studentWork.content.length === 0) {
+  if (!hasGradableAssignmentSubmission(studentWork)) {
+    await markAssignmentDocMissingGrade({
+      supabase,
+      assignmentId: id,
+      studentId,
+      gradedBy: user.id,
+    })
     return NextResponse.json({
-      graded_count: 0,
-      skipped_count: 1,
+      graded_count: 1,
+      skipped_count: 0,
       errors: undefined,
     })
   }
@@ -95,6 +109,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
       supabase,
       assignment,
       assignmentDoc: doc,
+      gradedBy: user.id,
       telemetry: {
         operation: 'single_grade',
         requestedStrategy: 'single',

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -34,6 +34,20 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
 
   const assignment = await assertTeacherOwnsAssignment(user.id, id)
   const supabase = getServiceRoleClient()
+  const { data: enrollments, error: enrollmentError } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', assignment.classroom_id)
+    .in('student_id', normalizedStudentIds)
+
+  if (enrollmentError) {
+    console.error('Error validating enrollments for auto-grade:', enrollmentError)
+    return NextResponse.json({ error: 'Failed to validate student enrollment' }, { status: 500 })
+  }
+
+  if (((enrollments as Array<{ student_id: string }> | null) ?? []).length !== normalizedStudentIds.length) {
+    return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
+  }
 
   if (normalizedStudentIds.length > 1) {
     const runResult = await createOrResumeAssignmentAiGradingRun({

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -12,10 +12,16 @@ function hasReturnableAssignmentGrade(doc: {
   score_completion: number | null
   score_thinking: number | null
   score_workflow: number | null
+  is_submitted?: boolean | null
+  returned_at?: string | null
 }) {
-  return doc.score_completion != null
+  const hasFullGrade = doc.score_completion != null
     && doc.score_thinking != null
     && doc.score_workflow != null
+
+  if (!hasFullGrade) return false
+
+  return !!doc.is_submitted || !doc.returned_at
 }
 
 async function updateAssignmentDocsForStudents(opts: {
@@ -83,7 +89,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
   const eligibleDocIds = new Set(eligibleDocs.map((doc) => doc.id))
   const actionableDocIds = new Set(
     loadedDocs
-      .filter((doc) => doc.is_submitted || eligibleDocIds.has(doc.id))
+      .filter((doc) => doc.is_submitted || eligibleDocIds.has(doc.id) || !!doc.returned_at)
       .map((doc) => doc.id),
   )
   const ungradedDocs = clearableDocs.filter((doc) => !eligibleDocIds.has(doc.id))

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -8,6 +8,16 @@ import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/ass
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+function hasReturnableAssignmentGrade(doc: {
+  score_completion: number | null
+  score_thinking: number | null
+  score_workflow: number | null
+}) {
+  return doc.score_completion != null
+    && doc.score_thinking != null
+    && doc.score_workflow != null
+}
+
 async function updateAssignmentDocsForStudents(opts: {
   supabase: ReturnType<typeof getServiceRoleClient>
   assignmentId: string
@@ -67,13 +77,15 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     return NextResponse.json({ error: 'Failed to load docs for return' }, { status: 500 })
   }
 
-  const clearableDocs = (docs || []).filter((doc) => doc.is_submitted)
-  const eligibleDocs = clearableDocs.filter((doc) =>
-    doc.score_completion != null
-    && doc.score_thinking != null
-    && doc.score_workflow != null
-  )
+  const loadedDocs = docs || []
+  const clearableDocs = loadedDocs.filter((doc) => doc.is_submitted)
+  const eligibleDocs = loadedDocs.filter(hasReturnableAssignmentGrade)
   const eligibleDocIds = new Set(eligibleDocs.map((doc) => doc.id))
+  const actionableDocIds = new Set(
+    loadedDocs
+      .filter((doc) => doc.is_submitted || eligibleDocIds.has(doc.id))
+      .map((doc) => doc.id),
+  )
   const ungradedDocs = clearableDocs.filter((doc) => !eligibleDocIds.has(doc.id))
 
   const now = new Date().toISOString()
@@ -171,7 +183,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
 
   const returnedCount = eligibleDocs.length
   const clearedCount = clearableDocs.length
-  const missingCount = Math.max(student_ids.length - clearableDocs.length, 0)
+  const missingCount = Math.max(student_ids.length - actionableDocIds.size, 0)
 
   return NextResponse.json({
     returned_count: returnedCount,

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -248,6 +248,23 @@ function getAssignmentAiRunPollDelayMs(run: AssignmentAiGradingRunSummary | null
   return Math.min(Math.max(delay, 1000), 10_000)
 }
 
+function summarizeAssignmentAiGradingErrors(run: AssignmentAiGradingRunSummary): string {
+  const counts = new Map<string, number>()
+
+  for (const sample of run.error_samples) {
+    const message = sample.message.trim()
+    if (!message) continue
+    counts.set(message, (counts.get(message) || 0) + 1)
+  }
+
+  if (counts.size === 0) return ''
+
+  return Array.from(counts.entries())
+    .slice(0, 3)
+    .map(([message, count]) => (count > 1 ? `${count} students: ${message}` : message))
+    .join(' · ')
+}
+
 function formatAssignmentAiGradingRunMessage(run: AssignmentAiGradingRunSummary): {
   info: string
   error: string
@@ -270,15 +287,12 @@ function formatAssignmentAiGradingRunMessage(run: AssignmentAiGradingRunSummary)
   const summary = summaryParts.length > 0
     ? summaryParts.join(' • ')
     : 'No grading changes were needed'
-  const errorDetails = run.error_samples
-    .slice(0, 3)
-    .map((sample) => sample.message)
-    .join('\n')
+  const errorSummary = summarizeAssignmentAiGradingErrors(run)
 
   if (run.status === 'completed_with_errors' || run.status === 'failed') {
     return {
       info: '',
-      error: errorDetails ? `${summary}\n${errorDetails}` : summary,
+      error: errorSummary ? `${summary}\n${errorSummary}` : summary,
     }
   }
 

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -249,19 +249,20 @@ function getAssignmentAiRunPollDelayMs(run: AssignmentAiGradingRunSummary | null
 }
 
 function summarizeAssignmentAiGradingErrors(run: AssignmentAiGradingRunSummary): string {
-  const counts = new Map<string, number>()
+  const uniqueMessages: string[] = []
+  const seen = new Set<string>()
 
   for (const sample of run.error_samples) {
     const message = sample.message.trim()
-    if (!message) continue
-    counts.set(message, (counts.get(message) || 0) + 1)
+    if (!message || seen.has(message)) continue
+    seen.add(message)
+    uniqueMessages.push(message)
   }
 
-  if (counts.size === 0) return ''
+  if (uniqueMessages.length === 0) return ''
 
-  return Array.from(counts.entries())
+  return uniqueMessages
     .slice(0, 3)
-    .map(([message, count]) => (count > 1 ? `${count} students: ${message}` : message))
     .join(' · ')
 }
 
@@ -274,11 +275,9 @@ function formatAssignmentAiGradingRunMessage(run: AssignmentAiGradingRunSummary)
   if (run.completed_count > 0) {
     summaryParts.push(`Graded ${run.completed_count}`)
   }
-  if (run.skipped_empty_count > 0) {
-    summaryParts.push(`${run.skipped_empty_count} empty`)
-  }
-  if (run.skipped_missing_count > 0) {
-    summaryParts.push(`${run.skipped_missing_count} missing`)
+  const missingCount = run.skipped_empty_count + run.skipped_missing_count
+  if (missingCount > 0) {
+    summaryParts.push(`${missingCount} missing`)
   }
   if (run.failed_count > 0) {
     summaryParts.push(`${run.failed_count} failed`)

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -67,8 +67,9 @@ function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: 
   return { value: `${suggestion}\n\n${base}`, hasFreshAI: true }
 }
 
-function getGradeSaveMode(doc: AssignmentDoc | null | undefined): GradeSaveMode {
-  return doc?.graded_at ? 'graded' : 'draft'
+function getInitialGradeSaveMode(doc: AssignmentDoc | null | undefined): GradeSaveMode {
+  if (doc?.graded_at) return 'graded'
+  return doc?.teacher_feedback_draft_updated_at ? 'draft' : 'graded'
 }
 
 function buildGradeSnapshot({
@@ -213,6 +214,7 @@ export function useTeacherStudentWorkController({
   const [scoreWorkflow, setScoreWorkflow] = useState('')
   const [feedbackDraft, setFeedbackDraft] = useState('')
   const [hasFreshAIDraft, setHasFreshAIDraft] = useState(false)
+  const [gradeMode, setGradeMode] = useState<GradeSaveMode>('graded')
   const [gradeSaving, setGradeSaving] = useState(false)
   const [showDraftAutosavedNotice, setShowDraftAutosavedNotice] = useState(false)
   const [gradeError, setGradeError] = useState('')
@@ -335,12 +337,13 @@ export function useTeacherStudentWorkController({
       setScoreWorkflow('')
       setFeedbackDraft('')
       setHasFreshAIDraft(false)
+      setGradeMode('graded')
       lastSavedGradeSnapshotRef.current = buildGradeSnapshot({
         scoreCompletion: '',
         scoreThinking: '',
         scoreWorkflow: '',
         feedbackDraft: '',
-        mode: 'draft',
+        mode: 'graded',
       })
       return
     }
@@ -356,12 +359,13 @@ export function useTeacherStudentWorkController({
     setScoreWorkflow(nextScoreWorkflow)
     setFeedbackDraft(mergedDraft.value)
     setHasFreshAIDraft(mergedDraft.hasFreshAI)
+    setGradeMode(getInitialGradeSaveMode(doc))
     lastSavedGradeSnapshotRef.current = buildGradeSnapshot({
       scoreCompletion: nextScoreCompletion,
       scoreThinking: nextScoreThinking,
       scoreWorkflow: nextScoreWorkflow,
       feedbackDraft: mergedDraft.value,
-      mode: getGradeSaveMode(doc),
+      mode: getInitialGradeSaveMode(doc),
     })
   }, [clearDraftAutosavedNotice])
 
@@ -552,6 +556,7 @@ export function useTeacherStudentWorkController({
         if (!response.ok) throw new Error(result.error || 'Failed to save grade')
         lastSavedGradeSnapshotRef.current = nextSnapshot
         setData((current) => (current ? { ...current, doc: result.doc } : current))
+        setGradeMode(getInitialGradeSaveMode(result.doc))
         dispatchGradeUpdated(result.doc)
         if (selectedSaveMode === 'draft') {
           flashDraftAutosavedNotice()
@@ -583,7 +588,7 @@ export function useTeacherStudentWorkController({
   useEffect(() => {
     if (!data || gradeSaving) return
 
-    const selectedSaveMode = getGradeSaveMode(data.doc)
+    const selectedSaveMode = gradeMode
     const nextSnapshot = buildGradeSnapshot({
       scoreCompletion,
       scoreThinking,
@@ -614,7 +619,7 @@ export function useTeacherStudentWorkController({
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [data, feedbackDraft, gradeSaving, persistGrade, scoreCompletion, scoreThinking, scoreWorkflow])
+  }, [data, feedbackDraft, gradeMode, gradeSaving, persistGrade, scoreCompletion, scoreThinking, scoreWorkflow])
 
   const updateScoreCompletion = useCallback((value: string) => {
     setGradeError('')
@@ -642,6 +647,7 @@ export function useTeacherStudentWorkController({
 
   const handleSetGradeMode = useCallback(
     async (selectedSaveMode: GradeSaveMode) => {
+      setGradeMode(selectedSaveMode)
       await persistGrade(selectedSaveMode, { source: 'manual' })
     },
     [persistGrade],
@@ -664,11 +670,13 @@ export function useTeacherStudentWorkController({
         setGradeError(result.errors.join(', '))
         return
       }
-      if (result.graded_count === 0) {
+      if ((result.graded_count ?? 0) === 0) {
         setGradeError('No gradable content found — the submission may be empty')
         return
       }
-      const refreshed = await loadStudentWork({ mergeFeedbackIntoDraftFrom: feedbackDraft })
+      const refreshed = await loadStudentWork({
+        mergeFeedbackIntoDraftFrom: feedbackDraft.trim() ? feedbackDraft : null,
+      })
       dispatchGradeUpdated(refreshed?.doc ?? null)
     } catch (err: any) {
       setGradeError(err.message || 'Auto-grade failed')
@@ -766,7 +774,6 @@ export function useTeacherStudentWorkController({
   }, [scoreCompletion, scoreThinking, scoreWorkflow])
 
   const totalPercent = useMemo(() => Math.round((totalScore / 30) * 100), [totalScore])
-  const gradeMode = getGradeSaveMode(data?.doc)
 
   return {
     data,

--- a/src/lib/ai-grading.ts
+++ b/src/lib/ai-grading.ts
@@ -238,6 +238,13 @@ function formatArtifactLabel(artifact: AssignmentArtifact): string {
   }
 }
 
+export function hasGradableAssignmentSubmission(studentWork: TiptapContent): boolean {
+  const studentText = extractPlainText(studentWork).trim()
+  const artifacts = extractAssignmentArtifacts(studentWork)
+
+  return studentText.length > 0 || artifacts.length > 0
+}
+
 function buildStudentSubmissionText(studentWork: TiptapContent): string {
   const studentText = extractPlainText(studentWork).trim()
   const artifacts = extractAssignmentArtifacts(studentWork)
@@ -258,7 +265,7 @@ function buildStudentSubmissionText(studentWork: TiptapContent): string {
     sections.push(`Attached Artifacts:\n${artifactLines.join('\n')}`)
   }
 
-  if (sections.length === 0) {
+  if (!hasGradableAssignmentSubmission(studentWork)) {
     throw new Error('Student work is empty')
   }
 

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -1,5 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { gradeStudentWork, isRetryableAssignmentAiGradingError } from '@/lib/ai-grading'
+import {
+  gradeStudentWork,
+  hasGradableAssignmentSubmission,
+  isRetryableAssignmentAiGradingError,
+} from '@/lib/ai-grading'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
@@ -18,6 +22,7 @@ import type {
 const DEFAULT_MODEL = 'gpt-5-nano'
 const RETRY_BACKOFF_SECONDS = [15, 60, 180]
 const TIMEOUT_RETRY_BACKOFF_SECONDS = [7, 20, 45]
+const MISSING_ASSIGNMENT_GRADE_FEEDBACK = 'Missing'
 
 export const ASSIGNMENT_AI_GRADING_RUN_CHUNK_SIZE = 4
 export const ASSIGNMENT_AI_GRADING_ITEM_CONCURRENCY = 2
@@ -42,6 +47,7 @@ type GradeAssignmentDocWithAiOptions = {
     feedback: string | null
     authenticity_score: number | null
   }
+  gradedBy?: string | null
   requestTimeoutMs?: number
   telemetry?: {
     operation?: string
@@ -263,16 +269,52 @@ async function maybeScoreAuthenticity(
     .eq('id', assignmentDocId)
 }
 
+export async function markAssignmentDocMissingGrade(opts: {
+  supabase: ServiceRoleSupabase
+  assignmentId: string
+  studentId: string
+  gradedBy?: string | null
+}): Promise<void> {
+  const now = new Date().toISOString()
+  const { error } = await opts.supabase
+    .from('assignment_docs')
+    .upsert({
+      assignment_id: opts.assignmentId,
+      student_id: opts.studentId,
+      score_completion: 0,
+      score_thinking: 0,
+      score_workflow: 0,
+      teacher_feedback_draft: MISSING_ASSIGNMENT_GRADE_FEEDBACK,
+      teacher_feedback_draft_updated_at: now,
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
+      graded_at: now,
+      graded_by: opts.gradedBy ?? 'teacher',
+    }, { onConflict: 'assignment_id,student_id' })
+
+  if (error) {
+    throw new Error(`Failed to save missing grade for student ${opts.studentId}`)
+  }
+}
+
 export async function gradeAssignmentDocWithAi({
   supabase,
   assignment,
   assignmentDoc,
+  gradedBy,
   requestTimeoutMs,
   telemetry,
 }: GradeAssignmentDocWithAiOptions): Promise<void> {
   const studentWork = parseContentField(assignmentDoc.content)
-  if (!studentWork.content || studentWork.content.length === 0) {
-    throw new Error('No gradable content found')
+  if (!hasGradableAssignmentSubmission(studentWork)) {
+    await markAssignmentDocMissingGrade({
+      supabase,
+      assignmentId: assignment.id,
+      studentId: assignmentDoc.student_id,
+      gradedBy,
+    })
+    return
   }
 
   const result = await gradeStudentWork({
@@ -293,17 +335,20 @@ export async function gradeAssignmentDocWithAi({
     },
   })
 
+  const now = new Date().toISOString()
   const { error: updateError } = await supabase
     .from('assignment_docs')
     .update({
       score_completion: result.score_completion,
       score_thinking: result.score_thinking,
       score_workflow: result.score_workflow,
+      teacher_feedback_draft: result.feedback,
+      teacher_feedback_draft_updated_at: now,
       ai_feedback_suggestion: result.feedback,
-      ai_feedback_suggested_at: new Date().toISOString(),
+      ai_feedback_suggested_at: now,
       ai_feedback_model: result.model,
-      graded_at: null,
-      graded_by: null,
+      graded_at: now,
+      graded_by: gradedBy ?? 'teacher',
     })
     .eq('id', assignmentDoc.id)
 
@@ -507,6 +552,12 @@ async function processAssignmentAiRunItem(opts: {
   }
 
   if (!assignmentDoc) {
+    await markAssignmentDocMissingGrade({
+      supabase,
+      assignmentId: run.assignment_id,
+      studentId: item.student_id,
+      gradedBy: run.triggered_by,
+    })
     await updateRunItem(supabase, item.id, {
       status: 'skipped',
       skip_reason: 'missing_doc',
@@ -519,7 +570,13 @@ async function processAssignmentAiRunItem(opts: {
   }
 
   const studentWork = parseContentField(assignmentDoc.content)
-  if (!studentWork.content || studentWork.content.length === 0) {
+  if (!hasGradableAssignmentSubmission(studentWork)) {
+    await markAssignmentDocMissingGrade({
+      supabase,
+      assignmentId: run.assignment_id,
+      studentId: item.student_id,
+      gradedBy: run.triggered_by,
+    })
     await updateRunItem(supabase, item.id, {
       status: 'skipped',
       skip_reason: 'empty_doc',
@@ -536,6 +593,7 @@ async function processAssignmentAiRunItem(opts: {
       supabase,
       assignment,
       assignmentDoc,
+      gradedBy: run.triggered_by,
       requestTimeoutMs: ASSIGNMENT_AI_GRADING_REQUEST_TIMEOUT_MS,
       telemetry: {
         operation: 'background_batch_item',
@@ -640,11 +698,20 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
   let gradableCount = 0
   let skippedMissingCount = 0
   let skippedEmptyCount = 0
+  const missingGradeWrites: Promise<void>[] = []
 
   const itemRows = normalizedStudentIds.map((studentId, index) => {
     const doc = docByStudentId.get(studentId)
     if (!doc) {
       skippedMissingCount += 1
+      missingGradeWrites.push(
+        markAssignmentDocMissingGrade({
+          supabase,
+          assignmentId: opts.assignmentId,
+          studentId,
+          gradedBy: opts.teacherId,
+        }),
+      )
       return {
         assignment_id: opts.assignmentId,
         student_id: studentId,
@@ -662,8 +729,16 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
     }
 
     const parsed = parseContentField(doc.content)
-    if (!parsed.content || parsed.content.length === 0) {
+    if (!hasGradableAssignmentSubmission(parsed)) {
       skippedEmptyCount += 1
+      missingGradeWrites.push(
+        markAssignmentDocMissingGrade({
+          supabase,
+          assignmentId: opts.assignmentId,
+          studentId,
+          gradedBy: opts.teacherId,
+        }),
+      )
       return {
         assignment_id: opts.assignmentId,
         student_id: studentId,
@@ -696,6 +771,10 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
       completed_at: null,
     }
   })
+
+  if (missingGradeWrites.length > 0) {
+    await Promise.all(missingGradeWrites)
+  }
 
   const initialStatus: AssignmentAiGradingRunStatus =
     gradableCount === 0 ? 'completed' : 'queued'

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -540,6 +540,39 @@ async function processAssignmentAiRunItem(opts: {
   const attemptCount = item.attempt_count + 1
   const now = new Date().toISOString()
 
+  async function markMissingGradeAndSkip(skipReason: 'missing_doc' | 'empty_doc'): Promise<void> {
+    try {
+      await markAssignmentDocMissingGrade({
+        supabase,
+        assignmentId: run.assignment_id,
+        studentId: item.student_id,
+        gradedBy: run.triggered_by,
+      })
+    } catch (error) {
+      await updateRunItem(supabase, item.id, {
+        status: 'failed',
+        skip_reason: null,
+        attempt_count: attemptCount,
+        last_error_code: 'save_missing_grade_failed',
+        last_error_message:
+          error instanceof Error
+            ? error.message
+            : 'Failed to save missing grade for skipped submission',
+        completed_at: now,
+      })
+      return
+    }
+
+    await updateRunItem(supabase, item.id, {
+      status: 'skipped',
+      skip_reason: skipReason,
+      attempt_count: attemptCount,
+      last_error_code: null,
+      last_error_message: null,
+      completed_at: now,
+    })
+  }
+
   await updateRunItem(supabase, item.id, {
     status: 'processing',
     started_at: item.started_at ?? now,
@@ -564,39 +597,13 @@ async function processAssignmentAiRunItem(opts: {
   }
 
   if (!assignmentDoc) {
-    await markAssignmentDocMissingGrade({
-      supabase,
-      assignmentId: run.assignment_id,
-      studentId: item.student_id,
-      gradedBy: run.triggered_by,
-    })
-    await updateRunItem(supabase, item.id, {
-      status: 'skipped',
-      skip_reason: 'missing_doc',
-      attempt_count: attemptCount,
-      last_error_code: null,
-      last_error_message: null,
-      completed_at: now,
-    })
+    await markMissingGradeAndSkip('missing_doc')
     return
   }
 
   const studentWork = parseContentField(assignmentDoc.content)
   if (!hasGradableAssignmentSubmission(studentWork)) {
-    await markAssignmentDocMissingGrade({
-      supabase,
-      assignmentId: run.assignment_id,
-      studentId: item.student_id,
-      gradedBy: run.triggered_by,
-    })
-    await updateRunItem(supabase, item.id, {
-      status: 'skipped',
-      skip_reason: 'empty_doc',
-      attempt_count: attemptCount,
-      last_error_code: null,
-      last_error_message: null,
-      completed_at: now,
-    })
+    await markMissingGradeAndSkip('empty_doc')
     return
   }
 

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -122,6 +122,18 @@ function isAssignmentAiGradingSchemaError(error: unknown): error is SupabaseSche
   return combined.includes('assignment_ai_grading_run')
 }
 
+function isAssignmentAiGradingCreateRpcError(error: unknown): error is SupabaseSchemaError {
+  if (!error || typeof error !== 'object') return false
+
+  const record = error as SupabaseSchemaError
+  if (record.code === 'PGRST202' || record.code === '42883') {
+    return true
+  }
+
+  const combined = `${record.message ?? ''} ${record.details ?? ''} ${record.hint ?? ''}`.toLowerCase()
+  return combined.includes('create_assignment_ai_grading_run_atomic')
+}
+
 function getSummaryNextRetryAt(items: AssignmentAiGradingRunItem[]): string | null {
   if (items.length === 0) return null
 
@@ -698,15 +710,12 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
   let gradableCount = 0
   let skippedMissingCount = 0
   let skippedEmptyCount = 0
-  const missingGradeStudentIds: string[] = []
 
   const itemRows = normalizedStudentIds.map((studentId, index) => {
     const doc = docByStudentId.get(studentId)
     if (!doc) {
       skippedMissingCount += 1
-      missingGradeStudentIds.push(studentId)
       return {
-        assignment_id: opts.assignmentId,
         student_id: studentId,
         assignment_doc_id: null,
         queue_position: index,
@@ -724,9 +733,7 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
     const parsed = parseContentField(doc.content)
     if (!hasGradableAssignmentSubmission(parsed)) {
       skippedEmptyCount += 1
-      missingGradeStudentIds.push(studentId)
       return {
-        assignment_id: opts.assignmentId,
         student_id: studentId,
         assignment_doc_id: doc.id,
         queue_position: index,
@@ -743,7 +750,6 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
 
     gradableCount += 1
     return {
-      assignment_id: opts.assignmentId,
       student_id: studentId,
       assignment_doc_id: doc.id,
       queue_position: index,
@@ -758,67 +764,39 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
     }
   })
 
-  const initialStatus: AssignmentAiGradingRunStatus =
-    gradableCount === 0 ? 'completed' : 'queued'
   const now = new Date().toISOString()
-  const runPayload = {
-    assignment_id: opts.assignmentId,
-    status: initialStatus,
-    triggered_by: opts.teacherId,
-    model: getModelAlias(),
-    requested_student_ids_json: normalizedStudentIds,
-    selection_hash: selectionHash,
-    requested_count: normalizedStudentIds.length,
-    gradable_count: gradableCount,
-    processed_count: skippedMissingCount + skippedEmptyCount,
-    completed_count: 0,
-    skipped_missing_count: skippedMissingCount,
-    skipped_empty_count: skippedEmptyCount,
-    failed_count: 0,
-    error_samples_json: [],
-    started_at: gradableCount === 0 ? now : null,
-    completed_at: gradableCount === 0 ? now : null,
-  }
-
-  const { data: run, error: runError } = await supabase
-    .from('assignment_ai_grading_runs')
-    .insert(runPayload)
-    .select('*')
-    .single()
+  const { data: run, error: runError } = await supabase.rpc('create_assignment_ai_grading_run_atomic', {
+    p_assignment_id: opts.assignmentId,
+    p_teacher_id: opts.teacherId,
+    p_model: getModelAlias(),
+    p_requested_student_ids: normalizedStudentIds,
+    p_selection_hash: selectionHash,
+    p_gradable_count: gradableCount,
+    p_skipped_missing_count: skippedMissingCount,
+    p_skipped_empty_count: skippedEmptyCount,
+    p_item_rows: itemRows,
+    p_now: now,
+  })
 
   if (runError || !run) {
+    if ((runError as SupabaseSchemaError | null | undefined)?.code === '23505') {
+      const concurrentRun = await fetchLatestActiveRun(supabase, opts.assignmentId)
+      if (concurrentRun) {
+        const items = await fetchAssignmentAiGradingRunItems(supabase, concurrentRun.id)
+        const summary = toAssignmentAiGradingRunSummary(concurrentRun, { items })
+        if (concurrentRun.selection_hash === selectionHash) {
+          return { kind: 'resumed', run: summary }
+        }
+        return { kind: 'conflict', run: summary }
+      }
+    }
+    if (isAssignmentAiGradingCreateRpcError(runError)) {
+      throw new Error('Assignment AI grading run transaction is unavailable. Apply migration 055.')
+    }
     if (isAssignmentAiGradingSchemaError(runError)) {
       throw new Error('Assignment AI grading run tables are unavailable. Apply migration 054.')
     }
     throw new Error('Failed to create assignment AI grading run')
-  }
-
-  const rowsWithRunId = itemRows.map((item) => ({
-    run_id: run.id,
-    ...item,
-  }))
-  const { error: itemsError } = await supabase
-    .from('assignment_ai_grading_run_items')
-    .insert(rowsWithRunId)
-
-  if (itemsError) {
-    if (isAssignmentAiGradingSchemaError(itemsError)) {
-      throw new Error('Assignment AI grading run tables are unavailable. Apply migration 054.')
-    }
-    throw new Error('Failed to create assignment AI grading run items')
-  }
-
-  if (missingGradeStudentIds.length > 0) {
-    await Promise.all(
-      missingGradeStudentIds.map((studentId) =>
-        markAssignmentDocMissingGrade({
-          supabase,
-          assignmentId: opts.assignmentId,
-          studentId,
-          gradedBy: opts.teacherId,
-        }),
-      ),
-    )
   }
 
   return {

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -698,20 +698,13 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
   let gradableCount = 0
   let skippedMissingCount = 0
   let skippedEmptyCount = 0
-  const missingGradeWrites: Promise<void>[] = []
+  const missingGradeStudentIds: string[] = []
 
   const itemRows = normalizedStudentIds.map((studentId, index) => {
     const doc = docByStudentId.get(studentId)
     if (!doc) {
       skippedMissingCount += 1
-      missingGradeWrites.push(
-        markAssignmentDocMissingGrade({
-          supabase,
-          assignmentId: opts.assignmentId,
-          studentId,
-          gradedBy: opts.teacherId,
-        }),
-      )
+      missingGradeStudentIds.push(studentId)
       return {
         assignment_id: opts.assignmentId,
         student_id: studentId,
@@ -731,14 +724,7 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
     const parsed = parseContentField(doc.content)
     if (!hasGradableAssignmentSubmission(parsed)) {
       skippedEmptyCount += 1
-      missingGradeWrites.push(
-        markAssignmentDocMissingGrade({
-          supabase,
-          assignmentId: opts.assignmentId,
-          studentId,
-          gradedBy: opts.teacherId,
-        }),
-      )
+      missingGradeStudentIds.push(studentId)
       return {
         assignment_id: opts.assignmentId,
         student_id: studentId,
@@ -771,10 +757,6 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
       completed_at: null,
     }
   })
-
-  if (missingGradeWrites.length > 0) {
-    await Promise.all(missingGradeWrites)
-  }
 
   const initialStatus: AssignmentAiGradingRunStatus =
     gradableCount === 0 ? 'completed' : 'queued'
@@ -824,6 +806,19 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
       throw new Error('Assignment AI grading run tables are unavailable. Apply migration 054.')
     }
     throw new Error('Failed to create assignment AI grading run items')
+  }
+
+  if (missingGradeStudentIds.length > 0) {
+    await Promise.all(
+      missingGradeStudentIds.map((studentId) =>
+        markAssignmentDocMissingGrade({
+          supabase,
+          assignmentId: opts.assignmentId,
+          studentId,
+          gradedBy: opts.teacherId,
+        }),
+      ),
+    )
   }
 
   return {

--- a/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
+++ b/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
@@ -1,192 +1,202 @@
-create or replace function public.create_assignment_ai_grading_run_atomic(
-  p_assignment_id uuid,
-  p_teacher_id uuid,
-  p_model text,
-  p_requested_student_ids uuid[],
-  p_selection_hash text,
-  p_gradable_count integer,
-  p_skipped_missing_count integer,
-  p_skipped_empty_count integer,
-  p_item_rows jsonb,
-  p_now timestamptz default now()
-)
-returns public.assignment_ai_grading_runs
-language plpgsql
-security definer
-set search_path = public
-as $$
-declare
-  v_requested_count integer := coalesce(cardinality(p_requested_student_ids), 0);
-  v_processed_count integer := greatest(coalesce(p_skipped_missing_count, 0), 0)
-    + greatest(coalesce(p_skipped_empty_count, 0), 0);
-  v_item_count integer := coalesce(jsonb_array_length(coalesce(p_item_rows, '[]'::jsonb)), 0);
-  v_run public.assignment_ai_grading_runs;
+do $migration$
 begin
-  if v_item_count <> v_requested_count then
-    raise exception 'Assignment AI grading run item payload count mismatch';
-  end if;
+  execute $function$
+    create or replace function public.create_assignment_ai_grading_run_atomic(
+      p_assignment_id uuid,
+      p_teacher_id uuid,
+      p_model text,
+      p_requested_student_ids uuid[],
+      p_selection_hash text,
+      p_gradable_count integer,
+      p_skipped_missing_count integer,
+      p_skipped_empty_count integer,
+      p_item_rows jsonb,
+      p_now timestamptz default now()
+    )
+    returns public.assignment_ai_grading_runs
+    language plpgsql
+    security definer
+    set search_path = public
+    as $body$
+    declare
+      v_requested_count integer := coalesce(cardinality(p_requested_student_ids), 0);
+      v_processed_count integer := greatest(coalesce(p_skipped_missing_count, 0), 0)
+        + greatest(coalesce(p_skipped_empty_count, 0), 0);
+      v_item_count integer := coalesce(jsonb_array_length(coalesce(p_item_rows, '[]'::jsonb)), 0);
+      v_run public.assignment_ai_grading_runs;
+    begin
+      if v_item_count <> v_requested_count then
+        raise exception 'Assignment AI grading run item payload count mismatch';
+      end if;
 
-  insert into public.assignment_ai_grading_runs (
-    assignment_id,
-    status,
-    triggered_by,
-    model,
-    requested_student_ids_json,
-    selection_hash,
-    requested_count,
-    gradable_count,
-    processed_count,
-    completed_count,
-    skipped_missing_count,
-    skipped_empty_count,
-    failed_count,
-    error_samples_json,
-    started_at,
-    completed_at
-  )
-  values (
-    p_assignment_id,
-    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then 'completed' else 'queued' end,
-    p_teacher_id,
-    p_model,
-    to_jsonb(coalesce(p_requested_student_ids, array[]::uuid[])),
-    p_selection_hash,
-    v_requested_count,
-    greatest(coalesce(p_gradable_count, 0), 0),
-    v_processed_count,
-    0,
-    greatest(coalesce(p_skipped_missing_count, 0), 0),
-    greatest(coalesce(p_skipped_empty_count, 0), 0),
-    0,
-    '[]'::jsonb,
-    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end,
-    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end
-  )
-  returning * into v_run;
+      insert into public.assignment_ai_grading_runs (
+        assignment_id,
+        status,
+        triggered_by,
+        model,
+        requested_student_ids_json,
+        selection_hash,
+        requested_count,
+        gradable_count,
+        processed_count,
+        completed_count,
+        skipped_missing_count,
+        skipped_empty_count,
+        failed_count,
+        error_samples_json,
+        started_at,
+        completed_at
+      )
+      values (
+        p_assignment_id,
+        case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then 'completed' else 'queued' end,
+        p_teacher_id,
+        p_model,
+        to_jsonb(coalesce(p_requested_student_ids, array[]::uuid[])),
+        p_selection_hash,
+        v_requested_count,
+        greatest(coalesce(p_gradable_count, 0), 0),
+        v_processed_count,
+        0,
+        greatest(coalesce(p_skipped_missing_count, 0), 0),
+        greatest(coalesce(p_skipped_empty_count, 0), 0),
+        0,
+        '[]'::jsonb,
+        case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end,
+        case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end
+      )
+      returning * into v_run;
 
-  insert into public.assignment_ai_grading_run_items (
-    run_id,
-    assignment_id,
-    student_id,
-    assignment_doc_id,
-    queue_position,
-    status,
-    skip_reason,
-    attempt_count,
-    next_retry_at,
-    last_error_code,
-    last_error_message,
-    started_at,
-    completed_at
-  )
-  select
-    v_run.id,
-    p_assignment_id,
-    item.student_id,
-    item.assignment_doc_id,
-    coalesce(item.queue_position, 0),
-    item.status,
-    item.skip_reason,
-    coalesce(item.attempt_count, 0),
-    item.next_retry_at,
-    item.last_error_code,
-    item.last_error_message,
-    item.started_at,
-    item.completed_at
-  from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
-    student_id uuid,
-    assignment_doc_id uuid,
-    queue_position integer,
-    status text,
-    skip_reason text,
-    attempt_count integer,
-    next_retry_at timestamptz,
-    last_error_code text,
-    last_error_message text,
-    started_at timestamptz,
-    completed_at timestamptz
-  );
+      insert into public.assignment_ai_grading_run_items (
+        run_id,
+        assignment_id,
+        student_id,
+        assignment_doc_id,
+        queue_position,
+        status,
+        skip_reason,
+        attempt_count,
+        next_retry_at,
+        last_error_code,
+        last_error_message,
+        started_at,
+        completed_at
+      )
+      select
+        v_run.id,
+        p_assignment_id,
+        item.student_id,
+        item.assignment_doc_id,
+        coalesce(item.queue_position, 0),
+        item.status,
+        item.skip_reason,
+        coalesce(item.attempt_count, 0),
+        item.next_retry_at,
+        item.last_error_code,
+        item.last_error_message,
+        item.started_at,
+        item.completed_at
+      from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
+        student_id uuid,
+        assignment_doc_id uuid,
+        queue_position integer,
+        status text,
+        skip_reason text,
+        attempt_count integer,
+        next_retry_at timestamptz,
+        last_error_code text,
+        last_error_message text,
+        started_at timestamptz,
+        completed_at timestamptz
+      );
 
-  insert into public.assignment_docs (
-    assignment_id,
-    student_id,
-    score_completion,
-    score_thinking,
-    score_workflow,
-    teacher_feedback_draft,
-    teacher_feedback_draft_updated_at,
-    ai_feedback_suggestion,
-    ai_feedback_suggested_at,
-    ai_feedback_model,
-    graded_at,
-    graded_by
-  )
-  select
-    p_assignment_id,
-    item.student_id,
-    0,
-    0,
-    0,
-    'Missing',
-    p_now,
-    null,
-    null,
-    null,
-    p_now,
-    p_teacher_id::text
-  from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
-    student_id uuid,
-    assignment_doc_id uuid,
-    queue_position integer,
-    status text,
-    skip_reason text,
-    attempt_count integer,
-    next_retry_at timestamptz,
-    last_error_code text,
-    last_error_message text,
-    started_at timestamptz,
-    completed_at timestamptz
-  )
-  where item.skip_reason in ('missing_doc', 'empty_doc')
-  on conflict (assignment_id, student_id) do update
-  set
-    score_completion = excluded.score_completion,
-    score_thinking = excluded.score_thinking,
-    score_workflow = excluded.score_workflow,
-    teacher_feedback_draft = excluded.teacher_feedback_draft,
-    teacher_feedback_draft_updated_at = excluded.teacher_feedback_draft_updated_at,
-    ai_feedback_suggestion = excluded.ai_feedback_suggestion,
-    ai_feedback_suggested_at = excluded.ai_feedback_suggested_at,
-    ai_feedback_model = excluded.ai_feedback_model,
-    graded_at = excluded.graded_at,
-    graded_by = excluded.graded_by;
+      insert into public.assignment_docs (
+        assignment_id,
+        student_id,
+        score_completion,
+        score_thinking,
+        score_workflow,
+        teacher_feedback_draft,
+        teacher_feedback_draft_updated_at,
+        ai_feedback_suggestion,
+        ai_feedback_suggested_at,
+        ai_feedback_model,
+        graded_at,
+        graded_by
+      )
+      select
+        p_assignment_id,
+        item.student_id,
+        0,
+        0,
+        0,
+        'Missing',
+        p_now,
+        null,
+        null,
+        null,
+        p_now,
+        p_teacher_id::text
+      from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
+        student_id uuid,
+        assignment_doc_id uuid,
+        queue_position integer,
+        status text,
+        skip_reason text,
+        attempt_count integer,
+        next_retry_at timestamptz,
+        last_error_code text,
+        last_error_message text,
+        started_at timestamptz,
+        completed_at timestamptz
+      )
+      where item.skip_reason in ('missing_doc', 'empty_doc')
+      on conflict (assignment_id, student_id) do update
+      set
+        score_completion = excluded.score_completion,
+        score_thinking = excluded.score_thinking,
+        score_workflow = excluded.score_workflow,
+        teacher_feedback_draft = excluded.teacher_feedback_draft,
+        teacher_feedback_draft_updated_at = excluded.teacher_feedback_draft_updated_at,
+        ai_feedback_suggestion = excluded.ai_feedback_suggestion,
+        ai_feedback_suggested_at = excluded.ai_feedback_suggested_at,
+        ai_feedback_model = excluded.ai_feedback_model,
+        graded_at = excluded.graded_at,
+        graded_by = excluded.graded_by;
 
-  return v_run;
+      return v_run;
+    end;
+    $body$;
+  $function$;
+
+  execute $revoke$
+    revoke all on function public.create_assignment_ai_grading_run_atomic(
+      uuid,
+      uuid,
+      text,
+      uuid[],
+      text,
+      integer,
+      integer,
+      integer,
+      jsonb,
+      timestamptz
+    ) from public, anon, authenticated;
+  $revoke$;
+
+  execute $grant$
+    grant execute on function public.create_assignment_ai_grading_run_atomic(
+      uuid,
+      uuid,
+      text,
+      uuid[],
+      text,
+      integer,
+      integer,
+      integer,
+      jsonb,
+      timestamptz
+    ) to service_role;
+  $grant$;
 end;
-$$;
-
-revoke all on function public.create_assignment_ai_grading_run_atomic(
-  uuid,
-  uuid,
-  text,
-  uuid[],
-  text,
-  integer,
-  integer,
-  integer,
-  jsonb,
-  timestamptz
-) from public, anon, authenticated;
-
-grant execute on function public.create_assignment_ai_grading_run_atomic(
-  uuid,
-  uuid,
-  text,
-  uuid[],
-  text,
-  integer,
-  integer,
-  integer,
-  jsonb,
-  timestamptz
-) to service_role;
+$migration$;

--- a/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
+++ b/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
@@ -165,6 +165,19 @@ begin
 end;
 $$;
 
+revoke all on function public.create_assignment_ai_grading_run_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid[],
+  text,
+  integer,
+  integer,
+  integer,
+  jsonb,
+  timestamptz
+) from public, anon, authenticated;
+
 grant execute on function public.create_assignment_ai_grading_run_atomic(
   uuid,
   uuid,
@@ -176,4 +189,4 @@ grant execute on function public.create_assignment_ai_grading_run_atomic(
   integer,
   jsonb,
   timestamptz
-) to authenticated, service_role;
+) to service_role;

--- a/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
+++ b/supabase/migrations/055_assignment_ai_grading_run_atomic_rpc.sql
@@ -1,0 +1,179 @@
+create or replace function public.create_assignment_ai_grading_run_atomic(
+  p_assignment_id uuid,
+  p_teacher_id uuid,
+  p_model text,
+  p_requested_student_ids uuid[],
+  p_selection_hash text,
+  p_gradable_count integer,
+  p_skipped_missing_count integer,
+  p_skipped_empty_count integer,
+  p_item_rows jsonb,
+  p_now timestamptz default now()
+)
+returns public.assignment_ai_grading_runs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_requested_count integer := coalesce(cardinality(p_requested_student_ids), 0);
+  v_processed_count integer := greatest(coalesce(p_skipped_missing_count, 0), 0)
+    + greatest(coalesce(p_skipped_empty_count, 0), 0);
+  v_item_count integer := coalesce(jsonb_array_length(coalesce(p_item_rows, '[]'::jsonb)), 0);
+  v_run public.assignment_ai_grading_runs;
+begin
+  if v_item_count <> v_requested_count then
+    raise exception 'Assignment AI grading run item payload count mismatch';
+  end if;
+
+  insert into public.assignment_ai_grading_runs (
+    assignment_id,
+    status,
+    triggered_by,
+    model,
+    requested_student_ids_json,
+    selection_hash,
+    requested_count,
+    gradable_count,
+    processed_count,
+    completed_count,
+    skipped_missing_count,
+    skipped_empty_count,
+    failed_count,
+    error_samples_json,
+    started_at,
+    completed_at
+  )
+  values (
+    p_assignment_id,
+    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then 'completed' else 'queued' end,
+    p_teacher_id,
+    p_model,
+    to_jsonb(coalesce(p_requested_student_ids, array[]::uuid[])),
+    p_selection_hash,
+    v_requested_count,
+    greatest(coalesce(p_gradable_count, 0), 0),
+    v_processed_count,
+    0,
+    greatest(coalesce(p_skipped_missing_count, 0), 0),
+    greatest(coalesce(p_skipped_empty_count, 0), 0),
+    0,
+    '[]'::jsonb,
+    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end,
+    case when greatest(coalesce(p_gradable_count, 0), 0) = 0 then p_now else null end
+  )
+  returning * into v_run;
+
+  insert into public.assignment_ai_grading_run_items (
+    run_id,
+    assignment_id,
+    student_id,
+    assignment_doc_id,
+    queue_position,
+    status,
+    skip_reason,
+    attempt_count,
+    next_retry_at,
+    last_error_code,
+    last_error_message,
+    started_at,
+    completed_at
+  )
+  select
+    v_run.id,
+    p_assignment_id,
+    item.student_id,
+    item.assignment_doc_id,
+    coalesce(item.queue_position, 0),
+    item.status,
+    item.skip_reason,
+    coalesce(item.attempt_count, 0),
+    item.next_retry_at,
+    item.last_error_code,
+    item.last_error_message,
+    item.started_at,
+    item.completed_at
+  from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
+    student_id uuid,
+    assignment_doc_id uuid,
+    queue_position integer,
+    status text,
+    skip_reason text,
+    attempt_count integer,
+    next_retry_at timestamptz,
+    last_error_code text,
+    last_error_message text,
+    started_at timestamptz,
+    completed_at timestamptz
+  );
+
+  insert into public.assignment_docs (
+    assignment_id,
+    student_id,
+    score_completion,
+    score_thinking,
+    score_workflow,
+    teacher_feedback_draft,
+    teacher_feedback_draft_updated_at,
+    ai_feedback_suggestion,
+    ai_feedback_suggested_at,
+    ai_feedback_model,
+    graded_at,
+    graded_by
+  )
+  select
+    p_assignment_id,
+    item.student_id,
+    0,
+    0,
+    0,
+    'Missing',
+    p_now,
+    null,
+    null,
+    null,
+    p_now,
+    p_teacher_id::text
+  from jsonb_to_recordset(coalesce(p_item_rows, '[]'::jsonb)) as item(
+    student_id uuid,
+    assignment_doc_id uuid,
+    queue_position integer,
+    status text,
+    skip_reason text,
+    attempt_count integer,
+    next_retry_at timestamptz,
+    last_error_code text,
+    last_error_message text,
+    started_at timestamptz,
+    completed_at timestamptz
+  )
+  where item.skip_reason in ('missing_doc', 'empty_doc')
+  on conflict (assignment_id, student_id) do update
+  set
+    score_completion = excluded.score_completion,
+    score_thinking = excluded.score_thinking,
+    score_workflow = excluded.score_workflow,
+    teacher_feedback_draft = excluded.teacher_feedback_draft,
+    teacher_feedback_draft_updated_at = excluded.teacher_feedback_draft_updated_at,
+    ai_feedback_suggestion = excluded.ai_feedback_suggestion,
+    ai_feedback_suggested_at = excluded.ai_feedback_suggested_at,
+    ai_feedback_model = excluded.ai_feedback_model,
+    graded_at = excluded.graded_at,
+    graded_by = excluded.graded_by;
+
+  return v_run;
+end;
+$$;
+
+grant execute on function public.create_assignment_ai_grading_run_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid[],
+  text,
+  integer,
+  integer,
+  integer,
+  jsonb,
+  timestamptz
+) to authenticated, service_role;

--- a/tests/api/teacher/assignments-auto-grade.test.ts
+++ b/tests/api/teacher/assignments-auto-grade.test.ts
@@ -4,9 +4,11 @@ import { NextRequest } from 'next/server'
 const {
   createOrResumeAssignmentAiGradingRun,
   gradeAssignmentDocWithAi,
+  markAssignmentDocMissingGrade,
 } = vi.hoisted(() => ({
   createOrResumeAssignmentAiGradingRun: vi.fn(),
   gradeAssignmentDocWithAi: vi.fn(),
+  markAssignmentDocMissingGrade: vi.fn(),
 }))
 
 const { assertTeacherOwnsAssignment } = vi.hoisted(() => ({
@@ -28,6 +30,7 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@/lib/server/assignment-ai-grading-runs', () => ({
   createOrResumeAssignmentAiGradingRun,
   gradeAssignmentDocWithAi,
+  markAssignmentDocMissingGrade,
 }))
 
 vi.mock('@/lib/server/repo-review', () => ({
@@ -59,6 +62,7 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
       classrooms: { teacher_id: 'teacher-1' },
     })
     gradeAssignmentDocWithAi.mockResolvedValue(undefined)
+    markAssignmentDocMissingGrade.mockResolvedValue(undefined)
     createOrResumeAssignmentAiGradingRun.mockResolvedValue({
       kind: 'created',
       run: {
@@ -147,6 +151,7 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
           student_id: 'student-1',
           feedback: 'Earlier feedback',
         }),
+        gradedBy: 'teacher-1',
         telemetry: expect.objectContaining({
           operation: 'single_grade',
           studentId: 'student-1',
@@ -155,7 +160,7 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
     )
   })
 
-  it('skips legacy stringified empty docs without calling the grader', async () => {
+  it('marks legacy stringified empty docs as missing without calling the grader', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignment_docs') {
         return {
@@ -193,11 +198,62 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({
-      graded_count: 0,
-      skipped_count: 1,
+      graded_count: 1,
+      skipped_count: 0,
       errors: undefined,
     })
     expect(gradeAssignmentDocWithAi).not.toHaveBeenCalled()
+    expect(markAssignmentDocMissingGrade).toHaveBeenCalledWith({
+      supabase: mockSupabaseClient,
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      gradedBy: 'teacher-1',
+    })
+  })
+
+  it('creates a missing grade when no assignment doc exists', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      graded_count: 1,
+      skipped_count: 0,
+      errors: undefined,
+    })
+    expect(gradeAssignmentDocWithAi).not.toHaveBeenCalled()
+    expect(markAssignmentDocMissingGrade).toHaveBeenCalledWith({
+      supabase: mockSupabaseClient,
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      gradedBy: 'teacher-1',
+    })
   })
 
   it('starts a resumable batch run for multi-student requests', async () => {

--- a/tests/api/teacher/assignments-auto-grade.test.ts
+++ b/tests/api/teacher/assignments-auto-grade.test.ts
@@ -41,6 +41,41 @@ import { POST } from '@/app/api/teacher/assignments/[id]/auto-grade/route'
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function buildEnrollmentTable(opts?: { enrolledIds?: string[]; error?: unknown }) {
+  const enrolledIds = opts?.enrolledIds ?? []
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn().mockResolvedValue({
+          data: enrolledIds.map((student_id) => ({ student_id })),
+          error: opts?.error ?? null,
+        }),
+      })),
+    })),
+  }
+}
+
+function mockAutoGradeTables(opts: {
+  enrolledIds: string[]
+  assignmentDocsTable?: unknown
+  enrollmentError?: unknown
+}) {
+  ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+    if (table === 'classroom_enrollments') {
+      return buildEnrollmentTable({
+        enrolledIds: opts.enrolledIds,
+        error: opts.enrollmentError,
+      })
+    }
+
+    if (table === 'assignment_docs' && opts.assignmentDocsTable) {
+      return opts.assignmentDocsTable
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
 describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -88,42 +123,39 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   })
 
   it('grades a single legacy stringified assignment doc synchronously', async () => {
-    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
+    mockAutoGradeTables({
+      enrolledIds: ['student-1'],
+      assignmentDocsTable: {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
             eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: {
-                    id: 'doc-1',
-                    student_id: 'student-1',
-                    content: JSON.stringify({
-                      type: 'doc',
-                      content: [
-                        {
-                          type: 'paragraph',
-                          content: [
-                            {
-                              type: 'text',
-                              text: 'My portfolio is attached here.',
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                    feedback: 'Earlier feedback',
-                    authenticity_score: 42,
-                  },
-                  error: null,
-                }),
-              })),
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'doc-1',
+                  student_id: 'student-1',
+                  content: JSON.stringify({
+                    type: 'doc',
+                    content: [
+                      {
+                        type: 'paragraph',
+                        content: [
+                          {
+                            type: 'text',
+                            text: 'My portfolio is attached here.',
+                          },
+                        ],
+                      },
+                    ],
+                  }),
+                  feedback: 'Earlier feedback',
+                  authenticity_score: 42,
+                },
+                error: null,
+              }),
             })),
           })),
-        }
-      }
-
-      throw new Error(`Unexpected table: ${table}`)
+        })),
+      },
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
@@ -161,29 +193,26 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   })
 
   it('marks legacy stringified empty docs as missing without calling the grader', async () => {
-    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
+    mockAutoGradeTables({
+      enrolledIds: ['student-1'],
+      assignmentDocsTable: {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
             eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: {
-                    id: 'doc-1',
-                    student_id: 'student-1',
-                    content: JSON.stringify({ type: 'doc', content: [] }),
-                    feedback: null,
-                    authenticity_score: 42,
-                  },
-                  error: null,
-                }),
-              })),
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'doc-1',
+                  student_id: 'student-1',
+                  content: JSON.stringify({ type: 'doc', content: [] }),
+                  feedback: null,
+                  authenticity_score: 42,
+                },
+                error: null,
+              }),
             })),
           })),
-        }
-      }
-
-      throw new Error(`Unexpected table: ${table}`)
+        })),
+      },
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
@@ -212,23 +241,20 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   })
 
   it('creates a missing grade when no assignment doc exists', async () => {
-    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
+    mockAutoGradeTables({
+      enrolledIds: ['student-1'],
+      assignmentDocsTable: {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
             eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                maybeSingle: vi.fn().mockResolvedValue({
-                  data: null,
-                  error: null,
-                }),
-              })),
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
             })),
           })),
-        }
-      }
-
-      throw new Error(`Unexpected table: ${table}`)
+        })),
+      },
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
@@ -257,6 +283,10 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   })
 
   it('starts a resumable batch run for multi-student requests', async () => {
+    mockAutoGradeTables({
+      enrolledIds: ['student-1', 'student-2'],
+    })
+
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
       method: 'POST',
       body: JSON.stringify({
@@ -283,6 +313,52 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
     })
   })
 
+  it('rejects single-student auto-grade for a non-enrolled student id', async () => {
+    mockAutoGradeTables({
+      enrolledIds: [],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-404'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({
+      error: 'Student is not enrolled in this classroom',
+    })
+    expect(markAssignmentDocMissingGrade).not.toHaveBeenCalled()
+    expect(gradeAssignmentDocWithAi).not.toHaveBeenCalled()
+  })
+
+  it('rejects batch auto-grade when any requested student is not enrolled', async () => {
+    mockAutoGradeTables({
+      enrolledIds: ['student-1'],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1', 'student-404'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({
+      error: 'Student is not enrolled in this classroom',
+    })
+    expect(createOrResumeAssignmentAiGradingRun).not.toHaveBeenCalled()
+    expect(markAssignmentDocMissingGrade).not.toHaveBeenCalled()
+  })
+
   it('returns the active run when another selection is already in progress', async () => {
     createOrResumeAssignmentAiGradingRun.mockResolvedValueOnce({
       kind: 'conflict',
@@ -305,6 +381,9 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
         completed_at: null,
         created_at: '2026-04-20T12:00:00.000Z',
       },
+    })
+    mockAutoGradeTables({
+      enrolledIds: ['student-1', 'student-2'],
     })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -193,6 +193,79 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     )
   })
 
+  it('returns graded missing work even when it was never submitted', async () => {
+    const docs = [
+      {
+        id: 'doc-1',
+        student_id: 'student-1',
+        is_submitted: false,
+        score_completion: 0,
+        score_thinking: 0,
+        score_workflow: 0,
+        teacher_feedback_draft: 'Missing',
+      },
+    ]
+
+    const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return assignmentDocsTable.table
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(1)
+    expect(data.cleared_count).toBe(0)
+    expect(data.missing_count).toBe(0)
+
+    expect(assignmentDocsTable.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        is_submitted: false,
+        returned_at: expect.any(String),
+        feedback_returned_at: expect.any(String),
+        teacher_cleared_at: expect.any(String),
+      }),
+    )
+    expect(appendAssignmentFeedbackEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: 'assignment-1',
+        studentId: 'student-1',
+        createdBy: 'teacher-1',
+        body: 'Missing',
+      }),
+    )
+  })
+
   it('returns 500 when returning docs update fails', async () => {
     const assignmentDocsTable = buildAssignmentDocsTable({
       docs: [

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -266,6 +266,65 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     )
   })
 
+  it('does not re-return work that was already returned and not resubmitted', async () => {
+    const docs = [
+      {
+        id: 'doc-1',
+        student_id: 'student-1',
+        is_submitted: false,
+        returned_at: '2026-04-20T12:00:00Z',
+        score_completion: 8,
+        score_thinking: 8,
+        score_workflow: 8,
+        teacher_feedback_draft: 'Already returned',
+      },
+    ]
+
+    const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return assignmentDocsTable.table
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(0)
+    expect(data.cleared_count).toBe(0)
+    expect(data.missing_count).toBe(0)
+    expect(assignmentDocsTable.update).not.toHaveBeenCalled()
+    expect(appendAssignmentFeedbackEntry).not.toHaveBeenCalled()
+  })
+
   it('returns 500 when returning docs update fails', async () => {
     const assignmentDocsTable = buildAssignmentDocsTable({
       docs: [

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -595,7 +595,7 @@ describe('TeacherClassroomView', () => {
     expect(mockClearSelection).toHaveBeenCalled()
   })
 
-  it('dedupes repeated assignment AI grading failures in the completion message', async () => {
+  it('shows only unique true errors in the completion message and treats empty work as missing', async () => {
     const initialRun = {
       id: 'run-1',
       assignment_id: 'assignment-1',
@@ -698,9 +698,10 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByText(/1 empty • 2 failed/)).toBeInTheDocument()
+      expect(screen.getByText(/1 missing • 2 failed/)).toBeInTheDocument()
     })
-    expect(screen.getByText(/2 students: AI grading service failed for this submission\. Try again\./)).toBeInTheDocument()
+    expect(screen.getByText(/AI grading service failed for this submission\. Try again\./)).toBeInTheDocument()
+    expect(screen.queryByText(/2 students:/)).not.toBeInTheDocument()
   })
 
   it('waits for the next retry window before polling tick again', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -595,6 +595,114 @@ describe('TeacherClassroomView', () => {
     expect(mockClearSelection).toHaveBeenCalled()
   })
 
+  it('dedupes repeated assignment AI grading failures in the completion message', async () => {
+    const initialRun = {
+      id: 'run-1',
+      assignment_id: 'assignment-1',
+      status: 'running',
+      model: 'gpt-5-nano',
+      requested_count: 3,
+      gradable_count: 2,
+      processed_count: 0,
+      completed_count: 0,
+      skipped_missing_count: 0,
+      skipped_empty_count: 1,
+      failed_count: 0,
+      pending_count: 3,
+      next_retry_at: null,
+      error_samples: [],
+      started_at: '2026-04-20T12:00:00Z',
+      completed_at: null,
+      created_at: '2026-04-20T12:00:00Z',
+    }
+
+    let assignmentFetchCount = 0
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        assignmentFetchCount += 1
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            makeAssignmentDetails(
+              'assignment-1',
+              'Assignment One',
+              'student-1',
+              assignmentFetchCount === 1 ? initialRun : null,
+            ),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/auto-grade-runs/run-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            run: {
+              ...initialRun,
+              processed_count: 1,
+              pending_count: 2,
+              next_retry_at: null,
+            },
+          }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/auto-grade-runs/run-1/tick') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            claimed: true,
+            run: {
+              ...initialRun,
+              status: 'completed_with_errors',
+              processed_count: 3,
+              completed_count: 0,
+              failed_count: 2,
+              pending_count: 0,
+              next_retry_at: null,
+              error_samples: [
+                {
+                  student_id: 'student-1',
+                  code: 'server',
+                  message: 'AI grading service failed for this submission. Try again.',
+                },
+                {
+                  student_id: 'student-2',
+                  code: 'server',
+                  message: 'AI grading service failed for this submission. Try again.',
+                },
+              ],
+              completed_at: '2026-04-20T12:02:00Z',
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 empty • 2 failed/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/2 students: AI grading service failed for this submission\. Try again\./)).toBeInTheDocument()
+  })
+
   it('waits for the next retry window before polling tick again', async () => {
     const nextRetryAt = new Date(Date.now() + 60_000).toISOString()
     let statusFetchCount = 0

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -305,14 +305,14 @@ describe('TeacherStudentWorkPanel', () => {
 
     expect(within(gradesSection).queryByRole('button', { name: 'AI grade' })).not.toBeInTheDocument()
     const gradeModeToggle = within(gradesSection).getByTestId('grade-mode-toggle')
-    expect(within(gradeModeToggle).getByRole('button', { name: 'Draft' })).toBeInTheDocument()
-    expect(within(gradeModeToggle).getByRole('button', { name: 'Final' })).toBeInTheDocument()
+    expect(within(gradeModeToggle).getByRole('button', { name: 'Draft' })).toHaveAttribute('aria-pressed', 'false')
+    expect(within(gradeModeToggle).getByRole('button', { name: 'Final' })).toHaveAttribute('aria-pressed', 'true')
     expect(within(gradesSection).queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
     const feedbackSection = screen.getByTestId('inspector-section-comments')
     expect(within(feedbackSection).getByRole('button', { name: 'Send feedback' })).toBeInTheDocument()
   })
 
-  it('autosaves valid grading edits as draft without a save button', async () => {
+  it('autosaves valid grading edits as final by default without a save button', async () => {
     const gradeBodies: Array<Record<string, unknown>> = []
 
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -339,14 +339,14 @@ describe('TeacherStudentWorkPanel', () => {
           ok: true,
           json: async () => ({
             doc: {
-              ...makeStudentWork('student-1', { graded: false }).doc,
+              ...makeStudentWork('student-1', { graded: true }).doc,
               score_completion: 6,
               score_thinking: 7,
               score_workflow: 8,
               teacher_feedback_draft: 'Teacher note',
               teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
-              graded_at: null,
-              graded_by: null,
+              graded_at: '2026-02-20T13:05:00Z',
+              graded_by: 'teacher@example.com',
             },
           }),
         })
@@ -393,13 +393,13 @@ describe('TeacherStudentWorkPanel', () => {
       score_thinking: 7,
       score_workflow: 8,
       feedback: 'Teacher note',
-      save_mode: 'draft',
+      save_mode: 'graded',
     })
-    expect(screen.getByText('Draft autosaved')).toBeInTheDocument()
+    expect(screen.getByText('Graded Feb 20, 8:05 AM')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
   })
 
-  it('autosaves feedback-only draft edits before scores are complete', async () => {
+  it('autosaves feedback-only edits after switching to draft', async () => {
     const gradeBodies: Array<Record<string, unknown>> = []
 
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -427,10 +427,10 @@ describe('TeacherStudentWorkPanel', () => {
           json: async () => ({
             doc: {
               ...makeStudentWork('student-1', { graded: false }).doc,
-              score_completion: null,
-              score_thinking: null,
-              score_workflow: null,
-              teacher_feedback_draft: 'Teacher note',
+              score_completion: body.score_completion ?? null,
+              score_thinking: body.score_thinking ?? null,
+              score_workflow: body.score_workflow ?? null,
+              teacher_feedback_draft: body.feedback ?? null,
               teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
               graded_at: null,
               graded_by: null,
@@ -459,6 +459,12 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     await screen.findByPlaceholderText('Teacher feedback draft')
+    await user.click(screen.getByRole('button', { name: 'Draft' }))
+
+    await waitFor(() => {
+      expect(gradeBodies).toHaveLength(1)
+    })
+    gradeBodies.length = 0
 
     await user.type(screen.getByPlaceholderText('Teacher feedback draft'), 'Teacher note')
 
@@ -508,10 +514,10 @@ describe('TeacherStudentWorkPanel', () => {
           json: async () => ({
             doc: {
               ...makeStudentWork('student-1', { graded: false }).doc,
-              score_completion: null,
-              score_thinking: null,
-              score_workflow: null,
-              teacher_feedback_draft: 'Teacher note',
+              score_completion: body.score_completion ?? null,
+              score_thinking: body.score_thinking ?? null,
+              score_workflow: body.score_workflow ?? null,
+              teacher_feedback_draft: body.feedback ?? null,
               teacher_feedback_draft_updated_at: '2026-02-20T13:05:00Z',
               graded_at: null,
               graded_by: null,
@@ -540,6 +546,12 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     await screen.findByPlaceholderText('Teacher feedback draft')
+    await user.click(screen.getByRole('button', { name: 'Draft' }))
+
+    await waitFor(() => {
+      expect(gradeBodies).toHaveLength(1)
+    })
+    gradeBodies.length = 0
 
     await user.type(screen.getByPlaceholderText('Teacher feedback draft'), 'Teacher note')
 

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -12,7 +12,10 @@ vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
 
-import { createOrResumeAssignmentAiGradingRun } from '@/lib/server/assignment-ai-grading-runs'
+import {
+  createOrResumeAssignmentAiGradingRun,
+  tickAssignmentAiGradingRun,
+} from '@/lib/server/assignment-ai-grading-runs'
 
 function buildSelectionHash(studentIds: string[]) {
   return createHash('sha256')
@@ -75,6 +78,178 @@ function buildRunItemsTable(items: unknown[] = []) {
       })),
     })),
   }
+}
+
+function buildTickHarness(opts: {
+  skipReason: 'missing_doc' | 'empty_doc'
+  assignmentDoc: {
+    id: string
+    student_id: string
+    content: unknown
+    feedback: string | null
+    authenticity_score: number | null
+  } | null
+  upsertError: unknown
+}) {
+  const run = {
+    id: 'run-1',
+    assignment_id: 'assignment-1',
+    status: 'queued',
+    triggered_by: 'teacher-1',
+    model: 'gpt-5-nano',
+    selection_hash: buildSelectionHash(['student-1']),
+    requested_student_ids_json: ['student-1'],
+    requested_count: 1,
+    gradable_count: 0,
+    processed_count: 0,
+    completed_count: 0,
+    skipped_missing_count: 0,
+    skipped_empty_count: 0,
+    failed_count: 0,
+    error_samples_json: [],
+    lease_token: null,
+    lease_expires_at: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-04-21T12:00:00.000Z',
+    updated_at: '2026-04-21T12:00:00.000Z',
+  }
+
+  const items = [
+    {
+      id: 'item-1',
+      run_id: 'run-1',
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      assignment_doc_id: opts.assignmentDoc?.id ?? null,
+      queue_position: 0,
+      status: 'queued',
+      skip_reason: opts.skipReason,
+      attempt_count: 0,
+      next_retry_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      started_at: null,
+      completed_at: null,
+      created_at: '2026-04-21T12:00:00.000Z',
+      updated_at: '2026-04-21T12:00:00.000Z',
+    },
+  ]
+
+  mockSupabaseClient.rpc.mockImplementation(async (fn: string) => {
+    if (fn === 'claim_assignment_ai_grading_run') {
+      return { data: true, error: null }
+    }
+    throw new Error(`Unexpected rpc: ${fn}`)
+  })
+
+  ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+    if (table === 'assignment_ai_grading_runs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((field: string, value: string) => {
+            if (field === 'id') {
+              return {
+                maybeSingle: vi.fn(async () => ({
+                  data: value === run.id ? { ...run } : null,
+                  error: null,
+                })),
+              }
+            }
+
+            if (field === 'assignment_id') {
+              return {
+                in: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    limit: vi.fn(async () => ({
+                      data:
+                        value === run.assignment_id && ['queued', 'running'].includes(run.status)
+                          ? [{ ...run }]
+                          : [],
+                      error: null,
+                    })),
+                  })),
+                })),
+              }
+            }
+
+            throw new Error(`Unexpected assignment_ai_grading_runs eq field: ${field}`)
+          }),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn((field: string, value: string) => ({
+            select: vi.fn(() => ({
+              single: vi.fn(async () => {
+                if (field !== 'id' || value !== run.id) {
+                  return { data: null, error: null }
+                }
+                Object.assign(run, payload)
+                return { data: { ...run }, error: null }
+              }),
+            })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_ai_grading_run_items') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((field: string, value: string) => ({
+            order: vi.fn(async () => ({
+              data:
+                field === 'run_id' && value === run.id
+                  ? items.map((item) => ({ ...item }))
+                  : [],
+              error: null,
+            })),
+          })),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn(async (field: string, value: string) => {
+            const item = items.find((candidate) => field === 'id' && candidate.id === value)
+            if (item) Object.assign(item, payload)
+            return { error: null }
+          }),
+        })),
+      }
+    }
+
+    if (table === 'assignments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(async () => ({
+              data: {
+                id: 'assignment-1',
+                title: 'Assignment One',
+                classroom_id: 'classroom-1',
+              },
+              error: null,
+            })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_docs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({
+              data: opts.assignmentDoc ? { ...opts.assignmentDoc } : null,
+              error: null,
+            })),
+          })),
+        })),
+        upsert: vi.fn(async () => ({ error: opts.upsertError })),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return { run, items }
 }
 
 describe('createOrResumeAssignmentAiGradingRun', () => {
@@ -270,5 +445,65 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
         status: 'queued',
       }),
     })
+  })
+
+  it('marks a missing-doc item failed when saving the Missing grade fails', async () => {
+    const harness = buildTickHarness({
+      skipReason: 'missing_doc',
+      assignmentDoc: null,
+      upsertError: { message: 'upsert failed' },
+    })
+
+    const result = await tickAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      runId: 'run-1',
+    })
+
+    expect(result.claimed).toBe(true)
+    expect(result.run).toEqual(expect.objectContaining({
+      status: 'completed_with_errors',
+      failed_count: 1,
+      skipped_missing_count: 0,
+    }))
+    expect(harness.items[0]).toEqual(expect.objectContaining({
+      status: 'failed',
+      skip_reason: null,
+      attempt_count: 1,
+      last_error_code: 'save_missing_grade_failed',
+      last_error_message: 'Failed to save missing grade for student student-1',
+    }))
+  })
+
+  it('marks an empty-doc item failed when saving the Missing grade fails', async () => {
+    const harness = buildTickHarness({
+      skipReason: 'empty_doc',
+      assignmentDoc: {
+        id: 'doc-1',
+        student_id: 'student-1',
+        content: JSON.stringify({ type: 'doc', content: [] }),
+        feedback: null,
+        authenticity_score: null,
+      },
+      upsertError: { message: 'upsert failed' },
+    })
+
+    const result = await tickAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      runId: 'run-1',
+    })
+
+    expect(result.claimed).toBe(true)
+    expect(result.run).toEqual(expect.objectContaining({
+      status: 'completed_with_errors',
+      failed_count: 1,
+      skipped_empty_count: 0,
+    }))
+    expect(harness.items[0]).toEqual(expect.objectContaining({
+      status: 'failed',
+      skip_reason: null,
+      attempt_count: 1,
+      last_error_code: 'save_missing_grade_failed',
+      last_error_message: 'Failed to save missing grade for student student-1',
+    }))
   })
 })

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -1,8 +1,10 @@
+import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockSupabaseClient } = vi.hoisted(() => ({
   mockSupabaseClient: {
     from: vi.fn(),
+    rpc: vi.fn(),
   },
 }))
 
@@ -12,165 +14,261 @@ vi.mock('@/lib/supabase', () => ({
 
 import { createOrResumeAssignmentAiGradingRun } from '@/lib/server/assignment-ai-grading-runs'
 
-function buildAssignmentDocsTable(opts: {
-  docs?: Array<{ id: string; student_id: string; content: unknown }>
-  upsertError?: unknown
-  operationLog?: string[]
-}) {
-  const upsert = vi.fn(async () => {
-    opts.operationLog?.push('missing-grade-upsert')
-    return { error: opts.upsertError ?? null }
-  })
+function buildSelectionHash(studentIds: string[]) {
+  return createHash('sha256')
+    .update(Array.from(new Set(studentIds.map((studentId) => studentId.trim()).filter(Boolean))).join('|'))
+    .digest('hex')
+}
 
+function buildRunsTable(activeRuns: unknown[] = []) {
   return {
-    table: {
-      select: vi.fn(() => ({
-        eq: vi.fn().mockReturnThis(),
-        in: vi.fn(async () => ({
-          data: opts.docs ?? [],
-          error: null,
-        })),
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn(async () => ({
+        data: activeRuns,
+        error: null,
       })),
-      upsert,
-    },
-    upsert,
+    })),
   }
 }
 
-function buildRunsTable(opts: {
-  activeRuns?: unknown[]
-  insertError?: unknown
-  operationLog?: string[]
-}) {
-  const insert = vi.fn((payload: Record<string, unknown>) => {
-    opts.operationLog?.push('insert-run')
-    return {
-      select: vi.fn(() => ({
-        single: vi.fn(async () => ({
-          data: opts.insertError
-            ? null
-            : {
-                id: 'run-1',
-                created_at: '2026-04-21T12:00:00.000Z',
-                ...payload,
-              },
-          error: opts.insertError ?? null,
-        })),
-      })),
-    }
-  })
-
+function buildRunsTableWithSequence(activeRunBatches: unknown[][]) {
+  let index = 0
   return {
-    table: {
-      select: vi.fn(() => ({
-        eq: vi.fn().mockReturnThis(),
-        in: vi.fn().mockReturnThis(),
-        order: vi.fn().mockReturnThis(),
-        limit: vi.fn(async () => ({
-          data: opts.activeRuns ?? [],
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn(async () => {
+        const batch = activeRunBatches[Math.min(index, activeRunBatches.length - 1)] ?? []
+        index += 1
+        return {
+          data: batch,
           error: null,
-        })),
-      })),
-      insert,
-    },
-    insert,
+        }
+      }),
+    })),
   }
 }
 
-function buildRunItemsTable(opts?: {
-  insertError?: unknown
-  operationLog?: string[]
-}) {
-  const insert = vi.fn(async () => {
-    opts?.operationLog?.push('insert-run-items')
-    return { error: opts?.insertError ?? null }
-  })
-
+function buildAssignmentDocsTable(docs: Array<{ id: string; student_id: string; content: unknown }> = []) {
   return {
-    table: { insert },
-    insert,
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn(async () => ({
+        data: docs,
+        error: null,
+      })),
+    })),
+  }
+}
+
+function buildRunItemsTable(items: unknown[] = []) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn(async () => ({
+        data: items,
+        error: null,
+      })),
+    })),
   }
 }
 
 describe('createOrResumeAssignmentAiGradingRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSupabaseClient.rpc.mockReset()
   })
 
-  it('does not persist missing grades when run creation fails', async () => {
-    const operationLog: string[] = []
-    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
-    const runsTable = buildRunsTable({
-      insertError: { message: 'insert failed' },
-      operationLog,
-    })
-    const runItemsTable = buildRunItemsTable({ operationLog })
+  it('creates the batch through the atomic RPC with queued and skipped item rows', async () => {
+    const runsTable = buildRunsTable()
+    const assignmentDocsTable = buildAssignmentDocsTable([
+      {
+        id: 'doc-empty',
+        student_id: 'student-empty',
+        content: JSON.stringify({ type: 'doc', content: [] }),
+      },
+      {
+        id: 'doc-gradable',
+        student_id: 'student-gradable',
+        content: JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        }),
+      },
+    ])
 
     ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
-      if (table === 'assignment_ai_grading_runs') return runsTable.table
-      if (table === 'assignment_docs') return assignmentDocsTable.table
-      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_docs') return assignmentDocsTable
       throw new Error(`Unexpected table: ${table}`)
     })
 
-    await expect(createOrResumeAssignmentAiGradingRun({
-      assignmentId: 'assignment-1',
-      teacherId: 'teacher-1',
-      studentIds: ['student-1'],
-    })).rejects.toThrow('Failed to create assignment AI grading run')
-
-    expect(assignmentDocsTable.upsert).not.toHaveBeenCalled()
-    expect(runItemsTable.insert).not.toHaveBeenCalled()
-    expect(operationLog).toEqual(['insert-run'])
-  })
-
-  it('does not persist missing grades when run item creation fails', async () => {
-    const operationLog: string[] = []
-    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
-    const runsTable = buildRunsTable({ operationLog })
-    const runItemsTable = buildRunItemsTable({
-      insertError: { message: 'insert failed' },
-      operationLog,
+    mockSupabaseClient.rpc.mockResolvedValue({
+      data: {
+        id: 'run-1',
+        assignment_id: 'assignment-1',
+        status: 'queued',
+        created_at: '2026-04-21T12:00:00.000Z',
+      },
+      error: null,
     })
 
-    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
-      if (table === 'assignment_ai_grading_runs') return runsTable.table
-      if (table === 'assignment_docs') return assignmentDocsTable.table
-      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
-      throw new Error(`Unexpected table: ${table}`)
-    })
-
-    await expect(createOrResumeAssignmentAiGradingRun({
+    const result = await createOrResumeAssignmentAiGradingRun({
       assignmentId: 'assignment-1',
       teacherId: 'teacher-1',
-      studentIds: ['student-1'],
-    })).rejects.toThrow('Failed to create assignment AI grading run items')
+      studentIds: ['student-missing', 'student-empty', 'student-gradable'],
+    })
 
-    expect(assignmentDocsTable.upsert).not.toHaveBeenCalled()
-    expect(operationLog).toEqual(['insert-run', 'insert-run-items'])
+    expect(result.kind).toBe('created')
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'create_assignment_ai_grading_run_atomic',
+      expect.objectContaining({
+        p_assignment_id: 'assignment-1',
+        p_teacher_id: 'teacher-1',
+        p_model: 'gpt-5-nano',
+        p_requested_student_ids: ['student-missing', 'student-empty', 'student-gradable'],
+        p_gradable_count: 1,
+        p_skipped_missing_count: 1,
+        p_skipped_empty_count: 1,
+        p_now: expect.any(String),
+        p_item_rows: [
+          expect.objectContaining({
+            student_id: 'student-missing',
+            assignment_doc_id: null,
+            queue_position: 0,
+            status: 'skipped',
+            skip_reason: 'missing_doc',
+          }),
+          expect.objectContaining({
+            student_id: 'student-empty',
+            assignment_doc_id: 'doc-empty',
+            queue_position: 1,
+            status: 'skipped',
+            skip_reason: 'empty_doc',
+          }),
+          expect.objectContaining({
+            student_id: 'student-gradable',
+            assignment_doc_id: 'doc-gradable',
+            queue_position: 2,
+            status: 'queued',
+            skip_reason: null,
+          }),
+        ],
+      }),
+    )
   })
 
-  it('persists missing grades only after the run and items exist', async () => {
-    const operationLog: string[] = []
-    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
-    const runsTable = buildRunsTable({ operationLog })
-    const runItemsTable = buildRunItemsTable({ operationLog })
+  it('resumes a matching active run without invoking the atomic RPC', async () => {
+    const selectionHash = buildSelectionHash(['student-1', 'student-2'])
+    const runsTable = buildRunsTable([
+      {
+        id: 'run-1',
+        assignment_id: 'assignment-1',
+        status: 'running',
+        selection_hash: selectionHash,
+        requested_count: 2,
+        created_at: '2026-04-21T12:00:00.000Z',
+      },
+    ])
+    const runItemsTable = buildRunItemsTable([])
 
     ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
-      if (table === 'assignment_ai_grading_runs') return runsTable.table
-      if (table === 'assignment_docs') return assignmentDocsTable.table
-      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_ai_grading_run_items') return runItemsTable
       throw new Error(`Unexpected table: ${table}`)
     })
 
     const result = await createOrResumeAssignmentAiGradingRun({
       assignmentId: 'assignment-1',
       teacherId: 'teacher-1',
-      studentIds: ['student-1'],
+      studentIds: ['student-1', 'student-2'],
     })
 
-    expect(result.kind).toBe('created')
-    expect(assignmentDocsTable.upsert).toHaveBeenCalledOnce()
-    expect(operationLog).toEqual(['insert-run', 'insert-run-items', 'missing-grade-upsert'])
+    expect(result).toEqual({
+      kind: 'resumed',
+      run: expect.objectContaining({
+        id: 'run-1',
+        status: 'running',
+      }),
+    })
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+  })
+
+  it('surfaces migration guidance when the atomic RPC is unavailable', async () => {
+    const runsTable = buildRunsTable()
+    const assignmentDocsTable = buildAssignmentDocsTable()
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_docs') return assignmentDocsTable
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    mockSupabaseClient.rpc.mockResolvedValue({
+      data: null,
+      error: {
+        code: 'PGRST202',
+        message: 'Could not find the function public.create_assignment_ai_grading_run_atomic',
+      },
+    })
+
+    await expect(createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })).rejects.toThrow('Assignment AI grading run transaction is unavailable. Apply migration 055.')
+  })
+
+  it('maps atomic insert conflicts back to the active-run resume behavior', async () => {
+    const selectionHash = buildSelectionHash(['student-1'])
+    const runsTable = buildRunsTableWithSequence([
+      [],
+      [{
+        id: 'run-1',
+        assignment_id: 'assignment-1',
+        status: 'queued',
+        selection_hash: selectionHash,
+        requested_count: 1,
+        created_at: '2026-04-21T12:00:00.000Z',
+      }],
+    ])
+    const assignmentDocsTable = buildAssignmentDocsTable()
+    const runItemsTable = buildRunItemsTable([])
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_docs') return assignmentDocsTable
+      if (table === 'assignment_ai_grading_run_items') return runItemsTable
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    mockSupabaseClient.rpc.mockResolvedValue({
+      data: null,
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "idx_assignment_ai_grading_runs_one_active"',
+      },
+    })
+
+    await expect(createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })).resolves.toEqual({
+      kind: 'resumed',
+      run: expect.objectContaining({
+        id: 'run-1',
+        status: 'queued',
+      }),
+    })
   })
 })

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSupabaseClient } = vi.hoisted(() => ({
+  mockSupabaseClient: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+import { createOrResumeAssignmentAiGradingRun } from '@/lib/server/assignment-ai-grading-runs'
+
+function buildAssignmentDocsTable(opts: {
+  docs?: Array<{ id: string; student_id: string; content: unknown }>
+  upsertError?: unknown
+  operationLog?: string[]
+}) {
+  const upsert = vi.fn(async () => {
+    opts.operationLog?.push('missing-grade-upsert')
+    return { error: opts.upsertError ?? null }
+  })
+
+  return {
+    table: {
+      select: vi.fn(() => ({
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn(async () => ({
+          data: opts.docs ?? [],
+          error: null,
+        })),
+      })),
+      upsert,
+    },
+    upsert,
+  }
+}
+
+function buildRunsTable(opts: {
+  activeRuns?: unknown[]
+  insertError?: unknown
+  operationLog?: string[]
+}) {
+  const insert = vi.fn((payload: Record<string, unknown>) => {
+    opts.operationLog?.push('insert-run')
+    return {
+      select: vi.fn(() => ({
+        single: vi.fn(async () => ({
+          data: opts.insertError
+            ? null
+            : {
+                id: 'run-1',
+                created_at: '2026-04-21T12:00:00.000Z',
+                ...payload,
+              },
+          error: opts.insertError ?? null,
+        })),
+      })),
+    }
+  })
+
+  return {
+    table: {
+      select: vi.fn(() => ({
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(async () => ({
+          data: opts.activeRuns ?? [],
+          error: null,
+        })),
+      })),
+      insert,
+    },
+    insert,
+  }
+}
+
+function buildRunItemsTable(opts?: {
+  insertError?: unknown
+  operationLog?: string[]
+}) {
+  const insert = vi.fn(async () => {
+    opts?.operationLog?.push('insert-run-items')
+    return { error: opts?.insertError ?? null }
+  })
+
+  return {
+    table: { insert },
+    insert,
+  }
+}
+
+describe('createOrResumeAssignmentAiGradingRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not persist missing grades when run creation fails', async () => {
+    const operationLog: string[] = []
+    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
+    const runsTable = buildRunsTable({
+      insertError: { message: 'insert failed' },
+      operationLog,
+    })
+    const runItemsTable = buildRunItemsTable({ operationLog })
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable.table
+      if (table === 'assignment_docs') return assignmentDocsTable.table
+      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })).rejects.toThrow('Failed to create assignment AI grading run')
+
+    expect(assignmentDocsTable.upsert).not.toHaveBeenCalled()
+    expect(runItemsTable.insert).not.toHaveBeenCalled()
+    expect(operationLog).toEqual(['insert-run'])
+  })
+
+  it('does not persist missing grades when run item creation fails', async () => {
+    const operationLog: string[] = []
+    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
+    const runsTable = buildRunsTable({ operationLog })
+    const runItemsTable = buildRunItemsTable({
+      insertError: { message: 'insert failed' },
+      operationLog,
+    })
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable.table
+      if (table === 'assignment_docs') return assignmentDocsTable.table
+      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })).rejects.toThrow('Failed to create assignment AI grading run items')
+
+    expect(assignmentDocsTable.upsert).not.toHaveBeenCalled()
+    expect(operationLog).toEqual(['insert-run', 'insert-run-items'])
+  })
+
+  it('persists missing grades only after the run and items exist', async () => {
+    const operationLog: string[] = []
+    const assignmentDocsTable = buildAssignmentDocsTable({ operationLog })
+    const runsTable = buildRunsTable({ operationLog })
+    const runItemsTable = buildRunItemsTable({ operationLog })
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable.table
+      if (table === 'assignment_docs') return assignmentDocsTable.table
+      if (table === 'assignment_ai_grading_run_items') return runItemsTable.table
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const result = await createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })
+
+    expect(result.kind).toBe('created')
+    expect(assignmentDocsTable.upsert).toHaveBeenCalledOnce()
+    expect(operationLog).toEqual(['insert-run', 'insert-run-items', 'missing-grade-upsert'])
+  })
+})

--- a/tests/unit/ai-grading.test.ts
+++ b/tests/unit/ai-grading.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { gradeStudentWork } from '@/lib/ai-grading'
+import { gradeStudentWork, hasGradableAssignmentSubmission } from '@/lib/ai-grading'
 
 describe('gradeStudentWork prompt rules', () => {
   const originalApiKey = process.env.OPENAI_API_KEY
@@ -243,5 +243,33 @@ describe('gradeStudentWork prompt rules', () => {
     expect(secondBody.max_output_tokens).toBe(420)
     expect(firstBody.reasoning).toEqual({ effort: 'minimal' })
     expect(secondBody.reasoning).toEqual({ effort: 'minimal' })
+  })
+})
+
+describe('hasGradableAssignmentSubmission', () => {
+  it('returns false for structurally present but empty content', () => {
+    expect(hasGradableAssignmentSubmission({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '   ' }],
+        },
+      ],
+    })).toBe(false)
+  })
+
+  it('returns true when submission includes an attached artifact', () => {
+    expect(hasGradableAssignmentSubmission({
+      type: 'doc',
+      content: [
+        {
+          type: 'image',
+          attrs: {
+            src: 'https://cdn.example.com/submission-images/final-site.png',
+          },
+        },
+      ],
+    })).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- save AI and manual assignment grades as final by default unless a teacher explicitly switches to draft
- auto-grade missing or empty submissions as `Missing` with zero scores and graded metadata instead of leaving them ungraded
- collapse repeated AI grading failure text into a concise grouped summary in the teacher classroom header

## Why
The grading flow was defaulting back to draft and treating missing or empty work as skipped, which left confusing status and repeated `student work is empty` errors in the browser.

## Impact
Teachers now get final grades by default, missing submissions are finalized consistently with clear feedback, and classroom-level grading messages are shorter and easier to scan.

## Validation
- `pnpm exec vitest run tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm exec eslint 'src/lib/ai-grading.ts' 'src/lib/server/assignment-ai-grading-runs.ts' 'src/app/api/teacher/assignments/[id]/auto-grade/route.ts' 'src/components/assignment-workspace/useTeacherStudentWorkController.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'tests/api/teacher/assignments-auto-grade.test.ts' 'tests/unit/ai-grading.test.ts' 'tests/components/TeacherStudentWorkPanel.test.tsx' 'tests/components/TeacherClassroomView.test.tsx'`
- visual verification of teacher desktop, teacher mobile, and student mobile grading views in the seeded classroom