### PR TITLE
[codex] Teacher tests workspace parity

### DIFF
--- a/.codex/prompts/assessment-ux-family-parity.md
+++ b/.codex/prompts/assessment-ux-family-parity.md
@@ -1,6 +1,34 @@
-Restyle an assessment surface so it clearly belongs to the same product family as assignments, while allowing slight aesthetic evolution.
+Restyle a teacher or student assessment surface so it clearly belongs to the same product family as assignments, while allowing slight aesthetic evolution.
 
 Use this mode when you want consistency, not cloning.
+
+## Read First
+
+1. `docs/guidance/ui/teacher-work-surfaces.md`
+2. `docs/guidance/assignment-ux-language.md`
+3. `docs/guides/assessment-ux-evaluation.md`
+
+If the task is teacher-side, treat the teacher work-surface canon as the stable authority.
+
+## Required Interaction Check
+
+Before editing, identify the current layer in the formal interaction ladder:
+
+- `entry`
+- `summary`
+- `workspace`
+- `workspace_mode`
+- `inspector_active`
+
+Preserve that ladder unless the task explicitly changes it.
+
+Defaults:
+
+- sub-routes are workspace states by default, not URL states
+- top tabs are post-selection workspace-mode controls
+- the right sidebar is a tool, not default chrome
+- parent tab re-click should return to `summary`
+- selected panel-based workspaces should remove outer gutters so tabs and pane shells sit flush with the main container
 
 ## Intent
 
@@ -14,8 +42,19 @@ It does need to preserve the same:
 - card semantics
 - empty-state calmness
 - content-first behavior
+- selection-driven progression into focused work
 
 Small aesthetic changes are acceptable if they are reusable across assessment surfaces and still feel like the same system.
+
+## Owner Check
+
+If a visible pane, placeholder, or blank column is wrong, verify ownership before editing:
+
+1. feature tab component
+2. surrounding classroom shell
+3. route or layout config
+
+Do not patch a shell or route problem only inside the local tab component.
 
 ## Allowed Evolution
 
@@ -42,6 +81,24 @@ But only if the result would still make sense as a future design direction for:
 - a new shell language that breaks family resemblance
 - controls taking visual priority over content
 - dashboard chrome or placeholder panes that assignments would not use
+- workspace-mode tabs in a passive pre-selection state
+- a blank passive pane or empty right column in a browsing state
+- extra outer gutter padding around a selected panel-based workspace
+
+Treat blank passive panes as hard failures.
+
+## Primitive Expectations
+
+When the existing surface fits, prefer:
+
+- `PageLayout`
+- `PageActionBar`
+- `PageContent`
+- `PageStack`
+- `EmptyState`
+- semantic tokens
+
+Do not invent a new shell when the existing family shell already fits the state.
 
 ## Design Test
 

--- a/.codex/prompts/teacher-tests-ux-parity.md
+++ b/.codex/prompts/teacher-tests-ux-parity.md
@@ -1,95 +1,82 @@
-Restyle the teacher tests passive browsing surface so it matches the teacher assignments UX system.
+Align the teacher tests surface to the teacher work-surface canon, using assignments as the current baseline reference.
 
-This is a task-scoped parity prompt for the teacher-tests authoring surface. That surface spans the test-authoring branch in `TeacherQuizzesTab` and the surrounding teacher assessment shell in `ClassroomPageClient`.
-
-Aim for the same **product family** as assignments, not a literal visual clone. Small aesthetic refinements are acceptable if they would also make sense as a future shared direction for assignments, tests, and quizzes.
+This is a task-scoped prompt for teacher tests. It should consume the canon, not reinvent the system design locally.
 
 ## Target
 
-- Primary file: `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
-- Supporting shell file: `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
-- Supporting layout config: `src/lib/layout-config.ts`
-- Branch: `assessmentType="test"` with `testsMode === 'authoring'`
+- target tab: teacher `Tests`
+- target family state: start from `entry` and `summary`, then preserve or refine `workspace`, `workspace_mode`, and `inspector_active` as needed
+- preserve existing test behavior unless the task explicitly changes it
 
-Do not treat teacher quizzes or grading mode as the primary target for this challenge.
-Do not treat unrelated classroom tabs as in scope.
+## Read First
 
-## Read Only These Files First
+1. `docs/guidance/ui/teacher-work-surfaces.md`
+2. `docs/guidance/assignment-ux-language.md`
+3. `docs/guides/assessment-ux-evaluation.md`
+4. `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
+5. `src/components/SortableAssignmentCard.tsx`
+6. `src/components/PageLayout.tsx`
+7. `src/ui/EmptyState.tsx`
+8. `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
+9. `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
+10. `src/lib/layout-config.ts`
+11. `src/components/QuizCard.tsx`
+12. `tests/components/TeacherQuizzesTab.test.tsx`
 
-1. `docs/guidance/assignment-ux-language.md`
-2. `docs/guides/assessment-ux-evaluation.md`
-3. `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
-4. `src/components/SortableAssignmentCard.tsx`
-5. `src/components/PageLayout.tsx`
-6. `src/ui/EmptyState.tsx`
-7. `src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`
-8. `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`
-9. `src/lib/layout-config.ts`
-10. `src/components/QuizCard.tsx`
-11. `tests/components/TeacherQuizzesTab.test.tsx`
+If the surrounding harness says the environment is already verified, do not rerun full repo startup or full-suite validation. Move directly into task-scoped work.
 
-If the surrounding harness says the environment is already verified, do not rerun full repo startup or full-suite validation. Move directly from these files into the implementation.
+When reading or editing App Router files from the shell, quote the path exactly because `[` and `]` will be treated as glob syntax by `zsh`.
 
-When reading or editing App Router files from the shell, quote the path exactly because `[` and `]` will be treated as glob syntax by `zsh`. Example:
+## Required Interpretation
 
-- `sed -n '1,220p' 'src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx'`
-- `sed -n '1,220p' 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx'`
-- `git diff -- 'src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx'`
+Before editing, identify:
+
+- the current interaction-ladder layer
+- the owning component for the visible behavior
+
+Use this ownership order:
+
+1. feature tab component
+2. classroom shell
+3. route/layout config
 
 ## Goal
 
-Make teacher tests authoring feel like teacher assignments summary/list state:
+Make teacher tests feel like the same product family as teacher assignments while preserving tests-specific business behavior.
 
-- quiet shell
-- content-first list
-- restrained action bar
-- no reserved right-side placeholder detail pane before selection
-- no reserved blank right-side column after the placeholder pane is removed
-- assignment-family card tone
+In practice:
 
-If the visible placeholder or split-pane treatment comes from the surrounding classroom shell rather than `TeacherQuizzesTab`, fix it there instead of forcing the tab component to work around it.
-If the blank right column is being created by the teacher tests route opening the right sidebar by default, fix that in `src/lib/layout-config.ts` rather than only hiding content inside the open shell.
-
-## Must Match
-
-- The default authoring view should feel complete as a list page, just like teacher assignments.
-- The default authoring view may evolve the shared aesthetic slightly, but it must still read as part of the same assignment-derived system at a glance.
-- The default authoring view must use the available main-content width for the test list. Hiding placeholder copy while leaving an empty right column is still a failure.
-- `New Test` can remain the primary action, but it should not be visually outnumbered by chrome.
-- The authoring/grading toggle may remain, but it must recede behind the content and should not be the first thing the eye lands on.
-- Empty or no-selection states should use `EmptyState` or a comparably quiet single-surface treatment.
-- Cards should read like descendants of `SortableAssignmentCard`, not a separate dashboard component family.
-- The teacher assessment sidebar or detail shell must not stay visually active in authoring mode when nothing is selected.
+- `summary` should feel complete as a full-width list state
+- `workspace` should appear only after selecting a test
+- `workspace_mode` tabs such as `Authoring` and `Grading` belong only inside a selected workspace
+- `inspector_active` should open only when the current mode and current selection justify it
 
 ## Must Preserve
 
-- Existing test data and API behavior
-- Existing grading mode behavior
-- Existing create/open/close actions
-- Existing sidebar and selection wiring that the rest of the classroom page depends on
-- Existing teacher assessment detail behavior once a test is actually selected
+- existing test data and API behavior
+- existing create, open, close, grading, AI grading, and return behavior
+- existing wiring the surrounding classroom shell depends on once a test is actually selected
 
 ## Must Not Introduce
 
-- A split-pane placeholder state in authoring mode before a selection exists
-- A large blank right pane with “Select a test” copy in passive browsing state
-- A large blank right pane or blank right column in passive browsing state even if the placeholder copy is removed
-- Louder controls than the content list
-- A new shell or layout system outside the existing page primitives
-- A workaround that hides the symptom in `TeacherQuizzesTab` while leaving the outer `ClassroomPageClient` shell behavior inconsistent
+- a passive split-pane placeholder before selection
+- a blank right pane or blank right column in `summary`
+- workspace-mode tabs before a test is selected
+- louder controls than the content list
+- a new shell system outside the family primitives
 
-## Expected Edit Shape
+## Typical Edit Shape
 
-The likely implementation should stay narrow:
+Most tasks should stay focused on one or more of:
 
-- reshape the `PageActionBar` hierarchy for the test authoring state
-- reshape the authoring branch of `TeacherQuizzesTab`
-- adjust the teacher assessment no-selection shell in `ClassroomPageClient` if that is what produces the placeholder pane
-- adjust the `tests-teacher` route config in `src/lib/layout-config.ts` if the route-level default sidebar state is what keeps the blank column alive
-- adapt `QuizCard` only if needed so teacher tests cards feel closer to assignment cards
-- avoid touching grading tables unless required for shared component compatibility
+- the teacher tests tab component
+- the surrounding `ClassroomPageClient`
+- `src/lib/layout-config.ts`
+- test-card anatomy if the cards are drifting from assignment-family scanning rules
 
-## Finish Checklist
+Do not broaden the change unless the canon clearly requires it.
+
+## Validation
 
 1. Run `pnpm exec vitest run tests/components/TeacherQuizzesTab.test.tsx`
 2. Run `pnpm e2e:verify assessment-ux-parity`
@@ -97,4 +84,4 @@ The likely implementation should stay narrow:
    - `artifacts/assessment-ux-parity/teacher-assignments-reference.png`
    - `artifacts/assessment-ux-parity/teacher-tests-target.png`
 4. Score the result with `docs/guides/assessment-ux-evaluation.md`
-5. Report pass/fail and list any remaining mismatches
+5. Report pass/fail and list remaining mismatches

--- a/.codex/skills/pika-ui-verify/scripts/ui_verify.sh
+++ b/.codex/skills/pika-ui-verify/scripts/ui_verify.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 PAGE="${1:-}"
 WORKTREE="${PIKA_WORKTREE:-$PWD}"
-BASE_URL="http://localhost:3000"
+BASE_URL="${E2E_BASE_URL:-http://localhost:3000}"
 AUTH_DIR="$WORKTREE/.auth"
 OUT_DIR="/tmp"
 
@@ -23,7 +23,8 @@ echo "Pika UI Verify — $URL"
 echo "=========================="
 
 # Check dev server
-if ! curl -sf "$BASE_URL/api/auth/me" > /dev/null 2>&1; then
+HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/api/auth/me" || true)"
+if [[ "$HTTP_CODE" == "000" || -z "$HTTP_CODE" ]]; then
   echo -e "${FAIL} Dev server not running at $BASE_URL"
   echo "   Run: pnpm -C \"$WORKTREE\" dev"
   exit 1
@@ -35,7 +36,7 @@ for role in teacher student; do
   AUTH_FILE="$AUTH_DIR/${role}.json"
   if [[ ! -f "$AUTH_FILE" ]]; then
     echo -e "${INFO} Auth state missing for $role — running e2e:auth"
-    pnpm -C "$WORKTREE" e2e:auth
+    E2E_BASE_URL="$BASE_URL" pnpm -C "$WORKTREE" e2e:auth
     break
   fi
 done

--- a/docs/guidance/assignment-ux-language.md
+++ b/docs/guidance/assignment-ux-language.md
@@ -1,6 +1,6 @@
 # Assignment UX Language
 
-This document codifies the current assignments experience as a reusable design language. It is the primary source of truth for the look, feel, structure, and interaction rhythm of assignment-style work in Pika.
+This document codifies the current assignments experience as a reusable design language. It is the assignment-specific reference implementation for the teacher work-surface family in Pika.
 
 The goal is not to freeze every pixel. The goal is to preserve the recognizable system:
 
@@ -10,7 +10,7 @@ The goal is not to freeze every pixel. The goal is to preserve the recognizable 
 - clear summary-to-detail progression
 - assignment-family cards and surfaces
 
