### PR TITLE
Polish the teacher course blueprint workflow

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9587,3 +9587,29 @@
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test:coverage`
+
+## 2026-04-28 — Issue #515 course blueprint workflow polish
+
+**Completed:**
+- Kept `Course Blueprint` as the teacher-facing reusable plan name and made `Course Package` the portable file name across the blueprint workspace, classroom creation flow, and classroom settings promotion flow.
+- Tightened teacher workflow copy for importing/exporting packages, using a blueprint for a classroom, saving a classroom as a course blueprint, planned-site publishing, AI drafting, and classroom update review.
+- Added a compact package contract panel to the selected blueprint workspace and improved the workspace layout so the sidebar no longer stretches into an empty column and metadata fields have room for real course names.
+- Documented the official `.course-package.tar` contract in `docs/guidance/course-blueprint-packages.md`, including included/excluded data and the repo/Codex/Claude round trip.
+- Added tests covering the updated classroom creation copy, settings promotion copy, blueprint workspace actions, and package documentation contract.
+
+**Validation:**
+- `pnpm test tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/unit/course-blueprint-package-docs.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test` (233 files, 1938 tests)
+- `pnpm test tests/components/TeacherBlueprintsPage.test.tsx`
+- Pika UI verification for `/teacher/blueprints` via `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "teacher/blueprints"`; local Supabase is missing course blueprint migrations, so selected-workspace verification used Playwright API mocks instead of applying migrations.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-teacher-blueprint-selected.png`
+  - `/tmp/pika-teacher-blueprint-selected-mobile.png`
+  - `/tmp/pika-teacher-blueprint-selected-dark.png`
+  - `/tmp/pika-teacher-settings-blueprint.png`
+  - `/tmp/pika-teacher-settings-blueprint-mobile.png`

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -30,6 +30,7 @@ After the startup set above, load task-specific docs:
 | Multi-agent delegation | [`docs/core/agents.md`](./core/agents.md) |
 | Product status or phase questions | [`docs/core/roadmap.md`](./core/roadmap.md) |
 | GitHub issue work | [`docs/workflow/handle-issue.md`](./workflow/handle-issue.md) |
+| Course blueprint package import/export | [`docs/guidance/course-blueprint-packages.md`](./guidance/course-blueprint-packages.md) |
 | Feature-specific behavior | `docs/guidance/*.md` or the closest focused spec |
 
 Inspect or modify source only after the startup set and the docs required by your task are loaded.

--- a/docs/guidance/course-blueprint-packages.md
+++ b/docs/guidance/course-blueprint-packages.md
@@ -1,0 +1,49 @@
+# Course Blueprint Packages
+
+This is the teacher-facing contract for portable course files.
+
+## Naming Decision
+
+- **Course Blueprint** is the reusable plan teachers edit in Pika.
+- **Course Package** is the portable exported file teachers can move between Pika, a repo, Codex, Claude, or another editing workflow.
+- The official exported file extension is `.course-package.tar`.
+
+## Package Format
+
+A course package is a tar archive with these root files:
+
+- `manifest.json`
+- `course-overview.md`
+- `course-outline.md`
+- `resources.md`
+- `assignments.md`
+- `quizzes.md`
+- `tests.md`
+- `lesson-plans.md`
+
+`manifest.json` stores package metadata and planned-site publishing settings. The Markdown files store the editable teacher-authored course content.
+
+## Included
+
+- Course title, subject, grade level, course code, and term template
+- Planned course site slug, published flag, and section visibility
+- Course overview, outline, and resources
+- Assignment plans, default due offsets, default due times, points, final-grade inclusion, and draft state
+- Quiz and test definitions represented in Markdown
+- Test document metadata/content when represented by the test Markdown format
+- Lesson plan templates
+
+## Excluded
+
+Course packages are reusable planning files, not classroom backups. They exclude students, submissions, grades, attendance, rosters, join codes, class days, classroom calendar overrides, live announcements, actual course website settings, and runtime storage objects.
+
+## Round Trip
+
+1. Export a course blueprint from Pika as `.course-package.tar`.
+2. Extract the archive.
+3. Edit the Markdown files in a repo, Codex, or Claude. Keep the filenames and `manifest.json` at the archive root.
+4. Repack the root files into a tar archive.
+5. Import the course package in Pika.
+6. Review the resulting Course Blueprint before using it to create a classroom or publishing its planned course site.
+
+Do not use this package for automatic `actual -> blueprint` sync. Classroom changes should be reviewed and explicitly saved back into a Course Blueprint.

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -261,11 +261,11 @@ export function TeacherSettingsTab({
       })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to create classroom blueprint')
