### PR TITLE
[codex] Polish test documents card UX

### DIFF
--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -89,6 +89,10 @@ export function QuizDetailPanel({
     () => 'questions'
   )
   const [isDocumentsCardExpanded, setIsDocumentsCardExpanded] = useState(true)
+  const [externalDocumentAddRequest, setExternalDocumentAddRequest] = useState<{
+    id: number
+    mode: 'link' | 'text' | 'upload'
+  } | null>(null)
   const [expandedQuestionIds, setExpandedQuestionIds] = useState<string[]>([])
   const [error, setError] = useState('')
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
@@ -1245,7 +1249,7 @@ export function QuizDetailPanel({
         documents={documents}
         apiBasePath={apiBasePath}
         isEditable={isEditable}
-        onUpdated={loadQuizDetails}
+        onDocumentsChange={setDocuments}
       />
     </div>
   )
@@ -1253,26 +1257,46 @@ export function QuizDetailPanel({
   const testsInlineDocumentsCard = (
     <div
       data-testid="test-documents-card"
-      className="overflow-hidden rounded-lg border border-border bg-surface"
+      className="rounded-lg border border-border bg-surface"
     >
-      <button
-        type="button"
-        data-testid="test-documents-card-toggle"
-        aria-expanded={isDocumentsCardExpanded}
-        aria-label={isDocumentsCardExpanded ? 'Collapse documents' : 'Expand documents'}
-        onClick={() => setIsDocumentsCardExpanded((prev) => !prev)}
-        className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
-      >
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-medium text-text-default">Documents</span>
-          <span className="text-xs text-text-muted">
-            {documents.length} document{documents.length === 1 ? '' : 's'}
+      <div className="flex items-center gap-3 px-3 py-3">
+        <button
+          type="button"
+          data-testid="test-documents-card-toggle"
+          aria-expanded={isDocumentsCardExpanded}
+          aria-label={isDocumentsCardExpanded ? 'Collapse documents' : 'Expand documents'}
+          onClick={() => setIsDocumentsCardExpanded((prev) => !prev)}
+          className="flex min-w-0 flex-1 items-center justify-between gap-3 text-left"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="text-sm font-medium text-text-default">Documents</span>
+            <span className="text-xs text-text-muted">
+              {documents.length} document{documents.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          <span className="text-text-muted">
+            {isDocumentsCardExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
           </span>
-        </div>
-        <span className="text-text-muted">
-          {isDocumentsCardExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-        </span>
-      </button>
+        </button>
+        {isEditable && !hasPendingMarkdownImport ? (
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            aria-label="Add Document"
+            className="h-8 w-8 shrink-0 px-0 text-base font-semibold leading-none"
+            onClick={() => {
+              setIsDocumentsCardExpanded(true)
+              setExternalDocumentAddRequest({
+                id: Date.now(),
+                mode: 'link',
+              })
+            }}
+          >
+            +
+          </Button>
+        ) : null}
+      </div>
       {isDocumentsCardExpanded ? (
         <div className="border-t border-border p-3">
           <TestDocumentsEditor
@@ -1280,7 +1304,10 @@ export function QuizDetailPanel({
             documents={documents}
             apiBasePath={apiBasePath}
             isEditable={isEditable && !hasPendingMarkdownImport}
-            onUpdated={loadQuizDetails}
+            onDocumentsChange={setDocuments}
+            addButtonPlacement="none"
+            externalAddRequest={externalDocumentAddRequest}
+            onExternalAddRequestHandled={() => setExternalDocumentAddRequest(null)}
           />
         </div>
       ) : null}
@@ -1632,13 +1659,14 @@ export function QuizDetailPanel({
           </div>
         ) : viewMode === 'documents' && isTestsView ? (
           <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-text-default">Reference Documents</h3>
             <TestDocumentsEditor
               testId={quiz.id}
               documents={documents}
               apiBasePath={apiBasePath}
               isEditable={isEditable}
-              onUpdated={loadQuizDetails}
+              onDocumentsChange={setDocuments}
+              addButtonPlacement="header"
+              headerTitle="Reference Documents"
             />
           </div>
         ) : viewMode === 'markdown' && isTestsView ? (

--- a/src/components/TestDocumentsEditor.tsx
+++ b/src/components/TestDocumentsEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useId, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ExternalLink, FileText, Link2, Pencil, RefreshCw, Trash2, Upload } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ExternalLink, Pencil, Plus, RefreshCw, Trash2, Upload } from 'lucide-react'
 import { Button, DialogPanel, Input } from '@/ui'
 import {
   MAX_TEST_DOCUMENT_TEXT_LENGTH,
@@ -18,17 +18,28 @@ interface Props {
   documents?: TestDocument[]
   apiBasePath?: string
   isEditable: boolean
-  onUpdated: () => void
+  onDocumentsChange?: (documents: TestDocument[]) => void
+  addButtonPlacement?: 'footer' | 'header' | 'none'
+  headerTitle?: string
+  externalAddRequest?: {
+    id: number
+    mode: AddDocumentTab
+  } | null
+  onExternalAddRequestHandled?: () => void
 }
 
-type AddDocumentModal = 'link' | 'text' | 'upload' | null
+type AddDocumentTab = 'link' | 'upload' | 'text'
 
 export function TestDocumentsEditor({
   testId,
   documents = [],
   apiBasePath = '/api/teacher/tests',
   isEditable,
-  onUpdated,
+  onDocumentsChange,
+  addButtonPlacement = 'footer',
+  headerTitle,
+  externalAddRequest,
+  onExternalAddRequestHandled,
 }: Props) {
   const [localDocs, setLocalDocs] = useState<TestDocument[]>(() => normalizeTestDocuments(documents))
   const [linkTitle, setLinkTitle] = useState('')
@@ -41,22 +52,25 @@ export function TestDocumentsEditor({
   const [editUrl, setEditUrl] = useState('')
   const [editContent, setEditContent] = useState('')
   const [selectedUploadFile, setSelectedUploadFile] = useState<File | null>(null)
-  const [isAddMenuOpen, setIsAddMenuOpen] = useState(false)
-  const [activeModal, setActiveModal] = useState<AddDocumentModal | 'edit'>(null)
+  const [activeAddTab, setActiveAddTab] = useState<AddDocumentTab>('link')
+  const [activeModal, setActiveModal] = useState<'add' | 'edit' | null>(null)
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [syncingDocId, setSyncingDocId] = useState<string | null>(null)
   const [error, setError] = useState('')
-  const [success, setSuccess] = useState('')
   const [nowMs, setNowMs] = useState(() => Date.now())
-  const addMenuId = useId()
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const addMenuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const normalized = normalizeTestDocuments(documents)
     setLocalDocs(normalized)
   }, [documents])
+
+  useEffect(() => {
+    if (!externalAddRequest) return
+    openAddModal(externalAddRequest.mode)
+    onExternalAddRequestHandled?.()
+  }, [externalAddRequest, onExternalAddRequestHandled])
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -72,46 +86,11 @@ export function TestDocumentsEditor({
     [localDocs, editingDocId]
   )
 
-  useEffect(() => {
-    if (!isAddMenuOpen) return
-
-    function handleClickOutside(event: MouseEvent) {
-      if (!addMenuRef.current) return
-      if (!addMenuRef.current.contains(event.target as Node)) {
-        setIsAddMenuOpen(false)
-      }
-    }
-
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsAddMenuOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [isAddMenuOpen])
-
-  function openAddModal(mode: Exclude<AddDocumentModal, null>) {
-    if (!isEditable || saving || uploading) return
-    setError('')
-    setSuccess('')
-    setIsAddMenuOpen(false)
-    setActiveModal(mode)
-    if (mode === 'link') {
-      setLinkTitle('')
-      setLinkUrl('')
-      return
-    }
-    if (mode === 'text') {
-      setTextTitle('')
-      setTextContent('')
-      return
-    }
+  function resetAddFormState() {
+    setLinkTitle('')
+    setLinkUrl('')
+    setTextTitle('')
+    setTextContent('')
     setUploadTitle('')
     setSelectedUploadFile(null)
     if (fileInputRef.current) {
@@ -119,7 +98,15 @@ export function TestDocumentsEditor({
     }
   }
 
-  function clearModalFields(mode: Exclude<AddDocumentModal, null>) {
+  function openAddModal(mode: AddDocumentTab = activeAddTab) {
+    if (!isEditable || saving || uploading) return
+    setError('')
+    setActiveAddTab(mode)
+    resetAddFormState()
+    setActiveModal('add')
+  }
+
+  function clearModalFields(mode: AddDocumentTab) {
     if (mode === 'link') {
       setLinkTitle('')
       setLinkUrl('')
@@ -146,7 +133,6 @@ export function TestDocumentsEditor({
   async function persistDocuments(nextDocs: TestDocument[]) {
     setSaving(true)
     setError('')
-    setSuccess('')
     try {
       const res = await fetch(`${apiBasePath}/${testId}`, {
         method: 'PATCH',
@@ -160,8 +146,7 @@ export function TestDocumentsEditor({
 
       const normalized = normalizeTestDocuments(data.quiz?.documents || nextDocs)
       setLocalDocs(normalized)
-      setSuccess('Documents saved')
-      onUpdated()
+      onDocumentsChange?.(normalized)
       return normalized
     } catch (err: any) {
       setError(err.message || 'Failed to save documents')
@@ -174,7 +159,6 @@ export function TestDocumentsEditor({
   async function syncLinkDocument(
     docId: string,
     options?: {
-      successMessage?: string
       failurePrefix?: string
       silent?: boolean
     }
@@ -182,7 +166,6 @@ export function TestDocumentsEditor({
     setSyncingDocId(docId)
     if (!options?.silent) {
       setError('')
-      setSuccess('')
     }
     try {
       const res = await fetch(`${apiBasePath}/${testId}/documents/${docId}/sync`, {
@@ -195,10 +178,7 @@ export function TestDocumentsEditor({
 
       const normalized = normalizeTestDocuments(data.quiz?.documents || localDocs)
       setLocalDocs(normalized)
-      if (!options?.silent) {
-        setSuccess(options?.successMessage || 'Document synced')
-      }
-      onUpdated()
+      onDocumentsChange?.(normalized)
       return normalized
     } catch (err: any) {
       const prefix = options?.failurePrefix || 'Failed to sync document'
@@ -216,7 +196,6 @@ export function TestDocumentsEditor({
   function openEditModal(doc: TestDocument) {
     if (!isEditable || saving || uploading) return
     setError('')
-    setSuccess('')
     setEditingDocId(doc.id)
     setEditTitle(doc.title)
     setEditUrl(doc.url || '')
@@ -266,7 +245,6 @@ export function TestDocumentsEditor({
       closeAddModal()
       if (urlChanged) {
         void syncLinkDocument(editingDoc.id, {
-          successMessage: 'Link saved and synced',
           failurePrefix: 'Link saved, but sync failed',
         })
       }
@@ -302,7 +280,6 @@ export function TestDocumentsEditor({
       clearModalFields('link')
       closeAddModal()
       void syncLinkDocument(nextLinkDoc.id, {
-        successMessage: 'Link saved and synced',
         failurePrefix: 'Link saved, but sync failed',
       })
     }
@@ -341,7 +318,6 @@ export function TestDocumentsEditor({
     if (!isEditable || uploading || saving) return
     setUploading(true)
     setError('')
-    setSuccess('')
     try {
       const formData = new FormData()
       formData.append('file', file)
@@ -383,19 +359,44 @@ export function TestDocumentsEditor({
     await persistDocuments(nextDocs)
   }
 
+  const addDocumentButton = (
+    <div>
+      <Button
+        type="button"
+        variant={addButtonPlacement === 'header' ? 'primary' : 'secondary'}
+        size="sm"
+        onClick={() => openAddModal()}
+        disabled={!isEditable || saving || uploading}
+        className="gap-1.5"
+        aria-label="Add Document"
+      >
+        <Plus className="h-4 w-4" />
+        Add Document
+      </Button>
+    </div>
+  )
+
   return (
     <div className="space-y-4">
+      {(headerTitle || addButtonPlacement === 'header') && (
+        <div className={`flex items-center gap-3 ${headerTitle ? 'justify-between' : 'justify-end'}`}>
+          {headerTitle ? (
+            <div className="min-w-0">
+              <h3 className="text-lg font-semibold text-text-default">{headerTitle}</h3>
+              <p className="text-sm text-text-muted">
+                {localDocs.length} document{localDocs.length === 1 ? '' : 's'}
+              </p>
+            </div>
+          ) : null}
+          {isEditable ? addDocumentButton : null}
+        </div>
+      )}
+
       {error && (
         <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
           {error}
         </div>
       )}
-      {success && (
-        <div className="rounded-md border border-success bg-success-bg px-3 py-2 text-sm text-success">
-          {success}
-        </div>
-      )}
-
       {localDocs.length > 0 && (
         <div className="space-y-2">
           {localDocs.map((doc) => (
@@ -475,84 +476,123 @@ export function TestDocumentsEditor({
         </div>
       )}
 
-      <div className="flex justify-center">
-        <div ref={addMenuRef} className="relative">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => setIsAddMenuOpen((prev) => !prev)}
-            disabled={!isEditable || saving || uploading}
-            className="gap-1.5"
-            aria-label="Add Document"
-            aria-haspopup="menu"
-            aria-expanded={isAddMenuOpen}
-            aria-controls={addMenuId}
-          >
-            Add Document
-            <ChevronDown className="h-4 w-4" />
-          </Button>
-          {isAddMenuOpen && (
-            <div
-              id={addMenuId}
-              role="menu"
-              className="absolute left-1/2 z-20 mt-1 w-44 -translate-x-1/2 rounded-md border border-border-strong bg-surface p-1 shadow-xl"
-            >
-              <button
+      {addButtonPlacement === 'footer' && isEditable ? (
+        <div className="flex justify-center">
+          {addDocumentButton}
+        </div>
+      ) : null}
+
+      <DialogPanel
+        isOpen={activeModal === 'add'}
+        onClose={closeAddModal}
+        maxWidth={activeAddTab === 'text' ? 'max-w-xl' : 'max-w-lg'}
+        ariaLabelledBy="add-test-document-title"
+      >
+        <h4 id="add-test-document-title" className="text-base font-semibold text-text-default">
+          Add Document
+        </h4>
+        <div className="mt-4">
+          <div role="tablist" aria-label="Document type" className="flex gap-2 border-b border-border">
+            {(['link', 'upload', 'text'] as const).map((tab) => {
+              const isActive = activeAddTab === tab
+              const label = tab === 'upload' ? 'PDF' : tab === 'link' ? 'Link' : 'Text'
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActiveAddTab(tab)}
+                  className={[
+                    'border-b-2 px-3 py-2 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'border-primary text-primary'
+                      : 'border-transparent text-text-muted hover:text-text-default',
+                  ].join(' ')}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+
+          {activeAddTab === 'link' ? (
+            <div className="mt-4 space-y-3">
+              <Input
+                placeholder="Title"
+                value={linkTitle}
+                onChange={(event) => setLinkTitle(event.target.value)}
+                disabled={!isEditable || saving || uploading}
+                aria-label="Document title"
+              />
+              <Input
+                placeholder="https://..."
+                value={linkUrl}
+                onChange={(event) => setLinkUrl(event.target.value)}
+                disabled={!isEditable || saving || uploading}
+                aria-label="Document URL"
+              />
+            </div>
+          ) : null}
+
+          {activeAddTab === 'text' ? (
+            <div className="mt-4 space-y-2">
+              <Input
+                placeholder="Title"
+                value={textTitle}
+                onChange={(event) => setTextTitle(event.target.value)}
+                disabled={!isEditable || saving || uploading}
+                aria-label="Document title"
+              />
+              <textarea
+                placeholder="Paste text students can reference during the test..."
+                value={textContent}
+                onChange={(event) => setTextContent(event.target.value.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH))}
+                disabled={!isEditable || saving || uploading}
+                rows={6}
+                className="w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+                aria-label="Document text"
+              />
+              <p className="text-xs text-text-muted">
+                {textContent.length}/{MAX_TEST_DOCUMENT_TEXT_LENGTH} characters
+              </p>
+            </div>
+          ) : null}
+
+          {activeAddTab === 'upload' ? (
+            <div className="mt-4 space-y-3">
+              <Input
+                placeholder="Title (optional)"
+                value={uploadTitle}
+                onChange={(event) => setUploadTitle(event.target.value)}
+                disabled={!isEditable || saving || uploading}
+                aria-label="Document title"
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={TEST_DOCUMENT_ACCEPT}
+                className="hidden"
+                onChange={(event) => {
+                  const file = event.target.files?.[0] || null
+                  setSelectedUploadFile(file)
+                }}
+              />
+              <Button
                 type="button"
-                role="menuitem"
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover"
-                onClick={() => openAddModal('link')}
-              >
-                <Link2 className="h-4 w-4" />
-                Link
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover"
-                onClick={() => openAddModal('text')}
-              >
-                <FileText className="h-4 w-4" />
-                Text
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover"
-                onClick={() => openAddModal('upload')}
+                variant="secondary"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!isEditable || saving || uploading}
+                className="gap-1.5"
               >
                 <Upload className="h-4 w-4" />
-                PDF
-              </button>
+                {selectedUploadFile ? 'Choose another file' : 'Choose file'}
+              </Button>
+              <p className="text-sm text-text-muted">
+                {selectedUploadFile ? `Selected: ${selectedUploadFile.name}` : 'No file selected'}
+              </p>
             </div>
-          )}
-        </div>
-      </div>
-
-      <DialogPanel
-        isOpen={activeModal === 'link'}
-        onClose={closeAddModal}
-        maxWidth="max-w-lg"
-        ariaLabelledBy="add-test-link-title"
-      >
-        <h4 id="add-test-link-title" className="text-base font-semibold text-text-default">
-          Add link
-        </h4>
-        <div className="mt-4 space-y-3">
-          <Input
-            placeholder="Title"
-            value={linkTitle}
-            onChange={(event) => setLinkTitle(event.target.value)}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Document title"
-          />
-          <Input
-            placeholder="https://..."
-            value={linkUrl}
-            onChange={(event) => setLinkUrl(event.target.value)}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Document URL"
-          />
+          ) : null}
         </div>
         <div className="mt-4 flex justify-end gap-2">
           <Button
@@ -566,121 +606,14 @@ export function TestDocumentsEditor({
           <Button
             type="button"
             onClick={() => {
-              void handleAddLink()
-            }}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Add link document"
-          >
-            Add link
-          </Button>
-        </div>
-      </DialogPanel>
-
-      <DialogPanel
-        isOpen={activeModal === 'text'}
-        onClose={closeAddModal}
-        maxWidth="max-w-xl"
-        ariaLabelledBy="add-test-text-title"
-      >
-        <h4 id="add-test-text-title" className="text-base font-semibold text-text-default">
-          Add Text
-        </h4>
-        <div className="mt-4 space-y-2">
-          <Input
-            placeholder="Title"
-            value={textTitle}
-            onChange={(event) => setTextTitle(event.target.value)}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Document title"
-          />
-          <textarea
-            placeholder="Paste text students can reference during the test..."
-            value={textContent}
-            onChange={(event) => setTextContent(event.target.value.slice(0, MAX_TEST_DOCUMENT_TEXT_LENGTH))}
-            disabled={!isEditable || saving || uploading}
-            rows={6}
-            className="w-full resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
-            aria-label="Document text"
-          />
-          <p className="text-xs text-text-muted">
-            {textContent.length}/{MAX_TEST_DOCUMENT_TEXT_LENGTH} characters
-          </p>
-        </div>
-        <div className="mt-4 flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={closeAddModal}
-            disabled={saving || uploading}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={() => {
-              void handleAddText()
-            }}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Add text document"
-          >
-            Add Text
-          </Button>
-        </div>
-      </DialogPanel>
-
-      <DialogPanel
-        isOpen={activeModal === 'upload'}
-        onClose={closeAddModal}
-        maxWidth="max-w-lg"
-        ariaLabelledBy="upload-test-pdf-title"
-      >
-        <h4 id="upload-test-pdf-title" className="text-base font-semibold text-text-default">
-          Upload pdf
-        </h4>
-        <div className="mt-4 space-y-3">
-          <Input
-            placeholder="Title (optional)"
-            value={uploadTitle}
-            onChange={(event) => setUploadTitle(event.target.value)}
-            disabled={!isEditable || saving || uploading}
-            aria-label="Document title"
-          />
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={TEST_DOCUMENT_ACCEPT}
-            className="hidden"
-            onChange={(event) => {
-              const file = event.target.files?.[0] || null
-              setSelectedUploadFile(file)
-            }}
-          />
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={!isEditable || saving || uploading}
-            className="gap-1.5"
-          >
-            <Upload className="h-4 w-4" />
-            {selectedUploadFile ? 'Choose another file' : 'Choose file'}
-          </Button>
-          <p className="text-sm text-text-muted">
-            {selectedUploadFile ? `Selected: ${selectedUploadFile.name}` : 'No file selected'}
-          </p>
-        </div>
-        <div className="mt-4 flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={closeAddModal}
-            disabled={saving || uploading}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={() => {
+              if (activeAddTab === 'link') {
+                void handleAddLink()
+                return
+              }
+              if (activeAddTab === 'text') {
+                void handleAddText()
+                return
+              }
               if (!selectedUploadFile) {
                 setError('Please choose a file to upload')
                 return
@@ -688,8 +621,21 @@ export function TestDocumentsEditor({
               void handleUploadFile(selectedUploadFile)
             }}
             disabled={!isEditable || saving || uploading}
+            aria-label={
+              activeAddTab === 'link'
+                ? 'Add link document'
+                : activeAddTab === 'text'
+                  ? 'Add text document'
+                  : 'Upload pdf document'
+            }
           >
-            {uploading ? 'Uploading...' : 'Upload pdf'}
+            {activeAddTab === 'link'
+              ? 'Add link'
+              : activeAddTab === 'text'
+                ? 'Add text'
+                : uploading
+                  ? 'Uploading...'
+                  : 'Upload pdf'}
           </Button>
         </div>
       </DialogPanel>

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -299,6 +299,7 @@ describe('QuizDetailPanel', () => {
       expect(within(editorPane).getByText('Documents')).toBeInTheDocument()
       expect(within(editorPane).getByText('0 documents')).toBeInTheDocument()
       expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toHaveTextContent('+')
 
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('2 questions')
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('9 pts')
@@ -335,7 +336,8 @@ describe('QuizDetailPanel', () => {
 
       await waitFor(() => {
         expect(within(editorPane).getByRole('button', { name: 'Expand documents' })).toBeInTheDocument()
-        expect(within(editorPane).queryByRole('button', { name: 'Add Document' })).not.toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toHaveTextContent('+')
       })
 
       fireEvent.click(within(editorPane).getByRole('button', { name: 'Expand documents' }))
@@ -1757,7 +1759,7 @@ Prompt:
 
       fireEvent.click(screen.getByRole('button', { name: /Documents/ }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
-      fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
+      expect(screen.getByRole('heading', { name: 'Add Document' })).toBeInTheDocument()
       fireEvent.change(screen.getByPlaceholderText('Title'), {
         target: { value: 'Java API' },
       })
@@ -1778,6 +1780,10 @@ Prompt:
             source: 'link',
           },
         ])
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Java API')).toBeInTheDocument()
       })
 
       await waitFor(() => {
@@ -2072,7 +2078,7 @@ Prompt:
 
       fireEvent.click(screen.getByRole('button', { name: 'Documents' }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
-      fireEvent.click(screen.getByRole('menuitem', { name: 'Text' }))
+      fireEvent.click(screen.getByRole('tab', { name: 'Text' }))
       fireEvent.change(screen.getByPlaceholderText('Title'), {
         target: { value: 'Allowed formulas' },
       })
@@ -2093,6 +2099,10 @@ Prompt:
             content: 'distance = rate * time',
           },
         ])
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Allowed formulas')).toBeInTheDocument()
       })
     })
 
@@ -2140,9 +2150,9 @@ Prompt:
 
       fireEvent.click(screen.getByRole('button', { name: 'Documents' }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
-      fireEvent.click(screen.getByRole('menuitem', { name: 'PDF' }))
+      fireEvent.click(screen.getByRole('tab', { name: 'PDF' }))
 
-      expect(screen.getByRole('heading', { name: 'Upload pdf' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Add Document' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Choose file' })).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
## What changed

This follow-up refines the teacher test authoring documents card.

- moves the add-document trigger into the documents collapsible header
- changes the visible trigger label to `+`
- keeps the add flow in a single modal with `Link`, `PDF`, and `Text` tabs
- removes the `Documents saved` success banner
- updates the documents card immediately from the server response so added documents appear in the same card without a panel reload

## Why

The previous add-document entry point moved around too much and created extra visual noise.
The goal here is to keep document actions local to the documents card, reduce chrome, and make the card update quietly after changes.

## Impact

Teachers authoring tests get a quieter documents workflow:

- the add action is located where the documents live
- the card stays visually compact when collapsed
- saves no longer show a transient success toast
- newly added documents appear immediately in the card they were added from

## Validation

- `pnpm exec vitest run tests/components/QuizDetailPanel.test.tsx`
- Playwright-based UI verification on `http://localhost:3005`
- manual teacher screenshot review of the updated documents card state
