### PR TITLE
Expand test coverage for classroom and repo-review flows

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9322,3 +9322,49 @@
 - `pnpm lint` (existing warning remains in `src/components/TestDocumentsEditor.tsx`)
 - `bash scripts/verify-env.sh`
 - `pika-ui-verify` classroom screenshot capture passed for teacher desktop, teacher mobile, and student mobile; focused grading-page capture was not available because the current dev database has no classrooms/tests.
+## 2026-04-22 (codex)
+- Expanded test hardening for low-coverage utility areas:
+  - Added `tests/unit/classroom-ux-metrics.test.ts` for tab-switch metric tracking behavior and edge cases.
+  - Added `tests/unit/server-classroom-order.test.ts` for Supabase query fallback/position logic.
+  - Added `tests/unit/repo-review-validation.test.ts` for schema defaults and validation failures.
+- Verified new tests pass with targeted Vitest run.
+
+## 2026-04-22 (codex follow-up review)
+- Reviewed and tightened the new coverage tests from the previous PR:
+  - Added stronger query-chain assertions in `server-classroom-order` tests (teacher filter, archived filter, ordering calls, and limit usage).
+  - Added `afterEach(vi.restoreAllMocks)` in classroom UX metrics tests to avoid mock leakage.
+  - Expanded repo-review validation coverage for defaulted `commit_emails` and invalid email rejection.
+- Re-ran the targeted test suite and confirmed all tests pass.
+
+## 2026-04-24 (codex)
+- Moved cloud-applied coverage test changes out of the hub checkout and into `codex/classroom-coverage-local`.
+- Created the worktree from `origin/main`, linked the shared `.env.local`, and installed dependencies.
+- Verified the worktree with `bash scripts/verify-env.sh` (210 test files / 1814 tests passed).
+
+## 2026-04-25 (codex)
+- Reviewed the codebase for additional test coverage opportunities in `codex/classroom-coverage-local`.
+- Ran `bash scripts/verify-env.sh` and `pnpm test:coverage`; both completed with the full Vitest suite passing.
+- Current measured coverage is 74.28% statements, 60.95% branches, and 86.25% functions across `src/lib`, `src/ui`, and `src/app/api/**/route.ts`.
+- Highest-value uncovered areas identified: repo-review assignment routes/helpers, teacher assignment reorder, attendance CSV/export success paths, roster GET/PATCH/error paths, class-day server helpers, and assignment-doc submit authenticity/history paths.
+
+## 2026-04-25 (codex follow-up)
+- Added targeted tests for the coverage opportunities identified earlier:
+  - Repo-review artifact run route and assignment repo target helpers.
+  - Assignment reorder route validation, ownership, mismatch, success, and failure paths.
+  - Attendance/export success paths with sorted students and CSV assertions.
+  - Roster GET/PATCH success and validation paths.
+  - Server class-day generation/upsert helpers.
+  - Assignment doc submit success, history, authenticity, and non-fatal side-effect failures.
+- Verification:
+  - Targeted test run: 9 test files / 41 tests passed.
+  - `bash scripts/verify-env.sh`: 214 test files / 1844 tests passed.
+  - `pnpm test:coverage`: 77.02% statements, 63.72% branches, 89.6% functions.
+  - `pnpm lint`: passed with the existing `src/components/TestDocumentsEditor.tsx` hook dependency warning.
+
+## 2026-04-26 (codex)
+- Re-reviewed the added coverage tests before commit.
+- Tightened Supabase mock reset setup in the new/expanded test files to prevent stale mock implementations from leaking into future tests.
+- Re-ran `pnpm test:coverage`, `pnpm lint`, and `git diff --check`:
+  - Coverage: 214 test files / 1844 tests passed.
+  - Lint: passed with the existing `src/components/TestDocumentsEditor.tsx` hook dependency warning.
+  - Diff check: clean.

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -14,11 +14,17 @@ vi.mock('@/lib/server/classrooms', () => ({
     classroom: { id: 'class-1', archived_at: null },
   })),
 }))
+vi.mock('@/lib/authenticity', () => ({
+  analyzeAuthenticity: vi.fn(() => ({ score: 0.82, flags: ['steady_revision'] })),
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
 
 describe('POST /api/assignment-docs/[id]/submit', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+  })
 
   it('should return 400 when doc does not exist', async () => {
     const mockFrom = vi.fn((table: string) => {
@@ -109,5 +115,188 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
 
     const response = await POST(request, { params: { id: 'assign-1' } })
     expect(response.status).toBe(400)
+  })
+
+  it('submits work, records history, and attaches authenticity results', async () => {
+    const historyInsert = vi.fn(async () => ({ error: null }))
+    const authenticityUpdate = vi.fn(async () => ({ error: null }))
+    const submittedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Finished work' }] }],
+    }
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1', is_draft: false, released_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'doc-1', student_id: 'student-1', content: submittedContent },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            if ('is_submitted' in payload) {
+              return {
+                eq: vi.fn(() => ({
+                  select: vi.fn(() => ({
+                    single: vi.fn().mockResolvedValue({
+                      data: {
+                        id: 'doc-1',
+                        student_id: 'student-1',
+                        content: submittedContent,
+                        is_submitted: true,
+                        submitted_at: payload.submitted_at,
+                      },
+                      error: null,
+                    }),
+                  })),
+                })),
+              }
+            }
+            return { eq: authenticityUpdate }
+          }),
+        }
+      }
+
+      if (table === 'assignment_doc_history') {
+        return {
+          insert: historyInsert,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'h-1', assignment_doc_id: 'doc-1', word_count: 1, char_count: 4, trigger: 'autosave' },
+                  { id: 'h-2', assignment_doc_id: 'doc-1', word_count: 2, char_count: 13, trigger: 'submit' },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.doc).toEqual(expect.objectContaining({
+      id: 'doc-1',
+      is_submitted: true,
+      authenticity_score: 0.82,
+      authenticity_flags: ['steady_revision'],
+    }))
+    expect(historyInsert).toHaveBeenCalledWith(expect.objectContaining({
+      assignment_doc_id: 'doc-1',
+      snapshot: submittedContent,
+      word_count: 2,
+      char_count: 13,
+      trigger: 'submit',
+    }))
+    expect(authenticityUpdate).toHaveBeenCalledWith('id', 'doc-1')
+  })
+
+  it('still returns the submitted doc when history or authenticity side effects fail', async () => {
+    const submittedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Finished work' }] }],
+    }
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1', is_draft: false, released_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'doc-1', student_id: 'student-1', content: submittedContent },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: submittedContent,
+                    is_submitted: true,
+                    submitted_at: '2026-04-25T12:00:00.000Z',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_doc_history') {
+        return {
+          insert: vi.fn(async () => {
+            throw new Error('history failed')
+          }),
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(async () => {
+                throw new Error('auth history failed')
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+    }), { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.doc).toEqual(expect.objectContaining({
+      id: 'doc-1',
+      is_submitted: true,
+    }))
   })
 })

