### PR TITLE
[codex] Align verify-env with pnpm workflow

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9368,3 +9368,14 @@
   - Coverage: 214 test files / 1844 tests passed.
   - Lint: passed with the existing `src/components/TestDocumentsEditor.tsx` hook dependency warning.
   - Diff check: clean.
+
+## 2026-04-26 — Align Package Manager Guidance
+
+- Updated `scripts/verify-env.sh` to honor the package manager declared in `package.json` instead of requiring `npm` up front.
+- The verifier now prefers `pnpm` directly, falls back to `corepack pnpm` when available, and only checks `npm` when the repo declares npm.
+- Updated `.ai/features.json` verification commands from `npm` to `pnpm` and refreshed its `lastUpdated` metadata.
+
+**Validation:**
+- `node scripts/features.mjs validate`
+- `pnpm install`
+- `bash scripts/verify-env.sh`

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "project": "pika",
-    "lastUpdated": "2026-01-10",
+    "lastUpdated": "2026-04-26",
     "phase": "Infrastructure — AI Effectiveness Layer",
     "DO_NOT_DELETE_FEATURES": "This inventory is APPEND-ONLY. Mark features as passing/failing, add new features, but NEVER DELETE FEATURES FROM THIS FILE. Deletion corrupts project history.",
     "deletionPolicy": "PROHIBITED",
@@ -15,7 +15,7 @@
       "phase": "Phase 0 — Setup",
       "description": "Project bootstrapped (Next.js + TypeScript + Tailwind + Supabase wiring)",
       "passes": true,
-      "verification": "Run: npm test",
+      "verification": "Run: pnpm test",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -25,7 +25,7 @@
       "phase": "Phase 1 — Auth",
       "description": "Email verification + password auth with secure sessions (iron-session), lockout, and role routing",
       "passes": true,
-      "verification": "Run: npm test. Manual smoke: signup → verify → create password → login → logout → reset password",
+      "verification": "Run: pnpm test. Manual smoke: signup → verify → create password → login → logout → reset password",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -35,7 +35,7 @@
       "phase": "Phase 2 — Student Experience",
       "description": "Student journal/attendance flows per classroom (Toronto timezone rules), plus student dashboards",
       "passes": true,
-      "verification": "Run: npm test. Manual smoke: student submits entry for today and sees history update",
+      "verification": "Run: pnpm test. Manual smoke: student submits entry for today and sees history update",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -45,7 +45,7 @@
       "phase": "Phase 3 — Teacher Dashboard",
       "description": "Teacher attendance matrix, entry drill-down, class day management, and CSV export",
       "passes": true,
-      "verification": "Run: npm test. Manual smoke: teacher views classroom attendance and exports CSV",
+      "verification": "Run: pnpm test. Manual smoke: teacher views classroom attendance and exports CSV",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -55,7 +55,7 @@
       "phase": "Phase 4 — Classrooms & Rosters",
       "description": "Classroom CRUD, join codes/links, enrollments, roster CSV upload, and per-classroom class days",
       "passes": true,
-      "verification": "Run: npm test. Manual smoke: teacher creates classroom and uploads roster; student joins by code",
+      "verification": "Run: pnpm test. Manual smoke: teacher creates classroom and uploads roster; student joins by code",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -65,7 +65,7 @@
       "phase": "Phase 5 — Assignments",
       "description": "Assignments per classroom with student editor (autosave + submit/unsubmit + late detection) and teacher read-only views",
       "passes": true,
-      "verification": "Run: npm test. Manual smoke: student edits + submits; teacher views submission status",
+      "verification": "Run: pnpm test. Manual smoke: student edits + submits; teacher views submission status",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12"
@@ -75,7 +75,7 @@
       "phase": "Phase 6 — Tests & Polish",
       "description": "Expand coverage, harden security, and keep docs in sync (coverage thresholds met and stable)",
       "passes": true,
