### PR TITLE
[codex] Refactor teacher work surface shell

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9449,3 +9449,8 @@
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1`
 - Targeted Playwright Back-flow check on teacher assignments verified Back from `Student2` returned to `Student1` within `tab=assignments`.
+## 2026-04-26 — Teacher work-surface canon adoption guidance
+
+- Added explicit AI routing for teacher assignments/quizzes/tests shell and layout tasks in `docs/ai-instructions.md`.
+- Expanded `docs/guidance/ui/teacher-work-surfaces.md` with an implemented primitive map, assignment-only reuse boundaries, an AI adoption contract, and a tests/quizzes migration template.
+- Verified the environment with `PATH=/opt/homebrew/bin:$PATH bash scripts/verify-env.sh`; all 218 test files and 1861 tests passed before the docs-only patch.

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9412,3 +9412,40 @@
 - `pnpm test tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec eslint 'src/app/classrooms/[classroomId]/TeacherClassroomView.tsx' tests/components/TeacherClassroomView.test.tsx`
 - `pnpm exec tsc --noEmit`
+## 2026-04-25 - Teacher Work-Surface Shell Refactor
+
+- Added dev-flow risk guidance for workspace-state, async-grading, exam-mode, and runtime-platform work, and routed non-trivial risk-profile declaration through AI session/TDD/audit prompts.
+- Extracted the assignment teacher work surface in layers: outer `TeacherWorkSurfaceShell`, workspace `TeacherWorkSurfaceModeBar`, reusable `TeacherWorkspaceSplit`, and assignment-local `TeacherAssignmentStudentTable`.
+- Migrated teacher assignments to the new structural pieces while leaving assignment loading, selection, grading, AI run, return, modal, and route/query behavior in `TeacherClassroomView`.
+- Updated `TeacherStudentWorkPanel` to use the shared teacher workspace split for individual-mode content/inspector panes.
+- Tightened the local Pika audit rule so cached read fetchers are not mistaken for uncached component reads while raw mutation fetches remain allowed.
+
+**Validation:**
+- `bash scripts/verify-env.sh` (210 files, 1804 tests)
+- `pnpm exec vitest run tests/components/TeacherWorkspaceSplit.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"` remained blocked because seeded teacher and student auth both returned `POST /api/auth/login 401`, so screenshots could not be captured in this local environment.
+## 2026-04-26 — Teacher work-surface canon fixes
+
+- Tightened `TeacherWorkspaceSplit` so the shared split primitive clamps inspector width changes with generic structural constraints instead of relying only on assignment-specific layout code.
+- Upgraded `TeacherWorkSurfaceModeBar` from pressed buttons to typed tab semantics with keyboard navigation, making it safer to reuse across selected workspaces.
+- Added an explicit `workspaceFrame` variant to `TeacherWorkSurfaceShell` so attached-tab and standalone selected workspaces are deliberate API choices.
+- Verified with focused component tests, full `verify-env.sh`, lint, build, audit, and teacher assignment visual captures.
+
+## 2026-04-26 — Teacher assignment browser-back workspace state
+
+- Made teacher assignment selection and selected-student inspection URL-backed with `assignmentId` and `assignmentStudentId`, so browser Back unwinds the assignment workspace before leaving the Assignments tab.
+- Kept cookies as a persistence fallback only; URL-controlled assignment views now suppress stale assignment cookies and sidebar/calendar assignment links write the routed state.
+- Added regression coverage for stale-cookie suppression, assignment selection history, default selected-student URL replacement, and student-row history updates.
+- Converted repeated assignment/announcement/result reads in the newly touched route files to the shared request cache and updated the audit rule to recognize `prefetchJSON` as cache-backed.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/NavItems.test.tsx`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `pnpm exec tsc --noEmit`
+- `bash scripts/verify-env.sh` (210 files, 1811 tests)
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1`
+- Targeted Playwright Back-flow check on teacher assignments verified Back from `Student2` returned to `Student1` within `tab=assignments`.