-If another surface borrows from assignments later, it should feel like a descendant of this system rather than a separate tool.
+Assignments are the current baseline for the teacher family, not permanent authority. This doc should support [`docs/guidance/ui/teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md), not compete with it.
 
 ## Canonical Sources
 
@@ -27,6 +27,25 @@ Read these files before reproducing the assignment experience:
   - `src/ui/EmptyState.tsx`
 
 These files define the real implementation. This doc explains the design language they express.
+
+## Relationship To The Teacher Work-Surface Canon
+
+The family canon names the formal interaction ladder:
+
+- `entry`
+- `summary`
+- `workspace`
+- `workspace_mode`
+- `inspector_active`
+
+Assignments are the clearest current implementation of that ladder on the teacher side:
+
+- tab click lands in `entry` and resolves to a calm assignment `summary`
+- selecting an assignment enters `workspace`
+- assignment review switches between `workspace_mode` states such as `overview` and `details`
+- the teacher grading/review pane becomes `inspector_active` only when the current mode and selection justify it
+
+When another teacher surface borrows from assignments later, it should feel like a descendant of this system rather than a separate tool.
 
 ## Required Primitives
 
@@ -77,9 +96,9 @@ The system feels purposeful, not ornamental.
 
 ## Teacher Assignments
 
-Teacher assignments have two dominant states: summary and workspace.
+Teacher assignments have a stable summary-to-workspace progression and are the current baseline reference for the teacher family.
 
-### Summary state
+### `summary`
 
 The summary state is the default browsing view.
 
@@ -98,7 +117,7 @@ Visual characteristics:
 - `PageStack` separates cards evenly
 - cards span the available content width
 
-### Workspace state
+### `workspace`
 
 Once a teacher selects an assignment, the interface can become denser and more tool-like, but it still keeps the same shell.
 
@@ -108,7 +127,23 @@ Important behavior:
 - the calm outer shell remains consistent
 - tables, grading panes, and side content are justified by active review work
 
-The assignments system earns complexity only after the user is inside the work.
+Assignments earn complexity only after the teacher is inside the work.
+
+### `workspace_mode`
+
+Teacher assignments use meaningful sub-modes inside the selected workspace.
+
+Those modes:
+
+- represent materially different work
+- do not appear before a selection exists
+- keep the same outer page-shell language
+
+### `inspector_active`
+
+The teacher workspace uses side-by-side review only when the current assignment mode and current student selection justify it.
+
+The assignments reference model does not reserve a passive inspector before that point.
 
 ## Student Assignments
 
@@ -258,42 +293,4 @@ When reproducing the assignment experience, preserve:
 - semantic-token usage
 - existing `@/ui` and page-shell primitives
 
-## What Not To Introduce
-
-Do not introduce any of the following into an assignment-style surface:
-
-- default split panes before selection
-- placeholder inspector panels
-- loud toggle bars
-- dashboard chrome
-- bespoke card families unrelated to assignment cards
-- extra framing around empty states
-- raw `dark:` classes in app code
-
-## AI Reproduction Checklist
-
-If an AI needs to reproduce the assignment style, it should verify:
-
-- `PageLayout` is the outer shell
-- `PageActionBar` stays sparse and stable
-- `PageContent` and `PageStack` control the browsing rhythm
-- cards fill the available content width
-- the first visual emphasis is on content, not controls
-- empty states use a single quiet surface
-- detail appears only after selection
-- status chips are compact
-- copy stays short and muted
-
-## Reuse Guidance
-
-If another feature later borrows from assignments, use this rule:
-
-Start from the assignment shell and only add complexity when the task truly requires it.
-
-That means:
-
-- browse like assignments
-- select like assignments
-- only become denser when active work or review genuinely needs it
-
-This keeps future surfaces in the same product family even if the exact domain behavior differs.
+If another teacher-family surface diverges from assignments, use the family canon to decide whether the divergence is a deliberate improvement or unsupported drift.

--- a/docs/guidance/ui/audit-teacher-work-surfaces.md
+++ b/docs/guidance/ui/audit-teacher-work-surfaces.md
@@ -22,6 +22,7 @@ Excluded:
 - the student product
 - the main classroom shell as a whole
 - unrelated teacher tabs
+- gradebook for now
 
 ## Foundations
 
@@ -34,6 +35,19 @@ These are already foundational and should stay shared:
 | Shared page shell primitives: `PageLayout`, `PageActionBar`, `PageContent`, `PageStack` | assignments, quizzes/tests | stable | keep as primitives | now |
 | Shared classroom shell: `ThreePanelShell`, `LeftSidebar`, `RightSidebar`, `MainContent` | classroom route layer | stable cross-cutting | keep as shell primitives | now |
 
+## Stable Family Contract
+
+These interaction rules are now considered stable for the teacher work-surface family.
+
+| Pattern | Current owners | Stability | Disposition | Priority |
+| --- | --- | --- | --- | --- |
+| Formal interaction ladder: `entry` -> `summary` -> `workspace` -> `workspace_mode` -> `inspector_active` | assignments as baseline, tests/quizzes as adopters | stable | reuse as the family state model | now |
+| Summary state is full-width and content-first | assignments | stable | treat as family default | now |
+| Workspace-mode tabs are post-selection only | assignments structure, tests emerging | stable | treat as family default | now |
+| Inspector activation is selection- and mode-driven, not passive | assignments as baseline, tests grading as adopter | stable | treat as family default | now |
+| Parent tab re-click returns to summary | assignments intent, tests implementation direction | stable | treat as family default | now |
+| Ownership check across feature tab, classroom shell, and route config | family-wide diagnostic rule | stable | require in future parity work | now |
+
 ## True Primitives
 
 These are the current or proposed structural primitives for the teacher work-surface family.
@@ -43,7 +57,7 @@ These are the current or proposed structural primitives for the teacher work-sur
 | Page-shell primitives (`PageLayout`, `PageActionBar`, `PageContent`, `PageStack`) | assignments, quizzes/tests | shared already | stable | keep as primitives | now |
 | Calm empty-state container via `EmptyState` | quizzes/tests today, assignments via similar composition | intended family-wide | stable | keep as primitive | now |
 | Teacher workspace split container derived from assignments | assignment viewing/grading + shell sidebar behavior | intended for quizzes/tests later | experimental candidate | extract as new primitive | now |
-| Shared teacher work-item card variant | `SortableAssignmentCard`, `QuizCard` | partial convergence only | experimental | revisit after convergence | later |
+| Shared teacher work-item card variant | `SortableAssignmentCard`, `QuizCard`, emerging test card variants | partial convergence only | experimental | revisit after convergence | later |
 | Generic teacher list/detail container | no single owner yet | conceptually repeated | unstable | do not extract yet | never for now |
 
 ## Composed Work-Surface Patterns
@@ -66,8 +80,22 @@ These should not be extracted into primitives.
 | --- | --- | --- | --- | --- |
 | Assignment grading logic and student work fetching | `TeacherClassroomView`, assignment workspace hooks | stable | keep feature-local | now |
 | Quiz/test authoring rules, question editing, and validation | `TeacherQuizzesTab`, `QuizModal`, question editors | stable per feature | keep feature-local | now |
-| Test grading batch actions, AI grading strategy, and return flows | `TeacherQuizzesTab` | experimental | keep feature-local | now |
-| Right-sidebar open/close decisions tied to route/query behavior | `ClassroomPageClient`, layout hooks | mixed | keep feature-local until split primitive is extracted | later |
+| Test grading batch actions, AI grading strategy, and return flows | `TeacherQuizzesTab` | feature-local | keep feature-local | now |
+| Assessment-specific workspace mode state machines | assignments/tests/quizzes owners | feature-local | keep feature-local | now |
+| Right-sidebar open/close decisions tied to route/query behavior | `ClassroomPageClient`, layout hooks | mixed structural/feature-local | keep feature-local until split primitive is extracted | later |
+
+## Current Assignment Audit
+
+Assignments remain the best baseline for the family contract.
+
+Observed status:
+
+- summary is already full-width and calm
+- selected work earns complexity rather than inheriting it by default
+- inspector behavior is justified by active review work
+- page-shell primitives are already the structural baseline
+
+No major contradiction currently requires an assignment redesign before tests or quizzes adopt the canon. Future assignment changes should be targeted only when the canon exposes a clear inconsistency.
 
 ## Legacy Drift To Avoid Copying Forward
 
@@ -83,7 +111,7 @@ These are present or recently present patterns that should not be treated as reu
 
 ### Now: teacher workspace split
 
-The first extraction target is a reusable teacher workspace split derived from assignments.
+The first extraction target remains a reusable teacher workspace split derived from assignments.
 
 Responsibilities:
 
@@ -136,4 +164,4 @@ When deciding whether a pattern should be promoted or extracted, answer:
 2. Does it appear in at least two places or clearly need to?
 3. Is the API narrow enough to stay comprehensible?
 4. Would extraction simplify future work instead of hiding important differences?
-5. Should the pattern be canonized first before code extraction?
+5. Has the interaction-ladder behavior been canonized first?

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -8,11 +8,11 @@ This document is the stable canon for the teacher-side work-surface family:
 
 It governs how those three tabs should feel, compose, and evolve. It does not govern:
 
-- the main classroom shell
+- the main classroom shell as a whole
 - unrelated teacher tabs such as attendance, roster, settings, gradebook, or calendar
 - the student product
 
-Assignments are the starting reference implementation for this family because they currently express the clearest summary-to-workspace flow. They are not permanent authority. If quizzes or tests produce a better pattern, this canon should be updated and assignments can then follow.
+Assignments are the current baseline source of truth for this family because they express the clearest teacher summary-to-workspace progression today. They are not permanent authority. If quizzes or tests later produce a better family pattern, this canon should be updated and assignments can then follow.
 
 ## Read Order
 
@@ -28,81 +28,247 @@ When a task touches teacher assignments, teacher quizzes, or teacher tests, read
 ## Authority Model
 
 - `stable.md` remains the source of truth for cross-cutting UI rules.
-- This file is the source of truth for teacher assignments/quizzes/tests composition and taste.
-- Experimental guidance may originate in assignments, quizzes, or tests.
+- This file is the stable authority for teacher assignments/quizzes/tests interaction structure, shell behavior, and family taste.
+- [`docs/guidance/assignment-ux-language.md`](/docs/guidance/assignment-ux-language.md) is the assignment-specific reference implementation, not a competing stable canon.
 - Nothing becomes stable for this family until this canon and the audit agree it is stable.
 
-## Stable Rules
+## Formal Interaction Ladder
 
-### 1. Teacher work surfaces begin in a quiet summary shell
+Use these state names explicitly in planning, prompts, reviews, and implementation notes:
 
-- The default teacher state is a scan-friendly list or summary surface, not a tool-heavy workspace.
-- The first visual emphasis belongs to the content list, not to toggles, segmented controls, or placeholder panels.
-- Empty states should feel calm and singular: one primary surface, one clear action, minimal framing.
+- `entry`: the teacher clicked the parent classroom tab
+- `summary`: the full-width browsing/list state with no passive inspector
+- `workspace`: a selected work item is open in the main content area
+- `workspace_mode`: a sub-mode inside the selected workspace, such as `authoring`, `grading`, `overview`, or `details`
+- `inspector_active`: a secondary pane is open because the current workspace mode and selection justify it
 
-Current grounding:
+Defaults for this family:
 
-- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
-- [`src/components/SortableAssignmentCard.tsx`](/src/components/SortableAssignmentCard.tsx)
+- sub-routes inside these tabs are workspace states by default, not URL states
+- top tabs belong inside selected workspaces, not in passive entry states
+- the right sidebar is a tool, not default chrome
+- re-clicking the parent nav tab should return the surface to `summary`
 
-### 2. Action bars stay stable, sparse, and subordinate to content
+## State Rules
+
+### 1. `entry`
+
+What the teacher sees:
+
+- the shared classroom shell with the family tab activated
+- a browsing-oriented first impression, not a dense authoring or grading workspace
+
+Allowed:
+
+- a sparse action bar
+- a full-width list or empty state
+- existing shell framing from the classroom route
+
+Must not appear:
+
+- a passive blank detail pane
+- an already-open inspector with no active selection
+- top tabs that imply a selected workspace before anything is selected
+
+Advances when:
+
+- the tab finishes loading and resolves into `summary`
+
+### 2. `summary`
+
+What the teacher sees:
+
+- one calm browsing surface
+- content-first cards, rows, or equivalent summary items
+- a stable, restrained top action bar
+
+Allowed:
+
+- one obvious primary action such as `New Assignment`, `New Test`, or `New Quiz`
+- quiet secondary controls when they are needed and visually subordinate
+- a single quiet `EmptyState`
+
+Must not appear:
+
+- a reserved placeholder pane
+- a visibly empty right column
+- workspace-mode tabs
+- controls that visually outrank the content list
+
+Advances when:
+
+- the teacher selects a work item
+- a summary action intentionally opens focused work
+
+### 3. `workspace`
+
+What the teacher sees:
+
+- the same outer shell, now centered on a selected item
+- denser content only because the teacher chose to work inside that item
+
+Allowed:
+
+- a selected-item title
+- context-aware actions
+- a main-pane editor, table, or review surface
+
+Must not appear:
+
+- summary-only placeholder messaging
+- a new shell language unrelated to the summary shell
+
+Advances when:
+
+- the teacher leaves the selected item and returns to `summary`
+- the workspace exposes a deeper `workspace_mode`
+
+### 4. `workspace_mode`
+
+What the teacher sees:
+
+- a selected workspace with top-level sub-modes only when they unlock materially different work
+
+Allowed:
+
+- tabs such as `Authoring` and `Grading`
+- mode-specific action bars
+- different main-pane surfaces for different kinds of work
+
+Must not appear:
+
+- workspace tabs before a selection exists
+- decorative or redundant mode switches that do not represent real workflow changes
+- mode chrome that visually dominates the selected content
+
+Advances when:
+
+- the teacher switches modes inside the selected workspace
+- the current mode and selection justify `inspector_active`
+
+### 5. `inspector_active`
+
+What the teacher sees:
+
+- a secondary pane that is actively supporting the current work
+
+Allowed:
+
+- grading inspectors
+- contextual review panes
+- split or resizable layouts when both panes are being used
+
+Must not appear:
+
+- a passive inspector before the current mode needs it
+- an inspector opened only to preserve layout symmetry
+- a secondary pane with no active contextual value
+
+Advances when:
+
+- the teacher selects the row, student, or sub-item that requires side-by-side work
+- the teacher closes, clears, or exits that focused selection and returns to the previous state
+
+## Shell And Chrome Rules
+
+### Action bar density
 
 - Use the shared page-shell composition already present in teacher assignments: `PageLayout`, `PageActionBar`, `PageContent`, `PageStack`.
-- The primary create/edit action may be prominent, but surrounding controls should remain restrained.
-- Mode controls are allowed only when they unlock a materially different teacher workflow. They should not visually outrank the list itself.
+- Summary states get a sparse action bar with one clear primary action and minimal surrounding chrome.
+- Workspace states may add contextual controls, but the shell should remain recognizable across nearby states.
+- Workspace-mode controls are justified only when they unlock genuinely different work.
 
-Current grounding:
+### Main-content width
 
-- [`src/components/PageLayout.tsx`](/src/components/PageLayout.tsx)
-- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
-- [`src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx`](/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx)
+- Summary states use the available main-content width.
+- Do not leave a silent empty column beside the browsing surface.
+- Do not preserve future detail space in a passive state.
 
-### 3. Card language stays compact, descriptive, and reusable
+### Selected-workspace gutters
 
-- Teacher work-item cards should surface the title, key status, time context, and the minimum metadata needed to decide what to open next.
-- Metadata density should stay restrained. Avoid secondary badges, helper copy, or action clusters that make cards feel like mini dashboards.
-- New shared card variants are acceptable only if assignments, quizzes, and tests converge on the same structure.
+- Summary states should keep the normal page rhythm from `PageContent` and `PageStack`.
+- Selected workspaces that render a primary panel shell, split shell, or top-mounted workspace tabs should remove outer `PageContent` gutter padding.
+- In those selected workspaces, the workspace container should sit flush with the main content bounds so the tabs and pane boundaries touch the container edge.
+- Extra outer gutter padding around a selected workspace shell is drift, not family polish.
 
-Current grounding:
+### Right-sidebar default behavior
 
-- [`src/components/SortableAssignmentCard.tsx`](/src/components/SortableAssignmentCard.tsx)
-- [`src/components/QuizCard.tsx`](/src/components/QuizCard.tsx)
+- The right sidebar should be closed or visually inactive by default in `entry` and `summary`.
+- Open the inspector only when the current workspace mode and current selection justify active side-by-side work.
+- Desktop split layouts are workspace tools, not default family chrome.
 
-### 4. Summary-to-detail progression should feel deliberate
+### Top-tab justification
 
-- The teacher should move from summary to focused work only after a real selection or workflow transition.
-- Passive browsing states should not reserve large empty detail panes purely to preserve structure.
-- Split or inspector layouts are justified only when the teacher is actively reviewing work, grading, authoring in detail, or comparing primary content with contextual inspection.
+- Top tabs are allowed only inside `workspace` as `workspace_mode` selectors.
+- They must represent real workflow changes.
+- They should not be the first visual emphasis in a browsing state.
 
-Current grounding:
+### Hard failures
 
-- [`src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`](/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx)
-- [`src/components/TeacherStudentWorkPanel.tsx`](/src/components/TeacherStudentWorkPanel.tsx)
-- [`src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`](/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx)
+Treat these as family-level hard failures:
 
-### 5. Split and resizable layouts are workspace tools, not default chrome
+- a passive blank pane before selection
+- a visibly empty right column after placeholder content is removed
+- workspace-mode tabs shown before selection
+- summary chrome that visually dominates the list
+- a selected workspace shell wrapped in extra outer gutters when the panel or tabs should sit flush
 
-- A split workspace is appropriate when the teacher is actively working in both panes.
-- A split workspace is not appropriate as a passive no-selection scaffold.
-- Width, collapse, and resize behavior should be structural and reusable. Business logic must stay outside the shared layout primitive.
-- The first extraction target for this family is a reusable teacher workspace split derived from assignments.
+## Card And Spacing Rules
 
-Current grounding:
+Teacher work-item cards and summary rows should follow assignment-family scanning priorities:
 
-- [`src/components/layout/ThreePanelShell.tsx`](/src/components/layout/ThreePanelShell.tsx)
-- [`src/components/layout/RightSidebar.tsx`](/src/components/layout/RightSidebar.tsx)
-- [`src/lib/layout-config.ts`](/src/lib/layout-config.ts)
+- title first
+- muted secondary metadata
+- compact status treatment
+- quiet row actions
+- modest vertical rhythm via `PageContent` and `PageStack`
 
-### 6. Tone and copy stay plain, product-like, and low-drama
+Card language should stay compact, descriptive, and reusable:
 
-- Prefer short labels and direct status language over decorative copy.
-- Empty and no-selection states should explain the next action without sounding instructional for the sake of it.
-- Reuse Toronto-aware date language and existing status terms where possible.
+- surface the minimum metadata needed to decide what to open next
+- avoid helper copy, badge piles, or action clusters that make each item feel like a mini dashboard
+- preserve a strong left-to-right reading order with the title as the strongest text
 
-Current grounding:
+Spacing should stay calm:
 
-- [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
-- [`docs/core/design.md`](/docs/core/design.md)
+- modest action-bar spacing
+- clear but not oversized separation between cards or rows
+- enough padding for readability without feeling loose
+- in selected panel-based workspaces, earn density by removing outer gutters rather than nesting padded boxes inside padded boxes
+
+## Ownership Checklist
+
+If a screen shows unwanted pane or chrome behavior, check ownership in this order before editing:
+
+1. the feature tab component
+2. the surrounding classroom shell
+3. route and layout config
+
+Typical ownership examples:
+
+- summary/workspace transitions often live in the feature tab component
+- passive no-selection panes may live in `ClassroomPageClient`
+- persistent blank columns may be owned by route config in `src/lib/layout-config.ts`
+
+Do not paper over an outer-shell problem only inside the local tab component.
+
+## Reuse Boundaries
+
+Keep these reusable:
+
+- shell/state rules
+- page-shell primitives
+- stable split-workspace structure when it is truly structural
+- future shared card variants only after real convergence
+
+Keep these feature-local:
+
+- grading behavior
+- quiz/test authoring rules and validation
+- assignment grading logic
+- assessment-specific state machines and domain controls
+
+Do not introduce a generic assessment mega-shell that tries to own assignments, quizzes, and tests in one abstraction.
 
 ## Componentization Rules
 
@@ -135,6 +301,20 @@ For this teacher work-surface family:
   - assessment-specific domain controls
   - authoring rules and validation logic
 
+## Documentation Checklist
+
+Use this checklist when changing or reviewing teacher-family UX:
+
+- full-width summary by default
+- no passive inspector before selection
+- selected workspace earns complexity
+- workspace tabs only after selection
+- inspector opens only for active comparative or review work
+- parent tab click returns to `summary`
+- page-shell primitives are reused
+- semantic tokens remain in app code
+- owner check covers feature tab, classroom shell, and layout config
+
 ## Lifecycle
 
 Every teacher work-surface pattern should be classified as one of:
@@ -157,6 +337,7 @@ The weekly promotion-review automation should be used to surface promotion candi
 
 Any meaningful teacher assignments/quizzes/tests UX change should update this canon when it changes:
 
+- the interaction ladder
 - shell structure
 - action hierarchy
 - card anatomy

--- a/docs/guides/assessment-ux-evaluation.md
+++ b/docs/guides/assessment-ux-evaluation.md
@@ -1,6 +1,6 @@
 # Assessment UX Evaluation
 
-Use this guide to verify that the new assignment-parity docs actually cause a fresh AI to produce assessment screens that match the existing assignments system.
+Use this guide to verify that the current teacher-family canon and parity prompts actually cause a fresh AI to produce assessment screens that match the assignment-derived system.
 
 This is a **rubric-and-screenshot** evaluation flow, not a pixel diff.
 
@@ -13,10 +13,11 @@ Passing means:
 - the resulting screen reads as the same product family as assignments at a glance
 - the code reuses the expected page primitives
 - the evaluator can explain parity using the rubric instead of relying on vague taste
+- failures can be described in terms of the formal interaction ladder, not only aesthetics
 
 Minor aesthetic evolution is acceptable. The pass condition is family consistency, not pixel identity.
 
-## Reference and Target Artifacts
+## Reference And Target Artifacts
 
 Capture screenshots with:
 
@@ -43,12 +44,31 @@ Use the assignment images as the reference set. Use the assessment images as the
 
 If you are intentionally testing a “same family, slightly evolved” direction, use the same rubric. The question is still whether the target reads as a descendant of assignments rather than a separate tool.
 
+## Interaction-Ladder Reference
+
+Use the teacher-family canon state names when logging failures:
+
+- `entry`
+- `summary`
+- `workspace`
+- `workspace_mode`
+- `inspector_active`
+
+When a target fails, say which layer drifted. Examples:
+
+- `summary` incorrectly reserves a passive inspector
+- `workspace_mode` tabs appear before selection
+- `inspector_active` opens too early
+
+This keeps failures structural rather than taste-based.
+
 ## Blind-Run Validation Workflow
 
 Run the docs in a fresh AI session with only:
 
+- `docs/guidance/ui/teacher-work-surfaces.md`
 - `docs/guidance/assignment-ux-language.md`
-- `.codex/prompts/assessment-ux-parity.md`
+- `.codex/prompts/assessment-ux-family-parity.md`
 - the target task request
 
 Do not provide prior design discussion or hidden context.
@@ -88,7 +108,6 @@ If the fresh AI never reaches implementation and spends the run reacquiring unre
 
 Also count it as a prompt-scoping failure if the fresh AI only inspects the local tab component while the visible no-selection shell actually lives in a surrounding container such as `ClassroomPageClient`.
 Also count it as a prompt-scoping failure if the persistent blank column is owned by route-level layout configuration such as `tests-teacher` in `src/lib/layout-config.ts` and the challenge packet never points the fresh AI there.
-
 Also count it as an execution-packet failure if the prompt names App Router files with bracketed path segments but does not tell the fresh AI to quote those paths in shell commands. In this repo, that causes `zsh` glob failures before implementation even starts.
 
 ## Rubric
@@ -129,6 +148,8 @@ The run fails immediately if any of these appear:
 - The empty state is materially noisier than assignments.
 - Controls or mode toggles visually dominate the screen before content.
 - The layout introduces a structural pattern that does not exist in assignments for the analogous state.
+- `workspace_mode` tabs appear before the surface is in `workspace`.
+- `inspector_active` occurs without the current mode and selection justifying it.
 
 ## Required Code Review Checks
 
@@ -140,8 +161,9 @@ Before approving a blind-run result, confirm the implementation reuses expected 
 - `PageStack`
 - `EmptyState`
 - semantic tokens instead of bespoke raw-theme styling
+- owner check across feature tab, classroom shell, and route config when pane or chrome issues are involved
 
-If the screenshots look close but the code invented a new shell or component family, treat that as drift and update the docs/prompt.
+If the screenshots look close but the code invented a new shell or component family, treat that as drift and update the docs or prompt.
 
 ## Failure Logging
 
@@ -149,24 +171,27 @@ Every failed run should produce a short note with:
 
 - challenge name
 - screenshot pair reviewed
+- interaction-ladder layer that drifted
 - rubric scores
 - hard failures, if any
 - whether the AI actually reached implementation
 - exact drift observed
 - whether the wrong owning component was targeted
 - where the docs were insufficient:
-  - UX system rule missing
+  - interaction rule missing
   - prompt instruction missing
   - primitive checklist missing
+  - owner-check instruction missing
 
 ## Iteration Rules
 
 Update the **UX spec** when the failure is system-level:
 
-- state progression is unclear
+- interaction-ladder progression is unclear
 - split-pane rules are underspecified
 - empty-state tone is underspecified
 - card or shell language is underspecified
+- inspector activation rules are underspecified
 
 Update the **parity prompt** when the failure is execution-level:
 
@@ -174,5 +199,6 @@ Update the **parity prompt** when the failure is execution-level:
 - the AI invented a new layout even though the spec was clear
 - the AI ignored primitive reuse
 - the AI needed stronger “must not introduce” constraints
+- the AI did not verify the owning component for the visible problem
 
 Do not call the guidance “working” after one success. Require repeatable passes across the full challenge set.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000'
 const resolvedBaseUrl = new URL(baseURL)
 const resolvedPort = resolvedBaseUrl.port || (resolvedBaseUrl.protocol === 'https:' ? '443' : '80')
-const webServerCommand = `pnpm run dev -- --port ${resolvedPort}`
+const webServerCommand = `pnpm exec next dev --port ${resolvedPort}`
 
 export default defineConfig({
   testDir: './e2e',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000'
+const resolvedBaseUrl = new URL(baseURL)
+const resolvedPort = resolvedBaseUrl.port || (resolvedBaseUrl.protocol === 'https:' ? '443' : '80')
+const webServerCommand = `pnpm run dev -- --port ${resolvedPort}`
 
 export default defineConfig({
   testDir: './e2e',
@@ -72,7 +75,7 @@ export default defineConfig({
 
   // Auto-start Next.js dev server
   webServer: {
-    command: 'pnpm run dev',
+    command: webServerCommand,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/scripts/run-teacher-tests-parity-challenge.sh
+++ b/scripts/run-teacher-tests-parity-challenge.sh
@@ -6,6 +6,8 @@ HUB="${HOME}/Repos/pika"
 MODEL="gpt-5.4"
 REFRESH_AUTH=0
 SKIP_PRECAPTURE=0
+TIMEOUT_SECONDS=900
+BASE_URL="${E2E_BASE_URL:-http://localhost:3000}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -21,9 +23,13 @@ while [[ $# -gt 0 ]]; do
       SKIP_PRECAPTURE=1
       shift
       ;;
+    --timeout)
+      TIMEOUT_SECONDS="${2:?missing value for --timeout}"
+      shift 2
+      ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: $0 [--model <model>] [--refresh-auth] [--skip-precapture]" >&2
+      echo "Usage: $0 [--model <model>] [--refresh-auth] [--skip-precapture] [--timeout <seconds>]" >&2
       exit 1
       ;;
   esac
@@ -51,22 +57,25 @@ TARGET_IMAGE="$ARTIFACT_DIR/teacher-tests-target.png"
 BEFORE_IMAGE="$ARTIFACT_DIR/teacher-tests-target-before-challenge.png"
 PROMPT_COPY="$ARTIFACT_DIR/teacher-tests-challenge-prompt.txt"
 LAST_MESSAGE="$ARTIFACT_DIR/teacher-tests-challenge-last.txt"
+RUN_LOG="$ARTIFACT_DIR/teacher-tests-challenge-run.log"
+RUN_STATUS="$ARTIFACT_DIR/teacher-tests-challenge-status.txt"
 
 mkdir -p "$ARTIFACT_DIR"
+rm -f "$LAST_MESSAGE" "$RUN_LOG" "$RUN_STATUS"
 
 if [[ $REFRESH_AUTH -eq 1 ]]; then
-  echo "Refreshing Playwright auth state..."
+  echo "Refreshing Playwright auth state against $BASE_URL..."
   (
     cd "$WORKTREE"
-    pnpm e2e:auth
+    E2E_BASE_URL="$BASE_URL" pnpm e2e:auth
   )
 fi
 
 if [[ $SKIP_PRECAPTURE -eq 0 ]]; then
-  echo "Capturing current parity references and targets..."
+  echo "Capturing current parity references and targets from $BASE_URL..."
   (
     cd "$WORKTREE"
-    pnpm e2e:verify assessment-ux-parity
+    E2E_BASE_URL="$BASE_URL" pnpm e2e:verify assessment-ux-parity
   )
 fi
 
@@ -99,23 +108,70 @@ $(<"$PROMPT_PATH")
 EOF
 
 echo "Running scoped teacher-tests parity challenge with model $MODEL..."
+CHALLENGE_EXIT_CODE=0
+set +e
 (
   cd "$WORKTREE"
-  env PIKA_WORKTREE="$WORKTREE" codex exec \
-    --ephemeral \
-    --full-auto \
-    -m "$MODEL" \
-    -C "$WORKTREE" \
-    -i "$REFERENCE_IMAGE" \
-    -i "$BEFORE_IMAGE" \
-    -o "$LAST_MESSAGE" \
-    - <"$PROMPT_COPY"
+  env PIKA_WORKTREE="$WORKTREE" python3 - "$WORKTREE" "$MODEL" "$REFERENCE_IMAGE" "$BEFORE_IMAGE" "$LAST_MESSAGE" "$PROMPT_COPY" "$TIMEOUT_SECONDS" >"$RUN_LOG" 2>&1 <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+
+worktree, model, reference_image, before_image, last_message, prompt_copy, timeout_seconds = sys.argv[1:]
+timeout_seconds = int(timeout_seconds)
+prompt_text = Path(prompt_copy).read_text()
+
+command = [
+    "codex",
+    "exec",
+    "--ephemeral",
+    "--full-auto",
+    "-m",
+    model,
+    "-C",
+    worktree,
+    "-i",
+    reference_image,
+    "-i",
+    before_image,
+    "-o",
+    last_message,
+    "-",
+]
+
+try:
+    completed = subprocess.run(
+        command,
+        input=prompt_text,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    raise SystemExit(completed.returncode)
+except subprocess.TimeoutExpired as exc:
+    if exc.stdout:
+        print(exc.stdout, end="")
+    if exc.stderr:
+        print(exc.stderr, end="", file=sys.stderr)
+    print(f"\n[challenge wrapper] codex exec timed out after {timeout_seconds}s", file=sys.stderr)
+    raise SystemExit(124)
+PY
 )
+CHALLENGE_EXIT_CODE=$?
+set -e
+
+if [[ $CHALLENGE_EXIT_CODE -eq 0 ]]; then
+  printf 'status=completed\nexit_code=0\n' >"$RUN_STATUS"
+elif [[ $CHALLENGE_EXIT_CODE -eq 124 ]]; then
+  printf 'status=timed_out\nexit_code=124\n' >"$RUN_STATUS"
+else
+  printf 'status=failed\nexit_code=%s\n' "$CHALLENGE_EXIT_CODE" >"$RUN_STATUS"
+fi
 
 echo "Re-capturing parity screenshots after the challenge..."
 (
   cd "$WORKTREE"
-  pnpm e2e:verify assessment-ux-parity
+  E2E_BASE_URL="$BASE_URL" pnpm e2e:verify assessment-ux-parity
 )
 
 printf '\nArtifacts:\n'
@@ -124,3 +180,13 @@ printf '  Before:    %s\n' "$BEFORE_IMAGE"
 printf '  After:     %s\n' "$TARGET_IMAGE"
 printf '  Prompt:    %s\n' "$PROMPT_COPY"
 printf '  Summary:   %s\n' "$LAST_MESSAGE"
+printf '  Run log:   %s\n' "$RUN_LOG"
+printf '  Status:    %s\n' "$RUN_STATUS"
+
+if [[ $CHALLENGE_EXIT_CODE -eq 124 ]]; then
+  printf '\nChallenge status: timed out after %ss\n' "$TIMEOUT_SECONDS"
+elif [[ $CHALLENGE_EXIT_CODE -ne 0 ]]; then
+  printf '\nChallenge status: failed (exit %s)\n' "$CHALLENGE_EXIT_CODE"
+else
+  printf '\nChallenge status: completed\n'
+fi

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -17,6 +17,7 @@ import { TeacherResourcesTab } from './TeacherResourcesTab'
 import { StudentClassResourcesSidebar } from './StudentClassResourcesSidebar'
 import { StudentResourcesTab } from './StudentResourcesTab'
 import { TeacherQuizzesTab } from './TeacherQuizzesTab'
+import { TeacherTestsTab } from './TeacherTestsTab'
 import { StudentQuizzesTab } from './StudentQuizzesTab'
 import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
 import { ClassDaysProvider } from '@/hooks/useClassDays'
@@ -444,7 +445,7 @@ function ClassroomPageContent({
   const [gradebookClassSummary, setGradebookClassSummary] = useState<GradebookClassSummary | null>(null)
   const [gradebookStudentDetailLoading, setGradebookStudentDetailLoading] = useState(false)
   const [gradebookStudentDetailError, setGradebookStudentDetailError] = useState('')
-  const [testsSidebarClickToken, setTestsSidebarClickToken] = useState(0)
+  const [testsTabClickToken, setTestsTabClickToken] = useState(0)
   const [testGradingPanelRefreshToken, setTestGradingPanelRefreshToken] = useState(0)
 
   const handleSelectQuiz = useCallback((quiz: QuizWithStats | null) => {
@@ -709,14 +710,12 @@ function ClassroomPageContent({
   useEffect(() => {
     if (!isTeacher || activeTab !== 'tests') return
     if (testGradingContext.mode === 'grading') return
-    if (selectedQuiz) return
     setRightSidebarOpen(false)
     closeMobileDrawer()
   }, [
     activeTab,
     closeMobileDrawer,
     isTeacher,
-    selectedQuiz,
     setRightSidebarOpen,
     testGradingContext.mode,
   ])
@@ -885,7 +884,7 @@ function ClassroomPageContent({
   const handleTabChange = useCallback(
     (tab: string) => {
       if (tab === 'tests') {
-        setTestsSidebarClickToken((prev) => prev + 1)
+        setTestsTabClickToken((prev) => prev + 1)
       }
       markClassroomTabSwitchStart(tab)
       navigateInClassroom((params) => {
@@ -1088,13 +1087,15 @@ function ClassroomPageContent({
                   )}
                   {mountedTabs.tests && (
                     <TabContentTransition isActive={activeTab === 'tests'}>
-                      <TeacherQuizzesTab
+                      <TeacherTestsTab
                         classroom={classroom}
-                        assessmentType="test"
-                        onSelectQuiz={handleSelectQuiz}
-                        testsSidebarClickToken={testsSidebarClickToken}
+                        testsTabClickToken={testsTabClickToken}
+                        onSelectTest={handleSelectQuiz}
                         onTestGradingDataRefresh={handleTestGradingDataRefresh}
                         onTestGradingContextChange={setTestGradingContext}
+                        onRequestDelete={() => {
+                          void handleRequestAssessmentDelete()
+                        }}
                       />
                     </TabContentTransition>
                   )}
@@ -1346,30 +1347,14 @@ function ClassroomPageContent({
               refreshToken={testGradingPanelRefreshToken}
               onSaveStateChange={setTestGradingSaveState}
             />
-          ) : isTeacher && isAssessmentTab && selectedQuiz ? (
+          ) : isTeacher && activeTab === 'quizzes' && selectedQuiz ? (
             <QuizDetailPanel
               quiz={selectedQuiz}
               classroomId={classroom.id}
               apiBasePath={assessmentApiBasePath}
               onQuizUpdate={handleQuizUpdate}
-              onRequestTestPreview={
-                activeTab === 'tests'
-                  ? (preview) => {
-                      setTeacherTestPreview(preview)
-                    }
-                  : undefined
-              }
-              onRequestDelete={
-                activeTab === 'tests'
-                  ? () => {
-                      void handleRequestAssessmentDelete()
-                    }
-                  : undefined
-              }
             />
-          ) : isTeacher &&
-            activeTab === 'tests' &&
-            testGradingContext.mode === 'authoring' ? null : isTeacher && isAssessmentTab ? (
+          ) : isTeacher && activeTab === 'tests' ? null : isTeacher && isAssessmentTab ? (
             <div className="flex h-full min-h-0 items-center p-4">
               <EmptyState
                 title={`Select a ${assessmentLabel}`}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -37,7 +37,7 @@ import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
-import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
@@ -1617,19 +1617,12 @@ export function TeacherClassroomView({
                   </div>
                 )
               ) : showOverviewInspector ? (
-                <WorkspaceSplitPane
+                <SummaryDetailWorkspaceShell
                   className="flex-1"
                   orientation="responsive"
-                  leftPaneClassName="min-h-0 flex-1 overflow-hidden"
-                  rightPaneClassName="min-h-0 overflow-hidden border-t border-border bg-surface lg:border-t-0"
-                  rightPaneStyle={
-                    isDesktop
-                      ? ({
-                          width: `${activeWorkspaceLayout.inspectorWidth}%`,
-                          flexBasis: `${activeWorkspaceLayout.inspectorWidth}%`,
-                        } as const)
-                      : undefined
-                  }
+                  leftPaneClassName="min-h-0"
+                  rightPaneClassName="min-h-0"
+                  rightWidthPercent={isDesktop ? activeWorkspaceLayout.inspectorWidth : undefined}
                   divider={{
                     label: 'Resize table and grading panes',
                     onPointerDown: handleOverviewInspectorResizeStart,

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -37,6 +37,7 @@ import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
+import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
@@ -1616,35 +1617,26 @@ export function TeacherClassroomView({
                   </div>
                 )
               ) : showOverviewInspector ? (
-                <div className="flex h-full min-h-0 flex-col lg:flex-row">
-                  <div className="min-h-0 flex-1 overflow-hidden">
-                    {studentTable}
-                  </div>
-                  {isDesktop && (
-                    <div className="relative hidden w-0 shrink-0 lg:block">
-                      <div
-                        role="separator"
-                        aria-orientation="vertical"
-                        aria-label="Resize table and grading panes"
-                        className="absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent"
-                        onPointerDown={handleOverviewInspectorResizeStart}
-                        onDoubleClick={handleOverviewInspectorResizeReset}
-                      >
-                        <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
-                      </div>
-                    </div>
-                  )}
-                  <div
-                    className="min-h-0 border-t border-border bg-surface lg:border-t-0"
-                    style={
-                      isDesktop
-                        ? ({
-                            width: `${activeWorkspaceLayout.inspectorWidth}%`,
-                            flexBasis: `${activeWorkspaceLayout.inspectorWidth}%`,
-                          } as const)
-                        : undefined
-                    }
-                  >
+                <WorkspaceSplitPane
+                  className="flex-1"
+                  orientation="responsive"
+                  leftPaneClassName="min-h-0 flex-1 overflow-hidden"
+                  rightPaneClassName="min-h-0 overflow-hidden border-t border-border bg-surface lg:border-t-0"
+                  rightPaneStyle={
+                    isDesktop
+                      ? ({
+                          width: `${activeWorkspaceLayout.inspectorWidth}%`,
+                          flexBasis: `${activeWorkspaceLayout.inspectorWidth}%`,
+                        } as const)
+                      : undefined
+                  }
+                  divider={{
+                    label: 'Resize table and grading panes',
+                    onPointerDown: handleOverviewInspectorResizeStart,
+                    onDoubleClick: handleOverviewInspectorResizeReset,
+                  }}
+                  left={studentTable}
+                  right={
                     <TeacherStudentWorkPanel
                       classroomId={classroom.id}
                       assignmentId={selection.assignmentId}
@@ -1655,8 +1647,8 @@ export function TeacherClassroomView({
                       totalWidth={workspaceWidth}
                       onLoadingStateChange={setWorkspaceLoading}
                     />
-                  </div>
-                </div>
+                  }
+                />
               ) : (
                 studentTable
               )}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -824,7 +824,7 @@ export function TeacherTestsTab({
   const batchGradeDescription = batchGradeDescriptionParts.join(' ')
 
   const gradingTable = (
-    <div className="space-y-3">
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       {gradingLoading ? (
         <div className="flex justify-center py-10">
           <Spinner />
@@ -836,7 +836,7 @@ export function TeacherTestsTab({
           tone="muted"
         />
       ) : (
-        <div className="overflow-hidden rounded-md border border-border bg-surface">
+        <div className="min-h-0 w-full overflow-hidden rounded-md border border-border bg-surface">
           <table className="w-full text-sm">
             <thead>
               <tr className="bg-surface-hover text-left text-text-muted">
@@ -1040,130 +1040,135 @@ export function TeacherTestsTab({
       </div>
 
       <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
-        <div className="min-w-0 max-w-[24rem] truncate text-center text-sm font-medium text-text-default">
-          {selectedTestTitle}
+        <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
+          {selectedWorkspaceTab === 'authoring' ? (
+            <>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setTestPreviewRequestToken((value) => value + 1)}
+              >
+                Preview
+              </Button>
+              {selectedTest?.status === 'draft' ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    void handleRequestSelectedTestActivate()
+                  }}
+                  disabled={!selectedActivation.valid || isReadOnly || statusUpdating || checkingActivation}
+                >
+                  <Play className="h-4 w-4" />
+                  Open
+                </Button>
+              ) : null}
+              {selectedTest?.status === 'active' ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowCloseConfirm(true)}
+                  disabled={isReadOnly || statusUpdating}
+                >
+                  <Square className="h-4 w-4" />
+                  Close
+                </Button>
+              ) : null}
+              {selectedTest?.status === 'closed' ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    void handleSelectedTestStatusChange('active')
+                  }}
+                  disabled={isReadOnly || statusUpdating}
+                >
+                  <Play className="h-4 w-4" />
+                  Reopen
+                </Button>
+              ) : null}
+              {onRequestDelete ? (
+                <Button
+                  type="button"
+                  variant="danger"
+                  size="sm"
+                  onClick={onRequestDelete}
+                  disabled={isReadOnly}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete
+                </Button>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={openBatchPromptGuidelineModal}
+                disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
+              >
+                AI Prompt
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  if (batchSelectedCount === 0) {
+                    setGradingWarning('Select students to grade')
+                    return
+                  }
+                  setShowBatchGradeModal(true)
+                }}
+                disabled={
+                  batchSelectedCount === 0 ||
+                  isBatchAutoGrading ||
+                  isBatchReturning ||
+                  isBatchClearingOpenGrades
+                }
+              >
+                <Check className="h-4 w-4" />
+                AI Grade
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  if (batchSelectedCount === 0) {
+                    setGradingWarning('Select students to return')
+                    return
+                  }
+                  setShowReturnConfirm(true)
+                }}
+                disabled={
+                  batchSelectedCount === 0 ||
+                  isBatchAutoGrading ||
+                  isBatchReturning ||
+                  isBatchClearingOpenGrades
+                }
+              >
+                <Send className="h-4 w-4" />
+                Return
+              </Button>
+            </>
+          )}
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
-        {selectedWorkspaceTab === 'authoring' ? (
-          <>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => setTestPreviewRequestToken((value) => value + 1)}
-            >
-              Preview
-            </Button>
-            {selectedTest?.status === 'draft' ? (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  void handleRequestSelectedTestActivate()
-                }}
-                disabled={!selectedActivation.valid || isReadOnly || statusUpdating || checkingActivation}
-              >
-                <Play className="h-4 w-4" />
-                Open
-              </Button>
-            ) : null}
-            {selectedTest?.status === 'active' ? (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => setShowCloseConfirm(true)}
-                disabled={isReadOnly || statusUpdating}
-              >
-                <Square className="h-4 w-4" />
-                Close
-              </Button>
-            ) : null}
-            {selectedTest?.status === 'closed' ? (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  void handleSelectedTestStatusChange('active')
-                }}
-                disabled={isReadOnly || statusUpdating}
-              >
-                <Play className="h-4 w-4" />
-                Reopen
-              </Button>
-            ) : null}
-            {onRequestDelete ? (
-              <Button
-                type="button"
-                variant="danger"
-                size="sm"
-                onClick={onRequestDelete}
-                disabled={isReadOnly}
-              >
-                <Trash2 className="h-4 w-4" />
-                Delete
-              </Button>
-            ) : null}
-          </>
-        ) : (
-          <>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={openBatchPromptGuidelineModal}
-              disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-            >
-              AI Prompt
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                if (batchSelectedCount === 0) {
-                  setGradingWarning('Select students to grade')
-                  return
-                }
-                setShowBatchGradeModal(true)
-              }}
-              disabled={
-                batchSelectedCount === 0 ||
-                isBatchAutoGrading ||
-                isBatchReturning ||
-                isBatchClearingOpenGrades
-              }
-            >
-              <Check className="h-4 w-4" />
-              AI Grade
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                if (batchSelectedCount === 0) {
-                  setGradingWarning('Select students to return')
-                  return
-                }
-                setShowReturnConfirm(true)
-              }}
-              disabled={
-                batchSelectedCount === 0 ||
-                isBatchAutoGrading ||
-                isBatchReturning ||
-                isBatchClearingOpenGrades
-              }
-            >
-              <Send className="h-4 w-4" />
-              Return
-            </Button>
-          </>
-        )}
+      <div className="flex min-w-0 basis-full justify-end sm:basis-auto sm:ml-auto">
+        <div
+          className="min-w-0 max-w-[22rem] truncate text-right text-sm font-medium text-text-default"
+          title={selectedTestTitle}
+        >
+          {selectedTestTitle}
+        </div>
       </div>
     </div>
   ) : (
@@ -1175,7 +1180,7 @@ export function TeacherTestsTab({
 
   return (
     <PageLayout className="flex h-full min-h-0 flex-col">
-      <PageActionBar primary={selectedHeader} />
+      <PageActionBar primary={selectedHeader} className={isSelectedWorkspace ? 'pl-0 pr-2' : ''} />
 
       <PageContent
         className={[
@@ -1233,24 +1238,26 @@ export function TeacherTestsTab({
           <div className="flex justify-center py-12">
             <Spinner size="lg" />
           </div>
-        ) : selectedWorkspaceTab === 'authoring' && selectedTest ? (
-          <div className="flex min-h-0 w-full flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
-            <QuizDetailPanel
-              quiz={selectedTest}
-              classroomId={classroom.id}
-              apiBasePath={apiBasePath}
-              onQuizUpdate={() => {
-                void loadTests()
-              }}
-              showInlineDeleteAction={false}
-              testQuestionLayout="summary-detail"
-              showPreviewButton={false}
-              showResultsTab={false}
-              previewRequestToken={testPreviewRequestToken}
-            />
-          </div>
         ) : (
-          gradingTable
+          <div className="flex min-h-0 w-full flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
+            {selectedWorkspaceTab === 'authoring' ? (
+              <QuizDetailPanel
+                quiz={selectedTest}
+                classroomId={classroom.id}
+                apiBasePath={apiBasePath}
+                onQuizUpdate={() => {
+                  void loadTests()
+                }}
+                showInlineDeleteAction={false}
+                testQuestionLayout="summary-detail"
+                showPreviewButton={false}
+                showResultsTab={false}
+                previewRequestToken={testPreviewRequestToken}
+              />
+            ) : (
+              gradingTable
+            )}
+          </div>
         )}
       </PageContent>
 

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -59,9 +59,10 @@ interface TestGradingQuestionSummary {
 
 type WorkspaceState = 'list' | 'selected'
 type WorkspaceTab = 'authoring' | 'grading'
-type TestAuthoringView = 'questions' | 'documents'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 type TestAiGradingStrategy = 'balanced' | 'aggressive_batch'
+
+const GRADING_POLL_INTERVAL_MS = 15_000
 
 const TEST_AI_GRADING_STRATEGY_OPTIONS = [
   { value: 'balanced', label: 'Balanced (Recommended)' },
@@ -168,7 +169,6 @@ export function TeacherTestsTab({
   const [loading, setLoading] = useState(true)
   const [workspaceState, setWorkspaceState] = useState<WorkspaceState>('list')
   const [selectedWorkspaceTab, setSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
-  const [selectedAuthoringView, setSelectedAuthoringView] = useState<TestAuthoringView>('questions')
   const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
@@ -176,6 +176,8 @@ export function TeacherTestsTab({
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
   const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
+  const [gradingServerTestStatus, setGradingServerTestStatus] = useState<Quiz['status'] | null>(null)
+  const [gradingServerTestId, setGradingServerTestId] = useState<string | null>(null)
   const [gradingLoading, setGradingLoading] = useState(false)
   const [gradingError, setGradingError] = useState('')
   const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
@@ -296,6 +298,8 @@ export function TeacherTestsTab({
     if (!selectedTestId) {
       setGradingStudents([])
       setGradingQuestions([])
+      setGradingServerTestStatus(null)
+      setGradingServerTestId(null)
       return
     }
 
@@ -306,6 +310,20 @@ export function TeacherTestsTab({
       const data = await response.json()
       if (!response.ok) throw new Error(data.error || 'Failed to load test results')
 
+      const nextStatus =
+        data?.quiz?.status === 'draft' || data?.quiz?.status === 'active' || data?.quiz?.status === 'closed'
+          ? (data.quiz.status as Quiz['status'])
+          : null
+
+      setGradingServerTestStatus(nextStatus)
+      setGradingServerTestId(selectedTestId)
+      if (nextStatus) {
+        setTests((prev) =>
+          prev.map((test) =>
+            test.id === selectedTestId && test.status !== nextStatus ? { ...test, status: nextStatus } : test
+          )
+        )
+      }
       setGradingStudents((data.students || []) as TestGradingStudentRow[])
       setGradingQuestions(
         Array.isArray(data.questions)
@@ -351,7 +369,6 @@ export function TeacherTestsTab({
 
     setWorkspaceState('list')
     setSelectedWorkspaceTab('authoring')
-    setSelectedAuthoringView('questions')
     setSelectedTestId(null)
     setSelectedStudentId(null)
     clearBatchSelection()
@@ -364,7 +381,6 @@ export function TeacherTestsTab({
     setSelectedTestId(pendingCreatedTestId)
     setWorkspaceState('selected')
     setSelectedWorkspaceTab('authoring')
-    setSelectedAuthoringView('questions')
     setSelectedStudentId(null)
     setPendingCreatedTestId(null)
     setRightSidebarOpen(false)
@@ -378,7 +394,6 @@ export function TeacherTestsTab({
 
     setWorkspaceState('list')
     setSelectedWorkspaceTab('authoring')
-    setSelectedAuthoringView('questions')
     setSelectedTestId(null)
     setSelectedStudentId(null)
     setGradingError('')
@@ -393,12 +408,78 @@ export function TeacherTestsTab({
       setSelectedStudentId(null)
       setGradingStudents([])
       setGradingQuestions([])
+      setGradingServerTestStatus(null)
+      setGradingServerTestId(null)
       clearBatchSelection()
       return
     }
 
     void loadGradingRows()
   }, [clearBatchSelection, loadGradingRows, selectedWorkspaceTab, workspaceState])
+
+  useEffect(() => {
+    if (
+      workspaceState !== 'selected' ||
+      selectedWorkspaceTab !== 'grading' ||
+      !selectedTestId ||
+      gradingServerTestId !== selectedTestId ||
+      gradingServerTestStatus !== 'active'
+    ) {
+      return
+    }
+
+    let intervalId: number | null = null
+    let disposed = false
+    let pollingInFlight = false
+
+    const canPollNow = () => document.visibilityState === 'visible' && document.hasFocus()
+
+    const stopPolling = () => {
+      if (intervalId === null) return
+      window.clearInterval(intervalId)
+      intervalId = null
+    }
+
+    const pollNow = async () => {
+      if (disposed || pollingInFlight || !canPollNow()) return
+      pollingInFlight = true
+      try {
+        await loadGradingRows()
+      } finally {
+        pollingInFlight = false
+      }
+    }
+
+    const startPolling = () => {
+      if (intervalId !== null || !canPollNow()) return
+      intervalId = window.setInterval(() => {
+        void pollNow()
+      }, GRADING_POLL_INTERVAL_MS)
+    }
+
+    const handlePollingStateChange = () => {
+      if (!canPollNow()) {
+        stopPolling()
+        return
+      }
+
+      startPolling()
+      void pollNow()
+    }
+
+    startPolling()
+    document.addEventListener('visibilitychange', handlePollingStateChange)
+    window.addEventListener('focus', handlePollingStateChange)
+    window.addEventListener('blur', handlePollingStateChange)
+
+    return () => {
+      disposed = true
+      stopPolling()
+      document.removeEventListener('visibilitychange', handlePollingStateChange)
+      window.removeEventListener('focus', handlePollingStateChange)
+      window.removeEventListener('blur', handlePollingStateChange)
+    }
+  }, [gradingServerTestId, gradingServerTestStatus, loadGradingRows, selectedTestId, selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
     function handleGradingRowUpdate(event: Event) {
@@ -485,7 +566,6 @@ export function TeacherTestsTab({
     setSelectedTestId(test.id)
     setWorkspaceState('selected')
     setSelectedWorkspaceTab('authoring')
-    setSelectedAuthoringView('questions')
     setSelectedStudentId(null)
     setGradingError('')
     setGradingWarning('')
@@ -970,22 +1050,6 @@ export function TeacherTestsTab({
           <>
             <Button
               type="button"
-              variant={selectedAuthoringView === 'questions' ? 'secondary' : 'ghost'}
-              size="sm"
-              onClick={() => setSelectedAuthoringView('questions')}
-            >
-              Questions
-            </Button>
-            <Button
-              type="button"
-              variant={selectedAuthoringView === 'documents' ? 'secondary' : 'ghost'}
-              size="sm"
-              onClick={() => setSelectedAuthoringView('documents')}
-            >
-              Documents
-            </Button>
-            <Button
-              type="button"
               variant="secondary"
               size="sm"
               onClick={() => setTestPreviewRequestToken((value) => value + 1)}
@@ -1170,7 +1234,7 @@ export function TeacherTestsTab({
             <Spinner size="lg" />
           </div>
         ) : selectedWorkspaceTab === 'authoring' && selectedTest ? (
-          <div className="flex min-h-0 flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
+          <div className="flex min-h-0 w-full flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
             <QuizDetailPanel
               quiz={selectedTest}
               classroomId={classroom.id}
@@ -1179,7 +1243,6 @@ export function TeacherTestsTab({
                 void loadTests()
               }}
               showInlineDeleteAction={false}
-              testAuthoringView={selectedAuthoringView}
               testQuestionLayout="summary-detail"
               showPreviewButton={false}
               showResultsTab={false}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1,0 +1,1410 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Check, Circle, ClockAlert, LogOut, Play, Plus, Send, Square, Trash2 } from 'lucide-react'
+import { Spinner } from '@/components/Spinner'
+import { QuizModal } from '@/components/QuizModal'
+import { QuizDetailPanel } from '@/components/QuizDetailPanel'
+import { TeacherTestCard } from '@/components/TeacherTestCard'
+import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { useRightSidebar } from '@/components/layout'
+import {
+  TEACHER_QUIZZES_UPDATED_EVENT,
+  TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
+  type TeacherTestGradingRowUpdatedEventDetail,
+} from '@/lib/events'
+import { getQuizExitCount } from '@/lib/quizzes'
+import { validateTestQuestionCreate } from '@/lib/test-questions'
+import { compareByNameFields } from '@/lib/table-sort'
+import { useStudentSelection } from '@/hooks/useStudentSelection'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
+import type { Classroom, Quiz, QuizFocusSummary, QuizWithStats } from '@/types'
+
+interface Props {
+  classroom: Classroom
+  testsTabClickToken?: number
+  onSelectTest?: (test: QuizWithStats | null) => void
+  onTestGradingDataRefresh?: () => void
+  onTestGradingContextChange?: (context: {
+    mode: 'authoring' | 'grading'
+    testId: string | null
+    studentId: string | null
+    studentName: string | null
+  }) => void
+  onRequestDelete?: () => void
+}
+
+interface TestGradingStudentRow {
+  student_id: string
+  name: string | null
+  first_name: string | null
+  last_name: string | null
+  email: string
+  status: 'not_started' | 'in_progress' | 'submitted' | 'returned'
+  submitted_at: string | null
+  last_activity_at: string | null
+  points_earned: number
+  points_possible: number
+  percent: number | null
+  graded_open_responses: number
+  ungraded_open_responses: number
+  focus_summary: QuizFocusSummary | null
+}
+
+interface TestGradingQuestionSummary {
+  id: string
+  questionType: 'multiple_choice' | 'open_response'
+  responseMonospace: boolean
+}
+
+type WorkspaceState = 'list' | 'selected'
+type WorkspaceTab = 'authoring' | 'grading'
+type TestAuthoringView = 'questions' | 'documents'
+type TestGradingSortColumn = 'first_name' | 'last_name'
+type TestAiGradingStrategy = 'balanced' | 'aggressive_batch'
+
+const TEST_AI_GRADING_STRATEGY_OPTIONS = [
+  { value: 'balanced', label: 'Balanced (Recommended)' },
+  { value: 'aggressive_batch', label: 'Aggressive Batch (Experimental)' },
+]
+
+const STATUS_META: Record<
+  TestGradingStudentRow['status'],
+  { label: string; className: string; icon: typeof Circle }
+> = {
+  not_started: { label: 'Not started', className: 'text-gray-400', icon: Circle },
+  in_progress: { label: 'In progress', className: 'text-yellow-500', icon: Circle },
+  submitted: { label: 'Submitted', className: 'text-green-500', icon: Check },
+  returned: { label: 'Returned', className: 'text-blue-500', icon: Send },
+}
+
+function splitDisplayName(name: string | null): { firstName: string | null; lastName: string | null } {
+  const trimmed = (name || '').trim()
+  if (!trimmed) return { firstName: null, lastName: null }
+
+  const parts = trimmed.split(/\s+/)
+  if (parts.length === 1) return { firstName: parts[0], lastName: null }
+
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(' '),
+  }
+}
+
+function getSortableNameParts(student: TestGradingStudentRow): { firstName: string | null; lastName: string | null } {
+  const firstName = (student.first_name || '').trim()
+  const lastName = (student.last_name || '').trim()
+  if (firstName || lastName) {
+    return {
+      firstName: firstName || null,
+      lastName: lastName || null,
+    }
+  }
+
+  return splitDisplayName(student.name)
+}
+
+function formatTorontoTime(iso: string | null): { value: string; isPm: boolean } {
+  if (!iso) return { value: '—', isPm: false }
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Toronto',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+  const parts = formatter.formatToParts(new Date(iso))
+  const hour = parts.find((part) => part.type === 'hour')?.value ?? ''
+  const minute = parts.find((part) => part.type === 'minute')?.value ?? ''
+  const dayPeriod = (parts.find((part) => part.type === 'dayPeriod')?.value ?? '').toLowerCase()
+  return {
+    value: `${hour}:${minute}`,
+    isPm: dayPeriod === 'pm',
+  }
+}
+
+function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2)
+}
+
+function summarizeBatchAutoGradeErrors(rawErrors: unknown): string {
+  if (!Array.isArray(rawErrors)) return ''
+
+  const counts = new Map<string, number>()
+  for (const rawError of rawErrors) {
+    if (typeof rawError !== 'string') continue
+    const trimmed = rawError.trim()
+    if (!trimmed) continue
+
+    const separatorIndex = trimmed.indexOf(': ')
+    const message = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 2).trim() : trimmed
+    if (!message) continue
+
+    counts.set(message, (counts.get(message) || 0) + 1)
+  }
+
+  if (counts.size === 0) return ''
+
+  return Array.from(counts.entries())
+    .slice(0, 3)
+    .map(([message, count]) => (count > 1 ? `${count} students: ${message}` : message))
+    .join(' · ')
+}
+
+export function TeacherTestsTab({
+  classroom,
+  testsTabClickToken = 0,
+  onSelectTest,
+  onTestGradingDataRefresh,
+  onTestGradingContextChange,
+  onRequestDelete,
+}: Props) {
+  const apiBasePath = '/api/teacher/tests'
+  const isReadOnly = !!classroom.archived_at
+  const { setOpen: setRightSidebarOpen } = useRightSidebar()
+  const previousTestsTabClickTokenRef = useRef(testsTabClickToken)
+
+  const [tests, setTests] = useState<QuizWithStats[]>([])
+  const [loading, setLoading] = useState(true)
+  const [workspaceState, setWorkspaceState] = useState<WorkspaceState>('list')
+  const [selectedWorkspaceTab, setSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
+  const [selectedAuthoringView, setSelectedAuthoringView] = useState<TestAuthoringView>('questions')
+  const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
+  const [testPreviewRequestToken, setTestPreviewRequestToken] = useState(0)
+
+  const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
+  const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
+  const [gradingLoading, setGradingLoading] = useState(false)
+  const [gradingError, setGradingError] = useState('')
+  const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
+  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const [gradingInfo, setGradingInfo] = useState('')
+  const [gradingWarning, setGradingWarning] = useState('')
+  const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
+  const [isBatchReturning, setIsBatchReturning] = useState(false)
+  const [isBatchClearingOpenGrades, setIsBatchClearingOpenGrades] = useState(false)
+  const [showReturnConfirm, setShowReturnConfirm] = useState(false)
+  const [showClearOpenGradesConfirm, setShowClearOpenGradesConfirm] = useState(false)
+  const [showBatchGradeModal, setShowBatchGradeModal] = useState(false)
+  const [showPromptGuidelineModal, setShowPromptGuidelineModal] = useState(false)
+  const [batchPromptGuideline, setBatchPromptGuideline] = useState('')
+  const [batchPromptGuidelineDraft, setBatchPromptGuidelineDraft] = useState('')
+  const [batchGradingStrategy, setBatchGradingStrategy] = useState<TestAiGradingStrategy>('balanced')
+  const [batchGradingStrategyDraft, setBatchGradingStrategyDraft] =
+    useState<TestAiGradingStrategy>('balanced')
+
+  const [statusActionError, setStatusActionError] = useState('')
+  const [statusUpdating, setStatusUpdating] = useState(false)
+  const [checkingActivation, setCheckingActivation] = useState(false)
+  const [showActivateConfirm, setShowActivateConfirm] = useState(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+
+  const selectedTest = useMemo(
+    () => tests.find((test) => test.id === selectedTestId) ?? null,
+    [selectedTestId, tests]
+  )
+
+  const sortedGradingStudents = useMemo(
+    () =>
+      [...gradingStudents].sort((a, b) => {
+        const aNameParts = getSortableNameParts(a)
+        const bNameParts = getSortableNameParts(b)
+        return compareByNameFields(
+          {
+            firstName: aNameParts.firstName,
+            lastName: aNameParts.lastName,
+            id: a.email || a.student_id,
+          },
+          {
+            firstName: bNameParts.firstName,
+            lastName: bNameParts.lastName,
+            id: b.email || b.student_id,
+          },
+          gradingSortColumn,
+          'asc'
+        )
+      }),
+    [gradingSortColumn, gradingStudents]
+  )
+
+  const gradingRowIds = useMemo(
+    () => sortedGradingStudents.map((student) => student.student_id),
+    [sortedGradingStudents]
+  )
+  const {
+    selectedIds: batchSelectedIds,
+    toggleSelect: toggleBatchSelect,
+    toggleSelectAll: toggleBatchSelectAll,
+    allSelected: batchAllSelected,
+    clearSelection: clearBatchSelection,
+    selectedCount: batchSelectedCount,
+  } = useStudentSelection(gradingRowIds)
+
+  const batchSelectedStudents = useMemo(
+    () => sortedGradingStudents.filter((student) => batchSelectedIds.has(student.student_id)),
+    [batchSelectedIds, sortedGradingStudents]
+  )
+  const batchSelectedStudentIds = useMemo(
+    () => batchSelectedStudents.map((student) => student.student_id),
+    [batchSelectedStudents]
+  )
+
+  const batchAutoGradePreflight = useMemo(() => {
+    const selectedCount = batchSelectedStudents.length
+    const ungradedResponses = batchSelectedStudents.reduce(
+      (sum, student) => sum + student.ungraded_open_responses,
+      0
+    )
+    const gradedResponses = batchSelectedStudents.reduce(
+      (sum, student) => sum + student.graded_open_responses,
+      0
+    )
+    const codeQuestions = gradingQuestions.filter(
+      (question) => question.questionType === 'open_response' && question.responseMonospace
+    ).length
+    const regularQuestions = gradingQuestions.filter(
+      (question) => question.questionType === 'open_response' && !question.responseMonospace
+    ).length
+
+    return {
+      selectedCount,
+      ungradedResponses,
+      gradedResponses,
+      codeQuestions,
+      regularQuestions,
+      potentialAiSends: ungradedResponses,
+    }
+  }, [batchSelectedStudents, gradingQuestions])
+
+  const loadTests = useCallback(async () => {
+    setLoading(true)
+    try {
+      const query = new URLSearchParams({ classroom_id: classroom.id })
+      const response = await fetch(`${apiBasePath}?${query.toString()}`)
+      const data = await response.json()
+      setTests(data.tests || data.quizzes || [])
+    } catch (error) {
+      console.error('Error loading tests:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [classroom.id])
+
+  const loadGradingRows = useCallback(async () => {
+    if (!selectedTestId) {
+      setGradingStudents([])
+      setGradingQuestions([])
+      return
+    }
+
+    setGradingLoading(true)
+    setGradingError('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTestId}/results`, { cache: 'no-store' })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load test results')
+
+      setGradingStudents((data.students || []) as TestGradingStudentRow[])
+      setGradingQuestions(
+        Array.isArray(data.questions)
+          ? data.questions.map((question: any) => ({
+              id: String(question.id),
+              questionType:
+                question.question_type === 'open_response' ? 'open_response' : 'multiple_choice',
+              responseMonospace: question.response_monospace === true,
+            }))
+          : []
+      )
+    } catch (error: any) {
+      setGradingError(error.message || 'Failed to load test results')
+      setGradingStudents([])
+      setGradingQuestions([])
+    } finally {
+      setGradingLoading(false)
+    }
+  }, [selectedTestId])
+
+  useEffect(() => {
+    void loadTests()
+  }, [loadTests])
+
+  useEffect(() => {
+    function handleTestsUpdated(event: Event) {
+      const detail = (event as CustomEvent<{ classroomId?: string }>).detail
+      if (!detail || detail.classroomId !== classroom.id) return
+      void loadTests()
+    }
+
+    window.addEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleTestsUpdated)
+    return () => window.removeEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleTestsUpdated)
+  }, [classroom.id, loadTests])
+
+  useEffect(() => {
+    onSelectTest?.(workspaceState === 'selected' ? selectedTest : null)
+  }, [onSelectTest, selectedTest, workspaceState])
+
+  useEffect(() => {
+    if (!selectedTestId) return
+    if (tests.some((test) => test.id === selectedTestId)) return
+
+    setWorkspaceState('list')
+    setSelectedWorkspaceTab('authoring')
+    setSelectedAuthoringView('questions')
+    setSelectedTestId(null)
+    setSelectedStudentId(null)
+    clearBatchSelection()
+  }, [clearBatchSelection, selectedTestId, tests])
+
+  useEffect(() => {
+    if (!pendingCreatedTestId) return
+    if (!tests.some((test) => test.id === pendingCreatedTestId)) return
+
+    setSelectedTestId(pendingCreatedTestId)
+    setWorkspaceState('selected')
+    setSelectedWorkspaceTab('authoring')
+    setSelectedAuthoringView('questions')
+    setSelectedStudentId(null)
+    setPendingCreatedTestId(null)
+    setRightSidebarOpen(false)
+  }, [pendingCreatedTestId, setRightSidebarOpen, tests])
+
+  useEffect(() => {
+    if (previousTestsTabClickTokenRef.current === testsTabClickToken) return
+    previousTestsTabClickTokenRef.current = testsTabClickToken
+
+    if (workspaceState !== 'selected') return
+
+    setWorkspaceState('list')
+    setSelectedWorkspaceTab('authoring')
+    setSelectedAuthoringView('questions')
+    setSelectedTestId(null)
+    setSelectedStudentId(null)
+    setGradingError('')
+    setGradingWarning('')
+    setGradingInfo('')
+    clearBatchSelection()
+    setRightSidebarOpen(false)
+  }, [clearBatchSelection, setRightSidebarOpen, testsTabClickToken, workspaceState])
+
+  useEffect(() => {
+    if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading') {
+      setSelectedStudentId(null)
+      setGradingStudents([])
+      setGradingQuestions([])
+      clearBatchSelection()
+      return
+    }
+
+    void loadGradingRows()
+  }, [clearBatchSelection, loadGradingRows, selectedWorkspaceTab, workspaceState])
+
+  useEffect(() => {
+    function handleGradingRowUpdate(event: Event) {
+      if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading' || !selectedTestId) return
+
+      const detail = (event as CustomEvent<TeacherTestGradingRowUpdatedEventDetail>).detail
+      if (!detail || detail.testId !== selectedTestId) return
+
+      setGradingStudents((prev) =>
+        prev.map((student) => {
+          if (student.student_id !== detail.studentId) return student
+          return {
+            ...student,
+            points_earned: detail.pointsEarned,
+            points_possible: detail.pointsPossible,
+            percent: detail.percent,
+            graded_open_responses: detail.gradedOpenResponses,
+            ungraded_open_responses: detail.ungradedOpenResponses,
+          }
+        })
+      )
+    }
+
+    window.addEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
+    return () => window.removeEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
+  }, [selectedTestId, selectedWorkspaceTab, workspaceState])
+
+  useEffect(() => {
+    if (!onTestGradingContextChange) return
+
+    if (workspaceState !== 'selected' || !selectedTestId || selectedWorkspaceTab === 'authoring') {
+      onTestGradingContextChange({
+        mode: 'authoring',
+        testId: workspaceState === 'selected' ? selectedTestId : null,
+        studentId: null,
+        studentName: null,
+      })
+      return
+    }
+
+    const selectedStudent =
+      gradingStudents.find((student) => student.student_id === selectedStudentId) || null
+    onTestGradingContextChange({
+      mode: 'grading',
+      testId: selectedTestId,
+      studentId: selectedStudent?.student_id || null,
+      studentName: selectedStudent?.name || selectedStudent?.email || null,
+    })
+  }, [
+    gradingStudents,
+    onTestGradingContextChange,
+    selectedStudentId,
+    selectedTestId,
+    selectedWorkspaceTab,
+    workspaceState,
+  ])
+
+  useEffect(() => {
+    if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading' || !selectedStudentId) {
+      setRightSidebarOpen(false)
+      return
+    }
+
+    setRightSidebarOpen(true)
+  }, [selectedStudentId, selectedWorkspaceTab, setRightSidebarOpen, workspaceState])
+
+  useEffect(() => {
+    if (!gradingWarning) return
+    if (batchSelectedCount > 0) {
+      setGradingWarning('')
+      return
+    }
+    const timer = window.setTimeout(() => setGradingWarning(''), 3000)
+    return () => window.clearTimeout(timer)
+  }, [batchSelectedCount, gradingWarning])
+
+  useEffect(() => {
+    if (!gradingInfo) return
+    const timer = window.setTimeout(() => setGradingInfo(''), 4000)
+    return () => window.clearTimeout(timer)
+  }, [gradingInfo])
+
+  function handleOpenTest(test: QuizWithStats) {
+    setSelectedTestId(test.id)
+    setWorkspaceState('selected')
+    setSelectedWorkspaceTab('authoring')
+    setSelectedAuthoringView('questions')
+    setSelectedStudentId(null)
+    setGradingError('')
+    setGradingWarning('')
+    setGradingInfo('')
+    clearBatchSelection()
+  }
+
+  function handleNewTest() {
+    setShowModal(true)
+  }
+
+  function handleTestCreated(test: Quiz) {
+    setShowModal(false)
+    setPendingCreatedTestId(test.id)
+    window.dispatchEvent(
+      new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
+    )
+  }
+
+  function openBatchPromptGuidelineModal() {
+    setBatchPromptGuidelineDraft(batchPromptGuideline)
+    setBatchGradingStrategyDraft(batchGradingStrategy)
+    setShowPromptGuidelineModal(true)
+  }
+
+  async function handleBatchAutoGrade(options?: {
+    studentIds?: string[]
+    preserveSelection?: boolean
+    infoPrefix?: string
+  }) {
+    const targetStudentIds = options?.studentIds || batchSelectedStudentIds
+    if (!selectedTestId || targetStudentIds.length === 0) return
+
+    setIsBatchAutoGrading(true)
+    setGradingError('')
+    setGradingInfo('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTestId}/auto-grade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          student_ids: targetStudentIds,
+          grading_strategy: batchGradingStrategy,
+          ...(batchPromptGuideline.trim()
+            ? { prompt_guideline: batchPromptGuideline.trim() }
+            : {}),
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Auto-grade failed')
+
+      const gradedStudents = Number(data.graded_students ?? 0)
+      const skippedStudents = Number(data.skipped_students ?? 0)
+      const errorSummary = summarizeBatchAutoGradeErrors(data.errors)
+      const summaryPrefix = options?.infoPrefix || 'AI graded'
+      setGradingInfo(
+        `${summaryPrefix} ${gradedStudents} student${gradedStudents === 1 ? '' : 's'}${skippedStudents > 0 ? ` • ${skippedStudents} skipped` : ''}`
+      )
+
+      if (!options?.preserveSelection) {
+        clearBatchSelection()
+      }
+      await loadGradingRows()
+      onTestGradingDataRefresh?.()
+      if (errorSummary) {
+        setGradingError(errorSummary)
+      }
+    } catch (error: any) {
+      setGradingError(error.message || 'Auto-grade failed')
+    } finally {
+      setIsBatchAutoGrading(false)
+    }
+  }
+
+  async function handleBatchReturn(options?: { closeTest?: boolean }) {
+    if (!selectedTestId || batchSelectedCount === 0) return
+
+    setIsBatchReturning(true)
+    setGradingError('')
+    setGradingInfo('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTestId}/return`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          student_ids: Array.from(batchSelectedIds),
+          close_test: options?.closeTest === true,
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Return failed')
+
+      const returnedCount = Number(data.returned_count ?? 0)
+      const skippedCount = Number(data.skipped_count ?? 0)
+      setGradingInfo(
+        `Returned ${returnedCount} student${returnedCount === 1 ? '' : 's'}${skippedCount > 0 ? ` • ${skippedCount} skipped` : ''}`
+      )
+
+      clearBatchSelection()
+      setShowReturnConfirm(false)
+      if (data.test_closed) {
+        await loadTests()
+      }
+      await loadGradingRows()
+    } catch (error: any) {
+      setGradingError(error.message || 'Return failed')
+    } finally {
+      setIsBatchReturning(false)
+    }
+  }
+
+  async function handleBatchClearOpenGrades() {
+    if (!selectedTestId || batchSelectedCount === 0) return
+
+    setIsBatchClearingOpenGrades(true)
+    setGradingError('')
+    setGradingInfo('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTestId}/clear-open-grades`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student_ids: Array.from(batchSelectedIds) }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Clear open grades failed')
+
+      const clearedStudents = Number(data.cleared_students ?? 0)
+      const skippedStudents = Number(data.skipped_students ?? 0)
+      const clearedResponses = Number(data.cleared_responses ?? 0)
+      setGradingInfo(
+        `Cleared ${clearedResponses} open response${clearedResponses === 1 ? '' : 's'} across ${clearedStudents} student${clearedStudents === 1 ? '' : 's'}${skippedStudents > 0 ? ` • ${skippedStudents} skipped` : ''}`
+      )
+
+      clearBatchSelection()
+      setShowClearOpenGradesConfirm(false)
+      await loadGradingRows()
+      onTestGradingDataRefresh?.()
+    } catch (error: any) {
+      setGradingError(error.message || 'Clear open grades failed')
+    } finally {
+      setIsBatchClearingOpenGrades(false)
+    }
+  }
+
+  async function patchSelectedTest(payload: Record<string, unknown>) {
+    if (!selectedTestId) return
+
+    setStatusUpdating(true)
+    setStatusActionError('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTestId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to update test')
+      }
+
+      await loadTests()
+    } catch (error: any) {
+      setStatusActionError(error?.message || 'Failed to update test')
+    } finally {
+      setStatusUpdating(false)
+      setShowActivateConfirm(false)
+      setShowCloseConfirm(false)
+    }
+  }
+
+  async function handleSelectedTestStatusChange(newStatus: 'active' | 'closed') {
+    await patchSelectedTest({ status: newStatus })
+  }
+
+  async function handleRequestSelectedTestActivate() {
+    if (!selectedTest || isReadOnly || statusUpdating || checkingActivation) return
+
+    const activation = validateSelectedTestActivation(selectedTest)
+    if (!activation.valid) {
+      setStatusActionError(activation.error || 'Test cannot be activated yet')
+      return
+    }
+
+    setCheckingActivation(true)
+    setStatusActionError('')
+    try {
+      const response = await fetch(`${apiBasePath}/${selectedTest.id}`)
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to validate test')
+      }
+
+      const questions = Array.isArray(data.questions) ? data.questions : []
+      if (questions.length < 1) {
+        setStatusActionError('Test must have at least 1 question')
+        return
+      }
+
+      for (let index = 0; index < questions.length; index += 1) {
+        const validation = validateTestQuestionCreate(questions[index] as Record<string, unknown>)
+        if (!validation.valid) {
+          setStatusActionError(`Q${index + 1}: ${validation.error}`)
+          return
+        }
+      }
+
+      setShowActivateConfirm(true)
+    } catch (error: any) {
+      setStatusActionError(error?.message || 'Failed to validate test')
+    } finally {
+      setCheckingActivation(false)
+    }
+  }
+
+  function validateSelectedTestActivation(test: QuizWithStats): { valid: boolean; error?: string } {
+    if ((test.stats.questions_count || 0) < 1) {
+      return { valid: false, error: 'Test must have at least 1 question' }
+    }
+    return { valid: true }
+  }
+
+  const returnWillCloseActiveTest =
+    selectedWorkspaceTab === 'grading' && selectedTest?.status === 'active'
+  const selectedTestTitle = selectedTest?.title || 'Test'
+  const selectedActivation = selectedTest ? validateSelectedTestActivation(selectedTest) : { valid: false }
+  const isSelectedWorkspace = workspaceState === 'selected'
+
+  const batchGradeDescriptionParts: string[] = []
+  if (batchAutoGradePreflight.selectedCount > 0) {
+    const questionBreakdown: string[] = []
+    if (batchAutoGradePreflight.codeQuestions > 0) {
+      questionBreakdown.push(
+        `${batchAutoGradePreflight.codeQuestions} code question${batchAutoGradePreflight.codeQuestions === 1 ? '' : 's'}`
+      )
+    }
+    if (batchAutoGradePreflight.regularQuestions > 0) {
+      questionBreakdown.push(
+        `${batchAutoGradePreflight.regularQuestions} regular question${batchAutoGradePreflight.regularQuestions === 1 ? '' : 's'}`
+      )
+    }
+
+    batchGradeDescriptionParts.push(
+      questionBreakdown.length > 0
+        ? `This will grade ${batchAutoGradePreflight.selectedCount} selected student${batchAutoGradePreflight.selectedCount === 1 ? '' : 's'} across ${questionBreakdown.join(' and ')}.`
+        : `This will grade ${batchAutoGradePreflight.selectedCount} selected student${batchAutoGradePreflight.selectedCount === 1 ? '' : 's'}.`
+    )
+    batchGradeDescriptionParts.push(
+      `Up to ${batchAutoGradePreflight.potentialAiSends} ungraded open response${batchAutoGradePreflight.potentialAiSends === 1 ? '' : 's'} may be sent to AI.`
+    )
+    if (batchAutoGradePreflight.gradedResponses > 0) {
+      batchGradeDescriptionParts.push(
+        `${batchAutoGradePreflight.gradedResponses} response${batchAutoGradePreflight.gradedResponses === 1 ? '' : 's'} already have grades and may be skipped.`
+      )
+    }
+  }
+  const batchGradeDescription = batchGradeDescriptionParts.join(' ')
+
+  const gradingTable = (
+    <div className="space-y-3">
+      {gradingLoading ? (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      ) : gradingStudents.length === 0 ? (
+        <EmptyState
+          title="No student rows yet"
+          description="Student attempts will appear here once learners begin the test."
+          tone="muted"
+        />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border bg-surface">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-surface-hover text-left text-text-muted">
+                <th className="w-10 px-3 py-2 font-medium">
+                  <input
+                    type="checkbox"
+                    checked={batchAllSelected}
+                    onChange={toggleBatchSelectAll}
+                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                    aria-label="Select all students"
+                  />
+                </th>
+                <th className="px-3 py-2 font-medium">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setGradingSortColumn((prev) => (prev === 'last_name' ? 'first_name' : 'last_name'))
+                    }}
+                    className="inline-flex items-center gap-2 text-left text-text-muted hover:text-text-default"
+                    aria-label={
+                      gradingSortColumn === 'last_name'
+                        ? 'Sort students by first name'
+                        : 'Sort students by last name'
+                    }
+                  >
+                    <span>Student</span>
+                    <span className="text-xs font-medium text-text-muted">
+                      {gradingSortColumn === 'last_name' ? 'Last' : 'First'}
+                    </span>
+                  </button>
+                </th>
+                <th className="w-8 px-2 py-2 font-medium" aria-label="Status" />
+                <th className="px-3 py-2 font-medium">Score</th>
+                <th className="px-3 py-2 font-medium">
+                  <Tooltip content="Most recent recorded in-test activity time (Toronto).">
+                    <span className="cursor-help">Last</span>
+                  </Tooltip>
+                </th>
+                <th className="px-3 py-2 font-medium">
+                  <Tooltip
+                    content={
+                      <div className="space-y-0.5">
+                        <p className="font-medium">Exits = combined count</p>
+                        <p>Away/focus events</p>
+                        <p>In-app exits</p>
+                        <p>Window/full-screen exits</p>
+                      </div>
+                    }
+                  >
+                    <span className="inline-flex cursor-help items-center" aria-label="Exits column">
+                      <LogOut className="h-4 w-4" />
+                    </span>
+                  </Tooltip>
+                </th>
+                <th className="px-3 py-2 font-medium">
+                  <Tooltip content="Total time this student was away from the test route.">
+                    <span className="inline-flex cursor-help items-center" aria-label="Away column">
+                      <ClockAlert className="h-4 w-4" />
+                    </span>
+                  </Tooltip>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedGradingStudents.map((student) => {
+                const isSelected = student.student_id === selectedStudentId
+                const scoreLabel =
+                  student.status === 'not_started'
+                    ? '—'
+                    : `${formatPoints(student.points_earned)}/${formatPoints(student.points_possible)}`
+                const statusMeta = STATUS_META[student.status]
+                const StatusIcon = statusMeta.icon
+                const awayCount = student.focus_summary?.away_count ?? 0
+                const awaySeconds = student.focus_summary?.away_total_seconds ?? 0
+                const awayMinutes = Math.floor(awaySeconds / 60)
+                const awayRemainder = awaySeconds % 60
+                const awayLabel = `${awayMinutes}:${String(awayRemainder).padStart(2, '0')}`
+                const routeExitAttempts = student.focus_summary?.route_exit_attempts ?? 0
+                const windowUnmaximizeAttempts = student.focus_summary?.window_unmaximize_attempts ?? 0
+                const exitsCount = getQuizExitCount(student.focus_summary)
+                const formattedLastActivity = formatTorontoTime(student.last_activity_at)
+
+                return (
+                  <tr
+                    key={student.student_id}
+                    className={[
+                      'cursor-pointer border-t border-border transition-colors hover:bg-surface-hover',
+                      isSelected ? 'bg-surface-selected' : '',
+                    ].join(' ')}
+                    onClick={() => setSelectedStudentId(student.student_id)}
+                  >
+                    <td className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={batchSelectedIds.has(student.student_id)}
+                        onChange={() => toggleBatchSelect(student.student_id)}
+                        onClick={(event) => event.stopPropagation()}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                        aria-label={`Select ${student.name || 'student'}`}
+                      />
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="font-medium text-text-default">{student.name || 'Student'}</div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Tooltip content={statusMeta.label}>
+                        <span
+                          className={`inline-flex min-w-5 cursor-help items-center justify-center text-sm font-semibold ${statusMeta.className}`}
+                          aria-label={statusMeta.label}
+                        >
+                          <StatusIcon className="h-4 w-4" />
+                        </span>
+                      </Tooltip>
+                    </td>
+                    <td className="px-3 py-2 text-text-default">{scoreLabel}</td>
+                    <td
+                      className={[
+                        'px-3 py-2 tabular-nums',
+                        formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
+                      ].join(' ')}
+                    >
+                      <Tooltip content="Most recent recorded in-test activity time (Toronto).">
+                        <span
+                          className={[
+                            'cursor-help',
+                            formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
+                          ].join(' ')}
+                        >
+                          {formattedLastActivity.value}
+                        </span>
+                      </Tooltip>
+                    </td>
+                    <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                      <Tooltip
+                        content={
+                          <div className="space-y-0.5">
+                            <p className="font-medium">Exits: {exitsCount}</p>
+                            <p>Away/focus: {awayCount}</p>
+                            <p>In-app exits: {routeExitAttempts}</p>
+                            <p>Window exits: {windowUnmaximizeAttempts}</p>
+                          </div>
+                        }
+                      >
+                        <span
+                          className="cursor-help"
+                          aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
+                        >
+                          {exitsCount}
+                        </span>
+                      </Tooltip>
+                    </td>
+                    <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                      <Tooltip content={`Away from test route for ${awayLabel} total.`}>
+                        <span
+                          className="cursor-help"
+                          aria-label={`Away time ${awayLabel}. Away from test route for ${awayLabel} total.`}
+                        >
+                          {awayLabel}
+                        </span>
+                      </Tooltip>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+
+  const selectedHeader = workspaceState === 'selected' ? (
+    <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
+      <div className="mb-[-1px] flex items-end gap-1 self-end">
+        <button
+          type="button"
+          className={[
+            selectedWorkspaceTab === 'authoring'
+              ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+              : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+            'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
+          ].join(' ')}
+          onClick={() => setSelectedWorkspaceTab('authoring')}
+          aria-pressed={selectedWorkspaceTab === 'authoring'}
+        >
+          Authoring
+        </button>
+        <button
+          type="button"
+          className={[
+            selectedWorkspaceTab === 'grading'
+              ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+              : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+            'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
+          ].join(' ')}
+          onClick={() => setSelectedWorkspaceTab('grading')}
+          aria-pressed={selectedWorkspaceTab === 'grading'}
+        >
+          Grading
+        </button>
+      </div>
+
+      <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
+        <div className="min-w-0 max-w-[24rem] truncate text-center text-sm font-medium text-text-default">
+          {selectedTestTitle}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+        {selectedWorkspaceTab === 'authoring' ? (
+          <>
+            <Button
+              type="button"
+              variant={selectedAuthoringView === 'questions' ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setSelectedAuthoringView('questions')}
+            >
+              Questions
+            </Button>
+            <Button
+              type="button"
+              variant={selectedAuthoringView === 'documents' ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setSelectedAuthoringView('documents')}
+            >
+              Documents
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setTestPreviewRequestToken((value) => value + 1)}
+            >
+              Preview
+            </Button>
+            {selectedTest?.status === 'draft' ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  void handleRequestSelectedTestActivate()
+                }}
+                disabled={!selectedActivation.valid || isReadOnly || statusUpdating || checkingActivation}
+              >
+                <Play className="h-4 w-4" />
+                Open
+              </Button>
+            ) : null}
+            {selectedTest?.status === 'active' ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowCloseConfirm(true)}
+                disabled={isReadOnly || statusUpdating}
+              >
+                <Square className="h-4 w-4" />
+                Close
+              </Button>
+            ) : null}
+            {selectedTest?.status === 'closed' ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  void handleSelectedTestStatusChange('active')
+                }}
+                disabled={isReadOnly || statusUpdating}
+              >
+                <Play className="h-4 w-4" />
+                Reopen
+              </Button>
+            ) : null}
+            {onRequestDelete ? (
+              <Button
+                type="button"
+                variant="danger"
+                size="sm"
+                onClick={onRequestDelete}
+                disabled={isReadOnly}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </Button>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={openBatchPromptGuidelineModal}
+              disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
+            >
+              AI Prompt
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                if (batchSelectedCount === 0) {
+                  setGradingWarning('Select students to grade')
+                  return
+                }
+                setShowBatchGradeModal(true)
+              }}
+              disabled={
+                batchSelectedCount === 0 ||
+                isBatchAutoGrading ||
+                isBatchReturning ||
+                isBatchClearingOpenGrades
+              }
+            >
+              <Check className="h-4 w-4" />
+              AI Grade
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                if (batchSelectedCount === 0) {
+                  setGradingWarning('Select students to return')
+                  return
+                }
+                setShowReturnConfirm(true)
+              }}
+              disabled={
+                batchSelectedCount === 0 ||
+                isBatchAutoGrading ||
+                isBatchReturning ||
+                isBatchClearingOpenGrades
+              }
+            >
+              <Send className="h-4 w-4" />
+              Return
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  ) : (
+    <Button onClick={handleNewTest} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
+      <Plus className="h-4 w-4" />
+      New Test
+    </Button>
+  )
+
+  return (
+    <PageLayout className="flex h-full min-h-0 flex-col">
+      <PageActionBar primary={selectedHeader} />
+
+      <PageContent
+        className={[
+          'flex min-h-0 flex-1 flex-col',
+          isSelectedWorkspace ? 'gap-0 px-0 pt-0' : 'gap-3',
+        ].join(' ')}
+      >
+        {statusActionError && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+            {statusActionError}
+          </div>
+        ) : null}
+        {gradingError && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+            {gradingError}
+          </div>
+        ) : null}
+        {gradingWarning && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+            {gradingWarning}
+          </div>
+        ) : null}
+        {gradingInfo && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+          <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
+            {gradingInfo}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : tests.length === 0 ? (
+          <EmptyState
+            title="No tests yet"
+            description="Create a test to get started."
+            tone="muted"
+            className="mx-auto w-full max-w-3xl"
+          />
+        ) : workspaceState === 'list' ? (
+          <PageStack className="mx-auto w-full max-w-6xl">
+            {tests.map((test) => (
+              <TeacherTestCard
+                key={test.id}
+                test={test}
+                isReadOnly={isReadOnly}
+                onSelect={() => handleOpenTest(test)}
+                onUpdate={() => {
+                  void loadTests()
+                }}
+              />
+            ))}
+          </PageStack>
+        ) : !selectedTest ? (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : selectedWorkspaceTab === 'authoring' && selectedTest ? (
+          <div className="flex min-h-0 flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
+            <QuizDetailPanel
+              quiz={selectedTest}
+              classroomId={classroom.id}
+              apiBasePath={apiBasePath}
+              onQuizUpdate={() => {
+                void loadTests()
+              }}
+              showInlineDeleteAction={false}
+              testAuthoringView={selectedAuthoringView}
+              testQuestionLayout="summary-detail"
+              showPreviewButton={false}
+              showResultsTab={false}
+              previewRequestToken={testPreviewRequestToken}
+            />
+          </div>
+        ) : (
+          gradingTable
+        )}
+      </PageContent>
+
+      <QuizModal
+        isOpen={showModal}
+        classroomId={classroom.id}
+        assessmentType="test"
+        apiBasePath={apiBasePath}
+        quiz={null}
+        onClose={() => setShowModal(false)}
+        onSuccess={handleTestCreated}
+      />
+
+      <DialogPanel
+        isOpen={showBatchGradeModal}
+        onClose={() => setShowBatchGradeModal(false)}
+        ariaLabelledBy="test-ai-grade-title"
+        maxWidth="max-w-lg"
+        className="p-6"
+      >
+        <h2 id="test-ai-grade-title" className="text-lg font-semibold text-text-default">
+          AI Grading
+        </h2>
+        <p className="mt-2 text-sm text-text-muted">
+          Review the current selection before starting AI grading.
+        </p>
+        <div className="mt-4 rounded-md border border-border bg-surface px-3 py-3 text-sm text-text-default">
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
+            <span>{batchAutoGradePreflight.selectedCount} selected</span>
+            <span>{batchAutoGradePreflight.codeQuestions} code</span>
+            <span>{batchAutoGradePreflight.regularQuestions} regular</span>
+          </div>
+          <p className="mt-2 text-sm text-text-muted">
+            {batchGradeDescription || 'This will grade the currently selected students.'}
+          </p>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setShowBatchGradeModal(false)
+              openBatchPromptGuidelineModal()
+            }}
+          >
+            AI Prompt
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setShowBatchGradeModal(false)
+              setShowClearOpenGradesConfirm(true)
+            }}
+          >
+            Clear Open Scores/Feedback
+          </Button>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setShowBatchGradeModal(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={isBatchAutoGrading}
+            onClick={() => {
+              setShowBatchGradeModal(false)
+              void handleBatchAutoGrade()
+            }}
+          >
+            {isBatchAutoGrading ? 'Grading...' : 'Grade with AI'}
+          </Button>
+        </div>
+      </DialogPanel>
+
+      <DialogPanel
+        isOpen={showPromptGuidelineModal}
+        onClose={() => {
+          setShowPromptGuidelineModal(false)
+          setBatchPromptGuidelineDraft(batchPromptGuideline)
+          setBatchGradingStrategyDraft(batchGradingStrategy)
+        }}
+        ariaLabelledBy="test-ai-prompt-guideline-title"
+        maxWidth="max-w-xl"
+        className="p-6"
+      >
+        <h2 id="test-ai-prompt-guideline-title" className="text-lg font-semibold text-text-default">
+          AI Prompt
+        </h2>
+        <p className="mt-2 text-sm text-text-muted">
+          Pika automatically uses the coding rubric for code-style questions and the regular rubric
+          for other open responses.
+        </p>
+        <div className="mt-4">
+          <FormField label="Grading strategy">
+            <Select
+              aria-label="Grading strategy"
+              options={TEST_AI_GRADING_STRATEGY_OPTIONS}
+              value={batchGradingStrategyDraft}
+              onChange={(event) =>
+                setBatchGradingStrategyDraft(event.target.value as TestAiGradingStrategy)
+              }
+            />
+          </FormField>
+          <p className="mt-2 text-xs text-text-muted">
+            Balanced reuses one question-level grading context per question. Aggressive Batch is
+            experimental and grades same-question responses together in one AI call.
+          </p>
+        </div>
+        <div className="mt-4">
+          <FormField label="Additional instructions (optional)">
+            <textarea
+              value={batchPromptGuidelineDraft}
+              onChange={(event) => setBatchPromptGuidelineDraft(event.target.value)}
+              rows={8}
+              placeholder="Optional teacher note to add on top of the built-in rubric for this run."
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </FormField>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setShowPromptGuidelineModal(false)
+              setBatchPromptGuidelineDraft(batchPromptGuideline)
+              setBatchGradingStrategyDraft(batchGradingStrategy)
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              setBatchPromptGuideline(batchPromptGuidelineDraft)
+              setBatchGradingStrategy(batchGradingStrategyDraft)
+              setShowPromptGuidelineModal(false)
+            }}
+          >
+            Save
+          </Button>
+        </div>
+      </DialogPanel>
+
+      <ConfirmDialog
+        isOpen={showActivateConfirm}
+        title="Activate test?"
+        description="Once activated, students will be able to respond."
+        confirmLabel={statusUpdating ? 'Activating...' : 'Activate'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={statusUpdating}
+        isCancelDisabled={statusUpdating}
+        onCancel={() => setShowActivateConfirm(false)}
+        onConfirm={() => handleSelectedTestStatusChange('active')}
+      />
+
+      <ConfirmDialog
+        isOpen={showCloseConfirm}
+        title="Close test?"
+        description="Students will no longer be able to respond."
+        confirmLabel={statusUpdating ? 'Closing...' : 'Close'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={statusUpdating}
+        isCancelDisabled={statusUpdating}
+        onCancel={() => setShowCloseConfirm(false)}
+        onConfirm={() => handleSelectedTestStatusChange('closed')}
+      />
+
+      <ConfirmDialog
+        isOpen={showClearOpenGradesConfirm}
+        title={`Clear open scores and feedback for ${batchSelectedCount} selected student(s)?`}
+        description="This removes all open-response scores and feedback (including AI grading metadata) for the selected students."
+        confirmLabel={isBatchClearingOpenGrades ? 'Clearing...' : 'Clear Open Grades'}
+        confirmVariant="danger"
+        cancelLabel="Cancel"
+        isConfirmDisabled={isBatchClearingOpenGrades}
+        isCancelDisabled={isBatchClearingOpenGrades}
+        onCancel={() => setShowClearOpenGradesConfirm(false)}
+        onConfirm={() => {
+          void handleBatchClearOpenGrades()
+        }}
+      />
+
+      <ConfirmDialog
+        isOpen={showReturnConfirm}
+        title={
+          returnWillCloseActiveTest
+            ? `Close test and return work to ${batchSelectedCount} selected student(s)?`
+            : `Return test work to ${batchSelectedCount} selected student(s)?`
+        }
+        description={
+          returnWillCloseActiveTest
+            ? 'This test is still open. Confirming will close it for all students before returning selected work.'
+            : 'Only students with fully graded open-response questions will be returned.'
+        }
+        confirmLabel={
+          isBatchReturning
+            ? returnWillCloseActiveTest
+              ? 'Closing and Returning...'
+              : 'Returning...'
+            : returnWillCloseActiveTest
+              ? 'Close and Return'
+              : 'Return'
+        }
+        cancelLabel="Cancel"
+        isConfirmDisabled={isBatchReturning}
+        isCancelDisabled={isBatchReturning}
+        onCancel={() => setShowReturnConfirm(false)}
+        onConfirm={() => {
+          void handleBatchReturn({ closeTest: returnWillCloseActiveTest })
+        }}
+      />
+    </PageLayout>
+  )
+}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -164,12 +164,23 @@ export function TeacherTestsTab({
   const isReadOnly = !!classroom.archived_at
   const { setOpen: setRightSidebarOpen } = useRightSidebar()
   const previousTestsTabClickTokenRef = useRef(testsTabClickToken)
+  const gradingSelectionRef = useRef<{
+    workspaceState: WorkspaceState
+    selectedWorkspaceTab: WorkspaceTab
+    selectedTestId: string | null
+  }>({
+    workspaceState: 'list',
+    selectedWorkspaceTab: 'authoring',
+    selectedTestId: null,
+  })
+  const latestGradingRequestIdRef = useRef(0)
 
   const [tests, setTests] = useState<QuizWithStats[]>([])
   const [loading, setLoading] = useState(true)
   const [workspaceState, setWorkspaceState] = useState<WorkspaceState>('list')
   const [selectedWorkspaceTab, setSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
   const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
+  const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
   const [testPreviewRequestToken, setTestPreviewRequestToken] = useState(0)
@@ -303,11 +314,24 @@ export function TeacherTestsTab({
       return
     }
 
+    const requestedTestId = selectedTestId
+    const requestId = ++latestGradingRequestIdRef.current
+    const isStaleRequest = () => {
+      const currentSelection = gradingSelectionRef.current
+      return (
+        latestGradingRequestIdRef.current !== requestId ||
+        currentSelection.workspaceState !== 'selected' ||
+        currentSelection.selectedWorkspaceTab !== 'grading' ||
+        currentSelection.selectedTestId !== requestedTestId
+      )
+    }
+
     setGradingLoading(true)
     setGradingError('')
     try {
-      const response = await fetch(`${apiBasePath}/${selectedTestId}/results`, { cache: 'no-store' })
+      const response = await fetch(`${apiBasePath}/${requestedTestId}/results`, { cache: 'no-store' })
       const data = await response.json()
+      if (isStaleRequest()) return
       if (!response.ok) throw new Error(data.error || 'Failed to load test results')
 
       const nextStatus =
@@ -316,11 +340,11 @@ export function TeacherTestsTab({
           : null
 
       setGradingServerTestStatus(nextStatus)
-      setGradingServerTestId(selectedTestId)
+      setGradingServerTestId(requestedTestId)
       if (nextStatus) {
         setTests((prev) =>
           prev.map((test) =>
-            test.id === selectedTestId && test.status !== nextStatus ? { ...test, status: nextStatus } : test
+            test.id === requestedTestId && test.status !== nextStatus ? { ...test, status: nextStatus } : test
           )
         )
       }
@@ -336,10 +360,12 @@ export function TeacherTestsTab({
           : []
       )
     } catch (error: any) {
+      if (isStaleRequest()) return
       setGradingError(error.message || 'Failed to load test results')
       setGradingStudents([])
       setGradingQuestions([])
     } finally {
+      if (isStaleRequest()) return
       setGradingLoading(false)
     }
   }, [selectedTestId])
@@ -362,6 +388,14 @@ export function TeacherTestsTab({
   useEffect(() => {
     onSelectTest?.(workspaceState === 'selected' ? selectedTest : null)
   }, [onSelectTest, selectedTest, workspaceState])
+
+  useEffect(() => {
+    gradingSelectionRef.current = {
+      workspaceState,
+      selectedWorkspaceTab,
+      selectedTestId,
+    }
+  }, [selectedTestId, selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
     if (!selectedTestId) return
@@ -410,12 +444,19 @@ export function TeacherTestsTab({
       setGradingQuestions([])
       setGradingServerTestStatus(null)
       setGradingServerTestId(null)
+      setGradingLoading(false)
       clearBatchSelection()
       return
     }
 
     void loadGradingRows()
   }, [clearBatchSelection, loadGradingRows, selectedWorkspaceTab, workspaceState])
+
+  useEffect(() => {
+    if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'authoring') {
+      setHasPendingMarkdownImport(false)
+    }
+  }, [selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
     if (
@@ -1048,6 +1089,7 @@ export function TeacherTestsTab({
                 variant="secondary"
                 size="sm"
                 onClick={() => setTestPreviewRequestToken((value) => value + 1)}
+                disabled={hasPendingMarkdownImport}
               >
                 Preview
               </Button>
@@ -1059,7 +1101,13 @@ export function TeacherTestsTab({
                   onClick={() => {
                     void handleRequestSelectedTestActivate()
                   }}
-                  disabled={!selectedActivation.valid || isReadOnly || statusUpdating || checkingActivation}
+                  disabled={
+                    !selectedActivation.valid ||
+                    isReadOnly ||
+                    statusUpdating ||
+                    checkingActivation ||
+                    hasPendingMarkdownImport
+                  }
                 >
                   <Play className="h-4 w-4" />
                   Open
@@ -1071,7 +1119,7 @@ export function TeacherTestsTab({
                   variant="secondary"
                   size="sm"
                   onClick={() => setShowCloseConfirm(true)}
-                  disabled={isReadOnly || statusUpdating}
+                  disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
                 >
                   <Square className="h-4 w-4" />
                   Close
@@ -1085,7 +1133,7 @@ export function TeacherTestsTab({
                   onClick={() => {
                     void handleSelectedTestStatusChange('active')
                   }}
-                  disabled={isReadOnly || statusUpdating}
+                  disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
                 >
                   <Play className="h-4 w-4" />
                   Reopen
@@ -1193,6 +1241,11 @@ export function TeacherTestsTab({
             {statusActionError}
           </div>
         ) : null}
+        {hasPendingMarkdownImport && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+            Apply or undo markdown changes before previewing or changing the test status.
+          </div>
+        ) : null}
         {gradingError && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
           <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {gradingError}
@@ -1248,6 +1301,7 @@ export function TeacherTestsTab({
                 onQuizUpdate={() => {
                   void loadTests()
                 }}
+                onPendingMarkdownImportChange={setHasPendingMarkdownImport}
                 showInlineDeleteAction={false}
                 testQuestionLayout="summary-detail"
                 showPreviewButton={false}

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -46,6 +46,7 @@ interface Props {
   onQuizUpdate: () => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
+  onPendingMarkdownImportChange?: (pending: boolean) => void
   showInlineDeleteAction?: boolean
   testQuestionLayout?: 'stacked' | 'summary-detail'
   showPreviewButton?: boolean
@@ -68,6 +69,7 @@ export function QuizDetailPanel({
   onQuizUpdate,
   onRequestDelete,
   onRequestTestPreview,
+  onPendingMarkdownImportChange,
   showInlineDeleteAction = true,
   testQuestionLayout = 'stacked',
   showPreviewButton = true,
@@ -354,6 +356,14 @@ export function QuizDetailPanel({
     }
     savedMarkdownRef.current = currentTestMarkdown
   }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
+
+  useEffect(() => {
+    onPendingMarkdownImportChange?.(isTestsView ? hasPendingMarkdownImport : false)
+
+    return () => {
+      onPendingMarkdownImportChange?.(false)
+    }
+  }, [hasPendingMarkdownImport, isTestsView, onPendingMarkdownImportChange])
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -1367,15 +1377,7 @@ export function QuizDetailPanel({
       right={
         <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col" data-testid="test-question-markdown-pane">
           <div className="flex min-h-0 flex-1 flex-col p-4">
-            {questions.length === 0 ? (
-              <EmptyState
-                title="No questions yet"
-                description="Add a question to begin authoring this test."
-                tone="muted"
-              />
-            ) : (
-              testsMarkdownPanel
-            )}
+            {testsMarkdownPanel}
           </div>
         </div>
       }

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -14,10 +14,12 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
+  useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Check, Copy, ExternalLink, Plus, X } from 'lucide-react'
-import { Button, Tooltip } from '@/ui'
+import { CSS } from '@dnd-kit/utilities'
+import { Check, Copy, ExternalLink, GripVertical, Plus, X } from 'lucide-react'
+import { Button, EmptyState, Tooltip } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { canEditQuizQuestions } from '@/lib/quizzes'
 import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
@@ -26,6 +28,7 @@ import { TestDocumentsEditor } from '@/components/TestDocumentsEditor'
 import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
+import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
@@ -45,6 +48,12 @@ interface Props {
   onQuizUpdate: () => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
+  showInlineDeleteAction?: boolean
+  testAuthoringView?: 'questions' | 'documents'
+  testQuestionLayout?: 'stacked' | 'summary-detail'
+  showPreviewButton?: boolean
+  showResultsTab?: boolean
+  previewRequestToken?: number
 }
 
 type AssessmentEditorDraft = {
@@ -62,6 +71,12 @@ export function QuizDetailPanel({
   onQuizUpdate,
   onRequestDelete,
   onRequestTestPreview,
+  showInlineDeleteAction = true,
+  testAuthoringView,
+  testQuestionLayout = 'stacked',
+  showPreviewButton = true,
+  showResultsTab,
+  previewRequestToken = 0,
 }: Props) {
   const AUTOSAVE_DEBOUNCE_MS = 3000
   const AUTOSAVE_MIN_INTERVAL_MS = 10_000
@@ -73,8 +88,10 @@ export function QuizDetailPanel({
   const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [viewMode, setViewMode] = useState<'questions' | 'documents' | 'markdown' | 'preview' | 'results'>(
-    () => (quiz.assessment_type === 'test' || apiBasePath.includes('/tests') ? 'markdown' : 'questions')
+    () => 'questions'
   )
+  const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null)
+  const [testDetailTab, setTestDetailTab] = useState<'details' | 'markdown'>('details')
   const [error, setError] = useState('')
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
   const [draftShowResults, setDraftShowResults] = useState(quiz.show_results)
@@ -105,6 +122,7 @@ export function QuizDetailPanel({
   const savedMarkdownRef = useRef('')
   const documentsRef = useRef(documents)
   const autoSyncAttemptedRef = useRef<Set<string>>(new Set())
+  const previousPreviewRequestTokenRef = useRef(previewRequestToken)
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -296,6 +314,12 @@ export function QuizDetailPanel({
       documents,
     })
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
+  const usesSummaryDetailQuestions = isTestsView && testQuestionLayout === 'summary-detail'
+  const resolvedShowResultsTab = showResultsTab ?? !isTestsView
+  const currentTestAuthoringView =
+    isTestsView && testAuthoringView ? testAuthoringView : viewMode
+  const selectedQuestion =
+    questions.find((question) => question.id === selectedQuestionId) ?? questions[0] ?? null
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -585,6 +609,23 @@ export function QuizDetailPanel({
     setViewMode('questions')
   }, [isTestsView, viewMode])
 
+  useEffect(() => {
+    if (questions.length === 0) {
+      setSelectedQuestionId(null)
+      return
+    }
+
+    if (!selectedQuestionId || !questions.some((question) => question.id === selectedQuestionId)) {
+      setSelectedQuestionId(questions[0]?.id ?? null)
+    }
+  }, [questions, selectedQuestionId])
+
+  useEffect(() => {
+    if (currentTestAuthoringView === 'documents') {
+      setTestDetailTab('details')
+    }
+  }, [currentTestAuthoringView])
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
@@ -715,6 +756,8 @@ export function QuizDetailPanel({
 
     const nextQuestions = normalizeQuestionPositions([...questions, nextQuestion])
     setQuestions(nextQuestions)
+    setSelectedQuestionId(nextQuestion.id)
+    setTestDetailTab('details')
 
     scheduleAutosave({
       title: editTitle,
@@ -750,6 +793,12 @@ export function QuizDetailPanel({
       questions.filter((question) => question.id !== questionId)
     )
     setQuestions(nextQuestions)
+    if (selectedQuestionId === questionId) {
+      const deletedIndex = questions.findIndex((question) => question.id === questionId)
+      const fallbackQuestion =
+        nextQuestions[Math.max(0, deletedIndex - 1)] || nextQuestions[0] || null
+      setSelectedQuestionId(fallbackQuestion?.id ?? null)
+    }
 
     scheduleAutosave({
       title: editTitle,
@@ -941,6 +990,241 @@ export function QuizDetailPanel({
     saveDraft,
   ])
 
+  useEffect(() => {
+    if (!isTestsView) return
+    if (previousPreviewRequestTokenRef.current === previewRequestToken) return
+    previousPreviewRequestTokenRef.current = previewRequestToken
+    if (previewRequestToken === 0) return
+
+    void handleOpenTestPreview()
+  }, [handleOpenTestPreview, isTestsView, previewRequestToken])
+
+  const testsMarkdownPanel = (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            void handleCopyMarkdown()
+          }}
+          className="gap-1.5"
+        >
+          <Copy className="h-4 w-4" />
+          Copy
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            void handleCopyMarkdownSchema()
+          }}
+          className="gap-1.5"
+        >
+          <Copy className="h-4 w-4" />
+          Copy Schema
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleRebuildMarkdownFromStructured}
+          disabled={markdownSaving}
+        >
+          Rebuild From Structured
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={handleResetMarkdown}
+          disabled={!markdownDirty || markdownSaving}
+        >
+          Reset
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            void handleApplyMarkdown()
+          }}
+          disabled={markdownSaving || !isEditable}
+        >
+          {markdownSaving ? 'Applying...' : 'Apply Markdown'}
+        </Button>
+      </div>
+      {!isEditable && (
+        <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+          This test is locked because students have responded.
+        </div>
+      )}
+      {markdownInfo && (
+        <div className="rounded-md border border-success bg-success-bg px-3 py-2 text-sm text-success">
+          {markdownInfo}
+        </div>
+      )}
+      {markdownError && (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger whitespace-pre-wrap">
+          {markdownError}
+        </div>
+      )}
+      <textarea
+        value={markdownContent}
+        onChange={(event) => handleMarkdownChange(event.target.value)}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+            event.preventDefault()
+            void handleApplyMarkdown()
+          }
+        }}
+        className="min-h-[420px] w-full rounded-md border border-border bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+        spellCheck={false}
+      />
+    </div>
+  )
+
+  const testsDocumentsPanel = (
+    <div className="space-y-3 p-4">
+      <div className="text-xs text-text-muted">
+        {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
+      </div>
+      <TestDocumentsEditor
+        testId={quiz.id}
+        documents={documents}
+        apiBasePath={apiBasePath}
+        isEditable={isEditable}
+        onUpdated={loadQuizDetails}
+      />
+    </div>
+  )
+
+  const testsSummaryDetailPanel = (
+    <WorkspaceSplitPane
+      orientation="row"
+      data-testid="test-summary-detail-layout"
+      leftPaneClassName="flex w-[18rem] shrink-0 flex-col bg-surface-2"
+      rightPaneClassName="flex min-h-0 min-w-0 flex-1 flex-col bg-surface"
+      left={
+        <div data-testid="test-question-summary-pane" className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-border px-3 py-3 text-xs text-text-muted">
+          {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-summary-list">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={questions.map((question) => question.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2">
+                {questions.map((question, index) => (
+                  <TestQuestionSummaryCard
+                    key={question.id}
+                    question={question}
+                    questionNumber={index + 1}
+                    isEditable={isEditable}
+                    isSelected={selectedQuestion?.id === question.id}
+                    onSelect={() => {
+                      setSelectedQuestionId(question.id)
+                      setTestDetailTab('details')
+                    }}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        {isEditable ? (
+          <div className="border-t border-border p-3">
+            <div className="grid gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => handleAddQuestion('multiple_choice')}
+                className="w-full gap-1.5"
+              >
+                <Plus className="h-4 w-4" />
+                Add MC Question
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => handleAddQuestion('open_response')}
+                className="w-full gap-1.5"
+              >
+                <Plus className="h-4 w-4" />
+                Add Open Question
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+      }
+      right={
+        <div
+          className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
+          data-testid="test-question-detail-pane"
+        >
+        <div className="border-b border-border px-4 pt-3">
+          <div className="flex items-end gap-1">
+            <button
+              type="button"
+              onClick={() => setTestDetailTab('details')}
+              className={[
+                testDetailTab === 'details'
+                  ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+                  : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+                'min-h-9 px-3 py-2 text-sm font-medium transition-colors',
+              ].join(' ')}
+            >
+              Details
+            </button>
+            <button
+              type="button"
+              onClick={() => setTestDetailTab('markdown')}
+              className={[
+                testDetailTab === 'markdown'
+                  ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+                  : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+                'min-h-9 px-3 py-2 text-sm font-medium transition-colors',
+              ].join(' ')}
+            >
+              Markdown
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          {testDetailTab === 'markdown' ? (
+            testsMarkdownPanel
+          ) : selectedQuestion ? (
+            <TestQuestionEditor
+              question={selectedQuestion}
+              questionNumber={questions.findIndex((question) => question.id === selectedQuestion.id) + 1}
+              isEditable={isEditable}
+              onChange={handleQuestionChange}
+              onDelete={handleQuestionDelete}
+              variant="detail"
+            />
+          ) : (
+            <EmptyState
+              title="No questions yet"
+              description="Add a question to begin authoring this test."
+              tone="muted"
+            />
+          )}
+        </div>
+      </div>
+      }
+    />
+  )
+
   if (loading) {
     return (
       <div className="p-4 flex justify-center">
@@ -952,7 +1236,8 @@ export function QuizDetailPanel({
   return (
     <div className="flex flex-col h-full">
       {/* Tabs */}
-      <div className="flex border-b border-border shrink-0">
+      {!usesSummaryDetailQuestions && (
+        <div className="flex border-b border-border shrink-0">
         <button
           type="button"
           onClick={() => setViewMode('questions')}
@@ -1003,18 +1288,20 @@ export function QuizDetailPanel({
             Preview
           </button>
         )}
-        <button
-          type="button"
-          onClick={() => setViewMode('results')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            viewMode === 'results'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-text-muted hover:text-text-default'
-          }`}
-        >
-          Results ({quiz.stats.responded})
-        </button>
-        {isTestsView && (
+        {resolvedShowResultsTab && (
+          <button
+            type="button"
+            onClick={() => setViewMode('results')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              viewMode === 'results'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-muted hover:text-text-default'
+            }`}
+          >
+            Results ({quiz.stats.responded})
+          </button>
+        )}
+        {isTestsView && showPreviewButton && (
           <div className="ml-2 flex items-center">
             <Button
               type="button"
@@ -1031,7 +1318,7 @@ export function QuizDetailPanel({
             </Button>
           </div>
         )}
-        {isTestsView && onRequestDelete ? (
+        {isTestsView && onRequestDelete && showInlineDeleteAction ? (
           <Button
             type="button"
             variant="danger"
@@ -1043,9 +1330,15 @@ export function QuizDetailPanel({
           </Button>
         ) : null}
       </div>
+      )}
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4">
+      <div
+        className={[
+          'flex-1',
+          usesSummaryDetailQuestions ? 'min-h-0 overflow-hidden p-0' : 'overflow-y-auto p-4',
+        ].join(' ')}
+      >
         {error && (
           <div className="p-2 bg-danger-bg text-danger text-sm rounded mb-4">{error}</div>
         )}
@@ -1058,7 +1351,11 @@ export function QuizDetailPanel({
           </div>
         )}
 
-        {viewMode === 'questions' ? (
+        {usesSummaryDetailQuestions && currentTestAuthoringView === 'documents' ? (
+          testsDocumentsPanel
+        ) : usesSummaryDetailQuestions && currentTestAuthoringView === 'questions' ? (
+          testsSummaryDetailPanel
+        ) : viewMode === 'questions' ? (
           <div className="space-y-3">
             {/* Inline editable title */}
             {isEditingTitle ? (
@@ -1192,89 +1489,7 @@ export function QuizDetailPanel({
             />
           </div>
         ) : viewMode === 'markdown' && isTestsView ? (
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  void handleCopyMarkdown()
-                }}
-                className="gap-1.5"
-              >
-                <Copy className="h-4 w-4" />
-                Copy
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  void handleCopyMarkdownSchema()
-                }}
-                className="gap-1.5"
-              >
-                <Copy className="h-4 w-4" />
-                Copy Schema
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={handleRebuildMarkdownFromStructured}
-                disabled={markdownSaving}
-              >
-                Rebuild From Structured
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={handleResetMarkdown}
-                disabled={!markdownDirty || markdownSaving}
-              >
-                Reset
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => {
-                  void handleApplyMarkdown()
-                }}
-                disabled={markdownSaving || !isEditable}
-              >
-                {markdownSaving ? 'Applying...' : 'Apply Markdown'}
-              </Button>
-            </div>
-            {!isEditable && (
-              <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-                This test is locked because students have responded.
-              </div>
-            )}
-            {markdownInfo && (
-              <div className="rounded-md border border-success bg-success-bg px-3 py-2 text-sm text-success">
-                {markdownInfo}
-              </div>
-            )}
-            {markdownError && (
-              <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger whitespace-pre-wrap">
-                {markdownError}
-              </div>
-            )}
-            <textarea
-              value={markdownContent}
-              onChange={(event) => handleMarkdownChange(event.target.value)}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
-                  event.preventDefault()
-                  void handleApplyMarkdown()
-                }
-              }}
-              className="min-h-[420px] w-full rounded-md border border-border bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-              spellCheck={false}
-            />
-          </div>
+          testsMarkdownPanel
         ) : viewMode === 'preview' ? (
           <QuizPreview questions={questions} isTestsView={isTestsView} />
         ) : (
@@ -1390,6 +1605,101 @@ function QuizPreview({ questions, isTestsView }: { questions: QuizQuestion[]; is
           )}
         </div>
       ))}
+    </div>
+  )
+}
+
+function summarizeQuestionText(questionText: string | null | undefined): string {
+  const flattened = (questionText || '')
+    .replace(/[#>*_`~-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return flattened || 'Untitled question'
+}
+
+function TestQuestionSummaryCard({
+  question,
+  questionNumber,
+  isEditable,
+  isSelected,
+  onSelect,
+}: {
+  question: QuizQuestion
+  questionNumber: number
+  isEditable: boolean
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: question.id,
+    disabled: !isEditable,
+  })
+
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition: isDragging ? undefined : transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={sortableStyle}>
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-label={`Select question ${questionNumber}`}
+        className={[
+          'flex w-full items-start gap-2 rounded-md border px-3 py-2 text-left transition-colors',
+          isSelected
+            ? 'border-primary bg-surface-hover text-text-default'
+            : 'border-border bg-surface text-text-default hover:border-border-strong hover:bg-surface-hover',
+          isDragging ? 'shadow-lg' : '',
+        ].join(' ')}
+      >
+        <div className="flex min-h-8 items-center pt-0.5">
+          {isEditable ? (
+            <span
+              className="cursor-grab touch-none text-text-muted hover:text-text-default active:cursor-grabbing"
+              aria-label="Drag to reorder"
+              onClick={(event) => event.stopPropagation()}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-4 w-4" />
+            </span>
+          ) : (
+            <span className="text-xs font-semibold text-text-muted">Q{questionNumber}</span>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {isEditable ? (
+              <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{questionNumber}</span>
+            ) : null}
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-default">
+              {summarizeQuestionText(question.question_text)}
+            </span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+            <span>{question.points ?? 0} pts</span>
+            {question.question_type === 'open_response' ? (
+              <label className="inline-flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  checked={question.response_monospace === true}
+                  readOnly
+                  tabIndex={-1}
+                  aria-label={`Question ${questionNumber} code response`}
+                  className="h-3.5 w-3.5 rounded border-border text-primary focus:ring-0"
+                />
+                <span>Code</span>
+              </label>
+            ) : (
+              <span>MC</span>
+            )}
+          </div>
+        </div>
+      </button>
     </div>
   )
 }

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -14,12 +14,10 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
-  useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { Check, Copy, ExternalLink, GripVertical, Plus, X } from 'lucide-react'
-import { Button, EmptyState, Tooltip } from '@/ui'
+import { Check, ChevronDown, ChevronUp, Copy, ExternalLink, Plus, RotateCcw, X } from 'lucide-react'
+import { Button, EmptyState, SplitButton, Tooltip, cn } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { canEditQuizQuestions } from '@/lib/quizzes'
 import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
@@ -28,7 +26,7 @@ import { TestDocumentsEditor } from '@/components/TestDocumentsEditor'
 import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
-import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
@@ -49,7 +47,6 @@ interface Props {
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   showInlineDeleteAction?: boolean
-  testAuthoringView?: 'questions' | 'documents'
   testQuestionLayout?: 'stacked' | 'summary-detail'
   showPreviewButton?: boolean
   showResultsTab?: boolean
@@ -72,7 +69,6 @@ export function QuizDetailPanel({
   onRequestDelete,
   onRequestTestPreview,
   showInlineDeleteAction = true,
-  testAuthoringView,
   testQuestionLayout = 'stacked',
   showPreviewButton = true,
   showResultsTab,
@@ -90,8 +86,8 @@ export function QuizDetailPanel({
   const [viewMode, setViewMode] = useState<'questions' | 'documents' | 'markdown' | 'preview' | 'results'>(
     () => 'questions'
   )
-  const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null)
-  const [testDetailTab, setTestDetailTab] = useState<'details' | 'markdown'>('details')
+  const [isDocumentsCardExpanded, setIsDocumentsCardExpanded] = useState(true)
+  const [expandedQuestionIds, setExpandedQuestionIds] = useState<string[]>([])
   const [error, setError] = useState('')
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
   const [draftShowResults, setDraftShowResults] = useState(quiz.show_results)
@@ -99,8 +95,12 @@ export function QuizDetailPanel({
   const [markdownError, setMarkdownError] = useState('')
   const [markdownInfo, setMarkdownInfo] = useState('')
   const [markdownDirty, setMarkdownDirty] = useState(false)
+  const [isMarkdownEditing, setIsMarkdownEditing] = useState(false)
   const [markdownSaving, setMarkdownSaving] = useState(false)
   const [openingTestPreview, setOpeningTestPreview] = useState(false)
+  const [preferredTestQuestionType, setPreferredTestQuestionType] = useState<'multiple_choice' | 'open_response'>(
+    'multiple_choice'
+  )
   const [conflictDraft, setConflictDraft] = useState<{
     version: number
     content: { title: string; show_results: boolean; questions: QuizQuestion[] }
@@ -123,6 +123,7 @@ export function QuizDetailPanel({
   const documentsRef = useRef(documents)
   const autoSyncAttemptedRef = useRef<Set<string>>(new Set())
   const previousPreviewRequestTokenRef = useRef(previewRequestToken)
+  const previousQuestionIdsRef = useRef<string[]>([])
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -287,6 +288,7 @@ export function QuizDetailPanel({
     setDraftShowResults(quiz.show_results)
     setIsEditingTitle(false)
     setConflictDraft(null)
+    setIsMarkdownEditing(false)
     setMarkdownDirty(false)
     markdownDirtyRef.current = false
     setMarkdownError('')
@@ -314,12 +316,44 @@ export function QuizDetailPanel({
       documents,
     })
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
+  const hasResponses = quiz.stats.responded > 0
+  const isEditable = canEditQuizQuestions(quiz, hasResponses)
+  const hasPendingMarkdownImport = isTestsView && markdownDirty
+  const isMarkdownEditable = isEditable && isMarkdownEditing
+  const markdownHelperStatus = markdownSaving
+    ? 'Applying markdown...'
+    : hasPendingMarkdownImport
+      ? 'Markdown edits not applied'
+      : isMarkdownEditing
+        ? 'Editing markdown'
+        : 'Markdown mirror'
   const usesSummaryDetailQuestions = isTestsView && testQuestionLayout === 'summary-detail'
   const resolvedShowResultsTab = showResultsTab ?? !isTestsView
-  const currentTestAuthoringView =
-    isTestsView && testAuthoringView ? testAuthoringView : viewMode
-  const selectedQuestion =
-    questions.find((question) => question.id === selectedQuestionId) ?? questions[0] ?? null
+  const totalQuestionPoints = useMemo(
+    () =>
+      questions.reduce(
+        (sum, question) =>
+          sum +
+          (typeof question.points === 'number'
+            ? question.points
+            : question.question_type === 'open_response'
+              ? DEFAULT_OPEN_RESPONSE_POINTS
+              : DEFAULT_MULTIPLE_CHOICE_POINTS),
+        0
+      ),
+    [questions]
+  )
+  const areAllQuestionsExpanded =
+    questions.length > 0 && questions.every((question) => expandedQuestionIds.includes(question.id))
+
+  useEffect(() => {
+    if (!isTestsView) return
+    if (markdownDirty) return
+    if (markdownContent !== currentTestMarkdown) {
+      setMarkdownContent(currentTestMarkdown)
+    }
+    savedMarkdownRef.current = currentTestMarkdown
+  }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -328,9 +362,6 @@ export function QuizDetailPanel({
       titleInputRef.current?.select()
     }
   }, [isEditingTitle])
-
-  const hasResponses = quiz.stats.responded > 0
-  const isEditable = canEditQuizQuestions(quiz, hasResponses)
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -610,21 +641,21 @@ export function QuizDetailPanel({
   }, [isTestsView, viewMode])
 
   useEffect(() => {
-    if (questions.length === 0) {
-      setSelectedQuestionId(null)
-      return
-    }
+    const currentQuestionIds = questions.map((question) => question.id)
+    const previousQuestionIds = previousQuestionIdsRef.current
 
-    if (!selectedQuestionId || !questions.some((question) => question.id === selectedQuestionId)) {
-      setSelectedQuestionId(questions[0]?.id ?? null)
-    }
-  }, [questions, selectedQuestionId])
+    setExpandedQuestionIds((prev) => {
+      const retained = prev.filter((questionId) => currentQuestionIds.includes(questionId))
+      if (previousQuestionIds.length === 0) {
+        return currentQuestionIds[0] ? [currentQuestionIds[0]] : []
+      }
 
-  useEffect(() => {
-    if (currentTestAuthoringView === 'documents') {
-      setTestDetailTab('details')
-    }
-  }, [currentTestAuthoringView])
+      const newQuestionIds = currentQuestionIds.filter((questionId) => !previousQuestionIds.includes(questionId))
+      return [...retained, ...newQuestionIds]
+    })
+
+    previousQuestionIdsRef.current = currentQuestionIds
+  }, [questions])
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -756,14 +787,19 @@ export function QuizDetailPanel({
 
     const nextQuestions = normalizeQuestionPositions([...questions, nextQuestion])
     setQuestions(nextQuestions)
-    setSelectedQuestionId(nextQuestion.id)
-    setTestDetailTab('details')
 
     scheduleAutosave({
       title: editTitle,
       show_results: draftShowResults,
       questions: nextQuestions,
     })
+  }
+
+  function handleAddTestQuestionViaSplitButton(
+    questionType: 'multiple_choice' | 'open_response' = preferredTestQuestionType
+  ) {
+    setPreferredTestQuestionType(questionType)
+    handleAddQuestion(questionType)
   }
 
   function handleQuestionChange(updatedQuestion: QuizQuestion, options?: { force?: boolean }) {
@@ -793,18 +829,59 @@ export function QuizDetailPanel({
       questions.filter((question) => question.id !== questionId)
     )
     setQuestions(nextQuestions)
-    if (selectedQuestionId === questionId) {
-      const deletedIndex = questions.findIndex((question) => question.id === questionId)
-      const fallbackQuestion =
-        nextQuestions[Math.max(0, deletedIndex - 1)] || nextQuestions[0] || null
-      setSelectedQuestionId(fallbackQuestion?.id ?? null)
-    }
 
     scheduleAutosave({
       title: editTitle,
       show_results: draftShowResults,
       questions: nextQuestions,
     })
+  }
+
+  function handleDuplicateQuestion(questionId: string) {
+    const sourceIndex = questions.findIndex((question) => question.id === questionId)
+    if (sourceIndex === -1) return
+
+    const sourceQuestion = questions[sourceIndex]
+    const now = new Date().toISOString()
+    const duplicatedQuestion: QuizQuestion = {
+      ...sourceQuestion,
+      id: crypto.randomUUID(),
+      options: [...sourceQuestion.options],
+      created_at: now,
+      updated_at: now,
+    }
+
+    const nextQuestions = normalizeQuestionPositions([
+      ...questions.slice(0, sourceIndex + 1),
+      duplicatedQuestion,
+      ...questions.slice(sourceIndex + 1),
+    ])
+
+    setQuestions(nextQuestions)
+    setExpandedQuestionIds((prev) =>
+      prev.includes(questionId) ? [...prev, duplicatedQuestion.id] : prev
+    )
+
+    scheduleAutosave({
+      title: editTitle,
+      show_results: draftShowResults,
+      questions: nextQuestions,
+    })
+  }
+
+  function handleToggleQuestionExpanded(questionId: string) {
+    setExpandedQuestionIds((prev) =>
+      prev.includes(questionId) ? prev.filter((id) => id !== questionId) : [...prev, questionId]
+    )
+  }
+
+  function handleToggleAllQuestions() {
+    if (questions.length === 0) {
+      setExpandedQuestionIds([])
+      return
+    }
+
+    setExpandedQuestionIds(areAllQuestionsExpanded ? [] : questions.map((question) => question.id))
   }
 
   function handleConflictReload() {
@@ -816,6 +893,7 @@ export function QuizDetailPanel({
   }
 
   function handleMarkdownChange(content: string) {
+    setIsMarkdownEditing(true)
     setMarkdownContent(content)
     setMarkdownDirty(true)
     markdownDirtyRef.current = true
@@ -823,20 +901,19 @@ export function QuizDetailPanel({
     setMarkdownInfo('')
   }
 
-  function handleResetMarkdown() {
-    setMarkdownContent(savedMarkdownRef.current || currentTestMarkdown)
-    setMarkdownDirty(false)
-    markdownDirtyRef.current = false
+  function handleEditMarkdown() {
+    setIsMarkdownEditing(true)
     setMarkdownError('')
     setMarkdownInfo('')
   }
 
-  function handleRebuildMarkdownFromStructured() {
+  function handleUndoMarkdownChanges() {
     setMarkdownContent(currentTestMarkdown)
-    setMarkdownDirty(true)
-    markdownDirtyRef.current = true
+    setIsMarkdownEditing(false)
+    setMarkdownDirty(false)
+    markdownDirtyRef.current = false
     setMarkdownError('')
-    setMarkdownInfo('Markdown rebuilt from structured editor')
+    setMarkdownInfo('')
   }
 
   async function handleCopyMarkdown() {
@@ -912,19 +989,32 @@ export function QuizDetailPanel({
       questions: nextQuestions,
     }
 
-    const saved = await saveDraft(nextDraft, {
-      forceFull: true,
+    const nextDerivedMarkdown = testToMarkdown({
+      title: parsed.draftContent.title,
+      show_results: parsed.draftContent.show_results,
+      questions: nextQuestions,
       documents: parsed.documents,
     })
 
+    setEditTitle(parsed.draftContent.title)
+    setDraftShowResults(parsed.draftContent.show_results)
+    setQuestions(nextQuestions)
+    setDocuments(parsed.documents)
+    setMarkdownContent(nextDerivedMarkdown)
+    savedMarkdownRef.current = nextDerivedMarkdown
+    setIsMarkdownEditing(false)
+    setMarkdownDirty(false)
+    markdownDirtyRef.current = false
+    setMarkdownError('')
+    setMarkdownInfo('')
+
+    const saved = await saveDraft(nextDraft, {
+      forceFull: true,
+      documents: parsed.documents,
+      sourceMarkdown: nextDerivedMarkdown,
+    })
+
     if (saved) {
-      setEditTitle(parsed.draftContent.title)
-      setDraftShowResults(parsed.draftContent.show_results)
-      setQuestions(nextQuestions)
-      setDocuments(parsed.documents)
-      setMarkdownDirty(false)
-      markdownDirtyRef.current = false
-      setMarkdownError('')
       setMarkdownInfo('Markdown applied')
     }
 
@@ -1000,60 +1090,74 @@ export function QuizDetailPanel({
   }, [handleOpenTestPreview, isTestsView, previewRequestToken])
 
   const testsMarkdownPanel = (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            void handleCopyMarkdown()
-          }}
-          className="gap-1.5"
-        >
-          <Copy className="h-4 w-4" />
-          Copy
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            void handleCopyMarkdownSchema()
-          }}
-          className="gap-1.5"
-        >
-          <Copy className="h-4 w-4" />
-          Copy Schema
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={handleRebuildMarkdownFromStructured}
-          disabled={markdownSaving}
-        >
-          Rebuild From Structured
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={handleResetMarkdown}
-          disabled={!markdownDirty || markdownSaving}
-        >
-          Reset
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          onClick={() => {
-            void handleApplyMarkdown()
-          }}
-          disabled={markdownSaving || !isEditable}
-        >
-          {markdownSaving ? 'Applying...' : 'Apply Markdown'}
-        </Button>
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span data-testid="markdown-helper-status" className="text-xs font-medium text-text-muted">
+          {markdownHelperStatus}
+        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              void handleCopyMarkdown()
+            }}
+            className="gap-1.5"
+          >
+            <Copy className="h-4 w-4" />
+            Copy
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              void handleCopyMarkdownSchema()
+            }}
+            className="gap-1.5"
+          >
+            <Copy className="h-4 w-4" />
+            Schema
+          </Button>
+          {!isMarkdownEditing ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleEditMarkdown}
+              disabled={!isEditable || markdownSaving}
+            >
+              Edit Markdown
+            </Button>
+          ) : null}
+          {hasPendingMarkdownImport ? (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Undo markdown edits"
+                title="Undo markdown edits"
+                onClick={handleUndoMarkdownChanges}
+                disabled={markdownSaving}
+                className="h-8 w-8 p-0"
+              >
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => {
+                  void handleApplyMarkdown()
+                }}
+                disabled={markdownSaving || !isEditable}
+              >
+                {markdownSaving ? 'Applying...' : 'Apply Markdown'}
+              </Button>
+            </>
+          ) : null}
+        </div>
       </div>
       {!isEditable && (
         <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
@@ -1071,19 +1175,55 @@ export function QuizDetailPanel({
         </div>
       )}
       <textarea
+        data-testid="test-markdown-editor"
         value={markdownContent}
+        readOnly={!isMarkdownEditable}
         onChange={(event) => handleMarkdownChange(event.target.value)}
         onKeyDown={(event) => {
-          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's' && hasPendingMarkdownImport) {
             event.preventDefault()
             void handleApplyMarkdown()
           }
         }}
-        className="min-h-[420px] w-full rounded-md border border-border bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+        className={cn(
+          'min-h-[420px] flex-1 w-full rounded-md border border-border p-3 font-mono text-sm text-text-default',
+          isMarkdownEditable
+            ? 'bg-surface focus:outline-none focus:ring-2 focus:ring-primary'
+            : 'cursor-default bg-surface-2 focus:outline-none'
+        )}
         spellCheck={false}
       />
     </div>
   )
+
+  function renderTestAddQuestionSplitButton() {
+    return (
+      <SplitButton
+        label={preferredTestQuestionType === 'open_response' ? '+ Open Question' : '+ MC Question'}
+        onPrimaryClick={() => handleAddTestQuestionViaSplitButton(preferredTestQuestionType)}
+        options={[
+          {
+            id: 'multiple_choice',
+            label: 'MC',
+            onSelect: () => handleAddTestQuestionViaSplitButton('multiple_choice'),
+          },
+          {
+            id: 'open_response',
+            label: 'Open',
+            onSelect: () => handleAddTestQuestionViaSplitButton('open_response'),
+          },
+        ]}
+        variant="primary"
+        size="sm"
+        disabled={hasPendingMarkdownImport}
+        className="flex w-full shadow-sm"
+        toggleAriaLabel="Choose question type"
+        primaryButtonProps={{
+          className: 'min-w-0 flex-1 justify-center font-semibold',
+        }}
+      />
+    )
+  }
 
   const testsDocumentsPanel = (
     <div className="space-y-3 p-4">
@@ -1100,127 +1240,144 @@ export function QuizDetailPanel({
     </div>
   )
 
+  const testsInlineDocumentsCard = (
+    <div
+      data-testid="test-documents-card"
+      className="overflow-hidden rounded-lg border border-border bg-surface"
+    >
+      <button
+        type="button"
+        data-testid="test-documents-card-toggle"
+        aria-expanded={isDocumentsCardExpanded}
+        aria-label={isDocumentsCardExpanded ? 'Collapse documents' : 'Expand documents'}
+        onClick={() => setIsDocumentsCardExpanded((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-sm font-medium text-text-default">Documents</span>
+          <span className="text-xs text-text-muted">
+            {documents.length} document{documents.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        <span className="text-text-muted">
+          {isDocumentsCardExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+      </button>
+      {isDocumentsCardExpanded ? (
+        <div className="border-t border-border p-3">
+          <TestDocumentsEditor
+            testId={quiz.id}
+            documents={documents}
+            apiBasePath={apiBasePath}
+            isEditable={isEditable && !hasPendingMarkdownImport}
+            onUpdated={loadQuizDetails}
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+
   const testsSummaryDetailPanel = (
-    <WorkspaceSplitPane
+    <SummaryDetailWorkspaceShell
       orientation="row"
       data-testid="test-summary-detail-layout"
-      leftPaneClassName="flex w-[18rem] shrink-0 flex-col bg-surface-2"
-      rightPaneClassName="flex min-h-0 min-w-0 flex-1 flex-col bg-surface"
+      leftPaneClassName="min-h-0 bg-surface-2"
+      rightPaneClassName="min-h-0"
+      rightWidthPercent={50}
       left={
-        <div data-testid="test-question-summary-pane" className="flex h-full min-h-0 flex-col">
-        <div className="border-b border-border px-3 py-3 text-xs text-text-muted">
-          {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
-        </div>
-        <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-summary-list">
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={questions.map((question) => question.id)}
-              strategy={verticalListSortingStrategy}
-            >
-              <div className="space-y-2">
-                {questions.map((question, index) => (
-                  <TestQuestionSummaryCard
-                    key={question.id}
-                    question={question}
-                    questionNumber={index + 1}
-                    isEditable={isEditable}
-                    isSelected={selectedQuestion?.id === question.id}
-                    onSelect={() => {
-                      setSelectedQuestionId(question.id)
-                      setTestDetailTab('details')
-                    }}
-                  />
-                ))}
+        <div data-testid="test-question-editor-pane" className="flex h-full min-h-0 flex-col">
+          <div className="border-b border-border px-3 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-muted">
+                <span>
+                  {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
+                </span>
+                <span aria-hidden="true">•</span>
+                <span data-testid="test-question-editor-header-summary">
+                  {questions.length} question{questions.length === 1 ? '' : 's'} • {totalQuestionPoints} pts
+                </span>
               </div>
-            </SortableContext>
-          </DndContext>
-        </div>
-
-        {isEditable ? (
-          <div className="border-t border-border p-3">
-            <div className="grid gap-2">
               <Button
-                variant="secondary"
+                type="button"
+                variant="ghost"
                 size="sm"
-                onClick={() => handleAddQuestion('multiple_choice')}
-                className="w-full gap-1.5"
+                aria-label={areAllQuestionsExpanded ? 'Collapse all questions' : 'Expand all questions'}
+                onClick={handleToggleAllQuestions}
+                disabled={questions.length === 0}
+                className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
               >
-                <Plus className="h-4 w-4" />
-                Add MC Question
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => handleAddQuestion('open_response')}
-                className="w-full gap-1.5"
-              >
-                <Plus className="h-4 w-4" />
-                Add Open Question
+                {areAllQuestionsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
               </Button>
             </div>
           </div>
-        ) : null}
-      </div>
-      }
-      right={
-        <div
-          className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
-          data-testid="test-question-detail-pane"
-        >
-        <div className="border-b border-border px-4 pt-3">
-          <div className="flex items-end gap-1">
-            <button
-              type="button"
-              onClick={() => setTestDetailTab('details')}
-              className={[
-                testDetailTab === 'details'
-                  ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-                  : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-                'min-h-9 px-3 py-2 text-sm font-medium transition-colors',
-              ].join(' ')}
-            >
-              Details
-            </button>
-            <button
-              type="button"
-              onClick={() => setTestDetailTab('markdown')}
-              className={[
-                testDetailTab === 'markdown'
-                  ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-                  : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-                'min-h-9 px-3 py-2 text-sm font-medium transition-colors',
-              ].join(' ')}
-            >
-              Markdown
-            </button>
+          <div className="relative min-h-0 flex-1">
+            <div className={cn('flex h-full min-h-0 flex-col', hasPendingMarkdownImport && 'opacity-60')}>
+              <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-accordion-list">
+                <div className="space-y-3">
+                  {testsInlineDocumentsCard}
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                  >
+                    <SortableContext
+                      items={questions.map((question) => question.id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <div className="space-y-3">
+                        {questions.map((question, index) => (
+                          <TestQuestionEditor
+                            key={question.id}
+                            question={question}
+                            questionNumber={index + 1}
+                            isEditable={isEditable}
+                            onChange={handleQuestionChange}
+                            onDuplicate={handleDuplicateQuestion}
+                            onDelete={handleQuestionDelete}
+                            variant="accordion"
+                            isExpanded={expandedQuestionIds.includes(question.id)}
+                            onToggleExpanded={() => handleToggleQuestionExpanded(question.id)}
+                          />
+                        ))}
+                      </div>
+                    </SortableContext>
+                  </DndContext>
+                </div>
+              </div>
+
+              {isEditable ? (
+                <div className="border-t border-border p-3">
+                  {renderTestAddQuestionSplitButton()}
+                </div>
+              ) : null}
+            </div>
+            {hasPendingMarkdownImport ? (
+              <div
+                data-testid="markdown-pending-lock"
+                className="absolute inset-0 z-10 flex items-center justify-center bg-surface/75 px-6 text-center"
+              >
+                <div className="max-w-sm rounded-md border border-warning bg-surface px-4 py-3 text-sm text-text-default shadow-lg">
+                  Apply or undo markdown changes to continue editing questions.
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
-
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          {testDetailTab === 'markdown' ? (
-            testsMarkdownPanel
-          ) : selectedQuestion ? (
-            <TestQuestionEditor
-              question={selectedQuestion}
-              questionNumber={questions.findIndex((question) => question.id === selectedQuestion.id) + 1}
-              isEditable={isEditable}
-              onChange={handleQuestionChange}
-              onDelete={handleQuestionDelete}
-              variant="detail"
-            />
-          ) : (
-            <EmptyState
-              title="No questions yet"
-              description="Add a question to begin authoring this test."
-              tone="muted"
-            />
-          )}
+      }
+      right={
+        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col" data-testid="test-question-markdown-pane">
+          <div className="flex min-h-0 flex-1 flex-col p-4">
+            {questions.length === 0 ? (
+              <EmptyState
+                title="No questions yet"
+                description="Add a question to begin authoring this test."
+                tone="muted"
+              />
+            ) : (
+              testsMarkdownPanel
+            )}
+          </div>
         </div>
-      </div>
       }
     />
   )
@@ -1234,7 +1391,7 @@ export function QuizDetailPanel({
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex h-full w-full min-w-0 flex-col">
       {/* Tabs */}
       {!usesSummaryDetailQuestions && (
         <div className="flex border-b border-border shrink-0">
@@ -1351,9 +1508,7 @@ export function QuizDetailPanel({
           </div>
         )}
 
-        {usesSummaryDetailQuestions && currentTestAuthoringView === 'documents' ? (
-          testsDocumentsPanel
-        ) : usesSummaryDetailQuestions && currentTestAuthoringView === 'questions' ? (
+        {usesSummaryDetailQuestions ? (
           testsSummaryDetailPanel
         ) : viewMode === 'questions' ? (
           <div className="space-y-3">
@@ -1408,73 +1563,69 @@ export function QuizDetailPanel({
               {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
             </div>
 
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={questions.map((q) => q.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {questions.map((question, index) => (
-                  isTestsView ? (
-                    <TestQuestionEditor
-                      key={question.id}
-                      question={question}
-                      questionNumber={index + 1}
-                      isEditable={isEditable}
-                      onChange={handleQuestionChange}
-                      onDelete={handleQuestionDelete}
-                    />
-                  ) : (
-                    <QuizQuestionEditor
-                      key={question.id}
-                      question={question}
-                      questionNumber={index + 1}
-                      isEditable={isEditable}
-                      onChange={handleQuestionChange}
-                      onDelete={handleQuestionDelete}
-                    />
-                  )
-                ))}
-              </SortableContext>
-            </DndContext>
-
-            {isEditable && (
-              isTestsView ? (
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => handleAddQuestion('multiple_choice')}
-                    className="w-full gap-1.5"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Add MC Question
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => handleAddQuestion('open_response')}
-                    className="w-full gap-1.5"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Add Open Question
-                  </Button>
-                </div>
-              ) : (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleAddQuestion('multiple_choice')}
-                  className="w-full gap-1.5"
+            <div className="relative">
+              <div className={cn('space-y-3', isTestsView && hasPendingMarkdownImport && 'opacity-60')}>
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
                 >
-                  <Plus className="h-4 w-4" />
-                  Add Question
-                </Button>
-              )
-            )}
+                  <SortableContext
+                    items={questions.map((q) => q.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {questions.map((question, index) => (
+                      isTestsView ? (
+                        <TestQuestionEditor
+                          key={question.id}
+                          question={question}
+                          questionNumber={index + 1}
+                          isEditable={isEditable}
+                          onChange={handleQuestionChange}
+                          onDuplicate={handleDuplicateQuestion}
+                          onDelete={handleQuestionDelete}
+                        />
+                      ) : (
+                        <QuizQuestionEditor
+                          key={question.id}
+                          question={question}
+                          questionNumber={index + 1}
+                          isEditable={isEditable}
+                          onChange={handleQuestionChange}
+                          onDelete={handleQuestionDelete}
+                        />
+                      )
+                    ))}
+                  </SortableContext>
+                </DndContext>
+
+                {isEditable && (
+                  isTestsView ? (
+                    renderTestAddQuestionSplitButton()
+                  ) : (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleAddQuestion('multiple_choice')}
+                      className="w-full gap-1.5"
+                    >
+                      <Plus className="h-4 w-4" />
+                      Add Question
+                    </Button>
+                  )
+                )}
+              </div>
+              {isTestsView && hasPendingMarkdownImport ? (
+                <div
+                  data-testid="markdown-pending-lock"
+                  className="absolute inset-0 z-10 flex items-center justify-center bg-surface/75 px-6 text-center"
+                >
+                  <div className="max-w-sm rounded-md border border-warning bg-surface px-4 py-3 text-sm text-text-default shadow-lg">
+                    Apply or undo markdown changes to continue editing questions.
+                  </div>
+                </div>
+              ) : null}
+            </div>
 
           </div>
         ) : viewMode === 'documents' && isTestsView ? (
@@ -1605,101 +1756,6 @@ function QuizPreview({ questions, isTestsView }: { questions: QuizQuestion[]; is
           )}
         </div>
       ))}
-    </div>
-  )
-}
-
-function summarizeQuestionText(questionText: string | null | undefined): string {
-  const flattened = (questionText || '')
-    .replace(/[#>*_`~-]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-
-  return flattened || 'Untitled question'
-}
-
-function TestQuestionSummaryCard({
-  question,
-  questionNumber,
-  isEditable,
-  isSelected,
-  onSelect,
-}: {
-  question: QuizQuestion
-  questionNumber: number
-  isEditable: boolean
-  isSelected: boolean
-  onSelect: () => void
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: question.id,
-    disabled: !isEditable,
-  })
-
-  const sortableStyle = {
-    transform: CSS.Transform.toString(transform),
-    transition: isDragging ? undefined : transition,
-  }
-
-  return (
-    <div ref={setNodeRef} style={sortableStyle}>
-      <button
-        type="button"
-        onClick={onSelect}
-        aria-label={`Select question ${questionNumber}`}
-        className={[
-          'flex w-full items-start gap-2 rounded-md border px-3 py-2 text-left transition-colors',
-          isSelected
-            ? 'border-primary bg-surface-hover text-text-default'
-            : 'border-border bg-surface text-text-default hover:border-border-strong hover:bg-surface-hover',
-          isDragging ? 'shadow-lg' : '',
-        ].join(' ')}
-      >
-        <div className="flex min-h-8 items-center pt-0.5">
-          {isEditable ? (
-            <span
-              className="cursor-grab touch-none text-text-muted hover:text-text-default active:cursor-grabbing"
-              aria-label="Drag to reorder"
-              onClick={(event) => event.stopPropagation()}
-              {...attributes}
-              {...listeners}
-            >
-              <GripVertical className="h-4 w-4" />
-            </span>
-          ) : (
-            <span className="text-xs font-semibold text-text-muted">Q{questionNumber}</span>
-          )}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            {isEditable ? (
-              <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{questionNumber}</span>
-            ) : null}
-            <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-default">
-              {summarizeQuestionText(question.question_text)}
-            </span>
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
-            <span>{question.points ?? 0} pts</span>
-            {question.question_type === 'open_response' ? (
-              <label className="inline-flex items-center gap-1.5">
-                <input
-                  type="checkbox"
-                  checked={question.response_monospace === true}
-                  readOnly
-                  tabIndex={-1}
-                  aria-label={`Question ${questionNumber} code response`}
-                  className="h-3.5 w-3.5 rounded border-border text-primary focus:ring-0"
-                />
-                <span>Code</span>
-              </label>
-            ) : (
-              <span>MC</span>
-            )}
-          </div>
-        </div>
-      </button>
     </div>
   )
 }

--- a/src/components/SummaryDetailWorkspaceShell.tsx
+++ b/src/components/SummaryDetailWorkspaceShell.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import type { CSSProperties, ComponentProps, ReactNode } from 'react'
+import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
+import { cn } from '@/ui/utils'
+
+type WorkspaceSplitDivider = NonNullable<ComponentProps<typeof WorkspaceSplitPane>['divider']>
+
+interface SummaryDetailWorkspaceShellProps {
+  left: ReactNode
+  right?: ReactNode
+  rightVisible?: boolean
+  className?: string
+  leftPaneClassName?: string
+  rightPaneClassName?: string
+  leftPaneStyle?: CSSProperties
+  rightPaneStyle?: CSSProperties
+  rightWidthPercent?: number
+  divider?: WorkspaceSplitDivider
+  orientation?: 'row' | 'responsive'
+  ['data-testid']?: string
+}
+
+export function SummaryDetailWorkspaceShell({
+  left,
+  right,
+  rightVisible = true,
+  className,
+  leftPaneClassName,
+  rightPaneClassName,
+  leftPaneStyle,
+  rightPaneStyle,
+  rightWidthPercent,
+  divider,
+  orientation = 'responsive',
+  'data-testid': dataTestId,
+}: SummaryDetailWorkspaceShellProps) {
+  const effectiveRightWidthPercent =
+    typeof rightWidthPercent === 'number'
+      ? rightWidthPercent
+      : orientation === 'row'
+        ? 50
+        : undefined
+
+  const resolvedRightPaneStyle = rightVisible
+    ? effectiveRightWidthPercent != null
+      ? {
+          width: `${effectiveRightWidthPercent}%`,
+          flexBasis: `${effectiveRightWidthPercent}%`,
+          ...rightPaneStyle,
+        }
+      : rightPaneStyle
+    : rightPaneStyle
+
+  const responsiveDividerBorderClass =
+    divider && orientation === 'responsive' ? 'border-t border-border lg:border-t-0' : ''
+
+  return (
+    <WorkspaceSplitPane
+      left={left}
+      right={right}
+      rightVisible={rightVisible}
+      divider={divider}
+      orientation={orientation}
+      data-testid={dataTestId}
+      className={cn('h-full w-full min-w-0 flex-1', className)}
+      leftPaneClassName={cn('min-h-0 flex-1 overflow-hidden', leftPaneClassName)}
+      rightPaneClassName={cn(
+        'min-h-0 overflow-hidden bg-surface',
+        responsiveDividerBorderClass,
+        rightPaneClassName,
+      )}
+      leftPaneStyle={leftPaneStyle}
+      rightPaneStyle={resolvedRightPaneStyle}
+    />
+  )
+}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
-import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -201,15 +201,6 @@ export function TeacherStudentWorkPanel({
   const studentDisplayName = data.student.name?.trim() || data.student.email
   const characterCount =
     displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
-  const inspectorPaneStyle = layout.inspectorCollapsed
-    ? undefined
-    : isDesktop
-      ? ({
-          width: `${layout.inspectorWidth}%`,
-          flexBasis: `${layout.inspectorWidth}%`,
-        } as const)
-      : undefined
-
   const inspector = (
     <TeacherWorkInspector
       data={data}
@@ -256,15 +247,15 @@ export function TeacherStudentWorkPanel({
 
   return (
     <div ref={workspaceRef} className="relative flex h-full min-h-0 flex-col">
-      <WorkspaceSplitPane
+      <SummaryDetailWorkspaceShell
         className="flex-1"
         orientation="responsive"
-        leftPaneClassName={`flex min-h-0 flex-1 flex-col ${
+        leftPaneClassName={`flex min-h-0 flex-col ${
           previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
         }`}
         rightVisible={!layout.inspectorCollapsed}
-        rightPaneClassName="flex min-h-0 flex-col overflow-hidden border-t border-border bg-surface lg:border-t-0"
-        rightPaneStyle={inspectorPaneStyle}
+        rightPaneClassName="flex min-h-0 flex-col"
+        rightWidthPercent={!layout.inspectorCollapsed && isDesktop ? layout.inspectorWidth : undefined}
         divider={
           layout.inspectorCollapsed
             ? undefined

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
+import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -254,61 +255,55 @@ export function TeacherStudentWorkPanel({
   }
 
   return (
-    <div ref={workspaceRef} className="relative flex h-full min-h-0 flex-col lg:flex-row">
-      <div
-        className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+    <div ref={workspaceRef} className="relative flex h-full min-h-0 flex-col">
+      <WorkspaceSplitPane
+        className="flex-1"
+        orientation="responsive"
+        leftPaneClassName={`flex min-h-0 flex-1 flex-col ${
           previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
         }`}
-      >
-        {previewEntry && (
-          <div
-            data-testid="individual-content-header"
-            className="border-b border-border bg-surface px-4 py-2 text-sm"
-          >
-            <div className="text-xs font-medium text-primary">
-              Previewing save from{' '}
-              {formatInTimeZone(
-                new Date(previewEntry.created_at),
-                'America/Toronto',
-                'MMM d, h:mm a',
-              )}
-            </div>
-          </div>
-        )}
-        {displayContent && !isEmpty(displayContent) ? (
-          <div className="min-h-0 flex-1 overflow-auto">
-            <RichTextViewer content={displayContent} fillHeight chrome="flush" />
-          </div>
-        ) : (
-          <div className="flex h-32 items-center justify-center text-text-muted">
-            No work submitted yet
-          </div>
-        )}
-      </div>
-
-      {!layout.inspectorCollapsed && (
-        <div className="relative hidden w-0 shrink-0 lg:block">
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize content and grading panes"
-            className="absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent"
-            onPointerDown={handleInspectorResizeStart}
-            onDoubleClick={handleInspectorResizeReset}
-          >
-            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
-          </div>
-        </div>
-      )}
-
-      {!layout.inspectorCollapsed && (
-        <div
-          className="flex min-h-0 flex-col overflow-hidden border-t border-border bg-surface lg:border-t-0"
-          style={inspectorPaneStyle}
-        >
-          {inspector}
-        </div>
-      )}
+        rightVisible={!layout.inspectorCollapsed}
+        rightPaneClassName="flex min-h-0 flex-col overflow-hidden border-t border-border bg-surface lg:border-t-0"
+        rightPaneStyle={inspectorPaneStyle}
+        divider={
+          layout.inspectorCollapsed
+            ? undefined
+            : {
+                label: 'Resize content and grading panes',
+                onPointerDown: handleInspectorResizeStart,
+                onDoubleClick: handleInspectorResizeReset,
+              }
+        }
+        left={
+          <>
+            {previewEntry && (
+              <div
+                data-testid="individual-content-header"
+                className="border-b border-border bg-surface px-4 py-2 text-sm"
+              >
+                <div className="text-xs font-medium text-primary">
+                  Previewing save from{' '}
+                  {formatInTimeZone(
+                    new Date(previewEntry.created_at),
+                    'America/Toronto',
+                    'MMM d, h:mm a',
+                  )}
+                </div>
+              </div>
+            )}
+            {displayContent && !isEmpty(displayContent) ? (
+              <div className="min-h-0 flex-1 overflow-auto">
+                <RichTextViewer content={displayContent} fillHeight chrome="flush" />
+              </div>
+            ) : (
+              <div className="flex h-32 items-center justify-center text-text-muted">
+                No work submitted yet
+              </div>
+            )}
+          </>
+        }
+        right={inspector}
+      />
     </div>
   )
 }

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Play, Square } from 'lucide-react'
+import { getAssessmentStatusLabel, getQuizStatusBadgeClass, canActivateQuiz } from '@/lib/quizzes'
+import { validateTestQuestionCreate } from '@/lib/test-questions'
+import { Button, ConfirmDialog, Tooltip } from '@/ui'
+import type { QuizWithStats } from '@/types'
+
+interface TeacherTestCardProps {
+  test: QuizWithStats
+  isReadOnly: boolean
+  onSelect: () => void
+  onUpdate: () => void
+}
+
+export function TeacherTestCard({
+  test,
+  isReadOnly,
+  onSelect,
+  onUpdate,
+}: TeacherTestCardProps) {
+  const [updating, setUpdating] = useState(false)
+  const [checkingActivation, setCheckingActivation] = useState(false)
+  const [showActivateConfirm, setShowActivateConfirm] = useState(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+  const [actionError, setActionError] = useState('')
+
+  useEffect(() => {
+    setActionError('')
+  }, [test.id, test.status, test.updated_at])
+
+  async function patchTest(payload: Record<string, unknown>) {
+    setUpdating(true)
+    setActionError('')
+    try {
+      const response = await fetch(`/api/teacher/tests/${test.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to update test')
+      }
+
+      onUpdate()
+    } catch (error: any) {
+      setActionError(error?.message || 'Failed to update test')
+    } finally {
+      setUpdating(false)
+      setShowActivateConfirm(false)
+      setShowCloseConfirm(false)
+    }
+  }
+
+  async function handleStatusChange(newStatus: 'active' | 'closed') {
+    await patchTest({ status: newStatus })
+  }
+
+  async function handleRequestActivate(event: React.MouseEvent) {
+    event.stopPropagation()
+    if (isReadOnly || updating || checkingActivation || !activation.valid) return
+
+    setCheckingActivation(true)
+    setActionError('')
+    try {
+      const response = await fetch(`/api/teacher/tests/${test.id}`)
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to validate test')
+      }
+
+      const questions = Array.isArray(data.questions) ? data.questions : []
+      if (questions.length < 1) {
+        setActionError('Test must have at least 1 question')
+        return
+      }
+
+      for (let index = 0; index < questions.length; index += 1) {
+        const validation = validateTestQuestionCreate(questions[index] as Record<string, unknown>)
+        if (!validation.valid) {
+          setActionError(`Q${index + 1}: ${validation.error}`)
+          return
+        }
+      }
+
+      setShowActivateConfirm(true)
+    } catch (error: any) {
+      setActionError(error?.message || 'Failed to validate test')
+    } finally {
+      setCheckingActivation(false)
+    }
+  }
+
+  const activation = canActivateQuiz(test, test.stats.questions_count)
+  const isDraft = test.status === 'draft'
+  const statusLabel = getAssessmentStatusLabel(test.status, 'test')
+  const statusBadgeClass = getQuizStatusBadgeClass(test.status)
+
+  return (
+    <>
+      <div
+        className={[
+          'w-full rounded-card border p-3.5 text-left shadow-elevated',
+          isDraft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface-panel',
+          isDraft
+            ? 'transition hover:border-border-strong hover:bg-surface-3'
+            : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
+        ].join(' ')}
+      >
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+          <button type="button" onClick={onSelect} className="min-w-0 text-left">
+            <h3 className={['truncate font-medium', isDraft ? 'text-text-muted' : 'text-text-default'].join(' ')}>
+              {test.title}
+            </h3>
+            <p className="mt-0.5 text-xs text-text-muted">
+              {isDraft ? 'Draft test' : `${test.stats.responded}/${test.stats.total_students} responded`}
+            </p>
+            {actionError ? (
+              <p className="mt-1 text-xs text-danger" role="alert">
+                {actionError}
+              </p>
+            ) : null}
+          </button>
+
+          <div className="flex items-center justify-start gap-2 sm:flex-col sm:items-center sm:justify-center sm:px-4 sm:text-center">
+            <span
+              className={`inline-flex shrink-0 items-center rounded-badge px-2.5 py-1 text-xs font-semibold ${statusBadgeClass}`}
+            >
+              {statusLabel}
+            </span>
+            {!isDraft ? (
+              <span className="text-sm text-text-muted">
+                {test.stats.responded}/{test.stats.total_students}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="flex items-center justify-end gap-1">
+            {test.status === 'draft' ? (
+              <Tooltip content={activation.valid ? 'Open test' : activation.error}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="p-1.5 text-success hover:bg-success-bg-muted"
+                  aria-label="Open test"
+                  disabled={isReadOnly || !activation.valid || updating || checkingActivation}
+                  onClick={handleRequestActivate}
+                >
+                  <Play className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </Tooltip>
+            ) : null}
+
+            {test.status === 'active' ? (
+              <Tooltip content="Close test">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="p-1.5 text-danger hover:bg-danger-bg"
+                  aria-label="Close test"
+                  disabled={isReadOnly || updating}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    setShowCloseConfirm(true)
+                  }}
+                >
+                  <Square className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </Tooltip>
+            ) : null}
+
+            {test.status === 'closed' ? (
+              <Tooltip content="Reopen test">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="p-1.5 text-success hover:bg-success-bg-muted"
+                  aria-label="Reopen test"
+                  disabled={isReadOnly || updating}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    void handleStatusChange('active')
+                  }}
+                >
+                  <Play className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </Tooltip>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={showActivateConfirm}
+        title="Activate test?"
+        description="Once activated, students will be able to respond."
+        confirmLabel={updating ? 'Activating...' : 'Activate'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={updating}
+        isCancelDisabled={updating}
+        onCancel={() => setShowActivateConfirm(false)}
+        onConfirm={() => handleStatusChange('active')}
+      />
+
+      <ConfirmDialog
+        isOpen={showCloseConfirm}
+        title="Close test?"
+        description="Students will no longer be able to respond."
+        confirmLabel={updating ? 'Closing...' : 'Close'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={updating}
+        isCancelDisabled={updating}
+        onCancel={() => setShowCloseConfirm(false)}
+        onConfirm={() => handleStatusChange('closed')}
+      />
+    </>
+  )
+}

--- a/src/components/TestQuestionEditor.tsx
+++ b/src/components/TestQuestionEditor.tsx
@@ -18,6 +18,7 @@ interface Props {
   isEditable: boolean
   onChange: (question: QuizQuestion, options?: { force?: boolean }) => void
   onDelete: (questionId: string) => void
+  variant?: 'card' | 'detail'
 }
 
 type LocalQuestionState = {
@@ -71,6 +72,7 @@ export function TestQuestionEditor({
   isEditable,
   onChange,
   onDelete,
+  variant = 'card',
 }: Props) {
   const {
     attributes,
@@ -88,14 +90,14 @@ export function TestQuestionEditor({
 
   const [state, setState] = useState<LocalQuestionState>(() => toLocalState(question))
   const [error, setError] = useState('')
-  const [isAnswerSectionOpen, setIsAnswerSectionOpen] = useState(false)
+  const [isAnswerSectionOpen, setIsAnswerSectionOpen] = useState(variant === 'detail')
   const codeToggleId = `question-${question.id}-code-toggle`
 
   useEffect(() => {
     setState(toLocalState(question))
     setError('')
-    setIsAnswerSectionOpen(false)
-  }, [question])
+    setIsAnswerSectionOpen(variant === 'detail')
+  }, [question, variant])
 
   const isDirty = useMemo(() => {
     const current = normalizeForComparison(state)
@@ -193,6 +195,171 @@ export function TestQuestionEditor({
         response_monospace: state.response_monospace,
       },
       { force: options?.force === true }
+    )
+  }
+
+  if (variant === 'detail' && isEditable) {
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-4">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
+              <span>Q{questionNumber}</span>
+              <span aria-hidden="true">•</span>
+              <span>{state.question_type === 'open_response' ? 'Open Response' : 'Multiple Choice'}</span>
+            </div>
+
+            <textarea
+              value={state.question_text}
+              onChange={(event) => updateState({ question_text: event.target.value })}
+              onBlur={() => handleSave()}
+              placeholder="Question prompt"
+              rows={4}
+              className="w-full min-h-[120px] resize-y rounded-md border border-border bg-surface px-3 py-3 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+
+            {state.question_type === 'multiple_choice' ? (
+              <div className="space-y-2">
+                {state.options.map((option, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name={`correct-option-${question.id}`}
+                      checked={state.correct_option === index}
+                      onChange={() => {
+                        updateState({ correct_option: index })
+                        setTimeout(() => handleSave(), 0)
+                      }}
+                      className="h-4 w-4"
+                    />
+                    <Input
+                      type="text"
+                      value={option}
+                      onChange={(event) => updateOption(index, event.target.value)}
+                      onBlur={() => handleSave()}
+                      placeholder={`Option ${String.fromCharCode(65 + index)}`}
+                      className="flex-1"
+                    />
+                    {state.options.length > 2 && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          removeOption(index)
+                          setTimeout(() => handleSave(), 0)
+                        }}
+                        className="p-1 text-text-muted hover:text-danger"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+                {state.options.length < MAX_QUIZ_OPTIONS && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={addOption}
+                    className="gap-1.5"
+                  >
+                    <Plus className="h-4 w-4" />
+                    Option
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-md border border-border bg-surface-2 px-3 py-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                  Student Response Style
+                </p>
+                <label htmlFor={codeToggleId} className="mt-3 flex items-center gap-2 text-sm text-text-default">
+                  <input
+                    id={codeToggleId}
+                    type="checkbox"
+                    checked={state.response_monospace}
+                    onChange={(event) => {
+                      updateState({ response_monospace: event.target.checked })
+                      setTimeout(() => handleSave(), 0)
+                    }}
+                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                  />
+                  Code / monospace response
+                </label>
+              </div>
+            )}
+          </div>
+
+          <div className="w-32 shrink-0 space-y-2 rounded-md border border-border bg-surface-2 p-3">
+            <div className="space-y-2">
+              <label className="text-[11px] font-medium uppercase tracking-wide leading-none text-text-muted">
+                Points
+              </label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={state.points}
+                onChange={(event) => updateState({ points: event.target.value })}
+                onBlur={() => handleSave()}
+                className="h-9 min-w-0 w-full px-2 text-sm"
+              />
+            </div>
+
+            <div className="space-y-2 pt-2">
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => handleSave({ force: true })}
+                disabled={!isDirty}
+                className="w-full min-w-0 px-2"
+              >
+                Save
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                size="sm"
+                onClick={() => onDelete(question.id)}
+                className="w-full min-w-0 px-2"
+              >
+                Delete
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {state.question_type === 'open_response' ? (
+          <div className="mt-auto space-y-3 rounded-md border border-border bg-surface-2 px-4 py-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Key</p>
+              <textarea
+                value={state.answer_key}
+                onChange={(event) => updateState({ answer_key: event.target.value })}
+                onBlur={() => handleSave()}
+                placeholder="Enter an optional answer key for AI-assisted grading..."
+                rows={4}
+                className="mt-2 w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Sample Solution</p>
+              <textarea
+                value={state.sample_solution}
+                onChange={(event) => updateState({ sample_solution: event.target.value })}
+                onBlur={() => handleSave()}
+                placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
+                rows={6}
+                className="mt-2 w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {error ? <p className="text-sm text-danger">{error}</p> : null}
+      </div>
     )
   }
 

--- a/src/components/TestQuestionEditor.tsx
+++ b/src/components/TestQuestionEditor.tsx
@@ -1,14 +1,12 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, Plus, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, Copy, GripVertical, Plus, Trash2 } from 'lucide-react'
 import { Button, Input } from '@/ui'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
-import {
-  defaultPointsForQuestionType,
-} from '@/lib/test-questions'
+import { defaultPointsForQuestionType } from '@/lib/test-questions'
 import { MAX_QUIZ_OPTIONS } from '@/lib/quizzes'
 import type { QuizQuestion, TestQuestionType } from '@/types'
 
@@ -18,7 +16,10 @@ interface Props {
   isEditable: boolean
   onChange: (question: QuizQuestion, options?: { force?: boolean }) => void
   onDelete: (questionId: string) => void
-  variant?: 'card' | 'detail'
+  onDuplicate?: (questionId: string) => void
+  variant?: 'card' | 'detail' | 'accordion'
+  isExpanded?: boolean
+  onToggleExpanded?: () => void
 }
 
 type LocalQuestionState = {
@@ -32,6 +33,17 @@ type LocalQuestionState = {
   sample_solution: string
 }
 
+function summarizeHeaderLine(questionText: string | null | undefined): string {
+  const firstMeaningfulLine =
+    (questionText || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) || ''
+
+  const flattened = firstMeaningfulLine.replace(/[#>*_`~-]/g, ' ').replace(/\s+/g, ' ').trim()
+  return flattened || 'Untitled question'
+}
+
 function toLocalState(question: QuizQuestion): LocalQuestionState {
   const questionType = question.question_type === 'open_response' ? 'open_response' : 'multiple_choice'
   return {
@@ -39,7 +51,9 @@ function toLocalState(question: QuizQuestion): LocalQuestionState {
     question_text: question.question_text ?? '',
     options: Array.isArray(question.options) ? question.options : ['Option 1', 'Option 2'],
     correct_option:
-      typeof question.correct_option === 'number' && Number.isInteger(question.correct_option) && question.correct_option >= 0
+      typeof question.correct_option === 'number' &&
+      Number.isInteger(question.correct_option) &&
+      question.correct_option >= 0
         ? question.correct_option
         : 0,
     points: String(question.points ?? defaultPointsForQuestionType(questionType)),
@@ -55,33 +69,21 @@ function toLocalState(question: QuizQuestion): LocalQuestionState {
   }
 }
 
-function normalizeForComparison(state: LocalQuestionState) {
-  return {
-    ...state,
-    question_text: state.question_text.trim(),
-    options: state.options.map((option) => option.trim()),
-    points: Number(state.points),
-    answer_key: state.answer_key.trim(),
-    sample_solution: state.sample_solution.trim(),
-  }
-}
-
 export function TestQuestionEditor({
   question,
   questionNumber,
   isEditable,
   onChange,
   onDelete,
+  onDuplicate,
   variant = 'card',
+  isExpanded = true,
+  onToggleExpanded,
 }: Props) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: question.id, disabled: !isEditable })
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: question.id,
+    disabled: !isEditable,
+  })
 
   const sortableStyle = {
     transform: CSS.Transform.toString(transform),
@@ -90,20 +92,18 @@ export function TestQuestionEditor({
 
   const [state, setState] = useState<LocalQuestionState>(() => toLocalState(question))
   const [error, setError] = useState('')
-  const [isAnswerSectionOpen, setIsAnswerSectionOpen] = useState(variant === 'detail')
+  const [isAnswerSectionOpen, setIsAnswerSectionOpen] = useState(variant !== 'card')
   const codeToggleId = `question-${question.id}-code-toggle`
+  const toggleLabel = `${isExpanded ? 'Collapse' : 'Expand'} question ${questionNumber}`
+  const questionPlaceholder = `Question ${questionNumber}`
+  const pointsLabel = `${Number.parseInt(state.points, 10) || question.points || defaultPointsForQuestionType(state.question_type)} pts`
+  const collapsedSummary = summarizeHeaderLine(state.question_text)
 
   useEffect(() => {
     setState(toLocalState(question))
     setError('')
-    setIsAnswerSectionOpen(variant === 'detail')
+    setIsAnswerSectionOpen(variant !== 'card')
   }, [question, variant])
-
-  const isDirty = useMemo(() => {
-    const current = normalizeForComparison(state)
-    const baseline = normalizeForComparison(toLocalState(question))
-    return JSON.stringify(current) !== JSON.stringify(baseline)
-  }, [question, state])
 
   function updateState(partial: Partial<LocalQuestionState>) {
     setState((prev) => ({ ...prev, ...partial }))
@@ -158,7 +158,11 @@ export function TestQuestionEditor({
         setError('Options cannot be empty')
         return
       }
-      if (!Number.isInteger(state.correct_option) || state.correct_option < 0 || state.correct_option >= nextOptions.length) {
+      if (
+        !Number.isInteger(state.correct_option) ||
+        state.correct_option < 0 ||
+        state.correct_option >= nextOptions.length
+      ) {
         setError('Select a correct option')
         return
       }
@@ -198,167 +202,351 @@ export function TestQuestionEditor({
     )
   }
 
-  if (variant === 'detail' && isEditable) {
-    return (
-      <div className="flex h-full min-h-0 flex-col gap-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1 space-y-4">
-            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
-              <span>Q{questionNumber}</span>
-              <span aria-hidden="true">•</span>
-              <span>{state.question_type === 'open_response' ? 'Open Response' : 'Multiple Choice'}</span>
-            </div>
-
-            <textarea
-              value={state.question_text}
-              onChange={(event) => updateState({ question_text: event.target.value })}
+  const multipleChoiceEditor = state.question_type === 'multiple_choice' ? (
+    <div
+      className={
+        variant === 'accordion'
+          ? 'space-y-2 border-t border-border bg-surface-2 px-4 py-4'
+          : 'space-y-2 rounded-md border border-border bg-surface-2 px-4 py-4'
+      }
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Options</p>
+      {state.options.map((option, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <input
+            type="radio"
+            name={`correct-option-${question.id}`}
+            checked={state.correct_option === index}
+            disabled={!isEditable}
+            onChange={() => {
+              updateState({ correct_option: index })
+              setTimeout(() => handleSave(), 0)
+            }}
+            className="h-4 w-4"
+          />
+          {isEditable ? (
+            <Input
+              type="text"
+              value={option}
+              onChange={(event) => updateOption(index, event.target.value)}
               onBlur={() => handleSave()}
-              placeholder="Question prompt"
-              rows={4}
-              className="w-full min-h-[120px] resize-y rounded-md border border-border bg-surface px-3 py-3 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+              placeholder={`Option ${String.fromCharCode(65 + index)}`}
+              className="flex-1"
             />
+          ) : (
+            <div className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default">
+              {option}
+            </div>
+          )}
+          {isEditable && state.options.length > 2 ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                removeOption(index)
+                setTimeout(() => handleSave(), 0)
+              }}
+              className="p-1 text-text-muted hover:text-danger"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          ) : null}
+        </div>
+      ))}
+      {isEditable && state.options.length < MAX_QUIZ_OPTIONS ? (
+        <Button type="button" variant="secondary" size="sm" onClick={addOption} className="gap-1.5">
+          <Plus className="h-4 w-4" />
+          Option
+        </Button>
+      ) : null}
+    </div>
+  ) : null
 
-            {state.question_type === 'multiple_choice' ? (
-              <div className="space-y-2">
-                {state.options.map((option, index) => (
-                  <div key={index} className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name={`correct-option-${question.id}`}
-                      checked={state.correct_option === index}
-                      onChange={() => {
-                        updateState({ correct_option: index })
-                        setTimeout(() => handleSave(), 0)
-                      }}
-                      className="h-4 w-4"
-                    />
-                    <Input
-                      type="text"
-                      value={option}
-                      onChange={(event) => updateOption(index, event.target.value)}
-                      onBlur={() => handleSave()}
-                      placeholder={`Option ${String.fromCharCode(65 + index)}`}
-                      className="flex-1"
-                    />
-                    {state.options.length > 2 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          removeOption(index)
-                          setTimeout(() => handleSave(), 0)
-                        }}
-                        className="p-1 text-text-muted hover:text-danger"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    )}
+  const openResponseEditor =
+    state.question_type === 'open_response' ? (
+      <div
+        className={
+          variant === 'accordion'
+            ? 'space-y-3 border-t border-border bg-surface-2 px-4 py-4'
+            : 'space-y-3 rounded-md border border-border bg-surface-2 px-4 py-4'
+        }
+      >
+        {variant === 'card' && isEditable ? (
+          <button
+            type="button"
+            onClick={() => setIsAnswerSectionOpen((prev) => !prev)}
+            className="w-full text-left text-xs font-semibold uppercase tracking-wide text-text-muted hover:text-text-default"
+          >
+            {isAnswerSectionOpen
+              ? 'Hide Grading Notes'
+              : state.answer_key.trim() || state.sample_solution.trim()
+                ? 'Grading Notes Added'
+                : 'Add Grading Notes'}
+          </button>
+        ) : (
+          <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Key</p>
+        )}
+
+        {variant !== 'card' || isAnswerSectionOpen ? (
+          <div className="space-y-3">
+            {variant === 'card' && isEditable ? null : (
+              <div>
+                {variant !== 'card' ? null : (
+                  <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Key</p>
+                )}
+                {isEditable ? (
+                  <textarea
+                    value={state.answer_key}
+                    onChange={(event) => updateState({ answer_key: event.target.value })}
+                    onBlur={() => handleSave()}
+                    placeholder="Enter an optional answer key for AI-assisted grading..."
+                    rows={4}
+                    className="w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                ) : (
+                  <div className="min-h-[96px] rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default whitespace-pre-wrap">
+                    {state.answer_key || 'No answer key provided.'}
                   </div>
-                ))}
-                {state.options.length < MAX_QUIZ_OPTIONS && (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    size="sm"
-                    onClick={addOption}
-                    className="gap-1.5"
-                  >
-                    <Plus className="h-4 w-4" />
-                    Option
-                  </Button>
                 )}
               </div>
+            )}
+
+            {variant === 'card' && isEditable ? (
+              <>
+                <textarea
+                  value={state.answer_key}
+                  onChange={(event) => updateState({ answer_key: event.target.value })}
+                  onBlur={() => handleSave()}
+                  placeholder="Enter an optional answer key for AI-assisted grading..."
+                  rows={4}
+                  className="w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                <textarea
+                  value={state.sample_solution}
+                  onChange={(event) => updateState({ sample_solution: event.target.value })}
+                  onBlur={() => handleSave()}
+                  placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
+                  rows={6}
+                  className="w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </>
             ) : (
-              <div className="rounded-md border border-border bg-surface-2 px-3 py-3">
-                <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                  Student Response Style
-                </p>
-                <label htmlFor={codeToggleId} className="mt-3 flex items-center gap-2 text-sm text-text-default">
-                  <input
-                    id={codeToggleId}
-                    type="checkbox"
-                    checked={state.response_monospace}
-                    onChange={(event) => {
-                      updateState({ response_monospace: event.target.checked })
-                      setTimeout(() => handleSave(), 0)
-                    }}
-                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Sample Solution</p>
+                {isEditable ? (
+                  <textarea
+                    value={state.sample_solution}
+                    onChange={(event) => updateState({ sample_solution: event.target.value })}
+                    onBlur={() => handleSave()}
+                    placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
+                    rows={6}
+                    className="w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
                   />
-                  Code / monospace response
-                </label>
+                ) : (
+                  <div className="min-h-[128px] rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default whitespace-pre-wrap">
+                    {state.sample_solution || 'No sample solution provided.'}
+                  </div>
+                )}
               </div>
             )}
           </div>
+        ) : null}
+      </div>
+    ) : null
 
-          <div className="w-32 shrink-0 space-y-2 rounded-md border border-border bg-surface-2 p-3">
-            <div className="space-y-2">
-              <label className="text-[11px] font-medium uppercase tracking-wide leading-none text-text-muted">
-                Points
-              </label>
-              <Input
-                type="text"
-                inputMode="decimal"
-                value={state.points}
-                onChange={(event) => updateState({ points: event.target.value })}
-                onBlur={() => handleSave()}
-                className="h-9 min-w-0 w-full px-2 text-sm"
-              />
-            </div>
-
-            <div className="space-y-2 pt-2">
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                onClick={() => handleSave({ force: true })}
-                disabled={!isDirty}
-                className="w-full min-w-0 px-2"
-              >
-                Save
-              </Button>
-              <Button
-                type="button"
-                variant="danger"
-                size="sm"
-                onClick={() => onDelete(question.id)}
-                className="w-full min-w-0 px-2"
-              >
-                Delete
-              </Button>
-            </div>
+  if (variant === 'detail' && isEditable) {
+    return (
+      <div className="flex h-full min-h-0 w-full max-w-none flex-col gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
+            <span>Q{questionNumber}</span>
+            <span aria-hidden="true">•</span>
+            <span>{state.question_type === 'open_response' ? 'Open Response' : 'Multiple Choice'}</span>
           </div>
         </div>
 
-        {state.question_type === 'open_response' ? (
-          <div className="mt-auto space-y-3 rounded-md border border-border bg-surface-2 px-4 py-4">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Key</p>
-              <textarea
-                value={state.answer_key}
-                onChange={(event) => updateState({ answer_key: event.target.value })}
-                onBlur={() => handleSave()}
-                placeholder="Enter an optional answer key for AI-assisted grading..."
-                rows={4}
-                className="mt-2 w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
+        <textarea
+          value={state.question_text}
+          onChange={(event) => updateState({ question_text: event.target.value })}
+          onBlur={() => handleSave()}
+          placeholder={questionPlaceholder}
+          rows={5}
+          className="w-full min-h-[144px] resize-y rounded-md border border-border bg-surface px-4 py-3 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+        />
 
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Sample Solution</p>
-              <textarea
-                value={state.sample_solution}
-                onChange={(event) => updateState({ sample_solution: event.target.value })}
-                onBlur={() => handleSave()}
-                placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
-                rows={6}
-                className="mt-2 w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-          </div>
-        ) : null}
+        {multipleChoiceEditor}
+        {openResponseEditor}
 
         {error ? <p className="text-sm text-danger">{error}</p> : null}
+      </div>
+    )
+  }
+
+  if (variant === 'accordion') {
+    return (
+      <div
+        ref={setNodeRef}
+        style={sortableStyle}
+        className={`rounded-lg border border-border bg-surface ${isDragging ? 'z-50 border-primary opacity-90 shadow-xl' : ''}`}
+      >
+        <div className="flex flex-wrap items-center gap-2 px-3 py-3">
+          <div className="flex min-h-8 items-center">
+            {isEditable ? (
+              <button
+                type="button"
+                className="cursor-grab touch-none p-0 text-text-muted hover:text-text-default active:cursor-grabbing"
+                {...attributes}
+                {...listeners}
+                aria-label="Drag to reorder"
+              >
+                <GripVertical className="h-4 w-4" />
+              </button>
+            ) : (
+              <span className="text-xs font-semibold text-text-muted">Q{questionNumber}</span>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            aria-expanded={isExpanded}
+            aria-label={toggleLabel}
+            className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          >
+            <span className="text-text-muted">
+              {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            </span>
+            {isEditable ? (
+              <span className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{questionNumber}</span>
+            ) : null}
+            {state.question_type === 'multiple_choice' ? (
+              <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+                MC
+              </span>
+            ) : null}
+            {!isExpanded ? (
+              <span
+                data-testid={`question-${question.id}-collapsed-summary`}
+                className="min-w-0 flex-1 truncate text-sm font-medium text-text-default"
+              >
+                {collapsedSummary}
+              </span>
+            ) : null}
+          </button>
+
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-3">
+            {isEditable ? (
+              <>
+                <label
+                  htmlFor={`question-${question.id}-accordion-points`}
+                  className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-text-muted"
+                >
+                  <span>Pts</span>
+                  <Input
+                    id={`question-${question.id}-accordion-points`}
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={state.points}
+                    aria-label={`Question ${questionNumber} points`}
+                    onClick={(event) => event.stopPropagation()}
+                    onChange={(event) => updateState({ points: event.target.value })}
+                    onBlur={() => handleSave()}
+                    className="h-8 w-16 px-2 text-sm"
+                  />
+                </label>
+                {state.question_type === 'open_response' ? (
+                  <label
+                    htmlFor={`${codeToggleId}-accordion`}
+                    className="inline-flex items-center gap-2 text-sm text-text-default"
+                  >
+                    <input
+                      id={`${codeToggleId}-accordion`}
+                      type="checkbox"
+                      checked={state.response_monospace}
+                      aria-label={`Question ${questionNumber} code response`}
+                      onClick={(event) => event.stopPropagation()}
+                      onChange={(event) => {
+                        updateState({ response_monospace: event.target.checked })
+                        setTimeout(() => handleSave(), 0)
+                      }}
+                      className="h-3.5 w-3.5 rounded border-border text-primary focus:ring-primary"
+                    />
+                    <span>Code</span>
+                  </label>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+                  {pointsLabel}
+                </span>
+                {state.question_type === 'open_response' && state.response_monospace ? (
+                  <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+                    Code
+                  </span>
+                ) : null}
+              </>
+            )}
+
+            {isEditable ? (
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Duplicate question ${questionNumber}`}
+                  className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
+                  onClick={() => onDuplicate?.(question.id)}
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Delete question ${questionNumber}`}
+                  className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-danger"
+                  onClick={() => onDelete(question.id)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {isExpanded ? (
+          <div className="space-y-0 border-t border-border">
+            {isEditable ? (
+              <>
+                <div className="bg-surface">
+                  <textarea
+                    value={state.question_text}
+                    onChange={(event) => updateState({ question_text: event.target.value })}
+                    onBlur={() => handleSave()}
+                    placeholder={questionPlaceholder}
+                    rows={4}
+                    className="block w-full min-h-[112px] resize-y border-0 bg-surface px-4 py-4 text-sm text-text-default placeholder:text-text-muted focus:outline-none focus:ring-0"
+                  />
+                </div>
+                {multipleChoiceEditor}
+                {openResponseEditor}
+              </>
+            ) : (
+              <>
+                <div className="bg-surface">
+                  <QuestionMarkdown content={state.question_text} className="px-4 py-4" />
+                </div>
+                {multipleChoiceEditor}
+                {openResponseEditor}
+              </>
+            )}
+
+            {error ? <p className="text-sm text-danger">{error}</p> : null}
+          </div>
+        ) : null}
       </div>
     )
   }
@@ -367,14 +555,14 @@ export function TestQuestionEditor({
     <div
       ref={setNodeRef}
       style={sortableStyle}
-      className={`border border-border rounded-lg p-3 bg-surface ${isDragging ? 'shadow-xl scale-[1.02] z-50 border-primary opacity-90' : ''}`}
+      className={`rounded-lg border border-border bg-surface p-3 ${isDragging ? 'z-50 scale-[1.02] border-primary opacity-90 shadow-xl' : ''}`}
     >
       <div className="grid gap-2 md:grid-cols-[16px_24px_minmax(0,1fr)_112px] md:gap-x-0">
         <div className="flex items-center justify-start md:self-center">
           {isEditable ? (
             <button
               type="button"
-              className="p-0 touch-none text-text-muted hover:text-text-default cursor-grab active:cursor-grabbing"
+              className="cursor-grab touch-none p-0 text-text-muted hover:text-text-default active:cursor-grabbing"
               {...attributes}
               {...listeners}
               aria-label="Drag to reorder"
@@ -397,97 +585,12 @@ export function TestQuestionEditor({
                 value={state.question_text}
                 onChange={(event) => updateState({ question_text: event.target.value })}
                 onBlur={() => handleSave()}
-                placeholder="Question prompt"
+                placeholder={questionPlaceholder}
                 rows={3}
                 className="w-full min-h-[88px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
               />
-
-              {state.question_type === 'multiple_choice' ? (
-                <div className="space-y-2">
-                  {state.options.map((option, index) => (
-                    <div key={index} className="flex items-center gap-2">
-                      <input
-                        type="radio"
-                        name={`correct-option-${question.id}`}
-                        checked={state.correct_option === index}
-                        onChange={() => {
-                          updateState({ correct_option: index })
-                          setTimeout(() => handleSave(), 0)
-                        }}
-                        className="h-4 w-4"
-                      />
-                      <Input
-                        type="text"
-                        value={option}
-                        onChange={(event) => updateOption(index, event.target.value)}
-                        onBlur={() => handleSave()}
-                        placeholder={`Option ${String.fromCharCode(65 + index)}`}
-                        className="flex-1"
-                      />
-                      {state.options.length > 2 && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            removeOption(index)
-                            setTimeout(() => handleSave(), 0)
-                          }}
-                          className="p-1 text-text-muted hover:text-danger"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      )}
-                    </div>
-                  ))}
-                  {state.options.length < MAX_QUIZ_OPTIONS && (
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={addOption}
-                      className="gap-1.5"
-                    >
-                      <Plus className="h-4 w-4" />
-                      Option
-                    </Button>
-                  )}
-                </div>
-              ) : (
-                <div className="space-y-2 rounded-md border border-border bg-surface-2 px-3 py-2">
-                  <button
-                    type="button"
-                    onClick={() => setIsAnswerSectionOpen((prev) => !prev)}
-                    className="w-full text-left text-xs font-semibold uppercase tracking-wide text-text-muted hover:text-text-default"
-                  >
-                    {isAnswerSectionOpen
-                      ? 'Hide Grading Notes'
-                      : state.answer_key.trim() || state.sample_solution.trim()
-                      ? 'Grading Notes Added'
-                      : 'Add Grading Notes'}
-                  </button>
-                  {isAnswerSectionOpen ? (
-                    <div className="space-y-2">
-                      <textarea
-                        value={state.answer_key}
-                        onChange={(event) => updateState({ answer_key: event.target.value })}
-                        onBlur={() => handleSave()}
-                        placeholder="Enter an optional answer key for AI-assisted grading..."
-                        rows={4}
-                        className="w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-                      />
-                      <textarea
-                        value={state.sample_solution}
-                        onChange={(event) => updateState({ sample_solution: event.target.value })}
-                        onBlur={() => handleSave()}
-                        placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
-                        rows={6}
-                        className="w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              )}
+              {multipleChoiceEditor}
+              {openResponseEditor}
             </>
           ) : (
             <>
@@ -511,7 +614,7 @@ export function TestQuestionEditor({
         {isEditable ? (
           <div className="w-full min-w-0 space-y-2 rounded-md border border-border bg-surface-2 p-2.5 md:self-start">
             <div className="grid min-w-0 grid-cols-[1fr_52px] items-center gap-2">
-              <label className="text-[11px] font-medium uppercase tracking-wide leading-none text-text-muted">
+              <label className="text-[11px] font-medium uppercase leading-none tracking-wide text-text-muted">
                 Points
               </label>
               <Input
@@ -526,7 +629,10 @@ export function TestQuestionEditor({
 
             {state.question_type === 'open_response' ? (
               <div className="grid min-w-0 grid-cols-[1fr_52px] items-center gap-2">
-                <label htmlFor={codeToggleId} className="text-[11px] font-medium uppercase tracking-wide leading-none text-text-muted">
+                <label
+                  htmlFor={codeToggleId}
+                  className="text-[11px] font-medium uppercase leading-none tracking-wide text-text-muted"
+                >
                   Code
                 </label>
                 <div className="flex h-8 items-center justify-start">
@@ -544,34 +650,22 @@ export function TestQuestionEditor({
               </div>
             ) : null}
 
-            <div className="space-y-2 pt-1">
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                onClick={() => handleSave({ force: true })}
-                disabled={!isDirty}
-                className="w-full min-w-0 px-2"
-              >
-                Save
-              </Button>
-              <Button
-                type="button"
-                variant="danger"
-                size="sm"
-                onClick={() => onDelete(question.id)}
-                className="w-full min-w-0 px-2"
-              >
-                Delete
-              </Button>
-            </div>
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              onClick={() => onDelete(question.id)}
+              className="w-full min-w-0 px-2"
+            >
+              Delete
+            </Button>
           </div>
         ) : (
           <div />
         )}
       </div>
 
-      {error && <p className="text-sm text-danger pl-7 mt-2">{error}</p>}
+      {error ? <p className="mt-2 pl-7 text-sm text-danger">{error}</p> : null}
     </div>
   )
 }

--- a/src/components/WorkspaceSplitPane.tsx
+++ b/src/components/WorkspaceSplitPane.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import type { CSSProperties, ReactNode, PointerEventHandler } from 'react'
+import { cn } from '@/ui/utils'
+
+interface WorkspaceSplitDivider {
+  label: string
+  onPointerDown: PointerEventHandler<HTMLDivElement>
+  onDoubleClick?: () => void
+  className?: string
+  lineClassName?: string
+}
+
+interface WorkspaceSplitPaneProps {
+  left: ReactNode
+  right?: ReactNode
+  rightVisible?: boolean
+  className?: string
+  leftPaneClassName?: string
+  rightPaneClassName?: string
+  leftPaneStyle?: CSSProperties
+  rightPaneStyle?: CSSProperties
+  divider?: WorkspaceSplitDivider
+  orientation?: 'row' | 'responsive'
+  ['data-testid']?: string
+}
+
+export function WorkspaceSplitPane({
+  left,
+  right,
+  rightVisible = true,
+  className,
+  leftPaneClassName,
+  rightPaneClassName,
+  leftPaneStyle,
+  rightPaneStyle,
+  divider,
+  orientation = 'responsive',
+  'data-testid': dataTestId,
+}: WorkspaceSplitPaneProps) {
+  const rootOrientationClass = orientation === 'row' ? 'flex-row' : 'flex-col lg:flex-row'
+  const dividerVisibilityClass = orientation === 'row' ? 'block' : 'hidden lg:block'
+  const rightBorderClass = orientation === 'row' ? 'border-l border-border' : 'border-t border-border lg:border-l lg:border-t-0'
+
+  return (
+    <div
+      className={cn('flex h-full min-h-0 overflow-hidden', rootOrientationClass, className)}
+      data-testid={dataTestId}
+    >
+      <div
+        className={cn('min-h-0 flex-1 overflow-hidden', leftPaneClassName)}
+        style={leftPaneStyle}
+      >
+        {left}
+      </div>
+
+      {rightVisible && divider ? (
+        <div className={cn('relative w-0 shrink-0', dividerVisibilityClass)}>
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={divider.label}
+            className={cn(
+              'absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent',
+              divider.className,
+            )}
+            onPointerDown={divider.onPointerDown}
+            onDoubleClick={divider.onDoubleClick}
+          >
+            <div
+              className={cn(
+                'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border',
+                divider.lineClassName,
+              )}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {rightVisible ? (
+        <div
+          className={cn('min-h-0 overflow-hidden', !divider && rightBorderClass, rightPaneClassName)}
+          style={rightPaneStyle}
+        >
+          {right}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
@@ -247,7 +247,7 @@ describe('QuizDetailPanel', () => {
       expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
     })
 
-    it('renders tests in summary-detail mode with question summaries on the left and details on the right', async () => {
+    it('renders tests in summary-detail mode with accordion editors on the left and markdown on the right', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -291,26 +291,453 @@ describe('QuizDetailPanel', () => {
       )
 
       expect(await screen.findByTestId('test-summary-detail-layout')).toBeInTheDocument()
-      expect(screen.getByTestId('test-question-summary-pane')).toBeInTheDocument()
-      expect(screen.getByTestId('test-question-detail-pane')).toBeInTheDocument()
+      const editorPane = screen.getByTestId('test-question-editor-pane')
+      const markdownPane = screen.getByTestId('test-question-markdown-pane')
+      expect(editorPane).toBeInTheDocument()
+      expect(markdownPane).toBeInTheDocument()
+      expect(within(editorPane).getByTestId('test-documents-card')).toBeInTheDocument()
+      expect(within(editorPane).getByText('Documents')).toBeInTheDocument()
+      expect(within(editorPane).getByText('0 documents')).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toBeInTheDocument()
 
-      expect(screen.getByText('6 pts')).toBeInTheDocument()
-      expect(screen.getByLabelText('Question 1 code response')).toBeChecked()
-      expect(screen.getByText('MC')).toBeInTheDocument()
-
-      expect(screen.getByDisplayValue('Explain the runtime complexity of your solution.')).toBeInTheDocument()
+      expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('2 questions')
+      expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('9 pts')
+      expect(within(editorPane).getByRole('button', { name: 'Expand all questions' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Collapse question 1' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Expand question 2' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Duplicate question 1' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toHaveClass('bg-primary')
+      expect(within(editorPane).getByRole('button', { name: 'Choose question type' })).toBeInTheDocument()
+      expect(within(editorPane).getByLabelText('Question 1 points')).toHaveValue(6)
+      expect(within(editorPane).getByLabelText('Question 1 code response')).toBeChecked()
+      expect(within(editorPane).getByTestId('question-sq2-collapsed-summary')).toHaveTextContent(
+        'Which traversal visits the root node first?'
+      )
+      expect(within(editorPane).getByDisplayValue('Explain the runtime complexity of your solution.')).toBeInTheDocument()
       expect(
-        screen.getByDisplayValue('Look for linear-time reasoning and mention of hash-map tradeoffs.')
+        within(editorPane).getByDisplayValue('Look for linear-time reasoning and mention of hash-map tradeoffs.')
       ).toBeInTheDocument()
+      expect(within(editorPane).queryByDisplayValue('Which traversal visits the root node first?')).not.toBeInTheDocument()
 
-      fireEvent.click(screen.getByRole('button', { name: 'Select question 2' }))
+      const markdownEditor = within(markdownPane).getByTestId('test-markdown-editor')
+      expect((markdownEditor as HTMLTextAreaElement).value).toContain('Explain the runtime complexity of your solution.')
+      expect((markdownEditor as HTMLTextAreaElement).value).toContain('Which traversal visits the root node first?')
+      expect(markdownEditor).toHaveProperty('readOnly', true)
+      expect(within(markdownPane).getByTestId('markdown-helper-status')).toHaveTextContent('Markdown mirror')
+      expect(within(markdownPane).getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
+      expect(within(markdownPane).queryByText('Markdown')).not.toBeInTheDocument()
+      expect(within(markdownPane).queryByText('Edit the full test source alongside the structured questions.')).not.toBeInTheDocument()
+      expect(within(markdownPane).queryByRole('button', { name: 'Details' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Select question 2' })).not.toBeInTheDocument()
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Collapse documents' }))
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('Which traversal visits the root node first?')).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Expand documents' })).toBeInTheDocument()
+        expect(within(editorPane).queryByRole('button', { name: 'Add Document' })).not.toBeInTheDocument()
       })
-      expect(screen.getByDisplayValue('Inorder')).toBeInTheDocument()
-      expect(screen.getByDisplayValue('Preorder')).toBeInTheDocument()
-      expect(screen.getByDisplayValue('Postorder')).toBeInTheDocument()
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Expand documents' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByRole('button', { name: 'Collapse documents' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Expand all questions' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByRole('button', { name: 'Collapse all questions' })).toBeInTheDocument()
+        expect(within(editorPane).getByLabelText('Question 2 points')).toHaveValue(3)
+        expect(within(editorPane).getByDisplayValue('Which traversal visits the root node first?')).toBeInTheDocument()
+        expect(within(editorPane).queryByTestId('question-sq2-collapsed-summary')).not.toBeInTheDocument()
+        expect(within(editorPane).getByDisplayValue('Inorder')).toBeInTheDocument()
+        expect(within(editorPane).getByDisplayValue('Preorder')).toBeInTheDocument()
+        expect(within(editorPane).getByDisplayValue('Postorder')).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Collapse all questions' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByRole('button', { name: 'Expand all questions' })).toBeInTheDocument()
+        expect(within(editorPane).queryByDisplayValue('Explain the runtime complexity of your solution.')).not.toBeInTheDocument()
+        expect(within(editorPane).queryByDisplayValue('Which traversal visits the root node first?')).not.toBeInTheDocument()
+        expect(within(editorPane).getByTestId('question-sq1-collapsed-summary')).toHaveTextContent(
+          'Explain the runtime complexity of your solution.'
+        )
+        expect(within(editorPane).getByTestId('question-sq2-collapsed-summary')).toHaveTextContent(
+          'Which traversal visits the root node first?'
+        )
+      })
+    })
+
+    it('duplicates a test question immediately below the source in summary-detail mode', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Duplicate Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Duplicate Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Duplicate question 1' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('3 questions')
+        expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('15 pts')
+        expect(within(editorPane).getByRole('button', { name: 'Collapse question 1' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Collapse question 2' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Expand question 3' })).toBeInTheDocument()
+        expect(within(editorPane).getByLabelText('Question 2 points')).toHaveValue(6)
+        expect(within(editorPane).getByLabelText('Question 2 code response')).toBeChecked()
+        expect(
+          within(editorPane).getAllByDisplayValue('Explain the runtime complexity of your solution.')
+        ).toHaveLength(2)
+        expect(within(editorPane).getByTestId('question-sq2-collapsed-summary')).toHaveTextContent(
+          'Which traversal visits the root node first?'
+        )
+      })
+    })
+
+    it('remembers the last selected question type in the add split button', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Split Button Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Split Button Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toBeInTheDocument()
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Choose question type' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('3 questions')
+        expect(within(editorPane).getByRole('button', { name: '+ Open Question' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: '+ Open Question' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('4 questions')
+        expect(within(editorPane).getByRole('button', { name: '+ Open Question' })).toBeInTheDocument()
+      })
+    })
+
+    it('updates the markdown mirror immediately after structured edits in summary-detail mode', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Mirror Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Mirror Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      const markdownPane = screen.getByTestId('test-question-markdown-pane')
+      const promptField = within(editorPane).getByDisplayValue('Explain the runtime complexity of your solution.')
+
+      fireEvent.change(promptField, {
+        target: { value: 'Explain the amortized runtime complexity of your solution.' },
+      })
+      fireEvent.blur(promptField)
+
+      await waitFor(() => {
+        expect(
+          (within(markdownPane).getByTestId('test-markdown-editor') as HTMLTextAreaElement).value
+        ).toContain('Explain the amortized runtime complexity of your solution.')
+      })
+
+      const patchCalls = fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')
+      expect(patchCalls).toHaveLength(0)
+    })
+
+    it('locks the left pane while markdown edits are pending in summary-detail mode', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Pending Markdown Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Pending Markdown Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      const markdownPane = screen.getByTestId('test-question-markdown-pane')
+      const markdownEditor = within(markdownPane).getByTestId('test-markdown-editor')
+
+      fireEvent.click(within(markdownPane).getByRole('button', { name: 'Edit Markdown' }))
+      expect(markdownEditor).toHaveProperty('readOnly', false)
+
+      fireEvent.change(markdownEditor, {
+        target: { value: '# Test\nTitle: Pending Markdown Test\nShow Results: true\n' },
+      })
+
+      await waitFor(() => {
+        expect(within(markdownPane).getByTestId('markdown-helper-status')).toHaveTextContent(
+          'Markdown edits not applied'
+        )
+        expect(within(markdownPane).getByRole('button', { name: 'Apply Markdown' })).toBeInTheDocument()
+        expect(within(markdownPane).getByRole('button', { name: 'Undo markdown edits' })).toBeInTheDocument()
+        expect(screen.getByTestId('markdown-pending-lock')).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toBeDisabled()
+      })
+    })
+
+    it('applies markdown to the left pane before the save request resolves', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      let resolvePatch: ((value: { ok: boolean; json: () => Promise<any> }) => void) | null = null
+      const patchPromise = new Promise<{ ok: boolean; json: () => Promise<any> }>((resolve) => {
+        resolvePatch = resolve
+      })
+
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Apply Timing Test',
+                show_results: true,
+                questions: summaryDetailQuestions,
+              },
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [],
+            },
+          }),
+        })
+        .mockImplementationOnce(() => patchPromise as unknown as Promise<Response>)
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Apply Timing Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      const markdownPane = screen.getByTestId('test-question-markdown-pane')
+
+      fireEvent.click(within(markdownPane).getByRole('button', { name: 'Edit Markdown' }))
+      fireEvent.change(within(markdownPane).getByTestId('test-markdown-editor'), {
+        target: {
+          value: `# Test
+Title: Apply Timing Test Updated
+Show Results: true
+
+## Questions
+### Question 1
+ID: ${markdownQuestionId1}
+Type: multiple_choice
+Points: 1
+Prompt:
+Updated prompt before save returns?
+Options:
+- A
+- B
+Correct Option: 2
+
+## Documents
+_None_
+`,
+        },
+      })
+      fireEvent.click(within(markdownPane).getByRole('button', { name: 'Apply Markdown' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByDisplayValue('Updated prompt before save returns?')).toBeInTheDocument()
+        expect(within(markdownPane).getByTestId('markdown-helper-status')).toHaveTextContent('Applying markdown...')
+      })
+
+      resolvePatch?.({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 2,
+            content: {
+              title: 'Apply Timing Test Updated',
+              show_results: true,
+              questions: [
+                {
+                  id: markdownQuestionId1,
+                  question_type: 'multiple_choice',
+                  question_text: 'Updated prompt before save returns?',
+                  options: ['A', 'B'],
+                  correct_option: 1,
+                  answer_key: null,
+                  sample_solution: null,
+                  points: 1,
+                  response_max_chars: 5000,
+                  response_monospace: false,
+                },
+              ],
+            },
+          },
+        }),
+      })
+
+      await waitFor(() => {
+        expect(within(markdownPane).getByText('Markdown applied')).toBeInTheDocument()
+      })
     })
 
     it('saves draft and opens student preview route for tests', async () => {
@@ -545,7 +972,7 @@ describe('QuizDetailPanel', () => {
   })
 
   describe('Markdown tab', () => {
-    it('loads and resets to the persisted source markdown instead of regenerating from structured fields', async () => {
+    it('loads persisted markdown as a read-only mirror and undo restores it after edits', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       const persistedSourceMarkdown = `# Test
 Title: Markdown Test
@@ -609,13 +1036,23 @@ Correct Option: 2
       fireEvent.click(await screen.findByText('Markdown'))
 
       const textarea = await screen.findByRole('textbox')
-      expect(textarea).toHaveValue(persistedSourceMarkdown)
+      expect((textarea as HTMLTextAreaElement).value).toContain('Favorite color?')
+      expect((textarea as HTMLTextAreaElement).value).toContain('Favorite animal?')
+      expect(textarea).not.toHaveValue(persistedSourceMarkdown)
+      expect(textarea).toHaveProperty('readOnly', true)
+      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Markdown mirror')
+      expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
 
+      fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
+      expect(screen.getByRole('textbox')).toHaveProperty('readOnly', false)
       fireEvent.change(textarea, { target: { value: 'edited markdown' } })
-      fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Markdown edits not applied')
+      fireEvent.click(screen.getByRole('button', { name: 'Undo markdown edits' }))
 
       await waitFor(() => {
-        expect(screen.getByRole('textbox')).toHaveValue(persistedSourceMarkdown)
+        expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('Favorite color?')
+        expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toContain('Favorite animal?')
+        expect(screen.getByRole('textbox')).toHaveProperty('readOnly', true)
       })
     })
 
@@ -700,6 +1137,7 @@ Correct Option: 2
       })
 
       fireEvent.click(screen.getByText('Markdown'))
+      fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
       fireEvent.change(screen.getByRole('textbox'), {
         target: {
           value: `# Test
@@ -798,6 +1236,7 @@ _None_
       })
 
       fireEvent.click(screen.getByText('Markdown'))
+      fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
       fireEvent.change(screen.getByRole('textbox'), {
         target: {
           value: `# Test
@@ -871,7 +1310,7 @@ Prompt:
       })
 
       fireEvent.click(screen.getByText('Markdown'))
-      fireEvent.click(screen.getByRole('button', { name: 'Copy Schema' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Schema' }))
 
       await waitFor(() => {
         expect(clipboardWriteText).toHaveBeenCalledWith(TEST_MARKDOWN_AI_SCHEMA)
@@ -966,15 +1405,13 @@ Prompt:
         expect(screen.getByDisplayValue('Explain your reasoning')).toBeInTheDocument()
       })
 
-      const promptField = screen.getByPlaceholderText('Question prompt')
+      const promptField = screen.getByPlaceholderText('Question 1')
       expect(promptField.tagName).toBe('TEXTAREA')
 
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.queryByPlaceholderText('Character limit')).not.toBeInTheDocument()
       expect(screen.getByLabelText('Code')).toBeInTheDocument()
       expect(screen.getByText('Points')).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
       const promptFieldGridCheck = screen.getByDisplayValue('Explain your reasoning')
       const gridContainer = promptFieldGridCheck.closest('div')?.parentElement
       expect(gridContainer?.className).toContain('md:grid-cols-[16px_24px_minmax(0,1fr)_112px]')
@@ -1089,18 +1526,13 @@ Prompt:
       })
 
       fireEvent.click(screen.getByRole('button', { name: 'Add Grading Notes' }))
+      const answerKeyField = screen.getByPlaceholderText('Enter an optional answer key for AI-assisted grading...')
       fireEvent.change(
-        screen.getByPlaceholderText('Enter an optional answer key for AI-assisted grading...'),
+        answerKeyField,
         { target: { value: 'Objects resist changes in motion.' } }
       )
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-
-      await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith(
-          expect.stringContaining('/api/teacher/tests/'),
-          expect.objectContaining({ method: 'PATCH' })
-        )
-      })
+      fireEvent.blur(answerKeyField)
+      await new Promise((resolve) => setTimeout(resolve, 3_200))
 
       const patchCall = [...fetchMock.mock.calls]
         .reverse()
@@ -1110,6 +1542,7 @@ Prompt:
             typeof call[0] === 'string' &&
             call[0].includes('/draft')
         )
+      expect(patchCall).toBeTruthy()
       const patchBody = JSON.parse(patchCall?.[1]?.body ?? '{}')
       const answerKeyFromContent = patchBody?.content?.questions?.[0]?.answer_key
       const answerKeyFromPatch = Array.isArray(patchBody?.patch)
@@ -1160,16 +1593,16 @@ Prompt:
       fireEvent.click(screen.getByText('Questions (0)'))
 
       await waitFor(() => {
-        expect(screen.getByText('Add MC Question')).toBeInTheDocument()
+        expect(screen.getByText('+ MC Question')).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByText('Add MC Question'))
+      fireEvent.click(screen.getByText('+ MC Question'))
 
       await waitFor(() => {
         expect(screen.getByText('Questions (1)')).toBeInTheDocument()
       })
 
-      const promptField = screen.getByPlaceholderText('Question prompt') as HTMLTextAreaElement
+      const promptField = screen.getByPlaceholderText('Question 1') as HTMLTextAreaElement
       expect(promptField.value).toBe('')
       expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
 

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -372,6 +372,66 @@ describe('QuizDetailPanel', () => {
       })
     })
 
+    it('keeps the markdown helper available for empty tests in summary-detail mode', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Empty Markdown Import Test',
+              show_results: true,
+              questions: [],
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Empty Markdown Import Test',
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const markdownPane = await screen.findByTestId('test-question-markdown-pane')
+      const markdownEditor = within(markdownPane).getByTestId('test-markdown-editor')
+
+      expect(markdownEditor).toBeInTheDocument()
+      expect(markdownEditor).toHaveProperty('readOnly', true)
+      expect(within(markdownPane).getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
+
+      fireEvent.click(within(markdownPane).getByRole('button', { name: 'Edit Markdown' }))
+      fireEvent.change(markdownEditor, {
+        target: { value: '# Test\nTitle: Empty Markdown Import Test\nShow Results: true\n' },
+      })
+
+      await waitFor(() => {
+        expect(within(markdownPane).getByRole('button', { name: 'Apply Markdown' })).toBeInTheDocument()
+      })
+    })
+
     it('duplicates a test question immediately below the source in summary-detail mode', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({
@@ -560,6 +620,7 @@ describe('QuizDetailPanel', () => {
     })
 
     it('locks the left pane while markdown edits are pending in summary-detail mode', async () => {
+      const onPendingMarkdownImportChange = vi.fn()
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -595,6 +656,7 @@ describe('QuizDetailPanel', () => {
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
           onQuizUpdate={vi.fn()}
+          onPendingMarkdownImportChange={onPendingMarkdownImportChange}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -621,6 +683,7 @@ describe('QuizDetailPanel', () => {
         expect(within(markdownPane).getByRole('button', { name: 'Undo markdown edits' })).toBeInTheDocument()
         expect(screen.getByTestId('markdown-pending-lock')).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toBeDisabled()
+        expect(onPendingMarkdownImportChange).toHaveBeenLastCalledWith(true)
       })
     })
 

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -25,6 +25,32 @@ const sampleQuestions: QuizQuestion[] = [
   createMockQuizQuestion({ id: 'q2', question_text: 'Favorite animal?', options: ['Cat', 'Dog'], position: 1 }),
 ]
 
+const summaryDetailQuestions: QuizQuestion[] = [
+  createMockQuizQuestion({
+    id: 'sq1',
+    assessment_type: 'test',
+    question_type: 'open_response',
+    question_text: 'Explain the runtime complexity of your solution.',
+    options: [],
+    correct_option: null,
+    answer_key: 'Look for linear-time reasoning and mention of hash-map tradeoffs.',
+    sample_solution: 'A good answer explains O(n) time and O(n) space.',
+    points: 6,
+    response_monospace: true,
+    position: 0,
+  }),
+  createMockQuizQuestion({
+    id: 'sq2',
+    assessment_type: 'test',
+    question_type: 'multiple_choice',
+    question_text: 'Which traversal visits the root node first?',
+    options: ['Inorder', 'Preorder', 'Postorder'],
+    correct_option: 1,
+    points: 3,
+    position: 1,
+  }),
+]
+
 const sampleResults: QuizResultsAggregate[] = [
   { question_id: 'q1', question_text: 'Favorite color?', options: ['Red', 'Blue', 'Green'], counts: [5, 10, 5], total_responses: 20 },
   { question_id: 'q2', question_text: 'Favorite animal?', options: ['Cat', 'Dog'], counts: [12, 8], total_responses: 20 },
@@ -217,8 +243,74 @@ describe('QuizDetailPanel', () => {
       const tabLabels = Array.from(tabStrip!.children)
         .filter((element) => element.tagName === 'BUTTON')
         .map((element) => element.textContent?.trim() || '')
-      expect(tabLabels).toEqual(['Questions (2)', 'Documents (1)', 'Markdown', 'Results (0)'])
+      expect(tabLabels).toEqual(['Questions (2)', 'Documents (1)', 'Markdown'])
       expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
+    })
+
+    it('renders tests in summary-detail mode with question summaries on the left and details on the right', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Two Pane Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Two Pane Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByTestId('test-summary-detail-layout')).toBeInTheDocument()
+      expect(screen.getByTestId('test-question-summary-pane')).toBeInTheDocument()
+      expect(screen.getByTestId('test-question-detail-pane')).toBeInTheDocument()
+
+      expect(screen.getByText('6 pts')).toBeInTheDocument()
+      expect(screen.getByLabelText('Question 1 code response')).toBeChecked()
+      expect(screen.getByText('MC')).toBeInTheDocument()
+
+      expect(screen.getByDisplayValue('Explain the runtime complexity of your solution.')).toBeInTheDocument()
+      expect(
+        screen.getByDisplayValue('Look for linear-time reasoning and mention of hash-map tradeoffs.')
+      ).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select question 2' }))
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Which traversal visits the root node first?')).toBeInTheDocument()
+      })
+      expect(screen.getByDisplayValue('Inorder')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Preorder')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Postorder')).toBeInTheDocument()
     })
 
     it('saves draft and opens student preview route for tests', async () => {
@@ -513,6 +605,8 @@ Correct Option: 2
         />,
         { wrapper: Wrapper }
       )
+
+      fireEvent.click(await screen.findByText('Markdown'))
 
       const textarea = await screen.findByRole('textbox')
       expect(textarea).toHaveValue(persistedSourceMarkdown)

--- a/tests/components/SummaryDetailWorkspaceShell.test.tsx
+++ b/tests/components/SummaryDetailWorkspaceShell.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+
+describe('SummaryDetailWorkspaceShell', () => {
+  it('defaults row workspaces to a 50/50 split', () => {
+    render(
+      <SummaryDetailWorkspaceShell
+        orientation="row"
+        data-testid="row-shell"
+        left={<div>Left pane</div>}
+        right={<div>Right pane</div>}
+      />,
+    )
+
+    expect(screen.getByText('Left pane')).toBeInTheDocument()
+    expect(screen.getByText('Right pane')).toBeInTheDocument()
+
+    const root = screen.getByTestId('row-shell')
+    const rightPane = root.lastElementChild as HTMLElement | null
+    expect(rightPane).toHaveStyle({
+      width: '50%',
+      flexBasis: '50%',
+    })
+  })
+
+  it('preserves divider interactions and custom right widths', () => {
+    const onPointerDown = vi.fn()
+    const onDoubleClick = vi.fn()
+
+    render(
+      <SummaryDetailWorkspaceShell
+        orientation="responsive"
+        data-testid="responsive-shell"
+        left={<div>Table pane</div>}
+        right={<div>Inspector pane</div>}
+        rightWidthPercent={42}
+        divider={{
+          label: 'Resize panes',
+          onPointerDown,
+          onDoubleClick,
+        }}
+      />,
+    )
+
+    const separator = screen.getByRole('separator', { name: 'Resize panes' })
+    fireEvent.pointerDown(separator)
+    fireEvent.doubleClick(separator)
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1)
+    expect(onDoubleClick).toHaveBeenCalledTimes(1)
+    const root = screen.getByTestId('responsive-shell')
+    const rightPane = root.lastElementChild as HTMLElement | null
+    expect(rightPane).toHaveStyle({
+      width: '42%',
+      flexBasis: '42%',
+    })
+  })
+})

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -3,15 +3,16 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { TeacherQuizzesTab } from '@/app/classrooms/[classroomId]/TeacherQuizzesTab'
 import { TooltipProvider } from '@/ui'
-import {
-  TEACHER_QUIZZES_UPDATED_EVENT,
-  TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
-} from '@/lib/events'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
 import type { QuizAssessmentType, QuizWithStats } from '@/types'
 
+const { setOpenMock } = vi.hoisted(() => ({
+  setOpenMock: vi.fn(),
+}))
+
 vi.mock('@/components/layout', () => ({
-  useRightSidebar: () => ({ setOpen: vi.fn() }),
+  useRightSidebar: () => ({ setOpen: setOpenMock }),
 }))
 
 vi.mock('@/components/QuizModal', () => ({
@@ -30,8 +31,8 @@ vi.mock('@/components/QuizModal', () => ({
         onClick={() =>
           onSuccess(
             createMockQuiz({
-              id: 'created-test-id',
-              title: 'Created Test',
+              id: 'created-quiz-id',
+              title: 'Created Quiz',
               assessment_type: assessmentType || 'quiz',
             }) as QuizWithStats
           )
@@ -57,16 +58,9 @@ function makeQuiz(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
 
 function listFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   return fetchMock.mock.calls.filter(
-    ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/') && url.includes('?classroom_id=')
+    ([url]: [string]) =>
+      typeof url === 'string' && url.includes('/api/teacher/quizzes') && url.includes('?classroom_id=')
   )
-}
-
-function studentCheckboxOrder(): string[] {
-  return screen
-    .getAllByRole('checkbox')
-    .map((checkbox) => checkbox.getAttribute('aria-label') || '')
-    .filter((label) => label.startsWith('Select ') && label !== 'Select all students')
-    .map((label) => label.replace(/^Select /, ''))
 }
 
 describe('TeacherQuizzesTab', () => {
@@ -76,6 +70,7 @@ describe('TeacherQuizzesTab', () => {
   beforeEach(() => {
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
+    setOpenMock.mockReset()
   })
 
   afterEach(() => {
@@ -90,29 +85,10 @@ describe('TeacherQuizzesTab', () => {
     })
   }
 
-  function renderTab(
-    assessmentType: QuizAssessmentType = 'quiz',
-    options?: {
-      onSelectQuiz?: (quiz: QuizWithStats | null) => void
-      onTestGradingDataRefresh?: () => void
-      onTestGradingContextChange?: (context: {
-        mode: 'authoring' | 'grading'
-        testId: string | null
-        studentId: string | null
-        studentName: string | null
-      }) => void
-    }
-  ) {
-    render(
-      <TeacherQuizzesTab
-        classroom={classroom}
-        assessmentType={assessmentType}
-        onSelectQuiz={options?.onSelectQuiz}
-        onTestGradingDataRefresh={options?.onTestGradingDataRefresh}
-        onTestGradingContextChange={options?.onTestGradingContextChange}
-      />,
-      { wrapper: Wrapper }
-    )
+  function renderTab(assessmentType: QuizAssessmentType = 'quiz') {
+    render(<TeacherQuizzesTab classroom={classroom} assessmentType={assessmentType} />, {
+      wrapper: Wrapper,
+    })
   }
 
   it('fetches quizzes once on mount', async () => {
@@ -122,6 +98,7 @@ describe('TeacherQuizzesTab', () => {
     await waitFor(() => {
       expect(listFetchCalls(fetchMock)).toHaveLength(1)
     })
+
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/quizzes?classroom_id=')
   })
 
@@ -133,7 +110,6 @@ describe('TeacherQuizzesTab', () => {
       expect(listFetchCalls(fetchMock)).toHaveLength(1)
     })
 
-    // Provide response for the event-triggered reload
     mockQuizzesResponse([])
 
     act(() => {
@@ -147,10 +123,6 @@ describe('TeacherQuizzesTab', () => {
     await waitFor(() => {
       expect(listFetchCalls(fetchMock)).toHaveLength(2)
     })
-
-    // Wait a tick to ensure no additional fetch sneaks in
-    await new Promise((r) => setTimeout(r, 50))
-    expect(listFetchCalls(fetchMock)).toHaveLength(2)
   })
 
   it('does not double-fetch after quiz creation', async () => {
@@ -161,760 +133,22 @@ describe('TeacherQuizzesTab', () => {
       expect(listFetchCalls(fetchMock)).toHaveLength(1)
     })
 
-    // Provide response for the post-creation reload
     mockQuizzesResponse([makeQuiz()])
 
-    // Open modal and trigger creation success
     fireEvent.click(screen.getByText('New Quiz'))
     fireEvent.click(screen.getByTestId('mock-quiz-save'))
 
-    // The event listener should trigger exactly one reload
     await waitFor(() => {
       expect(listFetchCalls(fetchMock)).toHaveLength(2)
     })
-
-    // Confirm no extra fetch
-    await new Promise((r) => setTimeout(r, 50))
-    expect(listFetchCalls(fetchMock)).toHaveLength(2)
   })
 
-  it('ignores update events for other classrooms', async () => {
-    mockQuizzesResponse([])
-    renderTab()
-
-    await waitFor(() => {
-      expect(listFetchCalls(fetchMock)).toHaveLength(1)
-    })
-
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, {
-          detail: { classroomId: 'other-classroom' },
-        })
-      )
-    })
-
-    await new Promise((r) => setTimeout(r, 50))
-    expect(listFetchCalls(fetchMock)).toHaveLength(1)
-  })
-
-  it('renders test mode and fetches from tests API', async () => {
-    mockQuizzesResponse([])
-    renderTab('test')
-
-    await waitFor(() => {
-      expect(listFetchCalls(fetchMock)).toHaveLength(1)
-    })
-
-    expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
-    expect(screen.getByText('New Test')).toBeInTheDocument()
-  })
-
-  it('renders tests in newest-first order without a closed-tests archive', async () => {
-    mockQuizzesResponse([
-      makeQuiz({ id: 'active-new', title: 'Newest Active Test', assessment_type: 'test', status: 'active', position: 4 }),
-      makeQuiz({ id: 'draft-old', title: 'Older Draft Test', assessment_type: 'test', status: 'draft', position: 3 }),
-      makeQuiz({ id: 'closed-new', title: 'Newest Closed Test', assessment_type: 'test', status: 'closed', position: 2 }),
-      makeQuiz({ id: 'closed-old', title: 'Older Closed Test', assessment_type: 'test', status: 'closed', position: 1 }),
-    ])
-
-    renderTab('test')
-
-    await waitFor(() => {
-      expect(screen.getByText('Newest Active Test')).toBeInTheDocument()
-    })
-
-    expect(screen.queryByRole('button', { name: /Closed tests \(\d+\)/i })).not.toBeInTheDocument()
-    expect(screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent)).toEqual([
-      'Newest Active Test',
-      'Older Draft Test',
-      'Newest Closed Test',
-      'Older Closed Test',
-    ])
-  })
-
-  it('auto-selects the first test in the newest-first list when grading mode opens', async () => {
-    const onSelectQuiz = vi.fn()
-    const onTestGradingContextChange = vi.fn()
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quizzes: [
-            makeQuiz({ id: 'closed-top', title: 'Closed Top Test', assessment_type: 'test', status: 'closed', position: 5 }),
-            makeQuiz({ id: 'active-next', title: 'Active Next Test', assessment_type: 'test', status: 'active', position: 4 }),
-          ],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: 'active-next', title: 'Active Next Test', grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
-          students: [],
-        }),
-      })
-
-    renderTab('test', { onSelectQuiz, onTestGradingContextChange })
-    await screen.findByText('Active Next Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-
-    await waitFor(() => {
-      expect(onSelectQuiz).toHaveBeenCalledWith(expect.objectContaining({ id: 'closed-top' }))
-    })
-    await waitFor(() => {
-      expect(onTestGradingContextChange).toHaveBeenCalledWith({
-        mode: 'grading',
-        testId: 'closed-top',
-        studentId: null,
-        studentName: null,
-      })
-    })
-  })
-
-  it('auto-selects newly created test and keeps tests in authoring mode', async () => {
-    const existing = makeQuiz({ id: 'existing-test', title: 'Existing Test', assessment_type: 'test' })
-    const created = makeQuiz({ id: 'created-test-id', title: 'Created Test', assessment_type: 'test', position: 1 })
-    const onSelectQuiz = vi.fn()
-    const onTestGradingContextChange = vi.fn()
-
-    mockQuizzesResponse([existing])
-    renderTab('test', { onSelectQuiz, onTestGradingContextChange })
-
-    await waitFor(() => {
-      expect(screen.getByText('New Test')).toBeInTheDocument()
-    })
-
-    mockQuizzesResponse([existing, created])
-    fireEvent.click(screen.getByText('New Test'))
-    fireEvent.click(screen.getByTestId('mock-quiz-save'))
-
-    await waitFor(() => {
-      expect(onSelectQuiz).toHaveBeenCalledWith(expect.objectContaining({ id: 'created-test-id' }))
-    })
-
-    await waitFor(() => {
-      expect(onTestGradingContextChange).toHaveBeenCalledWith({
-        mode: 'authoring',
-        testId: 'created-test-id',
-        studentId: null,
-        studentName: null,
-      })
-    })
-  })
-
-  it('shows iconized exits/away columns and formats last time without am/pm', async () => {
-    const quiz = makeQuiz({ id: 'test-signals', title: 'Signals Test', assessment_type: 'test' })
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
-          students: [
-            {
-              student_id: 'student-1',
-              name: 'Student One',
-              email: 'student1@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 1,
-              focus_summary: {
-                exit_count: 4,
-                away_total_seconds: 13,
-                away_count: 4,
-                route_exit_attempts: 2,
-                window_unmaximize_attempts: 3,
-              },
-            },
-          ],
-        }),
-      })
-
-    renderTab('test')
-    await screen.findByText('Signals Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-
-    const awaySignal = await screen.findByText('0:13')
-    const exitSignal = await screen.findByText('4')
-    const statusIcon = await screen.findByLabelText('Submitted')
-    const lastTimeCell = await screen.findByText('6:07')
-
-    expect(screen.queryByText('Status')).not.toBeInTheDocument()
-    expect(screen.getByLabelText('Exits column')).toBeInTheDocument()
-    expect(screen.getByLabelText('Away column')).toBeInTheDocument()
-    expect(statusIcon).toBeInTheDocument()
-    expect(lastTimeCell).toHaveClass('font-semibold')
-    expect(screen.queryByText(/am|pm/i)).not.toBeInTheDocument()
-
-    expect(exitSignal).toHaveAttribute(
-      'aria-label',
-      expect.stringContaining('Away/focus 4, in-app exits 2, window/full-screen exits 3')
-    )
-    expect(awaySignal).toHaveAttribute(
-      'aria-label',
-      expect.stringContaining('Away from test route')
-    )
-    expect(screen.queryByLabelText(/Focus events/i)).not.toBeInTheDocument()
-    expect(statusIcon).toHaveAttribute('aria-label', 'Submitted')
-    expect(statusIcon.querySelector('.lucide-check')).not.toBeNull()
-  })
-
-  it('toggles grading row sort between last-name asc and first-name asc from the student header', async () => {
-    const quiz = makeQuiz({
-      id: 'test-sort-names',
-      title: 'Sort Names Test',
-      assessment_type: 'test',
-    })
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
-          students: [
-            {
-              student_id: 'student-1',
-              name: 'Zoe Marie Anderson',
-              first_name: 'Zoe Marie',
-              last_name: 'Anderson',
-              email: 'zoe-marie@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 0,
-              focus_summary: null,
-            },
-            {
-              student_id: 'student-2',
-              name: 'Zoe Zimmer',
-              first_name: 'Zoe',
-              last_name: 'Zimmer',
-              email: 'zoe@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 0,
-              focus_summary: null,
-            },
-            {
-              student_id: 'student-3',
-              name: 'Amy Brown',
-              first_name: 'Amy',
-              last_name: 'Brown',
-              email: 'amy@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 0,
-              focus_summary: null,
-            },
-          ],
-        }),
-      })
-
-    renderTab('test')
-    await screen.findByText('Sort Names Test')
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-
-    await screen.findByText('Zoe Marie Anderson')
-    expect(studentCheckboxOrder()).toEqual(['Zoe Marie Anderson', 'Amy Brown', 'Zoe Zimmer'])
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sort students by first name' }))
-    expect(studentCheckboxOrder()).toEqual(['Amy Brown', 'Zoe Zimmer', 'Zoe Marie Anderson'])
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sort students by last name' }))
-    expect(studentCheckboxOrder()).toEqual(['Zoe Marie Anderson', 'Amy Brown', 'Zoe Zimmer'])
-  })
-
-  it('updates the grading row score from targeted sidebar save event without reloading', async () => {
-    const quiz = makeQuiz({ id: 'test-row-update', title: 'Row Update Test', assessment_type: 'test' })
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 1, grading_finalized: false },
-          students: [
-            {
-              student_id: 'student-1',
-              name: 'Student One',
-              email: 'student1@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 1,
-              focus_summary: null,
-            },
-          ],
-        }),
-      })
-
-    renderTab('test')
-    await screen.findByText('Row Update Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-    await screen.findByText('Student One')
-    expect(screen.getByText('1/6')).toBeInTheDocument()
-
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, {
-          detail: {
-            testId: 'test-row-update',
-            studentId: 'student-1',
-            pointsEarned: 4,
-            pointsPossible: 6,
-            percent: 66.7,
-            gradedOpenResponses: 1,
-            ungradedOpenResponses: 0,
-          },
-        })
-      )
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText('4/6')).toBeInTheDocument()
-    })
-    expect(screen.queryByText('1/6')).not.toBeInTheDocument()
-
-    const resultsCalls = fetchMock.mock.calls.filter(
-      ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/test-row-update/results')
-    )
-    expect(resultsCalls).toHaveLength(1)
-  })
-
-  it('prompts to close active test before return and sends close_test=true', async () => {
-    const quiz = makeQuiz({
-      id: 'test-active-return',
-      title: 'Active Return Test',
-      assessment_type: 'test',
-      status: 'active',
-    })
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
-          students: [
-            {
-              student_id: 'student-1',
-              name: 'Student One',
-              email: 'student1@example.com',
-              status: 'submitted',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 1,
-              focus_summary: null,
-            },
-          ],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ returned_count: 1, skipped_count: 0, test_closed: true }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [{ ...quiz, status: 'closed' }] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-          questions: [],
-          stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 0, grading_finalized: false },
-          students: [
-            {
-              student_id: 'student-1',
-              name: 'Student One',
-              email: 'student1@example.com',
-              status: 'returned',
-              submitted_at: '2026-02-25T15:06:00.000Z',
-              last_activity_at: '2026-02-25T23:07:00.000Z',
-              points_earned: 1,
-              points_possible: 6,
-              percent: 16.7,
-              graded_open_responses: 0,
-              ungraded_open_responses: 1,
-              focus_summary: null,
-            },
-          ],
-        }),
-      })
-
-    renderTab('test')
-    await screen.findByText('Active Return Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-    await screen.findByText('Student One')
-
-    fireEvent.click(screen.getByLabelText('Select Student One'))
-    fireEvent.click(screen.getByRole('button', { name: 'Return 1 selected tests' }))
-
-    expect(await screen.findByText('Close test and return work to 1 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText('This test is still open. Confirming will close it for all students before returning selected work.')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByText('Close and Return'))
-
-    await waitFor(() => {
-      const returnCall = fetchMock.mock.calls.find(
-        ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/test-active-return/return')
-      )
-      expect(returnCall).toBeDefined()
-      const [, init] = returnCall as [string, RequestInit]
-      expect(init.method).toBe('POST')
-      expect(JSON.parse(String(init.body))).toEqual({
-        student_ids: ['student-1'],
-        close_test: true,
-      })
-    })
-
-    const returnedStatusIcon = await screen.findByLabelText('Returned')
-    expect(returnedStatusIcon.querySelector('.lucide-send')).not.toBeNull()
-  })
-
-  it('uses automatic rubric selection and allows optional extra instructions plus grading strategy', async () => {
-    const onTestGradingDataRefresh = vi.fn()
-    const quiz = makeQuiz({
-      id: 'test-ai-guideline',
-      title: 'AI Guideline Test',
-      assessment_type: 'test',
-      status: 'active',
-    })
-
-    const initialResultsPayload = {
-      quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-      questions: [
-        {
-          id: 'q-open-code',
-          question_type: 'open_response',
-          response_monospace: true,
-        },
-        {
-          id: 'q-open-regular',
-          question_type: 'open_response',
-          response_monospace: false,
-        },
-      ],
-      stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 1, grading_finalized: false },
-      students: [
-        {
-          student_id: 'student-1',
-          name: 'Student One',
-          email: 'student1@example.com',
-          status: 'submitted',
-          submitted_at: '2026-02-25T15:06:00.000Z',
-          last_activity_at: '2026-02-25T23:07:00.000Z',
-          points_earned: 1,
-          points_possible: 6,
-          percent: 16.7,
-          graded_open_responses: 0,
-          ungraded_open_responses: 1,
-          focus_summary: null,
-        },
-      ],
-    }
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          graded_students: 1,
-          skipped_students: 0,
-          eligible_students: 1,
-          graded_responses: 1,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-
-    renderTab('test', { onTestGradingDataRefresh })
-    await screen.findByText('AI Guideline Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-    await screen.findByText('Student One')
-
-    fireEvent.click(screen.getByLabelText('Select Student One'))
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grade 1 selected' }))
-    expect(await screen.findByRole('heading', { name: 'AI Grading' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'AI Prompt' }))
-
-    expect(await screen.findByRole('heading', { name: 'AI Prompt' })).toBeInTheDocument()
-    expect(screen.queryByLabelText('Grading option')).not.toBeInTheDocument()
-    expect(screen.getByLabelText('Additional instructions (optional)')).toHaveValue('')
-    expect(
-      screen.getByText(
-        /Balanced adapts automatically: it reuses one question-level grading context per question and batches same-question responses when there is more than one to grade\./
-      )
-    ).toBeInTheDocument()
-    fireEvent.change(screen.getByLabelText('Grading strategy'), {
-      target: { value: 'aggressive_batch' },
-    })
-    fireEvent.change(screen.getByLabelText('Additional instructions (optional)'), {
-      target: { value: 'Focus on complete explanations.' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grade 1 selected' }))
-    expect(await screen.findByRole('heading', { name: 'AI Grading' })).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'This will grade 1 selected student across 1 code question and 1 regular question. Up to 1 ungraded open response may be sent to AI.'
-      )
-    ).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Grade with AI' }))
-
-    await waitFor(() => {
-      const gradeCall = fetchMock.mock.calls.find(
-        ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/test-ai-guideline/auto-grade')
-      )
-      expect(gradeCall).toBeDefined()
-      const [, init] = gradeCall as [string, RequestInit]
-      expect(JSON.parse(String(init.body))).toEqual({
-        student_ids: ['student-1'],
-        prompt_guideline: 'Focus on complete explanations.',
-        grading_strategy: 'aggressive_batch',
-      })
-    })
-
-    await waitFor(() => {
-      expect(onTestGradingDataRefresh).toHaveBeenCalledOnce()
-    })
-  })
-
-  it('summarizes repeated batch auto-grade failures without exposing student ids', async () => {
-    const quiz = makeQuiz({
-      id: 'test-ai-errors',
-      title: 'AI Errors Test',
-      assessment_type: 'test',
-      status: 'active',
-    })
-
-    const initialResultsPayload = {
-      quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-      questions: [],
-      stats: { open_questions_count: 0, graded_open_responses: 0, ungraded_open_responses: 2, grading_finalized: false },
-      students: [
-        {
-          student_id: 'student-1',
-          name: 'Student One',
-          email: 'student1@example.com',
-          status: 'submitted',
-          submitted_at: '2026-02-25T15:06:00.000Z',
-          last_activity_at: '2026-02-25T23:07:00.000Z',
-          points_earned: 1,
-          points_possible: 6,
-          percent: 16.7,
-          graded_open_responses: 0,
-          ungraded_open_responses: 1,
-          focus_summary: null,
-        },
-        {
-          student_id: 'student-2',
-          name: 'Student Two',
-          email: 'student2@example.com',
-          status: 'submitted',
-          submitted_at: '2026-02-25T15:06:00.000Z',
-          last_activity_at: '2026-02-25T23:07:00.000Z',
-          points_earned: 2,
-          points_possible: 6,
-          percent: 33.3,
-          graded_open_responses: 0,
-          ungraded_open_responses: 1,
-          focus_summary: null,
-        },
-      ],
-    }
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          graded_students: 0,
-          skipped_students: 2,
-          eligible_students: 2,
-          graded_responses: 0,
-          errors: [
-            'student-1: AI grading service failed for this response. Try again.',
-            'student-2: AI grading service failed for this response. Try again.',
-          ],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-
-    renderTab('test')
-    await screen.findByText('AI Errors Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-    await screen.findByText('Student One')
-
-    fireEvent.click(screen.getByLabelText('Select Student One'))
-    fireEvent.click(screen.getByLabelText('Select Student Two'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grade 2 selected' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Grade with AI' }))
-
-    expect(await screen.findByText('2 students: AI grading service failed for this response. Try again.')).toBeInTheDocument()
-    expect(screen.queryByText(/student-1:/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/student-2:/i)).not.toBeInTheDocument()
-  })
-
-  it('clears selected open scores/feedback with confirmation', async () => {
-    const onTestGradingDataRefresh = vi.fn()
-    const quiz = makeQuiz({
-      id: 'test-clear-open-grades',
-      title: 'Clear Open Grades Test',
-      assessment_type: 'test',
-      status: 'active',
-    })
-
-    const initialResultsPayload = {
-      quiz: { id: quiz.id, title: quiz.title, grading_finalized_at: null },
-      questions: [],
-      stats: { open_questions_count: 0, graded_open_responses: 1, ungraded_open_responses: 0, grading_finalized: false },
-      students: [
-        {
-          student_id: 'student-1',
-          name: 'Student One',
-          email: 'student1@example.com',
-          status: 'submitted',
-          submitted_at: '2026-02-25T15:06:00.000Z',
-          last_activity_at: '2026-02-25T23:07:00.000Z',
-          points_earned: 4,
-          points_possible: 6,
-          percent: 66.7,
-          graded_open_responses: 1,
-          ungraded_open_responses: 0,
-          focus_summary: null,
-        },
-      ],
-    }
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ quizzes: [quiz] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          cleared_students: 1,
-          skipped_students: 0,
-          cleared_responses: 1,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => initialResultsPayload,
-      })
-
-    renderTab('test', { onTestGradingDataRefresh })
-    await screen.findByText('Clear Open Grades Test')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-    await screen.findByText('Student One')
-
-    fireEvent.click(screen.getByLabelText('Select Student One'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grade 1 selected' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Clear Open Scores/Feedback' }))
-
-    expect(await screen.findByText('Clear open scores and feedback for 1 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText('This removes all open-response scores and feedback (including AI grading metadata) for the selected students.')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Clear Open Grades' }))
-
-    await waitFor(() => {
-      const clearCall = fetchMock.mock.calls.find(
-        ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/test-clear-open-grades/clear-open-grades')
-      )
-      expect(clearCall).toBeDefined()
-      const [, init] = clearCall as [string, RequestInit]
-      expect(init.method).toBe('POST')
-      expect(JSON.parse(String(init.body))).toEqual({
-        student_ids: ['student-1'],
-      })
-    })
-
-    await waitFor(() => {
-      expect(onTestGradingDataRefresh).toHaveBeenCalledOnce()
-    })
+  it('renders quiz mode with the quiz API and primary action', async () => {
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab('quiz')
+
+    expect(await screen.findByText('Loops Quiz')).toBeInTheDocument()
+    expect(screen.getByText('New Quiz')).toBeInTheDocument()
+    expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/quizzes?classroom_id=')
   })
 })

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -44,20 +44,17 @@ vi.mock('@/components/QuizModal', () => ({
 vi.mock('@/components/QuizDetailPanel', () => ({
   QuizDetailPanel: ({
     quiz,
-    testAuthoringView,
     testQuestionLayout,
     showPreviewButton,
     showResultsTab,
   }: {
     quiz: QuizWithStats
-    testAuthoringView?: string
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
   }) => (
     <div
       data-testid="mock-test-detail"
-      data-authoring-view={testAuthoringView}
       data-question-layout={testQuestionLayout}
       data-show-preview={String(showPreviewButton)}
       data-show-results={String(showResultsTab)}
@@ -92,14 +89,26 @@ function listFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   )
 }
 
+function resultsFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]: [string]) => typeof url === 'string' && url.includes('/api/teacher/tests/') && url.endsWith('/results')
+  )
+}
+
 function makeResultsResponse(overrides?: {
   students?: Array<Record<string, unknown>>
   questions?: Array<Record<string, unknown>>
+  quizStatus?: QuizWithStats['status']
 }) {
   return {
     ok: true,
     json: async () => ({
-      quiz: { id: 'test-1', title: 'Unit Test', grading_finalized_at: null },
+      quiz: {
+        id: 'test-1',
+        title: 'Unit Test',
+        status: overrides?.quizStatus ?? 'active',
+        grading_finalized_at: null,
+      },
       questions:
         overrides?.questions ?? [
           {
@@ -148,6 +157,7 @@ describe('TeacherTestsTab', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -200,12 +210,13 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByText('Unit Test'))
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
-    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-authoring-view', 'questions')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'summary-detail')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
     expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: 'Grading' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Questions' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Documents' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Back to tests' })).not.toBeInTheDocument()
     expect(onSelectTest).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'test-1', title: 'Unit Test' })
@@ -290,6 +301,144 @@ describe('TeacherTestsTab', () => {
       studentId: 'student-1',
       studentName: 'Alice Zephyr',
     })
+  })
+
+  it('polls grading rows only while grading is visible and focused', async () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    let hasFocus = true
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => hasFocus)
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((() => 1) as typeof window.setInterval)
+    const clearIntervalSpy = vi
+      .spyOn(window, 'clearInterval')
+      .mockImplementation((() => undefined) as typeof window.clearInterval)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValue(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15_000)
+
+    hasFocus = false
+    window.dispatchEvent(new Event('blur'))
+    expect(clearIntervalSpy).toHaveBeenCalled()
+
+    hasFocus = true
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(resultsFetchCalls(fetchMock)).toHaveLength(2)
+    })
+
+    visibilityState = 'hidden'
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await Promise.resolve()
+    })
+
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(2)
+
+    visibilityState = 'visible'
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(resultsFetchCalls(fetchMock)).toHaveLength(3)
+    })
+  })
+
+  it('does not start polling when the server reports the test is closed', async () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    let hasFocus = true
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => hasFocus)
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((() => 1) as typeof window.setInterval)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValue(makeResultsResponse({ quizStatus: 'closed' }))
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 15_000)
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('starts polling when the server reports the test is active even if the list was stale', async () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    let hasFocus = true
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => hasFocus)
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((() => 1) as typeof window.setInterval)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
+      })
+      .mockResolvedValue(makeResultsResponse({ quizStatus: 'active' }))
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15_000)
   })
 
   it('prompts to close an active test before return and sends close_test=true', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -47,11 +47,13 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     testQuestionLayout,
     showPreviewButton,
     showResultsTab,
+    onPendingMarkdownImportChange,
   }: {
     quiz: QuizWithStats
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
+    onPendingMarkdownImportChange?: (pending: boolean) => void
   }) => (
     <div
       data-testid="mock-test-detail"
@@ -60,6 +62,12 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       data-show-results={String(showResultsTab)}
     >
       Detail for {quiz.title}
+      <button type="button" onClick={() => onPendingMarkdownImportChange?.(true)}>
+        Mark pending markdown
+      </button>
+      <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
+        Clear pending markdown
+      </button>
     </div>
   ),
 }))
@@ -96,6 +104,8 @@ function resultsFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
 }
 
 function makeResultsResponse(overrides?: {
+  quizId?: string
+  quizTitle?: string
   students?: Array<Record<string, unknown>>
   questions?: Array<Record<string, unknown>>
   quizStatus?: QuizWithStats['status']
@@ -104,8 +114,8 @@ function makeResultsResponse(overrides?: {
     ok: true,
     json: async () => ({
       quiz: {
-        id: 'test-1',
-        title: 'Unit Test',
+        id: overrides?.quizId ?? 'test-1',
+        title: overrides?.quizTitle ?? 'Unit Test',
         status: overrides?.quizStatus ?? 'active',
         grading_finalized_at: null,
       },
@@ -221,6 +231,34 @@ describe('TeacherTestsTab', () => {
     expect(onSelectTest).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'test-1', title: 'Unit Test' })
     )
+  })
+
+  it('disables preview and status actions while markdown edits are pending', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark pending markdown' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+      expect(
+        screen.getByText('Apply or undo markdown changes before previewing or changing the test status.')
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear pending markdown' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+    })
   })
 
   it('opens a newly created test directly into authoring mode', async () => {
@@ -439,6 +477,117 @@ describe('TeacherTestsTab', () => {
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15_000)
+  })
+
+  it('ignores stale grading responses after switching to a different test', async () => {
+    let resolveFirstResults:
+      | ((value: { ok: boolean; json: () => Promise<any> }) => void)
+      | null = null
+    let resolveSecondResults:
+      | ((value: { ok: boolean; json: () => Promise<any> }) => void)
+      | null = null
+
+    const firstResultsPromise = new Promise<{ ok: boolean; json: () => Promise<any> }>((resolve) => {
+      resolveFirstResults = resolve
+    })
+    const secondResultsPromise = new Promise<{ ok: boolean; json: () => Promise<any> }>((resolve) => {
+      resolveSecondResults = resolve
+    })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tests: [
+            makeTest({ id: 'test-1', title: 'Unit Test A' }),
+            makeTest({ id: 'test-2', title: 'Unit Test B' }),
+          ],
+        }),
+      })
+      .mockImplementationOnce(() => firstResultsPromise as unknown as Promise<Response>)
+      .mockImplementationOnce(() => secondResultsPromise as unknown as Promise<Response>)
+
+    const view = renderTab({ testsTabClickToken: 0 })
+
+    fireEvent.click(await screen.findByText('Unit Test A'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={classroom}
+        testsTabClickToken={1}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Unit Test B'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    await act(async () => {
+      resolveSecondResults?.(
+        makeResultsResponse({
+          quizId: 'test-2',
+          quizTitle: 'Unit Test B',
+          students: [
+            {
+              student_id: 'student-2',
+              name: 'Bob Yellow',
+              first_name: 'Bob',
+              last_name: 'Yellow',
+              email: 'bob@example.com',
+              status: 'submitted',
+              submitted_at: null,
+              last_activity_at: '2026-04-17T18:20:00.000Z',
+              points_earned: 4,
+              points_possible: 5,
+              percent: 80,
+              graded_open_responses: 1,
+              ungraded_open_responses: 0,
+              focus_summary: null,
+            },
+          ],
+        })
+      )
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('Bob Yellow')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveFirstResults?.(
+        makeResultsResponse({
+          quizId: 'test-1',
+          quizTitle: 'Unit Test A',
+          students: [
+            {
+              student_id: 'student-1',
+              name: 'Alice Zephyr',
+              first_name: 'Alice',
+              last_name: 'Zephyr',
+              email: 'alice@example.com',
+              status: 'submitted',
+              submitted_at: null,
+              last_activity_at: '2026-04-17T18:15:00.000Z',
+              points_earned: 3,
+              points_possible: 5,
+              percent: 60,
+              graded_open_responses: 0,
+              ungraded_open_responses: 1,
+              focus_summary: null,
+            },
+          ],
+        })
+      )
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Bob Yellow')).toBeInTheDocument()
+      expect(screen.queryByText('Alice Zephyr')).not.toBeInTheDocument()
+    })
   })
 
   it('prompts to close an active test before return and sends close_test=true', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
 import { TooltipProvider } from '@/ui'
@@ -274,6 +274,103 @@ describe('TeacherTestsTab', () => {
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
     expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('validates and activates a draft test from authoring', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          questions: [
+            {
+              id: 'q1',
+              question_type: 'multiple_choice',
+              question_text: 'Ready to activate?',
+              options: ['Yes', 'No'],
+              correct_option: 0,
+              points: 1,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ test: { id: 'test-1', status: 'active' } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    expect(await screen.findByText('Activate test?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Activate' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/test-1', expect.objectContaining({ method: 'PATCH' }))
+    })
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url === '/api/teacher/tests/test-1' && init?.method === 'PATCH'
+    )
+    expect(patchCall).toBeTruthy()
+    expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ status: 'active' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+    })
+  })
+
+  it('confirms and closes an active test from authoring', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ test: { id: 'test-1', status: 'closed' } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
+      })
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(await screen.findByText('Close test?')).toBeInTheDocument()
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/test-1', expect.objectContaining({ method: 'PATCH' }))
+    })
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        url === '/api/teacher/tests/test-1' && init?.method === 'PATCH'
+    )
+    expect(patchCall).toBeTruthy()
+    expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ status: 'closed' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
+    })
   })
 
   it('returns to the tests list when the tests tab is clicked again', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
+import { TooltipProvider } from '@/ui'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
+import type { QuizWithStats } from '@/types'
+
+const { setOpenMock } = vi.hoisted(() => ({
+  setOpenMock: vi.fn(),
+}))
+
+vi.mock('@/components/layout', () => ({
+  useRightSidebar: () => ({ setOpen: setOpenMock }),
+}))
+
+vi.mock('@/components/QuizModal', () => ({
+  QuizModal: ({
+    isOpen,
+    onSuccess,
+  }: {
+    isOpen: boolean
+    onSuccess: (quiz: QuizWithStats) => void
+  }) =>
+    isOpen ? (
+      <button
+        data-testid="mock-test-save"
+        onClick={() =>
+          onSuccess(
+            createMockQuiz({
+              id: 'created-test-id',
+              title: 'Created Test',
+              assessment_type: 'test',
+            }) as QuizWithStats
+          )
+        }
+      >
+        Save Test
+      </button>
+    ) : null,
+}))
+
+vi.mock('@/components/QuizDetailPanel', () => ({
+  QuizDetailPanel: ({
+    quiz,
+    testAuthoringView,
+    testQuestionLayout,
+    showPreviewButton,
+    showResultsTab,
+  }: {
+    quiz: QuizWithStats
+    testAuthoringView?: string
+    testQuestionLayout?: string
+    showPreviewButton?: boolean
+    showResultsTab?: boolean
+  }) => (
+    <div
+      data-testid="mock-test-detail"
+      data-authoring-view={testAuthoringView}
+      data-question-layout={testQuestionLayout}
+      data-show-preview={String(showPreviewButton)}
+      data-show-results={String(showResultsTab)}
+    >
+      Detail for {quiz.title}
+    </div>
+  ),
+}))
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>
+}
+
+function makeTest(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
+  const base = createMockQuiz({
+    assessment_type: 'test',
+    status: 'draft',
+    ...overrides,
+  })
+  return {
+    ...base,
+    assessment_type: 'test',
+    stats: { total_students: 10, responded: 5, questions_count: 3 },
+    ...overrides,
+  } as QuizWithStats
+}
+
+function listFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]: [string]) =>
+      typeof url === 'string' && url.includes('/api/teacher/tests') && url.includes('?classroom_id=')
+  )
+}
+
+function makeResultsResponse(overrides?: {
+  students?: Array<Record<string, unknown>>
+  questions?: Array<Record<string, unknown>>
+}) {
+  return {
+    ok: true,
+    json: async () => ({
+      quiz: { id: 'test-1', title: 'Unit Test', grading_finalized_at: null },
+      questions:
+        overrides?.questions ?? [
+          {
+            id: 'q1',
+            question_type: 'open_response',
+            response_monospace: false,
+            points: 5,
+          },
+        ],
+      students:
+        overrides?.students ?? [
+          {
+            student_id: 'student-1',
+            name: 'Alice Zephyr',
+            first_name: 'Alice',
+            last_name: 'Zephyr',
+            email: 'alice@example.com',
+            status: 'submitted',
+            submitted_at: null,
+            last_activity_at: '2026-04-17T18:15:00.000Z',
+            points_earned: 3,
+            points_possible: 5,
+            percent: 60,
+            graded_open_responses: 0,
+            ungraded_open_responses: 1,
+            focus_summary: {
+              away_count: 1,
+              away_total_seconds: 45,
+              route_exit_attempts: 1,
+              window_unmaximize_attempts: 0,
+            },
+          },
+        ],
+    }),
+  }
+}
+
+describe('TeacherTestsTab', () => {
+  const classroom = createMockClassroom()
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    setOpenMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function mockTestsResponse(tests: QuizWithStats[] = []) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tests }),
+    })
+  }
+
+  function renderTab(options?: {
+    testsTabClickToken?: number
+    onSelectTest?: (test: QuizWithStats | null) => void
+    onTestGradingContextChange?: (context: {
+      mode: 'authoring' | 'grading'
+      testId: string | null
+      studentId: string | null
+      studentName: string | null
+    }) => void
+  }) {
+    return render(
+      <TeacherTestsTab
+        classroom={classroom}
+        testsTabClickToken={options?.testsTabClickToken}
+        onSelectTest={options?.onSelectTest}
+        onTestGradingContextChange={options?.onTestGradingContextChange}
+      />,
+      { wrapper: Wrapper }
+    )
+  }
+
+  it('renders the tests list by default with no selected workspace', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    renderTab()
+
+    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
+    expect(screen.getByText('New Test')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
+    expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
+  })
+
+  it('opens a selected test in authoring mode when the card is clicked', async () => {
+    const onSelectTest = vi.fn()
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    renderTab({ onSelectTest })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-authoring-view', 'questions')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'summary-detail')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
+    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Grading' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Back to tests' })).not.toBeInTheDocument()
+    expect(onSelectTest).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'test-1', title: 'Unit Test' })
+    )
+  })
+
+  it('opens a newly created test directly into authoring mode', async () => {
+    mockTestsResponse([])
+    renderTab()
+
+    expect(await screen.findByText('No tests yet')).toBeInTheDocument()
+
+    mockTestsResponse([makeTest({ id: 'created-test-id', title: 'Created Test' })])
+
+    fireEvent.click(screen.getByText('New Test'))
+    fireEvent.click(screen.getByTestId('mock-test-save'))
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
+    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('returns to the tests list when the tests tab is clicked again', async () => {
+    const onSelectTest = vi.fn()
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    const view = renderTab({ onSelectTest, testsTabClickToken: 0 })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={classroom}
+        testsTabClickToken={1}
+        onSelectTest={onSelectTest}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Unit Test')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(setOpenMock).toHaveBeenCalledWith(false)
+    expect(onSelectTest).toHaveBeenLastCalledWith(null)
+  })
+
+  it('shows grading in the main pane and only opens the inspector after row selection', async () => {
+    const onTestGradingContextChange = vi.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab({ onTestGradingContextChange })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    setOpenMock.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(setOpenMock).not.toHaveBeenCalledWith(true)
+    expect(onTestGradingContextChange).toHaveBeenLastCalledWith({
+      mode: 'grading',
+      testId: 'test-1',
+      studentId: null,
+      studentName: null,
+    })
+
+    fireEvent.click(screen.getByText('Alice Zephyr'))
+
+    await waitFor(() => {
+      expect(setOpenMock).toHaveBeenCalledWith(true)
+    })
+    expect(onTestGradingContextChange).toHaveBeenLastCalledWith({
+      mode: 'grading',
+      testId: 'test-1',
+      studentId: 'student-1',
+      studentName: 'Alice Zephyr',
+    })
+  })
+
+  it('prompts to close an active test before return and sends close_test=true', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ returned_count: 1, skipped_count: 0, test_closed: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
+    fireEvent.click(screen.getByRole('button', { name: 'Return' }))
+
+    expect(
+      await screen.findByText('This test is still open. Confirming will close it for all students before returning selected work.')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close and Return' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/teacher/tests/test-1/return',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    const returnCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/tests/test-1/return'
+    )
+    expect(returnCall).toBeTruthy()
+    expect(JSON.parse(returnCall?.[1]?.body as string)).toMatchObject({
+      student_ids: ['student-1'],
+      close_test: true,
+    })
+  })
+
+  it('reloads the list once when the update event fires', async () => {
+    mockTestsResponse([])
+    renderTab()
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    mockTestsResponse([])
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, {
+          detail: { classroomId: classroom.id },
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(2)
+    })
+  })
+})

--- a/tests/components/WorkspaceSplitPane.test.tsx
+++ b/tests/components/WorkspaceSplitPane.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { WorkspaceSplitPane } from '@/components/WorkspaceSplitPane'
+
+describe('WorkspaceSplitPane', () => {
+  it('renders both panes and exposes the optional divider', () => {
+    const onPointerDown = vi.fn()
+    const onDoubleClick = vi.fn()
+
+    render(
+      <WorkspaceSplitPane
+        left={<div>Left pane</div>}
+        right={<div>Right pane</div>}
+        divider={{
+          label: 'Resize panes',
+          onPointerDown,
+          onDoubleClick,
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Left pane')).toBeInTheDocument()
+    expect(screen.getByText('Right pane')).toBeInTheDocument()
+
+    const separator = screen.getByRole('separator', { name: 'Resize panes' })
+    fireEvent.pointerDown(separator)
+    fireEvent.doubleClick(separator)
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1)
+    expect(onDoubleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the right pane when rightVisible is false', () => {
+    render(
+      <WorkspaceSplitPane
+        left={<div>Left only</div>}
+        right={<div>Hidden right</div>}
+        rightVisible={false}
+      />,
+    )
+
+    expect(screen.getByText('Left only')).toBeInTheDocument()
+    expect(screen.queryByText('Hidden right')).not.toBeInTheDocument()
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/select-and-github-repos.test.tsx
+++ b/tests/unit/select-and-github-repos.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Select } from '@/ui'
+import { normalizeGitHubRepoUrl } from '@/lib/github-repos'
+
+describe('Select', () => {
+  it('renders placeholder and options with the expected disabled states', () => {
+    render(
+      <Select
+        aria-label="Repository type"
+        placeholder="Choose one"
+        options={[
+          { value: 'private', label: 'Private' },
+          { value: 'public', label: 'Public', disabled: true },
+        ]}
+        defaultValue=""
+      />
+    )
+
+    const select = screen.getByRole('combobox', { name: 'Repository type' })
+    expect(select).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Choose one' })).toBeDisabled()
+    expect(screen.getByRole('option', { name: 'Private' })).toBeEnabled()
+    expect(screen.getByRole('option', { name: 'Public' })).toBeDisabled()
+  })
+
+  it('forwards change events through the rendered select element', () => {
+    render(
+      <Select
+        aria-label="Visibility"
+        options={[
+          { value: 'private', label: 'Private' },
+          { value: 'public', label: 'Public' },
+        ]}
+        defaultValue="private"
+      />
+    )
+
+    const select = screen.getByRole('combobox', { name: 'Visibility' })
+    fireEvent.change(select, { target: { value: 'public' } })
+
+    expect(select).toHaveValue('public')
+  })
+})
+
+describe('normalizeGitHubRepoUrl', () => {
+  it('normalizes valid GitHub references to the canonical repo URL', () => {
+    expect(normalizeGitHubRepoUrl('codepetca/pika.git')).toBe('https://github.com/codepetca/pika')
+    expect(normalizeGitHubRepoUrl('https://www.github.com/codepetca/pika')).toBe(
+      'https://github.com/codepetca/pika'
+    )
+  })
+
+  it('returns null for invalid repository references', () => {
+    expect(normalizeGitHubRepoUrl('not a repo')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What changed

This PR brings teacher `Tests` onto the same workspace model as teacher `Assignments`.

It adds a dedicated teacher tests surface with:
- list-first default state
- selected-test workspace in the main pane
- `Authoring` / `Grading` tabs only after selection
- assignment-style full-width selected workspace shell
- grading that stays table-first and opens the inspector only after student selection

It also refines test authoring so the left pane handles structured question editing and documents, while the right pane serves as the markdown helper/mirror.

## Why

The previous tests UX was still diverging from assignments in structure and shell behavior. In practice that showed up as:
- inconsistent selected-workspace layout
- action bar alignment drifting from assignments
- grading not using the same selected-workspace container contract
- tests/quizzes still sharing assumptions that made tests harder to evolve cleanly

This change makes teacher tests use the same interaction core and selected-workspace shell language as assignments, while keeping test-specific business logic local.

## Impact

Teacher-facing:
- cleaner list-to-workspace flow for tests
- authoring and grading now feel like the same product family as assignments
- grading polling now trusts server-reported test status instead of stale local list state

Codebase:
- extracts reusable split/shell primitives for selected workspaces
- upgrades the teacher work-surface canon and prompts so future assessment-tab work is more repeatable
- keeps quiz-specific coverage separate from tests coverage

## Validation

Ran:
- `bash scripts/verify-env.sh --full`
- `./node_modules/.bin/vitest run tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/SummaryDetailWorkspaceShell.test.tsx tests/components/WorkspaceSplitPane.test.tsx`

Visual verification:
- reviewed fresh teacher tests screenshots for list, authoring, grading, and selected-student grading from a clean worktree dev server
