### PR TITLE
[codex] Fix test AI batch omission handling

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9628,3 +9628,19 @@
   - `/tmp/pika-teacher-resubmitted-status.png`
   - `/tmp/pika-teacher-resubmitted-status-mobile.png`
   - `/tmp/pika-student-assignments-mobile.png`
+## 2026-04-28 — Test AI batch grading omitted response fix
+
+**Context:** A teacher test AI grading run reported `Graded 15 • 4 failed` with repeated `AI batch grade suggestion omitted response ...` messages after grading practice tests where several students had not attempted.
+
+**Completed:**
+- Fixed test AI batch grading so a model omission for one response no longer fails the whole microbatch.
+- Kept available batch suggestions and lets the run processor retry only the omitted response.
+- Mapped exhausted omitted-response failures to the generic teacher-facing AI grading service error instead of exposing internal response IDs.
+- Added unit coverage for partial batch suggestions and run-state coverage for retry and exhausted-retry behavior.
+
+**Validation:**
+- `pnpm test tests/unit/ai-test-grading.test.ts`
+- `pnpm test tests/lib/test-ai-grading-runs.test.ts`
+- `pnpm lint`
+- `pnpm test` (233 files, 1941 tests)
+- `pnpm build`

--- a/src/lib/ai-test-grading.ts
+++ b/src/lib/ai-test-grading.ts
@@ -1231,21 +1231,24 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
     })
   }
 
