### PR TITLE
[codex] Allow teachers to return unsubmitted assignment work

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9390,3 +9390,16 @@
 - `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'src/app/api/teacher/assignments/[id]/route.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'src/lib/assignments.ts' 'tests/api/teacher/assignments-id-return.test.ts' 'tests/api/teacher/assignments-id.test.ts' 'tests/components/TeacherClassroomView.test.tsx' 'tests/unit/assignments.test.ts'`
 - `pnpm exec tsc --noEmit`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments'`
+
+## 2026-04-26 — Disable Assignment Return When Nothing Is Returnable
+
+- Disabled the teacher batch Return button when the selected students are only already-returned and/or partial-rubric blocked rows.
+- Added the tooltip copy `Nothing returnable selected` and kept missing no-doc students actionable because the return flow creates zero-grade returned docs for them.
+- Added component coverage for the disabled no-op return state.
+
+**Validation:**
+- `pnpm test`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec eslint 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec tsc --noEmit`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9379,3 +9379,14 @@
 - `node scripts/features.mjs validate`
 - `pnpm install`
 - `bash scripts/verify-env.sh`
+## 2026-04-26 — Revise Assignment Return For Missing And Already-Returned Work
+
+- Updated assignment return so enrolled students with no assignment doc get a returned 0/0/0 doc without being marked submitted.
+- Added already-returned-without-resubmission detection so repeated return attempts skip unchanged returned docs while allowing later student resubmissions to be returned again.
+- Updated teacher return confirmation/success messaging and assignment detail rows to support the revised selection behavior.
+
+**Validation:**
+- `pnpm test`
+- `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'src/app/api/teacher/assignments/[id]/route.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'src/lib/assignments.ts' 'tests/api/teacher/assignments-id-return.test.ts' 'tests/api/teacher/assignments-id.test.ts' 'tests/components/TeacherClassroomView.test.tsx' 'tests/unit/assignments.test.ts'`
+- `pnpm exec tsc --noEmit`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments'`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9403,3 +9403,12 @@
 - `pnpm exec eslint 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec tsc --noEmit`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments'`