--- a/.codex/prompts/audit.md
+++ b/.codex/prompts/audit.md
@@ -6,3 +6,12 @@ bash "$PIKA_WORKTREE/.codex/skills/pika-audit/scripts/audit.sh"
 ```
 
 Focus on the full result set, not only the first failure. The audit checks the highest-drift patterns: manual API-route error handling, illegal `dark:` classes, duplicated `parseContentField`, `console.log`, and related violations.
+
+Also declare the task risk profile before reporting audit status:
+- `none`
+- `workspace-state`
+- `async-grading`
+- `exam-mode`
+- `runtime-platform`
+
+If a non-`none` risk profile applies, review `docs/guidance/dev-flow-risk-checklists.md` and report whether the relevant behavioral checks were covered by tests, visual verification, or explicit follow-up.

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -17,5 +17,7 @@ Manual fallback:
    - Record: stable guidance followed
    - Record: experimental guidance introduced: yes/no
    - Record: human promotion needed: yes/no
+   - For non-trivial work, declare risk profile: `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform`.
+   - If any risk profile applies, read `docs/guidance/dev-flow-risk-checklists.md`.
 6. If `$ARGUMENTS` is an issue number, run `gh issue view $ARGUMENTS --json number,title,body,labels`.
 7. State the task, propose the approach, and wait for approval before coding.

--- a/.codex/prompts/tdd.md
+++ b/.codex/prompts/tdd.md
@@ -1,6 +1,7 @@
 Use TDD for the feature described in `$ARGUMENTS`.
 
 If you have not already loaded it, read `docs/core/tests.md` first.
+If the task touches workspace state, async grading, exam mode, or runtime/platform behavior, also read `docs/guidance/dev-flow-risk-checklists.md` and name the risk profile before writing tests.
 
 Steps:
 1. Identify the target test file under `tests/lib/`, `tests/api/`, `tests/hooks/`, or `tests/components/`.
@@ -10,3 +11,6 @@ Steps:
 5. Re-run the focused test, then refactor as needed.
 6. Re-run the focused test and any nearby regression tests.
 7. Check coverage when the change affects shared core logic.
+8. For workspace-state work, include a regression that the active editor/form/workspace stays mounted across non-destructive updates.
+9. For async-grading work, include recovery/retry/partial-failure coverage.
+10. For exam-mode work, include transient-loss, sustained-loss, restore, and draft-preservation coverage.

--- a/.codex/skills/pika-audit/SKILL.md
+++ b/.codex/skills/pika-audit/SKILL.md
@@ -29,6 +29,7 @@ Scan changed TypeScript files for codebase violations before committing. Catches
 | `dark-class` | `dark:` class outside `src/ui/` | Use semantic tokens from `docs/core/design.md` |
 | `duplicate-parseContentField` | Local `parseContentField` function | Import from `@/lib/tiptap-content` |
 | `console-log` | `console.log(` in non-test production code | Use `console.error`/`warn` or structured logging |
+| `uncached-fetch` | Raw read `fetch()` in classroom/client components | Use `fetchJSONWithCache`; raw mutation fetches are allowed |
 
 ## Script
 

--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -72,8 +72,15 @@ while IFS= read -r file; do
   # e) fetchJSON without cache in client components
   if [[ "$file" == src/components/* || "$file" == src/app/classrooms/* ]]; then
     while IFS=: read -r lineno _; do
-      report_violation "uncached-fetch" "$file:$lineno" "consider fetchJSONWithCache from @/lib/request-cache for repeated fetches"
-    done < <(grep -n "fetch('" "$FULL" 2>/dev/null || grep -n 'fetch(`' "$FULL" 2>/dev/null || true)
+      if sed -n "$((lineno - 4 < 1 ? 1 : lineno - 4)),$((lineno - 1))p" "$FULL" | grep -Eq 'fetchJSONWithCache|prefetchJSON'; then
+        continue
+      fi
+      # Raw fetch is allowed for one-off mutations; cache guidance targets repeated reads.
+      if sed -n "${lineno},$((lineno + 6))p" "$FULL" | grep -q 'method:'; then
+        continue
+      fi
+      report_violation "uncached-fetch" "$file:$lineno" "consider fetchJSONWithCache from @/lib/request-cache for repeated reads"
+    done < <(grep -n "fetch('" "$FULL" 2>/dev/null || true; grep -n 'fetch(`' "$FULL" 2>/dev/null || true)
   fi
 
 done <<< "$ALL_FILES"

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -23,6 +23,7 @@ After the startup set above, load task-specific docs:
 |---|---|
 | Any non-trivial code change | [`docs/core/architecture.md`](./core/architecture.md) |
 | UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
+| Teacher assignments, quizzes, or tests work-surface shell/layout work | [`docs/guidance/ui/teacher-work-surfaces.md`](./guidance/ui/teacher-work-surfaces.md), [`docs/guidance/assignment-ux-language.md`](./guidance/assignment-ux-language.md), [`docs/guidance/ui/audit-teacher-work-surfaces.md`](./guidance/ui/audit-teacher-work-surfaces.md) |
 | TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
 | Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |
 | Workspace state, grading runs, exam mode, or runtime platform risk | [`docs/guidance/dev-flow-risk-checklists.md`](./guidance/dev-flow-risk-checklists.md) |

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -25,6 +25,7 @@ After the startup set above, load task-specific docs:
 | UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
 | TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
 | Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |
+| Workspace state, grading runs, exam mode, or runtime platform risk | [`docs/guidance/dev-flow-risk-checklists.md`](./guidance/dev-flow-risk-checklists.md) |
 | Multi-agent delegation | [`docs/core/agents.md`](./core/agents.md) |
 | Product status or phase questions | [`docs/core/roadmap.md`](./core/roadmap.md) |
 | GitHub issue work | [`docs/workflow/handle-issue.md`](./workflow/handle-issue.md) |
@@ -45,6 +46,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
 - Workflow: do non-trivial work in a bound worktree, plan before coding, and keep `.ai/JOURNAL.md` append-only
+- Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map
 

--- a/docs/guidance/dev-flow-risk-checklists.md
+++ b/docs/guidance/dev-flow-risk-checklists.md
@@ -1,0 +1,67 @@
+# Dev Flow Risk Checklists
+
+Use this file when a task matches one of the risk profiles below. Keep the checklist compact and concrete in plans, PR notes, and review responses.
+
+## Risk Profile Declaration
+
+Every non-trivial task should declare one of:
+
+- `none`
+- `workspace-state`
+- `async-grading`
+- `exam-mode`
+- `runtime-platform`
+
+If more than one applies, list all matching profiles.
+
+## Workspace State
+
+Applies when changing long-lived workspaces, split panes, editors, autosave surfaces, overlays, or parent/child refresh behavior.
+
+- Treat current mounted editors/forms as stateful unless proven otherwise.
+- Preserve mounted workspace children across autosave, transient overlays, parent metadata updates, and background refetches.
+- Prefer local summary patching over full parent reloads when the child already has the fresh state.
+- Test that the active workspace does not remount when autosave completes or when non-destructive metadata changes.
+- For structural refactors, use this implementation contract:
+
+```text
+This is a structural refactor, not a redesign.
+
+Use teacher assignments as the visual and interaction reference. Extract only the repeated shell structure that already exists: page layout, action bar placement, summary spacing, selected-workspace gutter behavior, feedback banner placement, and selected-workspace frame.
+
+Do not move business logic, data loading, selection state, grading behavior, routing/query behavior, modal flows, or assessment-specific mode state into the shell.
+
+The migrated assignment UI should look and behave the same after the refactor. Any visible difference must be explicitly listed and justified before continuing.
+
+Stop and reassess if the new shell API starts needing domain-specific props such as assignment status, quiz status, grading state, AI run state, student selection, rubric state, or return behavior.
+```
+
+## Async Grading
+
+Applies when changing assignment/test AI grading, manual grading save flows, return flows, or background run processing.
+
+- Model grading as resumable run state, not one long request.
+- Keep ticks idempotent and bounded; each tick should have a narrow failure scope.
+- Persist enough state to recover after reload and to summarize partial failure.
+- Keep token controls explicit: structured output, bounded output caps, minimal prompt context, and reusable references where available.
+- Test missing, empty, partial, failed, retryable, and recovered work states.
+
+## Exam Mode
+
+Applies when changing student test taking, fullscreen/maximize checks, focus/away tracking, overlays, or draft preservation.
+
+- Derive lock state from a compliance snapshot, not a raw browser event alone.
+- Use a grace window for transient fullscreen/resize/focus changes before locking or logging violations.
+- Hide locked content instead of unmounting the active test form when draft preservation matters.
+- Test transient loss, sustained loss, restoration, and unsaved open-response preservation.
+- Verify teacher telemetry still distinguishes route exits, focus/away events, and window/fullscreen exits.
+
+## Runtime Platform
+
+Applies when changing cron, background work, deployment config, long-running routes, or Vercel behavior.
+
+- Check current Vercel plan constraints before adding repo-managed schedules.
+- On Hobby, Vercel cron schedules must run at most once per day.
+- Prefer teacher-driven ticks or resumable foreground progress for sub-daily or interactive background work.
+- Avoid routes that depend on one long request completing for bulk work.
+- Document any platform assumption in the task notes or PR body.

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -270,6 +270,76 @@ Keep these feature-local:
 
 Do not introduce a generic assessment mega-shell that tries to own assignments, quizzes, and tests in one abstraction.
 
+## Implemented Primitive Map
+
+The assignment refactor created stable structural primitives, plus assignment-local implementations that demonstrate how to compose them. Future tests/quizzes/gradebook work should use this map instead of inferring reuse from filenames alone.
+
+Stable structural primitives:
+
+| Component | Use for | Do not put here |
+|---|---|---|
+| `TeacherWorkSurfaceShell` | page layout, summary/workspace state, action bar placement, feedback placement, selected-workspace frame | data loading, routing/query behavior, selection state, grading state, assessment status, return behavior |
+| `TeacherWorkSurfaceModeBar<TMode>` | selected-workspace mode tabs with tab semantics and keyboard movement | domain-specific mode state machines, assessment-specific labels baked into the primitive |
+| `TeacherWorkspaceSplit` | bounded primary/inspector split panes when both panes are active work surfaces | grading behavior, student selection, assignment-specific width policy beyond generic min/max constraints |
+
+Assignment-local reference implementations:
+
+| Component | Role | Reuse boundary |
+|---|---|---|
+| `TeacherAssignmentStudentTable` | assignment student-status table with selection, artifacts, assignment statuses, and assignment grade summary | copy the table rhythm only after creating a domain-specific table for tests/quizzes; do not import it outside assignment work |
+| `TeacherStudentWorkPanel` | assignment document review surface that composes content preview with an inspector | use as a behavioral reference, not as a generic assessment panel |
+| `TeacherWorkInspector` | assignment grading/history/repo/comments inspector | assignment-only; tests/quizzes need their own inspector if their data and controls differ |
+| `useTeacherStudentWorkController` | assignment document loading, grading, autosave, history, repo analysis, and feedback return orchestration | assignment-only business logic |
+
+Stable hierarchy for teacher work tabs:
+
+```tsx
+<FeatureTeacherTab>
+  <TeacherWorkSurfaceShell
+    state={isSummary ? 'summary' : 'workspace'}
+    primary={summaryOrWorkspaceActionBar}
+    feedback={featureFeedback}
+    summary={featureSummary}
+    workspace={featureWorkspace}
+    workspaceFrame="attachedTabs | standalone"
+  />
+</FeatureTeacherTab>
+```
+
+Inside `workspace`, use `TeacherWorkSurfaceModeBar` only when the selected item has real workflow modes. Use `TeacherWorkspaceSplit` only when a current selection makes side-by-side work useful.
+
+## AI Adoption Contract
+
+Use this language when asking an AI agent to migrate tests, quizzes, or another teacher work tab:
+
+```text
+Use the assignment tab as the reference implementation, but do not copy assignment-specific components or logic.
+
+Reuse `TeacherWorkSurfaceShell`, `TeacherWorkSurfaceModeBar`, and `TeacherWorkspaceSplit` for structural shell behavior.
+
+Create domain-specific inner components for this tab. Do not import `TeacherAssignmentStudentTable`, `TeacherStudentWorkPanel`, `TeacherWorkInspector`, or `useTeacherStudentWorkController` unless the task is assignment work.
+
+Preserve the teacher work-surface ladder: summary -> selected workspace -> optional workspace mode -> optional active inspector.
+
+Keep data loading, routing/query behavior, selection state, grading state, return behavior, draft state, browser-event handling, and assessment-specific mode logic in the feature tab or feature-specific hooks, not in the shared shell primitives.
+
+Stop and reassess if a shared primitive needs props named after assignment, quiz, test, gradebook, student grading, AI runs, return flow, rubric, attempt, artifact, or assessment status.
+```
+
+## Tests And Quizzes Migration Template
+
+For future teacher tests/quizzes work, migrate in this order:
+
+1. Identify the existing states in the formal ladder: `summary`, `workspace`, `workspace_mode`, and `inspector_active`.
+2. Replace only the outer page rhythm with `TeacherWorkSurfaceShell`.
+3. Move selected-item mode controls into `TeacherWorkSurfaceModeBar` if the modes are real workflow changes.
+4. Use `TeacherWorkspaceSplit` only for active side-by-side review, grading, or authoring work.
+5. Extract feature-specific inner pieces under a feature-specific path such as `src/components/test-workspace/` or `src/components/quiz-workspace/`.
+6. Add focused component tests for shell state, mode tabs, split bounds, selected-workspace behavior, and browser-back behavior.
+7. Run UI verification against the migrated tab and compare it to the pre-refactor screenshots before migrating another tab.
+
+Do not migrate tests and quizzes in the same pass unless assignment parity has already been accepted and the first non-assignment migration has passed visual review.
+
 ## Componentization Rules
 
 Not every recurring UI idea should become a primitive.

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -48,7 +48,7 @@ import { StudentLogHistory } from '@/components/StudentLogHistory'
 import { LogSummary } from './LogSummary'
 import { ConfirmDialog, EmptyState, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
-import { prefetchJSON } from '@/lib/request-cache'
+import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
 import type {
   Classroom,
@@ -248,6 +248,7 @@ function ClassroomPageContent({
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
+  const assignmentStudentIdParam = searchParams.get('assignmentStudentId')
   const sectionParam = searchParams.get('section')
   const [mountedTabs, setMountedTabs] = useState<Record<string, boolean>>(() => ({
     [activeTab]: true,
@@ -541,7 +542,8 @@ function ClassroomPageContent({
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
     }
-    abortControllerRef.current = new AbortController()
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
 
     setMarkdownError(null)
     setMarkdownWarning(null)
@@ -549,10 +551,17 @@ function ClassroomPageContent({
     setMarkdownLoading(true)
 
     try {
-      const res = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`, {
-        signal: abortControllerRef.current.signal,
-      })
-      const data = await res.json()
+      const data = await fetchJSONWithCache<{ assignments?: Assignment[] }>(
+        `teacher-assignments:${classroom.id}`,
+        async () => {
+          const res = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`, {
+            signal: abortController.signal,
+          })
+          if (!res.ok) throw new Error('Failed to load assignments')
+          return res.json()
+        },
+        20_000,
+      )
       const assignments = (data.assignments || []) as Assignment[]
       setAssignmentsCache(assignments)
 
@@ -891,6 +900,7 @@ function ClassroomPageContent({
         params.set('tab', tab)
         if (tab !== 'assignments') {
           params.delete('assignmentId')
+          params.delete('assignmentStudentId')
         }
         if (tab !== 'resources' && tab !== 'settings') {
           params.delete('section')
@@ -952,8 +962,15 @@ function ClassroomPageContent({
     if (!selectedQuiz) return
 
     try {
-      const res = await fetch(`${assessmentApiBasePath}/${selectedQuiz.id}/results`)
-      const data = await res.json()
+      const data = await fetchJSONWithCache<{ stats?: { responded?: number } }>(
+        `teacher-assessment-results:${assessmentLabel}:${selectedQuiz.id}`,
+        async () => {
+          const res = await fetch(`${assessmentApiBasePath}/${selectedQuiz.id}/results`)
+          if (!res.ok) throw new Error('Failed to load assessment results')
+          return res.json()
+        },
+        0,
+      )
       setPendingAssessmentDelete({
         quiz: selectedQuiz,
         responsesCount: Number(data?.stats?.responded || 0),
@@ -1073,6 +1090,9 @@ function ClassroomPageContent({
                         onSelectAssignment={handleSelectAssignment}
                         onViewModeChange={handleViewModeChange}
                         isActive={activeTab === 'assignments'}
+                        selectedAssignmentId={assignmentIdParam}
+                        selectedAssignmentStudentId={assignmentStudentIdParam}
+                        updateSearchParams={navigateInClassroom}
                       />
                     </TabContentTransition>
                   )}
@@ -1104,12 +1124,23 @@ function ClassroomPageContent({
                       <TeacherLessonCalendarTab
                         classroom={classroom}
                         onSidebarStateChange={setCalendarSidebarState}
-                        onNavigateToAssignments={() => handleTabChange('assignments')}
+                        onNavigateToAssignments={(assignmentId) =>
+                          navigateInClassroom((params) => {
+                            params.set('tab', 'assignments')
+                            if (assignmentId) {
+                              params.set('assignmentId', assignmentId)
+                            } else {
+                              params.delete('assignmentId')
+                            }
+                            params.delete('assignmentStudentId')
+                          })
+                        }
                         onNavigateToAnnouncements={() =>
                           navigateInClassroom((params) => {
                             params.set('tab', 'resources')
                             params.delete('section')
                             params.delete('assignmentId')
+                            params.delete('assignmentStudentId')
                           })
                         }
                       />
@@ -1182,6 +1213,7 @@ function ClassroomPageContent({
                             } else {
                               params.delete('assignmentId')
                             }
+                            params.delete('assignmentStudentId')
                           })
                         }
                         onNavigateToAnnouncements={() =>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -32,38 +32,33 @@ import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
-import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import {
-  AssessmentStatusIcon,
-  type AssessmentStatusIconState,
-} from '@/components/AssessmentStatusIcon'
+  TeacherAssignmentStudentTable,
+  type TeacherAssignmentStudentRow,
+} from '@/components/assignment-workspace/TeacherAssignmentStudentTable'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
-import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
   ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
-  PageActionBar,
-  PageContent,
-  PageLayout,
   PageStack,
 } from '@/components/PageLayout'
 import { RightSidebarToggle } from '@/components/layout'
 import {
   calculateAssignmentStatus,
   getAssignmentRubricState,
-  getAssignmentStatusIconClass,
-  getAssignmentStatusLabel,
-  hasDraftSavedGrade,
   isAssignmentAlreadyReturnedWithoutResubmission,
 } from '@/lib/assignments'
 import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
 import {
+  ASSIGNMENT_GRADING_LAYOUT,
   getAssignmentWorkspaceStudentCookieName,
   parseAssignmentWorkspaceStudentId,
   type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
-import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import type {
   Classroom,
@@ -75,18 +70,6 @@ import type {
   TiptapContent,
 } from '@/types'
 import {
-  DataTable,
-  DataTableBody,
-  DataTableCell,
-  DataTableHead,
-  DataTableHeaderCell,
-  DataTableRow,
-  EmptyStateRow,
-  KeyboardNavigableTable,
-  SortableHeaderCell,
-  TableCard,
-} from '@/components/DataTable'
-import {
   TEACHER_ASSIGNMENTS_SELECTION_EVENT,
   TEACHER_ASSIGNMENTS_UPDATED_EVENT,
   TEACHER_GRADE_UPDATED_EVENT,
@@ -95,9 +78,7 @@ import {
 import { applyDirection, compareByNameFields, toggleSort as toggleSortState } from '@/lib/table-sort'
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
-import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
 import { readCookie, writeCookie } from '@/lib/cookies'
-import { useWindowSize } from '@/hooks/use-window-size'
 
 interface AssignmentWithStats extends Assignment {
   stats: AssignmentStats
@@ -105,27 +86,11 @@ interface AssignmentWithStats extends Assignment {
 
 type TeacherAssignmentSelection = { mode: 'summary' } | { mode: 'assignment'; assignmentId: string }
 
-interface StudentSubmissionRow {
-  student_id: string
-  student_email: string
-  student_first_name: string | null
-  student_last_name: string | null
-  status: AssignmentStatus
-  student_updated_at?: string | null
-  artifacts: AssignmentArtifact[]
-  doc: {
-    is_submitted?: boolean | null
-    submitted_at?: string | null
-    updated_at?: string | null
-    score_completion?: number | null
-    score_thinking?: number | null
-    score_workflow?: number | null
-    graded_at?: string | null
-    returned_at?: string | null
-    teacher_cleared_at?: string | null
-    feedback_returned_at?: string | null
-  } | null
-}
+type StudentSubmissionRow = TeacherAssignmentStudentRow
+type UpdateSearchParamsFn = (
+  updater: (params: URLSearchParams) => void,
+  options?: { replace?: boolean },
+) => void
 
 export type AssignmentViewMode = 'summary' | 'assignment'
 
@@ -134,17 +99,13 @@ interface Props {
   onSelectAssignment?: (assignment: { title: string; instructions: TiptapContent | string | null } | null) => void
   onViewModeChange?: (mode: AssignmentViewMode) => void
   isActive?: boolean
+  selectedAssignmentId?: string | null
+  selectedAssignmentStudentId?: string | null
+  updateSearchParams?: UpdateSearchParamsFn
 }
 
 function isScheduledAssignment(assignment: Assignment): boolean {
   return !assignment.is_draft && !!assignment.released_at && !isVisibleAtNow(assignment.released_at)
-}
-
-function getRowClassName(isSelected: boolean): string {
-  if (isSelected) {
-    return 'cursor-pointer border-l-2 border-l-primary bg-surface-selected shadow-sm'
-  }
-  return 'cursor-pointer hover:bg-surface-hover'
 }
 
 function MetricBar({ value }: { value: number }) {
@@ -157,60 +118,6 @@ function MetricBar({ value }: { value: number }) {
       />
     </div>
   )
-}
-
-function StatusIcon({
-  status,
-  wasLate,
-  hasDraftGrade = false,
-}: {
-  status: AssignmentStatus
-  wasLate?: boolean
-  hasDraftGrade?: boolean
-}) {
-  const showLate =
-    status === 'in_progress_late' ||
-    status === 'submitted_late' ||
-    ((status === 'graded' || status === 'returned' || status === 'resubmitted') && wasLate)
-
-  let iconState: AssessmentStatusIconState
-  switch (status) {
-    case 'not_started':
-      iconState = 'not_started'
-      break
-    case 'in_progress':
-    case 'in_progress_late':
-      iconState = 'in_progress'
-      break
-    case 'submitted_on_time':
-    case 'submitted_late':
-      iconState = hasDraftGrade ? 'draft_graded' : 'submitted'
-      break
-    case 'graded':
-      iconState = 'graded'
-      break
-    case 'returned':
-      iconState = 'returned'
-      break
-    case 'resubmitted':
-      iconState = 'resubmitted'
-      break
-    default:
-      iconState = 'not_started'
-  }
-
-  return <AssessmentStatusIcon state={iconState} late={showLate} />
-}
-
-function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLate: boolean): string {
-  const baseLabel = getAssignmentStatusLabel(status)
-  if (!wasLate) return baseLabel
-
-  if (status === 'graded' || status === 'returned' || status === 'resubmitted') {
-    return `${baseLabel} (late)`
-  }
-
-  return baseLabel
 }
 
 function getStudentDisplayName(row: StudentSubmissionRow | null): string | null {
@@ -307,10 +214,12 @@ export function TeacherClassroomView({
   onSelectAssignment,
   onViewModeChange,
   isActive = true,
+  selectedAssignmentId: selectedAssignmentIdProp,
+  selectedAssignmentStudentId,
+  updateSearchParams,
 }: Props) {
   const isReadOnly = !!classroom.archived_at
-  const { width: viewportWidth } = useWindowSize()
-  const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
+  const isUrlSelectionControlled = selectedAssignmentIdProp !== undefined
 
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([])
   const [classDays, setClassDays] = useState<ClassDay[]>([])
@@ -359,6 +268,7 @@ export function TeacherClassroomView({
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const workspaceContainerRef = useRef<HTMLDivElement | null>(null)
   const defaultedWorkspaceKeyRef = useRef<string | null>(null)
+  const syncedStudentUrlKeyRef = useRef<string | null>(null)
   const [workspaceWidth, setWorkspaceWidth] = useState(0)
 
   // Batch grading state
@@ -383,21 +293,28 @@ export function TeacherClassroomView({
       setLoading(true)
     }
     try {
-      const [assignmentsData, classDaysRes] = await Promise.all([
-        fetchJSONWithCache(
-          `teacher-assignments:${classroom.id}`,
-          async () => {
-            const response = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`)
-            if (!response.ok) throw new Error('Failed to load assignments')
-            return response.json()
-          },
-          20_000,
-        ),
-        fetch(`/api/classrooms/${classroom.id}/class-days`),
-      ])
-      const classDaysData = await classDaysRes.json().catch(() => ({ class_days: [] }))
-      setAssignments(assignmentsData.assignments || [])
-      setClassDays(classDaysData.class_days || [])
+	      const [assignmentsData, classDaysRes] = await Promise.all([
+	        fetchJSONWithCache(
+	          `teacher-assignments:${classroom.id}`,
+	          async () => {
+	            const response = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`)
+	            if (!response.ok) throw new Error('Failed to load assignments')
+	            return response.json()
+	          },
+	          20_000,
+	        ),
+	        fetchJSONWithCache(
+	          `class-days:${classroom.id}`,
+	          async () => {
+	            const response = await fetch(`/api/classrooms/${classroom.id}/class-days`)
+	            if (!response.ok) return { class_days: [] }
+	            return response.json().catch(() => ({ class_days: [] }))
+	          },
+	          20_000,
+	        ),
+	      ])
+	      setAssignments(assignmentsData.assignments || [])
+	      setClassDays(classDaysRes.class_days || [])
       setHasLoadedOnce(true)
       window.dispatchEvent(
         new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
@@ -478,6 +395,7 @@ export function TeacherClassroomView({
   )
 
   useEffect(() => {
+    if (isUrlSelectionControlled) return
     if (loading) return
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     const value = readCookie(cookieName)
@@ -497,10 +415,41 @@ export function TeacherClassroomView({
     } else {
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, loading])
+  }, [assignments, classroom.id, isUrlSelectionControlled, loading])
+
+  useEffect(() => {
+    if (!isUrlSelectionControlled) return
+    if (loading) return
+
+    const cookieName = `teacherAssignmentsSelection:${classroom.id}`
+    const value = selectedAssignmentIdProp
+    if (!value || value === 'summary') {
+      writeCookie(cookieName, 'summary')
+      setSelection({ mode: 'summary' })
+      return
+    }
+
+    const assignment = assignments.find((a) => a.id === value)
+    if (!assignment) {
+      writeCookie(cookieName, 'summary')
+      setSelection({ mode: 'summary' })
+      return
+    }
+
+    // Draft/scheduled assignments open the editor for release controls.
+    if (assignment.is_draft || isScheduledAssignment(assignment)) {
+      setEditAssignment(assignment)
+      writeCookie(cookieName, 'summary')
+      setSelection({ mode: 'summary' })
+    } else {
+      writeCookie(cookieName, value)
+      setSelection({ mode: 'assignment', assignmentId: value })
+    }
+  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp])
 
   useEffect(() => {
     function onSelectionEvent(e: Event) {
+      if (isUrlSelectionControlled) return
       const event = e as CustomEvent<{ classroomId?: string; value?: string }>
       if (!event.detail) return
       if (event.detail.classroomId !== classroom.id) return
@@ -526,7 +475,7 @@ export function TeacherClassroomView({
 
     window.addEventListener(TEACHER_ASSIGNMENTS_SELECTION_EVENT, onSelectionEvent)
     return () => window.removeEventListener(TEACHER_ASSIGNMENTS_SELECTION_EVENT, onSelectionEvent)
-  }, [assignments, classroom.id])
+  }, [assignments, classroom.id, isUrlSelectionControlled])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
@@ -539,15 +488,22 @@ export function TeacherClassroomView({
 
     const assignmentId = selection.assignmentId
 
-    async function loadSelectedAssignment() {
-      setSelectedAssignmentLoading(true)
-      setSelectedAssignmentError('')
-      try {
-        const response = await fetch(`/api/teacher/assignments/${assignmentId}`)
-        const data = await response.json()
-        if (!response.ok) {
-          throw new Error(data.error || 'Failed to load assignment')
-        }
+	    async function loadSelectedAssignment() {
+	      setSelectedAssignmentLoading(true)
+	      setSelectedAssignmentError('')
+	      try {
+	        const data = await fetchJSONWithCache(
+	          `teacher-assignment-detail:${assignmentId}:${refreshCounter}`,
+	          async () => {
+	            const response = await fetch(`/api/teacher/assignments/${assignmentId}`)
+	            const payload = await response.json()
+	            if (!response.ok) {
+	              throw new Error(payload.error || 'Failed to load assignment')
+	            }
+	            return payload
+	          },
+	          2_000,
+	        )
 
         setSelectedAssignmentData({
           assignment: data.assignment,
@@ -636,12 +592,44 @@ export function TeacherClassroomView({
     loadAssignments()
   }
 
-  function setSelectionAndPersist(next: TeacherAssignmentSelection) {
+  const setSelectionAndPersist = useCallback((
+    next: TeacherAssignmentSelection,
+    options: { updateUrl?: boolean; replace?: boolean } = {},
+  ) => {
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     const cookieValue = next.mode === 'summary' ? 'summary' : next.assignmentId
     writeCookie(cookieName, cookieValue)
     setSelection(next)
-  }
+    if (options.updateUrl === false || !updateSearchParams) return
+
+    updateSearchParams((params) => {
+      params.set('tab', 'assignments')
+      if (next.mode === 'assignment') {
+        params.set('assignmentId', next.assignmentId)
+      } else {
+        params.delete('assignmentId')
+      }
+      params.delete('assignmentStudentId')
+    }, { replace: options.replace })
+  }, [classroom.id, updateSearchParams])
+
+  const setSelectedStudentAndNavigate = useCallback((
+    studentId: string | null,
+    options: { updateUrl?: boolean; replace?: boolean } = {},
+  ) => {
+    setSelectedStudentId(studentId)
+    if (options.updateUrl === false || !updateSearchParams || selection.mode !== 'assignment') return
+
+    updateSearchParams((params) => {
+      params.set('tab', 'assignments')
+      params.set('assignmentId', selection.assignmentId)
+      if (studentId) {
+        params.set('assignmentStudentId', studentId)
+      } else {
+        params.delete('assignmentStudentId')
+      }
+    }, { replace: options.replace })
+  }, [selection, updateSearchParams])
 
   const sortedStudents = useMemo(() => {
     if (!selectedAssignmentData) return []
@@ -981,13 +969,47 @@ export function TeacherClassroomView({
 
   const handleGoPrevStudent = useCallback(() => {
     if (selectedStudentIndex <= 0) return
-    setSelectedStudentId(currentStudentRows[selectedStudentIndex - 1].student_id)
-  }, [currentStudentRows, selectedStudentIndex])
+    setSelectedStudentAndNavigate(currentStudentRows[selectedStudentIndex - 1].student_id)
+  }, [currentStudentRows, selectedStudentIndex, setSelectedStudentAndNavigate])
 
   const handleGoNextStudent = useCallback(() => {
     if (selectedStudentIndex === -1 || selectedStudentIndex >= currentStudentRows.length - 1) return
-    setSelectedStudentId(currentStudentRows[selectedStudentIndex + 1].student_id)
-  }, [currentStudentRows, selectedStudentIndex])
+    setSelectedStudentAndNavigate(currentStudentRows[selectedStudentIndex + 1].student_id)
+  }, [currentStudentRows, selectedStudentIndex, setSelectedStudentAndNavigate])
+
+  useEffect(() => {
+    if (!isUrlSelectionControlled) return
+    if (selection.mode !== 'assignment') {
+      syncedStudentUrlKeyRef.current = null
+      return
+    }
+
+    const nextStudentId = parseAssignmentWorkspaceStudentId(selectedAssignmentStudentId ?? null)
+    const syncKey = `${selection.assignmentId}:${nextStudentId ?? 'none'}`
+    if (syncedStudentUrlKeyRef.current === syncKey) return
+
+    if (nextStudentId && !currentStudentRows.some((student) => student.student_id === nextStudentId)) {
+      if (selectedAssignmentLoading || currentStudentRows.length === 0) return
+      syncedStudentUrlKeyRef.current = syncKey
+      defaultedWorkspaceKeyRef.current = null
+      setSelectedStudentId(null)
+      updateSearchParams?.((params) => {
+        params.delete('assignmentStudentId')
+      }, { replace: true })
+      return
+    }
+
+    syncedStudentUrlKeyRef.current = syncKey
+    defaultedWorkspaceKeyRef.current = null
+    setSelectedStudentId(nextStudentId)
+  }, [
+    currentStudentRows,
+    isUrlSelectionControlled,
+    selectedAssignmentLoading,
+    selectedAssignmentStudentId,
+    selection,
+    updateSearchParams,
+  ])
 
   useEffect(() => {
     if (selection.mode !== 'assignment' || !activeSelectedStudentId) return
@@ -1035,7 +1057,7 @@ export function TeacherClassroomView({
       const nextStudentId = resolveDetailsStudentId()
       if (!nextStudentId) return
       setIndividualHeaderMeta(null)
-      setSelectedStudentId(nextStudentId)
+      setSelectedStudentAndNavigate(nextStudentId, { replace: true })
     } else {
       setIndividualHeaderMeta(null)
     }
@@ -1046,6 +1068,7 @@ export function TeacherClassroomView({
     assignmentGradingLayout,
     assignmentWorkspaceMode,
     resolveDetailsStudentId,
+    setSelectedStudentAndNavigate,
     updateModeLayout,
   ])
 
@@ -1063,7 +1086,7 @@ export function TeacherClassroomView({
     const nextStudentId = resolveDetailsStudentId()
     if (nextStudentId) {
       defaultedWorkspaceKeyRef.current = workspaceKey
-      setSelectedStudentId(nextStudentId)
+      setSelectedStudentAndNavigate(nextStudentId, { replace: true })
     }
   }, [
     activeSelectedAssignmentData,
@@ -1071,6 +1094,7 @@ export function TeacherClassroomView({
     assignmentWorkspaceMode,
     resolveDetailsStudentId,
     selectedAssignmentLoading,
+    setSelectedStudentAndNavigate,
     selection,
   ])
 
@@ -1081,13 +1105,13 @@ export function TeacherClassroomView({
 
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        setSelectedStudentId(null)
+        setSelectedStudentAndNavigate(null)
       }
     }
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [assignmentWorkspaceMode, selectedStudentId])
+  }, [assignmentWorkspaceMode, selectedStudentId, setSelectedStudentAndNavigate])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
@@ -1199,207 +1223,173 @@ export function TeacherClassroomView({
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
     : `Starting grading for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
 
-  function handleOverviewInspectorResizeStart(event: React.PointerEvent<HTMLDivElement>) {
-    if (!workspaceContainerRef.current) return
-
-    event.preventDefault()
-    const { right, width } = workspaceContainerRef.current.getBoundingClientRect()
-    if (width <= 0) return
-
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
-      updateModeLayout('overview', (current) => ({
-        ...current,
-        inspectorCollapsed: false,
-        inspectorWidth: nextInspectorWidth,
-      }))
-    }
-
-    const handlePointerUp = () => {
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
-    }
-
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-  }
-
-  function handleOverviewInspectorResizeReset() {
-    updateModeLayout('overview', (current) => ({
-      ...current,
-      inspectorCollapsed: false,
-      inspectorWidth: 50,
-    }))
-  }
+  const studentBusyOverlay = showAssignmentAiRunOverlay || isArtifactRepoAnalyzing || isReturning ? (
+    <div className="absolute inset-0 z-10 flex items-start justify-center rounded-md bg-surface/70 px-4 pt-4">
+      <div className="flex max-w-[24rem] flex-col gap-1 rounded-2xl border border-border bg-surface px-3 py-2 text-xs leading-tight text-text-muted shadow-sm sm:max-w-[28rem] sm:text-sm">
+        <div className="flex items-center gap-2">
+          <Spinner />
+          <span>
+            {showAssignmentAiRunOverlay
+              ? assignmentAiRunOverlayLabel
+              : isArtifactRepoAnalyzing
+                ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+                : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
+          </span>
+        </div>
+        {showAssignmentAiRunOverlay ? (
+          <p className="pl-6 text-[11px] leading-tight text-text-muted sm:text-xs">
+            {ASSIGNMENT_AI_GRADING_RUN_NOTE}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  ) : null
 
   const studentTable = (
-    <div className="flex h-full min-h-0 flex-col">
-      <KeyboardNavigableTable
-        ref={tableContainerRef}
-        rowKeys={currentStudentRows.map((student) => student.student_id)}
-        selectedKey={activeSelectedStudentId}
-        onSelectKey={setSelectedStudentId}
-        onDeselect={() => setSelectedStudentId(null)}
-      >
-        <TableCard chrome="flush">
-          {selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError) ? (
-            <div className="flex justify-center py-10">
-              <Spinner />
-            </div>
-          ) : selectedAssignmentError ? (
-            <div className="p-4 text-sm text-danger">
-              {selectedAssignmentError}
-            </div>
-          ) : (
-            <div className="relative">
-              {(showAssignmentAiRunOverlay || isArtifactRepoAnalyzing || isReturning) && (
-                <div className="absolute inset-0 z-10 flex items-start justify-center rounded-md bg-surface/70 px-4 pt-4">
-                  <div className="flex max-w-[24rem] flex-col gap-1 rounded-2xl border border-border bg-surface px-3 py-2 text-xs leading-tight text-text-muted shadow-sm sm:max-w-[28rem] sm:text-sm">
-                    <div className="flex items-center gap-2">
-                      <Spinner />
-                      <span>
-                        {showAssignmentAiRunOverlay
-                          ? assignmentAiRunOverlayLabel
-                          : isArtifactRepoAnalyzing
-                            ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                            : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
-                      </span>
-                    </div>
-                    {showAssignmentAiRunOverlay ? (
-                      <p className="pl-6 text-[11px] leading-tight text-text-muted sm:text-xs">
-                        {ASSIGNMENT_AI_GRADING_RUN_NOTE}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              )}
-              <DataTable density={showOverviewInspector ? 'tight' : 'compact'}>
-                <DataTableHead>
-                  <DataTableRow>
-                    <DataTableHeaderCell className="w-10">
-                      <input
-                        type="checkbox"
-                        checked={batchAllSelected}
-                        onChange={batchToggleSelectAll}
-                        onClick={(e) => e.stopPropagation()}
-                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                        aria-label="Select all students"
-                      />
-                    </DataTableHeaderCell>
-                    <SortableHeaderCell
-                      label="First Name"
-                      isActive={sortColumn === 'first'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('first')}
-                      className="w-[7rem]"
-                    />
-                    <SortableHeaderCell
-                      label="Last Name"
-                      isActive={sortColumn === 'last'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('last')}
-                      className="w-[7rem]"
-                    />
-                    <SortableHeaderCell
-                      label="Status"
-                      isActive={sortColumn === 'status'}
-                      direction={sortDirection}
-                      onClick={() => toggleSort('status')}
-                      className="w-[4.5rem]"
-                    />
-                    <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
-                    <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
-                  </DataTableRow>
-                </DataTableHead>
-                <DataTableBody>
-                  {currentStudentRows.map((student) => {
-                    const isSelected = activeSelectedStudentId === student.student_id
-                    const totalScore =
-                      student.doc?.score_completion != null &&
-                      student.doc?.score_thinking != null &&
-                      student.doc?.score_workflow != null
-                        ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
-                        : null
-                    const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
-                      graded_at: student.doc.graded_at ?? null,
-                      score_completion: student.doc.score_completion ?? null,
-                      score_thinking: student.doc.score_thinking ?? null,
-                      score_workflow: student.doc.score_workflow ?? null,
-                    } : null)
-                    const wasLate = !!(
-                      student.doc?.submitted_at &&
-                      dueAtMs &&
-                      new Date(student.doc.submitted_at).getTime() > dueAtMs
-                    )
+    <TeacherAssignmentStudentTable
+      rows={currentStudentRows}
+      selectedStudentId={activeSelectedStudentId}
+      onSelectStudent={(studentId) => {
+        if (assignmentWorkspaceMode === 'details') {
+          setIndividualHeaderMeta(null)
+        }
+        setSelectedStudentAndNavigate(studentId)
+      }}
+      onDeselectStudent={() => setSelectedStudentAndNavigate(null)}
+      tableRef={tableContainerRef}
+      selectedIds={batchSelectedIds}
+      onToggleSelect={batchToggleSelect}
+      onToggleSelectAll={batchToggleSelectAll}
+      allSelected={batchAllSelected}
+      sortColumn={sortColumn}
+      sortDirection={sortDirection}
+      onToggleSort={toggleSort}
+      dueAtMs={dueAtMs}
+      density={showOverviewInspector ? 'tight' : 'compact'}
+      loading={selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError)}
+      error={selectedAssignmentError}
+      busyOverlay={studentBusyOverlay}
+    />
+  )
 
-                    return (
-                      <DataTableRow
-                        key={student.student_id}
-                        className={getRowClassName(isSelected)}
-                        onClick={() => {
-                          if (assignmentWorkspaceMode === 'details') {
-                            setIndividualHeaderMeta(null)
-                          }
-                          setSelectedStudentId(student.student_id)
-                        }}
-                      >
-                        <DataTableCell>
-                          <input
-                            type="checkbox"
-                            checked={batchSelectedIds.has(student.student_id)}
-                            onChange={() => batchToggleSelect(student.student_id)}
-                            onClick={(e) => e.stopPropagation()}
-                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                            aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
-                          />
-                        </DataTableCell>
-                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
-                          {student.student_first_name ? (
-                            <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
-                              <span>{student.student_first_name}</span>
-                            </Tooltip>
-                          ) : '—'}
-                        </DataTableCell>
-                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
-                          {student.student_last_name ? (
-                            <Tooltip content={student.student_last_name}>
-                              <span>{student.student_last_name}</span>
-                            </Tooltip>
-                          ) : '—'}
-                        </DataTableCell>
-                        <DataTableCell className="w-[4.5rem]">
-                          <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                            <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                              <StatusIcon
-                                status={student.status}
-                                wasLate={wasLate}
-                                hasDraftGrade={hasDraftGrade}
-                              />
-                            </span>
-                          </Tooltip>
-                        </DataTableCell>
-                        <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
-                          {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
-                        </DataTableCell>
-                        <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
-                          <AssignmentArtifactsCell
-                            artifacts={student.artifacts || []}
-                            isCompact={showOverviewInspector}
-                          />
-                        </DataTableCell>
-                      </DataTableRow>
-                    )
-                  })}
-                  {sortedStudents.length === 0 && (
-                    <EmptyStateRow colSpan={6} message="No students enrolled" />
-                  )}
-                </DataTableBody>
-              </DataTable>
-            </div>
-          )}
-        </TableCard>
-      </KeyboardNavigableTable>
+  const workspaceModeCenter = assignmentWorkspaceMode === 'overview' ? (
+    <>
+      <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
+        <SplitButton
+          label={
+            <span className="inline-flex items-center gap-2">
+              <Check className="h-4 w-4" aria-hidden="true" />
+              <span>AI Grade</span>
+            </span>
+          }
+          onPrimaryClick={() => {
+            void handleBatchAutoGrade()
+          }}
+          options={[
+            {
+              id: 'repo-analysis',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                  <span>Repo analysis</span>
+                </span>
+              ),
+              onSelect: () => {
+                void handleBatchArtifactRepoAnalyze()
+              },
+              disabled: isArtifactRepoAnalyzing || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+            },
+          ]}
+          disabled={isAutoGrading || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
+          className="inline-flex"
+          toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+          menuPlacement="down"
+          primaryButtonProps={{
+            'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+          }}
+        />
+      </Tooltip>
+
+      <Tooltip content={returnTooltipContent}>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="subtle"
+            size="sm"
+            className="px-4"
+            onClick={() => {
+              setShowReturnConfirm(true)
+            }}
+            disabled={isReturnDisabled}
+            aria-label={`Return${workspaceActionLabelSuffix}`}
+          >
+            <Send className="h-4 w-4" aria-hidden="true" />
+            <span>Return</span>
+          </Button>
+        </span>
+      </Tooltip>
+    </>
+  ) : (
+    <>
+      <div
+        className="min-w-0 max-w-[18rem] truncate text-center text-sm font-medium text-text-default"
+        title={selectedStudentDisplayName ?? undefined}
+      >
+        {selectedStudentDisplayName ?? 'No student selected'}
+      </div>
+      {individualCharacterCountLabel && (
+        <div className="shrink-0 text-xs text-text-muted" aria-label={individualCharacterCountLabel}>
+          {individualCharacterCountLabel}
+        </div>
+      )}
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+          onClick={handleGoPrevStudent}
+          disabled={!canGoPrevStudent}
+          aria-label="Previous student"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+          onClick={handleGoNextStudent}
+          disabled={!canGoNextStudent}
+          aria-label="Next student"
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </>
+  )
+
+  const workspaceModeStatus = workspaceLoading ? (
+    <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
+      <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+      <span>Updating</span>
     </div>
+  ) : null
+
+  const workspaceModeTrailing = (
+    <Tooltip content="Edit assignment">
+      <button
+        type="button"
+        className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex max-w-[22rem] items-center gap-2`}
+        onClick={() => {
+          if (activeSelectedAssignmentData) {
+            setEditAssignment(activeSelectedAssignmentData.assignment)
+          }
+        }}
+        disabled={!canEditAssignment}
+        aria-label="Edit assignment"
+        title={selectedAssignmentTitle}
+      >
+        <span className="truncate">{selectedAssignmentTitle}</span>
+        <Pencil className="h-4 w-4 shrink-0" aria-hidden="true" />
+      </button>
+    </Tooltip>
   )
 
   const primaryButtons =
@@ -1415,305 +1405,163 @@ export function TeacherClassroomView({
         <span>New</span>
       </button>
     ) : (
-      <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
-        <div className="mb-[-1px] flex items-end gap-1 self-end">
-          <button
-            type="button"
-            className={[
-              assignmentWorkspaceMode === 'overview'
-                ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-                : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-              'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
-            ].join(' ')}
-            onClick={() => handleSwitchWorkspaceMode('overview')}
-            aria-pressed={assignmentWorkspaceMode === 'overview'}
-          >
-            Class
-          </button>
-          <button
-            type="button"
-            className={[
-              assignmentWorkspaceMode === 'details'
-                ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-                : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-              !canOpenDetails ? 'cursor-not-allowed opacity-50 hover:bg-surface-2 hover:text-text-muted' : '',
-              'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
-            ].join(' ')}
-            onClick={() => handleSwitchWorkspaceMode('details')}
-            aria-pressed={assignmentWorkspaceMode === 'details'}
-            disabled={!canOpenDetails}
-          >
-            Individual
-          </button>
-        </div>
-
-        <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
-          <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
-            {assignmentWorkspaceMode === 'overview' ? (
-              <>
-                <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
-                  <SplitButton
-                    label={
-                      <span className="inline-flex items-center gap-2">
-                        <Check className="h-4 w-4" aria-hidden="true" />
-                        <span>AI Grade</span>
-                      </span>
-                    }
-                    onPrimaryClick={() => {
-                      void handleBatchAutoGrade()
-                    }}
-                    options={[
-                      {
-                        id: 'repo-analysis',
-                        label: (
-                          <span className="inline-flex items-center gap-2">
-                            <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                            <span>Repo analysis</span>
-                          </span>
-                        ),
-                        onSelect: () => {
-                          void handleBatchArtifactRepoAnalyze()
-                        },
-                        disabled: isArtifactRepoAnalyzing || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
-                      },
-                    ]}
-                    disabled={isAutoGrading || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
-                    className="inline-flex"
-                    toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
-                    menuPlacement="down"
-                    primaryButtonProps={{
-                      'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-                    }}
-                  />
-                </Tooltip>
-
-                <Tooltip content={returnTooltipContent}>
-                  <span className="inline-flex">
-                    <Button
-                      type="button"
-                      variant="subtle"
-                      size="sm"
-                      className="px-4"
-                      onClick={() => {
-                        setShowReturnConfirm(true)
-                      }}
-                      disabled={isReturnDisabled}
-                      aria-label={`Return${workspaceActionLabelSuffix}`}
-                    >
-                      <Send className="h-4 w-4" aria-hidden="true" />
-                      <span>Return</span>
-                    </Button>
-                  </span>
-                </Tooltip>
-              </>
-            ) : (
-              <>
-                <div
-                  className="min-w-0 max-w-[18rem] truncate text-center text-sm font-medium text-text-default"
-                  title={selectedStudentDisplayName ?? undefined}
-                >
-                  {selectedStudentDisplayName ?? 'No student selected'}
-                </div>
-                {individualCharacterCountLabel && (
-                  <div className="shrink-0 text-xs text-text-muted" aria-label={individualCharacterCountLabel}>
-                    {individualCharacterCountLabel}
-                  </div>
-                )}
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                    onClick={handleGoPrevStudent}
-                    disabled={!canGoPrevStudent}
-                    aria-label="Previous student"
-                  >
-                    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                    onClick={handleGoNextStudent}
-                    disabled={!canGoNextStudent}
-                    aria-label="Next student"
-                  >
-                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                  </button>
-                </div>
-              </>
-            )}
-
-            {workspaceLoading && (
-              <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
-                <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-                <span>Updating</span>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-1 sm:ml-auto sm:gap-2">
-          <Tooltip content="Edit assignment">
-            <button
-              type="button"
-              className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex max-w-[22rem] items-center gap-2`}
-              onClick={() => {
-                if (activeSelectedAssignmentData) {
-                  setEditAssignment(activeSelectedAssignmentData.assignment)
-                }
-              }}
-              disabled={!canEditAssignment}
-              aria-label="Edit assignment"
-              title={selectedAssignmentTitle}
-            >
-              <span className="truncate">{selectedAssignmentTitle}</span>
-              <Pencil className="h-4 w-4 shrink-0" aria-hidden="true" />
-            </button>
-          </Tooltip>
-        </div>
-      </div>
+      <TeacherWorkSurfaceModeBar
+        modes={[
+          { id: 'overview', label: 'Class' },
+          { id: 'details', label: 'Individual', disabled: !canOpenDetails },
+        ]}
+        activeMode={assignmentWorkspaceMode}
+        onModeChange={(mode) => handleSwitchWorkspaceMode(mode as AssignmentWorkspaceMode)}
+        center={workspaceModeCenter}
+        status={workspaceModeStatus}
+        trailing={workspaceModeTrailing}
+      />
     )
 
   const showMobileToggle = selection.mode === 'summary'
+  const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
+
+  const feedback = (
+    <>
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      )}
+      {info && (
+        <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
+          {info}
+        </div>
+      )}
+    </>
+  )
+
+  const summaryContent = showSummarySpinner ? (
+    <div className="flex justify-center py-8">
+      <Spinner />
+    </div>
+  ) : assignments.length === 0 ? (
+    <div className="py-6 text-center text-sm text-text-muted">
+      No assignments yet
+    </div>
+  ) : (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={assignments.map((assignment) => assignment.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <PageStack>
+          {assignments.map((assignment) => (
+            <SortableAssignmentCard
+              key={assignment.id}
+              assignment={assignment}
+              isReadOnly={isReadOnly}
+              isDragDisabled={isReordering}
+              onSelect={() => {
+                if (assignment.is_draft || isScheduledAssignment(assignment)) {
+                  setEditAssignment(assignment)
+                } else {
+                  setSelectionAndPersist({ mode: 'assignment', assignmentId: assignment.id })
+                }
+              }}
+              onEdit={() => setEditAssignment(assignment)}
+              onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
+            />
+          ))}
+        </PageStack>
+      </SortableContext>
+    </DndContext>
+  )
+
+  const workspaceContent = selectedAssignmentId == null ? null : assignmentWorkspaceMode === 'details' ? (
+    activeSelectedStudentId ? (
+      <TeacherStudentWorkPanel
+        classroomId={classroom.id}
+        assignmentId={selectedAssignmentId}
+        studentId={activeSelectedStudentId}
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={activeWorkspaceLayout.inspectorWidth}
+        totalWidth={workspaceWidth}
+        onLayoutChange={(next) => updateModeLayout('details', next)}
+        onLoadingStateChange={setWorkspaceLoading}
+        onGoPrevStudent={handleGoPrevStudent}
+        onGoNextStudent={handleGoNextStudent}
+        canGoPrevStudent={canGoPrevStudent}
+        canGoNextStudent={canGoNextStudent}
+        onDetailsMetaChange={setIndividualHeaderMeta}
+      />
+    ) : selectedAssignmentLoading || (!activeSelectedAssignmentData && !selectedAssignmentError) ? (
+      <div className="flex flex-1 items-center justify-center py-12">
+        <Spinner />
+      </div>
+    ) : selectedAssignmentError ? (
+      <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
+        {selectedAssignmentError}
+      </div>
+    ) : (
+      <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
+        No student submissions yet.
+      </div>
+    )
+  ) : showOverviewInspector ? (
+    <TeacherWorkspaceSplit
+      className="flex-1"
+      primaryClassName="min-h-0"
+      inspectorClassName="min-h-0"
+      inspectorCollapsed={false}
+      inspectorWidth={activeWorkspaceLayout.inspectorWidth}
+      minInspectorPx={ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx}
+      minPrimaryPx={ASSIGNMENT_GRADING_LAYOUT.overviewPrimaryMinPx}
+      onInspectorCollapsedChange={(collapsed) => {
+        updateModeLayout('overview', (current) => ({
+          ...current,
+          inspectorCollapsed: collapsed,
+        }))
+      }}
+      onInspectorWidthChange={(nextInspectorWidth) => {
+        updateModeLayout('overview', (current) => ({
+          ...current,
+          inspectorCollapsed: false,
+          inspectorWidth: nextInspectorWidth,
+        }))
+      }}
+      dividerLabel="Resize table and grading panes"
+      primary={studentTable}
+      inspector={
+        <TeacherStudentWorkPanel
+          classroomId={classroom.id}
+          assignmentId={selectedAssignmentId}
+          studentId={activeSelectedStudentId}
+          mode="overview"
+          inspectorCollapsed={false}
+          inspectorWidth={activeWorkspaceLayout.inspectorWidth}
+          totalWidth={workspaceWidth}
+          onLoadingStateChange={setWorkspaceLoading}
+        />
+      }
+    />
+  ) : (
+    studentTable
+  )
 
   return (
-    <PageLayout className="flex h-full min-h-0 flex-col">
-      <PageActionBar
+    <>
+      <TeacherWorkSurfaceShell
+        state={selection.mode === 'summary' ? 'summary' : 'workspace'}
         primary={primaryButtons}
         actions={[]}
         trailing={showMobileToggle ? <RightSidebarToggle /> : undefined}
-        className={selection.mode === 'summary' ? '' : 'pl-0 pr-2'}
+        feedback={feedback}
+        summary={summaryContent}
+        workspace={workspaceContent}
+        workspaceFrame="attachedTabs"
+        workspaceRef={workspaceContainerRef}
       />
-
-      <PageContent
-        className={
-          selection.mode === 'summary'
-            ? 'flex flex-col gap-3'
-            : 'px-0 flex min-h-0 flex-1 flex-col gap-3 pt-0'
-        }
-      >
-        {error && (
-          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-            {error}
-          </div>
-        )}
-        {info && (
-          <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
-            {info}
-          </div>
-        )}
-
-        {selection.mode === 'summary' ? (
-          <div>
-            {showSummarySpinner ? (
-              <div className="flex justify-center py-8">
-                <Spinner />
-              </div>
-            ) : assignments.length === 0 ? (
-              <div className="py-6 text-center text-sm text-text-muted">
-                No assignments yet
-              </div>
-            ) : (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={assignments.map((assignment) => assignment.id)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <PageStack>
-                    {assignments.map((assignment) => (
-                      <SortableAssignmentCard
-                        key={assignment.id}
-                        assignment={assignment}
-                        isReadOnly={isReadOnly}
-                        isDragDisabled={isReordering}
-                        onSelect={() => {
-                          if (assignment.is_draft || isScheduledAssignment(assignment)) {
-                            setEditAssignment(assignment)
-                          } else {
-                            setSelectionAndPersist({ mode: 'assignment', assignmentId: assignment.id })
-                          }
-                        }}
-                        onEdit={() => setEditAssignment(assignment)}
-                        onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
-                      />
-                    ))}
-                  </PageStack>
-                </SortableContext>
-              </DndContext>
-            )}
-          </div>
-        ) : (
-          <div className="flex min-h-0 flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
-            <div
-              ref={workspaceContainerRef}
-              className="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
-            >
-              {assignmentWorkspaceMode === 'details' ? (
-                activeSelectedStudentId ? (
-                  <TeacherStudentWorkPanel
-                    classroomId={classroom.id}
-                    assignmentId={selection.assignmentId}
-                    studentId={activeSelectedStudentId}
-                    mode="details"
-                    inspectorCollapsed={false}
-                    inspectorWidth={activeWorkspaceLayout.inspectorWidth}
-                    totalWidth={workspaceWidth}
-                    onLayoutChange={(next) => updateModeLayout('details', next)}
-                    onLoadingStateChange={setWorkspaceLoading}
-                    onGoPrevStudent={handleGoPrevStudent}
-                    onGoNextStudent={handleGoNextStudent}
-                    canGoPrevStudent={canGoPrevStudent}
-                    canGoNextStudent={canGoNextStudent}
-                    onDetailsMetaChange={setIndividualHeaderMeta}
-                  />
-                ) : selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError) ? (
-                  <div className="flex flex-1 items-center justify-center py-12">
-                    <Spinner />
-                  </div>
-                ) : selectedAssignmentError ? (
-                  <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
-                    {selectedAssignmentError}
-                  </div>
-                ) : (
-                  <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
-                    No student submissions yet.
-                  </div>
-                )
-              ) : showOverviewInspector ? (
-                <SummaryDetailWorkspaceShell
-                  className="flex-1"
-                  orientation="responsive"
-                  leftPaneClassName="min-h-0"
-                  rightPaneClassName="min-h-0"
-                  rightWidthPercent={isDesktop ? activeWorkspaceLayout.inspectorWidth : undefined}
-                  divider={{
-                    label: 'Resize table and grading panes',
-                    onPointerDown: handleOverviewInspectorResizeStart,
-                    onDoubleClick: handleOverviewInspectorResizeReset,
-                  }}
-                  left={studentTable}
-                  right={
-                    <TeacherStudentWorkPanel
-                      classroomId={classroom.id}
-                      assignmentId={selection.assignmentId}
-                      studentId={activeSelectedStudentId}
-                      mode="overview"
-                      inspectorCollapsed={false}
-                      inspectorWidth={activeWorkspaceLayout.inspectorWidth}
-                      totalWidth={workspaceWidth}
-                      onLoadingStateChange={setWorkspaceLoading}
-                    />
-                  }
-                />
-              ) : (
-                studentTable
-              )}
-            </div>
-          </div>
-        )}
 
       <ConfirmDialog
         isOpen={!!pendingDelete}
@@ -1763,8 +1611,7 @@ export function TeacherClassroomView({
           setIsCreateModalOpen(false)
         }}
       />
-      </PageContent>
-    </PageLayout>
+    </>
   )
 }
 

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -15,6 +15,7 @@ import type { Classroom, LessonPlan, TiptapContent, Assignment, Announcement } f
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
 import { normalizeLessonPlanMarkdown } from '@/lib/lesson-plan-content'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 
 /**
  * Returns true if the content change is identical to the last value emitted
@@ -47,7 +48,7 @@ export interface CalendarSidebarState {
 interface Props {
   classroom: Classroom
   onSidebarStateChange?: (state: CalendarSidebarState | null) => void
-  onNavigateToAssignments?: () => void
+  onNavigateToAssignments?: (assignmentId?: string | null) => void
   onNavigateToAnnouncements?: () => void
 }
 
@@ -166,8 +167,15 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     async function loadAssignments() {
       try {
-        const res = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`)
-        const data = await res.json()
+        const data = await fetchJSONWithCache<{ assignments?: Assignment[] }>(
+          `teacher-assignments:${classroom.id}`,
+          async () => {
+            const res = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`)
+            if (!res.ok) throw new Error('Failed to load assignments')
+            return res.json()
+          },
+          20_000,
+        )
         setAssignments(data.assignments || [])
       } catch (err) {
         console.error('Error loading assignments:', err)
@@ -179,6 +187,7 @@ export function TeacherLessonCalendarTab({
     const handleAssignmentsUpdated = (e: Event) => {
       const detail = (e as CustomEvent).detail
       if (!detail?.classroomId || detail.classroomId === classroom.id) {
+        invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
         loadAssignments()
       }
     }
@@ -192,8 +201,15 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     async function loadAnnouncements() {
       try {
-        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
-        const data = await res.json()
+        const data = await fetchJSONWithCache<{ announcements?: Announcement[] }>(
+          `teacher-announcements:${classroom.id}`,
+          async () => {
+            const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
+            if (!res.ok) throw new Error('Failed to load announcements')
+            return res.json()
+          },
+          20_000,
+        )
         setAnnouncements(data.announcements || [])
       } catch (err) {
         console.error('Error loading announcements:', err)
@@ -438,7 +454,7 @@ export function TeacherLessonCalendarTab({
           detail: { classroomId: classroom.id, value: assignment.id },
         })
       )
-      onNavigateToAssignments()
+      onNavigateToAssignments(assignment.id)
     },
     [onNavigateToAssignments, classroom.id]
   )

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
-import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
@@ -14,8 +14,6 @@ import {
   type AssignmentWorkspacePaneLayout,
 } from '@/lib/assignment-grading-layout'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
-import { useWindowSize } from '@/hooks/use-window-size'
-import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 
 interface TeacherStudentWorkPanelProps {
   classroomId: string
@@ -54,7 +52,6 @@ export function TeacherStudentWorkPanel({
   canGoNextStudent = false,
   onDetailsMetaChange,
 }: TeacherStudentWorkPanelProps) {
-  const workspaceRef = useRef<HTMLDivElement | null>(null)
   const {
     data,
     error,
@@ -100,8 +97,6 @@ export function TeacherStudentWorkPanel({
     studentId,
     onLoadingStateChange,
   })
-  const { width: viewportWidth } = useWindowSize()
-  const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
   const layout = useMemo(
     () =>
       clampAssignmentWorkspacePaneLayout(
@@ -125,42 +120,6 @@ export function TeacherStudentWorkPanel({
     },
     [onLayoutChange],
   )
-
-  const handleInspectorResizeStart = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (!workspaceRef.current) return
-
-      event.preventDefault()
-      const { right, width } = workspaceRef.current.getBoundingClientRect()
-      if (width <= 0) return
-
-      const handlePointerMove = (moveEvent: PointerEvent) => {
-        const nextInspectorWidth = ((right - moveEvent.clientX) / width) * 100
-        updateLayout((current) => ({
-          ...current,
-          inspectorCollapsed: false,
-          inspectorWidth: nextInspectorWidth,
-        }))
-      }
-
-      const handlePointerUp = () => {
-        window.removeEventListener('pointermove', handlePointerMove)
-        window.removeEventListener('pointerup', handlePointerUp)
-      }
-
-      window.addEventListener('pointermove', handlePointerMove)
-      window.addEventListener('pointerup', handlePointerUp)
-    },
-    [updateLayout],
-  )
-
-  const handleInspectorResizeReset = useCallback(() => {
-    updateLayout((current) => ({
-      ...current,
-      inspectorCollapsed: false,
-      inspectorWidth: 50,
-    }))
-  }, [updateLayout])
 
   useEffect(() => {
     if (mode !== 'details' || showInitialSpinner || error || !data) {
@@ -198,9 +157,6 @@ export function TeacherStudentWorkPanel({
   }
 
   const displayContent = previewContent || data.doc?.content
-  const studentDisplayName = data.student.name?.trim() || data.student.email
-  const characterCount =
-    displayContent && !isEmpty(displayContent) ? countCharacters(displayContent) : 0
   const inspector = (
     <TeacherWorkInspector
       data={data}
@@ -246,55 +202,59 @@ export function TeacherStudentWorkPanel({
   }
 
   return (
-    <div ref={workspaceRef} className="relative flex h-full min-h-0 flex-col">
-      <SummaryDetailWorkspaceShell
-        className="flex-1"
-        orientation="responsive"
-        leftPaneClassName={`flex min-h-0 flex-col ${
-          previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
-        }`}
-        rightVisible={!layout.inspectorCollapsed}
-        rightPaneClassName="flex min-h-0 flex-col"
-        rightWidthPercent={!layout.inspectorCollapsed && isDesktop ? layout.inspectorWidth : undefined}
-        divider={
-          layout.inspectorCollapsed
-            ? undefined
-            : {
-                label: 'Resize content and grading panes',
-                onPointerDown: handleInspectorResizeStart,
-                onDoubleClick: handleInspectorResizeReset,
-              }
-        }
-        left={
-          <>
-            {previewEntry && (
-              <div
-                data-testid="individual-content-header"
-                className="border-b border-border bg-surface px-4 py-2 text-sm"
-              >
-                <div className="text-xs font-medium text-primary">
-                  Previewing save from{' '}
-                  {formatInTimeZone(
-                    new Date(previewEntry.created_at),
-                    'America/Toronto',
-                    'MMM d, h:mm a',
-                  )}
-                </div>
+    <TeacherWorkspaceSplit
+      className="flex-1"
+      primaryClassName={`flex min-h-0 flex-col ${
+        previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
+      }`}
+      inspectorClassName="flex min-h-0 flex-col"
+      inspectorCollapsed={layout.inspectorCollapsed}
+      inspectorWidth={layout.inspectorWidth}
+      minInspectorPx={ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx}
+      minPrimaryPx={ASSIGNMENT_GRADING_LAYOUT.detailsPrimaryMinPx}
+      onInspectorCollapsedChange={(collapsed) => {
+        updateLayout((current) => ({
+          ...current,
+          inspectorCollapsed: collapsed,
+        }))
+      }}
+      onInspectorWidthChange={(nextInspectorWidth) => {
+        updateLayout((current) => ({
+          ...current,
+          inspectorCollapsed: false,
+          inspectorWidth: nextInspectorWidth,
+        }))
+      }}
+      dividerLabel="Resize content and grading panes"
+      primary={
+        <>
+          {previewEntry && (
+            <div
+              data-testid="individual-content-header"
+              className="border-b border-border bg-surface px-4 py-2 text-sm"
+            >
+              <div className="text-xs font-medium text-primary">
+                Previewing save from{' '}
+                {formatInTimeZone(
+                  new Date(previewEntry.created_at),
+                  'America/Toronto',
+                  'MMM d, h:mm a',
+                )}
               </div>
-            )}
-            {displayContent && !isEmpty(displayContent) ? (
-              <div className="min-h-0 flex-1 overflow-auto">
-                <RichTextViewer content={displayContent} fillHeight chrome="flush" />
-              </div>
-            ) : (
-              <div className="flex h-32 items-center justify-center text-text-muted">
-                No work submitted yet
-              </div>
-            )}
-          </>
-        }
-        right={inspector}
-      />
-    </div>
+            </div>
+          )}
+          {displayContent && !isEmpty(displayContent) ? (
+            <div className="min-h-0 flex-1 overflow-auto">
+              <RichTextViewer content={displayContent} fillHeight chrome="flush" />
+            </div>
+          ) : (
+            <div className="flex h-32 items-center justify-center text-text-muted">
+              No work submitted yet
+            </div>
+          )}
+        </>
+      }
+      inspector={inspector}
+    />
   )
 }

--- a/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
+++ b/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import type { ReactNode, Ref } from 'react'
+import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
+import {
+  AssessmentStatusIcon,
+  type AssessmentStatusIconState,
+} from '@/components/AssessmentStatusIcon'
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCell,
+  DataTableHead,
+  DataTableHeaderCell,
+  DataTableRow,
+  EmptyStateRow,
+  KeyboardNavigableTable,
+  SortableHeaderCell,
+  TableCard,
+} from '@/components/DataTable'
+import { Spinner } from '@/components/Spinner'
+import { Tooltip } from '@/ui'
+import {
+  getAssignmentStatusLabel,
+  hasDraftSavedGrade,
+} from '@/lib/assignments'
+import type { AssignmentStatus } from '@/types'
+import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
+import type { SortDirection } from '@/lib/table-sort'
+
+export interface TeacherAssignmentStudentRow {
+  student_id: string
+  student_email: string
+  student_first_name: string | null
+  student_last_name: string | null
+  status: AssignmentStatus
+  student_updated_at?: string | null
+  artifacts: AssignmentArtifact[]
+  doc: {
+    is_submitted?: boolean | null
+    submitted_at?: string | null
+    updated_at?: string | null
+    score_completion?: number | null
+    score_thinking?: number | null
+    score_workflow?: number | null
+    graded_at?: string | null
+    returned_at?: string | null
+    teacher_cleared_at?: string | null
+    feedback_returned_at?: string | null
+  } | null
+}
+
+interface TeacherAssignmentStudentTableProps {
+  rows: TeacherAssignmentStudentRow[]
+  selectedStudentId: string | null
+  onSelectStudent: (studentId: string) => void
+  onDeselectStudent: () => void
+  tableRef?: Ref<HTMLDivElement>
+  selectedIds: Set<string>
+  onToggleSelect: (studentId: string) => void
+  onToggleSelectAll: () => void
+  allSelected: boolean
+  sortColumn: 'first' | 'last' | 'status'
+  sortDirection: SortDirection
+  onToggleSort: (column: 'first' | 'last' | 'status') => void
+  dueAtMs: number
+  density: 'tight' | 'compact'
+  loading: boolean
+  error: string
+  emptyMessage?: string
+  busyOverlay?: ReactNode
+}
+
+function getRowClassName(isSelected: boolean): string {
+  if (isSelected) {
+    return 'cursor-pointer border-l-2 border-l-primary bg-surface-selected shadow-sm'
+  }
+  return 'cursor-pointer hover:bg-surface-hover'
+}
+
+function StatusIcon({
+  status,
+  wasLate,
+  hasDraftGrade = false,
+}: {
+  status: AssignmentStatus
+  wasLate?: boolean
+  hasDraftGrade?: boolean
+}) {
+  const showLate =
+    status === 'in_progress_late' ||
+    status === 'submitted_late' ||
+    ((status === 'graded' || status === 'returned' || status === 'resubmitted') && wasLate)
+
+  let iconState: AssessmentStatusIconState
+  switch (status) {
+    case 'not_started':
+      iconState = 'not_started'
+      break
+    case 'in_progress':
+    case 'in_progress_late':
+      iconState = 'in_progress'
+      break
+    case 'submitted_on_time':
+    case 'submitted_late':
+      iconState = hasDraftGrade ? 'draft_graded' : 'submitted'
+      break
+    case 'graded':
+      iconState = 'graded'
+      break
+    case 'returned':
+      iconState = 'returned'
+      break
+    case 'resubmitted':
+      iconState = 'resubmitted'
+      break
+    default:
+      iconState = 'not_started'
+  }
+
+  return <AssessmentStatusIcon state={iconState} late={showLate} />
+}
+
+function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLate: boolean): string {
+  const baseLabel = getAssignmentStatusLabel(status)
+  if (!wasLate) return baseLabel
+
+  if (status === 'graded' || status === 'returned' || status === 'resubmitted') {
+    return `${baseLabel} (late)`
+  }
+
+  return baseLabel
+}
+
+export function TeacherAssignmentStudentTable({
+  rows,
+  selectedStudentId,
+  onSelectStudent,
+  onDeselectStudent,
+  tableRef,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
+  allSelected,
+  sortColumn,
+  sortDirection,
+  onToggleSort,
+  dueAtMs,
+  density,
+  loading,
+  error,
+  emptyMessage = 'No students enrolled',
+  busyOverlay,
+}: TeacherAssignmentStudentTableProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <KeyboardNavigableTable
+        ref={tableRef}
+        rowKeys={rows.map((student) => student.student_id)}
+        selectedKey={selectedStudentId}
+        onSelectKey={onSelectStudent}
+        onDeselect={onDeselectStudent}
+      >
+        <TableCard chrome="flush">
+          {loading ? (
+            <div className="flex justify-center py-10">
+              <Spinner />
+            </div>
+          ) : error ? (
+            <div className="p-4 text-sm text-danger">
+              {error}
+            </div>
+          ) : (
+            <div className="relative">
+              {busyOverlay}
+              <DataTable density={density}>
+                <DataTableHead>
+                  <DataTableRow>
+                    <DataTableHeaderCell className="w-10">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={onToggleSelectAll}
+                        onClick={(event) => event.stopPropagation()}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                        aria-label="Select all students"
+                      />
+                    </DataTableHeaderCell>
+                    <SortableHeaderCell
+                      label="First Name"
+                      isActive={sortColumn === 'first'}
+                      direction={sortDirection}
+                      onClick={() => onToggleSort('first')}
+                      className="w-[7rem]"
+                    />
+                    <SortableHeaderCell
+                      label="Last Name"
+                      isActive={sortColumn === 'last'}
+                      direction={sortDirection}
+                      onClick={() => onToggleSort('last')}
+                      className="w-[7rem]"
+                    />
+                    <SortableHeaderCell
+                      label="Status"
+                      isActive={sortColumn === 'status'}
+                      direction={sortDirection}
+                      onClick={() => onToggleSort('status')}
+                      className="w-[4.5rem]"
+                    />
+                    <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
+                    <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {rows.map((student) => {
+                    const isSelected = selectedStudentId === student.student_id
+                    const totalScore =
+                      student.doc?.score_completion != null &&
+                      student.doc?.score_thinking != null &&
+                      student.doc?.score_workflow != null
+                        ? student.doc.score_completion + student.doc.score_thinking + student.doc.score_workflow
+                        : null
+                    const hasDraftGrade = hasDraftSavedGrade(student.doc ? {
+                      graded_at: student.doc.graded_at ?? null,
+                      score_completion: student.doc.score_completion ?? null,
+                      score_thinking: student.doc.score_thinking ?? null,
+                      score_workflow: student.doc.score_workflow ?? null,
+                    } : null)
+                    const wasLate = !!(
+                      student.doc?.submitted_at &&
+                      dueAtMs &&
+                      new Date(student.doc.submitted_at).getTime() > dueAtMs
+                    )
+
+                    return (
+                      <DataTableRow
+                        key={student.student_id}
+                        className={getRowClassName(isSelected)}
+                        onClick={() => onSelectStudent(student.student_id)}
+                      >
+                        <DataTableCell>
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(student.student_id)}
+                            onChange={() => onToggleSelect(student.student_id)}
+                            onClick={(event) => event.stopPropagation()}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
+                          />
+                        </DataTableCell>
+                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                          {student.student_first_name ? (
+                            <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
+                              <span>{student.student_first_name}</span>
+                            </Tooltip>
+                          ) : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                          {student.student_last_name ? (
+                            <Tooltip content={student.student_last_name}>
+                              <span>{student.student_last_name}</span>
+                            </Tooltip>
+                          ) : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[4.5rem]">
+                          <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                            <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                              <StatusIcon
+                                status={student.status}
+                                wasLate={wasLate}
+                                hasDraftGrade={hasDraftGrade}
+                              />
+                            </span>
+                          </Tooltip>
+                        </DataTableCell>
+                        <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
+                          {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
+                        </DataTableCell>
+                        <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
+                          <AssignmentArtifactsCell
+                            artifacts={student.artifacts || []}
+                            isCompact={density === 'tight'}
+                          />
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
+                  {rows.length === 0 && (
+                    <EmptyStateRow colSpan={6} message={emptyMessage} />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </div>
+          )}
+        </TableCard>
+      </KeyboardNavigableTable>
+    </div>
+  )
+}

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -183,9 +183,14 @@ export function NavItems({
     setAssignmentsExpanded(cookieValue !== 'collapsed')
   }, [classroomId, role])
 
-  // Load teacher assignment selection from cookie
+  // Teacher assignment selection is URL-backed when the assignments tab is active.
   useEffect(() => {
     if (role !== 'teacher') return
+    if (activeTab === 'assignments') {
+      setActiveAssignmentId(assignmentId)
+      return
+    }
+
     const selectionCookieName = `teacherAssignmentsSelection:${classroomId}`
     const selection = readCookie(selectionCookieName)
     if (!selection || selection === 'summary') {
@@ -193,7 +198,7 @@ export function NavItems({
       return
     }
     setActiveAssignmentId(selection)
-  }, [classroomId, role, activeTab])
+  }, [activeTab, assignmentId, classroomId, role])
 
   // Student assignment selection from URL
   useEffect(() => {
@@ -276,11 +281,20 @@ export function NavItems({
     writeCookie(`pika_sidebar_assignments:${classroomId}`, next ? 'expanded' : 'collapsed')
   }
 
-  function setAssignmentsSelectionCookie(assignmentId: string | null) {
+  function setTeacherAssignmentsSelection(assignmentId: string | null) {
     const name = `teacherAssignmentsSelection:${classroomId}`
     const value = assignmentId ? assignmentId : 'summary'
     writeCookie(name, value)
     setActiveAssignmentId(assignmentId)
+    updateSearchParams((params) => {
+      params.set('tab', 'assignments')
+      if (assignmentId) {
+        params.set('assignmentId', assignmentId)
+      } else {
+        params.delete('assignmentId')
+      }
+      params.delete('assignmentStudentId')
+    })
     window.dispatchEvent(
       new CustomEvent(TEACHER_ASSIGNMENTS_SELECTION_EVENT, {
         detail: { classroomId, value },
@@ -297,6 +311,7 @@ export function NavItems({
       } else {
         params.delete('assignmentId')
       }
+      params.delete('assignmentStudentId')
     })
   }
 
@@ -412,7 +427,7 @@ export function NavItems({
                 onClick={(event) => {
                   event.preventDefault()
                   onTabChange('assignments')
-                  setAssignmentsSelectionCookie(null)
+                  setTeacherAssignmentsSelection(null)
                   onNavigate()
                 }}
                 onMouseEnter={() => handleTabIntent('assignments')}
@@ -463,7 +478,7 @@ export function NavItems({
                         <button
                           type="button"
                           onClick={() => {
-                            setAssignmentsSelectionCookie(assignment.id)
+                            setTeacherAssignmentsSelection(assignment.id)
                             onTabChange('assignments')
                             onNavigate()
                           }}

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceModeBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceModeBar.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import type { KeyboardEvent, ReactNode } from 'react'
+import { useId } from 'react'
+
+export interface TeacherWorkSurfaceMode<TMode extends string = string> {
+  id: TMode
+  label: ReactNode
+  disabled?: boolean
+}
+
+interface TeacherWorkSurfaceModeBarProps<TMode extends string = string> {
+  modes: readonly TeacherWorkSurfaceMode<TMode>[]
+  activeMode: TMode
+  onModeChange: (mode: TMode) => void
+  center?: ReactNode
+  trailing?: ReactNode
+  status?: ReactNode
+  ariaLabel?: string
+}
+
+export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
+  modes,
+  activeMode,
+  onModeChange,
+  center,
+  trailing,
+  status,
+  ariaLabel = 'Workspace modes',
+}: TeacherWorkSurfaceModeBarProps<TMode>) {
+  const tabListId = useId()
+
+  const getTabId = (modeId: TMode) => `${tabListId}-${modeId}`
+
+  const selectMode = (mode: TeacherWorkSurfaceMode<TMode>) => {
+    if (mode.disabled) return
+    onModeChange(mode.id)
+  }
+
+  const moveToMode = (mode: TeacherWorkSurfaceMode<TMode>) => {
+    if (mode.disabled) return
+
+    document.getElementById(getTabId(mode.id))?.focus()
+    onModeChange(mode.id)
+  }
+
+  const findEnabledMode = (startIndex: number, direction: 1 | -1) => {
+    if (modes.length === 0) return null
+
+    for (let offset = 1; offset <= modes.length; offset += 1) {
+      const candidate = modes[(startIndex + offset * direction + modes.length) % modes.length]
+      if (candidate && !candidate.disabled) return candidate
+    }
+
+    return null
+  }
+
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    const enabledModes = modes.filter((mode) => !mode.disabled)
+    if (enabledModes.length === 0) return
+
+    if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      const nextMode = findEnabledMode(index, 1)
+      if (nextMode) moveToMode(nextMode)
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      const nextMode = findEnabledMode(index, -1)
+      if (nextMode) moveToMode(nextMode)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      const firstMode = enabledModes[0]
+      if (firstMode) moveToMode(firstMode)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      const lastMode = enabledModes[enabledModes.length - 1]
+      if (lastMode) moveToMode(lastMode)
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className="mb-[-1px] flex items-end gap-1 self-end"
+      >
+        {modes.map((mode, index) => {
+          const isActive = mode.id === activeMode
+          return (
+            <button
+              key={mode.id}
+              id={getTabId(mode.id)}
+              type="button"
+              role="tab"
+              className={[
+                isActive
+                  ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
+                  : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
+                mode.disabled ? 'cursor-not-allowed opacity-50 hover:bg-surface-2 hover:text-text-muted' : '',
+                'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
+              ].join(' ')}
+              onClick={() => selectMode(mode)}
+              onKeyDown={(event) => handleTabKeyDown(event, index)}
+              aria-selected={isActive}
+              aria-disabled={mode.disabled || undefined}
+              tabIndex={isActive && !mode.disabled ? 0 : -1}
+              disabled={mode.disabled}
+            >
+              {mode.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
+        <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
+          {center}
+          {status}
+        </div>
+      </div>
+
+      {trailing ? (
+        <div className="flex flex-wrap items-center gap-1 sm:ml-auto sm:gap-2">
+          {trailing}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceShell.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceShell.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import type { ReactNode, Ref } from 'react'
+import {
+  PageActionBar,
+  PageContent,
+  PageLayout,
+  type ActionBarItem,
+} from '@/components/PageLayout'
+import { cn } from '@/ui/utils'
+
+export type TeacherWorkSurfaceState = 'summary' | 'workspace'
+export type TeacherWorkSurfaceWorkspaceFrame = 'attachedTabs' | 'standalone'
+
+interface TeacherWorkSurfaceShellProps {
+  state: TeacherWorkSurfaceState
+  primary: ReactNode
+  actions?: ActionBarItem[]
+  trailing?: ReactNode
+  feedback?: ReactNode
+  summary: ReactNode
+  workspace: ReactNode
+  className?: string
+  actionBarClassName?: string
+  contentClassName?: string
+  summaryClassName?: string
+  workspaceClassName?: string
+  workspaceFrameClassName?: string
+  workspaceFrame?: TeacherWorkSurfaceWorkspaceFrame
+  workspaceRef?: Ref<HTMLDivElement>
+}
+
+export function TeacherWorkSurfaceShell({
+  state,
+  primary,
+  actions = [],
+  trailing,
+  feedback,
+  summary,
+  workspace,
+  className,
+  actionBarClassName,
+  contentClassName,
+  summaryClassName,
+  workspaceClassName,
+  workspaceFrameClassName,
+  workspaceFrame = 'attachedTabs',
+  workspaceRef,
+}: TeacherWorkSurfaceShellProps) {
+  const isSummary = state === 'summary'
+  const usesAttachedTabsFrame = workspaceFrame === 'attachedTabs'
+
+  return (
+    <PageLayout
+      className={cn('flex h-full min-h-0 flex-col', className)}
+    >
+      <PageActionBar
+        primary={primary}
+        actions={actions}
+        trailing={trailing}
+        className={cn(!isSummary && usesAttachedTabsFrame ? 'pl-0 pr-2' : '', actionBarClassName)}
+      />
+
+      <PageContent
+        className={cn(
+          isSummary
+            ? 'flex flex-col gap-3'
+            : 'px-0 flex min-h-0 flex-1 flex-col gap-3 pt-0',
+          contentClassName,
+        )}
+      >
+        {feedback}
+
+        {isSummary ? (
+          <div className={summaryClassName}>{summary}</div>
+        ) : (
+          <div
+            className={cn(
+              'flex min-h-0 flex-1 overflow-hidden border border-border bg-surface',
+              usesAttachedTabsFrame ? 'rounded-b-lg' : 'rounded-lg',
+              workspaceFrameClassName,
+            )}
+          >
+            <div
+              ref={workspaceRef}
+              className={cn('flex h-full min-h-0 flex-1 flex-col overflow-hidden', workspaceClassName)}
+            >
+              {workspace}
+            </div>
+          </div>
+        )}
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { useWindowSize } from '@/hooks/use-window-size'
+import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
+
+const DEFAULT_MIN_INSPECTOR_PX = 320
+const DEFAULT_MIN_PRIMARY_PX = 320
+
+interface TeacherWorkspaceSplitProps {
+  primary: ReactNode
+  inspector?: ReactNode
+  inspectorWidth: number
+  onInspectorWidthChange: (nextWidth: number) => void
+  inspectorCollapsed: boolean
+  onInspectorCollapsedChange?: (collapsed: boolean) => void
+  className?: string
+  primaryClassName?: string
+  inspectorClassName?: string
+  dividerLabel?: string
+  defaultInspectorWidth?: number
+  minInspectorPx?: number
+  minPrimaryPx?: number
+  minInspectorPercent?: number
+  maxInspectorPercent?: number
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (max <= min) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+function clampInspectorWidthPercent(
+  value: number,
+  totalWidth: number,
+  {
+    minInspectorPx,
+    minPrimaryPx,
+    minInspectorPercent,
+    maxInspectorPercent,
+  }: {
+    minInspectorPx: number
+    minPrimaryPx: number
+    minInspectorPercent: number
+    maxInspectorPercent: number
+  },
+): number {
+  const boundedMinPercent = clampNumber(minInspectorPercent, 0, 100)
+  const boundedMaxPercent = clampNumber(maxInspectorPercent, 0, 100)
+  const candidate = Number.isFinite(value) ? value : 50
+
+  if (!Number.isFinite(totalWidth) || totalWidth <= 0) {
+    return roundPercent(clampNumber(candidate, boundedMinPercent, boundedMaxPercent))
+  }
+
+  const minByInspectorPx = minInspectorPx > 0 ? (minInspectorPx / totalWidth) * 100 : 0
+  const maxByPrimaryPx = minPrimaryPx > 0 ? ((totalWidth - minPrimaryPx) / totalWidth) * 100 : 100
+  const min = clampNumber(Math.max(boundedMinPercent, minByInspectorPx), 0, 100)
+  const max = clampNumber(Math.min(boundedMaxPercent, maxByPrimaryPx), 0, 100)
+
+  return roundPercent(clampNumber(candidate, min, max))
+}
+
+export function TeacherWorkspaceSplit({
+  primary,
+  inspector,
+  inspectorWidth,
+  onInspectorWidthChange,
+  inspectorCollapsed,
+  onInspectorCollapsedChange,
+  className,
+  primaryClassName,
+  inspectorClassName,
+  dividerLabel = 'Resize workspace panes',
+  defaultInspectorWidth = 50,
+  minInspectorPx = DEFAULT_MIN_INSPECTOR_PX,
+  minPrimaryPx = DEFAULT_MIN_PRIMARY_PX,
+  minInspectorPercent = 0,
+  maxInspectorPercent = 100,
+}: TeacherWorkspaceSplitProps) {
+  const splitRef = useRef<HTMLDivElement | null>(null)
+  const [splitWidth, setSplitWidth] = useState(0)
+  const { width: viewportWidth } = useWindowSize()
+  const isDesktop = viewportWidth >= DESKTOP_BREAKPOINT
+  const inspectorVisible = !!inspector && !inspectorCollapsed
+  const constrainedInspectorWidth = clampInspectorWidthPercent(
+    inspectorWidth,
+    splitWidth,
+    {
+      minInspectorPx,
+      minPrimaryPx,
+      minInspectorPercent,
+      maxInspectorPercent,
+    },
+  )
+
+  useEffect(() => {
+    const splitElement = splitRef.current
+    if (!splitElement) return
+
+    const updateSplitWidth = () => {
+      setSplitWidth(splitElement.getBoundingClientRect().width)
+    }
+
+    updateSplitWidth()
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(updateSplitWidth)
+      resizeObserver.observe(splitElement)
+      return () => resizeObserver.disconnect()
+    }
+
+    window.addEventListener('resize', updateSplitWidth)
+    return () => window.removeEventListener('resize', updateSplitWidth)
+  }, [])
+
+  const handleResizeStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!splitRef.current) return
+
+      event.preventDefault()
+      onInspectorCollapsedChange?.(false)
+
+      const { right, width } = splitRef.current.getBoundingClientRect()
+      if (width <= 0) return
+
+      const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+        onInspectorWidthChange(
+          clampInspectorWidthPercent(
+            ((right - moveEvent.clientX) / width) * 100,
+            width,
+            {
+              minInspectorPx,
+              minPrimaryPx,
+              minInspectorPercent,
+              maxInspectorPercent,
+            },
+          ),
+        )
+      }
+
+      const handlePointerUp = () => {
+        window.removeEventListener('pointermove', handlePointerMove)
+        window.removeEventListener('pointerup', handlePointerUp)
+      }
+
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+    },
+    [
+      maxInspectorPercent,
+      minInspectorPercent,
+      minInspectorPx,
+      minPrimaryPx,
+      onInspectorCollapsedChange,
+      onInspectorWidthChange,
+    ],
+  )
+
+  const handleResizeReset = useCallback(() => {
+    onInspectorWidthChange(
+      clampInspectorWidthPercent(
+        defaultInspectorWidth,
+        splitWidth,
+        {
+          minInspectorPx,
+          minPrimaryPx,
+          minInspectorPercent,
+          maxInspectorPercent,
+        },
+      ),
+    )
+  }, [
+    defaultInspectorWidth,
+    maxInspectorPercent,
+    minInspectorPercent,
+    minInspectorPx,
+    minPrimaryPx,
+    onInspectorWidthChange,
+    splitWidth,
+  ])
+
+  return (
+    <div ref={splitRef} className="flex h-full min-h-0 flex-1">
+      <SummaryDetailWorkspaceShell
+        className={className}
+        orientation="responsive"
+        leftPaneClassName={primaryClassName}
+        rightVisible={inspectorVisible}
+        rightPaneClassName={inspectorClassName}
+        rightWidthPercent={inspectorVisible && isDesktop ? constrainedInspectorWidth : undefined}
+        divider={
+          inspectorVisible
+            ? {
+                label: dividerLabel,
+                onPointerDown: handleResizeStart,
+                onDoubleClick: handleResizeReset,
+              }
+            : undefined
+        }
+        left={primary}
+        right={inspector}
+      />
+    </div>
+  )
+}

--- a/tests/components/TeacherAssignmentStudentTable.test.tsx
+++ b/tests/components/TeacherAssignmentStudentTable.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  TeacherAssignmentStudentTable,
+  type TeacherAssignmentStudentRow,
+} from '@/components/assignment-workspace/TeacherAssignmentStudentTable'
+
+vi.mock('@/components/AssignmentArtifactsCell', () => ({
+  AssignmentArtifactsCell: () => <span>Artifacts</span>,
+}))
+
+vi.mock('@/ui', async () => {
+  const actual = await vi.importActual<typeof import('@/ui')>('@/ui')
+  return {
+    ...actual,
+    Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  }
+})
+
+const row: TeacherAssignmentStudentRow = {
+  student_id: 'student-1',
+  student_email: 'student-1@example.com',
+  student_first_name: 'Ada',
+  student_last_name: 'Lovelace',
+  status: 'submitted_on_time',
+  student_updated_at: '2026-04-10T12:00:00Z',
+  artifacts: [],
+  doc: {
+    submitted_at: '2026-04-10T12:00:00Z',
+    updated_at: '2026-04-10T12:00:00Z',
+    score_completion: 8,
+    score_thinking: 9,
+    score_workflow: 10,
+    graded_at: '2026-04-11T12:00:00Z',
+    returned_at: null,
+    feedback_returned_at: null,
+  },
+}
+
+describe('TeacherAssignmentStudentTable', () => {
+  it('renders assignment student rows with selection, sort, grade, and artifact cells', () => {
+    render(
+      <TeacherAssignmentStudentTable
+        rows={[row]}
+        selectedStudentId="student-1"
+        onSelectStudent={vi.fn()}
+        onDeselectStudent={vi.fn()}
+        selectedIds={new Set(['student-1'])}
+        onToggleSelect={vi.fn()}
+        onToggleSelectAll={vi.fn()}
+        allSelected
+        sortColumn="last"
+        sortDirection="asc"
+        onToggleSort={vi.fn()}
+        dueAtMs={new Date('2026-04-20T12:00:00Z').getTime()}
+        density="compact"
+        loading={false}
+        error=""
+      />,
+    )
+
+    expect(screen.getByText('Ada')).toBeInTheDocument()
+    expect(screen.getByText('Lovelace')).toBeInTheDocument()
+    expect(screen.getByText('90')).toBeInTheDocument()
+    expect(screen.getAllByText('Artifacts')).toHaveLength(2)
+    expect(screen.getByRole('checkbox', { name: 'Select all students' })).toBeChecked()
+  })
+
+  it('keeps row selection and batch selection as separate behaviors', () => {
+    const onSelectStudent = vi.fn()
+    const onToggleSelect = vi.fn()
+
+    render(
+      <TeacherAssignmentStudentTable
+        rows={[row]}
+        selectedStudentId={null}
+        onSelectStudent={onSelectStudent}
+        onDeselectStudent={vi.fn()}
+        selectedIds={new Set()}
+        onToggleSelect={onToggleSelect}
+        onToggleSelectAll={vi.fn()}
+        allSelected={false}
+        sortColumn="last"
+        sortDirection="asc"
+        onToggleSort={vi.fn()}
+        dueAtMs={new Date('2026-04-20T12:00:00Z').getTime()}
+        density="compact"
+        loading={false}
+        error=""
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Ada'))
+    expect(onSelectStudent).toHaveBeenCalledWith('student-1')
+
+    onSelectStudent.mockClear()
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))
+    expect(onToggleSelect).toHaveBeenCalledWith('student-1')
+    expect(onSelectStudent).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -283,6 +283,16 @@ function clearSelectionCookie() {
   document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=; Path=/; Max-Age=0; SameSite=Lax`
 }
 
+function applySearchParamsUpdate(
+  call: [(params: URLSearchParams) => void, { replace?: boolean } | undefined],
+  initial = 'tab=assignments',
+) {
+  const [updater, options] = call
+  const params = new URLSearchParams(initial)
+  updater(params)
+  return { params, options }
+}
+
 describe('TeacherClassroomView', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
@@ -298,11 +308,19 @@ describe('TeacherClassroomView', () => {
     mockStudentSelectionState.allSelected = false
     mockStudentSelectionState.selectedCount = 0
     clearSelectionCookie()
-    mockFetchJSONWithCache.mockResolvedValue({
-      assignments: [
-        makeAssignmentSummary('assignment-1', 'Assignment One'),
-        makeAssignmentSummary('assignment-2', 'Assignment Two'),
-      ],
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-1', 'Assignment One'),
+            makeAssignmentSummary('assignment-2', 'Assignment Two'),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
     })
   })
 
@@ -310,6 +328,189 @@ describe('TeacherClassroomView', () => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     clearSelectionCookie()
+  })
+
+  it('does not reopen a stale assignment cookie when URL selection is on summary', async () => {
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('pushes assignment selection into classroom history', async () => {
+    const updateSearchParams = vi.fn()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Assignment One' }))
+
+    expect(updateSearchParams).toHaveBeenCalled()
+    const { params, options } = applySearchParamsUpdate(
+      updateSearchParams.mock.calls[0],
+      'tab=assignments&assignmentStudentId=student-2',
+    )
+    expect(options?.replace).not.toBe(true)
+    expect(params.get('tab')).toBe('assignments')
+    expect(params.get('assignmentId')).toBe('assignment-1')
+    expect(params.get('assignmentStudentId')).toBeNull()
+  })
+
+  it('replaces the assignment history entry with the default selected student', async () => {
+    const updateSearchParams = vi.fn()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="assignment-1"
+        selectedAssignmentStudentId={null}
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    const replaceCall = updateSearchParams.mock.calls.find((call) => call[1]?.replace === true)
+    expect(replaceCall).toBeTruthy()
+    const { params } = applySearchParamsUpdate(replaceCall!, 'tab=assignments&assignmentId=assignment-1')
+    expect(params.get('assignmentStudentId')).toBe('student-1')
+  })
+
+  it('pushes selected student changes into classroom history', async () => {
+    const updateSearchParams = vi.fn()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        const details = makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1')
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            assignment: details.assignment,
+            students: [
+              ...details.students,
+              {
+                student_id: 'student-2',
+                student_email: 'student-2@example.com',
+                student_first_name: 'student-2',
+                student_last_name: 'Student',
+                status: 'submitted_on_time',
+                student_updated_at: '2026-04-10T12:00:00Z',
+                artifacts: [],
+                doc: {
+                  submitted_at: '2026-04-10T12:00:00Z',
+                  updated_at: '2026-04-10T12:00:00Z',
+                  score_completion: null,
+                  score_thinking: null,
+                  score_workflow: null,
+                  graded_at: null,
+                  returned_at: null,
+                  feedback_returned_at: null,
+                },
+              },
+            ],
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="assignment-1"
+        selectedAssignmentStudentId="student-1"
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    updateSearchParams.mockClear()
+    fireEvent.click(screen.getAllByText('student-2')[0])
+
+    await waitFor(() => {
+      expect(updateSearchParams).toHaveBeenCalled()
+    })
+    const { params, options } = applySearchParamsUpdate(
+      updateSearchParams.mock.calls[0],
+      'tab=assignments&assignmentId=assignment-1&assignmentStudentId=student-1',
+    )
+    expect(options?.replace).not.toBe(true)
+    expect(params.get('assignmentId')).toBe('assignment-1')
+    expect(params.get('assignmentStudentId')).toBe('student-2')
   })
 
   it('clears the old split pane while the next assignment roster is still loading', async () => {
@@ -406,8 +607,8 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
     })
 
-    expect(screen.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getByRole('button', { name: /Return/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
@@ -445,13 +646,13 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Individual' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Individual' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('details:assignment-1:student-1')
     })
 
-    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.queryByRole('button', { name: /AI Grade/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()
     expect(screen.getByText('student-1 Student')).toBeInTheDocument()
@@ -524,8 +725,8 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-2')
     })
 
-    expect(screen.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
   })
 
   it('resumes an active assignment AI grading run and reports the final counts', async () => {

--- a/tests/components/TeacherWorkSurfaceModeBar.test.tsx
+++ b/tests/components/TeacherWorkSurfaceModeBar.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
+
+describe('TeacherWorkSurfaceModeBar', () => {
+  it('renders workspace modes, center controls, status, and trailing controls', () => {
+    render(
+      <TeacherWorkSurfaceModeBar
+        modes={[
+          { id: 'overview', label: 'Class' },
+          { id: 'details', label: 'Individual' },
+        ]}
+        activeMode="overview"
+        onModeChange={vi.fn()}
+        center={<button type="button">AI Grade</button>}
+        status={<span>Updating</span>}
+        trailing={<button type="button">Edit assignment</button>}
+      />,
+    )
+
+    expect(screen.getByRole('tablist', { name: 'Workspace modes' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('button', { name: 'AI Grade' })).toBeInTheDocument()
+    expect(screen.getByText('Updating')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
+  })
+
+  it('delegates mode changes while respecting disabled modes', () => {
+    const onModeChange = vi.fn()
+
+    render(
+      <TeacherWorkSurfaceModeBar
+        modes={[
+          { id: 'overview', label: 'Class' },
+          { id: 'details', label: 'Individual', disabled: true },
+        ]}
+        activeMode="overview"
+        onModeChange={onModeChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Class' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Individual' }))
+
+    expect(onModeChange).toHaveBeenCalledTimes(1)
+    expect(onModeChange).toHaveBeenCalledWith('overview')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toBeDisabled()
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('supports keyboard navigation between enabled tabs', () => {
+    const onModeChange = vi.fn()
+
+    render(
+      <TeacherWorkSurfaceModeBar
+        modes={[
+          { id: 'overview', label: 'Class' },
+          { id: 'details', label: 'Individual' },
+          { id: 'analytics', label: 'Analytics', disabled: true },
+        ]}
+        activeMode="overview"
+        onModeChange={onModeChange}
+      />,
+    )
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Class' }), { key: 'ArrowRight' })
+    expect(onModeChange).toHaveBeenLastCalledWith('details')
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Individual' }), { key: 'ArrowRight' })
+    expect(onModeChange).toHaveBeenLastCalledWith('overview')
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Class' }), { key: 'End' })
+    expect(onModeChange).toHaveBeenLastCalledWith('details')
+  })
+})

--- a/tests/components/TeacherWorkSurfaceShell.test.tsx
+++ b/tests/components/TeacherWorkSurfaceShell.test.tsx
@@ -1,0 +1,105 @@
+import { useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+
+describe('TeacherWorkSurfaceShell', () => {
+  it('renders summary state with the standard teacher page rhythm', () => {
+    const { container } = render(
+      <TeacherWorkSurfaceShell
+        state="summary"
+        primary={<button type="button">New Assignment</button>}
+        feedback={<div role="status">Loaded assignments</div>}
+        summary={<div>Assignment list</div>}
+        workspace={<div>Workspace</div>}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'New Assignment' })).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Loaded assignments')
+    expect(screen.getByText('Assignment list')).toBeInTheDocument()
+    expect(screen.queryByText('Workspace')).not.toBeInTheDocument()
+
+    const content = screen.getByText('Assignment list').parentElement?.parentElement
+    expect(content).toHaveClass('flex', 'flex-col', 'gap-3')
+    expect(content).not.toHaveClass('px-0')
+    expect(container.querySelector('.rounded-b-lg.border.border-border.bg-surface')).toBeNull()
+  })
+
+  it('renders workspace state with gutterless content and the selected-workspace frame', () => {
+    render(
+      <TeacherWorkSurfaceShell
+        state="workspace"
+        primary={<div>Personal Narrative Essay</div>}
+        trailing={<button type="button">Toggle</button>}
+        feedback={<div role="alert">Workspace warning</div>}
+        summary={<div>Assignment list</div>}
+        workspace={<div>Student table</div>}
+      />,
+    )
+
+    expect(screen.getByText('Personal Narrative Essay')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Toggle' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Workspace warning')
+    expect(screen.queryByText('Assignment list')).not.toBeInTheDocument()
+    expect(screen.getByText('Student table')).toBeInTheDocument()
+
+    const content = screen.getByText('Student table').parentElement?.parentElement?.parentElement
+    expect(content).toHaveClass('px-0', 'pt-0', 'flex-1')
+    const frame = screen.getByText('Student table').parentElement?.parentElement
+    expect(frame).toHaveClass('rounded-b-lg', 'border', 'border-border', 'bg-surface')
+  })
+
+  it('supports standalone selected-workspace frames for non-tabbed workspaces', () => {
+    render(
+      <TeacherWorkSurfaceShell
+        state="workspace"
+        primary={<div>Gradebook</div>}
+        summary={<div>Summary</div>}
+        workspace={<div>Gradebook table</div>}
+        workspaceFrame="standalone"
+      />,
+    )
+
+    const frame = screen.getByText('Gradebook table').parentElement?.parentElement
+    expect(frame).toHaveClass('rounded-lg', 'border', 'border-border', 'bg-surface')
+    expect(frame).not.toHaveClass('rounded-b-lg')
+  })
+
+  it('keeps workspace children mounted across non-destructive shell updates', () => {
+    const onMount = vi.fn()
+
+    function StatefulWorkspace() {
+      useEffect(() => {
+        onMount()
+      }, [])
+
+      return <div>Stateful workspace</div>
+    }
+
+    const { rerender } = render(
+      <TeacherWorkSurfaceShell
+        state="workspace"
+        primary={<div>Assignment A</div>}
+        feedback={<div>Initial feedback</div>}
+        summary={<div>Summary</div>}
+        workspace={<StatefulWorkspace />}
+      />,
+    )
+
+    rerender(
+      <TeacherWorkSurfaceShell
+        state="workspace"
+        primary={<div>Assignment A</div>}
+        feedback={<div>Updated feedback</div>}
+        trailing={<button type="button">Open menu</button>}
+        summary={<div>Summary</div>}
+        workspace={<StatefulWorkspace />}
+      />,
+    )
+
+    expect(screen.getByText('Stateful workspace')).toBeInTheDocument()
+    expect(screen.getByText('Updated feedback')).toBeInTheDocument()
+    expect(onMount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/components/TeacherWorkspaceSplit.test.tsx
+++ b/tests/components/TeacherWorkspaceSplit.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
+
+describe('TeacherWorkspaceSplit', () => {
+  it('renders primary and inspector panes with a resize handle when expanded', () => {
+    render(
+      <TeacherWorkspaceSplit
+        primary={<div>Student table</div>}
+        inspector={<div>Inspector pane</div>}
+        inspectorWidth={42}
+        inspectorCollapsed={false}
+        onInspectorWidthChange={vi.fn()}
+        dividerLabel="Resize table and grading panes"
+      />,
+    )
+
+    expect(screen.getByText('Student table')).toBeInTheDocument()
+    expect(screen.getByText('Inspector pane')).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize table and grading panes' })).toBeInTheDocument()
+  })
+
+  it('hides the inspector and divider while preserving the primary pane when collapsed', () => {
+    render(
+      <TeacherWorkspaceSplit
+        primary={<div>Student table</div>}
+        inspector={<div>Inspector pane</div>}
+        inspectorWidth={42}
+        inspectorCollapsed
+        onInspectorWidthChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Student table')).toBeInTheDocument()
+    expect(screen.queryByText('Inspector pane')).not.toBeInTheDocument()
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+
+  it('reports clamped inspector width changes from the structural resize handle', () => {
+    const onInspectorWidthChange = vi.fn()
+    const onInspectorCollapsedChange = vi.fn()
+
+    render(
+      <TeacherWorkspaceSplit
+        primary={<div>Student table</div>}
+        inspector={<div>Inspector pane</div>}
+        inspectorWidth={50}
+        inspectorCollapsed={false}
+        onInspectorWidthChange={onInspectorWidthChange}
+        onInspectorCollapsedChange={onInspectorCollapsedChange}
+        dividerLabel="Resize panes"
+      />,
+    )
+
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: 600,
+      width: 1000,
+      height: 600,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.pointerDown(screen.getByRole('separator', { name: 'Resize panes' }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 700 }))
+    window.dispatchEvent(new MouseEvent('pointerup'))
+
+    expect(onInspectorCollapsedChange).toHaveBeenCalledWith(false)
+    expect(onInspectorWidthChange).toHaveBeenCalledWith(32)
+    rectSpy.mockRestore()
+  })
+
+  it('honors configured primary and inspector width bounds', () => {
+    const onInspectorWidthChange = vi.fn()
+
+    render(
+      <TeacherWorkspaceSplit
+        primary={<div>Student table</div>}
+        inspector={<div>Inspector pane</div>}
+        inspectorWidth={50}
+        inspectorCollapsed={false}
+        minInspectorPx={320}
+        minPrimaryPx={420}
+        onInspectorWidthChange={onInspectorWidthChange}
+        dividerLabel="Resize panes"
+      />,
+    )
+
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: 600,
+      width: 1000,
+      height: 600,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.pointerDown(screen.getByRole('separator', { name: 'Resize panes' }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 950 }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 100 }))
+    window.dispatchEvent(new MouseEvent('pointerup'))
+
+    expect(onInspectorWidthChange).toHaveBeenNthCalledWith(1, 32)
+    expect(onInspectorWidthChange).toHaveBeenNthCalledWith(2, 58)
+    rectSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

Refactors the teacher assignment work surface around narrow reusable primitives without moving assignment business logic into the shell. The assignment tab remains the golden reference while exposing canon-ready structural pieces for future test, quiz, and gradebook work surfaces.

## What Changed

- Added dev-flow risk checklist guidance and wired risk-profile declarations into AI instructions, TDD/session/audit prompts, and the audit skill.
- Added `TeacherWorkSurfaceShell`, `TeacherWorkSurfaceModeBar`, and `TeacherWorkspaceSplit` as shared structural primitives.
- Extracted the assignment student table into `TeacherAssignmentStudentTable` and migrated teacher assignments to the shared shell pieces.
- Updated `TeacherStudentWorkPanel` to use the shared workspace split for individual-mode panes.
- Fixed the review concerns before opening this PR:
  - split pane clamps generic width bounds inside the primitive
  - mode bar uses typed tab semantics and keyboard navigation
  - shell exposes `workspaceFrame` variants for attached-tab and standalone frames
- Fixed teacher assignment browser Back behavior by routing assignment/student workspace state through `assignmentId` and `assignmentStudentId` query params.
- Tightened request-cache/audit handling for the touched repeated-read client paths.

## Validation

- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/NavItems.test.tsx`
- `pnpm lint` (existing `src/components/TestDocumentsEditor.tsx` hook dependency warning remains)
- `pnpm exec tsc --noEmit`
- `bash scripts/verify-env.sh` (210 files, 1811 tests)
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1`
- Targeted Playwright check confirmed browser Back from selected `Student2` returns to previous selected student inside `tab=assignments` instead of jumping to the previous top-level tab.

## Review Notes

This PR intentionally standardizes only layout/work-surface structure. It does not move assignment loading, grading, selection state, modal flows, return behavior, or assessment-specific state into the shared shell.