+        throw new Error(data.error || 'Failed to save classroom as a course blueprint')
       }
       router.push(data.redirect_url || `/teacher/blueprints?blueprint=${data.blueprint_id}&fromClassroom=${classroom.id}`)
     } catch (err: any) {
-      setBlueprintError(err.message || 'Failed to create classroom blueprint')
+      setBlueprintError(err.message || 'Failed to save classroom as a course blueprint')
     } finally {
       setBlueprintBusy(false)
     }
@@ -577,8 +577,8 @@ export function TeacherSettingsTab({
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
               <div className="flex items-center gap-2">
-                <div className="text-sm font-semibold text-text-default">Course Reuse</div>
-                <Tooltip content="Create a reusable blueprint draft from this classroom’s teacher-authored course content" side="right">
+                <div className="text-sm font-semibold text-text-default">Course Blueprint</div>
+                <Tooltip content="Save this classroom's teacher-authored course content as a reusable course blueprint" side="right">
                   <span className="text-text-muted cursor-help">
                     <Info size={14} />
                   </span>
@@ -586,7 +586,7 @@ export function TeacherSettingsTab({
               </div>
 
               <p className="text-sm text-text-muted">
-                Turn this classroom’s overview, outline, resources, assignments, assessments, and lesson plans into a reusable course blueprint.
+                Save the classroom overview, outline, resources, assignments, quizzes, tests, and lesson plans as a reusable course blueprint. Students, submissions, grades, and attendance stay out of the blueprint.
               </p>
 
               <div className="flex flex-wrap gap-3">
@@ -596,7 +596,7 @@ export function TeacherSettingsTab({
                   onClick={openCreateBlueprintDialog}
                   disabled={blueprintBusy || isReadOnly}
                 >
-                  {blueprintBusy ? 'Working…' : 'Create Classroom Blueprint'}
+                  {blueprintBusy ? 'Working...' : 'Save as Course Blueprint'}
                 </Button>
               </div>
             </div>
@@ -622,11 +622,11 @@ export function TeacherSettingsTab({
               ariaLabelledBy="create-classroom-blueprint-title"
             >
               <h2 id="create-classroom-blueprint-title" className="mb-4 text-xl font-bold text-text-default">
-                Create Classroom Blueprint
+                Save Classroom as Course Blueprint
               </h2>
 
               <div className="space-y-4">
-                <FormField label="Blueprint Title" required>
+                <FormField label="Course Blueprint Title" required>
                   <Input
                     value={blueprintTitle}
                     onChange={(e) => setBlueprintTitle(e.target.value)}
@@ -636,7 +636,7 @@ export function TeacherSettingsTab({
                 </FormField>
 
                 <div className="rounded-md border border-border bg-surface-2 px-4 py-3 text-sm text-text-muted">
-                  This copies the classroom overview, outline, resources, assignments, quizzes, tests, and lesson plans into a new reusable blueprint draft. Students, submissions, grades, and attendance are not included.
+                  The course blueprint will include teacher-authored course content only. Students, submissions, grades, attendance, join codes, and roster data are not included.
                 </div>
 
                 {blueprintError ? (
@@ -662,7 +662,7 @@ export function TeacherSettingsTab({
                   className="flex-1"
                   disabled={blueprintBusy || !blueprintTitle.trim()}
                 >
-                  {blueprintBusy ? 'Creating…' : 'Create Blueprint'}
+                  {blueprintBusy ? 'Saving...' : 'Save Blueprint'}
                 </Button>
               </div>
             </DialogPanel>

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -52,9 +52,9 @@ const TAB_LABELS: Record<EditorTab, string> = {
   quizzes: 'Quizzes',
   tests: 'Tests',
   'lesson-plans': 'Lesson Plans',
-  copilot: 'Copilot',
+  copilot: 'AI Drafting',
   publish: 'Publish',
-  sync: 'Sync',
+  sync: 'Classroom Updates',
 }
 
 type DraftState = Record<Exclude<EditorTab, 'copilot' | 'publish' | 'sync'>, string>
@@ -129,8 +129,8 @@ export default function TeacherBlueprintsPage() {
     if (!fromClassroomId || !preferredBlueprintId || selectedBlueprintId !== preferredBlueprintId) return ''
     const classroomTitle = detail?.linked_classrooms.find((classroom) => classroom.id === fromClassroomId)?.title
     return classroomTitle
-      ? `Blueprint created from ${classroomTitle}. Review and refine it here before publishing or exporting.`
-      : 'Blueprint created from classroom content. Review and refine it here before publishing or exporting.'
+      ? `Course blueprint saved from ${classroomTitle}. Review it here, then use it for another classroom or export the course package.`
+      : 'Course blueprint saved from classroom content. Review it here, then use it for another classroom or export the course package.'
   }, [detail, fromClassroomId, preferredBlueprintId, selectedBlueprintId])
 
   async function loadBlueprints(preferredId?: string) {
@@ -381,12 +381,12 @@ export default function TeacherBlueprintsPage() {
       })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to apply classroom changes back into the blueprint')
+        throw new Error(data.error || 'Failed to save classroom changes to the course blueprint')
       }
       await loadDetail(selectedBlueprintId)
       await loadMergeSuggestions(mergeClassroomId)
     } catch (err: any) {
-      setError(err.message || 'Failed to apply classroom changes back into the blueprint')
+      setError(err.message || 'Failed to save classroom changes to the course blueprint')
     } finally {
       setMergeApplying(false)
     }
@@ -510,19 +510,19 @@ export default function TeacherBlueprintsPage() {
         primary={
           <div>
             <div className="text-sm font-medium text-text-default">Course Blueprints</div>
-            <div className="text-xs text-text-muted">Reusable course packages for new classrooms</div>
+            <div className="text-xs text-text-muted">Build, publish, export, and reuse course packages.</div>
           </div>
         }
         actions={[
           { id: 'back-classrooms', label: 'Classrooms', onSelect: () => router.push('/classrooms') },
-          { id: 'new-blueprint', label: 'New blueprint', onSelect: () => setShowCreate(true) },
-          { id: 'import-package', label: 'Import package', onSelect: () => importInputRef.current?.click() },
+          { id: 'new-blueprint', label: 'New Course Blueprint', onSelect: () => setShowCreate(true) },
+          { id: 'import-package', label: 'Import Course Package', onSelect: () => importInputRef.current?.click() },
           ...(selectedBlueprintId
             ? [
-                { id: 'create-classroom', label: 'Create classroom', onSelect: () => setShowCreateClassroom(true) },
-                { id: 'export-package', label: 'Export package', onSelect: handleExport },
+                { id: 'create-classroom', label: 'Use for Classroom', primary: true, onSelect: () => setShowCreateClassroom(true) },
+                { id: 'export-package', label: 'Export Course Package', onSelect: handleExport },
                 ...(plannedSite.published && plannedSite.slug
-                  ? [{ id: 'open-planned-site', label: 'Open planned site', onSelect: () => window.open(`/planned/${plannedSite.slug}`, '_blank') }]
+                  ? [{ id: 'open-planned-site', label: 'Open Planned Site', onSelect: () => window.open(`/planned/${plannedSite.slug}`, '_blank') }]
                   : []),
               ]
             : []),
@@ -549,7 +549,7 @@ export default function TeacherBlueprintsPage() {
         ) : null}
 
         <div className="grid gap-6 lg:grid-cols-[320px,minmax(0,1fr)]">
-          <aside className="rounded-card border border-border bg-surface p-4">
+          <aside className="self-start rounded-card border border-border bg-surface p-4">
             {loadingList ? (
               <div className="flex justify-center py-8">
                 <Spinner />
@@ -558,7 +558,7 @@ export default function TeacherBlueprintsPage() {
               <div className="space-y-3 text-center">
                 <p className="text-sm text-text-muted">No course blueprints yet.</p>
                 <Button type="button" onClick={() => setShowCreate(true)}>
-                  Create Blueprint
+                  Create Course Blueprint
                 </Button>
               </div>
             ) : (
@@ -597,7 +597,7 @@ export default function TeacherBlueprintsPage() {
               )
             ) : (
               <div className="space-y-5">
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                   <FormField label="Title">
                     <Input value={meta.title} onChange={(e) => setMeta((current) => ({ ...current, title: e.target.value }))} />
                   </FormField>
@@ -617,13 +617,26 @@ export default function TeacherBlueprintsPage() {
 
                 <div className="flex flex-wrap items-center gap-2">
                   <Button type="button" variant="secondary" onClick={saveMetadata} disabled={saving}>
-                    Save Metadata
+                    Save Details
                   </Button>
                   {counts ? (
                     <div className="text-xs text-text-muted">
                       {counts.assignments} assignments • {counts.quizzes} quizzes • {counts.tests} tests • {counts.lesson_templates} lesson templates
                     </div>
                   ) : null}
+                </div>
+
+                <div className="rounded-card border border-border bg-surface-2 p-4">
+                  <div className="text-sm font-semibold text-text-default">Course Blueprint</div>
+                  <div className="mt-1 text-sm text-text-muted">
+                    Edit the plan here, use it to create a classroom, or export a portable course package.
+                  </div>
+                  <div className="mt-3 rounded-md border border-border bg-surface px-3 py-2 text-sm">
+                    <div className="font-medium text-text-default">Portable Course Package</div>
+                    <div className="mt-1 text-text-muted">
+                      Exports a .course-package.tar file with manifest.json and editable Markdown files.
+                    </div>
+                  </div>
                 </div>
 
                 <div className="flex flex-wrap gap-2">
@@ -646,7 +659,7 @@ export default function TeacherBlueprintsPage() {
                 {activeTab === 'publish' ? (
                   <div className="space-y-4">
                     <div className="grid gap-4 md:grid-cols-[minmax(0,1fr),auto]">
-                      <FormField label="Planned Site Slug" hint="Leave blank to keep the planned site private.">
+                      <FormField label="Planned Course Site Slug" hint="Leave blank to keep the planned site private.">
                         <Input
                           value={plannedSite.slug}
                           onChange={(e) =>
@@ -680,7 +693,7 @@ export default function TeacherBlueprintsPage() {
                         }
                         className="h-4 w-4"
                       />
-                      Publish this planned course site using the slug above
+                        Publish this planned course site
                     </label>
 
                     <div className="rounded-card border border-border bg-surface-2 p-4">
@@ -709,13 +722,13 @@ export default function TeacherBlueprintsPage() {
 
                     {plannedSite.published && plannedSite.slug ? (
                       <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
-                        Planned site URL: <a className="text-primary underline" href={`/planned/${plannedSite.slug}`} target="_blank" rel="noreferrer">{`/planned/${plannedSite.slug}`}</a>
+                        Planned course site: <a className="text-primary underline" href={`/planned/${plannedSite.slug}`} target="_blank" rel="noreferrer">{`/planned/${plannedSite.slug}`}</a>
                       </div>
                     ) : null}
 
                     <div className="flex justify-end">
                       <Button type="button" onClick={savePlannedSite} disabled={saving}>
-                        {saving ? 'Saving...' : 'Save Publishing'}
+                        {saving ? 'Saving...' : 'Save Planned Site'}
                       </Button>
                     </div>
                   </div>
@@ -728,7 +741,7 @@ export default function TeacherBlueprintsPage() {
                     ) : (
                       <>
                         <div className="grid gap-4 md:grid-cols-[minmax(0,1fr),auto]">
-                          <FormField label="Linked Classroom" hint="Compare this live classroom against the reusable blueprint.">
+                          <FormField label="Classroom" hint="Review classroom changes before saving them to this course blueprint.">
                             <select
                               value={mergeClassroomId}
                               onChange={(e) => {
@@ -746,7 +759,7 @@ export default function TeacherBlueprintsPage() {
                           </FormField>
                           <div className="flex items-end">
                             <Button type="button" variant="secondary" onClick={() => loadMergeSuggestions()} disabled={mergeLoading || !mergeClassroomId}>
-                              {mergeLoading ? 'Comparing...' : 'Load Suggestions'}
+                              {mergeLoading ? 'Reviewing...' : 'Review Changes'}
                             </Button>
                           </div>
                         </div>
@@ -755,7 +768,7 @@ export default function TeacherBlueprintsPage() {
                           <div className="space-y-4">
                             {mergeSuggestions.suggestions.length === 0 ? (
                               <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
-                                No blueprint drift detected for this classroom.
+                                No classroom changes to save for this course blueprint.
                               </div>
                             ) : (
                               <>
@@ -784,8 +797,8 @@ export default function TeacherBlueprintsPage() {
                                           <div className="font-medium text-text-default">
                                             {item.label} • {item.operation}
                                           </div>
-                                          <div className="mt-1 text-text-muted">Blueprint: {item.current_summary}</div>
-                                          <div className="text-text-muted">Classroom: {item.proposed_summary}</div>
+                                          <div className="mt-1 text-text-muted">Current blueprint: {item.current_summary}</div>
+                                          <div className="text-text-muted">Classroom version: {item.proposed_summary}</div>
                                         </div>
                                       ))}
                                     </div>
@@ -801,7 +814,7 @@ export default function TeacherBlueprintsPage() {
 
                                 <div className="flex justify-end">
                                   <Button type="button" onClick={applyMergeSuggestions} disabled={mergeApplying}>
-                                    {mergeApplying ? 'Applying...' : 'Apply Selected Changes'}
+                                    {mergeApplying ? 'Saving...' : 'Save Selected Updates'}
                                   </Button>
                                 </div>
                               </>
@@ -814,7 +827,7 @@ export default function TeacherBlueprintsPage() {
                 ) : activeTab === 'copilot' ? (
                   <div className="space-y-4">
                     <div className="grid gap-4 md:grid-cols-[220px,minmax(0,1fr)]">
-                      <FormField label="Copilot Target">
+                      <FormField label="Draft Section">
                         <select
                           value={aiTarget}
                           onChange={(e) => setAiTarget(e.target.value as CopilotTarget)}
@@ -829,17 +842,17 @@ export default function TeacherBlueprintsPage() {
                           <option value="lesson-plans">Lesson Plans</option>
                         </select>
                       </FormField>
-                      <FormField label="Teacher Prompt">
+                      <FormField label="Direction">
                         <Input value={aiPrompt} onChange={(e) => setAiPrompt(e.target.value)} placeholder="Focus on a coding-heavy semester with weekly checkpoints." />
                       </FormField>
                     </div>
 
                     <div className="flex flex-wrap gap-2">
                       <Button type="button" onClick={() => runCopilot('analyze')} disabled={aiBusy}>
-                        {aiBusy ? 'Working...' : 'Analyze Blueprint'}
+                        {aiBusy ? 'Working...' : 'Review Course Blueprint'}
                       </Button>
                       <Button type="button" variant="secondary" onClick={() => runCopilot(aiTarget)} disabled={aiBusy}>
-                        Generate Preview
+                        Draft Preview
                       </Button>
                       {aiPreview ? (
                         <Button type="button" variant="secondary" onClick={applyCopilotPreview} disabled={aiBusy}>

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -137,7 +137,7 @@ export function CreateClassroomModal({
 
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
-        throw new Error(data.errors?.join('\n') || data.error || 'Failed to load blueprint file')
+        throw new Error(data.errors?.join('\n') || data.error || 'Failed to import course package')
       }
 
       const blueprint = data.blueprint as CourseBlueprint
@@ -147,7 +147,7 @@ export function CreateClassroomModal({
       })
       setSelectedBlueprintId(blueprint.id)
     } catch (err: any) {
-      setError(err.message || 'Failed to load blueprint file')
+      setError(err.message || 'Failed to import course package')
     } finally {
       setImportingBlueprint(false)
       if (event.target) event.target.value = ''
@@ -295,10 +295,10 @@ export function CreateClassroomModal({
               type="file"
               accept=".tar,.json,.course-package.tar"
               className="hidden"
-              aria-label="Load blueprint file"
+              aria-label="Import course package file"
               onChange={handleImportBlueprintFile}
             />
-            <FormField label="Blueprint" required>
+            <FormField label="Course Blueprint" required>
               <select
                 value={selectedBlueprintId}
                 onChange={(e) => {
@@ -313,14 +313,14 @@ export function CreateClassroomModal({
                 disabled={isBusy}
                 className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
               >
-                <option value="">Select a blueprint</option>
+                <option value="">Select a course blueprint</option>
                 {availableBlueprints.map((blueprint) => (
                   <option key={blueprint.id} value={blueprint.id}>
                     {blueprint.title}
                   </option>
                 ))}
                 <option value={CHOOSE_FILE_OPTION}>
-                  {importingBlueprint ? 'Loading file...' : 'Choose file...'}
+                  {importingBlueprint ? 'Importing package...' : 'Import course package...'}
                 </option>
               </select>
             </FormField>
@@ -484,7 +484,7 @@ export function CreateClassroomModal({
             options={[
               {
                 id: 'from-blueprint',
-                label: 'From Blueprint',
+                label: 'From Course Blueprint',
                 onSelect: () => {
                   if (!title) return
                   proceedFromName('blueprint')

--- a/tests/components/CreateClassroomModal.test.tsx
+++ b/tests/components/CreateClassroomModal.test.tsx
@@ -63,7 +63,7 @@ describe('CreateClassroomModal', () => {
   }
 
   function getBlueprintSelect() {
-    return screen.getByRole('combobox', { name: /blueprint/i })
+    return screen.getByRole('combobox', { name: /course blueprint/i })
   }
 
   async function openBlueprintSourceStep(title = 'Career Studies - Period 1') {
@@ -72,7 +72,7 @@ describe('CreateClassroomModal', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Choose classroom creation path' }))
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'From Blueprint' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'From Course Blueprint' }))
   }
 
   it('keeps the primary Next path as a blank-classroom flow', async () => {
@@ -89,7 +89,7 @@ describe('CreateClassroomModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
 
     expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
-    expect(screen.queryByRole('combobox', { name: /blueprint/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: /course blueprint/i })).not.toBeInTheDocument()
   })
 
   it('routes From Blueprint through a separate source step before calendar selection', async () => {
@@ -97,7 +97,7 @@ describe('CreateClassroomModal', () => {
 
     await openBlueprintSourceStep()
 
-    expect(await screen.findByRole('combobox', { name: /blueprint/i })).toBeInTheDocument()
+    expect(await screen.findByRole('combobox', { name: /course blueprint/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
 
     fireEvent.change(getBlueprintSelect(), {
@@ -120,7 +120,7 @@ describe('CreateClassroomModal', () => {
     renderModal()
     await openBlueprintSourceStep()
 
-    expect(screen.getByRole('combobox', { name: /blueprint/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /course blueprint/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
   })
 
@@ -143,11 +143,13 @@ describe('CreateClassroomModal', () => {
     renderModal()
     await openBlueprintSourceStep()
 
-    const fileInput = screen.getByLabelText('Load blueprint file')
+    const fileInput = screen.getByLabelText('Import course package file')
     const file = new File(['bundle'], 'course-package.tar', { type: 'application/x-tar' })
     Object.defineProperty(file, 'arrayBuffer', {
       value: async () => new TextEncoder().encode('bundle').buffer,
     })
+    expect(screen.getByRole('option', { name: 'Import course package...' })).toBeInTheDocument()
+
     fireEvent.change(getBlueprintSelect(), { target: { value: '__choose-file__' } })
     fireEvent.change(fileInput, { target: { files: [file] } })
 
@@ -169,7 +171,7 @@ describe('CreateClassroomModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
 
-    const blueprintSelect = await screen.findByRole('combobox', { name: /blueprint/i })
+    const blueprintSelect = await screen.findByRole('combobox', { name: /course blueprint/i })
     expect(blueprintSelect).toHaveValue(mockBlueprint.id)
     expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled()
   })

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -15,7 +15,16 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/components/PageLayout', () => ({
   PageLayout: ({ children }: any) => <div>{children}</div>,
   PageContent: ({ children }: any) => <div>{children}</div>,
-  PageActionBar: ({ primary }: any) => <div>{primary}</div>,
+  PageActionBar: ({ primary, actions = [] }: any) => (
+    <div>
+      {primary}
+      {actions.map((action: any) => (
+        <button key={action.id} type="button" onClick={action.onSelect}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
 }))
 
 vi.mock('@/components/CreateBlueprintModal', () => ({
@@ -117,13 +126,21 @@ describe('TeacherBlueprintsPage', () => {
     cleanup()
   })
 
-  it('selects the blueprint from the query param and shows the classroom-origin notice', async () => {
+  it('selects the blueprint from the query param and shows workflow-oriented package actions', async () => {
     render(<TeacherBlueprintsPage />)
 
     await waitFor(() => {
       expect(screen.getByDisplayValue('Blueprint Two')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Blueprint created from Semester 2. Review and refine it here before publishing or exporting.')).toBeInTheDocument()
+    expect(screen.getByText('Course Blueprint')).toBeInTheDocument()
+    expect(screen.getByText('Build, publish, export, and reuse course packages.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New Course Blueprint' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Import Course Package' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use for Classroom' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Export Course Package' })).toBeInTheDocument()
+    expect(screen.getByText('Course blueprint saved from Semester 2. Review it here, then use it for another classroom or export the course package.')).toBeInTheDocument()
+    expect(screen.getByText('Portable Course Package')).toBeInTheDocument()
+    expect(screen.getByText(/Exports a .course-package.tar file with manifest.json and editable Markdown files./)).toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -287,17 +287,17 @@ describe('TeacherSettingsTab - Classroom Blueprint Promotion', () => {
     cleanup()
   })
 
-  it('opens the create classroom blueprint dialog with the classroom title prefilled', () => {
+  it('opens the save-as-course-blueprint dialog with the classroom title prefilled', () => {
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create Classroom Blueprint' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Course Blueprint' }))
 
     const dialog = screen.getByRole('dialog')
-    expect(within(dialog).getByRole('heading', { name: 'Create Classroom Blueprint' })).toBeInTheDocument()
+    expect(within(dialog).getByRole('heading', { name: 'Save Classroom as Course Blueprint' })).toBeInTheDocument()
     expect(within(dialog).getByPlaceholderText('Grade 11 Computer Science')).toHaveValue('Test Course')
   })
 
-  it('creates a classroom blueprint and redirects into the blueprint workspace', async () => {
+  it('saves a classroom as a course blueprint and redirects into the blueprint workspace', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -309,10 +309,10 @@ describe('TeacherSettingsTab - Classroom Blueprint Promotion', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create Classroom Blueprint' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Course Blueprint' }))
     const dialog = screen.getByRole('dialog')
     fireEvent.change(within(dialog).getByPlaceholderText('Grade 11 Computer Science'), { target: { value: 'Reusable Draft' } })
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Create Blueprint' }))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save Blueprint' }))
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/tests/unit/course-blueprint-package-docs.test.ts
+++ b/tests/unit/course-blueprint-package-docs.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+function readRepoFile(relativePath: string) {
+  return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
+}
+
+describe('course blueprint package docs', () => {
+  it('documents the official portable package contract and round trip', () => {
+    const docs = readRepoFile('docs/guidance/course-blueprint-packages.md')
+
+    expect(docs).toContain('Course Blueprint')
+    expect(docs).toContain('.course-package.tar')
+    expect(docs).toContain('manifest.json')
+    expect(docs).toContain('course-overview.md')
+    expect(docs).toContain('assignments.md')
+    expect(docs).toContain('quizzes.md')
+    expect(docs).toContain('tests.md')
+    expect(docs).toContain('lesson-plans.md')
+    expect(docs).toContain('students, submissions, grades, attendance')
+    expect(docs).toContain('Edit the Markdown files in a repo, Codex, or Claude')
+  })
+})


### PR DESCRIPTION
## Summary
- tighten teacher-facing Course Blueprint/Course Package wording across blueprint workspace, classroom creation, and settings promotion
- add a compact portable package panel and improve selected blueprint layout
- document the official `.course-package.tar` contract and repo/Codex/Claude round trip

## Verification
- `pnpm test tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/unit/course-blueprint-package-docs.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- visual verification: `pika-ui-verify teacher/blueprints` plus Playwright mocked selected blueprint desktop/mobile/dark and classroom settings desktop/mobile screenshots

Closes #515