### PR TITLE
Issue 505: Teacher tests/quizzes work-surface shell

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9483,3 +9483,20 @@
 - `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
 - Reproduced the provided long Unit 5-style test in Playwright and confirmed MC selection keeps `window.scrollY` at 0 with no blank area
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
+
+## 2026-04-27 — Issue 505 Teacher Tests/Quizzes Work-Surface Shell
+
+- Migrated teacher tests to `TeacherWorkSurfaceShell`, with the authoring/grading mode bar and grading student inspector contained inside the tests workspace split.
+- Reworked teacher quizzes as a quiz-only work surface with URL-controlled selected quiz state and delete in the selected workspace.
+- Routed `testId`, `testMode`, `testStudentId`, and `quizId` through classroom search params, including active-tab re-click summary resets and stale param replacement.
+- Disabled external right sidebars for teacher tests/quizzes and updated coverage for the layout-provider expectation.
+
+**Validation:**
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx tests/components/TeacherWorkspaceSplit.test.tsx`
+- `pnpm test tests/components/ThreePanelProvider.test.tsx tests/unit/layout-config.test.ts`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `pnpm exec tsc --noEmit`
+- `bash scripts/verify-env.sh` (218 files, 1885 tests)
+- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:verify assessment-ux-parity`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=quizzes"`

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -41,12 +41,10 @@ import {
   TEACHER_ASSIGNMENTS_UPDATED_EVENT,
   TEACHER_QUIZZES_UPDATED_EVENT,
 } from '@/lib/events'
-import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TeacherTestPreviewPage } from '@/components/TeacherTestPreviewPage'
-import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
 import { LogSummary } from './LogSummary'