-  return responses.map((response) => {
+  const suggestions: TestOpenResponseBatchSuggestion[] = []
+  for (const response of responses) {
     const result = resultsById.get(response.responseId)
     if (!result) {
-      throw new Error(`AI batch grade suggestion omitted response ${response.responseId}`)
+      continue
     }
 
-    return {
+    suggestions.push({
       responseId: response.responseId,
       score: result.score,
       feedback: result.feedback,
       model: prepared.model,
       grading_basis: prepared.grading_basis,
       reference_answers: prepared.reference_answers,
-    }
-  })
+    })
+  }
+
+  return suggestions
 }
 
 export async function suggestTestOpenResponseGrade(input: {

--- a/src/lib/server/test-ai-grading-runs.ts
+++ b/src/lib/server/test-ai-grading-runs.ts
@@ -656,12 +656,24 @@ function toTeacherAutoGradeErrorMessage(error: unknown): string {
     message === 'OpenAI response incomplete: max_output_tokens' ||
     message === 'Failed to parse AI grade suggestion' ||
     message === 'Failed to parse AI batch grade suggestions' ||
-    message === 'Failed to parse AI reference answers'
+    message === 'Failed to parse AI reference answers' ||
+    message.startsWith('AI batch grade suggestion omitted response')
   ) {
     return 'AI grading service failed for this response. Try again.'
   }
 
   return message
+}
+
+function isBatchOmittedResponseError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith('AI batch grade suggestion omitted response')
+}
+
+function getRunItemErrorCode(error: unknown): string {
+  if (isBatchOmittedResponseError(error)) return 'invalid_output'
+  return error instanceof Error && 'kind' in error && typeof error.kind === 'string'
+    ? error.kind
+    : 'internal'
 }
 
 async function failOrRetryItem(opts: {
@@ -671,15 +683,13 @@ async function failOrRetryItem(opts: {
   error: unknown
 }): Promise<void> {
   const teacherMessage = toTeacherAutoGradeErrorMessage(opts.error)
+  const retryable = isRetryableTestAiGradingError(opts.error) || isBatchOmittedResponseError(opts.error)
 
-  if (
-    isRetryableTestAiGradingError(opts.error) &&
-    opts.attemptCount < TEST_AI_GRADING_MAX_ATTEMPTS
-  ) {
+  if (retryable && opts.attemptCount < TEST_AI_GRADING_MAX_ATTEMPTS) {
     await updateRunItem(opts.supabase, opts.item.id, {
       status: 'queued',
       attempt_count: opts.attemptCount,
-      last_error_code: opts.error.kind,
+      last_error_code: getRunItemErrorCode(opts.error),
       last_error_message: teacherMessage,
       next_retry_at: getNextRetryAt(opts.attemptCount),
       completed_at: null,
@@ -690,10 +700,7 @@ async function failOrRetryItem(opts: {
   await updateRunItem(opts.supabase, opts.item.id, {
     status: 'failed',
     attempt_count: opts.attemptCount,
-    last_error_code:
-      opts.error instanceof Error && 'kind' in opts.error && typeof opts.error.kind === 'string'
-        ? opts.error.kind
-        : 'internal',
+    last_error_code: getRunItemErrorCode(opts.error),
     last_error_message: teacherMessage,
     completed_at: new Date().toISOString(),
   })

--- a/tests/lib/test-ai-grading-runs.test.ts
+++ b/tests/lib/test-ai-grading-runs.test.ts
@@ -357,6 +357,110 @@ describe('tickTestAiGradingRun', () => {
     expect(suggestTestOpenResponseGradesBatchWithContext).toHaveBeenCalledTimes(1)
   })
 
+  it('retries only the response omitted from a batch suggestion', async () => {
+    const { items, responses } = buildTickHarness({
+      responseRows: [
+        { id: 'response-1', response_text: 'Answer one' },
+        { id: 'response-2', response_text: 'Answer two' },
+      ],
+    })
+
+    suggestTestOpenResponseGradesBatchWithContext.mockResolvedValue([
+      {
+        responseId: 'response-1',
+        score: 5,
+        feedback: 'Correct.',
+        model: 'gpt-5-nano',
+        grading_basis: 'teacher_key',
+        reference_answers: ['Use a hash map.'],
+      },
+    ])
+
+    const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
+
+    expect(result.claimed).toBe(true)
+    expect(result.run.status).toBe('running')
+    expect(result.run.completed_count).toBe(1)
+    expect(result.run.failed_count).toBe(0)
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        attempt_count: 1,
+      }),
+    )
+    expect(items[1]).toEqual(
+      expect.objectContaining({
+        status: 'queued',
+        attempt_count: 1,
+        last_error_code: 'invalid_output',
+        last_error_message: 'AI grading service failed for this response. Try again.',
+      }),
+    )
+    expect(items[1].next_retry_at).toEqual(expect.any(String))
+    expect(responses.get('response-1')).toEqual(
+      expect.objectContaining({
+        score: 5,
+        feedback: 'Correct.',
+      }),
+    )
+  })
+
+  it('fails only the omitted response after retries are exhausted without exposing the response id', async () => {
+    const { items, responses } = buildTickHarness({
+      responseRows: [
+        { id: 'response-1', response_text: 'Answer one' },
+        { id: 'response-2', response_text: 'Answer two' },
+      ],
+    })
+    items[1].attempt_count = 2
+
+    suggestTestOpenResponseGradesBatchWithContext.mockResolvedValue([
+      {
+        responseId: 'response-1',
+        score: 5,
+        feedback: 'Correct.',
+        model: 'gpt-5-nano',
+        grading_basis: 'teacher_key',
+        reference_answers: ['Use a hash map.'],
+      },
+    ])
+
+    const result = await tickTestAiGradingRun({ testId: 'test-1', runId: 'run-1' })
+
+    expect(result.claimed).toBe(true)
+    expect(result.run.status).toBe('completed_with_errors')
+    expect(result.run.completed_count).toBe(1)
+    expect(result.run.failed_count).toBe(1)
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        attempt_count: 1,
+      }),
+    )
+    expect(items[1]).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        attempt_count: 3,
+        last_error_code: 'invalid_output',
+        last_error_message: 'AI grading service failed for this response. Try again.',
+      }),
+    )
+    expect(result.run.error_samples).toEqual([
+      expect.objectContaining({
+        student_id: 'student-2',
+        code: 'invalid_output',
+        message: 'AI grading service failed for this response. Try again.',
+      }),
+    ])
+    expect(result.run.error_samples[0]?.message).not.toContain('response-2')
+    expect(responses.get('response-1')).toEqual(
+      expect.objectContaining({
+        score: 5,
+        feedback: 'Correct.',
+      }),
+    )
+  })
+
   it('fails only the missing response item and still grades available siblings', async () => {
     const { items, responses } = buildTickHarness({
       responseRows: [{ id: 'response-1', response_text: 'Answer one' }],

--- a/tests/unit/ai-test-grading.test.ts
+++ b/tests/unit/ai-test-grading.test.ts
@@ -397,6 +397,54 @@ describe('suggestTestOpenResponseGrade', () => {
     expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? '{}')).max_output_tokens).toBe(900)
   })
 
+  it('returns available batch suggestions when the model omits one requested response', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_parsed: {
+          results: [
+            {
+              response_id: 'response-1',
+              score: 4,
+              feedback: 'Good explanation. Add one key vocabulary word.',
+            },
+          ],
+        },
+      }),
+    })
+
+    const prepared = buildTestOpenResponsePreparedContext({
+      testTitle: 'Unit 1 Test',
+      questionText: 'Explain osmosis.',
+      maxPoints: 5,
+      answerKey: 'Water moves across a semipermeable membrane down its concentration gradient.',
+      promptProfile: 'bulk',
+    })
+
+    const suggestions = await suggestTestOpenResponseGradesBatchWithContext(
+      prepared,
+      [
+        { responseId: 'response-1', responseText: 'Water moves across the membrane.' },
+        { responseId: 'response-2', responseText: 'Water moves between cells.' },
+      ],
+      {
+        feature: 'test_auto_grade',
+        requestedStrategy: 'background_chunked',
+        resolvedStrategy: 'batch',
+        runId: 'run-1',
+      },
+    )
+
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        responseId: 'response-1',
+        score: 4,
+        feedback: 'Good explanation. Add one key vocabulary word.',
+      }),
+    ])
+  })
+
   it('keeps rounded integer scores within fractional max points', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Fixes test AI background grading when an OpenAI batch response omits one requested response id.

## Root Cause

Test auto-grading processes open responses in microbatches. The low-level batch parser previously threw as soon as any requested response id was missing from the model output. The run processor caught that thrown error at the batch level, so every response in that microbatch was retried or failed with the same omitted response id.

That matched the observed run shape: `Graded 15 • 4 failed` with the same omitted response id repeated. The five unattempted students were skipped separately; the four failures were the microbatch size.

## Changes

- Keep valid batch suggestions when one response is omitted instead of throwing away the whole batch.
- Retry only the omitted response item and preserve completed sibling grades.
- Classify omitted response output as `invalid_output`.
- Show a generic teacher-facing AI grading service message if retries are exhausted, without exposing internal response ids.
- Add regression coverage for partial batch suggestions, omitted-response retry behavior, and exhausted omitted-response failure behavior.
- Append the required AI journal entry.

## Validation

- `pnpm test tests/unit/ai-test-grading.test.ts`
- `pnpm test tests/lib/test-ai-grading-runs.test.ts`
- `pnpm lint`
- `pnpm test` (233 files, 1941 tests)
- `pnpm build`
- Re-ran focused grading suites after rebasing onto current `origin/main`.