--- a/tests/api/teacher/assignments-artifact-repo-run.test.ts
+++ b/tests/api/teacher/assignments-artifact-repo-run.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const {
+  mockSupabaseClient,
+  mockAnalyzeRepoReviewAssignment,
+  mockGradeRepoReviewFeedback,
+  mockResolveAssignmentRepoTarget,
+  mockSaveAssignmentRepoTarget,
+  mockValidatePublicGitHubRepo,
+  mockAssertTeacherOwnsAssignment,
+} = vi.hoisted(() => ({
+  mockSupabaseClient: { from: vi.fn() },
+  mockAnalyzeRepoReviewAssignment: vi.fn(),
+  mockGradeRepoReviewFeedback: vi.fn(),
+  mockResolveAssignmentRepoTarget: vi.fn(),
+  mockSaveAssignmentRepoTarget: vi.fn(),
+  mockValidatePublicGitHubRepo: vi.fn(),
+  mockAssertTeacherOwnsAssignment: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({ id: 'teacher-1', role: 'teacher' })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/repo-review', () => ({
+  REPO_REVIEW_METRICS_VERSION: 'metrics-v1',
+  REPO_REVIEW_PROMPT_VERSION: 'prompt-v1',
+  buildRepoReviewWindow: vi.fn(() => ({ start: null, end: null })),
+  formatRepoReviewRepoName: vi.fn(() => 'codepetca/pika'),
+  analyzeRepoReviewAssignment: mockAnalyzeRepoReviewAssignment,
+}))
+
+vi.mock('@/lib/repo-review-ai', () => ({
+  gradeRepoReviewFeedback: mockGradeRepoReviewFeedback,
+}))
+
+vi.mock('@/lib/server/assignment-repo-targets', () => ({
+  resolveAssignmentRepoTarget: mockResolveAssignmentRepoTarget,
+  saveAssignmentRepoTarget: mockSaveAssignmentRepoTarget,
+  validatePublicGitHubRepo: mockValidatePublicGitHubRepo,
+}))
+
+vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherOwnsAssignment: mockAssertTeacherOwnsAssignment,
+}))
+
+import { POST } from '@/app/api/teacher/assignments/[id]/artifact-repo/run/route'
+
+function installRepoRunTables(opts: {
+  enrollments: Array<{ student_id: string; users: { email: string } }>
+  profiles?: Array<{ user_id: string; first_name: string | null; last_name: string | null }>
+  docs?: Array<Record<string, unknown>>
+  targets?: Array<Record<string, unknown>>
+}) {
+  const insertedRuns: unknown[] = []
+  const insertedResults: unknown[] = []
+  const upsertedDocs: unknown[] = []
+  const runUpdates: unknown[] = []
+
+  mockSupabaseClient.from.mockImplementation((table: string) => {
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: opts.enrollments, error: null })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'student_profiles') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(async () => ({ data: opts.profiles ?? [], error: null })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_docs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: opts.docs ?? [], error: null })),
+          })),
+        })),
+        upsert: vi.fn(async (rows: unknown[]) => {
+          upsertedDocs.push(...rows)
+          return { error: null }
+        }),
+      }
+    }
+
+    if (table === 'assignment_repo_targets') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: opts.targets ?? [], error: null })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_repo_review_runs') {
+      return {
+        insert: vi.fn((row: unknown) => {
+          insertedRuns.push(row)
+          return {
+            select: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: { id: 'run-1', ...(row as object) }, error: null })),
+            })),
+          }
+        }),
+        update: vi.fn((payload: unknown) => {
+          runUpdates.push(payload)
+          return { eq: vi.fn(async () => ({ error: null })) }
+        }),
+      }
+    }
+
+    if (table === 'assignment_repo_review_results') {
+      return {
+        insert: vi.fn(async (rows: unknown[]) => {
+          insertedResults.push(...rows)
+          return { error: null }
+        }),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return { insertedRuns, insertedResults, upsertedDocs, runUpdates }
+}
+
+describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset()
+    mockAssertTeacherOwnsAssignment.mockResolvedValue({
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+      title: 'Repo review',
+      due_at: '2026-04-20T03:59:00.000Z',
+      released_at: '2026-04-01T12:00:00.000Z',
+    })
+  })
+
+  it('rejects missing and oversized student id batches before touching Supabase', async () => {
+    const emptyResponse = await POST(
+      new NextRequest('http://localhost/api/teacher/assignments/assignment-1/artifact-repo/run', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: [] }),
+      }),
+      { params: { id: 'assignment-1' } },
+    )
+    expect(emptyResponse.status).toBe(400)
+
+    const largeResponse = await POST(
+      new NextRequest('http://localhost/api/teacher/assignments/assignment-1/artifact-repo/run', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: Array.from({ length: 101 }, (_, index) => `student-${index}`) }),
+      }),
+      { params: { id: 'assignment-1' } },
+    )
+    expect(largeResponse.status).toBe(400)
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped reasons when enrolled students have no usable repo target', async () => {
+    mockResolveAssignmentRepoTarget.mockReturnValue({
+      effectiveRepoUrl: null,
+      effectiveGitHubUsername: null,
+      validationMessage: 'No repo link has been submitted yet.',
+    })
+    installRepoRunTables({
+      enrollments: [{ student_id: 'student-1', users: { email: 's1@example.com' } }],
+      docs: [{ student_id: 'student-1', repo_url: null, github_username: null }],
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/teacher/assignments/assignment-1/artifact-repo/run', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: ['student-1'] }),
+      }),
+      { params: { id: 'assignment-1' } },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      analyzed_students: 0,
+      repo_groups: 0,
+      skipped_reasons: { 'No repo link has been submitted yet.': 1 },
+    })
+    expect(mockValidatePublicGitHubRepo).not.toHaveBeenCalled()
+  })
+
+  it('groups valid repos, saves run results, and upserts draft grades', async () => {
+    mockResolveAssignmentRepoTarget.mockReturnValue({
+      effectiveRepoUrl: 'https://github.com/codepetca/pika',
+      effectiveGitHubUsername: 'student-login',
+      selectionMode: 'auto',
+      validationMessage: null,
+    })
+    mockValidatePublicGitHubRepo.mockResolvedValue({
+      repoUrl: 'https://github.com/codepetca/pika',
+      repoOwner: 'codepetca',
+      repoName: 'pika',
+      defaultBranch: 'main',
+      validationStatus: 'valid',
+      validationMessage: null,
+    })
+    mockAnalyzeRepoReviewAssignment.mockResolvedValue({
+      sourceRef: 'main',
+      warnings: [{ code: 'note', message: 'Low commit count', student_id: 'student-1' }],
+      confidence: 0.9,
+      students: [{
+        studentId: 'student-1',
+        githubLogin: 'student-login',
+        commitCount: 4,
+        activeDays: 2,
+        sessionCount: 1,
+        burstRatio: 0.25,
+        weightedContribution: 0.7,
+        relativeContributionShare: 1,
+        spreadScore: 0.8,
+        iterationScore: 0.6,
+        reviewActivityCount: 1,
+        areas: ['src'],
+        semanticBreakdown: { feature: 3 },
+        timeline: [{ date: '2026-04-01', count: 2 }],
+        evidence: [{ type: 'commit', message: 'Initial work' }],
+      }],
+    })
+    mockGradeRepoReviewFeedback.mockResolvedValue({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      feedback: 'Solid repo activity.',
+      confidence: 0.8,
+    })
+    const harness = installRepoRunTables({
+      enrollments: [{ student_id: 'student-1', users: { email: 's1@example.com' } }],
+      profiles: [{ user_id: 'student-1', first_name: 'Sam', last_name: 'Lee' }],
+      docs: [{
+        id: 'doc-1',
+        student_id: 'student-1',
+        content: { type: 'doc', content: [] },
+        repo_url: 'https://github.com/codepetca/pika',
+        github_username: 'student-login',
+        is_submitted: true,
+        submitted_at: '2026-04-02T12:00:00.000Z',
+      }],
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/teacher/assignments/assignment-1/artifact-repo/run', {
+        method: 'POST',
+        body: JSON.stringify({ student_ids: ['student-1'] }),
+      }),
+      { params: { id: 'assignment-1' } },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ analyzed_students: 1, repo_groups: 1, skipped_reasons: {} })
+    expect(mockSaveAssignmentRepoTarget).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      selectionMode: 'auto',
+      validationStatus: 'valid',
+      repoOwner: 'codepetca',
+      repoName: 'pika',
+    }))
+    expect(harness.insertedRuns).toHaveLength(1)
+    expect(harness.insertedResults).toEqual([
+      expect.objectContaining({
+        run_id: 'run-1',
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
+        github_login: 'student-login',
+        draft_score_completion: 8,
+        draft_score_thinking: 7,
+        draft_score_workflow: 9,
+        draft_feedback: 'Solid repo activity.',
+      }),
+    ])
+    expect(harness.upsertedDocs).toEqual([
+      expect.objectContaining({
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
+        score_completion: 8,
+        score_thinking: 7,
+        score_workflow: 9,
+        ai_feedback_suggestion: 'Solid repo activity.',
+        ai_feedback_model: 'repo-review-v2',
+      }),
+    ])
+    expect(harness.runUpdates).toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        source_ref: 'main',
+        model: 'repo-review-v2',
+      }),
+    ])
+  })
+})