-import { ConfirmDialog, EmptyState, TabContentTransition } from '@/ui'
+import { ConfirmDialog, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
 import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
@@ -249,6 +247,14 @@ function ClassroomPageContent({
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
   const assignmentStudentIdParam = searchParams.get('assignmentStudentId')
+  const quizIdParam = activeTab === 'quizzes' ? searchParams.get('quizId') : null
+  const testIdParam = activeTab === 'tests' ? searchParams.get('testId') : null
+  const rawTestModeParam = searchParams.get('testMode')
+  const testModeParam =
+    activeTab === 'tests' && (rawTestModeParam === 'authoring' || rawTestModeParam === 'grading')
+      ? rawTestModeParam
+      : null
+  const testStudentIdParam = activeTab === 'tests' ? searchParams.get('testStudentId') : null
   const sectionParam = searchParams.get('section')
   const [mountedTabs, setMountedTabs] = useState<Record<string, boolean>>(() => ({
     [activeTab]: true,
@@ -328,6 +334,41 @@ function ClassroomPageContent({
     },
     [activeTab, requestExamModeNavigation, searchParams, updateSearchParams]
   )
+
+  useEffect(() => {
+    if (!isTeacher || activeTab !== 'tests') return
+
+    const hasInvalidMode =
+      rawTestModeParam !== null && rawTestModeParam !== 'authoring' && rawTestModeParam !== 'grading'
+    const hasDanglingMode = !testIdParam && rawTestModeParam !== null
+    const hasDanglingStudent =
+      testStudentIdParam !== null && (!testIdParam || testModeParam !== 'grading')
+
+    if (!hasInvalidMode && !hasDanglingMode && !hasDanglingStudent) return
+
+    navigateInClassroom((params) => {
+      if (!testIdParam) {
+        params.delete('testMode')
+        params.delete('testStudentId')
+        return
+      }
+
+      if (hasInvalidMode) {
+        params.delete('testMode')
+      }
+      if (testModeParam !== 'grading') {
+        params.delete('testStudentId')
+      }
+    }, { replace: true })
+  }, [
+    activeTab,
+    isTeacher,
+    navigateInClassroom,
+    rawTestModeParam,
+    testIdParam,
+    testModeParam,
+    testStudentIdParam,
+  ])
 
   useEffect(() => {
     if (isTeacher) return
@@ -417,37 +458,16 @@ function ClassroomPageContent({
     responsesCount: number
   } | null>(null)
   const [isDeletingAssessment, setIsDeletingAssessment] = useState(false)
-  const [testGradingContext, setTestGradingContext] = useState<{
-    mode: 'authoring' | 'grading'
-    testId: string | null
-    studentId: string | null
-    studentName: string | null
-  }>({
-    mode: 'authoring',
-    testId: null,
-    studentId: null,
-    studentName: null,
-  })
   const [teacherTestPreview, setTeacherTestPreview] = useState<{
     testId: string
     title: string | null
   } | null>(null)
-  const [testGradingSaveState, setTestGradingSaveState] = useState<{
-    canSave: boolean
-    isSaving: boolean
-    status: 'idle' | 'unsaved' | 'saving' | 'saved'
-  }>({
-    canSave: false,
-    isSaving: false,
-    status: 'idle',
-  })
   const [selectedGradebookStudent, setSelectedGradebookStudent] = useState<GradebookStudentSummary | null>(null)
   const [gradebookStudentDetail, setGradebookStudentDetail] = useState<GradebookStudentDetail | null>(null)
   const [gradebookClassSummary, setGradebookClassSummary] = useState<GradebookClassSummary | null>(null)
   const [gradebookStudentDetailLoading, setGradebookStudentDetailLoading] = useState(false)
   const [gradebookStudentDetailError, setGradebookStudentDetailError] = useState('')
   const [testsTabClickToken, setTestsTabClickToken] = useState(0)
-  const [testGradingPanelRefreshToken, setTestGradingPanelRefreshToken] = useState(0)
 
   const handleSelectQuiz = useCallback((quiz: QuizWithStats | null) => {
     setSelectedQuiz(quiz)
@@ -456,13 +476,6 @@ function ClassroomPageContent({
   useEffect(() => {
     if (activeTab === 'quizzes' || activeTab === 'tests') {
       setSelectedQuiz(null)
-      setTestGradingContext({
-        mode: 'authoring',
-        testId: null,
-        studentId: null,
-        studentName: null,
-      })
-      setTestGradingSaveState({ canSave: false, isSaving: false, status: 'idle' })
     }
   }, [activeTab])
 
@@ -478,16 +491,6 @@ function ClassroomPageContent({
     if (selectedQuiz.id === teacherTestPreview.testId) return
     setTeacherTestPreview(null)
   }, [selectedQuiz, teacherTestPreview])
-
-  const handleQuizUpdate = useCallback(() => {
-    window.dispatchEvent(
-      new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
-    )
-  }, [classroom.id])
-
-  const handleTestGradingDataRefresh = useCallback(() => {
-    setTestGradingPanelRefreshToken((prev) => prev + 1)
-  }, [])
 
   const handleSelectGradebookStudent = useCallback((student: GradebookStudentSummary | null) => {
     setSelectedGradebookStudent(student)
@@ -688,10 +691,6 @@ function ClassroomPageContent({
   useEffect(() => {
     if (isTeacher && activeTab === 'assignments') {
       setRightSidebarWidth('50%')
-    } else if (isTeacher && activeTab === 'quizzes') {
-      setRightSidebarWidth('50%')
-    } else if (isTeacher && activeTab === 'tests') {
-      setRightSidebarWidth('60%')
     } else if (isTeacher && activeTab === 'gradebook') {
       setRightSidebarWidth(420)
     } else if (activeTab === 'resources') {
@@ -714,19 +713,6 @@ function ClassroomPageContent({
     assignmentViewMode,
     setRightSidebarOpen,
     closeMobileDrawer,
-  ])
-
-  useEffect(() => {
-    if (!isTeacher || activeTab !== 'tests') return
-    if (testGradingContext.mode === 'grading') return
-    setRightSidebarOpen(false)
-    closeMobileDrawer()
-  }, [
-    activeTab,
-    closeMobileDrawer,
-    isTeacher,
-    setRightSidebarOpen,
-    testGradingContext.mode,
   ])
 
   useEffect(() => {
@@ -905,12 +891,20 @@ function ClassroomPageContent({
         if (tab !== 'resources' && tab !== 'settings') {
           params.delete('section')
         }
+        if (tab !== 'tests' || activeTab === 'tests') {
+          params.delete('testId')
+          params.delete('testMode')
+          params.delete('testStudentId')
+        }
+        if (tab !== 'quizzes' || activeTab === 'quizzes') {
+          params.delete('quizId')
+        }
       })
       window.requestAnimationFrame(() => {
         markClassroomTabSwitchReady(tab)
       })
     },
-    [navigateInClassroom]
+    [activeTab, navigateInClassroom]
   )
 
   useEffect(() => {
@@ -923,6 +917,7 @@ function ClassroomPageContent({
   const isAssessmentTab = activeTab === 'quizzes' || activeTab === 'tests'
   const assessmentLabel = activeTab === 'tests' ? 'test' : 'quiz'
   const assessmentApiBasePath = activeTab === 'tests' ? '/api/teacher/tests' : '/api/teacher/quizzes'
+  const pendingAssessmentLabel = pendingAssessmentDelete?.quiz.assessment_type === 'test' ? 'test' : 'quiz'
   const examHeaderData = useMemo(() => {
     if (
       isTeacher ||
@@ -946,10 +941,6 @@ function ClassroomPageContent({
     studentTestExamMode.exitsCount,
     studentTestExamMode.testTitle,
   ])
-  const gradingTestId =
-    activeTab === 'tests'
-      ? (testGradingContext.testId || selectedQuiz?.id || null)
-      : null
   const pageDensity = isTeacher ? 'teacher' : 'student'
   const mainContentClassName =
     activeTab === 'calendar'
@@ -986,21 +977,34 @@ function ClassroomPageContent({
   async function handleConfirmAssessmentDelete() {
     if (!pendingAssessmentDelete) return
 
+    const deleteIsTest = pendingAssessmentDelete.quiz.assessment_type === 'test'
+    const deleteApiBasePath = deleteIsTest ? '/api/teacher/tests' : '/api/teacher/quizzes'
+    const deleteLabel = deleteIsTest ? 'test' : 'quiz'
+
     setIsDeletingAssessment(true)
     try {
-      const res = await fetch(`${assessmentApiBasePath}/${pendingAssessmentDelete.quiz.id}`, { method: 'DELETE' })
+      const res = await fetch(`${deleteApiBasePath}/${pendingAssessmentDelete.quiz.id}`, { method: 'DELETE' })
       if (!res.ok) {
         const data = await res.json()
-        throw new Error(data.error || `Failed to delete ${assessmentLabel}`)
+        throw new Error(data.error || `Failed to delete ${deleteLabel}`)
       }
 
       setSelectedQuiz(null)
+      navigateInClassroom((params) => {
+        if (deleteIsTest) {
+          params.delete('testId')
+          params.delete('testMode')
+          params.delete('testStudentId')
+        } else {
+          params.delete('quizId')
+        }
+      }, { replace: true })
       window.dispatchEvent(
         new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
       )
       setPendingAssessmentDelete(null)
     } catch (error) {
-      console.error(`Error deleting ${assessmentLabel}:`, error)
+      console.error(`Error deleting ${deleteLabel}:`, error)
     } finally {
       setIsDeletingAssessment(false)
     }
@@ -1101,7 +1105,12 @@ function ClassroomPageContent({
                       <TeacherQuizzesTab
                         classroom={classroom}
                         assessmentType="quiz"
+                        selectedQuizId={quizIdParam}
+                        updateSearchParams={navigateInClassroom}
                         onSelectQuiz={handleSelectQuiz}
+                        onRequestDelete={() => {
+                          void handleRequestAssessmentDelete()
+                        }}
                       />
                     </TabContentTransition>
                   )}
@@ -1110,9 +1119,11 @@ function ClassroomPageContent({
                       <TeacherTestsTab
                         classroom={classroom}
                         testsTabClickToken={testsTabClickToken}
+                        selectedTestId={testIdParam}
+                        selectedTestMode={testModeParam}
+                        selectedTestStudentId={testStudentIdParam}
+                        updateSearchParams={navigateInClassroom}
                         onSelectTest={handleSelectQuiz}
-                        onTestGradingDataRefresh={handleTestGradingDataRefresh}
-                        onTestGradingContextChange={setTestGradingContext}
                         onRequestDelete={() => {
                           void handleRequestAssessmentDelete()
                         }}
@@ -1249,21 +1260,6 @@ function ClassroomPageContent({
               ? selectedGradebookStudent
                 ? `${selectedGradebookStudent.student_first_name || ''} ${selectedGradebookStudent.student_last_name || ''}`.trim() || selectedGradebookStudent.student_email
                 : 'Gradebook'
-              : isTeacher &&
-                activeTab === 'tests' &&
-                testGradingContext.mode === 'grading'
-              ? (
-                <span className="relative flex w-full items-center">
-                  <span className="truncate pr-2 text-sm font-semibold text-text-default">
-                    {testGradingContext.studentName || 'Test Grading'}
-                  </span>
-                  {selectedQuiz?.title && (
-                    <span className="pointer-events-none absolute left-1/2 max-w-[70%] -translate-x-1/2 truncate text-center text-xs text-text-muted">
-                      {selectedQuiz.title}
-                    </span>
-                  )}
-                </span>
-              )
               : isTeacher && isAssessmentTab
               ? ''
               : isTeacher && activeTab === 'assignments'
@@ -1309,40 +1305,6 @@ function ClassroomPageContent({
               >
                 {calendarSidebarState.bulkSaving ? 'Saving...' : 'Save'}
               </button>
-            ) : isTeacher &&
-              activeTab === 'tests' &&
-              testGradingContext.mode === 'grading' &&
-              testGradingContext.studentId ? (
-              testGradingSaveState.status !== 'idle' ? (
-                <span
-                  className={[
-                    'px-1 text-xs',
-                    testGradingSaveState.status === 'saved'
-                      ? 'text-success font-medium'
-                      : testGradingSaveState.status === 'saving'
-                        ? 'text-text-muted'
-                        : 'text-warning',
-                  ].join(' ')}
-                >
-                  {testGradingSaveState.status === 'saved'
-                    ? 'Saved'
-                    : testGradingSaveState.status === 'saving'
-                      ? 'Saving...'
-                      : 'Unsaved'}
-                </span>
-              ) : null
-            ) : isTeacher &&
-              activeTab === 'quizzes' &&
-              selectedQuiz ? (
-              <button
-                type="button"
-                onClick={() => {
-                  void handleRequestAssessmentDelete()
-                }}
-                className="px-2 py-1 text-xs rounded border border-danger text-danger hover:bg-danger-bg disabled:opacity-50"
-              >
-                Delete
-              </button>
             ) : undefined
           }
         >
@@ -1368,37 +1330,8 @@ function ClassroomPageContent({
             <TeacherClassResourcesSidebar classroom={classroom} />
           ) : activeTab === 'resources' ? (
             <StudentClassResourcesSidebar classroom={classroom} />
-          ) : isTeacher &&
-            activeTab === 'tests' &&
-            testGradingContext.mode === 'grading' &&
-            gradingTestId ? (
-            <TestStudentGradingPanel
-              testId={gradingTestId}
-              selectedStudentId={testGradingContext.studentId}
-              apiBasePath={assessmentApiBasePath}
-              refreshToken={testGradingPanelRefreshToken}
-              onSaveStateChange={setTestGradingSaveState}
-            />
-          ) : isTeacher && activeTab === 'quizzes' && selectedQuiz ? (
-            <QuizDetailPanel
-              quiz={selectedQuiz}
-              classroomId={classroom.id}
-              apiBasePath={assessmentApiBasePath}
-              onQuizUpdate={handleQuizUpdate}
-            />
-          ) : isTeacher && activeTab === 'tests' ? null : isTeacher && isAssessmentTab ? (
-            <div className="flex h-full min-h-0 items-center p-4">
-              <EmptyState
-                title={`Select a ${assessmentLabel}`}
-                description={
-                  activeTab === 'tests'
-                    ? 'Choose a test to review settings, questions, and grading details.'
-                    : 'Choose a quiz to review settings, questions, and response details.'
-                }
-                className="w-full"
-                tone="muted"
-              />
-            </div>
+          ) : isTeacher && isAssessmentTab ? (
+            null
           ) : isTeacher && activeTab === 'gradebook' && selectedGradebookStudent ? (
             <div className="space-y-4 p-4">
               {gradebookStudentDetailError && (
@@ -1609,10 +1542,10 @@ function ClassroomPageContent({
 
       <ConfirmDialog
         isOpen={!!pendingAssessmentDelete}
-        title={`Delete ${assessmentLabel}?`}
+        title={`Delete ${pendingAssessmentLabel}?`}
         description={
           pendingAssessmentDelete && pendingAssessmentDelete.responsesCount > 0
-            ? `This ${assessmentLabel} has ${pendingAssessmentDelete.responsesCount} response${pendingAssessmentDelete.responsesCount === 1 ? '' : 's'}. Deleting it will permanently remove all student responses.`
+            ? `This ${pendingAssessmentLabel} has ${pendingAssessmentDelete.responsesCount} response${pendingAssessmentDelete.responsesCount === 1 ? '' : 's'}. Deleting it will permanently remove all student responses.`
             : 'This action cannot be undone.'
         }
         confirmLabel={isDeletingAssessment ? 'Deleting...' : 'Delete'}

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -1,590 +1,178 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Check, Circle, ClockAlert, LogOut, Plus, Send } from 'lucide-react'
+import { Plus, Trash2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
-import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, Select, Tooltip } from '@/ui'
-import { useRightSidebar } from '@/components/layout'
-import {
-  TEACHER_QUIZZES_UPDATED_EVENT,
-  TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
-  type TeacherTestGradingRowUpdatedEventDetail,
-} from '@/lib/events'
-import { getQuizExitCount } from '@/lib/quizzes'
-import { compareByNameFields } from '@/lib/table-sort'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizCard } from '@/components/QuizCard'
-import { useStudentSelection } from '@/hooks/useStudentSelection'
-import type { Classroom, Quiz, QuizAssessmentType, QuizFocusSummary, QuizWithStats } from '@/types'
+import { QuizDetailPanel } from '@/components/QuizDetailPanel'
+import { PageStack } from '@/components/PageLayout'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { Button, EmptyState } from '@/ui'
+import type {
+  AssessmentEditorSummaryUpdate,
+  Classroom,
+  Quiz,
+  QuizAssessmentType,
+  QuizWithStats,
+} from '@/types'
+
+type UpdateSearchOptions = {
+  replace?: boolean
+}
+
+type UpdateSearchParamsFn = (
+  updater: (params: URLSearchParams) => void,
+  options?: UpdateSearchOptions,
+) => void
 
 interface Props {
   classroom: Classroom
-  assessmentType: QuizAssessmentType
+  assessmentType?: QuizAssessmentType
+  selectedQuizId?: string | null
+  updateSearchParams?: UpdateSearchParamsFn
   onSelectQuiz?: (quiz: QuizWithStats | null) => void
-  testsSidebarClickToken?: number
-  onTestGradingDataRefresh?: () => void
-  onTestGradingContextChange?: (context: {
-    mode: 'authoring' | 'grading'
-    testId: string | null
-    studentId: string | null
-    studentName: string | null
-  }) => void
-}
-
-interface TestGradingStudentRow {
-  student_id: string
-  name: string | null
-  first_name: string | null
-  last_name: string | null
-  email: string
-  status: 'not_started' | 'in_progress' | 'submitted' | 'returned'
-  submitted_at: string | null
-  last_activity_at: string | null
-  points_earned: number
-  points_possible: number
-  percent: number | null
-  graded_open_responses: number
-  ungraded_open_responses: number
-  focus_summary: QuizFocusSummary | null
-}
-
-interface TestGradingQuestionSummary {
-  id: string
-  questionType: 'multiple_choice' | 'open_response'
-  responseMonospace: boolean
-}
-
-type TestGradingSortColumn = 'first_name' | 'last_name'
-type TestAiGradingStrategy = 'balanced' | 'aggressive_batch'
-
-const TEST_AI_GRADING_STRATEGY_OPTIONS = [
-  { value: 'balanced', label: 'Balanced (Recommended)' },
-  { value: 'aggressive_batch', label: 'Aggressive Batch (Experimental)' },
-]
-
-function splitDisplayName(name: string | null): { firstName: string | null; lastName: string | null } {
-  const trimmed = (name || '').trim()
-  if (!trimmed) return { firstName: null, lastName: null }
-
-  const parts = trimmed.split(/\s+/)
-  if (parts.length === 1) return { firstName: parts[0], lastName: null }
-
-  return {
-    firstName: parts[0],
-    lastName: parts.slice(1).join(' '),
-  }
-}
-
-function getSortableNameParts(student: TestGradingStudentRow): { firstName: string | null; lastName: string | null } {
-  const firstName = (student.first_name || '').trim()
-  const lastName = (student.last_name || '').trim()
-  if (firstName || lastName) {
-    return {
-      firstName: firstName || null,
-      lastName: lastName || null,
-    }
-  }
-
-  return splitDisplayName(student.name)
-}
-
-function formatTorontoTime(iso: string | null): { value: string; isPm: boolean } {
-  if (!iso) return { value: '—', isPm: false }
-
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Toronto',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  })
-  const parts = formatter.formatToParts(new Date(iso))
-  const hour = parts.find((part) => part.type === 'hour')?.value ?? ''
-  const minute = parts.find((part) => part.type === 'minute')?.value ?? ''
-  const dayPeriod = (parts.find((part) => part.type === 'dayPeriod')?.value ?? '').toLowerCase()
-  return {
-    value: `${hour}:${minute}`,
-    isPm: dayPeriod === 'pm',
-  }
-}
-
-function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(2)
-}
-
-function summarizeBatchAutoGradeErrors(rawErrors: unknown): string {
-  if (!Array.isArray(rawErrors)) return ''
-
-  const counts = new Map<string, number>()
-  for (const rawError of rawErrors) {
-    if (typeof rawError !== 'string') continue
-    const trimmed = rawError.trim()
-    if (!trimmed) continue
-
-    const separatorIndex = trimmed.indexOf(': ')
-    const message = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 2).trim() : trimmed
-    if (!message) continue
-
-    counts.set(message, (counts.get(message) || 0) + 1)
-  }
-
-  if (counts.size === 0) return ''
-
-  return Array.from(counts.entries())
-    .slice(0, 3)
-    .map(([message, count]) => (count > 1 ? `${count} students: ${message}` : message))
-    .join(' · ')
-}
-
-const STATUS_META: Record<
-  TestGradingStudentRow['status'],
-  { label: string; icon: typeof Circle; className: string }
-> = {
-  not_started: { label: 'Not started', icon: Circle, className: 'text-gray-400' },
-  in_progress: { label: 'In progress', icon: Circle, className: 'text-yellow-500' },
-  submitted: { label: 'Submitted', icon: Check, className: 'text-green-500' },
-  returned: { label: 'Returned', icon: Send, className: 'text-blue-500' },
+  onRequestDelete?: () => void
 }
 
 export function TeacherQuizzesTab({
   classroom,
-  assessmentType,
+  selectedQuizId: selectedQuizIdProp,
+  updateSearchParams,
   onSelectQuiz,
-  testsSidebarClickToken = 0,
-  onTestGradingDataRefresh,
-  onTestGradingContextChange,
+  onRequestDelete,
 }: Props) {
+  const apiBasePath = '/api/teacher/quizzes'
+  const isReadOnly = !!classroom.archived_at
+
   const [quizzes, setQuizzes] = useState<QuizWithStats[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedQuizId, setSelectedQuizId] = useState<string | null>(null)
+  const [internalSelectedQuizId, setInternalSelectedQuizId] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
   const [pendingCreatedQuizId, setPendingCreatedQuizId] = useState<string | null>(null)
+  const [selectedQuizDraftSummary, setSelectedQuizDraftSummary] =
+    useState<AssessmentEditorSummaryUpdate | null>(null)
 
-  const [testsMode, setTestsMode] = useState<'authoring' | 'grading'>('authoring')
-  const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
-  const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
-  const [gradingLoading, setGradingLoading] = useState(false)
-  const [gradingError, setGradingError] = useState('')
-  const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
-  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
-  const [gradingInfo, setGradingInfo] = useState('')
-  const [gradingWarning, setGradingWarning] = useState('')
-  const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
-  const [isBatchReturning, setIsBatchReturning] = useState(false)
-  const [isBatchClearingOpenGrades, setIsBatchClearingOpenGrades] = useState(false)
-  const [showReturnConfirm, setShowReturnConfirm] = useState(false)
-  const [showClearOpenGradesConfirm, setShowClearOpenGradesConfirm] = useState(false)
-  const [showBatchGradeModal, setShowBatchGradeModal] = useState(false)
-  const [showPromptGuidelineModal, setShowPromptGuidelineModal] = useState(false)
-  const [batchPromptGuideline, setBatchPromptGuideline] = useState('')
-  const [batchPromptGuidelineDraft, setBatchPromptGuidelineDraft] = useState('')
-  const [batchGradingStrategy, setBatchGradingStrategy] = useState<TestAiGradingStrategy>('balanced')
-  const [batchGradingStrategyDraft, setBatchGradingStrategyDraft] =
-    useState<TestAiGradingStrategy>('balanced')
+  const selectedQuizId =
+    selectedQuizIdProp !== undefined ? selectedQuizIdProp : internalSelectedQuizId
 
-  const { setOpen: setRightSidebarOpen } = useRightSidebar()
+  const selectedQuiz = useMemo(
+    () => quizzes.find((quiz) => quiz.id === selectedQuizId) ?? null,
+    [quizzes, selectedQuizId],
+  )
 
-  const isReadOnly = !!classroom.archived_at
-  const isTestsView = assessmentType === 'test'
-  const apiBasePath = isTestsView ? '/api/teacher/tests' : '/api/teacher/quizzes'
-
-  const sortedGradingStudents = useMemo(
-    () =>
-      [...gradingStudents].sort((a, b) => {
-        const aNameParts = getSortableNameParts(a)
-        const bNameParts = getSortableNameParts(b)
-        return compareByNameFields(
-          {
-            firstName: aNameParts.firstName,
-            lastName: aNameParts.lastName,
-            id: a.email || a.student_id,
-          },
-          {
-            firstName: bNameParts.firstName,
-            lastName: bNameParts.lastName,
-            id: b.email || b.student_id,
-          },
-          gradingSortColumn,
-          'asc'
-        )
-      }),
-    [gradingSortColumn, gradingStudents]
-  )
-  const gradingRowIds = useMemo(
-    () => sortedGradingStudents.map((student) => student.student_id),
-    [sortedGradingStudents]
-  )
-  const {
-    selectedIds: batchSelectedIds,
-    toggleSelect: toggleBatchSelect,
-    toggleSelectAll: toggleBatchSelectAll,
-    allSelected: batchAllSelected,
-    clearSelection: clearBatchSelection,
-    selectedCount: batchSelectedCount,
-  } = useStudentSelection(gradingRowIds)
-  const batchSelectedStudents = useMemo(
-    () => sortedGradingStudents.filter((student) => batchSelectedIds.has(student.student_id)),
-    [batchSelectedIds, sortedGradingStudents]
-  )
-  const batchSelectedStudentIds = useMemo(
-    () => batchSelectedStudents.map((student) => student.student_id),
-    [batchSelectedStudents]
-  )
-  const batchAutoGradePreflight = useMemo(() => {
-    const selectedCount = batchSelectedStudents.length
-    const ungradedResponses = batchSelectedStudents.reduce(
-      (sum, student) => sum + student.ungraded_open_responses,
-      0
-    )
-    const gradedResponses = batchSelectedStudents.reduce(
-      (sum, student) => sum + student.graded_open_responses,
-      0
-    )
-    const codeQuestions = gradingQuestions.filter(
-      (question) => question.questionType === 'open_response' && question.responseMonospace
-    ).length
-    const regularQuestions = gradingQuestions.filter(
-      (question) => question.questionType === 'open_response' && !question.responseMonospace
-    ).length
+  const selectedQuizWorkspace = useMemo(() => {
+    if (!selectedQuiz) return null
+    if (!selectedQuizDraftSummary) return selectedQuiz
 
     return {
-      selectedCount,
-      ungradedResponses,
-      gradedResponses,
-      codeQuestions,
-      regularQuestions,
-      potentialAiSends: ungradedResponses,
+      ...selectedQuiz,
+      title: selectedQuizDraftSummary.title,
+      show_results: selectedQuizDraftSummary.show_results,
+      stats: {
+        ...selectedQuiz.stats,
+        questions_count: selectedQuizDraftSummary.questions_count,
+      },
     }
-  }, [batchSelectedStudents, gradingQuestions])
+  }, [selectedQuiz, selectedQuizDraftSummary])
 
-  const loadGradingRows = useCallback(async () => {
-    if (!selectedQuizId) {
-      setGradingStudents([])
-      setGradingQuestions([])
-      return
-    }
+  const applyQuizSummaryPatch = useCallback((quizId: string, update: AssessmentEditorSummaryUpdate) => {
+    setQuizzes((prev) =>
+      prev.map((quiz) => {
+        if (quiz.id !== quizId) return quiz
 
-    setGradingLoading(true)
-    setGradingError('')
-    try {
-      const res = await fetch(`${apiBasePath}/${selectedQuizId}/results`, { cache: 'no-store' })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to load test results')
-      setGradingStudents((data.students || []) as TestGradingStudentRow[])
-      setGradingQuestions(
-        Array.isArray(data.questions)
-          ? data.questions.map((question: any) => ({
-              id: String(question.id),
-              questionType:
-                question.question_type === 'open_response' ? 'open_response' : 'multiple_choice',
-              responseMonospace: question.response_monospace === true,
-            }))
-          : []
-      )
-    } catch (err: any) {
-      setGradingError(err.message || 'Failed to load test results')
-      setGradingStudents([])
-      setGradingQuestions([])
-    } finally {
-      setGradingLoading(false)
-    }
-  }, [apiBasePath, selectedQuizId])
+        return {
+          ...quiz,
+          title: typeof update.title === 'string' ? update.title : quiz.title,
+          show_results: typeof update.show_results === 'boolean' ? update.show_results : quiz.show_results,
+          stats: {
+            ...quiz.stats,
+            questions_count:
+              typeof update.questions_count === 'number' ? update.questions_count : quiz.stats.questions_count,
+          },
+        }
+      }),
+    )
+  }, [])
+
+  const navigateQuizWorkspace = useCallback((
+    nextQuizId: string | null,
+    options?: UpdateSearchOptions,
+  ) => {
+    setInternalSelectedQuizId(nextQuizId)
+
+    updateSearchParams?.((params) => {
+      params.set('tab', 'quizzes')
+      if (nextQuizId) {
+        params.set('quizId', nextQuizId)
+      } else {
+        params.delete('quizId')
+      }
+      params.delete('testId')
+      params.delete('testMode')
+      params.delete('testStudentId')
+    }, options)
+  }, [updateSearchParams])
+
+  const clearQuizWorkspace = useCallback((options?: UpdateSearchOptions) => {
+    navigateQuizWorkspace(null, options)
+  }, [navigateQuizWorkspace])
 
   const loadQuizzes = useCallback(async () => {
     setLoading(true)
     try {
       const query = new URLSearchParams({ classroom_id: classroom.id })
-      const res = await fetch(`${apiBasePath}?${query.toString()}`)
-      const data = await res.json()
+      const response = await fetch(`${apiBasePath}?${query.toString()}`)
+      const data = await response.json()
       setQuizzes(data.quizzes || [])
-    } catch (err) {
-      console.error('Error loading quizzes:', err)
+    } catch (error) {
+      console.error('Error loading quizzes:', error)
     } finally {
       setLoading(false)
     }
-  }, [apiBasePath, classroom.id])
+  }, [classroom.id])
 
   useEffect(() => {
-    loadQuizzes()
+    void loadQuizzes()
   }, [loadQuizzes])
 
   useEffect(() => {
     function handleQuizzesUpdated(event: Event) {
       const detail = (event as CustomEvent<{ classroomId?: string }>).detail
       if (!detail || detail.classroomId !== classroom.id) return
-      loadQuizzes()
+      void loadQuizzes()
     }
+
     window.addEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleQuizzesUpdated)
     return () => window.removeEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleQuizzesUpdated)
   }, [classroom.id, loadQuizzes])
 
   useEffect(() => {
-    const selected = quizzes.find((q) => q.id === selectedQuizId) ?? null
-    onSelectQuiz?.(selected)
-  }, [selectedQuizId, quizzes, onSelectQuiz])
+    onSelectQuiz?.(selectedQuizWorkspace)
+  }, [onSelectQuiz, selectedQuizWorkspace])
 
   useEffect(() => {
-    if (!selectedQuizId) return
+    if (!selectedQuizId || loading) return
     if (quizzes.some((quiz) => quiz.id === selectedQuizId)) return
-    setSelectedQuizId(null)
-  }, [quizzes, selectedQuizId])
+
+    clearQuizWorkspace({ replace: true })
+  }, [clearQuizWorkspace, loading, quizzes, selectedQuizId])
+
+  useEffect(() => {
+    setSelectedQuizDraftSummary(null)
+  }, [selectedQuizId])
 
   useEffect(() => {
     if (!pendingCreatedQuizId) return
     if (!quizzes.some((quiz) => quiz.id === pendingCreatedQuizId)) return
-    setSelectedQuizId(pendingCreatedQuizId)
+
+    navigateQuizWorkspace(pendingCreatedQuizId)
     setPendingCreatedQuizId(null)
-    setRightSidebarOpen(true)
-  }, [pendingCreatedQuizId, quizzes, setRightSidebarOpen])
-
-  useEffect(() => {
-    if (!isTestsView || testsMode !== 'grading' || selectedQuizId || quizzes.length === 0) return
-    setSelectedQuizId(quizzes[0].id)
-  }, [isTestsView, quizzes, testsMode, selectedQuizId])
-
-  useEffect(() => {
-    if (!isTestsView) return
-    setTestsMode('authoring')
-    setSelectedStudentId(null)
-    setGradingError('')
-    setGradingWarning('')
-    setGradingInfo('')
-    clearBatchSelection()
-  }, [clearBatchSelection, isTestsView, testsSidebarClickToken])
-
-  useEffect(() => {
-    if (!isTestsView || testsMode !== 'grading' || !selectedQuizId) {
-      setGradingStudents([])
-      setGradingQuestions([])
-      setSelectedStudentId(null)
-      setGradingError('')
-      setGradingWarning('')
-      setGradingInfo('')
-      clearBatchSelection()
-      return
-    }
-
-    void loadGradingRows()
-  }, [clearBatchSelection, isTestsView, loadGradingRows, selectedQuizId, testsMode])
-
-  useEffect(() => {
-    function handleGradingRowUpdate(event: Event) {
-      if (!isTestsView || testsMode !== 'grading' || !selectedQuizId) return
-
-      const detail = (event as CustomEvent<TeacherTestGradingRowUpdatedEventDetail>).detail
-      if (!detail || detail.testId !== selectedQuizId) return
-
-      setGradingStudents((prev) =>
-        prev.map((student) => {
-          if (student.student_id !== detail.studentId) return student
-          return {
-            ...student,
-            points_earned: detail.pointsEarned,
-            points_possible: detail.pointsPossible,
-            percent: detail.percent,
-            graded_open_responses: detail.gradedOpenResponses,
-            ungraded_open_responses: detail.ungradedOpenResponses,
-          }
-        })
-      )
-    }
-
-    window.addEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
-    return () => window.removeEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
-  }, [isTestsView, selectedQuizId, testsMode])
-
-  useEffect(() => {
-    if (!isTestsView || testsMode !== 'grading') {
-      setSelectedStudentId(null)
-      return
-    }
-    if (sortedGradingStudents.length === 0) {
-      setSelectedStudentId(null)
-      return
-    }
-    if (
-      !selectedStudentId ||
-      !sortedGradingStudents.some((student) => student.student_id === selectedStudentId)
-    ) {
-      setSelectedStudentId(sortedGradingStudents[0].student_id)
-    }
-  }, [isTestsView, selectedStudentId, sortedGradingStudents, testsMode])
-
-  useEffect(() => {
-    if (!isTestsView || !onTestGradingContextChange) return
-
-    if (testsMode === 'authoring') {
-      onTestGradingContextChange({
-        mode: 'authoring',
-        testId: selectedQuizId,
-        studentId: null,
-        studentName: null,
-      })
-      return
-    }
-
-    const selectedStudent = gradingStudents.find((student) => student.student_id === selectedStudentId) || null
-    onTestGradingContextChange({
-      mode: 'grading',
-      testId: selectedQuizId,
-      studentId: selectedStudent?.student_id || null,
-      studentName: selectedStudent?.name || selectedStudent?.email || null,
-    })
-  }, [
-    gradingStudents,
-    isTestsView,
-    onTestGradingContextChange,
-    selectedQuizId,
-    selectedStudentId,
-    testsMode,
-  ])
-
-  useEffect(() => {
-    if (!gradingWarning) return
-    if (batchSelectedCount > 0) {
-      setGradingWarning('')
-      return
-    }
-    const timer = window.setTimeout(() => setGradingWarning(''), 3000)
-    return () => window.clearTimeout(timer)
-  }, [batchSelectedCount, gradingWarning])
-
-  useEffect(() => {
-    if (!gradingInfo) return
-    const timer = window.setTimeout(() => setGradingInfo(''), 4000)
-    return () => window.clearTimeout(timer)
-  }, [gradingInfo])
-
-  async function handleBatchAutoGrade(options?: {
-    studentIds?: string[]
-    preserveSelection?: boolean
-    infoPrefix?: string
-  }) {
-    const targetStudentIds = options?.studentIds || batchSelectedStudentIds
-    if (!selectedQuizId || targetStudentIds.length === 0) return
-
-    setIsBatchAutoGrading(true)
-    setGradingError('')
-    setGradingInfo('')
-    try {
-      const res = await fetch(`${apiBasePath}/${selectedQuizId}/auto-grade`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          student_ids: targetStudentIds,
-          grading_strategy: batchGradingStrategy,
-          ...(batchPromptGuideline.trim()
-            ? { prompt_guideline: batchPromptGuideline.trim() }
-            : {}),
-        }),
-      })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Auto-grade failed')
-
-      const gradedStudents = Number(data.graded_students ?? 0)
-      const skippedStudents = Number(data.skipped_students ?? 0)
-      const errorSummary = summarizeBatchAutoGradeErrors(data.errors)
-      const summaryPrefix = options?.infoPrefix || 'AI graded'
-      const summary = `${summaryPrefix} ${gradedStudents} student${gradedStudents === 1 ? '' : 's'}${skippedStudents > 0 ? ` • ${skippedStudents} skipped` : ''}`
-      setGradingInfo(summary)
-
-      if (!options?.preserveSelection) {
-        clearBatchSelection()
-      }
-      await loadGradingRows()
-      onTestGradingDataRefresh?.()
-      if (errorSummary) {
-        setGradingError(errorSummary)
-      }
-    } catch (err: any) {
-      setGradingError(err.message || 'Auto-grade failed')
-    } finally {
-      setIsBatchAutoGrading(false)
-    }
-  }
-
-  async function handleBatchReturn(options?: { closeTest?: boolean }) {
-    if (!selectedQuizId || batchSelectedCount === 0) return
-
-    setIsBatchReturning(true)
-    setGradingError('')
-    setGradingInfo('')
-    try {
-      const res = await fetch(`${apiBasePath}/${selectedQuizId}/return`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          student_ids: Array.from(batchSelectedIds),
-          close_test: options?.closeTest === true,
-        }),
-      })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Return failed')
-
-      const returnedCount = Number(data.returned_count ?? 0)
-      const skippedCount = Number(data.skipped_count ?? 0)
-      setGradingInfo(
-        `Returned ${returnedCount} student${returnedCount === 1 ? '' : 's'}${skippedCount > 0 ? ` • ${skippedCount} skipped` : ''}`
-      )
-
-      clearBatchSelection()
-      setShowReturnConfirm(false)
-      if (data.test_closed) {
-        await loadQuizzes()
-      }
-      await loadGradingRows()
-    } catch (err: any) {
-      setGradingError(err.message || 'Return failed')
-    } finally {
-      setIsBatchReturning(false)
-    }
-  }
-
-  async function handleBatchClearOpenGrades() {
-    if (!selectedQuizId || batchSelectedCount === 0) return
-
-    setIsBatchClearingOpenGrades(true)
-    setGradingError('')
-    setGradingInfo('')
-    try {
-      const res = await fetch(`${apiBasePath}/${selectedQuizId}/clear-open-grades`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: Array.from(batchSelectedIds) }),
-      })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Clear open grades failed')
-
-      const clearedStudents = Number(data.cleared_students ?? 0)
-      const skippedStudents = Number(data.skipped_students ?? 0)
-      const clearedResponses = Number(data.cleared_responses ?? 0)
-      setGradingInfo(
-        `Cleared ${clearedResponses} open response${clearedResponses === 1 ? '' : 's'} across ${clearedStudents} student${clearedStudents === 1 ? '' : 's'}${skippedStudents > 0 ? ` • ${skippedStudents} skipped` : ''}`
-      )
-
-      clearBatchSelection()
-      setShowClearOpenGradesConfirm(false)
-      await loadGradingRows()
-      onTestGradingDataRefresh?.()
-    } catch (err: any) {
-      setGradingError(err.message || 'Clear open grades failed')
-    } finally {
-      setIsBatchClearingOpenGrades(false)
-    }
-  }
-
-  function openBatchPromptGuidelineModal() {
-    setBatchPromptGuidelineDraft(batchPromptGuideline)
-    setBatchGradingStrategyDraft(batchGradingStrategy)
-    setShowPromptGuidelineModal(true)
-  }
+  }, [navigateQuizWorkspace, pendingCreatedQuizId, quizzes])
 
   function handleCardSelect(quiz: QuizWithStats) {
-    const newSelectedId = selectedQuizId === quiz.id ? null : quiz.id
-    setSelectedQuizId(newSelectedId)
-    if (newSelectedId) {
-      setRightSidebarOpen(true)
-    }
+    navigateQuizWorkspace(quiz.id)
   }
 
   function handleNewQuiz() {
@@ -593,583 +181,110 @@ export function TeacherQuizzesTab({
 
   function handleQuizCreated(quiz: Quiz) {
     setShowModal(false)
-    if (isTestsView) {
-      setTestsMode('authoring')
-      setPendingCreatedQuizId(quiz.id)
-    }
+    setPendingCreatedQuizId(quiz.id)
     window.dispatchEvent(
-      new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
+      new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } }),
     )
   }
 
-  const assessmentLabelPlural = isTestsView ? 'Tests' : 'Quizzes'
-  const selectedTest = quizzes.find((quiz) => quiz.id === selectedQuizId) || null
-  const selectedTestTitle = selectedTest?.title || 'No test selected'
-  const returnWillCloseActiveTest = isTestsView && testsMode === 'grading' && selectedTest?.status === 'active'
-  const batchGradeDescriptionParts: string[] = []
-  if (batchAutoGradePreflight.selectedCount > 0) {
-    const questionBreakdown: string[] = []
-    if (batchAutoGradePreflight.codeQuestions > 0) {
-      questionBreakdown.push(
-        `${batchAutoGradePreflight.codeQuestions} code question${batchAutoGradePreflight.codeQuestions === 1 ? '' : 's'}`
-      )
-    }
-    if (batchAutoGradePreflight.regularQuestions > 0) {
-      questionBreakdown.push(
-        `${batchAutoGradePreflight.regularQuestions} regular question${batchAutoGradePreflight.regularQuestions === 1 ? '' : 's'}`
-      )
-    }
-
-    if (questionBreakdown.length > 0) {
-      batchGradeDescriptionParts.push(
-        `This will grade ${batchAutoGradePreflight.selectedCount} selected student${batchAutoGradePreflight.selectedCount === 1 ? '' : 's'} across ${questionBreakdown.join(' and ')}.`
-      )
-    } else {
-      batchGradeDescriptionParts.push(
-        `This will grade ${batchAutoGradePreflight.selectedCount} selected student${batchAutoGradePreflight.selectedCount === 1 ? '' : 's'}.`
-      )
-    }
-
-    batchGradeDescriptionParts.push(
-      `Up to ${batchAutoGradePreflight.potentialAiSends} ungraded open response${batchAutoGradePreflight.potentialAiSends === 1 ? '' : 's'} may be sent to AI.`
-    )
-
-    if (batchAutoGradePreflight.gradedResponses > 0) {
-      batchGradeDescriptionParts.push(
-        `${batchAutoGradePreflight.gradedResponses} response${batchAutoGradePreflight.gradedResponses === 1 ? '' : 's'} already have grades and may be skipped.`
-      )
-    }
-  }
-  const batchGradeDescription = batchGradeDescriptionParts.join(' ')
-  const testsModeToggle = isTestsView ? (
-    <div className="inline-flex items-center rounded-md border border-border bg-surface p-0.5 shadow-sm">
-      <button
-        type="button"
-        onClick={() => {
-          setTestsMode('authoring')
-          setSelectedQuizId(null)
-          setRightSidebarOpen(false)
-        }}
-        className={[
-          'rounded px-2.5 py-1 text-xs font-medium transition-colors sm:px-3 sm:py-1.5 sm:text-sm',
-          testsMode === 'authoring'
-            ? 'bg-surface-panel text-text-default shadow-sm'
-            : 'text-text-muted hover:text-text-default',
-        ].join(' ')}
-        aria-pressed={testsMode === 'authoring'}
-      >
-        Authoring
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          setTestsMode('grading')
-          setRightSidebarOpen(true)
-        }}
-        className={[
-          'rounded px-2.5 py-1 text-xs font-medium transition-colors sm:px-3 sm:py-1.5 sm:text-sm',
-          testsMode === 'grading'
-            ? 'bg-surface-panel text-text-default shadow-sm'
-            : 'text-text-muted hover:text-text-default',
-        ].join(' ')}
-        aria-pressed={testsMode === 'grading'}
-      >
-        Grading
-      </button>
+  const primaryContent = selectedQuizWorkspace ? (
+    <div className="flex min-w-0 flex-wrap items-center gap-2">
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate text-sm font-semibold text-text-default" title={selectedQuizWorkspace.title}>
+          {selectedQuizWorkspace.title}
+        </h2>
+      </div>
+      {onRequestDelete ? (
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          onClick={onRequestDelete}
+          disabled={isReadOnly}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete Quiz
+        </Button>
+      ) : null}
     </div>
-  ) : null
+  ) : (
+    <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
+      <Plus className="h-4 w-4" />
+      New Quiz
+    </Button>
+  )
+
+  const summaryContent = loading ? (
+    <div className="flex justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : quizzes.length === 0 ? (
+    <EmptyState
+      title="No quizzes yet"
+      description="Create a quiz to get started."
+      tone="muted"
+      className="mx-auto w-full max-w-3xl"
+    />
+  ) : (
+    <PageStack className="w-full">
+      {quizzes.map((quiz) => (
+        <QuizCard
+          key={quiz.id}
+          quiz={quiz}
+          apiBasePath={apiBasePath}
+          isSelected={selectedQuizId === quiz.id}
+          isReadOnly={isReadOnly}
+          onSelect={() => handleCardSelect(quiz)}
+          onQuizUpdate={() => {
+            void loadQuizzes()
+          }}
+        />
+      ))}
+    </PageStack>
+  )
+
+  const workspaceContent = selectedQuizWorkspace ? (
+    <QuizDetailPanel
+      quiz={selectedQuizWorkspace}
+      classroomId={classroom.id}
+      apiBasePath={apiBasePath}
+      onDraftSummaryChange={setSelectedQuizDraftSummary}
+      onQuizUpdate={(update) => {
+        if (update) {
+          setSelectedQuizDraftSummary(update)
+          applyQuizSummaryPatch(selectedQuizWorkspace.id, update)
+          return
+        }
+        void loadQuizzes()
+      }}
+      onRequestDelete={onRequestDelete}
+      showInlineDeleteAction={false}
+    />
+  ) : (
+    <div className="flex flex-1 justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  )
 
   return (
-    <PageLayout className="flex h-full min-h-0 flex-col">
-      <PageActionBar
-        primary={
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            {isTestsView && testsMode === 'grading' ? (
-              <>
-                <div className="min-w-0 rounded-md border border-border bg-surface px-3 py-2 text-sm">
-                  <span className="block truncate font-medium text-text-default">{selectedTestTitle}</span>
-                </div>
-                {!isReadOnly ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => {
-                        if (batchSelectedCount === 0) {
-                          setGradingWarning('Select students to grade')
-                          return
-                        }
-                        setShowBatchGradeModal(true)
-                      }}
-                      className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
-                      aria-label={batchSelectedCount > 0 ? `Grade ${batchSelectedCount} selected` : 'Grade selected students'}
-                      disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-                    >
-                      <Check className="h-4 w-4 text-primary" />
-                    </Button>
-                    <Tooltip
-                      content={
-                        batchSelectedCount > 0
-                          ? `Return (${batchSelectedCount})`
-                          : 'Select students to return'
-                      }
-                    >
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        className={batchSelectedCount === 0 ? 'h-8 w-8 p-0 opacity-60' : 'h-8 w-8 p-0'}
-                        aria-label={batchSelectedCount > 0 ? `Return ${batchSelectedCount} selected tests` : 'Return selected tests'}
-                        disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-                        onClick={() => {
-                          if (batchSelectedCount === 0) {
-                            setGradingWarning('Select students to return')
-                            return
-                          }
-                          setShowReturnConfirm(true)
-                        }}
-                      >
-                        <Send className="h-4 w-4 text-primary" />
-                      </Button>
-                    </Tooltip>
-                  </>
-                ) : null}
-              </>
-            ) : (
-              !isReadOnly && (!isTestsView || testsMode === 'authoring') && (
-                <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5 shadow-sm">
-                  <Plus className="h-4 w-4" />
-                  {isTestsView ? 'New Test' : 'New Quiz'}
-                </Button>
-              )
-            )}
-          </div>
-        }
-        trailing={testsModeToggle}
+    <>
+      <TeacherWorkSurfaceShell
+        state={selectedQuizId ? 'workspace' : 'summary'}
+        primary={primaryContent}
+        summary={summaryContent}
+        workspace={workspaceContent}
+        workspaceFrame="standalone"
       />
-
-      <PageContent className="flex min-h-0 flex-1 flex-col gap-3">
-        {gradingError && isTestsView && testsMode === 'grading' && (
-          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-            {gradingError}
-          </div>
-        )}
-        {gradingWarning && isTestsView && testsMode === 'grading' && (
-          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-            {gradingWarning}
-          </div>
-        )}
-        {gradingInfo && isTestsView && testsMode === 'grading' && (
-          <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
-            {gradingInfo}
-          </div>
-        )}
-
-        {loading ? (
-          <div className="flex justify-center py-12">
-            <Spinner size="lg" />
-          </div>
-        ) : quizzes.length === 0 ? (
-          <EmptyState
-            title={`No ${assessmentLabelPlural.toLowerCase()} yet`}
-            description={`Create a ${isTestsView ? 'test' : 'quiz'} to get started.`}
-            tone="muted"
-            className="mx-auto w-full max-w-3xl"
-          />
-        ) : isTestsView && testsMode === 'grading' ? (
-          <div className="space-y-3">
-            {gradingLoading ? (
-              <div className="flex justify-center py-10">
-                <Spinner />
-              </div>
-            ) : gradingStudents.length === 0 ? (
-              <p className="text-sm text-text-muted">No student rows available for this test.</p>
-            ) : (
-              <div className="overflow-hidden rounded-md border border-border bg-surface">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="bg-surface-hover text-left text-text-muted">
-                      <th className="w-10 px-3 py-2 font-medium">
-                        <input
-                          type="checkbox"
-                          checked={batchAllSelected}
-                          onChange={toggleBatchSelectAll}
-                          className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                          aria-label="Select all students"
-                        />
-                      </th>
-                      <th className="px-3 py-2 font-medium">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setGradingSortColumn((prev) => (prev === 'last_name' ? 'first_name' : 'last_name'))
-                          }}
-                          className="inline-flex items-center gap-2 text-left text-text-muted hover:text-text-default"
-                          aria-label={
-                            gradingSortColumn === 'last_name'
-                              ? 'Sort students by first name'
-                              : 'Sort students by last name'
-                          }
-                        >
-                          <span>Student</span>
-                          <span className="text-xs font-medium text-text-muted">
-                            {gradingSortColumn === 'last_name' ? 'Last' : 'First'}
-                          </span>
-                        </button>
-                      </th>
-                      <th className="w-8 px-2 py-2 font-medium" aria-label="Status" />
-                      <th className="px-3 py-2 font-medium">Score</th>
-                      <th className="px-3 py-2 font-medium">
-                        <Tooltip content="Most recent recorded in-test activity time (Toronto).">
-                          <span className="cursor-help">Last</span>
-                        </Tooltip>
-                      </th>
-                      <th className="px-3 py-2 font-medium">
-                        <Tooltip
-                          content={
-                            <div className="space-y-0.5">
-                              <p className="font-medium">Exits = combined count</p>
-                              <p>Away/focus events</p>
-                              <p>In-app exits</p>
-                              <p>Window/full-screen exits</p>
-                            </div>
-                          }
-                        >
-                          <span className="inline-flex cursor-help items-center" aria-label="Exits column">
-                            <LogOut className="h-4 w-4" />
-                          </span>
-                        </Tooltip>
-                      </th>
-                      <th className="px-3 py-2 font-medium">
-                        <Tooltip content="Total time this student was away from the test route.">
-                          <span className="inline-flex cursor-help items-center" aria-label="Away column">
-                            <ClockAlert className="h-4 w-4" />
-                          </span>
-                        </Tooltip>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedGradingStudents.map((student) => {
-                      const isSelected = student.student_id === selectedStudentId
-                      const scoreLabel =
-                        student.status === 'not_started'
-                          ? '—'
-                          : `${formatPoints(student.points_earned)}/${formatPoints(student.points_possible)}`
-                      const statusMeta = STATUS_META[student.status]
-                      const StatusIcon = statusMeta.icon
-                      const awayCount = student.focus_summary?.away_count ?? 0
-                      const awaySeconds = student.focus_summary?.away_total_seconds ?? 0
-                      const awayMinutes = Math.floor(awaySeconds / 60)
-                      const awayRemainder = awaySeconds % 60
-                      const awayLabel = `${awayMinutes}:${String(awayRemainder).padStart(2, '0')}`
-                      const routeExitAttempts = student.focus_summary?.route_exit_attempts ?? 0
-                      const windowUnmaximizeAttempts =
-                        student.focus_summary?.window_unmaximize_attempts ?? 0
-                      const exitsCount = getQuizExitCount(student.focus_summary)
-                      const formattedLastActivity = formatTorontoTime(student.last_activity_at)
-
-                      return (
-                        <tr
-                          key={student.student_id}
-                          className={[
-                            'cursor-pointer border-t border-border transition-colors hover:bg-surface-hover',
-                            isSelected ? 'bg-primary/10' : '',
-                          ].join(' ')}
-                          onClick={() => {
-                            setSelectedStudentId(student.student_id)
-                            setRightSidebarOpen(true)
-                          }}
-                        >
-                          <td className="px-3 py-2">
-                            <input
-                              type="checkbox"
-                              checked={batchSelectedIds.has(student.student_id)}
-                              onChange={() => toggleBatchSelect(student.student_id)}
-                              onClick={(event) => event.stopPropagation()}
-                              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                              aria-label={`Select ${student.name || 'student'}`}
-                            />
-                          </td>
-                          <td className="px-3 py-2">
-                            <div className="font-medium text-text-default">{student.name || 'Student'}</div>
-                          </td>
-                          <td className="px-3 py-2">
-                            <Tooltip content={statusMeta.label}>
-                              <span
-                                className={`inline-flex min-w-5 cursor-help items-center justify-center text-sm font-semibold ${statusMeta.className}`}
-                                aria-label={statusMeta.label}
-                              >
-                                <StatusIcon className="h-4 w-4" />
-                              </span>
-                            </Tooltip>
-                          </td>
-                          <td className="px-3 py-2 text-text-default">{scoreLabel}</td>
-                          <td
-                            className={[
-                              'px-3 py-2 tabular-nums',
-                              formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
-                            ].join(' ')}
-                          >
-                            <Tooltip content="Most recent recorded in-test activity time (Toronto).">
-                              <span
-                                className={[
-                                  'cursor-help',
-                                  formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
-                                ].join(' ')}
-                              >
-                                {formattedLastActivity.value}
-                              </span>
-                            </Tooltip>
-                          </td>
-                          <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
-                            <Tooltip
-                              content={
-                                <div className="space-y-0.5">
-                                  <p className="font-medium">Exits: {exitsCount}</p>
-                                  <p>Away/focus: {awayCount}</p>
-                                  <p>In-app exits: {routeExitAttempts}</p>
-                                  <p>Window exits: {windowUnmaximizeAttempts}</p>
-                                </div>
-                              }
-                            >
-                              <span
-                                className="cursor-help"
-                                aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
-                              >
-                                {exitsCount}
-                              </span>
-                            </Tooltip>
-                          </td>
-                          <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
-                            <Tooltip
-                              content={`Away from test route for ${awayLabel} total.`}
-                            >
-                              <span
-                                className="cursor-help"
-                                aria-label={`Away time ${awayLabel}. Away from test route for ${awayLabel} total.`}
-                              >
-                                {awayLabel}
-                              </span>
-                            </Tooltip>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        ) : (
-          <PageStack className="mx-auto w-full max-w-6xl">
-            {quizzes.map((quiz) => (
-              <QuizCard
-                key={quiz.id}
-                quiz={quiz}
-                apiBasePath={apiBasePath}
-                isSelected={selectedQuizId === quiz.id}
-                isReadOnly={isReadOnly}
-                onSelect={() => handleCardSelect(quiz)}
-                onQuizUpdate={loadQuizzes}
-              />
-            ))}
-          </PageStack>
-        )}
-      </PageContent>
 
       <QuizModal
         isOpen={showModal}
         classroomId={classroom.id}
-        assessmentType={assessmentType}
+        assessmentType="quiz"
         apiBasePath={apiBasePath}
         quiz={null}
         onClose={() => setShowModal(false)}
         onSuccess={handleQuizCreated}
       />
-
-      <DialogPanel
-        isOpen={showBatchGradeModal}
-        onClose={() => setShowBatchGradeModal(false)}
-        ariaLabelledBy="test-ai-grade-title"
-        maxWidth="max-w-lg"
-        className="p-6"
-      >
-        <h2 id="test-ai-grade-title" className="text-lg font-semibold text-text-default">
-          AI Grading
-        </h2>
-        <p className="mt-2 text-sm text-text-muted">
-          Review the current selection before starting AI grading.
-        </p>
-        <div className="mt-4 rounded-md border border-border bg-surface px-3 py-3 text-sm text-text-default">
-          <div className="flex flex-wrap gap-x-4 gap-y-1">
-            <span>{batchAutoGradePreflight.selectedCount} selected</span>
-            <span>{batchAutoGradePreflight.codeQuestions} code</span>
-            <span>{batchAutoGradePreflight.regularQuestions} regular</span>
-          </div>
-          <p className="mt-2 text-sm text-text-muted">
-            {batchGradeDescription || 'This will grade the currently selected students.'}
-          </p>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => {
-              setShowBatchGradeModal(false)
-              openBatchPromptGuidelineModal()
-            }}
-          >
-            AI Prompt
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => {
-              setShowBatchGradeModal(false)
-              setShowClearOpenGradesConfirm(true)
-            }}
-          >
-            Clear Open Scores/Feedback
-          </Button>
-        </div>
-        <div className="mt-5 flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => setShowBatchGradeModal(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={isBatchAutoGrading}
-            onClick={() => {
-              setShowBatchGradeModal(false)
-              void handleBatchAutoGrade()
-            }}
-          >
-            {isBatchAutoGrading ? 'Grading...' : 'Grade with AI'}
-          </Button>
-        </div>
-      </DialogPanel>
-
-      <DialogPanel
-        isOpen={showPromptGuidelineModal}
-        onClose={() => {
-          setShowPromptGuidelineModal(false)
-          setBatchPromptGuidelineDraft(batchPromptGuideline)
-          setBatchGradingStrategyDraft(batchGradingStrategy)
-        }}
-        ariaLabelledBy="test-ai-prompt-guideline-title"
-        maxWidth="max-w-xl"
-        className="p-6"
-      >
-        <h2 id="test-ai-prompt-guideline-title" className="text-lg font-semibold text-text-default">
-          AI Prompt
-        </h2>
-        <p className="mt-2 text-sm text-text-muted">
-          Pika automatically uses the coding rubric for code-style questions and the regular rubric
-          for other open responses.
-        </p>
-        <div className="mt-4">
-          <FormField label="Grading strategy">
-            <Select
-              aria-label="Grading strategy"
-              options={TEST_AI_GRADING_STRATEGY_OPTIONS}
-              value={batchGradingStrategyDraft}
-              onChange={(event) =>
-                setBatchGradingStrategyDraft(event.target.value as TestAiGradingStrategy)
-              }
-            />
-          </FormField>
-          <p className="mt-2 text-xs text-text-muted">
-            Balanced adapts automatically: it reuses one question-level grading context per
-            question and batches same-question responses when there is more than one to grade.
-            Aggressive Batch is experimental and forces batching for each same-question group.
-          </p>
-        </div>
-        <div className="mt-4">
-          <FormField label="Additional instructions (optional)">
-            <textarea
-              value={batchPromptGuidelineDraft}
-              onChange={(event) => setBatchPromptGuidelineDraft(event.target.value)}
-              rows={8}
-              placeholder="Optional teacher note to add on top of the built-in rubric for this run."
-              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-          </FormField>
-        </div>
-        <div className="mt-5 flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => {
-              setShowPromptGuidelineModal(false)
-              setBatchPromptGuidelineDraft(batchPromptGuideline)
-              setBatchGradingStrategyDraft(batchGradingStrategy)
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={() => {
-              setBatchPromptGuideline(batchPromptGuidelineDraft)
-              setBatchGradingStrategy(batchGradingStrategyDraft)
-              setShowPromptGuidelineModal(false)
-            }}
-          >
-            Save
-          </Button>
-        </div>
-      </DialogPanel>
-
-      <ConfirmDialog
-        isOpen={showClearOpenGradesConfirm}
-        title={`Clear open scores and feedback for ${batchSelectedCount} selected student(s)?`}
-        description="This removes all open-response scores and feedback (including AI grading metadata) for the selected students."
-        confirmLabel={isBatchClearingOpenGrades ? 'Clearing...' : 'Clear Open Grades'}
-        confirmVariant="danger"
-        cancelLabel="Cancel"
-        isConfirmDisabled={isBatchClearingOpenGrades}
-        isCancelDisabled={isBatchClearingOpenGrades}
-        onCancel={() => setShowClearOpenGradesConfirm(false)}
-        onConfirm={() => {
-          void handleBatchClearOpenGrades()
-        }}
-      />
-
-      <ConfirmDialog
-        isOpen={showReturnConfirm}
-        title={
-          returnWillCloseActiveTest
-            ? `Close test and return work to ${batchSelectedCount} selected student(s)?`
-            : `Return test work to ${batchSelectedCount} selected student(s)?`
-        }
-        description={
-          returnWillCloseActiveTest
-            ? 'This test is still open. Confirming will close it for all students before returning selected work.'
-            : 'Only students with fully graded open-response questions will be returned.'
-        }
-        confirmLabel={
-          isBatchReturning
-            ? returnWillCloseActiveTest
-              ? 'Closing and Returning...'
-              : 'Returning...'
-            : returnWillCloseActiveTest
-              ? 'Close and Return'
-              : 'Return Test'
-        }
-        cancelLabel="Cancel"
-        isConfirmDisabled={isBatchReturning}
-        isCancelDisabled={isBatchReturning}
-        onCancel={() => setShowReturnConfirm(false)}
-        onConfirm={() => {
-          void handleBatchReturn({ closeTest: returnWillCloseActiveTest })
-        }}
-      />
-    </PageLayout>
+    </>
   )
 }

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -6,9 +6,12 @@ import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TeacherTestCard } from '@/components/TeacherTestCard'
-import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { PageStack } from '@/components/PageLayout'
 import { AssessmentStatusIcon, type AssessmentStatusIconState } from '@/components/AssessmentStatusIcon'
-import { useRightSidebar } from '@/components/layout'
+import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   TEACHER_QUIZZES_UPDATED_EVENT,
   TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
@@ -32,6 +35,10 @@ import type {
 interface Props {
   classroom: Classroom
   testsTabClickToken?: number
+  selectedTestId?: string | null
+  selectedTestMode?: WorkspaceTab | null
+  selectedTestStudentId?: string | null
+  updateSearchParams?: UpdateSearchParamsFn
   onSelectTest?: (test: QuizWithStats | null) => void
   onTestGradingDataRefresh?: () => void
   onTestGradingContextChange?: (context: {
@@ -42,6 +49,15 @@ interface Props {
   }) => void
   onRequestDelete?: () => void
 }
+
+type UpdateSearchOptions = {
+  replace?: boolean
+}
+
+type UpdateSearchParamsFn = (
+  updater: (params: URLSearchParams) => void,
+  options?: UpdateSearchOptions,
+) => void
 
 interface TestGradingStudentRow {
   student_id: string
@@ -194,6 +210,10 @@ function formatTestAiGradingRunMessage(run: TestAiGradingRunSummary): {
 export function TeacherTestsTab({
   classroom,
   testsTabClickToken = 0,
+  selectedTestId: selectedTestIdProp,
+  selectedTestMode,
+  selectedTestStudentId,
+  updateSearchParams,
   onSelectTest,
   onTestGradingDataRefresh,
   onTestGradingContextChange,
@@ -201,7 +221,6 @@ export function TeacherTestsTab({
 }: Props) {
   const apiBasePath = '/api/teacher/tests'
   const isReadOnly = !!classroom.archived_at
-  const { setOpen: setRightSidebarOpen } = useRightSidebar()
   const previousTestsTabClickTokenRef = useRef(testsTabClickToken)
   const gradingSelectionRef = useRef<{
     workspaceState: WorkspaceState
@@ -217,9 +236,8 @@ export function TeacherTestsTab({
 
   const [tests, setTests] = useState<QuizWithStats[]>([])
   const [loading, setLoading] = useState(true)
-  const [workspaceState, setWorkspaceState] = useState<WorkspaceState>('list')
-  const [selectedWorkspaceTab, setSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
-  const [selectedTestId, setSelectedTestId] = useState<string | null>(null)
+  const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
+  const [internalSelectedTestId, setInternalSelectedTestId] = useState<string | null>(null)
   const [selectedTestDraftSummary, setSelectedTestDraftSummary] = useState<AssessmentEditorSummaryUpdate | null>(null)
   const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [showModal, setShowModal] = useState(false)
@@ -235,7 +253,28 @@ export function TeacherTestsTab({
   const [gradingRefreshing, setGradingRefreshing] = useState(false)
   const [gradingError, setGradingError] = useState('')
   const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
-  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const [internalSelectedStudentId, setInternalSelectedStudentId] = useState<string | null>(null)
+  const [gradingInspectorWidth, setGradingInspectorWidth] = useState(50)
+  const [testGradingPanelRefreshToken, setTestGradingPanelRefreshToken] = useState(0)
+  const [testGradingSaveState, setTestGradingSaveState] = useState<{
+    canSave: boolean
+    isSaving: boolean
+    status: 'idle' | 'unsaved' | 'saving' | 'saved'
+  }>({
+    canSave: false,
+    isSaving: false,
+    status: 'idle',
+  })
+
+  const selectedTestId =
+    selectedTestIdProp !== undefined ? selectedTestIdProp : internalSelectedTestId
+  const selectedWorkspaceTab =
+    selectedTestMode === 'authoring' || selectedTestMode === 'grading'
+      ? selectedTestMode
+      : internalSelectedWorkspaceTab
+  const selectedStudentId =
+    selectedTestStudentId !== undefined ? selectedTestStudentId : internalSelectedStudentId
+  const workspaceState: WorkspaceState = selectedTestId ? 'selected' : 'list'
   const [gradingInfo, setGradingInfo] = useState('')
   const [gradingWarning, setGradingWarning] = useState('')
   const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
@@ -323,6 +362,59 @@ export function TeacherTestsTab({
     () => batchSelectedStudents.map((student) => student.student_id),
     [batchSelectedStudents]
   )
+
+  const setSelectedStudentId = useCallback((nextStudentId: string | null) => {
+    setInternalSelectedStudentId(nextStudentId)
+  }, [])
+
+  const navigateTestWorkspace = useCallback((
+    next: {
+      testId: string | null
+      mode?: WorkspaceTab | null
+      studentId?: string | null
+    },
+    options?: UpdateSearchOptions,
+  ) => {
+    setInternalSelectedTestId(next.testId)
+    setInternalSelectedWorkspaceTab(next.mode === 'grading' ? 'grading' : 'authoring')
+    setInternalSelectedStudentId(next.studentId ?? null)
+
+    updateSearchParams?.((params) => {
+      params.set('tab', 'tests')
+      if (next.testId) {
+        params.set('testId', next.testId)
+        params.set('testMode', next.mode === 'grading' ? 'grading' : 'authoring')
+        if (next.mode === 'grading' && next.studentId) {
+          params.set('testStudentId', next.studentId)
+        } else {
+          params.delete('testStudentId')
+        }
+      } else {
+        params.delete('testId')
+        params.delete('testMode')
+        params.delete('testStudentId')
+      }
+    }, options)
+  }, [updateSearchParams])
+
+  const clearTestWorkspace = useCallback((options?: UpdateSearchOptions) => {
+    navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
+  }, [navigateTestWorkspace])
+
+  const switchTestWorkspaceMode = useCallback((nextMode: WorkspaceTab) => {
+    if (!selectedTestId) return
+    navigateTestWorkspace({ testId: selectedTestId, mode: nextMode, studentId: null })
+  }, [navigateTestWorkspace, selectedTestId])
+
+  const selectGradingStudent = useCallback((studentId: string | null) => {
+    setInternalSelectedStudentId(studentId)
+    if (!selectedTestId || selectedWorkspaceTab !== 'grading') return
+    navigateTestWorkspace({
+      testId: selectedTestId,
+      mode: 'grading',
+      studentId,
+    })
+  }, [navigateTestWorkspace, selectedTestId, selectedWorkspaceTab])
 
   const batchAutoGradePreflight = useMemo(() => {
     const selectedCount = batchSelectedStudents.length
@@ -503,15 +595,12 @@ export function TeacherTestsTab({
   }, [selectedTestId, selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
-    if (!selectedTestId) return
+    if (!selectedTestId || loading) return
     if (tests.some((test) => test.id === selectedTestId)) return
 
-    setWorkspaceState('list')
-    setSelectedWorkspaceTab('authoring')
-    setSelectedTestId(null)
-    setSelectedStudentId(null)
+    clearTestWorkspace({ replace: true })
     clearBatchSelection()
-  }, [clearBatchSelection, selectedTestId, tests])
+  }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, tests])
 
   useEffect(() => {
     setSelectedTestDraftSummary(null)
@@ -521,13 +610,9 @@ export function TeacherTestsTab({
     if (!pendingCreatedTestId) return
     if (!tests.some((test) => test.id === pendingCreatedTestId)) return
 
-    setSelectedTestId(pendingCreatedTestId)
-    setWorkspaceState('selected')
-    setSelectedWorkspaceTab('authoring')
-    setSelectedStudentId(null)
+    navigateTestWorkspace({ testId: pendingCreatedTestId, mode: 'authoring', studentId: null })
     setPendingCreatedTestId(null)
-    setRightSidebarOpen(false)
-  }, [pendingCreatedTestId, setRightSidebarOpen, tests])
+  }, [navigateTestWorkspace, pendingCreatedTestId, tests])
 
   useEffect(() => {
     if (previousTestsTabClickTokenRef.current === testsTabClickToken) return
@@ -535,16 +620,12 @@ export function TeacherTestsTab({
 
     if (workspaceState !== 'selected') return
 
-    setWorkspaceState('list')
-    setSelectedWorkspaceTab('authoring')
-    setSelectedTestId(null)
-    setSelectedStudentId(null)
+    clearTestWorkspace()
     setGradingError('')
     setGradingWarning('')
     setGradingInfo('')
     clearBatchSelection()
-    setRightSidebarOpen(false)
-  }, [clearBatchSelection, setRightSidebarOpen, testsTabClickToken, workspaceState])
+  }, [clearBatchSelection, clearTestWorkspace, testsTabClickToken, workspaceState])
 
   useEffect(() => {
     if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading') {
@@ -561,7 +642,46 @@ export function TeacherTestsTab({
     }
 
     void loadGradingRows()
-  }, [clearBatchSelection, loadGradingRows, selectedWorkspaceTab, workspaceState])
+  }, [clearBatchSelection, loadGradingRows, selectedWorkspaceTab, setSelectedStudentId, workspaceState])
+
+  useEffect(() => {
+    if (workspaceState !== 'selected' || !selectedTestId) return
+    if (selectedWorkspaceTab === 'grading' || !selectedStudentId) return
+
+    navigateTestWorkspace(
+      { testId: selectedTestId, mode: selectedWorkspaceTab, studentId: null },
+      { replace: true },
+    )
+  }, [navigateTestWorkspace, selectedStudentId, selectedTestId, selectedWorkspaceTab, workspaceState])
+
+  useEffect(() => {
+    if (
+      workspaceState !== 'selected' ||
+      selectedWorkspaceTab !== 'grading' ||
+      !selectedTestId ||
+      !selectedStudentId ||
+      gradingLoading ||
+      gradingServerTestId !== selectedTestId
+    ) {
+      return
+    }
+
+    if (gradingStudents.some((student) => student.student_id === selectedStudentId)) return
+
+    navigateTestWorkspace(
+      { testId: selectedTestId, mode: 'grading', studentId: null },
+      { replace: true },
+    )
+  }, [
+    gradingLoading,
+    gradingServerTestId,
+    gradingStudents,
+    navigateTestWorkspace,
+    selectedStudentId,
+    selectedTestId,
+    selectedWorkspaceTab,
+    workspaceState,
+  ])
 
   useEffect(() => {
     if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'authoring') {
@@ -690,15 +810,6 @@ export function TeacherTestsTab({
   ])
 
   useEffect(() => {
-    if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading' || !selectedStudentId) {
-      setRightSidebarOpen(false)
-      return
-    }
-
-    setRightSidebarOpen(true)
-  }, [selectedStudentId, selectedWorkspaceTab, setRightSidebarOpen, workspaceState])
-
-  useEffect(() => {
     if (!gradingWarning) return
     if (batchSelectedCount > 0) {
       setGradingWarning('')
@@ -806,6 +917,7 @@ export function TeacherTestsTab({
     const message = formatTestAiGradingRunMessage(activeTestAiRun)
     clearBatchSelection()
     void loadGradingRows()
+    setTestGradingPanelRefreshToken((prev) => prev + 1)
     onTestGradingDataRefresh?.()
 
     if (message.error) {
@@ -818,10 +930,7 @@ export function TeacherTestsTab({
   }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh])
 
   function handleOpenTest(test: QuizWithStats) {
-    setSelectedTestId(test.id)
-    setWorkspaceState('selected')
-    setSelectedWorkspaceTab('authoring')
-    setSelectedStudentId(null)
+    navigateTestWorkspace({ testId: test.id, mode: 'authoring', studentId: null })
     setGradingError('')
     setGradingWarning('')
     setGradingInfo('')
@@ -902,6 +1011,7 @@ export function TeacherTestsTab({
         clearBatchSelection()
       }
       await loadGradingRows()
+      setTestGradingPanelRefreshToken((prev) => prev + 1)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Auto-grade failed')
@@ -940,6 +1050,8 @@ export function TeacherTestsTab({
         await loadTests()
       }
       await loadGradingRows()
+      setTestGradingPanelRefreshToken((prev) => prev + 1)
+      onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Return failed')
     } finally {
@@ -972,6 +1084,7 @@ export function TeacherTestsTab({
       clearBatchSelection()
       setShowClearOpenGradesConfirm(false)
       await loadGradingRows()
+      setTestGradingPanelRefreshToken((prev) => prev + 1)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Clear open grades failed')
@@ -1218,7 +1331,7 @@ export function TeacherTestsTab({
                       'cursor-pointer border-t border-border transition-colors hover:bg-surface-hover',
                       isSelected ? 'bg-surface-selected' : '',
                     ].join(' ')}
-                    onClick={() => setSelectedStudentId(student.student_id)}
+                    onClick={() => selectGradingStudent(student.student_id)}
                   >
                     <td className="px-3 py-2">
                       <input
@@ -1300,177 +1413,175 @@ export function TeacherTestsTab({
     </div>
   )
 
-  const selectedHeader = workspaceState === 'selected' ? (
-    <div className="flex w-full flex-wrap items-center gap-2 sm:min-h-[2.75rem]">
-      <div className="mb-[-1px] flex items-end gap-1 self-end">
-        <button
+  const workspaceModeCenter = selectedWorkspaceTab === 'authoring' ? (
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => setTestPreviewRequestToken((value) => value + 1)}
+        disabled={hasPendingMarkdownImport}
+      >
+        Preview
+      </Button>
+      {selectedTestWorkspace?.status === 'draft' ? (
+        <Button
           type="button"
-          className={[
-            selectedWorkspaceTab === 'authoring'
-              ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-              : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-            'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
-          ].join(' ')}
-          onClick={() => setSelectedWorkspaceTab('authoring')}
-          aria-pressed={selectedWorkspaceTab === 'authoring'}
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            void handleRequestSelectedTestActivate()
+          }}
+          disabled={
+            !selectedActivation.valid ||
+            isReadOnly ||
+            statusUpdating ||
+            checkingActivation ||
+            hasPendingMarkdownImport
+          }
         >
-          Authoring
-        </button>
-        <button
+          <Play className="h-4 w-4" />
+          Open
+        </Button>
+      ) : null}
+      {selectedTestWorkspace?.status === 'active' ? (
+        <Button
           type="button"
-          className={[
-            selectedWorkspaceTab === 'grading'
-              ? 'relative z-10 rounded-t-lg border border-border border-b-surface bg-surface text-text-default'
-              : 'rounded-t-lg border border-transparent bg-surface-2 text-text-muted hover:bg-surface-hover hover:text-text-default',
-            'min-h-10 px-3 py-2 text-sm font-medium transition-colors',
-          ].join(' ')}
-          onClick={() => setSelectedWorkspaceTab('grading')}
-          aria-pressed={selectedWorkspaceTab === 'grading'}
+          variant="secondary"
+          size="sm"
+          onClick={() => setShowCloseConfirm(true)}
+          disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
         >
-          Grading
-        </button>
-      </div>
-
-      <div className="flex min-w-0 basis-full justify-center sm:basis-auto sm:flex-1">
-        <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
-          {selectedWorkspaceTab === 'authoring' ? (
-            <>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => setTestPreviewRequestToken((value) => value + 1)}
-                disabled={hasPendingMarkdownImport}
-              >
-                Preview
-              </Button>
-              {selectedTestWorkspace?.status === 'draft' ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    void handleRequestSelectedTestActivate()
-                  }}
-                  disabled={
-                    !selectedActivation.valid ||
-                    isReadOnly ||
-                    statusUpdating ||
-                    checkingActivation ||
-                    hasPendingMarkdownImport
-                  }
-                >
-                  <Play className="h-4 w-4" />
-                  Open
-                </Button>
-              ) : null}
-              {selectedTestWorkspace?.status === 'active' ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setShowCloseConfirm(true)}
-                  disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
-                >
-                  <Square className="h-4 w-4" />
-                  Close
-                </Button>
-              ) : null}
-              {selectedTestWorkspace?.status === 'closed' ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    void handleSelectedTestStatusChange('active')
-                  }}
-                  disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
-                >
-                  <Play className="h-4 w-4" />
-                  Reopen
-                </Button>
-              ) : null}
-              {onRequestDelete ? (
-                <Button
-                  type="button"
-                  variant="danger"
-                  size="sm"
-                  onClick={onRequestDelete}
-                  disabled={isReadOnly}
-                >
-                  <Trash2 className="h-4 w-4" />
-                  Delete
-                </Button>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={openBatchPromptGuidelineModal}
-                disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-              >
-                AI Prompt
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  if (batchSelectedCount === 0) {
-                    setGradingWarning('Select students to grade')
-                    return
-                  }
-                  setShowBatchGradeModal(true)
-                }}
-                disabled={
-                  batchSelectedCount === 0 ||
-                  hasActiveTestAiRun ||
-                  isBatchAutoGrading ||
-                  isBatchReturning ||
-                  isBatchClearingOpenGrades
-                }
-              >
-                <Check className="h-4 w-4" />
-                AI Grade
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  if (batchSelectedCount === 0) {
-                    setGradingWarning('Select students to return')
-                    return
-                  }
-                  setShowReturnConfirm(true)
-                }}
-                disabled={
-                  batchSelectedCount === 0 ||
-                  isBatchAutoGrading ||
-                  isBatchReturning ||
-                  isBatchClearingOpenGrades
-                }
-              >
-                <Send className="h-4 w-4" />
-                Return
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
-
-      <div className="flex min-w-0 basis-full justify-end sm:basis-auto sm:ml-auto">
-        <div
-          className="min-w-0 max-w-[22rem] truncate text-right text-sm font-medium text-text-default"
-          title={selectedTestTitle}
+          <Square className="h-4 w-4" />
+          Close
+        </Button>
+      ) : null}
+      {selectedTestWorkspace?.status === 'closed' ? (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            void handleSelectedTestStatusChange('active')
+          }}
+          disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
         >
-          {selectedTestTitle}
-        </div>
-      </div>
+          <Play className="h-4 w-4" />
+          Reopen
+        </Button>
+      ) : null}
+      {onRequestDelete ? (
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          onClick={onRequestDelete}
+          disabled={isReadOnly}
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
+      ) : null}
+    </>
+  ) : (
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={openBatchPromptGuidelineModal}
+        disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
+      >
+        AI Prompt
+      </Button>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          if (batchSelectedCount === 0) {
+            setGradingWarning('Select students to grade')
+            return
+          }
+          setShowBatchGradeModal(true)
+        }}
+        disabled={
+          batchSelectedCount === 0 ||
+          hasActiveTestAiRun ||
+          isBatchAutoGrading ||
+          isBatchReturning ||
+          isBatchClearingOpenGrades
+        }
+      >
+        <Check className="h-4 w-4" />
+        AI Grade
+      </Button>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          if (batchSelectedCount === 0) {
+            setGradingWarning('Select students to return')
+            return
+          }
+          setShowReturnConfirm(true)
+        }}
+        disabled={
+          batchSelectedCount === 0 ||
+          isBatchAutoGrading ||
+          isBatchReturning ||
+          isBatchClearingOpenGrades
+        }
+      >
+        <Send className="h-4 w-4" />
+        Return
+      </Button>
+    </>
+  )
+
+  const workspaceModeStatus =
+    selectedWorkspaceTab === 'grading' && selectedStudentId && testGradingSaveState.status !== 'idle' ? (
+      <span
+        className={[
+          'text-xs',
+          testGradingSaveState.status === 'saved'
+            ? 'font-medium text-success'
+            : testGradingSaveState.status === 'saving'
+              ? 'text-text-muted'
+              : 'text-warning',
+        ].join(' ')}
+      >
+        {testGradingSaveState.status === 'saved'
+          ? 'Saved'
+          : testGradingSaveState.status === 'saving'
+            ? 'Saving...'
+            : 'Unsaved'}
+      </span>
+    ) : null
+
+  const workspaceModeTrailing = (
+    <div
+      className="min-w-0 max-w-[22rem] truncate text-right text-sm font-medium text-text-default"
+      title={selectedTestTitle}
+    >
+      {selectedTestTitle}
     </div>
+  )
+
+  const primaryContent = workspaceState === 'selected' ? (
+    <TeacherWorkSurfaceModeBar
+      modes={[
+        { id: 'authoring', label: 'Authoring' },
+        { id: 'grading', label: 'Grading' },
+      ]}
+      activeMode={selectedWorkspaceTab}
+      onModeChange={(mode) => switchTestWorkspaceMode(mode as WorkspaceTab)}
+      center={workspaceModeCenter}
+      status={workspaceModeStatus}
+      trailing={workspaceModeTrailing}
+      ariaLabel="Test workspace modes"
+    />
   ) : (
     <Button onClick={handleNewTest} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
       <Plus className="h-4 w-4" />
@@ -1478,102 +1589,125 @@ export function TeacherTestsTab({
     </Button>
   )
 
+  const feedback = (
+    <>
+      {statusActionError && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          {statusActionError}
+        </div>
+      ) : null}
+      {hasPendingMarkdownImport && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+        <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+          Apply or undo markdown changes before previewing or changing the test status.
+        </div>
+      ) : null}
+      {gradingError && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          {gradingError}
+        </div>
+      ) : null}
+      {gradingWarning && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+        <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+          {gradingWarning}
+        </div>
+      ) : null}
+      {gradingInfo && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+        <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
+          {gradingInfo}
+        </div>
+      ) : null}
+      {hasActiveTestAiRun && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
+        <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-muted">
+          {TEST_AI_GRADING_RUN_NOTE}
+        </div>
+      ) : null}
+    </>
+  )
+
+  const summaryContent = loading ? (
+    <div className="flex justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : tests.length === 0 ? (
+    <EmptyState
+      title="No tests yet"
+      description="Create a test to get started."
+      tone="muted"
+      className="mx-auto w-full max-w-3xl"
+    />
+  ) : (
+    <PageStack className="mx-auto w-full max-w-6xl">
+      {tests.map((test) => (
+        <TeacherTestCard
+          key={test.id}
+          test={test}
+          isReadOnly={isReadOnly}
+          onSelect={() => handleOpenTest(test)}
+          onUpdate={(update) => applyTestSummaryPatch(test.id, update)}
+        />
+      ))}
+    </PageStack>
+  )
+
+  const gradingInspector = selectedTest && selectedStudentId ? (
+    <TestStudentGradingPanel
+      testId={selectedTest.id}
+      selectedStudentId={selectedStudentId}
+      apiBasePath={apiBasePath}
+      refreshToken={testGradingPanelRefreshToken}
+      onSaveStateChange={setTestGradingSaveState}
+    />
+  ) : null
+
+  const workspaceContent = !selectedTest ? (
+    <div className="flex flex-1 justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : selectedWorkspaceTab === 'authoring' ? (
+    <QuizDetailPanel
+      quiz={selectedTest}
+      classroomId={classroom.id}
+      apiBasePath={apiBasePath}
+      onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
+      onQuizUpdate={(update) => {
+        if (update) {
+          applySelectedTestDraftSummary(update)
+          return
+        }
+        void loadTests()
+      }}
+      onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+      showInlineDeleteAction={false}
+      testQuestionLayout="summary-detail"
+      showPreviewButton={false}
+      showResultsTab={false}
+      previewRequestToken={testPreviewRequestToken}
+    />
+  ) : gradingInspector ? (
+    <TeacherWorkspaceSplit
+      primary={gradingTable}
+      inspector={gradingInspector}
+      inspectorWidth={gradingInspectorWidth}
+      inspectorCollapsed={false}
+      onInspectorWidthChange={setGradingInspectorWidth}
+      dividerLabel="Resize grading and student response panes"
+      minPrimaryPx={420}
+      minInspectorPx={360}
+    />
+  ) : (
+    gradingTable
+  )
+
   return (
-    <PageLayout className="flex h-full min-h-0 flex-col">
-      <PageActionBar primary={selectedHeader} className={isSelectedWorkspace ? 'pl-0 pr-2' : ''} />
-
-      <PageContent
-        className={[
-          'flex min-h-0 flex-1 flex-col',
-          isSelectedWorkspace ? 'gap-0 px-0 pt-0' : 'gap-3',
-        ].join(' ')}
-      >
-        {statusActionError && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
-          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-            {statusActionError}
-          </div>
-        ) : null}
-        {hasPendingMarkdownImport && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
-          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-            Apply or undo markdown changes before previewing or changing the test status.
-          </div>
-        ) : null}
-        {gradingError && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-            {gradingError}
-          </div>
-        ) : null}
-        {gradingWarning && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-          <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-            {gradingWarning}
-          </div>
-        ) : null}
-        {gradingInfo && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-          <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
-            {gradingInfo}
-          </div>
-        ) : null}
-        {hasActiveTestAiRun && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-          <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-muted">
-            {TEST_AI_GRADING_RUN_NOTE}
-          </div>
-        ) : null}
-
-        {loading ? (
-          <div className="flex justify-center py-12">
-            <Spinner size="lg" />
-          </div>
-        ) : tests.length === 0 ? (
-          <EmptyState
-            title="No tests yet"
-            description="Create a test to get started."
-            tone="muted"
-            className="mx-auto w-full max-w-3xl"
-          />
-        ) : workspaceState === 'list' ? (
-          <PageStack className="mx-auto w-full max-w-6xl">
-            {tests.map((test) => (
-              <TeacherTestCard
-                key={test.id}
-                test={test}
-                isReadOnly={isReadOnly}
-                onSelect={() => handleOpenTest(test)}
-                onUpdate={(update) => applyTestSummaryPatch(test.id, update)}
-              />
-            ))}
-          </PageStack>
-        ) : !selectedTest ? (
-          <div className="flex justify-center py-12">
-            <Spinner size="lg" />
-          </div>
-        ) : (
-          <div className="flex min-h-0 w-full flex-1 overflow-hidden rounded-b-lg border border-border bg-surface">
-            {selectedWorkspaceTab === 'authoring' ? (
-              <QuizDetailPanel
-                quiz={selectedTest}
-                classroomId={classroom.id}
-                apiBasePath={apiBasePath}
-                onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
-                onQuizUpdate={(update) => {
-                  if (update) {
-                    applySelectedTestDraftSummary(update)
-                    return
-                  }
-                  void loadTests()
-                }}
-                onPendingMarkdownImportChange={setHasPendingMarkdownImport}
-                showInlineDeleteAction={false}
-                testQuestionLayout="summary-detail"
-                showPreviewButton={false}
-                showResultsTab={false}
-                previewRequestToken={testPreviewRequestToken}
-              />
-            ) : (
-              gradingTable
-            )}
-          </div>
-        )}
-      </PageContent>
+    <>
+      <TeacherWorkSurfaceShell
+        state={workspaceState === 'selected' ? 'workspace' : 'summary'}
+        primary={primaryContent}
+        feedback={feedback}
+        summary={summaryContent}
+        workspace={workspaceContent}
+        workspaceFrame="attachedTabs"
+      />
 
       <QuizModal
         isOpen={showModal}
@@ -1770,6 +1904,6 @@ export function TeacherTestsTab({
           void handleBatchReturn({ closeTest: returnWillCloseActiveTest })
         }}
       />
-    </PageLayout>
+    </>
   )
 }

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -121,7 +121,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   'quizzes-teacher': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%' },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   'quizzes-student': {
@@ -129,7 +129,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'reading' },
   },
   'tests-teacher': {
-    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '60%' },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '60%' },
     mainContent: { maxWidth: 'full' },
   },
   'tests-student': {

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -40,7 +40,24 @@ vi.mock('@/components/QuizModal', () => ({
       >
         Save Quiz
       </button>
-    ) : null,
+	    ) : null,
+}))
+
+vi.mock('@/components/QuizDetailPanel', () => ({
+  QuizDetailPanel: ({
+    quiz,
+    onQuizUpdate,
+  }: {
+    quiz: QuizWithStats
+    onQuizUpdate?: () => void
+  }) => (
+    <div data-testid="mock-quiz-detail">
+      Detail for {quiz.title}
+      <button type="button" onClick={() => onQuizUpdate?.()}>
+        Simulate quiz update
+      </button>
+    </div>
+  ),
 }))
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -85,8 +102,22 @@ describe('TeacherQuizzesTab', () => {
     })
   }
 
-  function renderTab(assessmentType: QuizAssessmentType = 'quiz') {
-    render(<TeacherQuizzesTab classroom={classroom} assessmentType={assessmentType} />, {
+  function renderTab(options?: {
+    assessmentType?: QuizAssessmentType
+    selectedQuizId?: string | null
+    updateSearchParams?: (
+      updater: (params: URLSearchParams) => void,
+      options?: { replace?: boolean },
+    ) => void
+    onRequestDelete?: () => void
+  }) {
+    render(<TeacherQuizzesTab
+      classroom={classroom}
+      assessmentType={options?.assessmentType ?? 'quiz'}
+      selectedQuizId={options?.selectedQuizId}
+      updateSearchParams={options?.updateSearchParams}
+      onRequestDelete={options?.onRequestDelete}
+    />, {
       wrapper: Wrapper,
     })
   }
@@ -145,10 +176,96 @@ describe('TeacherQuizzesTab', () => {
 
   it('renders quiz mode with the quiz API and primary action', async () => {
     mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
-    renderTab('quiz')
+    renderTab({ assessmentType: 'quiz' })
 
     expect(await screen.findByText('Loops Quiz')).toBeInTheDocument()
     expect(screen.getByText('New Quiz')).toBeInTheDocument()
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/quizzes?classroom_id=')
+  })
+
+  it('opens a selected quiz in the main workspace without opening the passive sidebar', async () => {
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Loops Quiz'))
+
+    expect(await screen.findByTestId('mock-quiz-detail')).toHaveTextContent('Detail for Loops Quiz')
+    expect(screen.queryByText('New Quiz')).not.toBeInTheDocument()
+    expect(setOpenMock).not.toHaveBeenCalledWith(true)
+  })
+
+  it('reports quiz selection through search params', async () => {
+    const updateSearchParams = vi.fn((updater: (params: URLSearchParams) => void) => {
+      const params = new URLSearchParams('tab=quizzes')
+      updater(params)
+    })
+
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab({ selectedQuizId: null, updateSearchParams })
+
+    fireEvent.click(await screen.findByText('Loops Quiz'))
+
+    expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), undefined)
+    const params = new URLSearchParams('tab=quizzes')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('quizId')).toBe('quiz-1')
+  })
+
+  it('models Browser Back by following controlled quiz params back to summary', async () => {
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    const { rerender } = render(
+      <TeacherQuizzesTab
+        classroom={classroom}
+        assessmentType="quiz"
+        selectedQuizId="quiz-1"
+      />,
+      { wrapper: Wrapper },
+    )
+
+    expect(await screen.findByTestId('mock-quiz-detail')).toHaveTextContent('Detail for Loops Quiz')
+
+    rerender(
+      <TeacherQuizzesTab
+        classroom={classroom}
+        assessmentType="quiz"
+        selectedQuizId={null}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-quiz-detail')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Loops Quiz')).toBeInTheDocument()
+  })
+
+  it('shows delete only inside the selected quiz workspace', async () => {
+    const onRequestDelete = vi.fn()
+
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab({ onRequestDelete })
+
+    expect(await screen.findByText('Loops Quiz')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete Quiz' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Loops Quiz'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Quiz' }))
+
+    expect(onRequestDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces invalid controlled quiz params with summary params', async () => {
+    const updateSearchParams = vi.fn()
+
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab({ selectedQuizId: 'missing-quiz', updateSearchParams })
+
+    await waitFor(() => {
+      expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
+    })
+
+    const params = new URLSearchParams('tab=quizzes&quizId=missing-quiz')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('tab')).toBe('quizzes')
+    expect(params.get('quizId')).toBeNull()
   })
 })

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
 import { TooltipProvider } from '@/ui'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
@@ -106,6 +106,32 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       </button>
     </div>
   ),
+}))
+
+vi.mock('@/components/TestStudentGradingPanel', () => ({
+  TestStudentGradingPanel: ({
+    testId,
+    selectedStudentId,
+    onSaveStateChange,
+  }: {
+    testId: string
+    selectedStudentId: string | null
+    onSaveStateChange?: (state: {
+      canSave: boolean
+      isSaving: boolean
+      status: 'idle' | 'unsaved' | 'saving' | 'saved'
+    }) => void
+  }) => {
+    useEffect(() => {
+      onSaveStateChange?.({ canSave: false, isSaving: false, status: 'saved' })
+    }, [onSaveStateChange])
+
+    return (
+      <div data-testid="mock-test-grading-panel">
+        Grading panel for {testId}:{selectedStudentId || 'none'}
+      </div>
+    )
+  },
 }))
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -219,6 +245,13 @@ describe('TeacherTestsTab', () => {
 
   function renderTab(options?: {
     testsTabClickToken?: number
+    selectedTestId?: string | null
+    selectedTestMode?: 'authoring' | 'grading' | null
+    selectedTestStudentId?: string | null
+    updateSearchParams?: (
+      updater: (params: URLSearchParams) => void,
+      options?: { replace?: boolean },
+    ) => void
     onSelectTest?: (test: QuizWithStats | null) => void
     onTestGradingContextChange?: (context: {
       mode: 'authoring' | 'grading'
@@ -231,6 +264,10 @@ describe('TeacherTestsTab', () => {
       <TeacherTestsTab
         classroom={classroom}
         testsTabClickToken={options?.testsTabClickToken}
+        selectedTestId={options?.selectedTestId}
+        selectedTestMode={options?.selectedTestMode}
+        selectedTestStudentId={options?.selectedTestStudentId}
+        updateSearchParams={options?.updateSearchParams}
         onSelectTest={options?.onSelectTest}
         onTestGradingContextChange={options?.onTestGradingContextChange}
       />,
@@ -244,7 +281,7 @@ describe('TeacherTestsTab', () => {
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
     expect(screen.getByText('New Test')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
   })
@@ -261,8 +298,8 @@ describe('TeacherTestsTab', () => {
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'summary-detail')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
-    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'Grading' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Authoring' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Grading' })).toHaveAttribute('aria-selected', 'false')
     expect(screen.queryByRole('button', { name: 'Questions' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Documents' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Back to tests' })).not.toBeInTheDocument()
@@ -354,7 +391,7 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(screen.getByTestId('mock-test-save'))
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
-    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('tab', { name: 'Authoring' })).toHaveAttribute('aria-selected', 'true')
   })
 
   it('validates and activates a draft test from authoring', async () => {
@@ -510,12 +547,11 @@ describe('TeacherTestsTab', () => {
       expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
     })
     expect(screen.getByText('Unit Test')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
-    expect(setOpenMock).toHaveBeenCalledWith(false)
+    expect(screen.queryByRole('tab', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(onSelectTest).toHaveBeenLastCalledWith(null)
   })
 
-  it('shows grading in the main pane and only opens the inspector after row selection', async () => {
+  it('shows grading in the main pane and only renders the inspector after row selection', async () => {
     const onTestGradingContextChange = vi.fn()
 
     fetchMock
@@ -530,9 +566,10 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByText('Unit Test'))
     setOpenMock.mockClear()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.queryByTestId('mock-test-grading-panel')).not.toBeInTheDocument()
     expect(setOpenMock).not.toHaveBeenCalledWith(true)
     expect(onTestGradingContextChange).toHaveBeenLastCalledWith({
       mode: 'grading',
@@ -544,14 +581,109 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(screen.getByText('Alice Zephyr'))
 
     await waitFor(() => {
-      expect(setOpenMock).toHaveBeenCalledWith(true)
+      expect(screen.getByTestId('mock-test-grading-panel')).toHaveTextContent('Grading panel for test-1:student-1')
     })
+    expect(setOpenMock).not.toHaveBeenCalledWith(true)
     expect(onTestGradingContextChange).toHaveBeenLastCalledWith({
       mode: 'grading',
       testId: 'test-1',
       studentId: 'student-1',
       studentName: 'Alice Zephyr',
     })
+  })
+
+  it('uses controlled test params and reports selection changes through search params', async () => {
+    const updateSearchParams = vi.fn((updater: (params: URLSearchParams) => void) => {
+      const params = new URLSearchParams('tab=tests')
+      updater(params)
+    })
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    renderTab({ selectedTestId: null, updateSearchParams })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), undefined)
+    const params = new URLSearchParams('tab=tests')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('testId')).toBe('test-1')
+    expect(params.get('testMode')).toBe('authoring')
+    expect(params.get('testStudentId')).toBeNull()
+  })
+
+  it('models Browser Back by following controlled test params back to summary', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    const view = renderTab({ selectedTestId: 'test-1', selectedTestMode: 'authoring' })
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={classroom}
+        selectedTestId={null}
+        selectedTestMode={null}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Unit Test')).toBeInTheDocument()
+  })
+
+  it('keeps valid controlled test params while the test list is still loading', async () => {
+    let resolveTests:
+      | ((value: { ok: boolean; json: () => Promise<any> }) => void)
+      | null = null
+    const updateSearchParams = vi.fn()
+
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTests = resolve
+        }) as unknown as Promise<Response>,
+    )
+
+    renderTab({
+      selectedTestId: 'test-1',
+      selectedTestMode: 'authoring',
+      updateSearchParams,
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(updateSearchParams).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveTests?.({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(updateSearchParams).not.toHaveBeenCalled()
+  })
+
+  it('replaces invalid controlled test params with summary params', async () => {
+    const updateSearchParams = vi.fn()
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    renderTab({ selectedTestId: 'missing-test', selectedTestMode: 'grading', updateSearchParams })
+
+    await waitFor(() => {
+      expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
+    })
+
+    const params = new URLSearchParams('tab=tests&testId=missing-test&testMode=grading&testStudentId=student-1')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('tab')).toBe('tests')
+    expect(params.get('testId')).toBeNull()
+    expect(params.get('testMode')).toBeNull()
+    expect(params.get('testStudentId')).toBeNull()
   })
 
   it('polls grading rows only while grading is visible and focused', async () => {
@@ -580,7 +712,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -655,7 +787,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.getByText('3/5')).toBeInTheDocument()
@@ -725,7 +857,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -763,7 +895,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -801,7 +933,7 @@ describe('TeacherTestsTab', () => {
     const view = renderTab({ testsTabClickToken: 0 })
 
     fireEvent.click(await screen.findByText('Unit Test A'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     view.rerender(
       <TeacherTestsTab
@@ -815,7 +947,7 @@ describe('TeacherTestsTab', () => {
     })
 
     fireEvent.click(screen.getByText('Unit Test B'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
 
     await act(async () => {
       resolveSecondResults?.(
@@ -901,7 +1033,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
@@ -1013,7 +1145,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
@@ -1049,7 +1181,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
     await screen.findByText('Alice Zephyr')
 
     fireEvent.click(screen.getByRole('button', { name: 'AI Prompt' }))

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -21,6 +21,7 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
       <button onClick={() => setRouteKey('today')}>go-today</button>
       <button onClick={() => setRouteKey('assignments-student')}>go-assignments</button>
       <button onClick={() => setRouteKey('quizzes-teacher')}>go-quizzes</button>
+      <button onClick={() => setRouteKey('resources-teacher')}>go-resources</button>
       <button onClick={() => setRouteKey('roster')}>go-roster</button>
       <ThreePanelProvider
         routeKey={routeKey}
@@ -101,12 +102,25 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
     expect(screen.getByTestId('open').textContent).toBe('false')
 
-    // Go to quizzes-teacher (enabled, defaultOpen: true)
+    // Go to resources-teacher (enabled, defaultOpen: true)
     act(() => {
-      screen.getByText('go-quizzes').click()
+      screen.getByText('go-resources').click()
     })
     expect(screen.getByTestId('enabled').textContent).toBe('true')
     expect(screen.getByTestId('open').textContent).toBe('true')
+  })
+
+  it('keeps the external sidebar disabled for teacher quizzes', () => {
+    render(<TestHarness initialRouteKey="today" />)
+
+    expect(screen.getByTestId('open').textContent).toBe('true')
+
+    act(() => {
+      screen.getByText('go-quizzes').click()
+    })
+
+    expect(screen.getByTestId('enabled').textContent).toBe('false')
+    expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
   it('closes sidebar when switching from today to an enabled tab with defaultOpen: false', () => {

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -67,6 +67,19 @@ describe('getLayoutConfig', () => {
     expect(studentConfig.rightSidebar.defaultWidth).toBe('50%')
     expect(studentConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
   })
+
+  it('should not reserve external sidebars for teacher quizzes and tests', () => {
+    const quizzesConfig = getLayoutConfig('quizzes-teacher')
+    const testsConfig = getLayoutConfig('tests-teacher')
+
+    expect(quizzesConfig.rightSidebar.enabled).toBe(false)
+    expect(quizzesConfig.rightSidebar.defaultOpen).toBe(false)
+    expect(quizzesConfig.mainContent.maxWidth).toBe('full')
+
+    expect(testsConfig.rightSidebar.enabled).toBe(false)
+    expect(testsConfig.rightSidebar.defaultOpen).toBe(false)
+    expect(testsConfig.mainContent.maxWidth).toBe('full')
+  })
 })
 
 describe('getRightSidebarCookieName', () => {


### PR DESCRIPTION
## Summary
- Migrates teacher Tests to `TeacherWorkSurfaceShell` with an Authoring/Grading mode bar.
- Moves test grading detail into the selected tests workspace using `TeacherWorkspaceSplit`.
- Reworks teacher Quizzes as a quiz-only work surface with selected quiz detail in the main workspace.
- Adds URL-controlled `testId`, `testMode`, `testStudentId`, and `quizId` state and clears stale/dependent params with replace.
- Disables external right sidebar reservation for teacher tests/quizzes.

## Validation
- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx tests/components/TeacherWorkspaceSplit.test.tsx`
- `pnpm test tests/components/ThreePanelProvider.test.tsx tests/unit/layout-config.test.ts`
- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
- `pnpm exec tsc --noEmit`
- `bash scripts/verify-env.sh` (218 files, 1885 tests)
- `git diff --check`

## Visual Verification
- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:verify assessment-ux-parity`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=quizzes"`

## Intentional Visual Differences
- Teacher Tests and Quizzes no longer reserve or show the passive external right sidebar.
- Test grading detail appears inside the tests workspace split after a student row is selected.
- Quiz delete is available only in the selected quiz workspace.