### PR TITLE
[codex] Fix test authoring and submission UX

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9183,3 +9183,17 @@
 **Validation:**
 - `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizModal.test.tsx`
 - Manual Playwright verification on `http://localhost:3002/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests` with a disposable teacher test (`Resizable divider check 1776880025837`): markdown pane width changed from `695px` to `515.688px` after dragging, and the student tests view remained visually unchanged.
+
+## 2026-04-22 — Move Test Submit Action To The End Of The Assessment Flow
+
+- Updated `StudentQuizForm` so test assessments render the submit panel inline after the last question instead of using the sticky floating footer. Quiz assessments keep the existing sticky footer behavior.
+- Covered the new placement in `StudentQuizForm.test.tsx` and updated the active-test regression in `StudentQuizzesTab.test.tsx` to assert the submit panel now appears after the final question.
+- Visually verified both affected surfaces on the live dev server: the teacher test preview popup and the student exam-mode test flow now show the submit control at the bottom of the question stack.
+
+**Validation:**
+- `pnpm test tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm exec eslint src/components/StudentQuizForm.tsx tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" 'classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests'` with `E2E_BASE_URL=http://localhost:3002`
+- Manual Playwright screenshots:
+- `/tmp/pika-teacher-test-preview-submit-end.png`
+- `/tmp/pika-student-test-submit-end.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9163,3 +9163,23 @@
 
 **Validation:**
 - Manual migration diff review for semantic parity of the function body and permission changes.
+
+## 2026-04-22 — Fix New Test Title Placeholder Copy
+
+- Updated `QuizModal` to derive a shared assessment label so the create/edit heading and title placeholder both reflect `quiz` versus `test` correctly.
+- Added a focused component regression test to lock the new-test placeholder copy and preserve quiz copy in edit mode.
+- Visually verified the teacher new-test modal on desktop and mobile plus the student tests screen against a live dev server. Teacher mobile tests tab still has pre-existing horizontal overflow unrelated to this change.
+
+**Validation:**
+- `pnpm test tests/components/QuizModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
+- Manual Playwright verification on `http://localhost:3001/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests`
+
+## 2026-04-22 — Add Draggable Resize For Teacher Test Authoring Split
+
+- Added a draggable divider to the teacher test summary/detail authoring workspace in `QuizDetailPanel`, with local width state and double-click reset back to 50/50.
+- Clamped the markdown pane to a minimum of `360px` and the structured editor pane to a minimum of `420px`, so the allowed percentage range adjusts to the live workspace width instead of using a fixed cap.
+- Added a component regression that exercises drag-to-clamp in both directions and reset-on-double-click for the new divider.
+
+**Validation:**
+- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizModal.test.tsx`
+- Manual Playwright verification on `http://localhost:3002/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests` with a disposable teacher test (`Resizable divider check 1776880025837`): markdown pane width changed from `695px` to `515.688px` after dragging, and the student tests view remained visually unchanged.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9197,3 +9197,15 @@
 - Manual Playwright screenshots:
 - `/tmp/pika-teacher-test-preview-submit-end.png`
 - `/tmp/pika-student-test-submit-end.png`
+
+## 2026-04-23 — Harden Test Authoring Divider Cleanup
+
+- Updated the test authoring summary/detail divider in `QuizDetailPanel` to clean up drag listeners on interrupted drags, including window blur, pointer cancel, lost pointer capture, and unmount.
+- Added a focused regression in `QuizDetailPanel.test.tsx` that verifies interrupted drags remove the active listeners instead of leaving resize behavior stuck.
+- Added a student exam-mode regression in `StudentQuizzesTab.test.tsx` to assert ordinary in-window pointer dragging does not post exit or window-unmaximize focus events.
+
+**Validation:**
+- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm exec eslint src/components/QuizDetailPanel.tsx tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- Manual Playwright verification on `http://localhost:3001/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests` confirmed the teacher authoring divider still resizes normally after the cleanup change (`695px` to `840.938px` markdown pane width).
+- Live student exam-mode drag re-check was not possible because the seeded `Seed Test - Unattempted Demo` student attempt is already submitted in this environment; the no-false-exit path is covered by the automated regression instead.

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { Check, ChevronDown, ChevronUp, Copy, ExternalLink, Plus, RotateCcw, X } from 'lucide-react'
 import { Button, EmptyState, SplitButton, Tooltip, cn } from '@/ui'
 import { Spinner } from '@/components/Spinner'