--- a/tests/api/teacher/assignments-reorder.test.ts
+++ b/tests/api/teacher/assignments-reorder.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({ id: 'teacher-1', role: 'teacher' })),
+}))
+
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+import { POST } from '@/app/api/teacher/assignments/reorder/route'
+import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+describe('POST /api/teacher/assignments/reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset()
+  })
+
+  it('rejects missing params and duplicate assignment ids', async () => {
+    const missing = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1' }),
+    }))
+    expect(missing.status).toBe(400)
+
+    const duplicate = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1', 'a-1'] }),
+    }))
+    expect(duplicate.status).toBe(400)
+  })
+
+  it('returns the classroom ownership failure', async () => {
+    ;(assertTeacherCanMutateClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1'] }),
+    }))
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects ids that do not all belong to the classroom', async () => {
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          in: vi.fn(async () => ({ data: [{ id: 'a-1' }], error: null })),
+        })),
+      })),
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1', 'a-2'] }),
+    }))
+
+    expect(response.status).toBe(400)
+  })
+
+  it('persists each assignment position in submitted order', async () => {
+    const updates: unknown[] = []
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table !== 'assignments') throw new Error(`Unexpected table: ${table}`)
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [{ id: 'a-2' }, { id: 'a-1' }],
+              error: null,
+            })),
+          })),
+        })),
+        update: vi.fn((payload: unknown) => {
+          updates.push(payload)
+          return {
+            eq: vi.fn(async () => ({ error: null })),
+          }
+        }),
+      }
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-2', 'a-1'] }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(updates).toEqual([{ position: 0 }, { position: 1 }])
+  })
+
+  it('returns 500 when verifying or updating assignments fails', async () => {
+    mockSupabaseClient.from.mockReturnValueOnce({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          in: vi.fn(async () => ({ data: null, error: { message: 'verify failed' } })),
+        })),
+      })),
+    })
+
+    const verifyFailure = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1'] }),
+    }))
+    expect(verifyFailure.status).toBe(500)
+
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          in: vi.fn(async () => ({ data: [{ id: 'a-1' }], error: null })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(async () => ({ error: { message: 'update failed' } })),
+      })),
+    })
+
+    const updateFailure = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1'] }),
+    }))
+    expect(updateFailure.status).toBe(500)
+  })
+})

