### PR TITLE
[codex] Stabilize test authoring autosave UX

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9261,3 +9261,26 @@
 - `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
 - `pnpm lint`
 - Visual verification via Playwright screenshots on `/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests`, including teacher desktop/mobile, student mobile, and a teacher interaction capture before/after autosave.
+
+## 2026-04-23 — Make Test Authoring Header And Status Actions Update Locally
+
+- Added an immediate draft-summary callback path in `QuizDetailPanel` so structured authoring edits push `title`, `show_results`, and `questions_count` upward before autosave completes.
+- Updated `TeacherTestsTab` to keep a local selected-test draft summary for the authoring header and activation state, and stopped selected-workspace status actions from calling `loadTests()` after each patch.
+- Updated `TeacherTestCard` summary actions to apply local status patches instead of forcing a full tests-list refetch, and added regression coverage for immediate draft-state updates plus non-refetching status changes.
+
+**Validation:**
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
+- `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
+- Visual verification on `http://localhost:3001/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests`, including teacher desktop, student mobile, teacher mobile, a summary-card `Reopen` interaction, and a disposable draft where `Open` changed from disabled to enabled within 500ms after adding the first question
+
+## 2026-04-23 — Stop Duplicate First Autosaves In Test Authoring
+
+- Seeded a baseline `assessment_drafts` row during `POST /api/teacher/tests` and added rollback coverage so brand-new tests do not enter the editor without an initial draft record.
+- Fixed the real duplicate-save race in `QuizDetailPanel`: the unsaved-draft cleanup was keyed to `[saveDraft]`, so normal rerenders could trigger a forced save while the debounced autosave was still pending. The cleanup now uses a stable ref and only runs on actual unmount.
+- Added regression coverage that rerenders the editor with unsaved changes and asserts it still issues exactly one draft PATCH, matching the live duplicate-PATCH bug that previously produced the `409 Draft updated elsewhere` banner.
+
+**Validation:**
+- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-draft-route.test.ts`
+- `pnpm lint --file src/components/QuizDetailPanel.tsx --file src/app/api/teacher/tests/route.ts --file tests/components/QuizDetailPanel.test.tsx --file tests/api/teacher/tests-route.test.ts`
+- Visual verification on `http://localhost:3001/classrooms/f0c8c2d8-f1e2-4a2c-ad3f-3b0caa09b106?tab=tests`
+- Live Playwright regression trace confirmed a fresh draft now makes exactly one `PATCH /api/teacher/tests/:id/draft`, shows no conflict text, and returns to `Saved`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9251,3 +9251,13 @@
 - `pnpm exec vitest run tests/lib/test-ai-grading-runs.test.ts`
 - `pnpm exec vitest run tests/api/teacher/test-auto-grade-runs.test.ts tests/unit/ai-test-grading.test.ts`
 - `pnpm test`
