### PR TITLE
[codex] Gradebook tabs and tests category

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9644,3 +9644,25 @@
 - `pnpm lint`
 - `pnpm test` (233 files, 1941 tests)
 - `pnpm build`
+
+## 2026-04-28 — Gradebook tabs and tests category
+
+**Completed:**
+- Rebased the gradebook work onto current `origin/main` in the `codex/gradebook-tabs-refactor` worktree; prior gradebook branches had no commits ahead of `main`.
+- Refactored the teacher gradebook to use the shared teacher work-surface tab bar and summary/detail workspace shell used by assignments/tests.
+- Added `Grades` and `Settings` gradebook subtabs, with the Grades view using a 50/50 desktop split between the student table and summary/detail pane.
+- Added Tests as a first-class gradebook category across settings, class/student summaries, final-grade calculation, API payload types, and gradebook settings persistence.
+- Hardened settings loading so real `gradebook_settings` read failures return an error instead of silently falling back to defaults.
+- Added component coverage for the controlled gradebook tabs and the three Settings category weights.
+- Added migration `supabase/migrations/059_add_gradebook_tests_weight.sql` for `gradebook_settings.tests_weight`.
+
+**Validation:**
+- `pnpm test tests/unit/gradebook.test.ts tests/api/teacher/gradebook.test.ts tests/hooks/useGradebookData.test.ts tests/unit/layout-config.test.ts`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts tests/hooks/useGradebookData.test.ts tests/unit/layout-config.test.ts`
+- `pnpm lint`
+- `pnpm test` (234 files, 1947 tests)
+- `pnpm build`
+- Pika UI verification for teacher gradebook Grades and Settings:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`

--- a/src/app/api/teacher/gradebook/route.ts
+++ b/src/app/api/teacher/gradebook/route.ts
@@ -9,12 +9,51 @@ export const revalidate = 0
 
 const DEFAULT_SETTINGS = {
   use_weights: false,
-  assignments_weight: 70,
-  quizzes_weight: 30,
+  assignments_weight: 50,
+  quizzes_weight: 20,
+  tests_weight: 30,
 }
 
 const ASSIGNMENT_POINTS_DEFAULT = 30
 const QUIZ_POINTS_DEFAULT = 100
+
+type GradebookSettingsRow = {
+  use_weights: boolean
+  assignments_weight: number
+  quizzes_weight: number
+  tests_weight?: number | null
+}
+
+function mentionsMissingField(
+  error: { code?: string; message?: string; details?: string; hint?: string } | null | undefined,
+  field: string
+): boolean {
+  if (!error) return false
+  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  return combined.includes(field.toLowerCase()) && (
+    error.code === '42703' ||
+    error.code === 'PGRST204' ||
+    combined.includes('column')
+  )
+}
+
+function isMissingTableError(
+  error: { code?: string; message?: string; details?: string; hint?: string } | null | undefined
+): boolean {
+  if (!error) return false
+  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  return error.code === 'PGRST205' || combined.includes('could not find the table') || combined.includes('does not exist')
+}
+
+function normalizeSettings(row: GradebookSettingsRow | null | undefined) {
+  if (!row) return DEFAULT_SETTINGS
+  return {
+    use_weights: row.use_weights,
+    assignments_weight: Number(row.assignments_weight ?? DEFAULT_SETTINGS.assignments_weight),
+    quizzes_weight: Number(row.quizzes_weight ?? DEFAULT_SETTINGS.quizzes_weight),
+    tests_weight: Number(row.tests_weight ?? 0),
+  }
+}
 
 function round2(value: number): number {
   return Math.round(value * 100) / 100
@@ -59,13 +98,34 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
 
   const supabase = getServiceRoleClient()
 
-  const { data: settingsRow } = await supabase
+  const { data: settingsWithTests, error: settingsWithTestsError } = await supabase
     .from('gradebook_settings')
-    .select('use_weights, assignments_weight, quizzes_weight')
+    .select('use_weights, assignments_weight, quizzes_weight, tests_weight')
     .eq('classroom_id', classroomId)
     .maybeSingle()
 
-  const settings = settingsRow || DEFAULT_SETTINGS
+  let settingsRow = settingsWithTests as GradebookSettingsRow | null
+  if (settingsWithTestsError) {
+    if (!mentionsMissingField(settingsWithTestsError, 'tests_weight')) {
+      console.error('Error loading gradebook settings:', settingsWithTestsError)
+      return NextResponse.json({ error: 'Failed to load gradebook settings' }, { status: 500 })
+    }
+
+    const { data: legacySettingsRow, error: legacySettingsError } = await supabase
+      .from('gradebook_settings')
+      .select('use_weights, assignments_weight, quizzes_weight')
+      .eq('classroom_id', classroomId)
+      .maybeSingle()
+
+    if (legacySettingsError) {
+      console.error('Error loading legacy gradebook settings:', settingsWithTestsError, legacySettingsError)
+      return NextResponse.json({ error: 'Failed to load gradebook settings' }, { status: 500 })
+    }
+
+    settingsRow = legacySettingsRow as GradebookSettingsRow | null
+  }
+
+  const settings = normalizeSettings(settingsRow)
 
   const { data: enrollments, error: enrollmentError } = await supabase
     .from('classroom_enrollments')
@@ -356,17 +416,182 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     }
   }
 