--- a/tests/api/teacher/attendance.test.ts
+++ b/tests/api/teacher/attendance.test.ts
@@ -35,6 +35,7 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('GET /api/teacher/attendance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
   })
 
   it('should return 401 when not authenticated', async () => {
@@ -92,5 +93,112 @@ describe('GET /api/teacher/attendance', () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/attendance?classroom_id=classroom-999')
     const response = await GET(request)
     expect(response.status).toBe(404)
+  })
+
+  it('returns attendance records and sorted class-day dates for an owned classroom', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([
+      {
+        student_id: 'student-1',
+        student_email: 'a@example.com',
+        summary: { present: 1, absent: 0 },
+        dates: { '2026-04-20': 'present' },
+      },
+    ])
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { teacher_id: 'teacher-1' }, error: null }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  { date: '2026-04-20', is_class_day: true },
+                  { date: '2026-04-21', is_class_day: false },
+                  { date: '2026-04-22', is_class_day: true },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
+                { student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ id: 'entry-1' }], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/attendance?classroom_id=classroom-1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      attendance: [
+        {
+          student_id: 'student-1',
+          student_email: 'a@example.com',
+          summary: { present: 1, absent: 0 },
+          dates: { '2026-04-20': 'present' },
+        },
+      ],
+      dates: ['2026-04-20', '2026-04-22'],
+      classroom_id: 'classroom-1',
+    })
+    expect(computeAttendanceRecords).toHaveBeenCalledWith(
+      [
+        { id: 'student-1', email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+        { id: 'student-2', email: 'b@example.com', first_name: '', last_name: '' },
+      ],
+      [
+        { date: '2026-04-20', is_class_day: true },
+        { date: '2026-04-21', is_class_day: false },
+        { date: '2026-04-22', is_class_day: true },
+      ],
+      [{ id: 'entry-1' }],
+      expect.any(String),
+    )
   })
 })

--- a/tests/api/teacher/export-csv.test.ts
+++ b/tests/api/teacher/export-csv.test.ts
@@ -8,11 +8,16 @@ import { NextRequest } from 'next/server'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+vi.mock('@/lib/attendance', () => ({ computeAttendanceRecords: vi.fn(() => []) }))
+vi.mock('@/lib/timezone', () => ({ getTodayInToronto: vi.fn(() => '2026-04-25') }))
 
 const mockSupabaseClient = { from: vi.fn() }
 
 describe('GET /api/teacher/export-csv', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+  })
 
   it('should return 400 when classroom_id is missing', async () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/export-csv')
@@ -33,5 +38,126 @@ describe('GET /api/teacher/export-csv', () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/export-csv?classroom_id=c1')
     const response = await GET(request)
     expect(response.status).toBe(403)
+  })
+
+  it('returns a CSV export with class-day columns and attendance symbols', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([
+      {
+        student_id: 'student-2',
+        student_email: 'b@example.com',
+        summary: { present: 1, absent: 1 },
+        dates: {
+          '2026-04-20': 'present',
+          '2026-04-21': 'absent',
+        },
+      },
+      {
+        student_id: 'student-1',
+        student_email: 'a@example.com',
+        summary: { present: 2, absent: 0 },
+        dates: {
+          '2026-04-20': 'present',
+          '2026-04-21': 'present',
+        },
+      },
+    ])
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1', title: 'Period 1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  { date: '2026-04-20', is_class_day: true },
+                  { date: '2026-04-21', is_class_day: true },
+                  { date: '2026-04-22', is_class_day: false },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
+                { student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [
+                { user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' },
+                { user_id: 'student-2', first_name: 'Grace', last_name: 'Hopper' },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ id: 'entry-1' }], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/export-csv?classroom_id=c1')
+    const response = await GET(request)
+    const csv = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/csv')
+    expect(response.headers.get('Content-Disposition')).toMatch(/^attachment; filename="attendance-Period-1-/)
+    expect(csv).toBe([
+      'Student Email,Present,Absent,2026-04-20,2026-04-21',
+      'b@example.com,1,1,P,A',
+      'a@example.com,2,0,P,P',
+      '',
+    ].join('\n'))
+    expect(computeAttendanceRecords).toHaveBeenCalledWith(
+      [
+        { id: 'student-1', email: 'a@example.com', first_name: 'Ada', last_name: 'Lovelace' },
+        { id: 'student-2', email: 'b@example.com', first_name: 'Grace', last_name: 'Hopper' },
+      ],
+      [
+        { date: '2026-04-20', is_class_day: true },
+        { date: '2026-04-21', is_class_day: true },
+        { date: '2026-04-22', is_class_day: false },
+      ],
+      [{ id: 'entry-1' }],
+      '2026-04-25',
+    )
   })
 })

--- a/tests/api/teacher/roster-rosterId.test.ts
+++ b/tests/api/teacher/roster-rosterId.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { DELETE } from '@/app/api/teacher/classrooms/[id]/roster/[rosterId]/route'
+import { DELETE, PATCH } from '@/app/api/teacher/classrooms/[id]/roster/[rosterId]/route'
 import { NextRequest } from 'next/server'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
