### PR TITLE
Fix student MC selection scrolling test blank

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9468,3 +9468,18 @@
 - `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
 - Targeted Playwright student active-test screenshot after selecting an MC option
+
+## 2026-04-27 — Anchor Student MC Radios To Prevent Test Shell Scroll
+
+- Reproduced the remaining blank-screen issue with a long test containing code open-response questions before the first MC question.
+- Found that the `sr-only` radio input could receive focus outside the split-pane flow and scroll the whole page, leaving most of the fixed-height test shell above the viewport.
+- Replaced the `sr-only` MC radio positioning with an invisible radio anchored inside a relative option label, preserving keyboard focus styling without window scroll jumps.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `git diff --check`
+- `pnpm test`
+- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
+- Reproduced the provided long Unit 5-style test in Playwright and confirmed MC selection keeps `window.scrollY` at 0 with no blank area
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -527,7 +527,7 @@ export function StudentQuizForm({
                           return (
                             <label
                               key={optionIndex}
-                              className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+                              className={`relative flex items-center gap-3 p-3 rounded-lg border transition-colors ${
                                 isSelected
                                   ? 'border-primary bg-primary/5'
                                   : 'border-border hover:bg-surface-hover'
@@ -539,10 +539,10 @@ export function StudentQuizForm({
                                 checked={isSelected}
                                 disabled={isInteractionLocked}
                                 onChange={() => handleOptionSelect(question.id, optionIndex)}
-                                className="sr-only"
+                                className="peer absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 cursor-pointer opacity-0 disabled:cursor-not-allowed"
                               />
                               <span
-                                className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                                className={`w-5 h-5 rounded-full border-2 flex items-center justify-center peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 ${
                                   isSelected ? 'border-primary' : 'border-border'
                                 }`}
                               >

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -173,6 +173,36 @@ describe('StudentQuizForm preview mode', () => {
     expect(within(actionPanel).getByText('Answer all questions to submit')).toBeInTheDocument()
   })
 
+  it('keeps multiple-choice radios anchored inside their option labels', async () => {
+    const onSubmitted = vi.fn()
+
+    render(
+      <StudentQuizForm
+        quizId="test-radio-position-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Which option is correct?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        assessmentType="test"
+        previewMode
+        onSubmitted={onSubmitted}
+      />
+    )
+
+    const optionLabel = screen.getByText('A').closest('label')
+    const radio = within(optionLabel!).getByRole('radio')
+
+    expect(optionLabel).toHaveClass('relative')
+    expect(radio).not.toHaveClass('sr-only')
+    expect(radio).toHaveClass('absolute')
+    expect(radio).toHaveClass('left-3')
+  })
+
   it('keeps the sticky submit footer for quizzes', async () => {
     const onSubmitted = vi.fn()
 


### PR DESCRIPTION
## Summary
- reproduced the remaining blank-screen issue using the long Unit 5-style test with code open-response questions before MC questions
- confirmed reverting the Apr 21 exam-mode commits does not fix that reproduction
- anchors invisible MC radio inputs inside their option labels instead of using Tailwind sr-only positioning, preventing whole-page scroll jumps when radios receive focus
- preserves the custom radio UI and adds focus-visible styling to the custom control

## Validation
- pnpm exec vitest run tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx
- pnpm lint (existing TestDocumentsEditor hook dependency warning remains)
- git diff --check
- pnpm test
- E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth
- Playwright reproduction of the provided long Unit 5-style test: selecting Q3 MC keeps window.scrollY at 0, selected answer remains visible, no exam obscurer/blocker
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"