### PR TITLE
[codex] Disable exam lock overlay

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9284,3 +9284,17 @@
 - `pnpm lint --file src/components/QuizDetailPanel.tsx --file src/app/api/teacher/tests/route.ts --file tests/components/QuizDetailPanel.test.tsx --file tests/api/teacher/tests-route.test.ts`
 - Visual verification on `http://localhost:3001/classrooms/f0c8c2d8-f1e2-4a2c-ad3f-3b0caa09b106?tab=tests`
 - Live Playwright regression trace confirmed a fresh draft now makes exactly one `PATCH /api/teacher/tests/:id/draft`, shows no conflict text, and returns to `Saved`
+
+## 2026-04-24 — Fix Mobile Exam Mode Blank Screen On MC Selection
+
+- Reproduced the reported refresh/re-enter blank screen on an iPhone WebKit profile: the MC draft save succeeded, but mobile WebKit cannot enter fullscreen and reports a viewport height below the desktop maximized-window threshold, causing the exam lock overlay to hide the form.
+- Updated student test exam-window compliance so compact touch browsers without Fullscreen API support use the mobile fallback instead of the desktop maximized-window ratio check.
+- Disabled the exam lock overlay gate while preserving exam-mode telemetry, so non-compliant window/fullscreen events can still be logged without hiding or blocking active test content.
+- Added regression coverage for re-entering a saved test on a mobile/no-fullscreen browser, selecting a different MC choice, avoiding the obscurer overlay, and preserving the draft autosave.
+- Created and cleaned up a temporary Codex repro classroom/test fixture in the dev database for browser verification.
+
+**Validation:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx --testNamePattern "mobile browsers without fullscreen"`
+- `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
+- Playwright mobile WebKit repro before/after patch confirmed the post-autosave `Window must be maximized in exam mode` overlay no longer appears and `PATCH /api/student/tests/:id/attempt` returns 200; screenshot saved at `test-results/mobile-exam-overlay-disabled.png`.

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -87,9 +87,29 @@ function isFullscreenActive(): boolean {
   return typeof document !== 'undefined' && Boolean(document.fullscreenElement)
 }
 
+function isFullscreenApiSupported(): boolean {
+  if (typeof document === 'undefined') return false
+  const fullscreenElement = document.documentElement as FullscreenCapableElement
+  return typeof fullscreenElement?.requestFullscreen === 'function'
+}
+
+function isMobileBrowserWithoutFullscreen(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false
+  if (isFullscreenApiSupported()) return false
+
+  const maxTouchPoints = window.navigator?.maxTouchPoints ?? 0
+  const hasCoarsePointer =
+    typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches
+  const hasTouchInput = maxTouchPoints > 0 || hasCoarsePointer
+  const compactViewport = Math.min(window.innerWidth, window.innerHeight) <= 1024
+
+  return hasTouchInput && compactViewport
+}
+
 const EXAM_WINDOW_COMPLIANCE_GRACE_MS = 400
 const EXAM_WINDOW_MIN_WIDTH_RATIO = 0.92
 const EXAM_WINDOW_MIN_HEIGHT_RATIO = 0.88
