### PR TITLE
[codex] Clarify resubmitted assignment status

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9613,3 +9613,18 @@
   - `/tmp/pika-teacher-blueprint-selected-dark.png`
   - `/tmp/pika-teacher-settings-blueprint.png`
   - `/tmp/pika-teacher-settings-blueprint-mobile.png`
+
+## 2026-04-28 — Clarify resubmitted assignment status
+
+**Completed:**
+- Made the teacher assignment student table show `resubmitted` rows as a compact warning `Resub` chip instead of an icon-only status, so teachers can distinguish a returned-then-resubmitted row even when the grade column still has a score.
+- Added component coverage for the resubmitted chip and the shared resubmission status icon.
+
+**Validation:**
+- `pnpm test tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/AssessmentStatusIcon.test.tsx`
+- `pnpm lint`
+- `pnpm test` (233 files, 1940 tests)
+- Visual verification with Playwright route-mocked assignment data for:
+  - `/tmp/pika-teacher-resubmitted-status.png`
+  - `/tmp/pika-teacher-resubmitted-status-mobile.png`
+  - `/tmp/pika-student-assignments-mobile.png`

--- a/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
+++ b/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
@@ -118,7 +118,21 @@ function StatusIcon({
       iconState = 'not_started'
   }
 
-  return <AssessmentStatusIcon state={iconState} late={showLate} />
+  const icon = <AssessmentStatusIcon state={iconState} late={showLate} />
+
+  if (status === 'resubmitted') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-badge border border-warning bg-warning-bg px-1.5 py-0.5 text-[11px] font-semibold leading-none text-warning"
+        data-testid="assignment-status-resubmitted-chip"
+      >
+        {icon}
+        <span>Resub</span>
+      </span>
+    )
+  }
+
+  return icon
 }
 
 function getTeacherAssignmentStatusTooltipLabel(status: AssignmentStatus, wasLate: boolean): string {
@@ -205,7 +219,7 @@ export function TeacherAssignmentStudentTable({
                       isActive={sortColumn === 'status'}
                       direction={sortDirection}
                       onClick={() => onToggleSort('status')}
-                      className="w-[4.5rem]"
+                      className="w-[5.75rem]"
                     />
                     <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
                     <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
@@ -231,6 +245,7 @@ export function TeacherAssignmentStudentTable({
                       dueAtMs &&
                       new Date(student.doc.submitted_at).getTime() > dueAtMs
                     )
+                    const statusLabel = getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)
 
                     return (
                       <DataTableRow
@@ -262,9 +277,9 @@ export function TeacherAssignmentStudentTable({
                             </Tooltip>
                           ) : '—'}
                         </DataTableCell>
-                        <DataTableCell className="w-[4.5rem]">
-                          <Tooltip content={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
-                            <span className="inline-flex" role="img" aria-label={getTeacherAssignmentStatusTooltipLabel(student.status, wasLate)}>
+                        <DataTableCell className="w-[5.75rem]">
+                          <Tooltip content={statusLabel}>
+                            <span className="inline-flex" role="img" aria-label={statusLabel}>
                               <StatusIcon
                                 status={student.status}
                                 wasLate={wasLate}

--- a/tests/components/AssessmentStatusIcon.test.tsx
+++ b/tests/components/AssessmentStatusIcon.test.tsx
@@ -18,6 +18,12 @@ describe('AssessmentStatusIcon', () => {
     expect(screen.getByTestId('assessment-status-icon-returned')).toHaveClass('text-primary')
   })
 
+  it('renders resubmitted as the warning resubmission icon', () => {
+    render(<AssessmentStatusIcon state="resubmitted" />)
+
+    expect(screen.getByTestId('assessment-status-icon-resubmitted')).toHaveClass('text-warning')
+  })
+
   it('adds a late clock without changing the base status', () => {
     render(<AssessmentStatusIcon state="submitted" late />)
 

--- a/tests/components/TeacherAssignmentStudentTable.test.tsx
+++ b/tests/components/TeacherAssignmentStudentTable.test.tsx
@@ -99,4 +99,41 @@ describe('TeacherAssignmentStudentTable', () => {
     expect(onToggleSelect).toHaveBeenCalledWith('student-1')
     expect(onSelectStudent).not.toHaveBeenCalled()
   })
+
+  it('shows a distinct resubmitted status chip even when the row still has a grade', () => {
+    render(
+      <TeacherAssignmentStudentTable
+        rows={[{
+          ...row,
+          status: 'resubmitted',
+          doc: {
+            ...row.doc!,
+            submitted_at: '2026-04-22T12:00:00Z',
+            returned_at: '2026-04-21T12:00:00Z',
+            graded_at: '2026-04-21T12:00:00Z',
+          },
+        }]}
+        selectedStudentId={null}
+        onSelectStudent={vi.fn()}
+        onDeselectStudent={vi.fn()}
+        selectedIds={new Set()}
+        onToggleSelect={vi.fn()}
+        onToggleSelectAll={vi.fn()}
+        allSelected={false}
+        sortColumn="last"
+        sortDirection="asc"
+        onToggleSort={vi.fn()}
+        dueAtMs={new Date('2026-04-20T12:00:00Z').getTime()}
+        density="compact"
+        loading={false}
+        error=""
+      />,
+    )
+
+    expect(screen.getByTestId('assignment-status-resubmitted-chip')).toHaveTextContent('Resub')
+    expect(screen.getByTestId('assessment-status-icon-resubmitted')).toBeInTheDocument()
+    expect(screen.getByTestId('assessment-status-icon-late-clock')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Resubmitted (late)' })).toBeInTheDocument()
+    expect(screen.getByText('90')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

- Show resubmitted assignment rows in the teacher student table as a compact warning `Resub` chip instead of an icon-only status.
- Preserve the existing resubmission and late icon signals inside the chip so returned-then-resubmitted work is visibly distinct even when an old grade remains in the grade column.
- Add focused component coverage for the teacher table chip and shared resubmission status icon.

## Validation

- `pnpm test tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/AssessmentStatusIcon.test.tsx`
- `pnpm lint`
- `pnpm test` (233 files, 1940 tests)
- Visual verification with Playwright route-mocked assignment data:
  - `/tmp/pika-teacher-resubmitted-status.png`
  - `/tmp/pika-teacher-resubmitted-status-mobile.png`
  - `/tmp/pika-student-assignments-mobile.png`

## Notes

- The local UI verification route used mocked assignment API responses because the new worktree's local database returned stale classroom access responses for teacher assignment details.
- Teacher screenshots still surfaced an existing Radix/SplitButton ref warning in dev console; this PR does not touch that component.