+  let tests: Array<{
+    id: string
+    title: string
+    status: 'draft' | 'active' | 'closed' | null
+    include_in_final: boolean
+  }> = []
+
+  const { data: testsWithMeta, error: testsWithMetaError } = await supabase
+    .from('tests')
+    .select('id, title, status, include_in_final')
+    .eq('classroom_id', classroomId)
+
+  if (!testsWithMetaError) {
+    tests = (testsWithMeta || []).map((test) => ({
+      id: test.id,
+      title: test.title,
+      status: test.status ?? null,
+      include_in_final: test.include_in_final !== false,
+    }))
+  } else if (mentionsMissingField(testsWithMetaError, 'include_in_final')) {
+    const { data: testsLegacy, error: testsLegacyError } = await supabase
+      .from('tests')
+      .select('id, title, status')
+      .eq('classroom_id', classroomId)
+
+    if (!testsLegacyError) {
+      tests = (testsLegacy || []).map((test) => ({
+        id: test.id,
+        title: test.title,
+        status: test.status ?? null,
+        include_in_final: true,
+      }))
+    } else if (!isMissingTableError(testsLegacyError)) {
+      console.error('Error loading tests for gradebook:', testsWithMetaError, testsLegacyError)
+      return NextResponse.json({ error: 'Failed to load tests for gradebook' }, { status: 500 })
+    }
+  } else if (!isMissingTableError(testsWithMetaError)) {
+    console.error('Error loading tests for gradebook:', testsWithMetaError)
+    return NextResponse.json({ error: 'Failed to load tests for gradebook' }, { status: 500 })
+  }
+
+  const testIds = tests.map((test) => test.id)
+  const { data: testQuestions, error: testQuestionsError } = testIds.length
+    ? await supabase
+        .from('test_questions')
+        .select('id, test_id, points')
+        .in('test_id', testIds)
+    : { data: [] as Array<any>, error: null }
+
+  if (testQuestionsError && !isMissingTableError(testQuestionsError)) {
+    console.error('Error loading test questions for gradebook:', testQuestionsError)
+    return NextResponse.json({ error: 'Failed to load test questions for gradebook' }, { status: 500 })
+  }
+
+  const { data: testResponses, error: testResponsesError } = testIds.length && studentIds.length
+    ? await supabase
+        .from('test_responses')
+        .select('test_id, question_id, student_id, score')
+        .in('test_id', testIds)
+        .in('student_id', studentIds)
+    : { data: [] as Array<any>, error: null }
+
+  if (testResponsesError && !isMissingTableError(testResponsesError)) {
+    console.error('Error loading test responses for gradebook:', testResponsesError)
+    return NextResponse.json({ error: 'Failed to load test responses for gradebook' }, { status: 500 })
+  }
+
+  const { data: testAttempts, error: testAttemptsError } = testIds.length && studentIds.length
+    ? await supabase
+        .from('test_attempts')
+        .select('test_id, student_id, is_submitted')
+        .in('test_id', testIds)
+        .in('student_id', studentIds)
+    : { data: [] as Array<any>, error: null }
+
+  if (testAttemptsError && !isMissingTableError(testAttemptsError)) {
+    console.error('Error loading test attempts for gradebook:', testAttemptsError)
+    return NextResponse.json({ error: 'Failed to load test attempts for gradebook' }, { status: 500 })
+  }
+
+  const testMap = new Map(tests.map((test) => [test.id, test]))
+  const testQuestionsByTest = new Map<string, Array<{ id: string; points: number }>>()
+  for (const question of testQuestions || []) {
+    const rows = testQuestionsByTest.get(question.test_id) || []
+    rows.push({ id: question.id, points: Number(question.points ?? 0) })
+    testQuestionsByTest.set(question.test_id, rows)
+  }
+
+  const submittedTestAttempts = new Set<string>()
+  for (const attempt of testAttempts || []) {
+    if (!attempt.is_submitted) continue
+    submittedTestAttempts.add(`${attempt.test_id}:${attempt.student_id}`)
+  }
+
+  const testResponsesByStudentTest = new Map<string, Map<string, { score: number | null }>>()
+  for (const response of testResponses || []) {
+    const key = `${response.test_id}:${response.student_id}`
+    const byQuestion = testResponsesByStudentTest.get(key) || new Map<string, { score: number | null }>()
+    byQuestion.set(response.question_id, {
+      score: response.score == null ? null : Number(response.score),
+    })
+    testResponsesByStudentTest.set(key, byQuestion)
+  }
+
+  const testRowsByStudent = new Map<string, Array<{ earned: number; possible: number }>>()
+  const testScoresByTest = new Map<string, Array<{ earned: number; possible: number }>>()
+  const testDetailsByStudent = new Map<string, Array<{
+    test_id: string
+    title: string
+    earned: number
+    possible: number
+    percent: number
+    status: 'active' | 'closed' | 'draft' | null
+  }>>()
+
+  for (const studentId of studentIds) {
+    for (const testId of testIds) {
+      const test = testMap.get(testId)
+      if (!test || test.include_in_final === false) continue
+      if (test.status === 'draft') continue
+
+      const questionsForTest = testQuestionsByTest.get(testId) || []
+      const possible = questionsForTest.reduce((sum, question) => sum + question.points, 0)
+      if (possible <= 0) continue
+
+      const responseKey = `${testId}:${studentId}`
+      const responsesForStudent = testResponsesByStudentTest.get(responseKey)
+      if (!submittedTestAttempts.has(responseKey) && !responsesForStudent?.size) continue
+
+      let earned = 0
+      let isFullyScored = true
+      for (const question of questionsForTest) {
+        const response = responsesForStudent?.get(question.id)
+        if (!response || response.score == null) {
+          isFullyScored = false
+          break
+        }
+        earned += response.score
+      }
+      if (!isFullyScored) continue
+
+      const rows = testRowsByStudent.get(studentId) || []
+      rows.push({ earned, possible })
+      testRowsByStudent.set(studentId, rows)
+
+      const testScores = testScoresByTest.get(test.id) || []
+      testScores.push({ earned, possible })
+      testScoresByTest.set(test.id, testScores)
+
+      const details = testDetailsByStudent.get(studentId) || []
+      details.push({
+        test_id: test.id,
+        title: test.title,
+        earned: round2(earned),
+        possible: round2(possible),
+        percent: round2((earned / possible) * 100),
+        status: test.status,
+      })
+      testDetailsByStudent.set(studentId, details)
+    }
+  }
+
   const students = (enrollments || []).map((enrollment) => {
     const studentId = enrollment.student_id
     const profile = profileMap.get(studentId)
     const assignmentRows = assignmentRowsByStudent.get(studentId) || []
     const quizRows = quizRowsByStudent.get(studentId) || []
+    const testRows = testRowsByStudent.get(studentId) || []
     const calc = calculateFinalPercent({
       useWeights: settings.use_weights,
       assignmentsWeight: settings.assignments_weight,
       quizzesWeight: settings.quizzes_weight,
+      testsWeight: settings.tests_weight,
       assignments: assignmentRows,
       quizzes: quizRows,
+      tests: testRows,
     })
     const assignmentTotals = assignmentRows.reduce(
       (totals, row) => ({
@@ -376,6 +601,13 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       { earned: 0, possible: 0 }
     )
     const quizTotals = quizRows.reduce(
+      (totals, row) => ({
+        earned: totals.earned + row.earned,
+        possible: totals.possible + row.possible,
+      }),
+      { earned: 0, possible: 0 }
+    )
+    const testTotals = testRows.reduce(
       (totals, row) => ({
         earned: totals.earned + row.earned,
         possible: totals.possible + row.possible,
@@ -394,6 +626,9 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       quizzes_earned: quizTotals.possible > 0 ? round2(quizTotals.earned) : null,
       quizzes_possible: quizTotals.possible > 0 ? round2(quizTotals.possible) : null,
       quizzes_percent: calc.quizzesPercent,
+      tests_earned: testTotals.possible > 0 ? round2(testTotals.earned) : null,
+      tests_possible: testTotals.possible > 0 ? round2(testTotals.possible) : null,
+      tests_percent: calc.testsPercent,
       final_percent: calc.finalPercent,
     }
   })
@@ -461,6 +696,28 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       }
     })
 
+  const classTestSummaries = tests
+    .filter((test) => test.status !== 'draft')
+    .map((test) => {
+      const questionsForTest = testQuestionsByTest.get(test.id) || []
+      const possible = questionsForTest.reduce((sum, question) => sum + question.points, 0)
+      const scored = testScoresByTest.get(test.id) || []
+      const averagePercent = scored.length > 0
+        ? round2(
+            scored.reduce((sum, row) => sum + (row.earned / row.possible) * 100, 0) / scored.length
+          )
+        : null
+
+      return {
+        test_id: test.id,
+        title: test.title,
+        status: test.status,
+        possible: round2(possible),
+        scored_count: scored.length,
+        average_percent: averagePercent,
+      }
+    })
+
   const finalPercents = students
     .map((student) => student.final_percent)
     .filter((value): value is number => value != null)
@@ -508,6 +765,9 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
           quizzes: (quizDetailsByStudent.get(selectedStudent.student_id) || []).sort((a, b) =>
             a.title.localeCompare(b.title)
           ),
+          tests: (testDetailsByStudent.get(selectedStudent.student_id) || []).sort((a, b) =>
+            a.title.localeCompare(b.title)
+          ),
         }
       : null,
     class_summary: {
@@ -518,10 +778,12 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
         : null,
       assignments: classAssignmentSummaries,
       quizzes: classQuizSummaries,
+      tests: classTestSummaries,
     },
     totals: {
       assignments: assignments.length || 0,
       quizzes: quizzes.filter((quiz) => quiz.status !== 'draft').length || 0,
+      tests: tests.filter((test) => test.status !== 'draft').length || 0,
     },
   })
 })