@@ -17,8 +17,82 @@ vi.mock('@/lib/server/classrooms', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+describe('PATCH /api/teacher/classrooms/[id]/roster/[rosterId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+  })
+
+  it('validates counselor_email input and requires a valid update field', async () => {
+    const invalidType = await PATCH(new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/r-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ counselor_email: 123 }),
+    }), { params: { id: 'c-1', rosterId: 'r-1' } })
+    expect(invalidType.status).toBe(400)
+
+    const noFields = await PATCH(new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/r-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ first_name: 'Ignored' }),
+    }), { params: { id: 'c-1', rosterId: 'r-1' } })
+    expect(noFields.status).toBe(400)
+  })
+
+  it('trims counselor_email, persists null for blanks, and returns the updated row', async () => {
+    const update = vi.fn((payload: unknown) => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'r-1', counselor_email: null },
+              error: null,
+            }),
+          })),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table !== 'classroom_roster') throw new Error(`Unexpected table: ${table}`)
+      return { update }
+    })
+
+    const response = await PATCH(new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/r-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ counselor_email: '   ' }),
+    }), { params: { id: 'c-1', rosterId: 'r-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(update).toHaveBeenCalledWith({ counselor_email: null })
+    expect(data).toEqual({ success: true, roster: { id: 'r-1', counselor_email: null } })
+  })
+
+  it('returns 404 when the update completes without a row', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            })),
+          })),
+        })),
+      })),
+    }))
+
+    const response = await PATCH(new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/r-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ counselor_email: 'counselor@example.com' }),
+    }), { params: { id: 'c-1', rosterId: 'r-1' } })
+
+    expect(response.status).toBe(404)
+  })
+})
+
 describe('DELETE /api/teacher/classrooms/[id]/roster/[rosterId]', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+  })
 
   it('should return 403 when not classroom owner', async () => {
     const { assertTeacherCanMutateClassroom } = await import('@/lib/server/classrooms')

--- a/tests/api/teacher/roster.test.ts
+++ b/tests/api/teacher/roster.test.ts
@@ -18,7 +18,10 @@ vi.mock('@/lib/server/classrooms', () => ({
 const mockSupabaseClient = { from: vi.fn() }
 
 describe('GET /api/teacher/classrooms/[id]/roster', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+  })
 
   it('should return 403 when not classroom owner', async () => {
     const { assertTeacherOwnsClassroom } = await import('@/lib/server/classrooms')
@@ -31,5 +34,82 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster')
     const response = await GET(request, { params: { id: 'c-1' } })
     expect(response.status).toBe(403)
+  })
+
+  it('returns roster rows annotated with joined enrollment metadata', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classroom_roster') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'r-1',
+                  email: 'Joined@Example.com',
+                  student_number: '1001',
+                  first_name: 'Ada',
+                  last_name: 'Lovelace',
+                  counselor_email: 'c@example.com',
+                  created_at: '2026-04-01T12:00:00.000Z',
+                  updated_at: '2026-04-02T12:00:00.000Z',
+                },
+                {
+                  id: 'r-2',
+                  email: 'waiting@example.com',
+                  student_number: null,
+                  first_name: null,
+                  last_name: null,
+                  counselor_email: null,
+                  created_at: '2026-04-03T12:00:00.000Z',
+                  updated_at: '2026-04-04T12:00:00.000Z',
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  student_id: 'student-1',
+                  created_at: '2026-04-05T12:00:00.000Z',
+                  users: { email: 'joined@example.com' },
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster')
+    const response = await GET(request, { params: { id: 'c-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.roster).toEqual([
+      expect.objectContaining({
+        id: 'r-1',
+        email: 'Joined@Example.com',
+        joined: true,
+        student_id: 'student-1',
+        joined_at: '2026-04-05T12:00:00.000Z',
+      }),
+      expect.objectContaining({
+        id: 'r-2',
+        email: 'waiting@example.com',
+        joined: false,
+        student_id: null,
+        joined_at: null,
+      }),
+    ])
   })
 })

--- a/tests/unit/assignment-repo-targets.test.ts
+++ b/tests/unit/assignment-repo-targets.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSupabaseClient } = vi.hoisted(() => ({
+  mockSupabaseClient: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+import {
+  extractRepoArtifactsFromContent,
+  loadAssignmentRepoTarget,
+  resolveAssignmentRepoTarget,
+  saveAssignmentRepoTarget,
+  validatePublicGitHubRepo,
+} from '@/lib/server/assignment-repo-targets'
+import type { AssignmentRepoTarget } from '@/types'
+
+function buildRepoTarget(overrides: Partial<AssignmentRepoTarget> = {}): AssignmentRepoTarget {
+  return {
+    id: 'target-1',
+    assignment_id: 'assignment-1',
+    student_id: 'student-1',
+    selected_repo_url: null,
+    override_github_username: null,
+    repo_owner: null,
+    repo_name: null,
+    selection_mode: 'auto',
+    validation_status: 'valid',
+    validation_message: null,
+    validated_at: null,
+    created_at: '2026-04-25T12:00:00.000Z',
+    updated_at: '2026-04-25T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('assignment repo target helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset()
+    vi.unstubAllGlobals()
+    delete process.env.GITHUB_PAT
+    delete process.env.GITHUB_FEEDBACK_TOKEN
+  })
+
+  it('extracts only GitHub repo artifacts from assignment content', () => {
+    const artifacts = extractRepoArtifactsFromContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Repo https://github.com/codepetca/pika and site https://example.com' },
+          ],
+        },
+        {
+          type: 'image',
+          attrs: { src: 'https://cdn.example.com/submission-images/shot.png' },
+        },
+      ],
+    })
+
+    expect(artifacts).toEqual([
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
+      },
+    ])
+  })
+
+  it('uses a teacher override repo and username ahead of submitted values', () => {
+    const resolved = resolveAssignmentRepoTarget({
+      submittedRepoUrl: 'https://github.com/student/submitted',
+      submittedGitHubUsername: 'student-login',
+      target: buildRepoTarget({
+        selected_repo_url: 'https://github.com/teacher/override',
+        override_github_username: 'override-login',
+        repo_owner: 'teacher',
+        repo_name: 'override',
+        selection_mode: 'teacher_override',
+        validation_status: 'valid',
+      }),
+    })
+
+    expect(resolved).toEqual(expect.objectContaining({
+      effectiveRepoUrl: 'https://github.com/teacher/override',
+      effectiveGitHubUsername: 'override-login',
+      repoOwner: 'teacher',
+      repoName: 'override',
+      selectionMode: 'teacher_override',
+      validationStatus: 'valid',
+    }))
+  })
+
+  it('reports actionable missing and invalid states before repo analysis can run', () => {
+    expect(resolveAssignmentRepoTarget({
+      submittedRepoUrl: null,
+      submittedGitHubUsername: 'student-login',
+      target: null,
+    })).toEqual(expect.objectContaining({
+      effectiveRepoUrl: null,
+      effectiveGitHubUsername: 'student-login',
+      selectionMode: 'auto',
+      validationStatus: 'missing',
+      validationMessage: 'No repo link has been submitted yet.',
+    }))
+
+    expect(resolveAssignmentRepoTarget({
+      submittedRepoUrl: 'github.com/codepetca/pika',
+      submittedGitHubUsername: null,
+      target: null,
+    })).toEqual(expect.objectContaining({
+      effectiveRepoUrl: 'github.com/codepetca/pika',
+      effectiveGitHubUsername: null,
+      validationStatus: 'invalid',
+      validationMessage: 'GitHub username is required before repo analysis can run.',
+    }))
+  })
+
+  it('validates public GitHub repositories and maps inaccessible/private repos to statuses', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ status: 403, ok: false })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: vi.fn(async () => ({ private: true, default_branch: 'trunk' })),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: vi.fn(async () => ({ private: false, default_branch: 'main' })),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(validatePublicGitHubRepo('not a repo')).resolves.toEqual({
+      repoUrl: 'not a repo',
+      repoOwner: '',
+      repoName: '',
+      defaultBranch: 'main',
+      validationStatus: 'invalid',
+      validationMessage: 'Repo URL must point to a GitHub repository.',
+    })
+
+    await expect(validatePublicGitHubRepo('codepetca/private')).resolves.toEqual(expect.objectContaining({
+      repoUrl: 'https://github.com/codepetca/private',
+      repoOwner: 'codepetca',
+      repoName: 'private',
+      validationStatus: 'inaccessible',
+    }))
+
+    await expect(validatePublicGitHubRepo('https://github.com/codepetca/secret')).resolves.toEqual(expect.objectContaining({
+      repoUrl: 'https://github.com/codepetca/secret',
+      defaultBranch: 'trunk',
+      validationStatus: 'private',
+    }))
+
+    await expect(validatePublicGitHubRepo('https://github.com/codepetca/pika')).resolves.toEqual({
+      repoUrl: 'https://github.com/codepetca/pika',
+      repoOwner: 'codepetca',
+      repoName: 'pika',
+      defaultBranch: 'main',
+      validationStatus: 'valid',
+      validationMessage: null,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('uses a configured GitHub token when validating repos', async () => {
+    process.env.GITHUB_PAT = '  token-1  '
+    const fetchMock = vi.fn(async () => ({
+      status: 200,
+      ok: true,
+      json: vi.fn(async () => ({ private: false, default_branch: 'main' })),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await validatePublicGitHubRepo('codepetca/pika')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/codepetca/pika',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-1',
+        }),
+        cache: 'no-store',
+      }),
+    )
+  })
+
+  it('loads and saves repo targets through the assignment/student key', async () => {
+    const saved = buildRepoTarget({
+      selected_repo_url: 'https://github.com/codepetca/pika',
+      override_github_username: 'student-login',
+      repo_owner: 'codepetca',
+      repo_name: 'pika',
+      selection_mode: 'teacher_override',
+    })
+
+    const maybeSingle = vi.fn(async () => ({ data: saved, error: null }))
+    const single = vi.fn(async () => ({ data: saved, error: null }))
+    const upsert = vi.fn(() => ({ select: vi.fn(() => ({ single })) }))
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle })),
+        })),
+      })),
+      upsert,
+    })
+
+    await expect(loadAssignmentRepoTarget('assignment-1', 'student-1')).resolves.toEqual(saved)
+    await expect(saveAssignmentRepoTarget({
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      repoUrl: 'https://github.com/codepetca/pika',
+      overrideGitHubUsername: 'student-login',
+      selectionMode: 'teacher_override',
+      validationStatus: 'valid',
+      validationMessage: null,
+      repoOwner: 'codepetca',
+      repoName: 'pika',
+    })).resolves.toEqual(saved)
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
+        selected_repo_url: 'https://github.com/codepetca/pika',
+        override_github_username: 'student-login',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        selection_mode: 'teacher_override',
+        validation_status: 'valid',
+      }),
+      { onConflict: 'assignment_id,student_id' },
+    )
+  })
+
+  it('throws API errors when target load or save fails', async () => {
+    mockSupabaseClient.from
+      .mockReturnValueOnce({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: null, error: { message: 'boom' } })),
+            })),
+          })),
+        })),
+      })
+      .mockReturnValueOnce({
+        upsert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: null, error: { message: 'boom' } })),
+          })),
+        })),
+      })
+
+    await expect(loadAssignmentRepoTarget('assignment-1', 'student-1')).rejects.toThrow('Failed to load repo target')
+    await expect(saveAssignmentRepoTarget({
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      repoUrl: null,
+      overrideGitHubUsername: null,
+      selectionMode: 'auto',
+      validationStatus: 'missing',
+      validationMessage: 'No repo',
+      repoOwner: null,
+      repoName: null,
+    })).rejects.toThrow('Failed to save repo target')
+  })
+})