+import { useRefRect } from '@/hooks/use-element-rect'
 import { canEditQuizQuestions } from '@/lib/quizzes'
 import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
 import { TestQuestionEditor } from '@/components/TestQuestionEditor'
@@ -60,6 +61,40 @@ type AssessmentEditorDraft = {
   questions: QuizQuestion[]
   source_format?: 'markdown'
   source_markdown?: string
+}
+
+const TEST_SUMMARY_DETAIL_LAYOUT = {
+  defaultMarkdownWidth: 50,
+  minMarkdownWidthPx: 360,
+  minEditorWidthPx: 420,
+} as const
+
+function roundPercent(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (max <= min) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+function clampSummaryDetailMarkdownWidthPercent(value: number, totalWidth: number): number {
+  if (!Number.isFinite(value)) {
+    return TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
+  }
+
+  if (!Number.isFinite(totalWidth) || totalWidth <= 0) {
+    return roundPercent(value)
+  }
+
+  const minPercent =
+    (TEST_SUMMARY_DETAIL_LAYOUT.minMarkdownWidthPx / totalWidth) * 100
+  const maxPercent = Math.max(
+    minPercent,
+    ((totalWidth - TEST_SUMMARY_DETAIL_LAYOUT.minEditorWidthPx) / totalWidth) * 100,
+  )
+
+  return roundPercent(clampNumber(value, minPercent, maxPercent))
 }
 
 export function QuizDetailPanel({
@@ -130,6 +165,10 @@ export function QuizDetailPanel({
   const autoSyncAttemptedRef = useRef<Set<string>>(new Set())
   const previousPreviewRequestTokenRef = useRef(previewRequestToken)
   const previousQuestionIdsRef = useRef<string[]>([])
+  const summaryDetailWorkspaceRef = useRef<HTMLDivElement>(null)
+  const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState(
+    TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
+  )
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -334,6 +373,9 @@ export function QuizDetailPanel({
         ? 'Editing markdown'
         : 'Markdown mirror'
   const usesSummaryDetailQuestions = isTestsView && testQuestionLayout === 'summary-detail'
+  const { width: summaryDetailWorkspaceWidth } = useRefRect(summaryDetailWorkspaceRef, {
+    enabled: usesSummaryDetailQuestions,
+  })
   const resolvedShowResultsTab = showResultsTab ?? !isTestsView
   const totalQuestionPoints = useMemo(
     () =>
@@ -351,6 +393,14 @@ export function QuizDetailPanel({
   )
   const areAllQuestionsExpanded =
     questions.length > 0 && questions.every((question) => expandedQuestionIds.includes(question.id))
+  const clampedSummaryDetailMarkdownWidthPercent = useMemo(
+    () =>
+      clampSummaryDetailMarkdownWidthPercent(
+        summaryDetailMarkdownWidthPercent,
+        summaryDetailWorkspaceWidth
+      ),
+    [summaryDetailMarkdownWidthPercent, summaryDetailWorkspaceWidth]
+  )
 
   useEffect(() => {
     if (!isTestsView) return
@@ -898,6 +948,33 @@ export function QuizDetailPanel({
     setExpandedQuestionIds(areAllQuestionsExpanded ? [] : questions.map((question) => question.id))
   }
 
+  const handleSummaryDetailResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!summaryDetailWorkspaceRef.current) return
+
+    event.preventDefault()
+    const { right, width } = summaryDetailWorkspaceRef.current.getBoundingClientRect()
+    if (width <= 0) return
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextMarkdownWidth = ((right - moveEvent.clientX) / width) * 100
+      setSummaryDetailMarkdownWidthPercent(
+        clampSummaryDetailMarkdownWidthPercent(nextMarkdownWidth, width)
+      )
+    }
+
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+  }, [])
+
+  const handleSummaryDetailResizeReset = useCallback(() => {
+    setSummaryDetailMarkdownWidthPercent(TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth)
+  }, [])
+
   function handleConflictReload() {
     if (!conflictDraft) return
     applyServerDraft({
@@ -1315,13 +1392,23 @@ export function QuizDetailPanel({
   )
 
   const testsSummaryDetailPanel = (
-    <SummaryDetailWorkspaceShell
-      orientation="row"
+    <div
+      ref={summaryDetailWorkspaceRef}
       data-testid="test-summary-detail-layout"
-      leftPaneClassName="min-h-0 bg-surface-2"
-      rightPaneClassName="min-h-0"
-      rightWidthPercent={50}
-      left={
+      className="flex h-full min-h-0 flex-1"
+    >
+      <SummaryDetailWorkspaceShell
+        className="flex-1"
+        orientation="row"
+        leftPaneClassName="min-h-0 bg-surface-2"
+        rightPaneClassName="min-h-0"
+        rightWidthPercent={clampedSummaryDetailMarkdownWidthPercent}
+        divider={{
+          label: 'Resize question and markdown panes',
+          onPointerDown: handleSummaryDetailResizeStart,
+          onDoubleClick: handleSummaryDetailResizeReset,
+        }}
+        left={
         <div data-testid="test-question-editor-pane" className="flex h-full min-h-0 flex-col">
           <div className="border-b border-border px-3 py-3">
             <div className="flex items-center justify-between gap-3">
@@ -1400,15 +1487,16 @@ export function QuizDetailPanel({
             ) : null}
           </div>
         </div>
-      }
-      right={
+        }
+        right={
         <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col" data-testid="test-question-markdown-pane">
           <div className="flex min-h-0 flex-1 flex-col p-4">
             {testsMarkdownPanel}
           </div>
         </div>
-      }
-    />
+        }
+      />
+    </div>
   )
 
   if (loading) {

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -167,7 +167,7 @@ export function QuizDetailPanel({
   const previousQuestionIdsRef = useRef<string[]>([])
   const summaryDetailWorkspaceRef = useRef<HTMLDivElement>(null)
   const summaryDetailResizeCleanupRef = useRef<(() => void) | null>(null)
-  const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState(
+  const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState<number>(
     TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
   )
 

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -166,6 +166,7 @@ export function QuizDetailPanel({
   const previousPreviewRequestTokenRef = useRef(previewRequestToken)
   const previousQuestionIdsRef = useRef<string[]>([])
   const summaryDetailWorkspaceRef = useRef<HTMLDivElement>(null)
+  const summaryDetailResizeCleanupRef = useRef<(() => void) | null>(null)
   const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState(
     TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
   )
@@ -948,10 +949,19 @@ export function QuizDetailPanel({
     setExpandedQuestionIds(areAllQuestionsExpanded ? [] : questions.map((question) => question.id))
   }
 
+  const clearSummaryDetailResizeListeners = useCallback(() => {
+    summaryDetailResizeCleanupRef.current?.()
+    summaryDetailResizeCleanupRef.current = null
+  }, [])
+
   const handleSummaryDetailResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!summaryDetailWorkspaceRef.current) return
 
+    clearSummaryDetailResizeListeners()
     event.preventDefault()
+
+    const divider = event.currentTarget
+    const pointerId = event.pointerId
     const { right, width } = summaryDetailWorkspaceRef.current.getBoundingClientRect()
     if (width <= 0) return
 
@@ -962,18 +972,58 @@ export function QuizDetailPanel({
       )
     }
 
-    const handlePointerUp = () => {
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
+    const handleResizeEnd = () => {
+      if (summaryDetailResizeCleanupRef.current !== cleanup) return
+      summaryDetailResizeCleanupRef.current = null
+      cleanup()
     }
 
+    const handleLostPointerCapture = () => {
+      handleResizeEnd()
+    }
+
+    const cleanup = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handleResizeEnd)
+      window.removeEventListener('pointercancel', handleResizeEnd)
+      window.removeEventListener('blur', handleResizeEnd)
+      divider.removeEventListener('lostpointercapture', handleLostPointerCapture)
+
+      if (divider.hasPointerCapture?.(pointerId)) {
+        try {
+          divider.releasePointerCapture(pointerId)
+        } catch {
+          // Pointer capture may already be released by the browser.
+        }
+      }
+    }
+
+    summaryDetailResizeCleanupRef.current = cleanup
+
+    if (divider.setPointerCapture) {
+      try {
+        divider.setPointerCapture(pointerId)
+      } catch {
+        // Browsers may reject pointer capture for synthetic or interrupted events.
+      }
+    }
+
+    divider.addEventListener('lostpointercapture', handleLostPointerCapture)
     window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-  }, [])
+    window.addEventListener('pointerup', handleResizeEnd)
+    window.addEventListener('pointercancel', handleResizeEnd)
+    window.addEventListener('blur', handleResizeEnd)
+  }, [clearSummaryDetailResizeListeners])
 
   const handleSummaryDetailResizeReset = useCallback(() => {
     setSummaryDetailMarkdownWidthPercent(TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth)
   }, [])
+
+  useEffect(() => {
+    return () => {
+      clearSummaryDetailResizeListeners()
+    }
+  }, [clearSummaryDetailResizeListeners])
 
   function handleConflictReload() {
     if (!conflictDraft) return

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -30,6 +30,8 @@ export function QuizModal({
   const [error, setError] = useState('')
 
   const isEditMode = !!quiz
+  const isTest = (quiz?.assessment_type ?? assessmentType) === 'test'
+  const assessmentLabel = isTest ? 'Test' : 'Quiz'
 
   useEffect(() => {
     if (!isOpen) return
@@ -107,13 +109,7 @@ export function QuizModal({
       ariaLabelledBy="quiz-modal-title"
     >
       <h2 id="quiz-modal-title" className="text-xl font-bold text-text-default mb-4 flex-shrink-0">
-        {isEditMode
-          ? quiz.assessment_type === 'test'
-            ? 'Edit Test'
-            : 'Edit Quiz'
-          : assessmentType === 'test'
-            ? 'New Test'
-            : 'New Quiz'}
+        {isEditMode ? `Edit ${assessmentLabel}` : `New ${assessmentLabel}`}
       </h2>
 
       <form onSubmit={handleSubmit} className="space-y-4 flex-1 min-h-0 overflow-y-auto">
@@ -123,7 +119,7 @@ export function QuizModal({
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="Enter quiz title"
+            placeholder={`Enter ${assessmentLabel.toLowerCase()} title`}
             disabled={saving}
           />
         </FormField>

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -61,6 +61,7 @@ export function StudentQuizForm({
     apiBasePath.includes('/tests') ||
     enableDraftAutosave ||
     questions.some((question) => question.question_type === 'open_response')
+  const isTestAssessment = assessmentType === 'test' || apiBasePath.includes('/tests')
 
   const [responses, setResponses] = useState<TestResponses>(
     normalizeTestResponses(initialResponses)
@@ -92,6 +93,42 @@ export function StudentQuizForm({
   })
   const saveStatusLabel =
     saveStatus === 'saving' ? 'Saving...' : saveStatus === 'saved' ? 'Saved' : 'Unsaved changes'
+
+  const submitActions = (
+    <div
+      data-testid="student-quiz-action-footer"
+      className={
+        isTestAssessment
+          ? 'rounded-xl border border-border bg-surface p-4 shadow-sm'
+          : 'sticky bottom-0 z-10 mt-auto rounded-lg border border-border bg-surface p-3 shadow-sm'
+      }
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          {shouldAutosave && (
+            <p className="text-xs text-text-muted">{saveStatusLabel}</p>
+          )}
+          {!allAnswered && (
+            <p className="text-sm text-text-muted">Answer all questions to submit</p>
+          )}
+        </div>
+        <Button
+          onClick={() => {
+            if (flaggedQuestions.length > 0) {
+              setShowFlaggedWarning(true)
+            } else {
+              setShowConfirm(true)
+            }
+          }}
+          disabled={isInteractionLocked || !allAnswered || submitting}
+          className="w-full sm:min-w-[10rem] sm:w-auto"
+        >
+          Submit
+        </Button>
+      </div>
+    </div>
+  )
+
   useEffect(() => {
     const normalized = normalizeTestResponses(initialResponses)
     setResponses(normalized)
@@ -534,36 +571,11 @@ export function StudentQuizForm({
               {previewSubmitMessage}
             </div>
           )}
+
+          {isTestAssessment ? submitActions : null}
         </div>
 
-        <div
-          data-testid="student-quiz-action-footer"
-          className="sticky bottom-0 z-10 mt-auto rounded-lg border border-border bg-surface p-3 shadow-sm"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="space-y-1">
-              {shouldAutosave && (
-                <p className="text-xs text-text-muted">{saveStatusLabel}</p>
-              )}
-              {!allAnswered && (
-                <p className="text-sm text-text-muted">Answer all questions to submit</p>
-              )}
-            </div>
-            <Button
-              onClick={() => {
-                if (flaggedQuestions.length > 0) {
-                  setShowFlaggedWarning(true)
-                } else {
-                  setShowConfirm(true)
-                }
-              }}
-              disabled={isInteractionLocked || !allAnswered || submitting}
-              className="w-full sm:min-w-[10rem] sm:w-auto"
-            >
-              Submit
-            </Button>
-          </div>
-        </div>
+        {isTestAssessment ? null : submitActions}
       </div>
 
       <ConfirmDialog

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
@@ -291,6 +291,9 @@ describe('QuizDetailPanel', () => {
       )
 
       expect(await screen.findByTestId('test-summary-detail-layout')).toBeInTheDocument()
+      expect(
+        screen.getByRole('separator', { name: 'Resize question and markdown panes' })
+      ).toBeInTheDocument()
       const editorPane = screen.getByTestId('test-question-editor-pane')
       const markdownPane = screen.getByTestId('test-question-markdown-pane')
       expect(editorPane).toBeInTheDocument()
@@ -371,6 +374,100 @@ describe('QuizDetailPanel', () => {
         expect(within(editorPane).getByTestId('question-sq2-collapsed-summary')).toHaveTextContent(
           'Which traversal visits the root node first?'
         )
+      })
+    })
+
+    it('allows dragging the summary-detail divider within the editor bounds and resets on double click', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Resizable Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Resizable Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const layout = await screen.findByTestId('test-summary-detail-layout')
+      const separator = screen.getByRole('separator', { name: 'Resize question and markdown panes' })
+      const markdownPaneWrapper = screen.getByTestId('test-question-markdown-pane').parentElement
+      const pointerListeners: {
+        move?: (event: PointerEvent) => void
+        up?: (event: PointerEvent) => void
+      } = {}
+      const originalAddEventListener = window.addEventListener.bind(window)
+
+      vi.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
+        if (type === 'pointermove') {
+          pointerListeners.move = listener as (event: PointerEvent) => void
+        }
+        if (type === 'pointerup') {
+          pointerListeners.up = listener as (event: PointerEvent) => void
+        }
+        return originalAddEventListener(type, listener, options)
+      })
+
+      expect(markdownPaneWrapper).toHaveStyle({ width: '50%', flexBasis: '50%' })
+
+      vi.spyOn(layout, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 1200, 800))
+
+      fireEvent.pointerDown(separator)
+
+      await act(async () => {
+        pointerListeners.move?.({ clientX: 900 } as PointerEvent)
+      })
+
+      await waitFor(() => {
+        expect(markdownPaneWrapper).toHaveStyle({ width: '30%', flexBasis: '30%' })
+      })
+
+      await act(async () => {
+        pointerListeners.move?.({ clientX: 250 } as PointerEvent)
+      })
+
+      await waitFor(() => {
+        expect(markdownPaneWrapper).toHaveStyle({ width: '65%', flexBasis: '65%' })
+      })
+
+      await act(async () => {
+        pointerListeners.up?.({} as PointerEvent)
+      })
+      fireEvent.doubleClick(separator)
+
+      await waitFor(() => {
+        expect(markdownPaneWrapper).toHaveStyle({ width: '50%', flexBasis: '50%' })
       })
     })
 

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -377,7 +377,7 @@ describe('QuizDetailPanel', () => {
       })
     })
 
-    it('allows dragging the summary-detail divider within the editor bounds and resets on double click', async () => {
+    it('cleans up interrupted summary-detail drags and resets on double click', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -426,8 +426,11 @@ describe('QuizDetailPanel', () => {
       const pointerListeners: {
         move?: (event: PointerEvent) => void
         up?: (event: PointerEvent) => void
+        cancel?: (event: PointerEvent) => void
+        blur?: (event: Event) => void
       } = {}
       const originalAddEventListener = window.addEventListener.bind(window)
+      const originalRemoveEventListener = window.removeEventListener.bind(window)
 
       vi.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
         if (type === 'pointermove') {
@@ -436,7 +439,28 @@ describe('QuizDetailPanel', () => {
         if (type === 'pointerup') {
           pointerListeners.up = listener as (event: PointerEvent) => void
         }
+        if (type === 'pointercancel') {
+          pointerListeners.cancel = listener as (event: PointerEvent) => void
+        }
+        if (type === 'blur') {
+          pointerListeners.blur = listener as (event: Event) => void
+        }
         return originalAddEventListener(type, listener, options)
+      })
+      vi.spyOn(window, 'removeEventListener').mockImplementation((type, listener, options) => {
+        if (type === 'pointermove' && pointerListeners.move === listener) {
+          pointerListeners.move = undefined
+        }
+        if (type === 'pointerup' && pointerListeners.up === listener) {
+          pointerListeners.up = undefined
+        }
+        if (type === 'pointercancel' && pointerListeners.cancel === listener) {
+          pointerListeners.cancel = undefined
+        }
+        if (type === 'blur' && pointerListeners.blur === listener) {
+          pointerListeners.blur = undefined
+        }
+        return originalRemoveEventListener(type, listener, options)
       })
 
       expect(markdownPaneWrapper).toHaveStyle({ width: '50%', flexBasis: '50%' })
@@ -444,6 +468,10 @@ describe('QuizDetailPanel', () => {
       vi.spyOn(layout, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 1200, 800))
 
       fireEvent.pointerDown(separator)
+      expect(pointerListeners.move).toBeTypeOf('function')
+      expect(pointerListeners.up).toBeTypeOf('function')
+      expect(pointerListeners.cancel).toBeTypeOf('function')
+      expect(pointerListeners.blur).toBeTypeOf('function')
 
       await act(async () => {
         pointerListeners.move?.({ clientX: 900 } as PointerEvent)
@@ -462,8 +490,14 @@ describe('QuizDetailPanel', () => {
       })
 
       await act(async () => {
-        pointerListeners.up?.({} as PointerEvent)
+        pointerListeners.blur?.(new Event('blur'))
       })
+
+      expect(pointerListeners.move).toBeUndefined()
+      expect(pointerListeners.up).toBeUndefined()
+      expect(pointerListeners.cancel).toBeUndefined()
+      expect(pointerListeners.blur).toBeUndefined()
+
       fireEvent.doubleClick(separator)
 
       await waitFor(() => {

--- a/tests/components/QuizModal.test.tsx
+++ b/tests/components/QuizModal.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QuizModal } from '@/components/QuizModal'
+import { createMockQuiz } from '../helpers/mocks'
+
+describe('QuizModal', () => {
+  it('uses test-specific title copy when creating a test', () => {
+    render(
+      <QuizModal
+        isOpen={true}
+        classroomId="classroom-1"
+        assessmentType="test"
+        apiBasePath="/api/teacher/tests"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'New Test' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter test title')).toBeInTheDocument()
+  })
+
+  it('keeps quiz-specific title copy when editing a quiz', () => {
+    render(
+      <QuizModal
+        isOpen={true}
+        classroomId="classroom-1"
+        quiz={createMockQuiz({ assessment_type: 'quiz', title: 'Vocabulary Quiz' })}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Edit Quiz' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Vocabulary Quiz')).toHaveAttribute(
+      'placeholder',
+      'Enter quiz title'
+    )
+  })
+})

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -128,7 +128,7 @@ describe('StudentQuizForm preview mode', () => {
     })
   })
 
-  it('renders a persistent action footer with save state and submit controls', async () => {
+  it('renders test submit actions inline after the last question', async () => {
     const onSubmitted = vi.fn()
 
     render(
@@ -137,10 +137,17 @@ describe('StudentQuizForm preview mode', () => {
         questions={[
           createMockQuizQuestion({
             id: 'q1',
-            question_text: 'Which option is correct?',
+            question_text: 'Question 1?',
             options: ['A', 'B'],
             question_type: 'multiple_choice',
             position: 0,
+          }),
+          createMockQuizQuestion({
+            id: 'q2',
+            question_text: 'Question 2?',
+            options: ['C', 'D'],
+            question_type: 'multiple_choice',
+            position: 1,
           }),
         ]}
         initialResponses={{
@@ -155,9 +162,40 @@ describe('StudentQuizForm preview mode', () => {
       />
     )
 
-    const footer = screen.getByTestId('student-quiz-action-footer')
-    expect(within(footer).getByText('Saved')).toBeInTheDocument()
-    expect(within(footer).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+    const actionPanel = screen.getByTestId('student-quiz-action-footer')
+    const questionsStack = screen.getByText('Question 2?').closest('[data-question-id="q2"]')
+      ?.parentElement
+
+    expect(questionsStack?.lastElementChild).toBe(actionPanel)
+    expect(actionPanel.className).not.toContain('sticky')
+    expect(within(actionPanel).getByText('Saved')).toBeInTheDocument()
+    expect(within(actionPanel).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+    expect(within(actionPanel).getByText('Answer all questions to submit')).toBeInTheDocument()
+  })
+
+  it('keeps the sticky submit footer for quizzes', async () => {
+    const onSubmitted = vi.fn()
+
+    render(
+      <StudentQuizForm
+        quizId="quiz-footer-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Quiz question?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        assessmentType="quiz"
+        onSubmitted={onSubmitted}
+      />
+    )
+
+    const actionPanel = screen.getByTestId('student-quiz-action-footer')
+    expect(actionPanel.className).toContain('sticky')
+    expect(within(actionPanel).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
   })
 
   it('notifies the parent when a submit fails because the test is no longer active', async () => {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -985,6 +985,110 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(within(actionFooter).getByText('Answer all questions to submit')).toBeInTheDocument()
   })
 
+  it('does not record exam exits for in-window pointer dragging during an active test', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        focusBodies.push(JSON.parse(String(options?.body || '{}')) as Record<string, any>)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: makeFocusSummary(),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    const detailPane = await screen.findByTestId('student-test-detail-pane')
+
+    fireEvent.pointerDown(detailPane, { clientX: 300, clientY: 320 })
+    fireEvent.pointerMove(detailPane, { clientX: 460, clientY: 320 })
+    fireEvent.pointerUp(detailPane, { clientX: 460, clientY: 320 })
+
+    expect(focusBodies).toEqual([])
+  })
+
   it('suppresses iframe doc-triggered fullscreen and resize exits', async () => {
     const focusBodies: Array<Record<string, any>> = []
     let fullscreenElement: Element | null = null

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -889,7 +889,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(splitContainerBack.className).toContain('lg:grid-cols-[30%_70%]')
   })
 
-  it('keeps the submit footer mounted while the right pane scrolls through a long active test', async () => {
+  it('renders the submit actions after the last question in an active test', async () => {
     let fullscreenElement: Element | null = null
 
     Object.defineProperty(document, 'fullscreenElement', {
@@ -975,10 +975,12 @@ describe('StudentQuizzesTab exam mode', () => {
 
     const detailPane = screen.getByTestId('student-test-detail-pane')
     const actionFooter = within(detailPane).getByTestId('student-quiz-action-footer')
-
-    fireEvent.scroll(detailPane, { target: { scrollTop: 1200 } })
+    const questionsStack = screen.getByText('Question 12?').closest('[data-question-id="q12"]')
+      ?.parentElement
 
     expect(detailPane.className).toContain('overflow-y-auto')
+    expect(questionsStack?.lastElementChild).toBe(actionFooter)
+    expect(actionFooter.className).not.toContain('sticky')
     expect(within(actionFooter).getByRole('button', { name: 'Submit' })).toBeInTheDocument()
     expect(within(actionFooter).getByText('Answer all questions to submit')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

This PR fixes three related UX issues in the teacher/student test flows:

- correct the new-test title placeholder and modal copy so tests use test-specific wording
- add draggable resizing to the teacher test authoring summary/detail split, including cleanup for interrupted drags
- move the test submit action out of the floating footer and render it inline after the last question in exam mode and teacher preview

## Root Cause

The tests workflow was still reusing some quiz-oriented UI assumptions:

- the modal title field copy was hard-coded to quiz language
- the test authoring split never wired up the existing shared resizable workspace affordance
- the student test form always rendered a sticky action footer, which reads like a floating action button in exam mode and preview

## Impact

- teachers now see correct test wording when creating tests
- teachers can resize the authoring panes while building tests
- interrupted divider drags no longer leave global resize listeners active
- students and teachers now encounter the submit action where the test actually ends, matching the intended completion flow
- ordinary in-window pointer dragging during exam mode is covered so it does not log a false exit event

## Validation

- `pnpm test tests/components/QuizModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizModal.test.tsx`
- `pnpm test tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
- `pnpm exec eslint src/components/QuizDetailPanel.tsx tests/components/QuizDetailPanel.test.tsx src/components/QuizModal.tsx tests/components/QuizModal.test.tsx`
- `pnpm exec eslint src/components/StudentQuizForm.tsx tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
- `pnpm exec eslint src/components/QuizDetailPanel.tsx tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx`
- manual Playwright verification on the teacher tests page, teacher preview, student exam-mode submit placement, and teacher authoring divider drag