+
+## 2026-04-27 — Clarify Assignment Return Success Counts
+
+- Changed the teacher return success message so existing returned docs and newly created zero-grade returns are counted separately without double-counting created docs.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec eslint 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec tsc --noEmit`

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -3,7 +3,10 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { appendAssignmentFeedbackEntry } from '@/lib/server/assignment-feedback'
 import { withErrorHandler } from '@/lib/api-handler'
-import { getAssignmentRubricState } from '@/lib/assignments'
+import {
+  getAssignmentRubricState,
+  isAssignmentAlreadyReturnedWithoutResubmission,
+} from '@/lib/assignments'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
 
 export const dynamic = 'force-dynamic'
@@ -21,6 +24,38 @@ async function updateAssignmentDocsForStudents(opts: {
     .update(values)
     .eq('assignment_id', assignmentId)
     .in('student_id', studentIds)
+
+  return error
+}
+
+async function insertZeroReturnedAssignmentDocsForStudents(opts: {
+  supabase: ReturnType<typeof getServiceRoleClient>
+  assignmentId: string
+  studentIds: string[]
+  now: string
+  includeTeacherClearedAt: boolean
+}) {
+  const { supabase, assignmentId, studentIds, now, includeTeacherClearedAt } = opts
+  const rows = studentIds.map((studentId) => ({
+    assignment_id: assignmentId,
+    student_id: studentId,
+    content: { type: 'doc', content: [] },
+    is_submitted: false,
+    submitted_at: null,
+    score_completion: 0,
+    score_thinking: 0,
+    score_workflow: 0,
+    feedback: null,
+    graded_at: now,
+    graded_by: 'teacher',
+    returned_at: now,
+    feedback_returned_at: now,
+    ...(includeTeacherClearedAt ? { teacher_cleared_at: now } : {}),
+  }))
+
+  const { error } = await supabase
+    .from('assignment_docs')
+    .insert(rows)
 
   return error
 }
@@ -69,21 +104,26 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
   }
 
   const existingDocs = docs || []
-  const returnableDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) !== 'partial')
   const blockedDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) === 'partial')
+  const nonPartialDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) !== 'partial')
+  const alreadyReturnedDocs = nonPartialDocs.filter((doc) => isAssignmentAlreadyReturnedWithoutResubmission(doc))
+  const returnableDocs = nonPartialDocs.filter((doc) => !isAssignmentAlreadyReturnedWithoutResubmission(doc))
   const existingStudentIds = new Set(existingDocs.map((doc) => doc.student_id))
-  const returnedStudentIds = returnableDocs.map((doc) => doc.student_id)
+  const returnableStudentIds = returnableDocs.map((doc) => doc.student_id)
+  const alreadyReturnedStudentIds = alreadyReturnedDocs.map((doc) => doc.student_id)
   const blockedStudentIds = blockedDocs.map((doc) => doc.student_id)
   const missingStudentIds = student_ids.filter((studentId) => !existingStudentIds.has(studentId))
 
   const now = new Date().toISOString()
   let mailboxTrackingAvailable = true
+  let createdStudentIds: string[] = []
+  let uncreatedMissingStudentIds: string[] = missingStudentIds
 
   if (returnableDocs.length > 0) {
     let updateError = await updateAssignmentDocsForStudents({
       supabase,
       assignmentId: id,
-      studentIds: returnedStudentIds,
+      studentIds: returnableStudentIds,
       values: {
         is_submitted: false,
         teacher_cleared_at: now,
@@ -97,7 +137,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
       updateError = await updateAssignmentDocsForStudents({
         supabase,
         assignmentId: id,
-        studentIds: returnedStudentIds,
+        studentIds: returnableStudentIds,
         values: {
           is_submitted: false,
           returned_at: now,
@@ -140,19 +180,70 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     )
   }
 
-  const returnedCount = returnableDocs.length
+  if (missingStudentIds.length > 0) {
+    const { data: enrollments, error: enrollmentError } = await supabase
+      .from('classroom_enrollments')
+      .select('student_id')
+      .eq('classroom_id', assignment.classroom_id)
+      .in('student_id', missingStudentIds)
+
+    if (enrollmentError) {
+      console.error('Error loading enrollments for return:', enrollmentError)
+      return NextResponse.json({ error: 'Failed to load enrollments for return' }, { status: 500 })
+    }
+
+    const enrolledMissingStudentIds = new Set((enrollments || []).map((enrollment) => enrollment.student_id))
+    createdStudentIds = missingStudentIds.filter((studentId) => enrolledMissingStudentIds.has(studentId))
+    uncreatedMissingStudentIds = missingStudentIds.filter((studentId) => !enrolledMissingStudentIds.has(studentId))
+
+    if (createdStudentIds.length > 0) {
+      let insertError = await insertZeroReturnedAssignmentDocsForStudents({
+        supabase,
+        assignmentId: id,
+        studentIds: createdStudentIds,
+        now,
+        includeTeacherClearedAt: true,
+      })
+
+      if (isMissingAssignmentTeacherClearedAtColumnError(insertError)) {
+        mailboxTrackingAvailable = false
+        insertError = await insertZeroReturnedAssignmentDocsForStudents({
+          supabase,
+          assignmentId: id,
+          studentIds: createdStudentIds,
+          now,
+          includeTeacherClearedAt: false,
+        })
+      }
+
+      if (insertError) {
+        console.error('Error creating zero returned assignment docs:', insertError)
+        return NextResponse.json({ error: 'Failed to create returned docs' }, { status: 500 })
+      }
+    }
+  }
+
+  const returnedStudentIds = [...returnableStudentIds, ...createdStudentIds]
+  const returnedCount = returnedStudentIds.length
   const clearedCount = returnedCount
   const blockedCount = blockedDocs.length
-  const missingCount = missingStudentIds.length
+  const missingCount = uncreatedMissingStudentIds.length
+  const alreadyReturnedCount = alreadyReturnedDocs.length
+  const createdCount = createdStudentIds.length
 
   return NextResponse.json({
     returned_count: returnedCount,
     cleared_count: clearedCount,
+    updated_count: returnableDocs.length,
+    created_count: createdCount,
+    created_student_ids: createdStudentIds,
     returned_student_ids: returnedStudentIds,
     blocked_count: blockedCount,
     blocked_student_ids: blockedStudentIds,
+    already_returned_count: alreadyReturnedCount,
+    already_returned_student_ids: alreadyReturnedStudentIds,
     missing_count: missingCount,
-    missing_student_ids: missingStudentIds,
+    missing_student_ids: uncreatedMissingStudentIds,
     mailbox_tracking_available: mailboxTrackingAvailable,
   })
 })

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -3,26 +3,11 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { appendAssignmentFeedbackEntry } from '@/lib/server/assignment-feedback'
 import { withErrorHandler } from '@/lib/api-handler'
+import { getAssignmentRubricState } from '@/lib/assignments'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-
-function hasReturnableAssignmentGrade(doc: {
-  score_completion: number | null
-  score_thinking: number | null
-  score_workflow: number | null
-  is_submitted?: boolean | null
-  returned_at?: string | null
-}) {
-  const hasFullGrade = doc.score_completion != null
-    && doc.score_thinking != null
-    && doc.score_workflow != null
-
-  if (!hasFullGrade) return false
-
-  return !!doc.is_submitted || !doc.returned_at
-}
 
 async function updateAssignmentDocsForStudents(opts: {
   supabase: ReturnType<typeof getServiceRoleClient>
@@ -40,7 +25,7 @@ async function updateAssignmentDocsForStudents(opts: {
   return error
 }
 
-// POST /api/teacher/assignments/[id]/return - Return graded work to students
+// POST /api/teacher/assignments/[id]/return - Return assignment work to students
 export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (request, context) => {
   const user = await requireRole('teacher')
   const { id } = await context.params
@@ -83,25 +68,22 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     return NextResponse.json({ error: 'Failed to load docs for return' }, { status: 500 })
   }
 
-  const loadedDocs = docs || []
-  const clearableDocs = loadedDocs.filter((doc) => doc.is_submitted)
-  const eligibleDocs = loadedDocs.filter(hasReturnableAssignmentGrade)
-  const eligibleDocIds = new Set(eligibleDocs.map((doc) => doc.id))
-  const actionableDocIds = new Set(
-    loadedDocs
-      .filter((doc) => doc.is_submitted || eligibleDocIds.has(doc.id) || !!doc.returned_at)
-      .map((doc) => doc.id),
-  )
-  const ungradedDocs = clearableDocs.filter((doc) => !eligibleDocIds.has(doc.id))
+  const existingDocs = docs || []
+  const returnableDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) !== 'partial')
+  const blockedDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) === 'partial')
+  const existingStudentIds = new Set(existingDocs.map((doc) => doc.student_id))
+  const returnedStudentIds = returnableDocs.map((doc) => doc.student_id)
+  const blockedStudentIds = blockedDocs.map((doc) => doc.student_id)
+  const missingStudentIds = student_ids.filter((studentId) => !existingStudentIds.has(studentId))
 
   const now = new Date().toISOString()
   let mailboxTrackingAvailable = true
 
-  if (eligibleDocs.length > 0) {
+  if (returnableDocs.length > 0) {
     let updateError = await updateAssignmentDocsForStudents({
       supabase,
       assignmentId: id,
-      studentIds: eligibleDocs.map((doc) => doc.student_id),
+      studentIds: returnedStudentIds,
       values: {
         is_submitted: false,
         teacher_cleared_at: now,
@@ -115,7 +97,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
       updateError = await updateAssignmentDocsForStudents({
         supabase,
         assignmentId: id,
-        studentIds: eligibleDocs.map((doc) => doc.student_id),
+        studentIds: returnedStudentIds,
         values: {
           is_submitted: false,
           returned_at: now,
@@ -130,7 +112,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     }
 
     await Promise.all(
-      eligibleDocs
+      returnableDocs
         .filter((doc) => typeof doc.teacher_feedback_draft === 'string' && doc.teacher_feedback_draft.trim())
         .map((doc) =>
           appendAssignmentFeedbackEntry({
@@ -145,7 +127,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     )
 
     await Promise.all(
-      eligibleDocs
+      returnableDocs
         .filter((doc) => typeof doc.teacher_feedback_draft === 'string' && doc.teacher_feedback_draft.trim())
         .map((doc) =>
           supabase
@@ -158,43 +140,19 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     )
   }
 
-  if (ungradedDocs.length > 0) {
-    let reopenError = await updateAssignmentDocsForStudents({
-      supabase,
-      assignmentId: id,
-      studentIds: ungradedDocs.map((doc) => doc.student_id),
-      values: {
-        is_submitted: false,
-        ...(mailboxTrackingAvailable ? { teacher_cleared_at: now } : {}),
-      },
-    })
-
-    if (isMissingAssignmentTeacherClearedAtColumnError(reopenError)) {
-      mailboxTrackingAvailable = false
-      reopenError = await updateAssignmentDocsForStudents({
-        supabase,
-        assignmentId: id,
-        studentIds: ungradedDocs.map((doc) => doc.student_id),
-        values: {
-          is_submitted: false,
-        },
-      })
-    }
-
-    if (reopenError) {
-      console.error('Error reopening ungraded assignment docs:', reopenError)
-      return NextResponse.json({ error: 'Failed to clear assignment mailbox' }, { status: 500 })
-    }
-  }
-
-  const returnedCount = eligibleDocs.length
-  const clearedCount = clearableDocs.length
-  const missingCount = Math.max(student_ids.length - actionableDocIds.size, 0)
+  const returnedCount = returnableDocs.length
+  const clearedCount = returnedCount
+  const blockedCount = blockedDocs.length
+  const missingCount = missingStudentIds.length
 
   return NextResponse.json({
     returned_count: returnedCount,
     cleared_count: clearedCount,
+    returned_student_ids: returnedStudentIds,
+    blocked_count: blockedCount,
+    blocked_student_ids: blockedStudentIds,
     missing_count: missingCount,
+    missing_student_ids: missingStudentIds,
     mailbox_tracking_available: mailboxTrackingAvailable,
   })
 })

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -120,6 +120,7 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
       student_updated_at: doc ? (studentUpdatedAtByDocId.get(doc.id) ?? null) : null,
       doc: doc
         ? {
+            is_submitted: doc.is_submitted,
             submitted_at: doc.submitted_at,
             updated_at: doc.updated_at,
             score_completion: doc.score_completion,
@@ -127,6 +128,7 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
             score_workflow: doc.score_workflow,
             graded_at: doc.graded_at,
             returned_at: doc.returned_at,
+            teacher_cleared_at: doc.teacher_cleared_at,
             feedback_returned_at: doc.feedback_returned_at,
           }
         : null,

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1183,6 +1183,14 @@ export function TeacherClassroomView({
     !selectedAssignmentLoading &&
     currentStudentRows.length > 0
   const workspaceActionLabelSuffix = batchSelectedCount > 0 ? ` (${batchSelectedCount})` : ''
+  const hasReturnableSelection =
+    batchSelectedReturnSummary.returnableCount + batchSelectedReturnSummary.missingCount > 0
+  const isReturnDisabled =
+    isReturning || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
+  const returnTooltipContent =
+    batchSelectedCount > 0 && !hasReturnableSelection
+      ? 'Nothing returnable selected'
+      : `Return${workspaceActionLabelSuffix}`
   const showAssignmentAiRunOverlay = isAutoGrading || hasActiveAssignmentAiRun
   const assignmentAiRunOverlayLabel = hasActiveAssignmentAiRun && activeAssignmentAiRun
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
@@ -1476,21 +1484,23 @@ export function TeacherClassroomView({
                   />
                 </Tooltip>
 
-                <Tooltip content={`Return${workspaceActionLabelSuffix}`}>
-                  <Button
-                    type="button"
-                    variant="subtle"
-                    size="sm"
-                    className="px-4"
-                    onClick={() => {
-                      setShowReturnConfirm(true)
-                    }}
-                    disabled={isReturning || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
-                    aria-label={`Return${workspaceActionLabelSuffix}`}
-                  >
-                    <Send className="h-4 w-4" aria-hidden="true" />
-                    <span>Return</span>
-                  </Button>
+                <Tooltip content={returnTooltipContent}>
+                  <span className="inline-flex">
+                    <Button
+                      type="button"
+                      variant="subtle"
+                      size="sm"
+                      className="px-4"
+                      onClick={() => {
+                        setShowReturnConfirm(true)
+                      }}
+                      disabled={isReturnDisabled}
+                      aria-label={`Return${workspaceActionLabelSuffix}`}
+                    >
+                      <Send className="h-4 w-4" aria-hidden="true" />
+                      <span>Return</span>
+                    </Button>
+                  </span>
                 </Tooltip>
               </>
             ) : (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -935,8 +935,11 @@ export function TeacherClassroomView({
         batchClearSelection()
       }
 
+      const updatedCount = Math.max(0, returnedCount - createdCount)
       const summaryParts: string[] = []
-      summaryParts.push(`Returned ${returnedCount}`)
+      if (updatedCount > 0) {
+        summaryParts.push(`Returned ${updatedCount}`)
+      }
       if (createdCount > 0) {
         summaryParts.push(`Created ${createdCount} zero-grade return${createdCount === 1 ? '' : 's'}`)
       }

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -51,6 +51,8 @@ import {
 import { RightSidebarToggle } from '@/components/layout'
 import {
   calculateAssignmentStatus,
+  getAssignmentRubricState,
+  getAssignmentStatusIconClass,
   getAssignmentStatusLabel,
   hasDraftSavedGrade,
 } from '@/lib/assignments'
@@ -212,6 +214,13 @@ function getStudentDisplayName(row: StudentSubmissionRow | null): string | null 
   if (!row) return null
   const fullName = [row.student_first_name, row.student_last_name].filter(Boolean).join(' ').trim()
   return fullName || row.student_email || null
+}
+
+function getBatchReturnEligibility(
+  doc: StudentSubmissionRow['doc']
+): 'missing' | 'blocked' | 'returnable' {
+  if (!doc) return 'missing'
+  return getAssignmentRubricState(doc) === 'partial' ? 'blocked' : 'returnable'
 }
 
 function isAssignmentAiGradingRunActive(run: AssignmentAiGradingRunSummary | null): boolean {
@@ -680,6 +689,7 @@ export function TeacherClassroomView({
     toggleSelectAll: batchToggleSelectAll,
     allSelected: batchAllSelected,
     clearSelection: batchClearSelection,
+    setSelection: batchSetSelection,
     selectedCount: batchSelectedCount,
   } = useStudentSelection(studentRowIds)
 
@@ -691,24 +701,29 @@ export function TeacherClassroomView({
     batchClearSelection()
   }, [batchClearSelection, selectedAssignmentKey, selection.mode])
 
-  const batchSelectedGradedCount = useMemo(() => {
-    if (currentStudentRows.length === 0) return 0
-    let graded = 0
+  const batchSelectedReturnSummary = useMemo(() => {
+    let returnableCount = 0
+    let blockedCount = 0
+    let missingCount = 0
+
     for (const student of currentStudentRows) {
-      const doc = student.doc
-      const hasDraftScores = !!(
-        doc &&
-        doc.score_completion != null &&
-        doc.score_thinking != null &&
-        doc.score_workflow != null
-      )
-      if (batchSelectedIds.has(student.student_id) && (doc?.graded_at || hasDraftScores)) {
-        graded += 1
+      if (!batchSelectedIds.has(student.student_id)) continue
+
+      switch (getBatchReturnEligibility(student.doc)) {
+        case 'returnable':
+          returnableCount += 1
+          break
+        case 'blocked':
+          blockedCount += 1
+          break
+        case 'missing':
+          missingCount += 1
+          break
       }
     }
-    return graded
+
+    return { returnableCount, blockedCount, missingCount }
   }, [batchSelectedIds, currentStudentRows])
-  const batchSelectedUngradedCount = batchSelectedCount - batchSelectedGradedCount
 
   useEffect(() => {
     if (!info) return
@@ -891,11 +906,32 @@ export function TeacherClassroomView({
       if (!res.ok) throw new Error(data.error || 'Return failed')
       const returnedCount = Number(data.returned_count ?? 0)
       const clearedCount = Number(data.cleared_count ?? returnedCount)
+      const blockedCount = Number(data.blocked_count ?? 0)
       const missingCount = Number(data.missing_count ?? 0)
-      setInfo(
-        `Cleared ${clearedCount} mailbox item(s)${returnedCount > 0 ? ` • ${returnedCount} returned with grades` : ''}${missingCount > 0 ? ` • ${missingCount} no work yet` : ''}`
+      const returnedStudentIds = Array.isArray(data.returned_student_ids)
+        ? data.returned_student_ids.filter((value: unknown): value is string => typeof value === 'string')
+        : []
+      const remainingSelectedIds = Array.from(batchSelectedIds).filter(
+        (studentId) => !returnedStudentIds.includes(studentId)
       )
-      batchClearSelection()
+      if (remainingSelectedIds.length > 0) {
+        batchSetSelection(remainingSelectedIds)
+      } else {
+        batchClearSelection()
+      }
+
+      const summaryParts: string[] = []
+      summaryParts.push(`Returned ${returnedCount}`)
+      if (blockedCount > 0) {
+        summaryParts.push(`Blocked ${blockedCount} partial-rubric draft${blockedCount === 1 ? '' : 's'}`)
+      }
+      if (missingCount > 0) {
+        summaryParts.push(`${missingCount} with no work yet`)
+      }
+      if (returnedCount === 0 && clearedCount > 0) {
+        summaryParts.push(`Cleared ${clearedCount}`)
+      }
+      setInfo(summaryParts.join(' • '))
       setShowReturnConfirm(false)
       // Reload assignment data to refresh statuses/grades
       setRefreshCounter((c) => c + 1)
@@ -1662,7 +1698,7 @@ export function TeacherClassroomView({
       <ConfirmDialog
         isOpen={showReturnConfirm}
         title={`Return work to ${batchSelectedCount} selected student(s)?`}
-        description={`This clears the assignment mailbox for the selected students. ${batchSelectedGradedCount} ready item(s) will also be returned to students now.${batchSelectedUngradedCount > 0 ? ` ${batchSelectedUngradedCount} not-yet-graded item(s) will be cleared from the mailbox only.` : ''}`}
+        description={`Returning will mark ${batchSelectedReturnSummary.returnableCount} selected student document(s) as returned now, even if the work was never submitted. ${batchSelectedReturnSummary.blockedCount > 0 ? `${batchSelectedReturnSummary.blockedCount} selected student(s) have partial rubric drafts and must be completed or cleared before return. ` : ''}${batchSelectedReturnSummary.missingCount > 0 ? `${batchSelectedReturnSummary.missingCount} selected student(s) have no work yet and will be left unchanged.` : ''}`.trim()}
         confirmLabel={isReturning ? 'Returning...' : 'Return'}
         cancelLabel="Cancel"
         isConfirmDisabled={isReturning}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -55,6 +55,7 @@ import {
   getAssignmentStatusIconClass,
   getAssignmentStatusLabel,
   hasDraftSavedGrade,
+  isAssignmentAlreadyReturnedWithoutResubmission,
 } from '@/lib/assignments'
 import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
 import {
@@ -113,6 +114,7 @@ interface StudentSubmissionRow {
   student_updated_at?: string | null
   artifacts: AssignmentArtifact[]
   doc: {
+    is_submitted?: boolean | null
     submitted_at?: string | null
     updated_at?: string | null
     score_completion?: number | null
@@ -120,6 +122,7 @@ interface StudentSubmissionRow {
     score_workflow?: number | null
     graded_at?: string | null
     returned_at?: string | null
+    teacher_cleared_at?: string | null
     feedback_returned_at?: string | null
   } | null
 }
@@ -218,9 +221,11 @@ function getStudentDisplayName(row: StudentSubmissionRow | null): string | null 
 
 function getBatchReturnEligibility(
   doc: StudentSubmissionRow['doc']
-): 'missing' | 'blocked' | 'returnable' {
+): 'missing' | 'blocked' | 'already_returned' | 'returnable' {
   if (!doc) return 'missing'
-  return getAssignmentRubricState(doc) === 'partial' ? 'blocked' : 'returnable'
+  if (getAssignmentRubricState(doc) === 'partial') return 'blocked'
+  if (isAssignmentAlreadyReturnedWithoutResubmission(doc)) return 'already_returned'
+  return 'returnable'
 }
 
 function isAssignmentAiGradingRunActive(run: AssignmentAiGradingRunSummary | null): boolean {
@@ -705,6 +710,7 @@ export function TeacherClassroomView({
     let returnableCount = 0
     let blockedCount = 0
     let missingCount = 0
+    let alreadyReturnedCount = 0
 
     for (const student of currentStudentRows) {
       if (!batchSelectedIds.has(student.student_id)) continue
@@ -719,10 +725,13 @@ export function TeacherClassroomView({
         case 'missing':
           missingCount += 1
           break
+        case 'already_returned':
+          alreadyReturnedCount += 1
+          break
       }
     }
 
-    return { returnableCount, blockedCount, missingCount }
+    return { returnableCount, blockedCount, missingCount, alreadyReturnedCount }
   }, [batchSelectedIds, currentStudentRows])
 
   useEffect(() => {
@@ -906,13 +915,19 @@ export function TeacherClassroomView({
       if (!res.ok) throw new Error(data.error || 'Return failed')
       const returnedCount = Number(data.returned_count ?? 0)
       const clearedCount = Number(data.cleared_count ?? returnedCount)
+      const createdCount = Number(data.created_count ?? 0)
       const blockedCount = Number(data.blocked_count ?? 0)
+      const alreadyReturnedCount = Number(data.already_returned_count ?? 0)
       const missingCount = Number(data.missing_count ?? 0)
       const returnedStudentIds = Array.isArray(data.returned_student_ids)
         ? data.returned_student_ids.filter((value: unknown): value is string => typeof value === 'string')
         : []
+      const alreadyReturnedStudentIds = Array.isArray(data.already_returned_student_ids)
+        ? data.already_returned_student_ids.filter((value: unknown): value is string => typeof value === 'string')
+        : []
+      const completedStudentIds = new Set([...returnedStudentIds, ...alreadyReturnedStudentIds])
       const remainingSelectedIds = Array.from(batchSelectedIds).filter(
-        (studentId) => !returnedStudentIds.includes(studentId)
+        (studentId) => !completedStudentIds.has(studentId)
       )
       if (remainingSelectedIds.length > 0) {
         batchSetSelection(remainingSelectedIds)
@@ -922,11 +937,17 @@ export function TeacherClassroomView({
 
       const summaryParts: string[] = []
       summaryParts.push(`Returned ${returnedCount}`)
+      if (createdCount > 0) {
+        summaryParts.push(`Created ${createdCount} zero-grade return${createdCount === 1 ? '' : 's'}`)
+      }
+      if (alreadyReturnedCount > 0) {
+        summaryParts.push(`Skipped ${alreadyReturnedCount} already returned`)
+      }
       if (blockedCount > 0) {
         summaryParts.push(`Blocked ${blockedCount} partial-rubric draft${blockedCount === 1 ? '' : 's'}`)
       }
       if (missingCount > 0) {
-        summaryParts.push(`${missingCount} with no work yet`)
+        summaryParts.push(`${missingCount} unavailable`)
       }
       if (returnedCount === 0 && clearedCount > 0) {
         summaryParts.push(`Cleared ${clearedCount}`)
@@ -1698,7 +1719,7 @@ export function TeacherClassroomView({
       <ConfirmDialog
         isOpen={showReturnConfirm}
         title={`Return work to ${batchSelectedCount} selected student(s)?`}
-        description={`Returning will mark ${batchSelectedReturnSummary.returnableCount} selected student document(s) as returned now, even if the work was never submitted. ${batchSelectedReturnSummary.blockedCount > 0 ? `${batchSelectedReturnSummary.blockedCount} selected student(s) have partial rubric drafts and must be completed or cleared before return. ` : ''}${batchSelectedReturnSummary.missingCount > 0 ? `${batchSelectedReturnSummary.missingCount} selected student(s) have no work yet and will be left unchanged.` : ''}`.trim()}
+        description={`Returning will mark ${batchSelectedReturnSummary.returnableCount} existing student document(s) as returned now, even if the work was never submitted. ${batchSelectedReturnSummary.missingCount > 0 ? `${batchSelectedReturnSummary.missingCount} selected student(s) have no work yet; Pika will create returned 0/0/0 documents for them without marking them submitted. ` : ''}${batchSelectedReturnSummary.alreadyReturnedCount > 0 ? `${batchSelectedReturnSummary.alreadyReturnedCount} selected student(s) were already returned and will be skipped. ` : ''}${batchSelectedReturnSummary.blockedCount > 0 ? `${batchSelectedReturnSummary.blockedCount} selected student(s) have partial rubric drafts and must be completed or cleared before return.` : ''}`.trim()}
         confirmLabel={isReturning ? 'Returning...' : 'Return'}
         cancelLabel="Cancel"
         isConfirmDisabled={isReturning}

--- a/src/hooks/useStudentSelection.ts
+++ b/src/hooks/useStudentSelection.ts
@@ -41,12 +41,17 @@ export function useStudentSelection(rowIds: string[]) {
     setSelectedIds(new Set())
   }, [])
 
+  const setSelection = useCallback((ids: Iterable<string>) => {
+    setSelectedIds(new Set(ids))
+  }, [])
+
   return {
     selectedIds,
     toggleSelect,
     toggleSelectAll,
     allSelected,
     clearSelection,
+    setSelection,
     selectedCount,
   }
 }

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -2,12 +2,22 @@ import { Assignment, AssignmentDoc, AssignmentStatus, AssignmentStats } from '@/
 import { formatInTimeZone } from 'date-fns-tz'
 
 type AssignmentStatDoc = Pick<AssignmentDoc, 'is_submitted' | 'submitted_at' | 'returned_at' | 'teacher_cleared_at'>
-type AssignmentRubricDoc = Pick<AssignmentDoc, 'score_completion' | 'score_thinking' | 'score_workflow'>
+type AssignmentRubricDoc = {
+  score_completion?: number | null
+  score_thinking?: number | null
+  score_workflow?: number | null
+}
+type AssignmentReturnDoc = {
+  is_submitted?: boolean | null
+  submitted_at?: string | null
+  returned_at?: string | null
+  teacher_cleared_at?: string | null
+}
 
 export type AssignmentRubricState = 'blank' | 'partial' | 'complete'
 
-function getAssignmentFullReturnAt(
-  doc: Pick<AssignmentDoc, 'teacher_cleared_at' | 'returned_at'>
+export function getAssignmentFullReturnAt(
+  doc: Pick<AssignmentReturnDoc, 'teacher_cleared_at' | 'returned_at'>
 ): string | null {
   const timestamps = [doc.teacher_cleared_at, doc.returned_at].filter((value): value is string => typeof value === 'string')
   if (timestamps.length === 0) return null
@@ -38,6 +48,18 @@ export function isAssignmentReturnable(
 ): boolean {
   const rubricState = getAssignmentRubricState(doc)
   return rubricState === 'blank' || rubricState === 'complete'
+}
+
+export function isAssignmentAlreadyReturnedWithoutResubmission(
+  doc: AssignmentReturnDoc | null | undefined
+): boolean {
+  if (!doc) return false
+
+  const fullReturnAt = getAssignmentFullReturnAt(doc)
+  if (!fullReturnAt) return false
+  if (!doc.is_submitted || !doc.submitted_at) return true
+
+  return new Date(doc.submitted_at).getTime() <= new Date(fullReturnAt).getTime()
 }
 
 /**

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -2,6 +2,9 @@ import { Assignment, AssignmentDoc, AssignmentStatus, AssignmentStats } from '@/
 import { formatInTimeZone } from 'date-fns-tz'
 
 type AssignmentStatDoc = Pick<AssignmentDoc, 'is_submitted' | 'submitted_at' | 'returned_at' | 'teacher_cleared_at'>
+type AssignmentRubricDoc = Pick<AssignmentDoc, 'score_completion' | 'score_thinking' | 'score_workflow'>
+
+export type AssignmentRubricState = 'blank' | 'partial' | 'complete'
 
 function getAssignmentFullReturnAt(
   doc: Pick<AssignmentDoc, 'teacher_cleared_at' | 'returned_at'>
@@ -12,6 +15,29 @@ function getAssignmentFullReturnAt(
   return timestamps.reduce((latest, current) =>
     new Date(current).getTime() > new Date(latest).getTime() ? current : latest
   )
+}
+
+export function getAssignmentRubricState(
+  doc: AssignmentRubricDoc | null | undefined
+): AssignmentRubricState | null {
+  if (!doc) return null
+
+  const filledCount = [
+    doc.score_completion,
+    doc.score_thinking,
+    doc.score_workflow,
+  ].filter((value) => value !== null && value !== undefined).length
+
+  if (filledCount === 0) return 'blank'
+  if (filledCount === 3) return 'complete'
+  return 'partial'
+}
+
+export function isAssignmentReturnable(
+  doc: AssignmentRubricDoc | null | undefined
+): boolean {
+  const rubricState = getAssignmentRubricState(doc)
+  return rubricState === 'blank' || rubricState === 'complete'
 }
 
 /**

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -28,6 +28,7 @@ function buildAssignmentDocsTable(options?: {
   docs?: any[]
   returnUpdateError?: any
   feedbackUpdateError?: any
+  insertError?: any
   selectError?: any
 }) {
   const docs = options?.docs ?? []
@@ -45,6 +46,9 @@ function buildAssignmentDocsTable(options?: {
       })
     }),
   }))
+  const insert = vi.fn().mockResolvedValue({
+    error: options?.insertError ?? null,
+  })
 
   return {
     table: {
@@ -57,8 +61,26 @@ function buildAssignmentDocsTable(options?: {
         })),
       })),
       update,
+      insert,
     },
     update,
+    insert,
+  }
+}
+
+function buildClassroomEnrollmentsTable(options?: {
+  enrollments?: any[]
+  selectError?: any
+}) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn().mockResolvedValue({
+          data: options?.enrollments ?? [],
+          error: options?.selectError ?? null,
+        }),
+      })),
+    })),
   }
 }
 
@@ -82,7 +104,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     expect(data.error).toBe('student_ids array is required')
   })
 
-  it('returns existing docs with blank or complete rubrics and blocks partial rubrics', async () => {
+  it('returns existing docs, creates zero returns for enrolled missing work, and blocks partial rubrics', async () => {
     const docs = [
       {
         id: 'doc-1',
@@ -117,6 +139,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     ]
 
     const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-4' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -140,6 +165,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
         return assignmentDocsTable.table
       }
 
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
+      }
+
       throw new Error(`Unexpected table in test: ${table}`)
     })
 
@@ -154,13 +183,18 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.returned_count).toBe(2)
-    expect(data.cleared_count).toBe(2)
-    expect(data.returned_student_ids).toEqual(['student-1', 'student-2'])
+    expect(data.returned_count).toBe(3)
+    expect(data.cleared_count).toBe(3)
+    expect(data.updated_count).toBe(2)
+    expect(data.created_count).toBe(1)
+    expect(data.created_student_ids).toEqual(['student-4'])
+    expect(data.returned_student_ids).toEqual(['student-1', 'student-2', 'student-4'])
     expect(data.blocked_count).toBe(1)
     expect(data.blocked_student_ids).toEqual(['student-3'])
-    expect(data.missing_count).toBe(1)
-    expect(data.missing_student_ids).toEqual(['student-4'])
+    expect(data.already_returned_count).toBe(0)
+    expect(data.already_returned_student_ids).toEqual([])
+    expect(data.missing_count).toBe(0)
+    expect(data.missing_student_ids).toEqual([])
 
     const payloads = assignmentDocsTable.update.mock.calls.map(([payload]) => payload)
     expect(payloads).toEqual(expect.arrayContaining([
@@ -176,6 +210,24 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     expect(
       payloads.every((payload: any) => !('submitted_at' in payload))
     ).toBe(true)
+
+    expect(assignmentDocsTable.insert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        assignment_id: 'assignment-1',
+        student_id: 'student-4',
+        is_submitted: false,
+        submitted_at: null,
+        score_completion: 0,
+        score_thinking: 0,
+        score_workflow: 0,
+        feedback: null,
+        graded_at: expect.any(String),
+        graded_by: 'teacher',
+        returned_at: expect.any(String),
+        feedback_returned_at: expect.any(String),
+        teacher_cleared_at: expect.any(String),
+      }),
+    ])
 
     expect(appendAssignmentFeedbackEntry).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -312,9 +364,72 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.returned_count).toBe(1)
-    expect(data.cleared_count).toBe(1)
+    expect(data.returned_count).toBe(0)
+    expect(data.cleared_count).toBe(0)
+    expect(data.already_returned_count).toBe(1)
+    expect(data.already_returned_student_ids).toEqual(['student-1'])
     expect(data.missing_count).toBe(0)
+    expect(assignmentDocsTable.update).not.toHaveBeenCalled()
+    expect(appendAssignmentFeedbackEntry).not.toHaveBeenCalled()
+  })
+
+  it('returns already returned work after the student resubmits', async () => {
+    const docs = [
+      {
+        id: 'doc-1',
+        student_id: 'student-1',
+        is_submitted: true,
+        submitted_at: '2026-04-21T12:00:00Z',
+        returned_at: '2026-04-20T12:00:00Z',
+        teacher_cleared_at: '2026-04-20T12:00:00Z',
+        score_completion: 8,
+        score_thinking: 8,
+        score_workflow: 8,
+        teacher_feedback_draft: 'Revision checked',
+      },
+    ]
+
+    const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return assignmentDocsTable.table
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(1)
+    expect(data.already_returned_count).toBe(0)
+    expect(data.returned_student_ids).toEqual(['student-1'])
     expect(assignmentDocsTable.update).toHaveBeenCalledWith(
       expect.objectContaining({
         is_submitted: false,
@@ -328,7 +443,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
         assignmentId: 'assignment-1',
         studentId: 'student-1',
         createdBy: 'teacher-1',
-        body: 'Already returned',
+        body: 'Revision checked',
       }),
     )
   })

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -26,10 +26,9 @@ const mockSupabaseClient = { from: vi.fn() }
 
 function buildAssignmentDocsTable(options?: {
   docs?: any[]
-  selectError?: any
-  clearUpdateError?: any
   returnUpdateError?: any
   feedbackUpdateError?: any
+  selectError?: any
 }) {
   const docs = options?.docs ?? []
   const update = vi.fn((payload: Record<string, unknown>) => ({
@@ -38,13 +37,6 @@ function buildAssignmentDocsTable(options?: {
         return {
           in: vi.fn().mockResolvedValue({
             error: options?.returnUpdateError ?? null,
-          }),
-        }
-      }
-      if ('teacher_cleared_at' in payload || payload.is_submitted === false) {
-        return {
-          in: vi.fn().mockResolvedValue({
-            error: options?.clearUpdateError ?? null,
           }),
         }
       }
@@ -90,12 +82,13 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     expect(data.error).toBe('student_ids array is required')
   })
 
-  it('clears submitted docs and fully returns only graded ones', async () => {
+  it('returns existing docs with blank or complete rubrics and blocks partial rubrics', async () => {
     const docs = [
       {
         id: 'doc-1',
         student_id: 'student-1',
         is_submitted: true,
+        submitted_at: '2026-04-10T12:00:00.000Z',
         score_completion: 4,
         score_thinking: 4,
         score_workflow: 4,
@@ -104,19 +97,21 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
       {
         id: 'doc-2',
         student_id: 'student-2',
-        is_submitted: true,
+        is_submitted: false,
+        submitted_at: null,
         score_completion: null,
-        score_thinking: 3,
-        score_workflow: 3,
+        score_thinking: null,
+        score_workflow: null,
         teacher_feedback_draft: '',
       },
       {
         id: 'doc-3',
         student_id: 'student-3',
         is_submitted: false,
-        score_completion: null,
+        submitted_at: null,
+        score_completion: 2,
         score_thinking: 3,
-        score_workflow: 3,
+        score_workflow: null,
         teacher_feedback_draft: 'Missing completion score',
       },
     ]
@@ -151,7 +146,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
       method: 'POST',
       body: JSON.stringify({
-        student_ids: ['student-1', 'student-2', 'student-3'],
+        student_ids: ['student-1', 'student-2', 'student-3', 'student-4'],
       }),
     })
 
@@ -159,9 +154,13 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.returned_count).toBe(1)
+    expect(data.returned_count).toBe(2)
     expect(data.cleared_count).toBe(2)
+    expect(data.returned_student_ids).toEqual(['student-1', 'student-2'])
+    expect(data.blocked_count).toBe(1)
+    expect(data.blocked_student_ids).toEqual(['student-3'])
     expect(data.missing_count).toBe(1)
+    expect(data.missing_student_ids).toEqual(['student-4'])
 
     const payloads = assignmentDocsTable.update.mock.calls.map(([payload]) => payload)
     expect(payloads).toEqual(expect.arrayContaining([
@@ -175,12 +174,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
       }),
     ]))
     expect(
-      payloads.some((payload: any) =>
-        payload.is_submitted === false
-        && typeof payload.teacher_cleared_at === 'string'
-        && !('returned_at' in payload)
-        && !('feedback_returned_at' in payload)
-      )
+      payloads.every((payload: any) => !('submitted_at' in payload))
     ).toBe(true)
 
     expect(appendAssignmentFeedbackEntry).toHaveBeenCalledWith(
@@ -245,7 +239,7 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
     expect(response.status).toBe(200)
     expect(data.returned_count).toBe(1)
-    expect(data.cleared_count).toBe(0)
+    expect(data.cleared_count).toBe(1)
     expect(data.missing_count).toBe(0)
 
     expect(assignmentDocsTable.update).toHaveBeenCalledWith(
@@ -318,11 +312,25 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.returned_count).toBe(0)
-    expect(data.cleared_count).toBe(0)
+    expect(data.returned_count).toBe(1)
+    expect(data.cleared_count).toBe(1)
     expect(data.missing_count).toBe(0)
-    expect(assignmentDocsTable.update).not.toHaveBeenCalled()
-    expect(appendAssignmentFeedbackEntry).not.toHaveBeenCalled()
+    expect(assignmentDocsTable.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        is_submitted: false,
+        returned_at: expect.any(String),
+        feedback_returned_at: expect.any(String),
+        teacher_cleared_at: expect.any(String),
+      }),
+    )
+    expect(appendAssignmentFeedbackEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: 'assignment-1',
+        studentId: 'student-1',
+        createdBy: 'teacher-1',
+        body: 'Already returned',
+      }),
+    )
   })
 
   it('returns 500 when returning docs update fails', async () => {
@@ -379,20 +387,19 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     expect(data.error).toBe('Failed to return docs')
   })
 
-  it('returns 500 when mailbox clear update fails for reasons other than missing column', async () => {
+  it('does not return partial rubric drafts when every selected doc is blocked', async () => {
     const assignmentDocsTable = buildAssignmentDocsTable({
       docs: [
         {
           id: 'doc-1',
           student_id: 'student-1',
-          is_submitted: true,
-          score_completion: null,
+          is_submitted: false,
+          score_completion: 5,
           score_thinking: null,
-          score_workflow: null,
+          score_workflow: 7,
           teacher_feedback_draft: '',
         },
       ],
-      clearUpdateError: { code: '23505', message: 'boom' },
     })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
@@ -430,7 +437,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
     const data = await response.json()
 
-    expect(response.status).toBe(500)
-    expect(data.error).toBe('Failed to clear assignment mailbox')
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(0)
+    expect(data.blocked_count).toBe(1)
+    expect(data.blocked_student_ids).toEqual(['student-1'])
+    expect(assignmentDocsTable.update).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -175,6 +175,7 @@ describe('GET /api/teacher/assignments/[id]', () => {
       { type: 'image', url: 'https://cdn.example.com/submission-images/shot.png' },
     ])
     expect(data.students[0].doc).toEqual({
+      is_submitted: true,
       submitted_at: submittedAt,
       updated_at: updatedAt,
       score_completion: 9,
@@ -182,10 +183,8 @@ describe('GET /api/teacher/assignments/[id]', () => {
       score_workflow: 7,
       graded_at: '2026-03-10T12:00:00.000Z',
       returned_at: null,
-      feedback_returned_at: undefined,
     })
     expect(data.students[0].doc).not.toHaveProperty('content')
-    expect(data.students[0].doc).not.toHaveProperty('is_submitted')
     expect(data.active_ai_grading_run).toBeNull()
   })
 })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -9,6 +9,7 @@ const mockFetchJSONWithCache = vi.fn()
 const mockToggleSelect = vi.fn()
 const mockToggleSelectAll = vi.fn()
 const mockClearSelection = vi.fn()
+const mockSetSelection = vi.fn()
 const mockStudentSelectionState = {
   selectedIds: new Set<string>(),
   allSelected: false,
@@ -33,7 +34,16 @@ vi.mock('@dnd-kit/sortable', () => ({
 
 vi.mock('@/ui', () => ({
   Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-  ConfirmDialog: () => null,
+  ConfirmDialog: ({ isOpen, title, description, confirmLabel, cancelLabel, onConfirm, onCancel, isConfirmDisabled, isCancelDisabled }: any) => (
+    isOpen ? (
+      <div>
+        <div>{title}</div>
+        {description ? <div>{description}</div> : null}
+        <button type="button" onClick={onCancel} disabled={isCancelDisabled}>{cancelLabel}</button>
+        <button type="button" onClick={onConfirm} disabled={isConfirmDisabled}>{confirmLabel}</button>
+      </div>
+    ) : null
+  ),
   SplitButton: ({ label, onPrimaryClick, disabled, primaryButtonProps }: any) => (
     <button
       type="button"
@@ -58,6 +68,7 @@ vi.mock('@/hooks/useStudentSelection', () => ({
     toggleSelectAll: mockToggleSelectAll,
     allSelected: mockStudentSelectionState.allSelected,
     clearSelection: mockClearSelection,
+    setSelection: mockSetSelection,
     selectedCount: mockStudentSelectionState.selectedCount,
   }),
 }))
@@ -117,6 +128,14 @@ vi.mock('@/components/layout', () => ({
 
 vi.mock('@/lib/assignments', () => ({
   calculateAssignmentStatus: vi.fn(() => 'submitted_on_time'),
+  getAssignmentRubricState: vi.fn((doc: any) => {
+    if (!doc) return null
+    const filledCount = [doc.score_completion, doc.score_thinking, doc.score_workflow]
+      .filter((value) => value !== null && value !== undefined).length
+    if (filledCount === 0) return 'blank'
+    if (filledCount === 3) return 'complete'
+    return 'partial'
+  }),
   getAssignmentStatusIconClass: vi.fn(() => ''),
   getAssignmentStatusLabel: vi.fn(() => 'Submitted'),
   hasDraftSavedGrade: vi.fn(() => false),
@@ -266,6 +285,7 @@ describe('TeacherClassroomView', () => {
     mockToggleSelect.mockReset()
     mockToggleSelectAll.mockReset()
     mockClearSelection.mockReset()
+    mockSetSelection.mockReset()
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
     mockStudentSelectionState.selectedCount = 0
@@ -905,5 +925,122 @@ describe('TeacherClassroomView', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('keeps blocked and missing students selected after a mixed batch return', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2', 'student-3'])
+    mockStudentSelectionState.selectedCount = 3
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1').assignment,
+            students: [
+              {
+                student_id: 'student-1',
+                student_email: 'student-1@example.com',
+                student_first_name: 'student-1',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  submitted_at: '2026-04-10T12:00:00Z',
+                  updated_at: '2026-04-10T12:00:00Z',
+                  score_completion: 8,
+                  score_thinking: 7,
+                  score_workflow: 9,
+                  graded_at: '2026-04-10T13:00:00Z',
+                  returned_at: null,
+                  feedback_returned_at: null,
+                },
+              },
+              {
+                student_id: 'student-2',
+                student_email: 'student-2@example.com',
+                student_first_name: 'student-2',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  submitted_at: '2026-04-10T12:00:00Z',
+                  updated_at: '2026-04-10T12:00:00Z',
+                  score_completion: 8,
+                  score_thinking: null,
+                  score_workflow: 9,
+                  graded_at: null,
+                  returned_at: null,
+                  feedback_returned_at: null,
+                },
+              },
+              {
+                student_id: 'student-3',
+                student_email: 'student-3@example.com',
+                student_first_name: 'student-3',
+                student_last_name: 'Student',
+                status: 'not_started',
+                student_updated_at: null,
+                artifacts: [],
+                doc: null,
+              },
+            ],
+          }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/return') {
+        expect(init?.method).toBe('POST')
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            returned_count: 1,
+            cleared_count: 1,
+            returned_student_ids: ['student-1'],
+            blocked_count: 1,
+            blocked_student_ids: ['student-2'],
+            missing_count: 1,
+            missing_student_ids: ['student-3'],
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Return/i }))
+
+    expect(
+      screen.getByText(/partial rubric drafts and must be completed or cleared before return/i),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Return' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Returned 1 • Blocked 1 partial-rubric draft • 1 with no work yet')).toBeInTheDocument()
+    })
+    expect(mockSetSelection).toHaveBeenCalledWith(['student-2', 'student-3'])
   })
 })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -136,6 +136,12 @@ vi.mock('@/lib/assignments', () => ({
     if (filledCount === 3) return 'complete'
     return 'partial'
   }),
+  isAssignmentAlreadyReturnedWithoutResubmission: vi.fn((doc: any) => {
+    if (!doc?.returned_at && !doc?.teacher_cleared_at) return false
+    const returnedAt = new Date(doc.teacher_cleared_at || doc.returned_at).getTime()
+    if (!doc.is_submitted || !doc.submitted_at) return true
+    return new Date(doc.submitted_at).getTime() <= returnedAt
+  }),
   getAssignmentStatusIconClass: vi.fn(() => ''),
   getAssignmentStatusLabel: vi.fn(() => 'Submitted'),
   hasDraftSavedGrade: vi.fn(() => false),
@@ -927,9 +933,9 @@ describe('TeacherClassroomView', () => {
     }
   })
 
-  it('keeps blocked and missing students selected after a mixed batch return', async () => {
-    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2', 'student-3'])
-    mockStudentSelectionState.selectedCount = 3
+  it('keeps blocked students selected and clears returned, created, and already-returned students after a mixed batch return', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2', 'student-3', 'student-4'])
+    mockStudentSelectionState.selectedCount = 4
 
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
@@ -995,6 +1001,27 @@ describe('TeacherClassroomView', () => {
                 artifacts: [],
                 doc: null,
               },
+              {
+                student_id: 'student-4',
+                student_email: 'student-4@example.com',
+                student_first_name: 'student-4',
+                student_last_name: 'Student',
+                status: 'returned',
+                student_updated_at: '2026-04-09T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  is_submitted: false,
+                  submitted_at: '2026-04-09T12:00:00Z',
+                  updated_at: '2026-04-09T12:00:00Z',
+                  score_completion: 7,
+                  score_thinking: 7,
+                  score_workflow: 7,
+                  graded_at: '2026-04-09T13:00:00Z',
+                  returned_at: '2026-04-09T14:00:00Z',
+                  teacher_cleared_at: '2026-04-09T14:00:00Z',
+                  feedback_returned_at: '2026-04-09T14:00:00Z',
+                },
+              },
             ],
           }),
         })
@@ -1005,13 +1032,16 @@ describe('TeacherClassroomView', () => {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            returned_count: 1,
-            cleared_count: 1,
-            returned_student_ids: ['student-1'],
+            returned_count: 2,
+            cleared_count: 2,
+            created_count: 1,
+            returned_student_ids: ['student-1', 'student-3'],
             blocked_count: 1,
             blocked_student_ids: ['student-2'],
-            missing_count: 1,
-            missing_student_ids: ['student-3'],
+            already_returned_count: 1,
+            already_returned_student_ids: ['student-4'],
+            missing_count: 0,
+            missing_student_ids: [],
           }),
         })
       }
@@ -1035,12 +1065,14 @@ describe('TeacherClassroomView', () => {
     expect(
       screen.getByText(/partial rubric drafts and must be completed or cleared before return/i),
     ).toBeInTheDocument()
+    expect(screen.getByText(/create returned 0\/0\/0 documents/i)).toBeInTheDocument()
+    expect(screen.getByText(/already returned and will be skipped/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Return' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Returned 1 • Blocked 1 partial-rubric draft • 1 with no work yet')).toBeInTheDocument()
+      expect(screen.getByText('Returned 2 • Created 1 zero-grade return • Skipped 1 already returned • Blocked 1 partial-rubric draft')).toBeInTheDocument()
     })
-    expect(mockSetSelection).toHaveBeenCalledWith(['student-2', 'student-3'])
+    expect(mockSetSelection).toHaveBeenCalledWith(['student-2'])
   })
 })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1162,7 +1162,7 @@ describe('TeacherClassroomView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Return' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Returned 2 • Created 1 zero-grade return • Skipped 1 already returned • Blocked 1 partial-rubric draft')).toBeInTheDocument()
+      expect(screen.getByText('Returned 1 • Created 1 zero-grade return • Skipped 1 already returned • Blocked 1 partial-rubric draft')).toBeInTheDocument()
     })
     expect(mockSetSelection).toHaveBeenCalledWith(['student-2'])
   })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -54,7 +54,9 @@ vi.mock('@/ui', () => ({
       {label}
     </button>
   ),
-  Tooltip: ({ children }: any) => <>{children}</>,
+  Tooltip: ({ children, content }: any) => (
+    <span data-tooltip={typeof content === 'string' ? content : undefined}>{children}</span>
+  ),
 }))
 
 vi.mock('@/hooks/useDelayedBusy', () => ({
@@ -931,6 +933,95 @@ describe('TeacherClassroomView', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('disables batch return when selected students have nothing returnable', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
+    mockStudentSelectionState.selectedCount = 2
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1').assignment,
+            students: [
+              {
+                student_id: 'student-1',
+                student_email: 'student-1@example.com',
+                student_first_name: 'student-1',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  is_submitted: false,
+                  submitted_at: '2026-04-09T12:00:00Z',
+                  updated_at: '2026-04-09T12:00:00Z',
+                  score_completion: 7,
+                  score_thinking: 7,
+                  score_workflow: 7,
+                  graded_at: '2026-04-09T13:00:00Z',
+                  returned_at: '2026-04-09T14:00:00Z',
+                  teacher_cleared_at: '2026-04-09T14:00:00Z',
+                  feedback_returned_at: '2026-04-09T14:00:00Z',
+                },
+              },
+              {
+                student_id: 'student-2',
+                student_email: 'student-2@example.com',
+                student_first_name: 'student-2',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  is_submitted: false,
+                  submitted_at: null,
+                  updated_at: '2026-04-10T12:00:00Z',
+                  score_completion: 8,
+                  score_thinking: null,
+                  score_workflow: 9,
+                  graded_at: null,
+                  returned_at: null,
+                  teacher_cleared_at: null,
+                  feedback_returned_at: null,
+                },
+              },
+            ],
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    const returnButton = screen.getByRole('button', { name: /Return/i })
+    expect(returnButton).toBeDisabled()
+    expect(returnButton.closest('[data-tooltip]')).toHaveAttribute('data-tooltip', 'Nothing returnable selected')
+
+    fireEvent.click(returnButton)
+    expect(screen.queryByText(/Return work to 2 selected student/)).not.toBeInTheDocument()
   })
 
   it('keeps blocked students selected and clears returned, created, and already-returned students after a mixed batch return', async () => {

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -10,7 +10,9 @@ import {
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
   getAssignmentStatusIconClass,
+  getAssignmentRubricState,
   hasDraftSavedGrade,
+  isAssignmentReturnable,
   formatDueDate,
   isPastDue,
   formatRelativeDueDate,
@@ -671,6 +673,46 @@ describe('assignment utilities', () => {
 
     it('should return gray for invalid status', () => {
       expect(getAssignmentStatusIconClass('invalid_status' as any)).toBe('text-gray-400')
+    })
+  })
+
+  describe('assignment rubric helpers', () => {
+    it('returns null rubric state for a missing doc', () => {
+      expect(getAssignmentRubricState(null)).toBeNull()
+      expect(isAssignmentReturnable(null)).toBe(false)
+    })
+
+    it('treats a fully blank rubric as returnable', () => {
+      const doc = createMockAssignmentDoc({
+        score_completion: null,
+        score_thinking: null,
+        score_workflow: null,
+      })
+
+      expect(getAssignmentRubricState(doc)).toBe('blank')
+      expect(isAssignmentReturnable(doc)).toBe(true)
+    })
+
+    it('treats a fully completed rubric as returnable, including zeroes', () => {
+      const doc = createMockAssignmentDoc({
+        score_completion: 0,
+        score_thinking: 0,
+        score_workflow: 0,
+      })
+
+      expect(getAssignmentRubricState(doc)).toBe('complete')
+      expect(isAssignmentReturnable(doc)).toBe(true)
+    })
+
+    it('treats partial rubric drafts as blocked from return', () => {
+      const doc = createMockAssignmentDoc({
+        score_completion: 8,
+        score_thinking: null,
+        score_workflow: 6,
+      })
+
+      expect(getAssignmentRubricState(doc)).toBe('partial')
+      expect(isAssignmentReturnable(doc)).toBe(false)
     })
   })
 

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -11,7 +11,9 @@ import {
   getAssignmentStatusBadgeClass,
   getAssignmentStatusIconClass,
   getAssignmentRubricState,
+  getAssignmentFullReturnAt,
   hasDraftSavedGrade,
+  isAssignmentAlreadyReturnedWithoutResubmission,
   isAssignmentReturnable,
   formatDueDate,
   isPastDue,
@@ -713,6 +715,33 @@ describe('assignment utilities', () => {
 
       expect(getAssignmentRubricState(doc)).toBe('partial')
       expect(isAssignmentReturnable(doc)).toBe(false)
+    })
+  })
+
+  describe('assignment return helpers', () => {
+    it('uses the latest full-return timestamp', () => {
+      expect(getAssignmentFullReturnAt({
+        returned_at: '2026-04-20T12:00:00.000Z',
+        teacher_cleared_at: '2026-04-20T13:00:00.000Z',
+      })).toBe('2026-04-20T13:00:00.000Z')
+    })
+
+    it('treats returned work without a newer submission as already returned', () => {
+      expect(isAssignmentAlreadyReturnedWithoutResubmission({
+        is_submitted: false,
+        submitted_at: '2026-04-20T12:00:00.000Z',
+        returned_at: '2026-04-20T13:00:00.000Z',
+        teacher_cleared_at: '2026-04-20T13:00:00.000Z',
+      })).toBe(true)
+    })
+
+    it('does not treat resubmitted work as already returned', () => {
+      expect(isAssignmentAlreadyReturnedWithoutResubmission({
+        is_submitted: true,
+        submitted_at: '2026-04-21T12:00:00.000Z',
+        returned_at: '2026-04-20T13:00:00.000Z',
+        teacher_cleared_at: '2026-04-20T13:00:00.000Z',
+      })).toBe(false)
     })
   })
 

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -719,6 +719,10 @@ describe('assignment utilities', () => {
   })
 
   describe('assignment return helpers', () => {
+    it('does not treat a missing doc as already returned', () => {
+      expect(isAssignmentAlreadyReturnedWithoutResubmission(null)).toBe(false)
+    })
+
     it('uses the latest full-return timestamp', () => {
       expect(getAssignmentFullReturnAt({
         returned_at: '2026-04-20T12:00:00.000Z',


### PR DESCRIPTION
## What changed
- allow teachers to return any existing assignment doc even if the student never submitted it
- block return when the rubric is partial; only fully complete or fully blank rubrics can be returned
- keep missing docs untouched and report blocked/missing students back to the teacher UI
- keep blocked and missing students selected after a batch return so the teacher can fix and retry quickly

## Why
The old return flow silently skipped unsubmitted work and mixed "mailbox clear" behavior with true student-visible return behavior. Teachers needed a way to finalize missing work with the current grade/feedback state while still preventing half-complete rubric drafts from being exposed.

## Impact
- teachers can return unsubmitted work with zeroes, blank grades, or blank feedback
- partial rubric drafts are explicitly blocked instead of leaking incomplete grading to students
- batch return messaging now explains returned, blocked, and missing counts

## Validation
- `pnpm test tests/unit/assignments.test.ts tests/api/teacher/assignments-id-return.test.ts tests/components/TeacherClassroomView.test.tsx`
- `pnpm exec eslint 'src/app/api/teacher/assignments/[id]/return/route.ts' 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' 'src/hooks/useStudentSelection.ts' 'src/lib/assignments.ts' 'tests/api/teacher/assignments-id-return.test.ts' 'tests/components/TeacherClassroomView.test.tsx' 'tests/unit/assignments.test.ts'`