--- a/tests/unit/classroom-ux-metrics.test.ts
+++ b/tests/unit/classroom-ux-metrics.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getRecentClassroomTabMetrics,
+  markClassroomTabSwitchReady,
+  markClassroomTabSwitchStart,
+} from '@/lib/classroom-ux-metrics'
+
+describe('classroom ux tab switch metrics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    window.__classroomPendingTabMark = null
+    window.__classroomTabMetrics = []
+  })
+
+  it('records duration when a matching tab is marked ready', () => {
+    const perfSpy = vi.spyOn(performance, 'now')
+    perfSpy.mockReturnValueOnce(10).mockReturnValueOnce(26)
+
+    markClassroomTabSwitchStart('assignments')
+    markClassroomTabSwitchReady('assignments')
+
+    expect(getRecentClassroomTabMetrics()).toEqual([
+      {
+        tab: 'assignments',
+        startedAt: 10,
+        readyAt: 26,
+        durationMs: 16,
+      },
+    ])
+    expect(window.__classroomPendingTabMark).toBeNull()
+  })
+
+  it('ignores ready marks for a different tab', () => {
+    markClassroomTabSwitchStart('attendance')
+    markClassroomTabSwitchReady('gradebook')
+
+    expect(getRecentClassroomTabMetrics()).toEqual([])
+    expect(window.__classroomPendingTabMark).toEqual({ tab: 'attendance', startedAt: expect.any(Number) })
+  })
+
+  it('keeps only the most recent 20 metrics', () => {
+    const nowSpy = vi.spyOn(performance, 'now')
+    for (let i = 0; i < 21; i += 1) {
+      nowSpy.mockReturnValueOnce(i * 10).mockReturnValueOnce(i * 10 + 3)
+      const tab = `tab-${i}`
+      markClassroomTabSwitchStart(tab)
+      markClassroomTabSwitchReady(tab)
+    }
+
+    const metrics = getRecentClassroomTabMetrics()
+    expect(metrics).toHaveLength(20)
+    expect(metrics[0]?.tab).toBe('tab-1')
+    expect(metrics[19]?.tab).toBe('tab-20')
+  })
+
+  it('clamps negative durations to 0 when clock moves backward', () => {
+    const nowSpy = vi.spyOn(performance, 'now')
+    nowSpy.mockReturnValueOnce(100).mockReturnValueOnce(90)
+
+    markClassroomTabSwitchStart('tests')
+    markClassroomTabSwitchReady('tests')
+
+    expect(getRecentClassroomTabMetrics()[0]?.durationMs).toBe(0)
+  })
+})