+## 2026-04-22 — Keep Test Authoring Workspace Stable Across Autosave
+
+- Changed `QuizDetailPanel` to emit a lightweight saved-summary payload (`title`, `show_results`, `questions_count`) after successful draft saves instead of only signaling a generic refresh.
+- Updated `TeacherTestsTab` to apply that payload directly to local selected-test state so adding/removing questions no longer forces a blocking full tests-list reload and spinner swap.
+- Added regression coverage for the saved-summary callback and for keeping the selected test workspace mounted after autosave, plus tightened one flaky summary-detail accordion assertion to wait for settled UI state.
+
+**Validation:**
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
+- `pnpm lint`
+- Visual verification via Playwright screenshots on `/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests`, including teacher desktop/mobile, student mobile, and a teacher interaction capture before/after autosave.

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -5,6 +5,8 @@ import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/l
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import {
+  buildTestDraftContentFromRows,
+  createAssessmentDraft,
   isMissingAssessmentDraftsError,
   validateTestDraftContent,
   type TestDraftContent,
@@ -209,6 +211,43 @@ export const POST = withErrorHandler('CreateTeacherTest', async (request) => {
     }
     console.error('Error creating test:', error)
     return NextResponse.json({ error: 'Failed to create test' }, { status: 500 })
+  }
+
+  const initialDraftContent = buildTestDraftContentFromRows(
+    {
+      title: test.title,
+      show_results: test.show_results,
+    },
+    []
+  )
+
+  const { draft: createdDraft, error: draftError } = await createAssessmentDraft<TestDraftContent>(
+    supabase,
+    {
+      assessmentType: 'test',
+      assessmentId: test.id,
+      classroomId: classroom_id,
+      userId: user.id,
+      content: initialDraftContent,
+    }
+  )
+
+  if (draftError || !createdDraft) {
+    console.error('Error creating initial test draft:', draftError)
+
+    const { error: cleanupError } = await supabase.from('tests').delete().eq('id', test.id)
+    if (cleanupError) {
+      console.error('Error cleaning up test after draft creation failure:', cleanupError)
+    }
+
+    if (isMissingAssessmentDraftsError(draftError)) {
+      return NextResponse.json(
+        { error: 'Assessment drafts require migration 045 to be applied' },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ error: 'Failed to create test draft' }, { status: 500 })
   }
 
   return NextResponse.json(

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -20,6 +20,7 @@ import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
+  AssessmentWorkspaceSummaryPatch,
   Classroom,
   Quiz,
   QuizFocusSummary,
@@ -218,6 +219,7 @@ export function TeacherTestsTab({
   const [workspaceState, setWorkspaceState] = useState<WorkspaceState>('list')
   const [selectedWorkspaceTab, setSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
   const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
+  const [selectedTestDraftSummary, setSelectedTestDraftSummary] = useState<AssessmentEditorSummaryUpdate | null>(null)
   const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
@@ -260,6 +262,20 @@ export function TeacherTestsTab({
   }, [selectedTestId, testAiGradingRun])
   const activeTestAiRunId = activeTestAiRun?.id ?? null
   const hasActiveTestAiRun = isTestAiGradingRunActive(activeTestAiRun)
+  const selectedTestWorkspace = useMemo(() => {
+    if (!selectedTest) return null
+    if (!selectedTestDraftSummary) return selectedTest
+
+    return {
+      ...selectedTest,
+      title: selectedTestDraftSummary.title,
+      show_results: selectedTestDraftSummary.show_results,
+      stats: {
+        ...selectedTest.stats,
+        questions_count: selectedTestDraftSummary.questions_count,
+      },
+    }
+  }, [selectedTest, selectedTestDraftSummary])
 
   const sortedGradingStudents = useMemo(
     () =>
@@ -333,28 +349,38 @@ export function TeacherTestsTab({
     }
   }, [batchSelectedStudents, gradingQuestions])
 
+  const applyTestSummaryPatch = useCallback((testId: string, update: AssessmentWorkspaceSummaryPatch) => {
+    setTests((prev) =>
+      prev.map((test) => {
+        if (test.id !== testId) return test
+
+        return {
+          ...test,
+          title: typeof update.title === 'string' ? update.title : test.title,
+          show_results: typeof update.show_results === 'boolean' ? update.show_results : test.show_results,
+          status: update.status ?? test.status,
+          stats: {
+            ...test.stats,
+            questions_count:
+              typeof update.questions_count === 'number' ? update.questions_count : test.stats.questions_count,
+          },
+        }
+      })
+    )
+  }, [])
+
   const applySelectedTestDraftSummary = useCallback(
     (update: AssessmentEditorSummaryUpdate) => {
       if (!selectedTestId) return
 
-      setTests((prev) =>
-        prev.map((test) =>
-          test.id === selectedTestId
-            ? {
-                ...test,
-                title: update.title,
-                show_results: update.show_results,
-                stats: {
-                  ...test.stats,
-                  questions_count: update.questions_count,
-                },
-              }
-            : test
-        )
-      )
+      setSelectedTestDraftSummary(update)
+      applyTestSummaryPatch(selectedTestId, update)
     },
-    [selectedTestId]
+    [applyTestSummaryPatch, selectedTestId]
   )
+  const handleSelectedTestDraftSummaryChange = useCallback((update: AssessmentEditorSummaryUpdate) => {
+    setSelectedTestDraftSummary(update)
+  }, [])
 
   const loadTests = useCallback(async () => {
     setLoading(true)
@@ -454,8 +480,8 @@ export function TeacherTestsTab({
   }, [classroom.id, loadTests])
 
   useEffect(() => {
-    onSelectTest?.(workspaceState === 'selected' ? selectedTest : null)
-  }, [onSelectTest, selectedTest, workspaceState])
+    onSelectTest?.(workspaceState === 'selected' ? selectedTestWorkspace : null)
+  }, [onSelectTest, selectedTestWorkspace, workspaceState])
 
   useEffect(() => {
     gradingSelectionRef.current = {
@@ -475,6 +501,10 @@ export function TeacherTestsTab({
     setSelectedStudentId(null)
     clearBatchSelection()
   }, [clearBatchSelection, selectedTestId, tests])
+
+  useEffect(() => {
+    setSelectedTestDraftSummary(null)
+  }, [selectedTestId])
 
   useEffect(() => {
     if (!pendingCreatedTestId) return
@@ -954,7 +984,25 @@ export function TeacherTestsTab({
         throw new Error(data.error || 'Failed to update test')
       }
 
-      await loadTests()
+      const nextStatus =
+        data?.test?.status === 'draft' || data?.test?.status === 'active' || data?.test?.status === 'closed'
+          ? data.test.status
+          : payload.status === 'draft' || payload.status === 'active' || payload.status === 'closed'
+            ? payload.status
+            : undefined
+
+      applyTestSummaryPatch(selectedTestId, {
+        status: nextStatus,
+        title: typeof data?.test?.title === 'string' ? data.test.title : undefined,
+        show_results: typeof data?.test?.show_results === 'boolean' ? data.test.show_results : undefined,
+        questions_count:
+          typeof data?.test?.stats?.questions_count === 'number' ? data.test.stats.questions_count : undefined,
+      })
+
+      if (nextStatus) {
+        setGradingServerTestStatus(nextStatus)
+        setGradingServerTestId(selectedTestId)
+      }
     } catch (error: any) {
       setStatusActionError(error?.message || 'Failed to update test')
     } finally {
@@ -969,9 +1017,9 @@ export function TeacherTestsTab({
   }
 
   async function handleRequestSelectedTestActivate() {
-    if (!selectedTest || isReadOnly || statusUpdating || checkingActivation) return
+    if (!selectedTest || !selectedTestWorkspace || isReadOnly || statusUpdating || checkingActivation) return
 
-    const activation = validateSelectedTestActivation(selectedTest)
+    const activation = validateSelectedTestActivation(selectedTestWorkspace.stats.questions_count || 0)
     if (!activation.valid) {
       setStatusActionError(activation.error || 'Test cannot be activated yet')
       return
@@ -1008,17 +1056,19 @@ export function TeacherTestsTab({
     }
   }
 
-  function validateSelectedTestActivation(test: QuizWithStats): { valid: boolean; error?: string } {
-    if ((test.stats.questions_count || 0) < 1) {
+  function validateSelectedTestActivation(questionCount: number): { valid: boolean; error?: string } {
+    if (questionCount < 1) {
       return { valid: false, error: 'Test must have at least 1 question' }
     }
     return { valid: true }
   }
 
   const returnWillCloseActiveTest =
-    selectedWorkspaceTab === 'grading' && selectedTest?.status === 'active'
-  const selectedTestTitle = selectedTest?.title || 'Test'
-  const selectedActivation = selectedTest ? validateSelectedTestActivation(selectedTest) : { valid: false }
+    selectedWorkspaceTab === 'grading' && selectedTestWorkspace?.status === 'active'
+  const selectedTestTitle = selectedTestWorkspace?.title || 'Test'
+  const selectedActivation = selectedTestWorkspace
+    ? validateSelectedTestActivation(selectedTestWorkspace.stats.questions_count || 0)
+    : { valid: false }
   const isSelectedWorkspace = workspaceState === 'selected'
 
   const batchGradeDescriptionParts: string[] = []
@@ -1280,7 +1330,7 @@ export function TeacherTestsTab({
               >
                 Preview
               </Button>
-              {selectedTest?.status === 'draft' ? (
+              {selectedTestWorkspace?.status === 'draft' ? (
                 <Button
                   type="button"
                   variant="secondary"
@@ -1300,7 +1350,7 @@ export function TeacherTestsTab({
                   Open
                 </Button>
               ) : null}
-              {selectedTest?.status === 'active' ? (
+              {selectedTestWorkspace?.status === 'active' ? (
                 <Button
                   type="button"
                   variant="secondary"
@@ -1312,7 +1362,7 @@ export function TeacherTestsTab({
                   Close
                 </Button>
               ) : null}
-              {selectedTest?.status === 'closed' ? (
+              {selectedTestWorkspace?.status === 'closed' ? (
                 <Button
                   type="button"
                   variant="secondary"
@@ -1474,9 +1524,7 @@ export function TeacherTestsTab({
                 test={test}
                 isReadOnly={isReadOnly}
                 onSelect={() => handleOpenTest(test)}
-                onUpdate={() => {
-                  void loadTests()
-                }}
+                onUpdate={(update) => applyTestSummaryPatch(test.id, update)}
               />
             ))}
           </PageStack>
@@ -1491,6 +1539,7 @@ export function TeacherTestsTab({
                 quiz={selectedTest}
                 classroomId={classroom.id}
                 apiBasePath={apiBasePath}
+                onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
                 onQuizUpdate={(update) => {
                   if (update) {
                     applySelectedTestDraftSummary(update)

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -17,8 +17,15 @@ import { getQuizExitCount } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Tooltip } from '@/ui'
-import type { Classroom, Quiz, QuizFocusSummary, QuizWithStats, TestAiGradingRunSummary } from '@/types'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
+import type {
+  AssessmentEditorSummaryUpdate,
+  Classroom,
+  Quiz,
+  QuizFocusSummary,
+  QuizWithStats,
+  TestAiGradingRunSummary,
+} from '@/types'
 
 interface Props {
   classroom: Classroom
@@ -325,6 +332,29 @@ export function TeacherTestsTab({
       potentialAiSends: ungradedResponses,
     }
   }, [batchSelectedStudents, gradingQuestions])
+
+  const applySelectedTestDraftSummary = useCallback(
+    (update: AssessmentEditorSummaryUpdate) => {
+      if (!selectedTestId) return
+
+      setTests((prev) =>
+        prev.map((test) =>
+          test.id === selectedTestId
+            ? {
+                ...test,
+                title: update.title,
+                show_results: update.show_results,
+                stats: {
+                  ...test.stats,
+                  questions_count: update.questions_count,
+                },
+              }
+            : test
+        )
+      )
+    },
+    [selectedTestId]
+  )
 
   const loadTests = useCallback(async () => {
     setLoading(true)
@@ -1461,7 +1491,11 @@ export function TeacherTestsTab({
                 quiz={selectedTest}
                 classroomId={classroom.id}
                 apiBasePath={apiBasePath}
-                onQuizUpdate={() => {
+                onQuizUpdate={(update) => {
+                  if (update) {
+                    applySelectedTestDraftSummary(update)
+                    return
+                  }
                   void loadTests()
                 }}
                 onPendingMarkdownImportChange={setHasPendingMarkdownImport}

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -33,6 +33,7 @@ import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import { markdownToTest, testToMarkdown, TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
 import type {
+  AssessmentEditorSummaryUpdate,
   JsonPatchOperation,
   QuizQuestion,
   QuizWithStats,
@@ -44,7 +45,7 @@ interface Props {
   quiz: QuizWithStats
   classroomId: string
   apiBasePath?: string
-  onQuizUpdate: () => void
+  onQuizUpdate: (update?: AssessmentEditorSummaryUpdate) => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onPendingMarkdownImportChange?: (pending: boolean) => void
@@ -95,6 +96,16 @@ function clampSummaryDetailMarkdownWidthPercent(value: number, totalWidth: numbe
   )
 
   return roundPercent(clampNumber(value, minPercent, maxPercent))
+}
+
+function summarizeDraftContent(
+  content: Pick<AssessmentEditorDraft, 'title' | 'show_results' | 'questions'>
+): AssessmentEditorSummaryUpdate {
+  return {
+    title: content.title,
+    show_results: content.show_results,
+    questions_count: content.questions.length,
+  }
 }
 
 export function QuizDetailPanel({
@@ -540,6 +551,19 @@ export function QuizDetailPanel({
           | undefined
         if (serverDraft?.content) {
           applyServerDraft(serverDraft)
+          onQuizUpdate({
+            title:
+              typeof serverDraft.content.title === 'string'
+                ? serverDraft.content.title
+                : contentDraft.title,
+            show_results:
+              typeof serverDraft.content.show_results === 'boolean'
+                ? serverDraft.content.show_results
+                : contentDraft.show_results,
+            questions_count: Array.isArray(serverDraft.content.questions)
+              ? serverDraft.content.questions.length
+              : contentDraft.questions.length,
+          })
         } else {
           draftVersionRef.current += 1
           lastSavedDraftRef.current = nextSerialized
@@ -547,8 +571,8 @@ export function QuizDetailPanel({
           setSaveStatus('saved')
           setError('')
           setConflictDraft(null)
+          onQuizUpdate(summarizeDraftContent(contentDraft))
         }
-        onQuizUpdate()
         return true
       } catch (saveError: any) {
         console.error('Error saving draft:', saveError)

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -46,6 +46,7 @@ interface Props {
   classroomId: string
   apiBasePath?: string
   onQuizUpdate: (update?: AssessmentEditorSummaryUpdate) => void
+  onDraftSummaryChange?: (update: AssessmentEditorSummaryUpdate) => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onPendingMarkdownImportChange?: (pending: boolean) => void
@@ -113,6 +114,7 @@ export function QuizDetailPanel({
   classroomId,
   apiBasePath = '/api/teacher/quizzes',
   onQuizUpdate,
+  onDraftSummaryChange,
   onRequestDelete,
   onRequestTestPreview,
   onPendingMarkdownImportChange,
@@ -170,6 +172,13 @@ export function QuizDetailPanel({
   const lastSavedDraftRef = useRef('')
   const saveStatusRef = useRef<'saved' | 'saving' | 'unsaved'>('saved')
   const pendingDraftRef = useRef<AssessmentEditorDraft | null>(null)
+  const saveDraftRef = useRef<
+    | ((
+        nextDraft: AssessmentEditorDraft,
+        options?: { forceFull?: boolean; documents?: TestDocument[]; sourceMarkdown?: string }
+      ) => Promise<boolean>)
+    | null
+  >(null)
   const markdownDirtyRef = useRef(false)
   const savedMarkdownRef = useRef('')
   const documentsRef = useRef(documents)
@@ -181,6 +190,7 @@ export function QuizDetailPanel({
   const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState<number>(
     TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
   )
+  const loadedDraftQuizIdRef = useRef<string | null>(null)
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -332,15 +342,17 @@ export function QuizDetailPanel({
       draftVersionRef.current = draft.version
       lastSavedDraftRef.current = JSON.stringify(nextSnapshot)
       pendingDraftRef.current = nextSnapshot
+      loadedDraftQuizIdRef.current = quiz.id
       setSaveStatus('saved')
       setError('')
       setConflictDraft(null)
     },
-    [normalizeDraftQuestions, quiz.show_results, quiz.title]
+    [normalizeDraftQuestions, quiz.id, quiz.show_results, quiz.title]
   )
 
   // Sync editTitle when quiz changes
   useEffect(() => {
+    loadedDraftQuizIdRef.current = null
     setEditTitle(quiz.title)
     setDraftShowResults(quiz.show_results)
     setIsEditingTitle(false)
@@ -359,6 +371,25 @@ export function QuizDetailPanel({
   useEffect(() => {
     autoSyncAttemptedRef.current.clear()
   }, [quiz.id])
+
+  const emitDraftSummaryChange = useCallback(
+    (content: Pick<AssessmentEditorDraft, 'title' | 'show_results' | 'questions'>) => {
+      if (!onDraftSummaryChange) return
+      onDraftSummaryChange(summarizeDraftContent(content))
+    },
+    [onDraftSummaryChange]
+  )
+
+  useEffect(() => {
+    if (!onDraftSummaryChange) return
+    if (loadedDraftQuizIdRef.current !== quiz.id) return
+
+    emitDraftSummaryChange({
+      title: editTitle,
+      show_results: draftShowResults,
+      questions,
+    })
+  }, [draftShowResults, editTitle, emitDraftSummaryChange, onDraftSummaryChange, questions, quiz.id])
 
   useEffect(() => {
     documentsRef.current = documents
@@ -762,6 +793,11 @@ export function QuizDetailPanel({
 
       const reordered = normalizeQuestionPositions(arrayMove(questions, oldIndex, newIndex))
       setQuestions(reordered)
+      emitDraftSummaryChange({
+        title: editTitle,
+        show_results: draftShowResults,
+        questions: reordered,
+      })
 
       scheduleAutosave({
         title: editTitle,
@@ -769,7 +805,7 @@ export function QuizDetailPanel({
         questions: reordered,
       })
     },
-    [draftShowResults, editTitle, isEditable, normalizeQuestionPositions, questions, scheduleAutosave]
+    [draftShowResults, editTitle, emitDraftSummaryChange, isEditable, normalizeQuestionPositions, questions, scheduleAutosave]
   )
 
   useEffect(() => {
@@ -777,14 +813,18 @@ export function QuizDetailPanel({
   }, [saveStatus])
 
   useEffect(() => {
+    saveDraftRef.current = saveDraft
+  }, [saveDraft])
+
+  useEffect(() => {
     return () => {
       if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
       if (throttledSaveTimeoutRef.current) clearTimeout(throttledSaveTimeoutRef.current)
       if (pendingDraftRef.current && saveStatusRef.current === 'unsaved') {
-        void saveDraft(pendingDraftRef.current, { forceFull: true })
+        void saveDraftRef.current?.(pendingDraftRef.current, { forceFull: true })
       }
     }
-  }, [saveDraft])
+  }, [])
 
   async function handleTitleSave() {
     const trimmed = editTitle.trim()
@@ -881,6 +921,11 @@ export function QuizDetailPanel({
 
     const nextQuestions = normalizeQuestionPositions([...questions, nextQuestion])
     setQuestions(nextQuestions)
+    emitDraftSummaryChange({
+      title: editTitle,
+      show_results: draftShowResults,
+      questions: nextQuestions,
+    })
 
     scheduleAutosave({
       title: editTitle,
@@ -909,6 +954,7 @@ export function QuizDetailPanel({
       show_results: draftShowResults,
       questions: nextQuestions,
     }
+    emitDraftSummaryChange(nextDraft)
 
     if (options?.force) {
       scheduleSave(nextDraft, { force: true })
@@ -923,6 +969,11 @@ export function QuizDetailPanel({
       questions.filter((question) => question.id !== questionId)
     )
     setQuestions(nextQuestions)
+    emitDraftSummaryChange({
+      title: editTitle,
+      show_results: draftShowResults,
+      questions: nextQuestions,
+    })
 
     scheduleAutosave({
       title: editTitle,
@@ -955,6 +1006,11 @@ export function QuizDetailPanel({
     setExpandedQuestionIds((prev) =>
       prev.includes(questionId) ? [...prev, duplicatedQuestion.id] : prev
     )
+    emitDraftSummaryChange({
+      title: editTitle,
+      show_results: draftShowResults,
+      questions: nextQuestions,
+    })
 
     scheduleAutosave({
       title: editTitle,
@@ -1176,6 +1232,7 @@ export function QuizDetailPanel({
     setDraftShowResults(parsed.draftContent.show_results)
     setQuestions(nextQuestions)
     setDocuments(parsed.documents)
+    emitDraftSummaryChange(nextDraft)
     setMarkdownContent(nextDerivedMarkdown)
     savedMarkdownRef.current = nextDerivedMarkdown
     setIsMarkdownEditing(false)
@@ -1721,7 +1778,15 @@ export function QuizDetailPanel({
                   ref={titleInputRef}
                   type="text"
                   value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
+                  onChange={(e) => {
+                    const nextTitle = e.target.value
+                    setEditTitle(nextTitle)
+                    emitDraftSummaryChange({
+                      title: nextTitle,
+                      show_results: draftShowResults,
+                      questions,
+                    })
+                  }}
                   onKeyDown={handleTitleKeyDown}
                   onBlur={handleTitleSave}
                   disabled={savingTitle}

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -5,13 +5,13 @@ import { Play, Square } from 'lucide-react'
 import { getAssessmentStatusLabel, getQuizStatusBadgeClass, canActivateQuiz } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
-import type { QuizWithStats } from '@/types'
+import type { AssessmentWorkspaceSummaryPatch, QuizWithStats } from '@/types'
 
 interface TeacherTestCardProps {
   test: QuizWithStats
   isReadOnly: boolean
   onSelect: () => void
-  onUpdate: () => void
+  onUpdate: (update: AssessmentWorkspaceSummaryPatch) => void
 }
 
 export function TeacherTestCard({
@@ -44,7 +44,20 @@ export function TeacherTestCard({
         throw new Error(data.error || 'Failed to update test')
       }
 
-      onUpdate()
+      const nextStatus =
+        data?.test?.status === 'draft' || data?.test?.status === 'active' || data?.test?.status === 'closed'
+          ? data.test.status
+          : payload.status === 'draft' || payload.status === 'active' || payload.status === 'closed'
+            ? payload.status
+            : undefined
+
+      onUpdate({
+        status: nextStatus,
+        title: typeof data?.test?.title === 'string' ? data.test.title : undefined,
+        show_results: typeof data?.test?.show_results === 'boolean' ? data.test.show_results : undefined,
+        questions_count:
+          typeof data?.test?.stats?.questions_count === 'number' ? data.test.stats.questions_count : undefined,
+      })
     } catch (error: any) {
       setActionError(error?.message || 'Failed to update test')
     } finally {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -743,6 +743,12 @@ export interface QuizWithStats extends Quiz {
   }
 }
 
+export interface AssessmentEditorSummaryUpdate {
+  title: string
+  show_results: boolean
+  questions_count: number
+}
+
 export type StudentQuizStatus = 'not_started' | 'responded' | 'can_view_results'
 
 export interface StudentQuizView extends Quiz {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -749,6 +749,10 @@ export interface AssessmentEditorSummaryUpdate {
   questions_count: number
 }
 
+export interface AssessmentWorkspaceSummaryPatch extends Partial<AssessmentEditorSummaryUpdate> {
+  status?: QuizStatus
+}
+
 export type StudentQuizStatus = 'not_started' | 'responded' | 'can_view_results'
 
 export interface StudentQuizView extends Quiz {

--- a/tests/api/teacher/tests-route.test.ts
+++ b/tests/api/teacher/tests-route.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
-import { GET } from '@/app/api/teacher/tests/route'
+import { GET, POST } from '@/app/api/teacher/tests/route'
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -334,5 +334,167 @@ describe('GET /api/teacher/tests', () => {
     expect(data.quizzes).toHaveLength(1)
     expect(data.quizzes[0].stats.total_students).toBe(2)
     expect(data.quizzes[0].stats.responded).toBe(2)
+  })
+})
+
+describe('POST /api/teacher/tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a new test at the next position and seeds an initial draft row', async () => {
+    const deleteEqSpy = vi.fn().mockResolvedValue({ error: null })
+    const deleteSpy = vi.fn(() => ({
+      eq: deleteEqSpy,
+    }))
+    const assessmentDraftInsertSpy = vi.fn((payload: Record<string, unknown>) => ({
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: { id: 'draft-1', ...payload },
+          error: null,
+        }),
+      })),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { position: 2 },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          })),
+          insert: vi.fn((payload: Record<string, unknown>) => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'test-1',
+                  show_results: false,
+                  documents: null,
+                  ...payload,
+                },
+                error: null,
+              }),
+            })),
+          })),
+          delete: deleteSpy,
+        }
+      }
+
+      if (table === 'assessment_drafts') {
+        return {
+          insert: assessmentDraftInsertSpy,
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests', {
+        method: 'POST',
+        body: JSON.stringify({ classroom_id: 'classroom-1', title: ' New Test ' }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data.quiz.position).toBe(3)
+    expect(data.quiz.title).toBe('New Test')
+    expect(assessmentDraftInsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assessment_type: 'test',
+        assessment_id: 'test-1',
+        classroom_id: 'classroom-1',
+        version: 1,
+        created_by: 'teacher-1',
+        updated_by: 'teacher-1',
+        content: {
+          title: 'New Test',
+          show_results: false,
+          questions: [],
+          source_format: 'markdown',
+        },
+      })
+    )
+    expect(deleteSpy).not.toHaveBeenCalled()
+  })
+
+  it('rolls back the new test when the assessment drafts table is unavailable', async () => {
+    const deleteEqSpy = vi.fn().mockResolvedValue({ error: null })
+    const deleteSpy = vi.fn(() => ({
+      eq: deleteEqSpy,
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { position: 0 },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          })),
+          insert: vi.fn((payload: Record<string, unknown>) => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'test-1',
+                  show_results: false,
+                  documents: null,
+                  ...payload,
+                },
+                error: null,
+              }),
+            })),
+          })),
+          delete: deleteSpy,
+        }
+      }
+
+      if (table === 'assessment_drafts') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: {
+                  code: 'PGRST205',
+                  message: 'relation "assessment_drafts" does not exist',
+                },
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests', {
+        method: 'POST',
+        body: JSON.stringify({ classroom_id: 'classroom-1', title: 'Draftless Test' }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Assessment drafts require migration 045 to be applied')
+    expect(deleteSpy).toHaveBeenCalledTimes(1)
+    expect(deleteEqSpy).toHaveBeenCalledWith('id', 'test-1')
   })
 })

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -306,11 +306,13 @@ describe('QuizDetailPanel', () => {
 
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('2 questions')
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('9 pts')
-      expect(within(editorPane).getByRole('button', { name: 'Expand all sections' })).toBeInTheDocument()
-      expect(within(editorPane).getByRole('button', { name: 'Collapse question 1' })).toBeInTheDocument()
-      expect(within(editorPane).getByRole('button', { name: 'Expand question 2' })).toBeInTheDocument()
-      expect(within(editorPane).getByRole('button', { name: 'Duplicate question 1' })).toBeInTheDocument()
-      expect(within(editorPane).getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
+      await waitFor(() => {
+        expect(within(editorPane).getByRole('button', { name: 'Expand all sections' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Collapse question 1' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Expand question 2' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Duplicate question 1' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
+      })
       expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toHaveClass('bg-primary')
       expect(within(editorPane).getByRole('button', { name: 'Choose question type' })).toBeInTheDocument()
       expect(within(editorPane).getByLabelText('Question 1 points')).toHaveValue(6)
@@ -1257,6 +1259,7 @@ Correct Option: 2
 
     it('applies valid markdown and saves through draft endpoint', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const onQuizUpdate = vi.fn()
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
@@ -1326,7 +1329,7 @@ Correct Option: 2
           quiz={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onQuizUpdate={onQuizUpdate}
         />,
         { wrapper: Wrapper }
       )
@@ -1388,6 +1391,11 @@ _None_
       expect(body.content.show_results).toBe(true)
       expect(body.content.questions).toHaveLength(2)
       expect(body.documents).toEqual([])
+      expect(onQuizUpdate).toHaveBeenLastCalledWith({
+        title: 'Markdown Test Updated',
+        show_results: true,
+        questions_count: 2,
+      })
     })
 
     it('blocks apply when markdown is invalid', async () => {

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -570,6 +570,176 @@ describe('QuizDetailPanel', () => {
       })
     })
 
+    it('emits draft summary changes immediately for structured test edits before autosave completes', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const onDraftSummaryChange = vi.fn()
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Two Pane Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Two Pane Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          onDraftSummaryChange={onDraftSummaryChange}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const editorPane = await screen.findByTestId('test-question-editor-pane')
+      await waitFor(() => {
+        expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('2 questions')
+      })
+      onDraftSummaryChange.mockClear()
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: '+ MC Question' }))
+
+      await waitFor(() => {
+        expect(onDraftSummaryChange).toHaveBeenLastCalledWith({
+          title: 'Two Pane Test',
+          show_results: true,
+          questions_count: 3,
+        })
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not force-save unsaved drafts again when callback props change before autosave fires', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (url === '/api/teacher/tests/quiz-race-test/draft' && !options) {
+          return {
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: 1,
+                content: {
+                  title: 'Race Test',
+                  show_results: false,
+                  questions: [],
+                },
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-race-test' && !options) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [],
+              },
+            }),
+          }
+        }
+
+        if (url === '/api/teacher/tests/quiz-race-test/draft' && options?.method === 'PATCH') {
+          const body = JSON.parse(String(options.body ?? '{}'))
+          return {
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: Number(body.version ?? 1) + 1,
+                content: body.content,
+              },
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
+      })
+
+      const testQuiz = makeQuizWithStats({
+        id: 'quiz-race-test',
+        assessment_type: 'test',
+        title: 'Race Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+
+      const onQuizUpdateInitial = vi.fn()
+      const { rerender } = render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={onQuizUpdateInitial}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const addQuestionButton = await screen.findByRole('button', { name: '+ MC Question' })
+      fireEvent.click(addQuestionButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+      })
+
+      const onQuizUpdateNext = vi.fn()
+      rerender(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={onQuizUpdateNext}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      let patchCalls = fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')
+      expect(patchCalls).toHaveLength(0)
+
+      await new Promise((resolve) => setTimeout(resolve, 3_200))
+
+      await waitFor(() => {
+        patchCalls = fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')
+        expect(patchCalls).toHaveLength(1)
+      })
+
+      const patchBody = JSON.parse(String(patchCalls[0]?.[1]?.body ?? '{}'))
+      expect(String(patchCalls[0]?.[0])).toContain('/api/teacher/tests/quiz-race-test/draft')
+      expect(patchBody.version).toBe(1)
+      expect(patchBody.content?.questions).toHaveLength(1)
+    }, 10_000)
+
     it('duplicates a test question immediately below the source in summary-detail mode', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showPreviewButton,
     showResultsTab,
     onPendingMarkdownImportChange,
+    onDraftSummaryChange,
     onQuizUpdate,
   }: {
     quiz: QuizWithStats
@@ -55,6 +56,11 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showPreviewButton?: boolean
     showResultsTab?: boolean
     onPendingMarkdownImportChange?: (pending: boolean) => void
+    onDraftSummaryChange?: (update: {
+      title: string
+      show_results: boolean
+      questions_count: number
+    }) => void
     onQuizUpdate?: (update?: {
       title: string
       show_results: boolean
@@ -73,6 +79,18 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       </button>
       <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
         Clear pending markdown
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onDraftSummaryChange?.({
+            title: `${quiz.title} Draft`,
+            show_results: false,
+            questions_count: 0,
+          })
+        }
+      >
+        Simulate draft change
       </button>
       <button
         type="button"
@@ -281,7 +299,28 @@ describe('TeacherTestsTab', () => {
     })
   })
 
-  it('keeps the selected workspace mounted and updates local test metadata after autosave', async () => {
+  it('updates the authoring header and activation state immediately from local draft changes', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Simulate draft change' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Unit Test Draft')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+    })
+
+    expect(screen.getByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('keeps the selected workspace mounted and updates saved test metadata after autosave', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
     renderTab()
 
@@ -343,10 +382,6 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ test: { id: 'test-1', status: 'active' } }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
-      })
 
     renderTab()
 
@@ -372,6 +407,7 @@ describe('TeacherTestsTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
     })
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
   it('confirms and closes an active test from authoring', async () => {
@@ -383,10 +419,6 @@ describe('TeacherTestsTab', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ test: { id: 'test-1', status: 'closed' } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
       })
 
     renderTab()
@@ -413,6 +445,48 @@ describe('TeacherTestsTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
     })
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('updates summary-card status actions locally without refetching the full list', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          questions: [
+            {
+              id: 'q1',
+              question_type: 'multiple_choice',
+              question_text: 'Ready to activate?',
+              options: ['Yes', 'No'],
+              correct_option: 0,
+              points: 1,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ test: { id: 'test-1', status: 'active' } }),
+      })
+
+    renderTab()
+
+    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open test' }))
+    expect(await screen.findByText('Activate test?')).toBeInTheDocument()
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Activate' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close test' })).toBeInTheDocument()
+    })
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
   it('returns to the tests list when the tests tab is clicked again', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -48,12 +48,18 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showPreviewButton,
     showResultsTab,
     onPendingMarkdownImportChange,
+    onQuizUpdate,
   }: {
     quiz: QuizWithStats
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
     onPendingMarkdownImportChange?: (pending: boolean) => void
+    onQuizUpdate?: (update?: {
+      title: string
+      show_results: boolean
+      questions_count: number
+    }) => void
   }) => (
     <div
       data-testid="mock-test-detail"
@@ -67,6 +73,18 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       </button>
       <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
         Clear pending markdown
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onQuizUpdate?.({
+            title: `${quiz.title} Updated`,
+            show_results: false,
+            questions_count: 0,
+          })
+        }
+      >
+        Simulate autosave update
       </button>
     </div>
   ),
@@ -261,6 +279,28 @@ describe('TeacherTestsTab', () => {
       expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
       expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
     })
+  })
+
+  it('keeps the selected workspace mounted and updates local test metadata after autosave', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Simulate autosave update' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test Updated')
+      expect(screen.getByText('Unit Test Updated')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+    })
+
+    expect(screen.getByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
   it('opens a newly created test directly into authoring mode', async () => {


### PR DESCRIPTION
## What changed
- stopped the tests authoring workspace from forcing a blocking full list reload after every successful draft autosave
- added a small `AssessmentEditorSummaryUpdate` payload so `QuizDetailPanel` can report the saved title, `show_results`, and question count back to the parent
- updated `TeacherTestsTab` to patch the selected test in local state instead of tearing down the workspace to refetch the full tests collection
- added regression coverage for the new callback contract and for keeping the selected test workspace mounted after autosave

## Why this changed
Editing test questions had a bad UX: after the autosave debounce fired, the parent tab refetched the entire tests list and temporarily replaced the selected workspace with a loading state. That made add/remove question changes feel like a page refresh even though the editor already had the fresh state it needed.

## Impact
- adding or removing test questions now keeps the authoring workspace visible through autosave
- the authoring header and action availability still stay in sync because the parent now updates local title/show-results/question-count metadata directly
- no change to server-side draft persistence or markdown application behavior

## Root cause
`QuizDetailPanel` called `onQuizUpdate()` after successful saves, and `TeacherTestsTab` handled that by calling `loadTests()`, which set the tab-level `loading` flag and swapped the entire selected workspace back to a spinner.

## Validation
- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
- `pnpm lint`
- Playwright visual verification on `/classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests`
- teacher interaction capture covering add question -> autosave -> stable workspace
