### PR TITLE
[codex] Smooth test grading refreshes

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9310,3 +9310,15 @@
 - `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
 - `bash scripts/verify-env.sh`
 - Browser verification confirmed the restored desktop overlay with `exam-content-obscurer` and blocker active; screenshot saved at `test-results/desktop-exam-lock-overlay-restored.png`.
+
+## 2026-04-24 — Smooth Test Grading Poll Refreshes
+
+- Kept test grading rows mounted during background poll refreshes so the grading screen no longer drops to a full loading state while teachers are reviewing submissions.
+- Added a shared assessment status icon component and reused it from both the assignments table and test grading rows, including the submitted green circle treatment.
+- Added regression coverage for the preserved grading rows during polling and the shared submitted/returned/late status icon states.
+
+**Validation:**
+- `pnpm test -- tests/components/AssessmentStatusIcon.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
+- `bash scripts/verify-env.sh`
+- `pika-ui-verify` classroom screenshot capture passed for teacher desktop, teacher mobile, and student mobile; focused grading-page capture was not available because the current dev database has no classrooms/tests.

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -21,12 +21,9 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
-  Circle,
-  Clock,
   LoaderCircle,
   Pencil,
   Plus,
-  RotateCcw,
   Send,
 } from 'lucide-react'
 import { Button, ConfirmDialog, SplitButton, Tooltip } from '@/ui'