--- a/tests/unit/repo-review-validation.test.ts
+++ b/tests/unit/repo-review-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { repoReviewConfigSchema, repoReviewRunSchema } from '@/lib/validations/repo-review'
+
+describe('repo review validation schemas', () => {
+  it('applies defaults for omitted repo review config fields', () => {
+    const parsed = repoReviewConfigSchema.parse({ repo_url: 'https://github.com/acme/pika-demo' })
+
+    expect(parsed).toMatchObject({
+      provider: 'github',
+      default_branch: 'main',
+      include_pr_reviews: true,
+      student_mappings: [],
+    })
+  })
+
+  it('accepts nullable mapping values and mixed student id formats', () => {
+    const parsed = repoReviewConfigSchema.parse({
+      repo_url: 'https://github.com/acme/pika-demo',
+      student_mappings: [
+        {
+          student_id: 'f9318894-e454-4b42-8a17-7ad31090d4f7',
+          github_login: null,
+          commit_emails: [],
+        },
+        {
+          student_id: 'internal-student-id',
+          github_login: 'student-login',
+          commit_emails: ['student@example.com'],
+        },
+      ],
+    })
+
+    expect(parsed.student_mappings).toHaveLength(2)
+    expect(parsed.student_mappings[1]?.commit_emails).toEqual(['student@example.com'])
+  })
+
+  it('rejects blank repo_url values', () => {
+    expect(() => repoReviewConfigSchema.parse({ repo_url: '' })).toThrow('repo_url is required')
+  })
+
+  it('defaults commit_emails to an empty list when omitted', () => {
+    const parsed = repoReviewConfigSchema.parse({
+      repo_url: 'https://github.com/acme/pika-demo',
+      student_mappings: [{ student_id: 'student-123' }],
+    })
+
+    expect(parsed.student_mappings[0]?.commit_emails).toEqual([])
+  })
+
+  it('rejects invalid commit email addresses in mappings', () => {
+    expect(() =>
+      repoReviewConfigSchema.parse({
+        repo_url: 'https://github.com/acme/pika-demo',
+        student_mappings: [
+          {
+            student_id: 'student-123',
+            commit_emails: ['not-an-email'],
+          },
+        ],
+      })
+    ).toThrow()
+  })
+
+  it('allows optional force flag in run schema', () => {
+    expect(repoReviewRunSchema.parse({})).toEqual({})
+    expect(repoReviewRunSchema.parse({ force: true })).toEqual({ force: true })
+  })
+})

--- a/tests/unit/server-class-days.test.ts
+++ b/tests/unit/server-class-days.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSupabaseClient, mockGetTodayInToronto } = vi.hoisted(() => ({
+  mockSupabaseClient: {
+    from: vi.fn(),
+  },
+  mockGetTodayInToronto: vi.fn(() => '2026-04-25'),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/timezone', () => ({
+  getTodayInToronto: mockGetTodayInToronto,
+}))
+
+import {
+  fetchClassDaysForClassroom,
+  generateClassDaysForClassroom,
+  upsertClassDayForClassroom,
+} from '@/lib/server/class-days'
+
+describe('server class-day helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset()
+    mockGetTodayInToronto.mockReturnValue('2026-04-25')
+  })
+
+  it('fetches class days sorted by date', async () => {
+    const order = vi.fn(async () => ({ data: [{ id: 'day-1', date: '2026-04-27' }], error: null }))
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ order })),
+      })),
+    })
+
+    await expect(fetchClassDaysForClassroom('classroom-1')).resolves.toEqual({
+      classDays: [{ id: 'day-1', date: '2026-04-27' }],
+      error: null,
+    })
+    expect(order).toHaveBeenCalledWith('date', { ascending: true })
+  })
+
+  it('rejects generation when class days already exist or params are incomplete', async () => {
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          limit: vi.fn(async () => ({ data: [{ id: 'existing' }], error: null })),
+        })),
+      })),
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+      semester: 'semester1',
+      year: 2026,
+    })).resolves.toEqual({
+      ok: false,
+      status: 409,
+      error: 'Class days already exist for this classroom. Use PATCH to update.',
+    })
+
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        })),
+      })),
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+    })).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Either (semester + year) or (start_date + end_date) are required',
+    })
+  })
+
+  it('validates custom ranges before creating rows', async () => {
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        })),
+      })),
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+      startDate: '2026-04-03',
+      endDate: '2026-04-01',
+    })).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'end_date must be after start_date',
+    })
+  })
+
+  it('returns range update and insert failures during generation', async () => {
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({ data: [], error: null })),
+            })),
+          })),
+        }
+      }
+      if (table === 'classrooms') {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(async () => ({ error: { message: 'range failed' } })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+      startDate: '2026-04-01',
+      endDate: '2026-04-03',
+    })).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: 'Failed to update classroom calendar range',
+    })
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({ data: [], error: null })),
+            })),
+          })),
+          insert: vi.fn(() => ({
+            select: vi.fn(async () => ({ data: null, error: { message: 'insert failed' } })),
+          })),
+        }
+      }
+      if (table === 'classrooms') {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(async () => ({ error: null })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+      startDate: '2026-04-01',
+      endDate: '2026-04-03',
+    })).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: 'Failed to create class days',
+    })
+  })
+
+  it('creates custom range class days after updating the classroom range', async () => {
+    const classroomUpdate = vi.fn(() => ({ eq: vi.fn(async () => ({ error: null })) }))
+    const insert = vi.fn(() => ({
+      select: vi.fn(async () => ({
+        data: [
+          { date: '2026-04-01' },
+          { date: '2026-04-02' },
+        ],
+        error: null,
+      })),
+    }))
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === 'class_days') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({ data: [], error: null })),
+            })),
+          })),
+          insert,
+        }
+      }
+      if (table === 'classrooms') {
+        return { update: classroomUpdate }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    await expect(generateClassDaysForClassroom({
+      classroomId: 'classroom-1',
+      startDate: '2026-04-01',
+      endDate: '2026-04-03',
+    })).resolves.toEqual({
+      ok: true,
+      count: 2,
+      classDays: [
+        { date: '2026-04-01' },
+        { date: '2026-04-02' },
+      ],
+    })
+    expect(classroomUpdate).toHaveBeenCalledWith({
+      start_date: '2026-04-01',
+      end_date: '2026-04-03',
+    })
+    expect(insert).toHaveBeenCalledWith([
+      { classroom_id: 'classroom-1', date: '2026-04-01', is_class_day: true, prompt_text: null },
+      { classroom_id: 'classroom-1', date: '2026-04-02', is_class_day: true, prompt_text: null },
+    ])
+  })
+
+  it('rejects invalid and past upsert dates before querying Supabase', async () => {
+    await expect(upsertClassDayForClassroom({
+      classroomId: 'classroom-1',
+      date: '04/26/2026',
+      isClassDay: true,
+    })).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Invalid date format (use YYYY-MM-DD)',
+    })
+
+    await expect(upsertClassDayForClassroom({
+      classroomId: 'classroom-1',
+      date: '2026-04-24',
+      isClassDay: true,
+    })).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot modify past class days',
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('creates a class day when no row exists and updates when one exists', async () => {
+    mockSupabaseClient.from.mockImplementation(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: null, error: { code: 'PGRST116' } })),
+          })),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({
+            data: { id: 'day-1', date: '2026-04-27', is_class_day: true },
+            error: null,
+          })),
+        })),
+      })),
+    }))
+
+    await expect(upsertClassDayForClassroom({
+      classroomId: 'classroom-1',
+      date: '2026-04-27',
+      isClassDay: true,
+    })).resolves.toEqual({
+      ok: true,
+      classDay: { id: 'day-1', date: '2026-04-27', is_class_day: true },
+    })
+
+    mockSupabaseClient.from.mockReset()
+    mockSupabaseClient.from.mockImplementation(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: { id: 'day-1' }, error: null })),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({
+              data: { id: 'day-1', date: '2026-04-27', is_class_day: false },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    }))
+
+    await expect(upsertClassDayForClassroom({
+      classroomId: 'classroom-1',
+      date: '2026-04-27',
+      isClassDay: false,
+    })).resolves.toEqual({
+      ok: true,
+      classDay: { id: 'day-1', date: '2026-04-27', is_class_day: false },
+    })
+  })
+})

