### PR TITLE
[codex] Restore exam lock overlay

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9298,3 +9298,15 @@
 - `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx --testNamePattern "mobile browsers without fullscreen"`
 - `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
 - Playwright mobile WebKit repro before/after patch confirmed the post-autosave `Window must be maximized in exam mode` overlay no longer appears and `PATCH /api/student/tests/:id/attempt` returns 200; screenshot saved at `test-results/mobile-exam-overlay-disabled.png`.
+
+## 2026-04-24 — Restore Exam Lock Overlay
+
+- Re-enabled the exam lock overlay for desktop/non-mobile exam mode window and fullscreen non-compliance.
+- Kept the mobile/no-Fullscreen fallback from the blank-screen fix so compact touch browsers that cannot request fullscreen are treated as compliant instead of being trapped behind the overlay.
+- Restored desktop regression expectations that sustained fullscreen loss or reduced exam windows obscure the active test, while preserving mobile regression coverage for saved-test re-entry and MC autosave.
+
+**Validation:**
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
+- `bash scripts/verify-env.sh`
+- Browser verification confirmed the restored desktop overlay with `exam-content-obscurer` and blocker active; screenshot saved at `test-results/desktop-exam-lock-overlay-restored.png`.

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -109,7 +109,7 @@ function isMobileBrowserWithoutFullscreen(): boolean {
 const EXAM_WINDOW_COMPLIANCE_GRACE_MS = 400
 const EXAM_WINDOW_MIN_WIDTH_RATIO = 0.92
 const EXAM_WINDOW_MIN_HEIGHT_RATIO = 0.88
-const EXAM_LOCK_OVERLAY_ENABLED = false
+const EXAM_LOCK_OVERLAY_ENABLED = true
 const DOCS_EXIT_SUPPRESSION_WINDOW_MS = 1200
 const UNSUPPRESSED_ROUTE_EXIT_SOURCES = new Set([
   'tab_navigation',

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -2739,7 +2739,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
   })
 
-  it('logs sustained fullscreen loss without obscuring the active test', async () => {
+  it('locks after sustained fullscreen loss when the window remains non-compliant', async () => {
     const focusBodies: Array<Record<string, any>> = []
     let fullscreenElement: Element | null = null
 
@@ -2871,8 +2871,8 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
-    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3039,7 +3039,7 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(focusBodies.filter((body) => body.event_type === 'window_unmaximize_attempt')).toHaveLength(0)
   })
 
-  it('logs reduced exam mode windows without obscuring the active test', async () => {
+  it('locks after the grace window when exam mode window is reduced', async () => {
     const focusBodies: Array<Record<string, any>> = []
     let fullscreenElement: Element | null = null
 
@@ -3176,8 +3176,8 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
-    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).not.toBeVisible()
     expect(
       focusBodies.some(
         (body) =>
@@ -3579,8 +3579,7 @@ describe('StudentQuizzesTab exam mode', () => {
       vi.advanceTimersByTime(450)
     })
 
-    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
-    expect(screen.getByDisplayValue('TDD clarifies expected behavior before coding.')).toBeVisible()
+    expect(screen.getByTestId('exam-content-obscurer')).toBeInTheDocument()
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,


### PR DESCRIPTION
## Summary

- Re-enable the exam lock overlay for desktop/non-mobile exam mode window and fullscreen non-compliance.
- Keep the mobile/no-Fullscreen fallback from the blank-screen fix so compact touch browsers that cannot request fullscreen remain usable.
- Restore regression expectations for desktop overlay locking while preserving the mobile saved-test re-entry and MC autosave coverage.

## Validation

- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx`
- `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
- `bash scripts/verify-env.sh`
- Browser verification: restored desktop overlay screenshot at `test-results/desktop-exam-lock-overlay-restored.png`