@@ -36,6 +33,10 @@ import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
+import {
+  AssessmentStatusIcon,
+  type AssessmentStatusIconState,
+} from '@/components/AssessmentStatusIcon'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
 import {
@@ -50,7 +51,6 @@ import {
 import { RightSidebarToggle } from '@/components/layout'
 import {
   calculateAssignmentStatus,
-  getAssignmentStatusIconClass,
   getAssignmentStatusLabel,
   hasDraftSavedGrade,
 } from '@/lib/assignments'
@@ -142,9 +142,6 @@ function getRowClassName(isSelected: boolean): string {
   return 'cursor-pointer hover:bg-surface-hover'
 }
 
-const STATUS_ICON_CLASS = 'h-4 w-4'
-const LATE_CLOCK_CLASS = 'h-3 w-3'
-
 function MetricBar({ value }: { value: number }) {
   const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
   return (
@@ -166,52 +163,38 @@ function StatusIcon({
   wasLate?: boolean
   hasDraftGrade?: boolean
 }) {
-  const colorClass = getAssignmentStatusIconClass(status)
-  let iconColorClass = colorClass
-  let icon: React.ReactElement
-
-  // Determine if this status should show the late clock indicator.
-  // "late" statuses always show it; downstream statuses show it when wasLate is true.
   const showLate =
     status === 'in_progress_late' ||
     status === 'submitted_late' ||
     ((status === 'graded' || status === 'returned' || status === 'resubmitted') && wasLate)
 
-  // Pick the base icon for each status.
-  // Submitted is a circle unless draft grading has been saved.
+  let iconState: AssessmentStatusIconState
   switch (status) {
     case 'not_started':
+      iconState = 'not_started'
+      break
     case 'in_progress':
     case 'in_progress_late':
-      icon = <Circle className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
+      iconState = 'in_progress'
       break
     case 'submitted_on_time':
     case 'submitted_late':
-      if (hasDraftGrade) {
-        iconColorClass = 'text-gray-400'
-        icon = <Check className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
-      } else {
-        icon = <Circle className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
-      }
+      iconState = hasDraftGrade ? 'draft_graded' : 'submitted'
       break
     case 'graded':
-      iconColorClass = 'text-green-500'
-      icon = <Check className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
+      iconState = 'graded'
       break
     case 'returned':
-      icon = <Send className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
+      iconState = 'returned'
       break
     case 'resubmitted':
-      icon = <RotateCcw className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
+      iconState = 'resubmitted'
       break
     default:
-      icon = <Circle className={`${STATUS_ICON_CLASS} ${iconColorClass}`} />
+      iconState = 'not_started'
   }
 
-  if (showLate) {
-    return <span className={`inline-flex items-center gap-0.5 ${iconColorClass}`}>{icon}<Clock className={LATE_CLOCK_CLASS} /></span>
-  }
-  return icon
+  return <AssessmentStatusIcon state={iconState} late={showLate} />
 }
 
 function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLate: boolean): string {

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Circle, ClockAlert, LogOut, Play, Plus, Send, Square, Trash2 } from 'lucide-react'
+import { Check, ClockAlert, LogOut, Play, Plus, Send, Square, Trash2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TeacherTestCard } from '@/components/TeacherTestCard'
 import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { AssessmentStatusIcon, type AssessmentStatusIconState } from '@/components/AssessmentStatusIcon'
 import { useRightSidebar } from '@/components/layout'
 import {
   TEACHER_QUIZZES_UPDATED_EVENT,
@@ -17,7 +18,7 @@ import { getQuizExitCount } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, RefreshingIndicator, Select, Tooltip } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
   AssessmentWorkspaceSummaryPatch,
@@ -75,12 +76,12 @@ const TEST_AI_GRADING_RUN_NOTE =
 
 const STATUS_META: Record<
   TestGradingStudentRow['status'],
-  { label: string; className: string; icon: typeof Circle }
+  { label: string; iconState: AssessmentStatusIconState }
 > = {
-  not_started: { label: 'Not started', className: 'text-gray-400', icon: Circle },
-  in_progress: { label: 'In progress', className: 'text-yellow-500', icon: Circle },
-  submitted: { label: 'Submitted', className: 'text-green-500', icon: Check },
-  returned: { label: 'Returned', className: 'text-blue-500', icon: Send },
+  not_started: { label: 'Not started', iconState: 'not_started' },
+  in_progress: { label: 'In progress', iconState: 'in_progress' },
+  submitted: { label: 'Submitted', iconState: 'submitted' },
+  returned: { label: 'Returned', iconState: 'returned' },
 }
 
 function splitDisplayName(name: string | null): { firstName: string | null; lastName: string | null } {
@@ -231,6 +232,7 @@ export function TeacherTestsTab({
   const [gradingServerTestId, setGradingServerTestId] = useState<string | null>(null)
   const [testAiGradingRun, setTestAiGradingRun] = useState<TestAiGradingRunSummary | null>(null)
   const [gradingLoading, setGradingLoading] = useState(false)
+  const [gradingRefreshing, setGradingRefreshing] = useState(false)
   const [gradingError, setGradingError] = useState('')
   const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
@@ -396,16 +398,18 @@ export function TeacherTestsTab({
     }
   }, [classroom.id])
 
-  const loadGradingRows = useCallback(async () => {
+  const loadGradingRows = useCallback(async (options?: { preserveRows?: boolean }) => {
     if (!selectedTestId) {
       setGradingStudents([])
       setGradingQuestions([])
       setGradingServerTestStatus(null)
       setGradingServerTestId(null)
       setTestAiGradingRun(null)
+      setGradingRefreshing(false)
       return
     }
 
+    const preserveRows = options?.preserveRows ?? false
     const requestedTestId = selectedTestId
     const requestId = ++latestGradingRequestIdRef.current
     const isStaleRequest = () => {
@@ -418,7 +422,11 @@ export function TeacherTestsTab({
       )
     }
 
-    setGradingLoading(true)
+    if (preserveRows) {
+      setGradingRefreshing(true)
+    } else {
+      setGradingLoading(true)
+    }
     setGradingError('')
     try {
       const response = await fetch(`${apiBasePath}/${requestedTestId}/results`, { cache: 'no-store' })
@@ -455,12 +463,15 @@ export function TeacherTestsTab({
     } catch (error: any) {
       if (isStaleRequest()) return
       setGradingError(error.message || 'Failed to load test results')
-      setGradingStudents([])
-      setGradingQuestions([])
-      setTestAiGradingRun(null)
+      if (!preserveRows) {
+        setGradingStudents([])
+        setGradingQuestions([])
+        setTestAiGradingRun(null)
+      }
     } finally {
       if (isStaleRequest()) return
       setGradingLoading(false)
+      setGradingRefreshing(false)
     }
   }, [selectedTestId])
 
@@ -543,6 +554,7 @@ export function TeacherTestsTab({
       setGradingServerTestStatus(null)
       setGradingServerTestId(null)
       setGradingLoading(false)
+      setGradingRefreshing(false)
       setTestAiGradingRun(null)
       clearBatchSelection()
       return
@@ -584,7 +596,7 @@ export function TeacherTestsTab({
       if (disposed || pollingInFlight || !canPollNow()) return
       pollingInFlight = true
       try {
-        await loadGradingRows()
+        await loadGradingRows({ preserveRows: true })
       } finally {
         pollingInFlight = false
       }
@@ -1103,7 +1115,10 @@ export function TeacherTestsTab({
 
   const gradingTable = (
     <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-      {gradingLoading ? (
+      {gradingRefreshing ? (
+        <RefreshingIndicator label="Refreshing grading rows..." className="px-3 py-2" />
+      ) : null}
+      {gradingLoading && gradingStudents.length === 0 ? (
         <div className="flex justify-center py-10">
           <Spinner />
         </div>
@@ -1186,7 +1201,6 @@ export function TeacherTestsTab({
                     ? '—'
                     : `${formatPoints(student.points_earned)}/${formatPoints(student.points_possible)}`
                 const statusMeta = STATUS_META[student.status]
-                const StatusIcon = statusMeta.icon
                 const awayCount = student.focus_summary?.away_count ?? 0
                 const awaySeconds = student.focus_summary?.away_total_seconds ?? 0
                 const awayMinutes = Math.floor(awaySeconds / 60)
@@ -1222,10 +1236,10 @@ export function TeacherTestsTab({
                     <td className="px-3 py-2">
                       <Tooltip content={statusMeta.label}>
                         <span
-                          className={`inline-flex min-w-5 cursor-help items-center justify-center text-sm font-semibold ${statusMeta.className}`}
+                          className="inline-flex min-w-5 cursor-help items-center justify-center"
                           aria-label={statusMeta.label}
                         >
-                          <StatusIcon className="h-4 w-4" />
+                          <AssessmentStatusIcon state={statusMeta.iconState} />
                         </span>
                       </Tooltip>
                     </td>

--- a/src/components/AssessmentStatusIcon.tsx
+++ b/src/components/AssessmentStatusIcon.tsx
@@ -1,0 +1,58 @@
+import { Check, Circle, Clock, RotateCcw, Send, type LucideIcon } from 'lucide-react'
+
+export type AssessmentStatusIconState =
+  | 'not_started'
+  | 'in_progress'
+  | 'submitted'
+  | 'draft_graded'
+  | 'graded'
+  | 'returned'
+  | 'resubmitted'
+
+interface AssessmentStatusIconProps {
+  state: AssessmentStatusIconState
+  late?: boolean
+  className?: string
+}
+
+const ICON_CLASS = 'h-4 w-4'
+const LATE_CLOCK_CLASS = 'h-3 w-3'
+
+const STATUS_ICON_META: Record<AssessmentStatusIconState, { icon: LucideIcon; className: string }> = {
+  not_started: { icon: Circle, className: 'text-text-muted' },
+  in_progress: { icon: Circle, className: 'text-warning' },
+  submitted: { icon: Circle, className: 'text-success' },
+  draft_graded: { icon: Check, className: 'text-text-muted' },
+  graded: { icon: Check, className: 'text-success' },
+  returned: { icon: Send, className: 'text-primary' },
+  resubmitted: { icon: RotateCcw, className: 'text-warning' },
+}
+
+export function AssessmentStatusIcon({
+  state,
+  late = false,
+  className = '',
+}: AssessmentStatusIconProps) {
+  const meta = STATUS_ICON_META[state]
+  const Icon = meta.icon
+
+  if (late) {
+    return (
+      <span
+        className={['inline-flex items-center gap-0.5', meta.className, className].filter(Boolean).join(' ')}
+        data-testid={`assessment-status-icon-${state}-late`}
+      >
+        <Icon className={ICON_CLASS} aria-hidden="true" data-testid={`assessment-status-icon-${state}`} />
+        <Clock className={LATE_CLOCK_CLASS} aria-hidden="true" data-testid="assessment-status-icon-late-clock" />
+      </span>
+    )
+  }
+
+  return (
+    <Icon
+      className={[ICON_CLASS, meta.className, className].filter(Boolean).join(' ')}
+      aria-hidden="true"
+      data-testid={`assessment-status-icon-${state}`}
+    />
+  )
+}

--- a/tests/components/AssessmentStatusIcon.test.tsx
+++ b/tests/components/AssessmentStatusIcon.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { AssessmentStatusIcon } from '@/components/AssessmentStatusIcon'
+
+describe('AssessmentStatusIcon', () => {
+  it('renders submitted as the shared green circle status', () => {
+    render(<AssessmentStatusIcon state="submitted" />)
+
+    const icon = screen.getByTestId('assessment-status-icon-submitted')
+    expect(icon).toHaveClass('text-success')
+    expect(icon.querySelector('circle')).not.toBeNull()
+  })
+
+  it('renders returned as the primary return icon', () => {
+    render(<AssessmentStatusIcon state="returned" />)
+
+    expect(screen.getByTestId('assessment-status-icon-returned')).toHaveClass('text-primary')
+  })
+
+  it('adds a late clock without changing the base status', () => {
+    render(<AssessmentStatusIcon state="submitted" late />)
+
+    expect(screen.getByTestId('assessment-status-icon-submitted-late')).toHaveClass('text-success')
+    expect(screen.getByTestId('assessment-status-icon-submitted')).toBeInTheDocument()
+    expect(screen.getByTestId('assessment-status-icon-late-clock')).toBeInTheDocument()
+  })
+})

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -624,6 +624,84 @@ describe('TeacherTestsTab', () => {
     })
   })
 
+  it('keeps grading rows visible while a background poll refreshes', async () => {
+    let intervalCallback: (() => void) | null = null
+    let resolvePoll:
+      | ((value: { ok: boolean; json: () => Promise<any> }) => void)
+      | null = null
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => true)
+    vi.spyOn(window, 'setInterval').mockImplementation(((callback: TimerHandler) => {
+      intervalCallback = callback as () => void
+      return 1
+    }) as typeof window.setInterval)
+
+    const pollResultsPromise = new Promise<{ ok: boolean; json: () => Promise<any> }>((resolve) => {
+      resolvePoll = resolve
+    })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+      .mockImplementationOnce(() => pollResultsPromise as unknown as Promise<Response>)
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByText('3/5')).toBeInTheDocument()
+    expect(screen.getByTestId('assessment-status-icon-submitted')).toHaveClass('text-success')
+
+    await act(async () => {
+      intervalCallback?.()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByText('3/5')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Refreshing grading rows...')
+
+    await act(async () => {
+      resolvePoll?.(
+        makeResultsResponse({
+          students: [
+            {
+              student_id: 'student-1',
+              name: 'Alice Zephyr',
+              first_name: 'Alice',
+              last_name: 'Zephyr',
+              email: 'alice@example.com',
+              status: 'submitted',
+              submitted_at: null,
+              last_activity_at: '2026-04-17T18:20:00.000Z',
+              points_earned: 4,
+              points_possible: 5,
+              percent: 80,
+              graded_open_responses: 1,
+              ungraded_open_responses: 0,
+              focus_summary: null,
+            },
+          ],
+        })
+      )
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('4/5')).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
   it('does not start polling when the server reports the test is closed', async () => {
     let visibilityState: DocumentVisibilityState = 'visible'
     let hasFocus = true


### PR DESCRIPTION
## Summary
- Keep existing test grading rows mounted during background polling and show a small refresh indicator instead of a full table-loading swap.
- Add a shared `AssessmentStatusIcon` component and use it for both assignments and test grading status cells.
- Align submitted test rows with the assignments tab submitted treatment: green circle.

## Root Cause
The grading poll reused the same full-load path as the initial grading fetch, so every periodic refresh put the table back into the blocking loading state and visually cleared the workspace.

## Validation
- `pnpm test -- tests/components/AssessmentStatusIcon.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm lint` (existing unrelated warning remains in `src/components/TestDocumentsEditor.tsx`)
- `bash scripts/verify-env.sh` (`207` test files, `1799` tests)
- `git diff --check`
- `pika-ui-verify` classroom screenshots passed for teacher desktop, teacher mobile, and student mobile. Focused grading-page capture was not available because the current dev database has no classrooms/tests; I did not reset or seed the shared DB.