@@ -547,6 +809,9 @@ export const PATCH = withErrorHandler('PatchGradebook', async (request: NextRequ
   const quizzesWeight = body.quizzes_weight == null
     ? DEFAULT_SETTINGS.quizzes_weight
     : Number(body.quizzes_weight)
+  const testsWeight = body.tests_weight == null
+    ? DEFAULT_SETTINGS.tests_weight
+    : Number(body.tests_weight)
 
   if (!Number.isInteger(assignmentsWeight) || assignmentsWeight < 0 || assignmentsWeight > 100) {
     return NextResponse.json({ error: 'assignments_weight must be an integer 0-100' }, { status: 400 })
@@ -556,26 +821,46 @@ export const PATCH = withErrorHandler('PatchGradebook', async (request: NextRequ
     return NextResponse.json({ error: 'quizzes_weight must be an integer 0-100' }, { status: 400 })
   }
 
-  if (useWeights && assignmentsWeight + quizzesWeight !== 100) {
-    return NextResponse.json({ error: 'assignments_weight + quizzes_weight must equal 100' }, { status: 400 })
+  if (!Number.isInteger(testsWeight) || testsWeight < 0 || testsWeight > 100) {
+    return NextResponse.json({ error: 'tests_weight must be an integer 0-100' }, { status: 400 })
+  }
+
+  if (useWeights && assignmentsWeight + quizzesWeight + testsWeight !== 100) {
+    return NextResponse.json({ error: 'assignments_weight + quizzes_weight + tests_weight must equal 100' }, { status: 400 })
   }
 
   const supabase = getServiceRoleClient()
-  const { data, error } = await supabase
+  let { data, error } = await supabase
     .from('gradebook_settings')
     .upsert({
       classroom_id: classroomId,
       use_weights: useWeights,
       assignments_weight: assignmentsWeight,
       quizzes_weight: quizzesWeight,
+      tests_weight: testsWeight,
     }, { onConflict: 'classroom_id' })
-    .select('use_weights, assignments_weight, quizzes_weight')
+    .select('use_weights, assignments_weight, quizzes_weight, tests_weight')
     .single()
+
+  if (error && mentionsMissingField(error, 'tests_weight')) {
+    const legacyResult = await supabase
+      .from('gradebook_settings')
+      .upsert({
+        classroom_id: classroomId,
+        use_weights: useWeights,
+        assignments_weight: assignmentsWeight,
+        quizzes_weight: quizzesWeight,
+      }, { onConflict: 'classroom_id' })
+      .select('use_weights, assignments_weight, quizzes_weight')
+      .single()
+    data = legacyResult.data ? { ...legacyResult.data, tests_weight: 0 } : legacyResult.data
+    error = legacyResult.error
+  }
 
   if (error || !data) {
     console.error('Error saving gradebook settings:', error)
     return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 })
   }
 
-  return NextResponse.json({ settings: data })
+  return NextResponse.json({ settings: normalizeSettings(data as GradebookSettingsRow) })
 })

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -32,7 +32,7 @@ import {
   useMobileDrawer,
   useRightSidebar,
 } from '@/components/layout'
-import { DESKTOP_BREAKPOINT, getRouteKeyFromTab } from '@/lib/layout-config'
+import { getRouteKeyFromTab } from '@/lib/layout-config'
 import { RichTextViewer } from '@/components/editor'
 import { Spinner } from '@/components/Spinner'
 import {
@@ -55,9 +55,6 @@ import type {
   TiptapContent,
   Assignment,
   QuizWithStats,
-  GradebookStudentSummary,
-  GradebookStudentDetail,
-  GradebookClassSummary,
 } from '@/types'
 
 interface UserInfo {
@@ -104,23 +101,6 @@ interface PendingExamNavigation {
   source: string
   nextTab: string | null
   navigate: () => void
-}
-
-function formatTorontoDateShort(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    timeZone: 'America/Toronto',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
-function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(2)
-}
-
-function formatPercent1(value: number | null): string {
-  if (value == null) return '—'
-  return `${value.toFixed(1)} %`
 }
 
 export function ClassroomPageClient({
@@ -242,7 +222,7 @@ function ClassroomPageContent({
   searchParams: URLSearchParams
   updateSearchParams: UpdateSearchParamsFn
 }) {
-  const { openLeft, openRight, close: closeMobileDrawer } = useMobileDrawer()
+  const { openLeft, close: closeMobileDrawer } = useMobileDrawer()
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
@@ -256,6 +236,7 @@ function ClassroomPageContent({
       : null
   const testStudentIdParam = activeTab === 'tests' ? searchParams.get('testStudentId') : null
   const sectionParam = searchParams.get('section')
+  const gradebookSectionParam = searchParams.get('gradebookSection')
   const [mountedTabs, setMountedTabs] = useState<Record<string, boolean>>(() => ({
     [activeTab]: true,
   }))
@@ -462,11 +443,6 @@ function ClassroomPageContent({
     testId: string
     title: string | null
   } | null>(null)
-  const [selectedGradebookStudent, setSelectedGradebookStudent] = useState<GradebookStudentSummary | null>(null)
-  const [gradebookStudentDetail, setGradebookStudentDetail] = useState<GradebookStudentDetail | null>(null)
-  const [gradebookClassSummary, setGradebookClassSummary] = useState<GradebookClassSummary | null>(null)
-  const [gradebookStudentDetailLoading, setGradebookStudentDetailLoading] = useState(false)
-  const [gradebookStudentDetailError, setGradebookStudentDetailError] = useState('')
   const [testsTabClickToken, setTestsTabClickToken] = useState(0)
 
   const handleSelectQuiz = useCallback((quiz: QuizWithStats | null) => {
@@ -491,10 +467,6 @@ function ClassroomPageContent({
     if (selectedQuiz.id === teacherTestPreview.testId) return
     setTeacherTestPreview(null)
   }, [selectedQuiz, teacherTestPreview])
-
-  const handleSelectGradebookStudent = useCallback((student: GradebookStudentSummary | null) => {
-    setSelectedGradebookStudent(student)
-  }, [])
 
   // State for markdown mode (teacher assignments tab - summary view only)
   const [assignmentViewMode, setAssignmentViewMode] = useState<AssignmentViewMode>('summary')
@@ -691,8 +663,6 @@ function ClassroomPageContent({
   useEffect(() => {
     if (isTeacher && activeTab === 'assignments') {
       setRightSidebarWidth('50%')
-    } else if (isTeacher && activeTab === 'gradebook') {
-      setRightSidebarWidth(420)
     } else if (activeTab === 'resources') {
       setRightSidebarWidth('50%')
     }
@@ -720,61 +690,6 @@ function ClassroomPageContent({
       setRightSidebarOpen(false)
     }
   }, [activeTab, setRightSidebarOpen])
-
-  useEffect(() => {
-    if (activeTab !== 'gradebook') {
-      setSelectedGradebookStudent(null)
-      setGradebookStudentDetail(null)
-      setGradebookClassSummary(null)
-      setGradebookStudentDetailError('')
-      setGradebookStudentDetailLoading(false)
-    }
-  }, [activeTab])
-
-  useEffect(() => {
-    if (!isTeacher || activeTab !== 'gradebook' || !selectedGradebookStudent) return
-    const selectedStudentId = selectedGradebookStudent.student_id
-
-    if (window.innerWidth < DESKTOP_BREAKPOINT) {
-      openRight()
-    } else {
-      setRightSidebarOpen(true)
-    }
-
-    let cancelled = false
-
-    async function loadStudentDetail() {
-      setGradebookStudentDetailLoading(true)
-      setGradebookStudentDetailError('')
-      try {
-        const response = await fetch(
-          `/api/teacher/gradebook?classroom_id=${classroom.id}&student_id=${selectedStudentId}`
-        )
-        const data = await response.json()
-        if (!response.ok) {
-          throw new Error(data.error || 'Failed to load gradebook details')
-        }
-
-        if (!cancelled) {
-          setGradebookStudentDetail((data.selected_student as GradebookStudentDetail | null) || null)
-        }
-      } catch (err: any) {
-        if (!cancelled) {
-          setGradebookStudentDetail(null)
-          setGradebookStudentDetailError(err.message || 'Failed to load gradebook details')
-        }
-      } finally {
-        if (!cancelled) {
-          setGradebookStudentDetailLoading(false)
-        }
-      }
-    }
-
-    loadStudentDetail()
-    return () => {
-      cancelled = true
-    }
-  }, [isTeacher, activeTab, selectedGradebookStudent, classroom.id, setRightSidebarOpen, openRight])
 
   const prefetchTabData = useCallback((tab: string) => {
     const now = Date.now()
@@ -1079,12 +994,16 @@ function ClassroomPageContent({
                   )}
                   {mountedTabs.gradebook && (
                     <TabContentTransition isActive={activeTab === 'gradebook'}>
-                  <TeacherGradebookTab
-                    classroom={classroom}
-                    selectedStudentId={selectedGradebookStudent?.student_id ?? null}
-                    onSelectStudent={handleSelectGradebookStudent}
-                    onClassSummaryChange={setGradebookClassSummary}
-                  />
+                      <TeacherGradebookTab
+                        classroom={classroom}
+                        sectionParam={gradebookSectionParam}
+                        onSectionChange={(section) =>
+                          navigateInClassroom((params) => {
+                            params.set('tab', 'gradebook')
+                            params.set('gradebookSection', section)
+                          })
+                        }
+                      />
                     </TabContentTransition>
                   )}
                   {mountedTabs.assignments && (
@@ -1256,10 +1175,6 @@ function ClassroomPageContent({
               ? 'Assignments'
               : isTeacher && activeTab === 'calendar' && calendarSidebarState
               ? 'Calendar'
-              : isTeacher && activeTab === 'gradebook'
-              ? selectedGradebookStudent
-                ? `${selectedGradebookStudent.student_first_name || ''} ${selectedGradebookStudent.student_last_name || ''}`.trim() || selectedGradebookStudent.student_email
-                : 'Gradebook'
               : isTeacher && isAssessmentTab
               ? ''
               : isTeacher && activeTab === 'assignments'
@@ -1332,159 +1247,6 @@ function ClassroomPageContent({
             <StudentClassResourcesSidebar classroom={classroom} />
           ) : isTeacher && isAssessmentTab ? (
             null
-          ) : isTeacher && activeTab === 'gradebook' && selectedGradebookStudent ? (
-            <div className="space-y-4 p-4">
-              {gradebookStudentDetailError && (
-                <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-                  {gradebookStudentDetailError}
-                </div>
-              )}
-              {gradebookStudentDetailLoading ? (
-                <div className="flex justify-center py-8">
-                  <Spinner />
-                </div>
-              ) : (
-                <>
-                  <div className="rounded-md border border-border bg-surface-2 p-3">
-                    <div className="text-xs text-text-muted">Overall</div>
-                    <div className="mt-1 text-lg font-semibold text-text-default">
-                      {formatPercent1(gradebookStudentDetail?.final_percent ?? null)}
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-sm font-semibold text-text-default">Assignments</h3>
-                    {gradebookStudentDetail?.assignments?.length ? (
-                      <div className="mt-2 space-y-2">
-                        {gradebookStudentDetail.assignments.map((item) => (
-                          <div
-                            key={item.assignment_id}
-                            className={[
-                              'rounded-md border px-3 py-2',
-                              item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
-                            ].join(' ')}
-                          >
-                            <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3">
-                              <div className="min-w-0">
-                                <div className="truncate text-sm text-text-default">{item.title}</div>
-                                <div className="text-xs text-text-muted">
-                                  {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
-                                  {!item.is_graded ? ` . No grade (${formatPoints(item.possible)} pts)` : ''}
-                                </div>
-                              </div>
-                              <div className="text-right text-sm font-semibold tabular-nums text-text-default">
-                                {item.is_graded && item.earned != null
-                                  ? `${formatPoints(item.earned)}/${formatPoints(item.possible)}`
-                                  : '—'}
-                              </div>
-                              <div className="text-right text-sm font-semibold tabular-nums text-text-default">
-                                {item.is_graded && item.percent != null ? `${item.percent.toFixed(1)}%` : '—'}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="mt-2 text-sm text-text-muted">No assignments yet.</p>
-                    )}
-                  </div>
-
-                  <div>
-                    <h3 className="text-sm font-semibold text-text-default">Quizzes</h3>
-                    {gradebookStudentDetail?.quizzes?.length ? (
-                      <div className="mt-2 space-y-2">
-                        {gradebookStudentDetail.quizzes.map((item) => (
-                          <div key={item.quiz_id} className="rounded-md border border-border px-3 py-2">
-                            <div className="text-sm text-text-default">{item.title}</div>
-                            <div className="text-xs text-text-muted">
-                              <span className="font-semibold text-text-default">
-                                {formatPoints(item.earned)}/{formatPoints(item.possible)}
-                              </span>
-                              {' . '}
-                              <span className="font-semibold text-text-default">{formatPercent1(item.percent)}</span>
-                              {item.is_manual_override ? ' • Manual override' : ''}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="mt-2 text-sm text-text-muted">No scored quizzes yet.</p>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-          ) : isTeacher && activeTab === 'gradebook' ? (
-            <div className="space-y-4 p-4">
-              <div className="rounded-md border border-border bg-surface-2 p-3">
-                <div className="text-lg font-semibold text-text-default">
-                  {formatPercent1(gradebookClassSummary?.average_final_percent ?? null)}
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-sm font-semibold text-text-default">Assignments</h3>
-                {gradebookClassSummary?.assignments?.length ? (
-                  <div className="mt-2 space-y-2">
-                    <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3 px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
-                      <div />
-                      <div className="text-right">Avg</div>
-                      <div className="text-right">Med</div>
-                      <div className="text-right">#</div>
-                    </div>
-                    {gradebookClassSummary.assignments.map((item) => (
-                      <div
-                        key={item.assignment_id}
-                        className={[
-                          'rounded-md border px-3 py-2',
-                          item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
-                        ].join(' ')}
-                      >
-                        <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3">
-                          <div className="min-w-0">
-                            <div className="truncate text-sm text-text-default">{item.title}</div>
-                            <div className="text-xs text-text-muted">
-                              {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
-                            </div>
-                          </div>
-                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
-                            {item.average_percent != null ? item.average_percent.toFixed(1) : '—'}
-                          </div>
-                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
-                            {item.median_percent != null ? item.median_percent.toFixed(1) : '—'}
-                          </div>
-                          <div className="text-right text-sm font-semibold tabular-nums text-text-default">
-                            {item.graded_count}/{gradebookClassSummary.total_students}
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="mt-2 text-sm text-text-muted">No assignments yet.</p>
-                )}
-              </div>
-
-              <div>
-                <h3 className="text-sm font-semibold text-text-default">Quizzes</h3>
-                {gradebookClassSummary?.quizzes?.length ? (
-                  <div className="mt-2 space-y-2">
-                    {gradebookClassSummary.quizzes.map((item) => (
-                      <div key={item.quiz_id} className="rounded-md border border-border px-3 py-2">
-                        <div className="text-sm text-text-default">{item.title}</div>
-                        <div className="text-xs text-text-muted">
-                          {item.status || 'unknown'} • {item.average_percent != null
-                            ? `Avg ${formatPercent1(item.average_percent)} • Scored ${item.scored_count}/${gradebookClassSummary.total_students}`
-                            : `No scored responses • Scored ${item.scored_count}/${gradebookClassSummary.total_students}`}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="mt-2 text-sm text-text-muted">No quizzes yet.</p>
-                )}
-              </div>
-            </div>
           ) : isTeacher && activeTab === 'attendance' && selectedStudentId ? (
             <StudentLogHistory
               studentId={selectedStudentId}

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1,10 +1,17 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import type { Classroom, GradebookClassSummary, GradebookStudentSummary } from '@/types'
-import { Button } from '@/ui'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  Classroom,
+  GradebookClassSummary,
+  GradebookStudentDetail,
+  GradebookStudentSummary,
+} from '@/types'
+import { Button, FormField, Input } from '@/ui'
 import { Spinner } from '@/components/Spinner'
-import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import {
   DataTable,
   DataTableBody,
@@ -16,84 +23,431 @@ import {
   KeyboardNavigableTable,
   TableCard,
 } from '@/components/DataTable'
+import {
+  fetchJSONWithCache,
+  invalidateCachedJSONMatching,
+} from '@/lib/request-cache'
+
+type GradebookSection = 'grades' | 'settings'
 
 interface GradebookSettingsState {
   use_weights: boolean
   assignments_weight: number
   quizzes_weight: number
+  tests_weight: number
+}
+
+interface GradebookPayload {
+  settings: GradebookSettingsState
+  students: GradebookStudentSummary[]
+  selected_student?: GradebookStudentDetail | null
+  class_summary?: GradebookClassSummary | null
 }
 
 interface Props {
   classroom: Classroom
-  selectedStudentId?: string | null
-  onSelectStudent?: (student: GradebookStudentSummary | null) => void
-  onClassSummaryChange?: (summary: GradebookClassSummary | null) => void
+  sectionParam?: string | null
+  onSectionChange?: (section: GradebookSection) => void
+}
+
+const DEFAULT_SETTINGS: GradebookSettingsState = {
+  use_weights: false,
+  assignments_weight: 50,
+  quizzes_weight: 20,
+  tests_weight: 30,
 }
 
 function formatPercent(value: number | null): string {
   if (value == null) return '—'
-  return `${value.toFixed(1)} %`
+  return `${value.toFixed(1)}%`
+}
+
+function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}
+
+function formatTorontoDateShort(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'America/Toronto',
+    }).format(new Date(iso))
+  } catch {
+    return iso
+  }
+}
+
+function getStudentName(student: GradebookStudentSummary): string {
+  return `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim() || student.student_email
+}
+
+function getSettingsWithDefaults(settings: Partial<GradebookSettingsState> | null | undefined): GradebookSettingsState {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...(settings || {}),
+    tests_weight: Number(settings?.tests_weight ?? DEFAULT_SETTINGS.tests_weight),
+  }
+}
+
+function CategoryHeading({ children }: { children: string }) {
+  return <h3 className="text-sm font-semibold text-text-default">{children}</h3>
+}
+
+function ClassSummaryPanel({ summary }: { summary: GradebookClassSummary | null }) {
+  return (
+    <div className="space-y-4 p-4">
+      <div className="rounded-md border border-border bg-surface-2 p-3">
+        <div className="text-xs text-text-muted">Class average</div>
+        <div className="mt-1 text-lg font-semibold text-text-default">
+          {formatPercent(summary?.average_final_percent ?? null)}
+        </div>
+      </div>
+
+      <div>
+        <CategoryHeading>Assignments</CategoryHeading>
+        {summary?.assignments?.length ? (
+          <div className="mt-2 space-y-2">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3 px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+              <div />
+              <div className="text-right">Avg</div>
+              <div className="text-right">Med</div>
+              <div className="text-right">#</div>
+            </div>
+            {summary.assignments.map((item) => (
+              <div
+                key={item.assignment_id}
+                className={[
+                  'rounded-md border px-3 py-2',
+                  item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
+                ].join(' ')}
+              >
+                <div className="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm text-text-default">{item.title}</div>
+                    <div className="text-xs text-text-muted">
+                      {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
+                    </div>
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                    {item.average_percent != null ? item.average_percent.toFixed(1) : '—'}
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                    {item.median_percent != null ? item.median_percent.toFixed(1) : '—'}
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                    {item.graded_count}/{summary.total_students}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-text-muted">No assignments yet.</p>
+        )}
+      </div>
+
+      <ClassAssessmentSummarySection
+        title="Quizzes"
+        emptyMessage="No quizzes yet."
+        totalStudents={summary?.total_students ?? 0}
+        items={(summary?.quizzes || []).map((item) => ({
+          id: item.quiz_id,
+          title: item.title,
+          status: item.status,
+          scored_count: item.scored_count,
+          average_percent: item.average_percent,
+        }))}
+      />
+
+      <ClassAssessmentSummarySection
+        title="Tests"
+        emptyMessage="No tests yet."
+        totalStudents={summary?.total_students ?? 0}
+        items={(summary?.tests || []).map((item) => ({
+          id: item.test_id,
+          title: item.title,
+          status: item.status,
+          scored_count: item.scored_count,
+          average_percent: item.average_percent,
+        }))}
+      />
+    </div>
+  )
+}
+
+function ClassAssessmentSummarySection({
+  title,
+  emptyMessage,
+  totalStudents,
+  items,
+}: {
+  title: string
+  emptyMessage: string
+  totalStudents: number
+  items: Array<{
+    id: string
+    title: string
+    status: 'draft' | 'active' | 'closed' | null
+    scored_count: number
+    average_percent: number | null
+  }>
+}) {
+  return (
+    <div>
+      <CategoryHeading>{title}</CategoryHeading>
+      {items.length ? (
+        <div className="mt-2 space-y-2">
+          {items.map((item) => (
+            <div key={item.id} className="rounded-md border border-border px-3 py-2">
+              <div className="text-sm text-text-default">{item.title}</div>
+              <div className="text-xs text-text-muted">
+                {item.status || 'unknown'} . {item.average_percent != null
+                  ? `Avg ${formatPercent(item.average_percent)} . Scored ${item.scored_count}/${totalStudents}`
+                  : `No scored responses . Scored ${item.scored_count}/${totalStudents}`}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-text-muted">{emptyMessage}</p>
+      )}
+    </div>
+  )
+}
+
+function StudentDetailPanel({
+  detail,
+  loading,
+  error,
+}: {
+  detail: GradebookStudentDetail | null
+  loading: boolean
+  error: string
+}) {
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {error && (
+        <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-md border border-border bg-surface-2 p-3">
+        <div className="text-xs text-text-muted">Overall</div>
+        <div className="mt-1 text-lg font-semibold text-text-default">
+          {formatPercent(detail?.final_percent ?? null)}
+        </div>
+      </div>
+
+      <div>
+        <CategoryHeading>Assignments</CategoryHeading>
+        {detail?.assignments?.length ? (
+          <div className="mt-2 space-y-2">
+            {detail.assignments.map((item) => (
+              <div
+                key={item.assignment_id}
+                className={[
+                  'rounded-md border px-3 py-2',
+                  item.is_draft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface',
+                ].join(' ')}
+              >
+                <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm text-text-default">{item.title}</div>
+                    <div className="text-xs text-text-muted">
+                      {`Due ${formatTorontoDateShort(item.due_at)}${item.is_draft ? ' . Draft' : ''}`}
+                      {!item.is_graded ? ` . No grade (${formatPoints(item.possible)} pts)` : ''}
+                    </div>
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                    {item.is_graded && item.earned != null
+                      ? `${formatPoints(item.earned)}/${formatPoints(item.possible)}`
+                      : '—'}
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums text-text-default">
+                    {item.is_graded && item.percent != null ? `${item.percent.toFixed(1)}%` : '—'}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-text-muted">No assignments yet.</p>
+        )}
+      </div>
+
+      <StudentAssessmentDetailSection
+        title="Quizzes"
+        emptyMessage="No scored quizzes yet."
+        items={(detail?.quizzes || []).map((item) => ({
+          id: item.quiz_id,
+          title: item.title,
+          earned: item.earned,
+          possible: item.possible,
+          percent: item.percent,
+          meta: item.is_manual_override ? 'Manual override' : null,
+        }))}
+      />
+
+      <StudentAssessmentDetailSection
+        title="Tests"
+        emptyMessage="No scored tests yet."
+        items={(detail?.tests || []).map((item) => ({
+          id: item.test_id,
+          title: item.title,
+          earned: item.earned,
+          possible: item.possible,
+          percent: item.percent,
+          meta: item.status || null,
+        }))}
+      />
+    </div>
+  )
+}
+
+function StudentAssessmentDetailSection({
+  title,
+  emptyMessage,
+  items,
+}: {
+  title: string
+  emptyMessage: string
+  items: Array<{
+    id: string
+    title: string
+    earned: number
+    possible: number
+    percent: number
+    meta: string | null
+  }>
+}) {
+  return (
+    <div>
+      <CategoryHeading>{title}</CategoryHeading>
+      {items.length ? (
+        <div className="mt-2 space-y-2">
+          {items.map((item) => (
+            <div key={item.id} className="rounded-md border border-border px-3 py-2">
+              <div className="text-sm text-text-default">{item.title}</div>
+              <div className="text-xs text-text-muted">
+                <span className="font-semibold text-text-default">
+                  {formatPoints(item.earned)}/{formatPoints(item.possible)}
+                </span>
+                {' . '}
+                <span className="font-semibold text-text-default">{formatPercent(item.percent)}</span>
+                {item.meta ? ` . ${item.meta}` : ''}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-text-muted">{emptyMessage}</p>
+      )}
+    </div>
+  )
 }
 
 export function TeacherGradebookTab({
   classroom,
-  selectedStudentId = null,
-  onSelectStudent,
-  onClassSummaryChange,
+  sectionParam,
+  onSectionChange = () => {},
 }: Props) {
+  const section: GradebookSection = sectionParam === 'settings' ? 'settings' : 'grades'
   const isReadOnly = !!classroom.archived_at
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
-  const [settings, setSettings] = useState<GradebookSettingsState>({
-    use_weights: false,
-    assignments_weight: 70,
-    quizzes_weight: 30,
-  })
+  const [settings, setSettings] = useState<GradebookSettingsState>(DEFAULT_SETTINGS)
   const [students, setStudents] = useState<GradebookStudentSummary[]>([])
-  const tableContainerRef = useRef<HTMLDivElement>(null)
+  const [classSummary, setClassSummary] = useState<GradebookClassSummary | null>(null)
+  const [selectedStudent, setSelectedStudent] = useState<GradebookStudentSummary | null>(null)
+  const [studentDetail, setStudentDetail] = useState<GradebookStudentDetail | null>(null)
+  const [studentDetailLoading, setStudentDetailLoading] = useState(false)
+  const [studentDetailError, setStudentDetailError] = useState('')
 
   const rowKeys = useMemo(() => students.map((student) => student.student_id), [students])
 
-  async function loadGradebook() {
+  const loadGradebook = useCallback(async () => {
     setLoading(true)
     setError('')
     try {
-      const response = await fetch(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
-      const data = await response.json()
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to load gradebook')
-      }
+      const data = await fetchJSONWithCache<GradebookPayload>(
+        `gradebook:${classroom.id}:class`,
+        async () => {
+          const response = await fetch(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
+          const json = await response.json()
+          if (!response.ok) throw new Error(json.error || 'Failed to load gradebook')
+          return json
+        },
+        60_000,
+      )
 
-      setSettings(data.settings)
+      setSettings(getSettingsWithDefaults(data.settings))
       setStudents(data.students || [])
-      onClassSummaryChange?.((data.class_summary as GradebookClassSummary | null) || null)
-    } catch (err: any) {
-      setError(err.message || 'Failed to load gradebook')
-      onClassSummaryChange?.(null)
+      setClassSummary(data.class_summary || null)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to load gradebook')
+      setClassSummary(null)
     } finally {
       setLoading(false)
     }
-  }
+  }, [classroom.id])
 
   useEffect(() => {
-    loadGradebook()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [classroom.id, onClassSummaryChange])
+    void loadGradebook()
+  }, [loadGradebook])
 
   useEffect(() => {
-    if (!selectedStudentId) return
+    if (section !== 'grades' || !selectedStudent) return
+    const selectedStudentId = selectedStudent.student_id
+    let cancelled = false
 
-    function handleMouseDown(event: MouseEvent) {
-      const target = event.target as HTMLElement
-      if (tableContainerRef.current?.contains(target)) return
-      if (target.closest('aside') || target.closest('[role="dialog"]')) return
-      onSelectStudent?.(null)
+    async function loadStudentDetail() {
+      setStudentDetailLoading(true)
+      setStudentDetailError('')
+      try {
+        const data = await fetchJSONWithCache<GradebookPayload>(
+          `gradebook:${classroom.id}:student:${selectedStudentId}`,
+          async () => {
+            const response = await fetch(
+              `/api/teacher/gradebook?classroom_id=${classroom.id}&student_id=${selectedStudentId}`
+            )
+            const json = await response.json()
+            if (!response.ok) throw new Error(json.error || 'Failed to load gradebook details')
+            return json
+          },
+          60_000,
+        )
+
+        if (!cancelled) {
+          setStudentDetail(data.selected_student || null)
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setStudentDetail(null)
+          setStudentDetailError(err instanceof Error ? err.message : 'Failed to load gradebook details')
+        }
+      } finally {
+        if (!cancelled) {
+          setStudentDetailLoading(false)
+        }
+      }
     }
 
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [selectedStudentId, onSelectStudent])
+    void loadStudentDetail()
+    return () => {
+      cancelled = true
+    }
+  }, [classroom.id, section, selectedStudent])
 
   async function saveSettings() {
     if (isReadOnly) return
@@ -109,6 +463,7 @@ export function TeacherGradebookTab({
           use_weights: settings.use_weights,
           assignments_weight: settings.assignments_weight,
           quizzes_weight: settings.quizzes_weight,
+          tests_weight: settings.tests_weight,
         }),
       })
       const data = await response.json()
@@ -116,151 +471,214 @@ export function TeacherGradebookTab({
         throw new Error(data.error || 'Failed to save settings')
       }
 
-      setSettings(data.settings)
+      setSettings(getSettingsWithDefaults(data.settings))
+      invalidateCachedJSONMatching(`gradebook:${classroom.id}:`)
       await loadGradebook()
-    } catch (err: any) {
-      setError(err.message || 'Failed to save settings')
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings')
     } finally {
       setSaving(false)
     }
   }
 
   const totalWeight = useMemo(
-    () => Number(settings.assignments_weight || 0) + Number(settings.quizzes_weight || 0),
-    [settings.assignments_weight, settings.quizzes_weight]
+    () =>
+      Number(settings.assignments_weight || 0) +
+      Number(settings.quizzes_weight || 0) +
+      Number(settings.tests_weight || 0),
+    [settings.assignments_weight, settings.quizzes_weight, settings.tests_weight],
   )
 
-  if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
-    )
-  }
-
-  return (
-    <PageLayout>
-      <PageActionBar
-        primary={
-          <div className="flex flex-wrap items-center gap-3">
-            <label className="inline-flex items-center gap-2 text-sm text-text-default">
-              <input
-                type="checkbox"
-                checked={settings.use_weights}
-                onChange={(e) => setSettings((prev) => ({ ...prev, use_weights: e.target.checked }))}
-                disabled={isReadOnly}
-                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              Use weights
-            </label>
-
-            <label className="inline-flex items-center gap-2 text-sm text-text-default">
-              Assignments
-              <input
-                type="number"
-                min={0}
-                max={100}
-                value={settings.assignments_weight}
-                onChange={(e) => setSettings((prev) => ({ ...prev, assignments_weight: Number(e.target.value || 0) }))}
-                disabled={isReadOnly}
-                className="w-20 rounded border border-border bg-surface px-2 py-1"
-              />
-              %
-            </label>
-
-            <label className="inline-flex items-center gap-2 text-sm text-text-default">
-              Quizzes
-              <input
-                type="number"
-                min={0}
-                max={100}
-                value={settings.quizzes_weight}
-                onChange={(e) => setSettings((prev) => ({ ...prev, quizzes_weight: Number(e.target.value || 0) }))}
-                disabled={isReadOnly}
-                className="w-20 rounded border border-border bg-surface px-2 py-1"
-              />
-              %
-            </label>
-
-            <div className={`text-sm ${totalWeight === 100 ? 'text-success' : 'text-danger'}`}>
-              Total: {totalWeight}%
-            </div>
-
-            <Button
-              onClick={saveSettings}
-              disabled={isReadOnly || saving || (settings.use_weights && totalWeight !== 100)}
-            >
-              {saving ? 'Saving...' : 'Save'}
-            </Button>
-          </div>
-        }
-      />
-
-      <PageContent>
-        <div ref={tableContainerRef}>
+  const gradesWorkspace = loading ? (
+    <div className="flex flex-1 justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : (
+    <SummaryDetailWorkspaceShell
+      className="flex-1"
+      orientation="responsive"
+      leftPaneClassName="flex min-h-0 flex-col lg:basis-1/2"
+      rightPaneClassName="flex min-h-0 flex-col lg:basis-1/2"
+      left={
+        <div className="min-h-0 min-w-0 flex-1 overflow-auto">
           <TableCard>
-            {error && (
-              <div className="p-3 border-b border-border">
-                <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-                  {error}
-                </div>
-              </div>
-            )}
-
             <KeyboardNavigableTable
               rowKeys={rowKeys}
-              selectedKey={selectedStudentId}
+              selectedKey={selectedStudent?.student_id ?? null}
               onSelectKey={(studentId) => {
                 const student = students.find((row) => row.student_id === studentId) || null
-                onSelectStudent?.(student)
+                setSelectedStudent(student)
               }}
-              onDeselect={() => onSelectStudent?.(null)}
+              onDeselect={() => setSelectedStudent(null)}
             >
-              <DataTable>
+              <DataTable density="tight">
                 <DataTableHead>
-                <DataTableRow>
-                  <DataTableHeaderCell>Student</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Assignments</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Quizzes</DataTableHeaderCell>
-                  <DataTableHeaderCell align="right">Final %</DataTableHeaderCell>
-                </DataTableRow>
-              </DataTableHead>
+                  <DataTableRow>
+                    <DataTableHeaderCell className="text-xs sm:text-sm">Student</DataTableHeaderCell>
+                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Assignments">
+                      <span className="hidden sm:inline">Assignments</span>
+                      <span className="sm:hidden">Assign.</span>
+                    </DataTableHeaderCell>
+                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Quizzes">
+                      <span className="hidden sm:inline">Quizzes</span>
+                      <span className="sm:hidden">Quiz</span>
+                    </DataTableHeaderCell>
+                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Tests">
+                      <span className="hidden sm:inline">Tests</span>
+                      <span className="sm:hidden">Test</span>
+                    </DataTableHeaderCell>
+                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm">Final</DataTableHeaderCell>
+                  </DataTableRow>
+                </DataTableHead>
                 <DataTableBody>
                   {students.map((student) => {
-                    const fullName = `${student.student_first_name || ''} ${student.student_last_name || ''}`.trim()
-                    const isSelected = student.student_id === selectedStudentId
+                    const isSelected = student.student_id === selectedStudent?.student_id
                     return (
                       <DataTableRow
                         key={student.student_id}
                         className={[
                           'cursor-pointer transition-colors',
-                          isSelected ? 'bg-info-bg hover:bg-info-bg-hover' : 'hover:bg-surface-hover',
+                          isSelected ? 'bg-surface-selected hover:bg-surface-selected' : 'hover:bg-surface-hover',
                         ].join(' ')}
-                      onClick={() => onSelectStudent?.(isSelected ? null : student)}
-                    >
-                      <DataTableCell>{fullName || student.student_email}</DataTableCell>
-                      <DataTableCell align="right">
-                        {formatPercent(student.assignments_percent)}
-                      </DataTableCell>
-                      <DataTableCell align="right">
-                        {formatPercent(student.quizzes_percent)}
-                      </DataTableCell>
-                      <DataTableCell align="right" className="font-semibold">
-                        {formatPercent(student.final_percent)}
-                      </DataTableCell>
+                        onClick={() => setSelectedStudent(isSelected ? null : student)}
+                      >
+                        <DataTableCell className="max-w-[7rem] text-xs sm:max-w-none sm:text-sm">
+                          {getStudentName(student)}
+                        </DataTableCell>
+                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                          {formatPercent(student.assignments_percent)}
+                        </DataTableCell>
+                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                          {formatPercent(student.quizzes_percent)}
+                        </DataTableCell>
+                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                          {formatPercent(student.tests_percent)}
+                        </DataTableCell>
+                        <DataTableCell align="right" className="whitespace-nowrap text-xs font-semibold sm:text-sm">
+                          {formatPercent(student.final_percent)}
+                        </DataTableCell>
                       </DataTableRow>
                     )
                   })}
 
                   {students.length === 0 && (
-                    <EmptyStateRow colSpan={4} message="No students enrolled yet" />
+                    <EmptyStateRow colSpan={5} message="No students enrolled yet" />
                   )}
                 </DataTableBody>
               </DataTable>
             </KeyboardNavigableTable>
           </TableCard>
         </div>
-      </PageContent>
-    </PageLayout>
+      }
+      right={
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {selectedStudent ? (
+            <StudentDetailPanel
+              detail={studentDetail}
+              loading={studentDetailLoading}
+              error={studentDetailError}
+            />
+          ) : (
+            <ClassSummaryPanel summary={classSummary} />
+          )}
+        </div>
+      }
+    />
+  )
+
+  const settingsWorkspace = (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4">
+      <div className="max-w-2xl space-y-5">
+        <label className="inline-flex items-center gap-2 text-sm text-text-default">
+          <input
+            type="checkbox"
+            checked={settings.use_weights}
+            onChange={(event) => setSettings((previous) => ({ ...previous, use_weights: event.target.checked }))}
+            disabled={isReadOnly}
+            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+          />
+          Use category weights
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <FormField label="Assignments">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={settings.assignments_weight}
+              onChange={(event) =>
+                setSettings((previous) => ({ ...previous, assignments_weight: Number(event.target.value || 0) }))
+              }
+              disabled={isReadOnly}
+            />
+          </FormField>
+          <FormField label="Quizzes">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={settings.quizzes_weight}
+              onChange={(event) =>
+                setSettings((previous) => ({ ...previous, quizzes_weight: Number(event.target.value || 0) }))
+              }
+              disabled={isReadOnly}
+            />
+          </FormField>
+          <FormField label="Tests">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={settings.tests_weight}
+              onChange={(event) =>
+                setSettings((previous) => ({ ...previous, tests_weight: Number(event.target.value || 0) }))
+              }
+              disabled={isReadOnly}
+            />
+          </FormField>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div className={`text-sm ${totalWeight === 100 ? 'text-success' : 'text-danger'}`}>
+            Total: {totalWeight}%
+          </div>
+          <Button
+            onClick={saveSettings}
+            disabled={isReadOnly || saving || (settings.use_weights && totalWeight !== 100)}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+
+  return (
+    <TeacherWorkSurfaceShell
+      state="workspace"
+      workspaceFrame="attachedTabs"
+      primary={
+        <TeacherWorkSurfaceModeBar
+          modes={[
+            { id: 'grades', label: 'Grades' },
+            { id: 'settings', label: 'Settings' },
+          ]}
+          activeMode={section}
+          onModeChange={(mode) => onSectionChange(mode as GradebookSection)}
+          ariaLabel="Gradebook sections"
+        />
+      }
+      feedback={
+        error ? (
+          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+            {error}
+          </div>
+        ) : null
+      }
+      summary={null}
+      workspace={section === 'grades' ? gradesWorkspace : settingsWorkspace}
+      workspaceClassName="bg-surface"
+    />
   )
 }

--- a/src/lib/gradebook.ts
+++ b/src/lib/gradebook.ts
@@ -7,13 +7,16 @@ export interface GradebookCalculationInput {
   useWeights: boolean
   assignmentsWeight: number
   quizzesWeight: number
+  testsWeight: number
   assignments: GradebookCategoryInput[]
   quizzes: GradebookCategoryInput[]
+  tests: GradebookCategoryInput[]
 }
 
 export interface GradebookCalculationResult {
   assignmentsPercent: number | null
   quizzesPercent: number | null
+  testsPercent: number | null
   finalPercent: number | null
 }
 
@@ -35,17 +38,24 @@ function toPercent(rows: GradebookCategoryInput[]): number | null {
 export function calculateFinalPercent(input: GradebookCalculationInput): GradebookCalculationResult {
   const assignmentsPercent = toPercent(input.assignments)
   const quizzesPercent = toPercent(input.quizzes)
+  const testsPercent = toPercent(input.tests)
 
-  if (assignmentsPercent == null && quizzesPercent == null) {
-    return { assignmentsPercent: null, quizzesPercent: null, finalPercent: null }
+  if (assignmentsPercent == null && quizzesPercent == null && testsPercent == null) {
+    return {
+      assignmentsPercent: null,
+      quizzesPercent: null,
+      testsPercent: null,
+      finalPercent: null,
+    }
   }
 
   // Unweighted: blend all scored items by points.
   if (!input.useWeights) {
-    const all = [...input.assignments, ...input.quizzes]
+    const all = [...input.assignments, ...input.quizzes, ...input.tests]
     return {
       assignmentsPercent,
       quizzesPercent,
+      testsPercent,
       finalPercent: toPercent(all),
     }
   }
@@ -58,11 +68,14 @@ export function calculateFinalPercent(input: GradebookCalculationInput): Gradebo
   if (quizzesPercent != null && input.quizzesWeight > 0) {
     components.push({ percent: quizzesPercent, weight: input.quizzesWeight })
   }
+  if (testsPercent != null && input.testsWeight > 0) {
+    components.push({ percent: testsPercent, weight: input.testsWeight })
+  }
 
   if (components.length === 0) {
     // fall back when scores exist but configured weights are zero
-    const fallback = assignmentsPercent ?? quizzesPercent
-    return { assignmentsPercent, quizzesPercent, finalPercent: fallback ?? null }
+    const fallback = assignmentsPercent ?? quizzesPercent ?? testsPercent
+    return { assignmentsPercent, quizzesPercent, testsPercent, finalPercent: fallback ?? null }
   }
 
   const weightTotal = components.reduce((sum, c) => sum + c.weight, 0)
@@ -71,6 +84,7 @@ export function calculateFinalPercent(input: GradebookCalculationInput): Gradebo
   return {
     assignmentsPercent,
     quizzesPercent,
+    testsPercent,
     finalPercent: round2(weighted),
   }
 }

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -101,7 +101,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'wide' },
   },
   gradebook: {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: 420 },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   today: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -970,6 +970,7 @@ export interface GradebookSettings {
   use_weights: boolean
   assignments_weight: number
   quizzes_weight: number
+  tests_weight: number
 }
 
 export interface GradebookStudentSummary {
@@ -983,6 +984,9 @@ export interface GradebookStudentSummary {
   quizzes_earned: number | null
   quizzes_possible: number | null
   quizzes_percent: number | null
+  tests_earned: number | null
+  tests_possible: number | null
+  tests_percent: number | null
   final_percent: number | null
 }
 
@@ -1007,9 +1011,19 @@ export interface GradebookQuizDetail {
   is_manual_override: boolean
 }
 
+export interface GradebookTestDetail {
+  test_id: string
+  title: string
+  earned: number
+  possible: number
+  percent: number
+  status: 'draft' | 'active' | 'closed' | null
+}
+
 export interface GradebookStudentDetail extends GradebookStudentSummary {
   assignments: GradebookAssignmentDetail[]
   quizzes: GradebookQuizDetail[]
+  tests: GradebookTestDetail[]
 }
 
 export interface GradebookClassAssignmentSummary {
@@ -1032,12 +1046,22 @@ export interface GradebookClassQuizSummary {
   average_percent: number | null
 }
 
+export interface GradebookClassTestSummary {
+  test_id: string
+  title: string
+  status: 'draft' | 'active' | 'closed' | null
+  possible: number
+  scored_count: number
+  average_percent: number | null
+}
+
 export interface GradebookClassSummary {
   total_students: number
   students_with_final: number
   average_final_percent: number | null
   assignments: GradebookClassAssignmentSummary[]
   quizzes: GradebookClassQuizSummary[]
+  tests: GradebookClassTestSummary[]
 }
 
 export type ReportCardTerm = 'midterm' | 'final'

--- a/supabase/migrations/059_add_gradebook_tests_weight.sql
+++ b/supabase/migrations/059_add_gradebook_tests_weight.sql
@@ -1,0 +1,7 @@
+-- Add tests as a first-class gradebook weighting category.
+alter table if exists public.gradebook_settings
+  add column if not exists tests_weight smallint not null default 0 check (tests_weight >= 0 and tests_weight <= 100);
+
+-- Existing rows keep a zero tests weight; new rows created outside the app get the new default.
+alter table if exists public.gradebook_settings
+  alter column tests_weight set default 30;

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -16,7 +16,12 @@ type GradebookFixture = {
   quizQuestions?: Array<any>
   quizResponses?: Array<any>
   quizOverrides?: Array<any>
-  settings?: { use_weights: boolean; assignments_weight: number; quizzes_weight: number } | null
+  tests?: Array<any>
+  testQuestions?: Array<any>
+  testResponses?: Array<any>
+  testAttempts?: Array<any>
+  settings?: { use_weights: boolean; assignments_weight: number; quizzes_weight: number; tests_weight?: number } | null
+  settingsError?: { code?: string; message?: string; details?: string; hint?: string } | null
 }
 
 function buildMockFrom(fixture: GradebookFixture) {
@@ -40,7 +45,7 @@ function buildMockFrom(fixture: GradebookFixture) {
           eq: vi.fn(() => ({
             maybeSingle: vi.fn().mockResolvedValue({
               data: fixture.settings ?? null,
-              error: null,
+              error: fixture.settingsError ?? null,
             }),
           })),
         })),
@@ -154,6 +159,54 @@ function buildMockFrom(fixture: GradebookFixture) {
       }
     }
 
+    if (table === 'tests') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({
+            data: fixture.tests ?? [],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'test_questions') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: fixture.testQuestions ?? [],
+            error: null,
+          }),
+        })),
+      }
+    }
+
+    if (table === 'test_responses') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: fixture.testResponses ?? [],
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'test_attempts') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: fixture.testAttempts ?? [],
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
     throw new Error(`Unexpected table in test: ${table}`)
   })
 }
@@ -245,6 +298,64 @@ describe('GET /api/teacher/gradebook', () => {
         is_manual_override: false,
       },
     ])
+    expect(body.selected_student.tests).toEqual([])
+  })
+
+  it('includes fully scored tests in grade calculations and class summary', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      tests: [{ id: 't1', title: 'Unit Test', status: 'closed', include_in_final: true }],
+      testQuestions: [
+        { id: 'tq1', test_id: 't1', points: 5 },
+        { id: 'tq2', test_id: 't1', points: 5 },
+      ],
+      testResponses: [
+        { test_id: 't1', question_id: 'tq1', student_id: 'student-1', score: 5 },
+        { test_id: 't1', question_id: 'tq2', student_id: 'student-1', score: 3 },
+      ],
+      testAttempts: [{ test_id: 't1', student_id: 'student-1', is_submitted: true }],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1&student_id=student-1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students[0].tests_percent).toBe(80)
+    expect(body.students[0].final_percent).toBe(80)
+    expect(body.selected_student.tests).toEqual([
+      {
+        test_id: 't1',
+        title: 'Unit Test',
+        earned: 8,
+        possible: 10,
+        percent: 80,
+        status: 'closed',
+      },
+    ])
+    expect(body.class_summary.tests).toEqual([
+      {
+        test_id: 't1',
+        title: 'Unit Test',
+        status: 'closed',
+        possible: 10,
+        scored_count: 1,
+        average_percent: 80,
+      },
+    ])
+    expect(body.totals.tests).toBe(1)
+  })
+
+  it('returns 500 when gradebook settings cannot be loaded', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      settingsError: { message: 'database unavailable' },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe('Failed to load gradebook settings')
   })
 
   it('includes all assignments (graded/ungraded/future) in selected student details by assignment order', async () => {
@@ -496,6 +607,42 @@ describe('GET /api/teacher/gradebook', () => {
         }
       }
 
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table in test: ${table}`)
     })
 
@@ -535,7 +682,7 @@ describe('PATCH /api/teacher/gradebook', () => {
           upsert: vi.fn(() => ({
             select: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({
-                data: { use_weights: false, assignments_weight: 10, quizzes_weight: 20 },
+                data: { use_weights: false, assignments_weight: 10, quizzes_weight: 20, tests_weight: 30 },
                 error: null,
               }),
             })),
@@ -553,6 +700,7 @@ describe('PATCH /api/teacher/gradebook', () => {
         use_weights: false,
         assignments_weight: 10,
         quizzes_weight: 20,
+        tests_weight: 30,
       }),
     })
 
@@ -564,6 +712,7 @@ describe('PATCH /api/teacher/gradebook', () => {
       use_weights: false,
       assignments_weight: 10,
       quizzes_weight: 20,
+      tests_weight: 30,
     })
   })
 })

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TeacherGradebookTab } from '@/app/classrooms/[classroomId]/TeacherGradebookTab'
+import { createMockClassroom } from '../helpers/mocks'
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: vi.fn((_key: string, load: () => Promise<unknown>) => load()),
+  invalidateCachedJSONMatching: vi.fn(),
+}))
+
+function gradebookResponse() {
+  return {
+    settings: {
+      use_weights: false,
+      assignments_weight: 50,
+      quizzes_weight: 20,
+      tests_weight: 30,
+    },
+    students: [
+      {
+        student_id: 'student-1',
+        student_email: 'ada@example.com',
+        student_first_name: 'Ada',
+        student_last_name: 'Lovelace',
+        assignments_earned: 8,
+        assignments_possible: 10,
+        assignments_percent: 80,
+        quizzes_earned: null,
+        quizzes_possible: null,
+        quizzes_percent: null,
+        tests_earned: 9,
+        tests_possible: 10,
+        tests_percent: 90,
+        final_percent: 85,
+      },
+    ],
+    class_summary: {
+      total_students: 1,
+      average_final_percent: 85,
+      assignments: [],
+      quizzes: [],
+      tests: [],
+    },
+  }
+}
+
+describe('TeacherGradebookTab', () => {
+  const classroom = createMockClassroom()
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => gradebookResponse(),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the Grades tab and delegates controlled section changes', async () => {
+    const onSectionChange = vi.fn()
+
+    render(
+      <TeacherGradebookTab
+        classroom={classroom}
+        sectionParam="grades"
+        onSectionChange={onSectionChange}
+      />,
+    )
+
+    expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Grades' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('columnheader', { name: 'Tests' })).toBeInTheDocument()
+    expect(screen.getByRole('row', { name: /Ada Lovelace .* 85\.0%/ })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }))
+
+    expect(onSectionChange).toHaveBeenCalledWith('settings')
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
+    })
+  })
+
+  it('renders Settings with assignments, quizzes, and tests weights', async () => {
+    render(<TeacherGradebookTab classroom={classroom} sectionParam="settings" />)
+
+    expect(await screen.findByLabelText('Assignments')).toHaveValue(50)
+    expect(screen.getByLabelText('Quizzes')).toHaveValue(20)
+    expect(screen.getByLabelText('Tests')).toHaveValue(30)
+    expect(screen.getByText('Total: 100%')).toBeInTheDocument()
+  })
+})

--- a/tests/hooks/useGradebookData.test.ts
+++ b/tests/hooks/useGradebookData.test.ts
@@ -25,6 +25,9 @@ function makeStudentSummary(): GradebookStudentSummary {
     quizzes_earned: 16,
     quizzes_possible: 20,
     quizzes_percent: 80,
+    tests_earned: 18,
+    tests_possible: 20,
+    tests_percent: 90,
     final_percent: 75,
   }
 }
@@ -36,6 +39,7 @@ function makeClassSummary(): GradebookClassSummary {
     average_final_percent: 75,
     assignments: [],
     quizzes: [],
+    tests: [],
   }
 }
 
@@ -57,12 +61,14 @@ describe('useGradebookData', () => {
       final_percent: 75,
       assignments: [],
       quizzes: [],
+      tests: [],
     }
     const secondDetail: GradebookStudentDetail = {
       ...student,
       final_percent: 92,
       assignments: [],
       quizzes: [],
+      tests: [],
     }
 
     const cacheFetchMock = vi.mocked(fetchJSONWithCache)

--- a/tests/unit/gradebook.test.ts
+++ b/tests/unit/gradebook.test.ts
@@ -5,15 +5,18 @@ describe('gradebook final percent', () => {
   it('returns nulls when no scores exist', () => {
     const result = calculateFinalPercent({
       useWeights: false,
-      assignmentsWeight: 70,
-      quizzesWeight: 30,
+      assignmentsWeight: 50,
+      quizzesWeight: 20,
+      testsWeight: 30,
       assignments: [],
       quizzes: [],
+      tests: [],
     })
 
     expect(result).toEqual({
       assignmentsPercent: null,
       quizzesPercent: null,
+      testsPercent: null,
       finalPercent: null,
     })
   })
@@ -21,45 +24,54 @@ describe('gradebook final percent', () => {
   it('computes unweighted percent using points across categories', () => {
     const result = calculateFinalPercent({
       useWeights: false,
-      assignmentsWeight: 70,
-      quizzesWeight: 30,
+      assignmentsWeight: 50,
+      quizzesWeight: 20,
+      testsWeight: 30,
       assignments: [
         { earned: 24, possible: 30 },
         { earned: 18, possible: 20 },
       ],
       quizzes: [{ earned: 8, possible: 10 }],
+      tests: [{ earned: 45, possible: 50 }],
     })
 
     expect(result.assignmentsPercent).toBe(84)
     expect(result.quizzesPercent).toBe(80)
-    expect(result.finalPercent).toBe(83.33)
+    expect(result.testsPercent).toBe(90)
+    expect(result.finalPercent).toBe(86.36)
   })
 
   it('computes weighted percent when enabled', () => {
     const result = calculateFinalPercent({
       useWeights: true,
-      assignmentsWeight: 70,
-      quizzesWeight: 30,
+      assignmentsWeight: 50,
+      quizzesWeight: 20,
+      testsWeight: 30,
       assignments: [{ earned: 24, possible: 30 }],
       quizzes: [{ earned: 8, possible: 10 }],
+      tests: [{ earned: 45, possible: 50 }],
     })
 
     expect(result.assignmentsPercent).toBe(80)
     expect(result.quizzesPercent).toBe(80)
-    expect(result.finalPercent).toBe(80)
+    expect(result.testsPercent).toBe(90)
+    expect(result.finalPercent).toBe(83)
   })
 
   it('renormalizes weighted calc when one category has no scores', () => {
     const result = calculateFinalPercent({
       useWeights: true,
-      assignmentsWeight: 70,
-      quizzesWeight: 30,
+      assignmentsWeight: 50,
+      quizzesWeight: 20,
+      testsWeight: 30,
       assignments: [{ earned: 27, possible: 30 }],
       quizzes: [],
+      tests: [],
     })
 
     expect(result.assignmentsPercent).toBe(90)
     expect(result.quizzesPercent).toBeNull()
+    expect(result.testsPercent).toBeNull()
     expect(result.finalPercent).toBe(90)
   })
 })

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -68,9 +68,14 @@ describe('getLayoutConfig', () => {
     expect(studentConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
   })
 
-  it('should not reserve external sidebars for teacher quizzes and tests', () => {
+  it('should not reserve external sidebars for teacher gradebook, quizzes, and tests', () => {
+    const gradebookConfig = getLayoutConfig('gradebook')
     const quizzesConfig = getLayoutConfig('quizzes-teacher')
     const testsConfig = getLayoutConfig('tests-teacher')
+
+    expect(gradebookConfig.rightSidebar.enabled).toBe(false)
+    expect(gradebookConfig.rightSidebar.defaultOpen).toBe(false)
+    expect(gradebookConfig.mainContent.maxWidth).toBe('full')
 
     expect(quizzesConfig.rightSidebar.enabled).toBe(false)
     expect(quizzesConfig.rightSidebar.defaultOpen).toBe(false)


### PR DESCRIPTION
## Summary
- Refactor teacher gradebook into Grades and Settings subtabs using shared teacher work-surface components.
- Move gradebook summary/detail behavior into an internal 50/50 Grades split instead of the outer classroom right sidebar.
- Add Tests as a first-class gradebook category across settings, calculations, API payloads, types, and persistence.

## Validation
- pnpm lint
- pnpm build
- pnpm test (234 files, 1947 tests)
- Pika UI verification for gradebook Grades and Settings on teacher desktop/mobile, with student capture unaffected.