-      "verification": "Run: npm run test:coverage (and meet thresholds). Add missing tests as needed.",
+      "verification": "Run: pnpm test:coverage (and meet thresholds). Add missing tests as needed.",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2025-12-12",

--- a/scripts/verify-env.sh
+++ b/scripts/verify-env.sh
@@ -27,20 +27,37 @@ if [[ "$NODE_MAJOR" -ne 24 ]]; then
 fi
 echo "✅ Node.js $NODE_VERSION"
 
-if ! command -v npm >/dev/null 2>&1; then
-  echo "❌ npm not found"
-  echo "   Install Node.js with npm"
-  exit 1
-fi
-echo "✅ npm available"
+PACKAGE_MANAGER="$(node -p "const p=require('./package.json'); (p.packageManager || 'npm').split('@')[0]")"
+PM_CMD=()
 
-PM_CMD="npm"
-if command -v corepack >/dev/null 2>&1; then
-  # Prefer pnpm via Corepack when the repo declares a packageManager.
-  if node -e "const p=require('./package.json'); process.exit(p.packageManager ? 0 : 1)" >/dev/null 2>&1; then
-    PM_CMD="corepack pnpm"
-  fi
-fi
+case "$PACKAGE_MANAGER" in
+  pnpm)
+    if command -v pnpm >/dev/null 2>&1; then
+      PM_CMD=(pnpm)
+      echo "✅ pnpm available"
+    elif command -v corepack >/dev/null 2>&1; then
+      PM_CMD=(corepack pnpm)
+      echo "✅ corepack pnpm available"
+    else
+      echo "❌ pnpm not found"
+      echo "   Install pnpm or enable Corepack for the declared package manager"
+      exit 1
+    fi
+    ;;
+  npm)
+    if ! command -v npm >/dev/null 2>&1; then
+      echo "❌ npm not found"
+      echo "   Install Node.js with npm"
+      exit 1
+    fi
+    PM_CMD=(npm)
+    echo "✅ npm available"
+    ;;
+  *)
+    echo "❌ Unsupported package manager in package.json: $PACKAGE_MANAGER"
+    exit 1
+    ;;
+esac
 
 if [[ ! -d ".ai" ]]; then
   echo "❌ .ai/ directory not found"
@@ -57,22 +74,22 @@ fi
 
 if [[ ! -d "node_modules" ]]; then
   echo "❌ node_modules not found"
-  echo "   Install dependencies: $PM_CMD install"
+  echo "   Install dependencies: ${PM_CMD[*]} install"
   exit 1
 fi
 echo "✅ Dependencies installed"
 
 echo "Running tests..."
-$PM_CMD test
+"${PM_CMD[@]}" test
 echo "✅ Tests passing"
 
 if [[ "$MODE" == "--full" ]]; then
   echo "Running lint..."
-  $PM_CMD run lint
+  "${PM_CMD[@]}" run lint
   echo "✅ Lint passing"
 
   echo "Running build..."
-  $PM_CMD run build
+  "${PM_CMD[@]}" run build
   echo "✅ Build successful"
 fi
 


### PR DESCRIPTION
## What changed
- updated `scripts/verify-env.sh` to honor the package manager declared in `package.json`
- prefer `pnpm` directly, fall back to `corepack pnpm`, and only require `npm` when the repo declares npm
- updated `.ai/features.json` verification commands from `npm` to `pnpm`
- added the session entry to `.ai/JOURNAL.md`

## Why
The repo declares `pnpm@10.25.0`, but the environment verifier still hard-required `npm` before selecting a package manager. That made the repo's own setup check reject a valid pnpm-oriented environment and left the AI continuity docs pointing at stale npm commands.

## Impact
- `verify-env.sh` now matches repo policy
- new worktrees get the correct package-manager guidance
- `.ai` verification text is consistent with the declared workflow

## Validation
- `pnpm install`
- `node scripts/features.mjs validate`
- `bash scripts/verify-env.sh`

## Review
No code review findings in the changed scope. Residual risk is low and limited to shell compatibility in `verify-env.sh`, which was exercised through the full verifier run.