### PR TITLE
Fix student test blanking after MC clicks

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9454,3 +9454,17 @@
 - Added explicit AI routing for teacher assignments/quizzes/tests shell and layout tasks in `docs/ai-instructions.md`.
 - Expanded `docs/guidance/ui/teacher-work-surfaces.md` with an implemented primitive map, assignment-only reuse boundaries, an AI adoption contract, and a tests/quizzes migration template.
 - Verified the environment with `PATH=/opt/homebrew/bin:$PATH bash scripts/verify-env.sh`; all 218 test files and 1861 tests passed before the docs-only patch.
+
+## 2026-04-27 — Student Test MC Transient Resize Lock Fix
+
+- Traced the student MC blank-screen regression to the Apr 21 exam-mode window-compliance changes, where transient answer-click resize signals could hide the mounted active test behind the lock overlay.
+- Added an in-test interaction guard so a `window_resize` immediately following a test-form pointer/key interaction gets a short delayed confirmation instead of blanking the active test immediately.
+- Added regression coverage proving an MC answer tap remains visible, selected, and does not log a window-unmaximize attempt when the resize is transient.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
+- Targeted Playwright student active-test screenshot after selecting an MC option

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -110,6 +110,7 @@ const EXAM_WINDOW_COMPLIANCE_GRACE_MS = 400
 const EXAM_WINDOW_MIN_WIDTH_RATIO = 0.92
 const EXAM_WINDOW_MIN_HEIGHT_RATIO = 0.88
 const EXAM_LOCK_OVERLAY_ENABLED = true
+const EXAM_FORM_INTERACTION_RESIZE_SUPPRESSION_MS = 1500
 const DOCS_EXIT_SUPPRESSION_WINDOW_MS = 1200
 const UNSUPPRESSED_ROUTE_EXIT_SOURCES = new Set([
   'tab_navigation',
@@ -235,6 +236,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const pendingNonCompliantSourceRef = useRef<'fullscreen_exit' | 'window_resize' | null>(null)
   const lastRouteExitRef = useRef<{ source: string; loggedAtMs: number } | null>(null)
   const lastWindowSignalRef = useRef<{ source: string; loggedAtMs: number } | null>(null)
+  const lastExamFormInteractionAtRef = useRef(0)
   const findIntentUntilRef = useRef(0)
   const findSuppressionUntilRef = useRef(0)
   const docsInteractionSuppressionUntilRef = useRef(0)
@@ -296,6 +298,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       clearPendingNonCompliantTimeout()
       lastRouteExitRef.current = null
       lastWindowSignalRef.current = null
+      lastExamFormInteractionAtRef.current = 0
       findIntentUntilRef.current = 0
       findSuppressionUntilRef.current = 0
       docsInteractionSuppressionUntilRef.current = 0
@@ -491,6 +494,11 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     docsInteractionSuppressionUntilRef.current = Date.now() + DOCS_EXIT_SUPPRESSION_WINDOW_MS
   }, [isTestsView])
 