--- a/tests/unit/server-classroom-order.test.ts
+++ b/tests/unit/server-classroom-order.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getNextTeacherClassroomPosition, listActiveTeacherClassrooms } from '@/lib/server/classroom-order'
+
+function makePositionQuery(result: unknown) {
+  const query = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    is: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+  }
+
+  query.select.mockReturnValue(query)
+  query.eq.mockReturnValue(query)
+  query.is.mockReturnValue(query)
+  query.order.mockReturnValue(query)
+  query.limit.mockReturnValue(query)
+  query.maybeSingle.mockResolvedValue(result)
+
+  return query
+}
+
+describe('server classroom-order helpers', () => {
+  it('returns ordered classrooms when position sort succeeds', async () => {
+    const result = { data: [{ id: 'c1' }], error: null }
+    const query = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      is: vi.fn(),
+      order: vi.fn(),
+    }
+    query.select.mockReturnValue(query)
+    query.eq.mockReturnValue(query)
+    query.is.mockReturnValue(query)
+    query.order.mockReturnValueOnce(query).mockResolvedValueOnce(result)
+
+    const supabase = { from: vi.fn().mockReturnValue(query) }
+
+    await expect(listActiveTeacherClassrooms(supabase as never, 'teacher-1')).resolves.toBe(result)
+
+    expect(query.eq).toHaveBeenCalledWith('teacher_id', 'teacher-1')
+    expect(query.is).toHaveBeenCalledWith('archived_at', null)
+    expect(query.order).toHaveBeenNthCalledWith(1, 'position', { ascending: true })
+    expect(query.order).toHaveBeenNthCalledWith(2, 'updated_at', { ascending: false })
+  })
+
+  it('falls back to updated_at ordering when position query errors', async () => {
+    const fallbackResult = { data: [{ id: 'c2' }], error: null }
+
+    const firstQuery = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      is: vi.fn(),
+      order: vi.fn(),
+    }
+    firstQuery.select.mockReturnValue(firstQuery)
+    firstQuery.eq.mockReturnValue(firstQuery)
+    firstQuery.is.mockReturnValue(firstQuery)
+    firstQuery.order
+      .mockReturnValueOnce(firstQuery)
+      .mockResolvedValueOnce({ data: null, error: { message: 'missing column' } })
+
+    const fallbackQuery = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      is: vi.fn(),
+      order: vi.fn(),
+    }
+    fallbackQuery.select.mockReturnValue(fallbackQuery)
+    fallbackQuery.eq.mockReturnValue(fallbackQuery)
+    fallbackQuery.is.mockReturnValue(fallbackQuery)
+    fallbackQuery.order.mockResolvedValue(fallbackResult)
+
+    const supabase = {
+      from: vi.fn().mockReturnValueOnce(firstQuery).mockReturnValueOnce(fallbackQuery),
+    }
+
+    await expect(listActiveTeacherClassrooms(supabase as never, 'teacher-2')).resolves.toBe(fallbackResult)
+
+    expect(supabase.from).toHaveBeenCalledTimes(2)
+    expect(firstQuery.order).toHaveBeenNthCalledWith(1, 'position', { ascending: true })
+    expect(firstQuery.order).toHaveBeenNthCalledWith(2, 'updated_at', { ascending: false })
+    expect(fallbackQuery.eq).toHaveBeenCalledWith('teacher_id', 'teacher-2')
+    expect(fallbackQuery.is).toHaveBeenCalledWith('archived_at', null)
+    expect(fallbackQuery.order).toHaveBeenCalledWith('updated_at', { ascending: false })
+  })
+
+  it('returns null next position when first classroom lookup fails', async () => {
+    const failing = makePositionQuery({ data: null, error: { message: 'boom' } })
+    const supabase = { from: vi.fn().mockReturnValue(failing) }
+
+    await expect(getNextTeacherClassroomPosition(supabase as never, 'teacher-3')).resolves.toBeNull()
+  })
+
+  it('returns previous position when the first classroom has a numeric position', async () => {
+    const firstClassroom = makePositionQuery({ data: { position: 8 }, error: null })
+    const supabase = { from: vi.fn().mockReturnValue(firstClassroom) }
+
+    await expect(getNextTeacherClassroomPosition(supabase as never, 'teacher-4')).resolves.toBe(7)
+    expect(firstClassroom.limit).toHaveBeenCalledWith(1)
+  })
+
+  it('defaults to 0 when first classroom has no numeric position', async () => {
+    const missingPosition = makePositionQuery({ data: { position: null }, error: null })
+    const supabase = { from: vi.fn().mockReturnValue(missingPosition) }
+
+    await expect(getNextTeacherClassroomPosition(supabase as never, 'teacher-5')).resolves.toBe(0)
+    expect(missingPosition.eq).toHaveBeenCalledWith('teacher_id', 'teacher-5')
+  })
+})


### PR DESCRIPTION
## Summary
- Add targeted unit/API coverage for classroom ordering, class days, classroom UX metrics, repo-review validation, repo target helpers, and repo-review artifact runs.
- Expand teacher attendance/export/roster/assignment reorder and assignment-doc submit tests across success, validation, and failure paths.
- Tighten Supabase mock reset setup in the added/expanded tests to avoid stale mock leakage.

## Validation
- `bash scripts/verify-env.sh` (214 test files / 1844 tests passed)
- `pnpm test:coverage` (214 test files / 1844 tests passed; 77.02% statements, 63.72% branches, 89.6% functions, 77.94% lines)
- `pnpm lint` (passes; existing `src/components/TestDocumentsEditor.tsx` hook dependency warning remains)
- `git diff --check`