+const EXAM_LOCK_OVERLAY_ENABLED = false
 const DOCS_EXIT_SUPPRESSION_WINDOW_MS = 1200
 const UNSUPPRESSED_ROUTE_EXIT_SOURCES = new Set([
   'tab_navigation',
@@ -129,11 +149,13 @@ function getExamWindowComplianceSnapshot(): ExamWindowComplianceSnapshot {
   const availHeight = window.screen?.availHeight || innerHeight
   const widthRatio = availWidth > 0 ? innerWidth / availWidth : 1
   const heightRatio = availHeight > 0 ? innerHeight / availHeight : 1
+  const mobileFullscreenFallback = isMobileBrowserWithoutFullscreen()
 
   return {
     isFullscreen,
     isCompliant:
       isFullscreen ||
+      mobileFullscreenFallback ||
       (widthRatio >= EXAM_WINDOW_MIN_WIDTH_RATIO && heightRatio >= EXAM_WINDOW_MIN_HEIGHT_RATIO),
     widthRatio,
     heightRatio,
@@ -1089,7 +1111,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const awayCount = focusSummary?.away_count ?? 0
     const routeExitAttempts = focusSummary?.route_exit_attempts ?? 0
     const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
-    const showNotMaximizedWarning = showCurrentTestInfoPanel && !isWindowCompliantStable
+    const showNotMaximizedWarning =
+      EXAM_LOCK_OVERLAY_ENABLED && showCurrentTestInfoPanel && !isWindowCompliantStable
     const iframeDocs = allowedDocs.filter((doc) => doc.source !== 'text' && Boolean(doc.url))
     const selectedTestTitle = hasSelectedQuiz ? selectedQuiz.quiz.title : ''
     const selectedTestPanelTitle = isViewingResults

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -2739,7 +2739,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
   })
 
-  it('locks after sustained fullscreen loss when the window remains non-compliant', async () => {
+  it('logs sustained fullscreen loss without obscuring the active test', async () => {
     const focusBodies: Array<Record<string, any>> = []
     let fullscreenElement: Element | null = null
 
@@ -2871,8 +2871,8 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
-    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3039,7 +3039,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
   })
 
-  it('locks after the grace window when exam mode window is reduced', async () => {
+  it('logs reduced exam mode windows without obscuring the active test', async () => {
     const focusBodies: Array<Record<string, any>> = []
     let fullscreenElement: Element | null = null
 
@@ -3176,8 +3176,8 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
-    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3187,7 +3187,209 @@ describe('StudentQuizzesTab exam mode', () => {
     ).toBe(true)
   })
 
-  it('preserves unsaved in-progress test answers when the maximize lock overlay appears and clears', async () => {
+  it('keeps mobile browsers without fullscreen support usable after re-entering a saved test', async () => {
+    const requestFullscreenDescriptor = Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      'requestFullscreen'
+    )
+    const maxTouchPointsDescriptor = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      'maxTouchPoints'
+    )
+    let savedResponses: Record<string, unknown> = {
+      q1: { question_type: 'multiple_choice', selected_option: 2 },
+    }
+
+    try {
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => null,
+      })
+      Object.defineProperty(document.documentElement, 'requestFullscreen', {
+        configurable: true,
+        value: undefined,
+      })
+      Object.defineProperty(window.navigator, 'maxTouchPoints', {
+        configurable: true,
+        value: 5,
+      })
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: 390,
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        writable: true,
+        value: 664,
+      })
+      Object.defineProperty(window.screen, 'availWidth', {
+        configurable: true,
+        value: 390,
+      })
+      Object.defineProperty(window.screen, 'availHeight', {
+        configurable: true,
+        value: 844,
+      })
+
+      fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (url.includes('/api/student/tests?classroom_id=')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quizzes: [{
+                id: 'test-1',
+                title: 'Midterm Test',
+                assessment_type: 'test',
+                status: 'active',
+                show_results: false,
+                position: 0,
+                student_status: 'not_started',
+              }],
+            }),
+          }
+        }
+
+        if (url.includes('/api/student/tests/test-1/session-status')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                id: 'test-1',
+                status: 'active',
+                assessment_type: 'test',
+                student_status: 'not_started',
+                returned_at: null,
+              },
+              student_status: 'not_started',
+              returned_at: null,
+              can_continue: true,
+              message: null,
+            }),
+          }
+        }
+
+        if (url.includes('/api/student/tests/test-1') && !url.includes('/session-status') && !url.includes('/focus-events') && !url.includes('/attempt')) {
+          return {
+            ok: true,
+            json: async () => ({
+              quiz: {
+                id: 'test-1',
+                title: 'Midterm Test',
+                assessment_type: 'test',
+                status: 'active',
+                show_results: false,
+                position: 0,
+                student_status: 'not_started',
+              },
+              student_status: 'not_started',
+              questions: [
+                {
+                  id: 'q1',
+                  quiz_id: 'test-1',
+                  question_text: 'Which HTTP method is usually used for partial updates?',
+                  options: ['GET', 'POST', 'PATCH', 'DELETE'],
+                  question_type: 'multiple_choice',
+                  points: 1,
+                  response_max_chars: 5000,
+                  position: 0,
+                },
+              ],
+              student_responses: savedResponses,
+              focus_summary: makeFocusSummary(),
+            }),
+          }
+        }
+
+        if (url.includes('/api/student/tests/test-1/attempt') && options?.method === 'PATCH') {
+          const body = JSON.parse(String(options.body || '{}')) as { responses?: Record<string, unknown> }
+          savedResponses = body.responses || {}
+          return {
+            ok: true,
+            json: async () => ({
+              attempt: {
+                id: 'attempt-1',
+                responses: savedResponses,
+                is_submitted: false,
+              },
+            }),
+          }
+        }
+
+        if (url.includes('/api/student/tests/test-1/focus-events')) {
+          return {
+            ok: true,
+            json: async () => ({
+              success: true,
+              focus_summary: makeFocusSummary(),
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`)
+      })
+
+      render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Midterm Test'))
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+      await waitFor(() => {
+        expect(screen.getByText('Start this test?')).toBeInTheDocument()
+      })
+
+      vi.useFakeTimers()
+      fireEvent.click(screen.getByText('Start test'))
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(screen.getByText('Which HTTP method is usually used for partial updates?')).toBeInTheDocument()
+      expect(screen.getByText('PATCH').closest('label')).toHaveClass('border-primary')
+
+      fireEvent.click(screen.getByText('GET'))
+
+      await act(async () => {
+        vi.advanceTimersByTime(450)
+        await Promise.resolve()
+      })
+
+      expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+      expect(screen.getByText('Which HTTP method is usually used for partial updates?')).toBeVisible()
+      expect(screen.getByText('GET').closest('label')).toHaveClass('border-primary')
+
+      await act(async () => {
+        vi.advanceTimersByTime(5_000)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(savedResponses).toEqual({
+        q1: { question_type: 'multiple_choice', selected_option: 0 },
+      })
+    } finally {
+      if (requestFullscreenDescriptor) {
+        Object.defineProperty(document.documentElement, 'requestFullscreen', requestFullscreenDescriptor)
+      } else {
+        delete (document.documentElement as HTMLElement & { requestFullscreen?: unknown }).requestFullscreen
+      }
+
+      if (maxTouchPointsDescriptor) {
+        Object.defineProperty(window.navigator, 'maxTouchPoints', maxTouchPointsDescriptor)
+      } else {
+        delete (window.navigator as Navigator & { maxTouchPoints?: unknown }).maxTouchPoints
+      }
+    }
+  })
+
+  it('preserves unsaved in-progress test answers when exam window compliance changes', async () => {
     let fullscreenElement: Element | null = null
     let savedResponses: Record<string, unknown> = {}
     const focusBodies: Array<Record<string, any>> = []
@@ -3377,7 +3579,8 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('TDD clarifies expected behavior before coding.')).toBeVisible()
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,


### PR DESCRIPTION
## Summary

- disable the student exam lock overlay so window/fullscreen compliance can no longer hide or block active test content
- keep exam-mode telemetry running so fullscreen loss and window resize events still log
- add a mobile/no-fullscreen regression covering re-entering a saved test and selecting an MC answer

## Root Cause

I reproduced the blank-screen report on an iPhone WebKit profile. The MC autosave succeeded, but mobile WebKit has no Fullscreen API and failed the desktop maximized-window height ratio check, so the exam lock overlay intentionally hid the test content. Because the same overlay is the only code path that deliberately obscures the test, this PR disables that gate for the incident path.

## Validation

- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx --testNamePattern "mobile browsers without fullscreen"`
- `pnpm lint` (existing `TestDocumentsEditor.tsx` hook warning remains)
- mobile WebKit Playwright check: selected MC answer stayed visible after autosave and `PATCH /api/student/tests/:id/attempt` returned 200

## Review Notes

- Self-review: the overlay is gated with `EXAM_LOCK_OVERLAY_ENABLED = false`; no blocker/obscurer can render while the flag is false.
- Telemetry path remains active: non-compliant fullscreen/window events still call the existing focus-event logging path.
- Temporary browser repro fixtures were cleaned up from the dev database.