+  const markExamFormInteraction = useCallback(() => {
+    if (!focusEnabledRef.current || !isTestsView) return
+    lastExamFormInteractionAtRef.current = Date.now()
+  }, [isTestsView])
+
   const shouldSuppressForDocInteraction = useCallback((source?: string) => {
     if (!focusEnabledRef.current || !isTestsView) return false
     if (source && UNSUPPRESSED_ROUTE_EXIT_SOURCES.has(source)) return false
@@ -622,6 +630,35 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     if (snapshot.isCompliant) {
       clearPendingNonCompliantTimeout()
       setIsWindowCompliantStable(true)
+      return snapshot
+    }
+
+    const now = Date.now()
+    const resizeFollowedExamInteraction =
+      source === 'window_resize' &&
+      isWindowCompliantStableRef.current &&
+      now - lastExamFormInteractionAtRef.current <= EXAM_FORM_INTERACTION_RESIZE_SUPPRESSION_MS
+
+    if (resizeFollowedExamInteraction) {
+      clearPendingNonCompliantTimeout()
+      setIsWindowCompliantStable(true)
+      pendingNonCompliantSourceRef.current = source
+      pendingNonCompliantTimeoutRef.current = window.setTimeout(() => {
+        pendingNonCompliantTimeoutRef.current = null
+        const confirmedSource = pendingNonCompliantSourceRef.current
+        pendingNonCompliantSourceRef.current = null
+        const confirmedSnapshot = getExamWindowComplianceSnapshot()
+        applyWindowComplianceSnapshot(confirmedSnapshot)
+
+        if (confirmedSnapshot.isCompliant) {
+          setIsWindowCompliantStable(true)
+          return
+        }
+
+        if (confirmedSource) {
+          confirmNonCompliantWindow(confirmedSource, confirmedSnapshot)
+        }
+      }, EXAM_FORM_INTERACTION_RESIZE_SUPPRESSION_MS)
       return snapshot
     }
 
@@ -1340,6 +1377,8 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                     } ${
                       showNotMaximizedWarning ? 'border-warning bg-warning-bg/20' : ''
                     }`}
+                    onPointerDownCapture={markExamFormInteraction}
+                    onKeyDownCapture={markExamFormInteraction}
                   >
                     {selectedQuizId && loadingQuiz ? (
                       <div className="flex justify-center py-12">

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -3187,6 +3187,178 @@ describe('StudentQuizzesTab exam mode', () => {
     ).toBe(true)
   })
 
+  it('keeps the active test visible when an answer tap causes a transient resize', async () => {
+    const focusBodies: Array<Record<string, any>> = []
+    let fullscreenElement: Element | null = null
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    })
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockImplementation(async () => {
+        fullscreenElement = document.documentElement
+        document.dispatchEvent(new Event('fullscreenchange'))
+      }),
+    })
+
+    fetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.includes('/api/student/tests?classroom_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quizzes: [{
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            }],
+          }),
+        }
+      }
+
+      if (url.endsWith('/api/student/tests/test-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            quiz: {
+              id: 'test-1',
+              title: 'Midterm Test',
+              assessment_type: 'test',
+              status: 'active',
+              show_results: false,
+              position: 0,
+              student_status: 'not_started',
+            },
+            student_status: 'not_started',
+            questions: [
+              {
+                id: 'q1',
+                quiz_id: 'test-1',
+                question_text: '2 + 2 = ?',
+                options: ['3', '4'],
+                question_type: 'multiple_choice',
+                points: 1,
+                response_max_chars: 5000,
+                position: 0,
+              },
+            ],
+            student_responses: {},
+            focus_summary: null,
+          }),
+        }
+      }
+
+      if (url.includes('/api/student/tests/test-1/focus-events')) {
+        const parsedBody = JSON.parse(String(options?.body || '{}')) as Record<string, any>
+        focusBodies.push(parsedBody)
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            focus_summary: {
+              away_count: 0,
+              away_total_seconds: 0,
+              route_exit_attempts: 0,
+              window_unmaximize_attempts: focusBodies.filter(
+                (body) => body.event_type === 'window_unmaximize_attempt'
+              ).length,
+              last_away_started_at: null,
+              last_away_ended_at: null,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    })
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+      expect(fullscreenElement).toBe(document.documentElement)
+    })
+
+    vi.useFakeTimers()
+    const answer = screen.getByText('3')
+    fireEvent.pointerDown(answer)
+    fireEvent.click(answer)
+
+    fullscreenElement = null
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 700,
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+    fireEvent(window, new Event('resize'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(450)
+    })
+
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
+    expect(screen.getByText('3').closest('label')).toHaveClass('border-primary')
+    expect(
+      focusBodies.some(
+        (body) =>
+          body.event_type === 'window_unmaximize_attempt' &&
+          body.metadata?.source === 'window_resize'
+      )
+    ).toBe(false)
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1400,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 900,
+    })
+    fireEvent(window, new Event('resize'))
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_600)
+    })
+
+    expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
+    expect(screen.getByText('2 + 2 = ?')).toBeVisible()
+  })
+
   it('keeps mobile browsers without fullscreen support usable after re-entering a saved test', async () => {
     const requestFullscreenDescriptor = Object.getOwnPropertyDescriptor(
       document.documentElement,


### PR DESCRIPTION
## Summary
- identifies Apr 21 exam-mode window-compliance changes as the likely regression source for MC-triggered blank screens
- keeps active student tests visible when a transient resize follows an in-test pointer/key interaction
- still confirms sustained noncompliant window state before applying the exam lock overlay
- adds regression coverage for MC answer taps followed by transient resize signals

## Validation
- pnpm exec vitest run tests/components/StudentQuizzesTab.test.tsx
- pnpm lint (existing TestDocumentsEditor hook dependency warning remains)
- git diff --check
- E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"
- targeted Playwright student active-test screenshot after selecting an MC option