### PR TITLE
Harden teacher assessment URL state

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9500,3 +9500,18 @@
 - `E2E_BASE_URL=http://localhost:3000 pnpm e2e:verify assessment-ux-parity`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=quizzes"`
+
+## 2026-04-27 — Issue 512 Teacher Assessment URL-State Hardening
+
+- Added Chromium Playwright coverage for teacher Tests and Quizzes URL-state flows: deep links, selected assessment params, grading mode, selected test student, browser Back unwinding, and active nav re-click summary resets.
+- Changed teacher Tests mode switches to replace the selected test history entry, so Back from a selected grading student clears `testStudentId` and then returns to the Tests summary.
+- Added component coverage for the replace-on-mode-switch behavior and reused existing async grading coverage in the standard verifier.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
+- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/teacher-assessment-url-state.spec.ts --project=chromium-desktop`
+- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
+- `pnpm exec tsc --noEmit`
+- `bash scripts/verify-env.sh` (218 files, 1886 tests)
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=quizzes"`

--- a/e2e/teacher-assessment-url-state.spec.ts
+++ b/e2e/teacher-assessment-url-state.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const TEACHER_STORAGE = '.auth/teacher.json'
+
+interface ClassroomRecord {
+  id: string
+  title?: string | null
+}
+
+interface AssessmentRecord {
+  id: string
+  title: string
+  stats?: {
+    total_students?: number
+    responded?: number
+  }
+}
+
+interface TestGradingStudentRecord {
+  student_id: string
+  name: string | null
+  email: string
+  status: 'not_started' | 'in_progress' | 'submitted' | 'returned'
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function loadJson<T>(page: Page, path: string): Promise<T> {
+  return page.evaluate(async (apiPath) => {
+    const response = await fetch(apiPath)
+    if (!response.ok) {
+      throw new Error(`Failed to load ${apiPath}: ${response.status}`)
+    }
+    return response.json()
+  }, path) as Promise<T>
+}
+
+async function postJson<T>(page: Page, path: string, body: Record<string, unknown>): Promise<T> {
+  return page.evaluate(async ({ apiPath, payload }) => {
+    const response = await fetch(apiPath, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data?.error || `Failed to post ${apiPath}: ${response.status}`)
+    }
+    return data
+  }, { apiPath: path, payload: body }) as Promise<T>
+}
+
+async function loadTeacherClassroom(page: Page): Promise<ClassroomRecord> {
+  await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+  const data = await loadJson<{ classrooms?: ClassroomRecord[] }>(page, '/api/teacher/classrooms')
+  const classrooms = data.classrooms || []
+  const classroom =
+    classrooms.find((candidate) => candidate.title?.toLowerCase().includes('test classroom')) ||
+    classrooms[0]
+
+  expect(classroom, 'Seed a teacher classroom before running assessment URL-state e2e tests.').toBeTruthy()
+  return classroom!
+}
+
+async function loadTeacherQuiz(page: Page, classroomId: string): Promise<AssessmentRecord> {
+  const data = await loadJson<{ quizzes?: AssessmentRecord[] }>(
+    page,
+    `/api/teacher/quizzes?classroom_id=${encodeURIComponent(classroomId)}`,
+  )
+  const existing =
+    (data.quizzes || []).find((quiz) => quiz.title === 'URL State E2E Quiz') ||
+    (data.quizzes || [])[0]
+
+  if (existing) return existing
+
+  const created = await postJson<{ quiz: AssessmentRecord }>(page, '/api/teacher/quizzes', {
+    classroom_id: classroomId,
+    title: 'URL State E2E Quiz',
+  })
+  return created.quiz
+}
+
+async function loadTeacherTestWithStudent(page: Page, classroomId: string): Promise<{
+  testRecord: AssessmentRecord
+  student: TestGradingStudentRecord
+}> {
+  const data = await loadJson<{ quizzes?: AssessmentRecord[]; tests?: AssessmentRecord[] }>(
+    page,
+    `/api/teacher/tests?classroom_id=${encodeURIComponent(classroomId)}`,
+  )
+  const tests = data.tests || data.quizzes || []
+  const preferredTests = [
+    ...tests.filter((candidate) => Number(candidate.stats?.responded || 0) > 0),
+    ...tests.filter((candidate) => Number(candidate.stats?.responded || 0) <= 0),
+  ]
+
+  for (const testRecord of preferredTests) {
+    const results = await loadJson<{ students?: TestGradingStudentRecord[] }>(
+      page,
+      `/api/teacher/tests/${encodeURIComponent(testRecord.id)}/results`,
+    )
+    const student =
+      (results.students || []).find((candidate) => candidate.status !== 'not_started') ||
+      (results.students || [])[0]
+    if (student) {
+      return { testRecord, student }
+    }
+  }
+
+  throw new Error('Seed a teacher test with enrolled students before running assessment URL-state e2e tests.')
+}
+
+async function expectSearchParam(page: Page, name: string, expected: string): Promise<void> {
+  await expect.poll(() => new URL(page.url()).searchParams.get(name)).toBe(expected)
+}
+
+async function expectNoSearchParam(page: Page, name: string): Promise<void> {
+  await expect.poll(() => new URL(page.url()).searchParams.has(name)).toBe(false)
+}
+
+async function expectSummaryUrl(page: Page, classroomId: string, tab: 'tests' | 'quizzes'): Promise<void> {
+  await expect.poll(() => {
+    const url = new URL(page.url())
+    const params = url.searchParams
+    return {
+      pathname: url.pathname,
+      tab: params.get('tab'),
+      quizId: params.get('quizId'),
+      testId: params.get('testId'),
+      testMode: params.get('testMode'),
+      testStudentId: params.get('testStudentId'),
+    }
+  }).toEqual({
+    pathname: `/classrooms/${classroomId}`,
+    tab,
+    quizId: null,
+    testId: null,
+    testMode: null,
+    testStudentId: null,
+  })
+}
+
+test.describe('teacher assessment URL state', () => {
+  test.use({ storageState: TEACHER_STORAGE })
+
+  test('Tests deep links, browser Back, and active-nav reset preserve the work-surface ladder', async ({ page }) => {
+    const classroom = await loadTeacherClassroom(page)
+    const { testRecord, student } = await loadTeacherTestWithStudent(page, classroom.id)
+    const studentLabel = student.name || student.email
+
+    await page.goto(`/classrooms/${classroom.id}?tab=tests&testId=${testRecord.id}`, {
+      waitUntil: 'domcontentloaded',
+    })
+
+    await expect(page.getByRole('tab', { name: 'Authoring' })).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByText(testRecord.title).first()).toBeVisible()
+    await expectSearchParam(page, 'testId', testRecord.id)
+    await expectNoSearchParam(page, 'testStudentId')
+
+    await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('button', { name: 'New Test' })).toBeVisible()
+
+    await page.getByRole('button', { name: new RegExp(escapeRegExp(testRecord.title)) }).first().click()
+    await expectSearchParam(page, 'testId', testRecord.id)
+
+    await page.getByRole('tab', { name: 'Grading' }).click()
+    await expectSearchParam(page, 'testMode', 'grading')
+    await expect(page.getByText(studentLabel).first()).toBeVisible({ timeout: 15_000 })
+
+    await page.getByText(studentLabel).first().click()
+    await expectSearchParam(page, 'testStudentId', student.student_id)
+
+    await page.goBack()
+    await expectSearchParam(page, 'testMode', 'grading')
+    await expectNoSearchParam(page, 'testStudentId')
+    await expect(page.getByText(studentLabel).first()).toBeVisible()
+
+    await page.goBack()
+    await expectSummaryUrl(page, classroom.id, 'tests')
+    await expect(page.getByRole('button', { name: 'New Test' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Authoring' })).toHaveCount(0)
+
+    await page.goto(
+      `/classrooms/${classroom.id}?tab=tests&testId=${testRecord.id}&testMode=grading&testStudentId=${student.student_id}`,
+      { waitUntil: 'domcontentloaded' },
+    )
+    await expectSearchParam(page, 'testStudentId', student.student_id)
+
+    await page.getByRole('link', { name: 'Tests' }).click()
+    await expectSummaryUrl(page, classroom.id, 'tests')
+    await expect(page.getByRole('button', { name: 'New Test' })).toBeVisible()
+  })
+
+  test('Quizzes deep links, browser Back, and active-nav reset return to summary', async ({ page }) => {
+    const classroom = await loadTeacherClassroom(page)
+    const quiz = await loadTeacherQuiz(page, classroom.id)
+
+    await page.goto(`/classrooms/${classroom.id}?tab=quizzes&quizId=${quiz.id}`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await expect(page.getByText(quiz.title).first()).toBeVisible()
+    await expectSearchParam(page, 'quizId', quiz.id)
+
+    await page.goto(`/classrooms/${classroom.id}?tab=quizzes`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('button', { name: 'New Quiz' })).toBeVisible()
+
+    await page.getByRole('button', { name: new RegExp(escapeRegExp(quiz.title)) }).first().click()
+    await expectSearchParam(page, 'quizId', quiz.id)
+    await expect(page.getByText(quiz.title).first()).toBeVisible()
+
+    await page.goBack()
+    await expectSummaryUrl(page, classroom.id, 'quizzes')
+    await expect(page.getByRole('button', { name: 'New Quiz' })).toBeVisible()
+
+    await page.goto(`/classrooms/${classroom.id}?tab=quizzes&quizId=${quiz.id}`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await expectSearchParam(page, 'quizId', quiz.id)
+
+    await page.getByRole('link', { name: 'Quizzes' }).click()
+    await expectSummaryUrl(page, classroom.id, 'quizzes')
+    await expect(page.getByRole('button', { name: 'New Quiz' })).toBeVisible()
+  })
+})

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -403,7 +403,10 @@ export function TeacherTestsTab({
 
   const switchTestWorkspaceMode = useCallback((nextMode: WorkspaceTab) => {
     if (!selectedTestId) return
-    navigateTestWorkspace({ testId: selectedTestId, mode: nextMode, studentId: null })
+    navigateTestWorkspace(
+      { testId: selectedTestId, mode: nextMode, studentId: null },
+      { replace: true },
+    )
   }, [navigateTestWorkspace, selectedTestId])
 
   const selectGradingStudent = useCallback((studentId: string | null) => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -611,6 +611,38 @@ describe('TeacherTestsTab', () => {
     expect(params.get('testStudentId')).toBeNull()
   })
 
+  it('replaces the selected test history entry when switching workspace modes', async () => {
+    const updateSearchParams = vi.fn()
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab({
+      selectedTestId: 'test-1',
+      selectedTestMode: 'authoring',
+      updateSearchParams,
+    })
+
+    await screen.findByTestId('mock-test-detail')
+    updateSearchParams.mockClear()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+
+    await waitFor(() => {
+      expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
+    })
+
+    const params = new URLSearchParams('tab=tests&testId=test-1&testMode=authoring')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('testId')).toBe('test-1')
+    expect(params.get('testMode')).toBe('grading')
+    expect(params.get('testStudentId')).toBeNull()
+  })
+
   it('models Browser Back by following controlled test params back to summary', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     const view = renderTab({ selectedTestId: 'test-1', selectedTestMode: 'authoring' })


### PR DESCRIPTION
Closes #512

## Summary
- Add Chromium Playwright coverage for teacher Tests and Quizzes URL-state flows: deep links, selected assessment params, grading mode, selected test student, Browser Back unwinding, and active nav re-click summary resets.
- Replace the Tests mode-switch history entry so Back from a selected grading student clears `testStudentId`, then returns to the Tests summary.
- Add component coverage for the replace-on-mode-switch behavior and append the session journal entry.

## Validation
- `pnpm exec vitest run tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/teacher-assessment-url-state.spec.ts --project=chromium-desktop`
- `pnpm lint` (existing `TestDocumentsEditor` hook dependency warning remains)
- `pnpm exec tsc --noEmit`
- `bash scripts/verify-env.sh` (218 files, 1886 tests)
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests"`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=quizzes"`