### PR TITLE
[codex] Add assignment Apply Grade to Selected Students action

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10058,3 +10058,21 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-30 — Split apply grade and comments batch actions
+
+**Completed:**
+- Split the assignment grading batch menu into `Apply Grade to Selected Students` and `Apply Comments to Selected Students`.
+- Scoped the batch grade API with `apply_target` so grade application updates only scores/graded state, while comments application updates only the teacher comment draft.
+- Updated confirmation copy, hover highlighting, and component/API coverage for the separate grade and comments flows.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-grade-selected.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshot for the assignment workspace split menu:
+  - `/tmp/pika-assignment-apply-menu.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10041,3 +10041,20 @@
 - `bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"` (235 files / 1958 tests before the focused regression was added)
 - `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/ui/SplitButton.test.tsx`
 - `pnpm lint`
+
+## 2026-04-30 — Rename grading feedback copy to comments
+
+**Completed:**
+- Renamed visible assignment grading feedback copy to comment/comments language in the teacher inspector, Apply Grade confirmation, return-comment validation, and student returned-comments panel.
+- Updated related quiz/test grading placeholders from `Feedback (optional)` to `Comment (optional)`.
+- Left internal API/database names and the app-level `Send Feedback` product-feedback dialog unchanged.
+
+**Validation:**
+- `pnpm test` (241 files / 1992 tests)
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/components/TestStudentGradingPanel.test.tsx tests/api/teacher/assignments-id-feedback-return.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10096,3 +10096,20 @@
   - `/tmp/pika-teacher-mobile.png`
 - Manual Playwright screenshot for the assignment apply confirmation dialog:
   - `/tmp/pika-apply-confirm-label.png`
+
+## 2026-04-30 — Shorten apply dialog descriptions
+
+**Completed:**
+- Replaced the assignment apply grade/apply comments confirmation descriptions with concise current-student copy.
+- Removed the “It will not…” caveat text from the apply confirmation dialog.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshot for the shortened apply confirmation:
+  - `/tmp/pika-apply-dialog-short-copy.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10079,3 +10079,20 @@
 - Manual Playwright screenshot for the assignment workspace split menu:
   - `/tmp/pika-assignment-apply-menu.png`
   - `/tmp/pika-return-in-split-menu.png`
+
+## 2026-04-30 — Shorten apply confirmation label
+
+**Completed:**
+- Changed the assignment batch apply confirmation button label to `Apply` for both grade and comments apply flows.
+- Updated component coverage to confirm the generic apply button drives the existing score-only and comments-only requests.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshot for the assignment apply confirmation dialog:
+  - `/tmp/pika-apply-confirm-label.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10113,3 +10113,14 @@
   - `/tmp/pika-teacher-mobile.png`
 - Manual Playwright screenshot for the shortened apply confirmation:
   - `/tmp/pika-apply-dialog-short-copy.png`
+
+## 2026-04-30 — Guard stale apply source in parent
+
+**Completed:**
+- Added a parent-side source match for assignment apply grade/apply comments actions.
+- Disabled apply actions and blocked confirmation submits unless the saved template belongs to the active selected student.
+- Closed any open apply confirmation when selecting another student.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10011,3 +10011,22 @@
 - Manual Playwright screenshots for the assignment workspace `Apply Grade` menu and confirmation dialog:
   - `/tmp/pika-apply-grade-menu.png`
   - `/tmp/pika-apply-grade-dialog.png`
+
+## 2026-04-29 — Highlight Apply Grade source cards
+
+**Completed:**
+- Renamed the teacher-facing batch menu option to `Apply Grade to Selected Students`.
+- Highlighted the grade and feedback inspector cards while the batch menu option is hovered or focused, making the copied source fields explicit before confirmation.
+- Added split-button hover state plumbing and component coverage for the highlighted inspector sections.
+
+**Validation:**
+- `pnpm test` during session start (235 files, 1955 tests)
+- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshot for the assignment workspace hover highlight:
+  - `/tmp/pika-apply-grade-selected-hover-highlight.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9995,3 +9995,19 @@
   - `/tmp/pika-copy-grade-dialog.png`
   - `/tmp/pika-copy-grade-mobile-menu.png`
   - `/tmp/pika-copy-grade-mobile-dialog.png`
+
+## 2026-04-29 — Rename assignment batch action to Apply Grade
+
+**Completed:**
+- Renamed the teacher-facing assignment batch action from `Copy Grade` to `Apply Grade`.
+- Updated confirmation, busy, success, and fallback error text to use apply-grade language while preserving the same save-only behavior.
+- Updated component coverage for the revised label and dialog copy.
+
+**Validation:**
+- `pnpm test` during session start (235 files, 1955 tests)
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Manual Playwright screenshots for the assignment workspace `Apply Grade` menu and confirmation dialog:
+  - `/tmp/pika-apply-grade-menu.png`
+  - `/tmp/pika-apply-grade-dialog.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10065,9 +10065,11 @@
 - Split the assignment grading batch menu into `Apply Grade to Selected Students` and `Apply Comments to Selected Students`.
 - Scoped the batch grade API with `apply_target` so grade application updates only scores/graded state, while comments application updates only the teacher comment draft.
 - Updated confirmation copy, hover highlighting, and component/API coverage for the separate grade and comments flows.
+- Preserved the `origin/main` behavior that keeps `Return` inside the `AI Grade` split menu instead of as a separate action-bar button.
 
 **Validation:**
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-grade-selected.test.ts`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
 - `pnpm lint`
 - `pnpm build`
 - Pika UI verification script for `/classrooms`:
@@ -10076,3 +10078,4 @@
   - `/tmp/pika-teacher-mobile.png`
 - Manual Playwright screenshot for the assignment workspace split menu:
   - `/tmp/pika-assignment-apply-menu.png`
+  - `/tmp/pika-return-in-split-menu.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10030,3 +10030,14 @@
   - `/tmp/pika-teacher-mobile.png`
 - Manual Playwright screenshot for the assignment workspace hover highlight:
   - `/tmp/pika-apply-grade-selected-hover-highlight.png`
+
+## 2026-04-30 — Fix Apply Grade stale source during student switches
+
+**Completed:**
+- Cleared the assignment grade template while the overview inspector still holds the prior student's loaded data during a next-student fetch.
+- Added component regression coverage that switches from one overview student to another with a deferred load and verifies the batch apply source is cleared until the new student's data arrives.
+
+**Validation:**
+- `bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"` (235 files / 1958 tests before the focused regression was added)
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/ui/SplitButton.test.tsx`
+- `pnpm lint`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9962,3 +9962,36 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+## 2026-04-29 — Assignment grade selected batch action
+
+**Completed:**
+- Added a teacher assignment `Grade Selected` action to the existing `AI Grade` split-button menu, gated by checked student rows and an active right-side grader template.
+- Added a confirmation dialog that calls out selected count and saved score/feedback draft overwrites without returning feedback to students.
+- Added `POST /api/teacher/assignments/[id]/grade-selected` with shared grade payload parsing/upsert logic reused by the existing single-student grade route.
+- Patched assignment rows locally after batch save, refreshed the active inspector in place, showed a success banner, and cleared checkbox selection only on success.
+- Added API and component coverage for batch validation, grade upserts, confirmation flow, request payloads, success row patching, and error selection preservation.
+
+**Validation:**
+- `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `pnpm test` (235 files, 1955 tests)
+- `pnpm build`
+- Visual verification attempted with the local dev server, but blocked because seeded teacher/student auth was unavailable and `pnpm seed` failed during Supabase-backed test account creation.
+
+## 2026-04-29 — Rename assignment batch copy action
+
+**Completed:**
+- Renamed the teacher-facing assignment batch action from `Grade Selected` to `Copy Grade`.
+- Updated the confirmation dialog, busy text, success text, and error fallback to describe copying the open student's grade and feedback draft to checked students.
+- Kept the existing batch save route and copy behavior unchanged.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification script for `/classrooms` with generated teacher/student auth screenshots.
+- Manual Playwright screenshots for the assignment workspace `Copy Grade` menu and confirmation dialog:
+  - `/tmp/pika-copy-grade-menu.png`
+  - `/tmp/pika-copy-grade-dialog.png`
+  - `/tmp/pika-copy-grade-mobile-menu.png`
+  - `/tmp/pika-copy-grade-mobile-dialog.png`

--- a/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
@@ -40,7 +40,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentFeedbackReturn', asyn
     : (existingDoc?.teacher_feedback_draft || '').trim()
 
   if (!feedbackDraft) {
-    throw apiErrors.badRequest('Feedback draft is required before returning feedback')
+    throw apiErrors.badRequest('Comment draft is required before returning comments')
   }
 
   const now = new Date().toISOString()

--- a/src/app/api/teacher/assignments/[id]/grade-selected/route.ts
+++ b/src/app/api/teacher/assignments/[id]/grade-selected/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server'
+import { getServiceRoleClient } from '@/lib/supabase'
+import { requireRole } from '@/lib/auth'
+import { apiErrors, withErrorHandler } from '@/lib/api-handler'
+import {
+  assertStudentsEnrolledForAssignmentGrade,
+  loadTeacherOwnedAssignmentForGrade,
+  normalizeAssignmentGradeStudentIds,
+  parseAssignmentGradePayload,
+  upsertAssignmentGradeRows,
+} from '@/lib/server/assignment-grades'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// POST /api/teacher/assignments/[id]/grade-selected - Save the same grade for selected students
+export const POST = withErrorHandler('PostTeacherAssignmentGradeSelected', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const body = await request.json()
+  const studentIds = normalizeAssignmentGradeStudentIds(body?.student_ids)
+
+  if (studentIds.length === 0) {
+    throw apiErrors.badRequest('student_ids array is required')
+  }
+
+  if (studentIds.length > 100) {
+    throw apiErrors.badRequest('Cannot grade more than 100 students at once')
+  }
+
+  const grade = parseAssignmentGradePayload({
+    score_completion: body?.score_completion,
+    score_thinking: body?.score_thinking,
+    score_workflow: body?.score_workflow,
+    feedback: body?.feedback,
+    save_mode: body?.save_mode,
+  })
+  const supabase = getServiceRoleClient()
+  const assignment = await loadTeacherOwnedAssignmentForGrade({
+    supabase,
+    assignmentId: id,
+    teacherId: user.id,
+  })
+
+  await assertStudentsEnrolledForAssignmentGrade({
+    supabase,
+    classroomId: assignment.classroom_id,
+    studentIds,
+  })
+
+  // Upsert supports grading students even when no submission/doc exists yet.
+  // It intentionally leaves feedback_returned_at, returned_at, and feedback untouched.
+  const { data: docs, error: upsertError } = await upsertAssignmentGradeRows({
+    supabase,
+    assignmentId: id,
+    studentIds,
+    grade,
+  })
+
+  if (upsertError || !docs) {
+    console.error('Error saving selected grades:', upsertError)
+    return NextResponse.json({ error: 'Failed to save selected grades' }, { status: 500 })
+  }
+
+  const updatedDocs = Array.isArray(docs) ? docs : []
+
+  return NextResponse.json({
+    updated_count: updatedDocs.length,
+    updated_student_ids: updatedDocs.map((doc) => doc.student_id),
+    docs: updatedDocs,
+  })
+})

--- a/src/app/api/teacher/assignments/[id]/grade-selected/route.ts
+++ b/src/app/api/teacher/assignments/[id]/grade-selected/route.ts
@@ -34,6 +34,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentGradeSelected', async
     score_workflow: body?.score_workflow,
     feedback: body?.feedback,
     save_mode: body?.save_mode,
+    apply_target: body?.apply_target,
   })
   const supabase = getServiceRoleClient()
   const assignment = await loadTeacherOwnedAssignmentForGrade({

--- a/src/app/api/teacher/assignments/[id]/grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/grade/route.ts
@@ -1,17 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { withErrorHandler } from '@/lib/api-handler'
+import { apiErrors, withErrorHandler } from '@/lib/api-handler'
+import {
+  assertStudentsEnrolledForAssignmentGrade,
+  loadTeacherOwnedAssignmentForGrade,
+  parseAssignmentGradePayload,
+  upsertAssignmentGradeRows,
+} from '@/lib/server/assignment-grades'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-
-function parseDraftScore(value: unknown): number | null | typeof Number.NaN {
-  if (value === '' || value === null || value === undefined) return null
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 10) return Number.NaN
-  return parsed
-}
 
 // POST /api/teacher/assignments/[id]/grade - Save grade for a student
 export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (request, context) => {
@@ -28,88 +27,38 @@ export const POST = withErrorHandler('PostTeacherAssignmentGrade', async (reques
   } = body
 
   if (!student_id || typeof student_id !== 'string') {
-    return NextResponse.json({ error: 'student_id is required' }, { status: 400 })
-  }
-
-  if (typeof feedback !== 'string') {
-    return NextResponse.json({ error: 'feedback must be a string' }, { status: 400 })
-  }
-
-  if (save_mode !== undefined && save_mode !== 'draft' && save_mode !== 'graded') {
-    return NextResponse.json({ error: 'save_mode must be "draft" or "graded"' }, { status: 400 })
-  }
-
-  const shouldMarkGraded = save_mode === 'graded' || save_mode === undefined
-  const parsedScores = {
-    score_completion: shouldMarkGraded ? Number(score_completion) : parseDraftScore(score_completion),
-    score_thinking: shouldMarkGraded ? Number(score_thinking) : parseDraftScore(score_thinking),
-    score_workflow: shouldMarkGraded ? Number(score_workflow) : parseDraftScore(score_workflow),
-  }
-
-  for (const [name, value] of Object.entries(parsedScores)) {
-    if (shouldMarkGraded) {
-      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
-        return NextResponse.json({ error: `${name} must be an integer 0–10` }, { status: 400 })
-      }
-      continue
-    }
-
-    if (Number.isNaN(value)) {
-      return NextResponse.json({ error: `${name} must be blank or an integer 0–10` }, { status: 400 })
-    }
+    throw apiErrors.badRequest('student_id is required')
   }
 
   const supabase = getServiceRoleClient()
-
-  // Verify teacher owns this assignment
-  const { data: assignment, error: assignmentError } = await supabase
-    .from('assignments')
-    .select(`
-      *,
-      classrooms!inner (
-        teacher_id
-      )
-    `)
-    .eq('id', id)
-    .single()
-
-  if (assignmentError || !assignment) {
-    return NextResponse.json({ error: 'Assignment not found' }, { status: 404 })
-  }
-
-  if (assignment.classrooms.teacher_id !== user.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
-  }
-
-  const { data: enrollment } = await supabase
-    .from('classroom_enrollments')
-    .select('id')
-    .eq('classroom_id', assignment.classroom_id)
-    .eq('student_id', student_id)
-    .maybeSingle()
-
-  if (!enrollment) {
-    return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
-  }
+  const grade = parseAssignmentGradePayload({
+    score_completion,
+    score_thinking,
+    score_workflow,
+    feedback,
+    save_mode,
+  })
+  const assignment = await loadTeacherOwnedAssignmentForGrade({
+    supabase,
+    assignmentId: id,
+    teacherId: user.id,
+  })
+  await assertStudentsEnrolledForAssignmentGrade({
+    supabase,
+    classroomId: assignment.classroom_id,
+    studentIds: [student_id],
+  })
 
   // Upsert supports grading students even when no submission/doc exists yet.
-  const { data: doc, error: upsertError } = await supabase
-    .from('assignment_docs')
-    .upsert({
-      assignment_id: id,
-      student_id,
-      score_completion: parsedScores.score_completion,
-      score_thinking: parsedScores.score_thinking,
-      score_workflow: parsedScores.score_workflow,
-      teacher_feedback_draft: feedback,
-      teacher_feedback_draft_updated_at: new Date().toISOString(),
-      graded_at: shouldMarkGraded ? new Date().toISOString() : null,
-      graded_by: shouldMarkGraded ? 'teacher' : null,
-    }, { onConflict: 'assignment_id,student_id' })
-    .select()
-    .single()
+  const { data: docs, error: upsertError } = await upsertAssignmentGradeRows({
+    supabase,
+    assignmentId: id,
+    studentIds: [student_id],
+    grade,
+  })
+  const doc = Array.isArray(docs) ? docs[0] : null
 
-  if (upsertError) {
+  if (upsertError || !doc) {
     console.error('Error saving grade:', upsertError)
     return NextResponse.json({ error: 'Failed to save grade' }, { status: 500 })
   }

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -21,6 +21,7 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  Copy,
   LoaderCircle,
   Pencil,
   Plus,
@@ -36,7 +37,10 @@ import {
   TeacherAssignmentStudentTable,
   type TeacherAssignmentStudentRow,
 } from '@/components/assignment-workspace/TeacherAssignmentStudentTable'
-import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
+import {
+  TeacherStudentWorkPanel,
+  type TeacherAssignmentGradeTemplate,
+} from '@/components/TeacherStudentWorkPanel'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
@@ -87,6 +91,10 @@ interface AssignmentWithStats extends Assignment {
 type TeacherAssignmentSelection = { mode: 'summary' } | { mode: 'assignment'; assignmentId: string }
 
 type StudentSubmissionRow = TeacherAssignmentStudentRow
+type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
+  student_id: string
+  updated_at?: string | null
+}
 type UpdateSearchParamsFn = (
   updater: (params: URLSearchParams) => void,
   options?: { replace?: boolean },
@@ -152,6 +160,24 @@ function getAssignmentAiRunPollDelayMs(run: AssignmentAiGradingRunSummary | null
 
   const delay = retryAt - Date.now() + 250
   return Math.min(Math.max(delay, 1000), 10_000)
+}
+
+function isGradeSelectedScoreValueValid(value: string, allowBlank: boolean): boolean {
+  const trimmed = value.trim()
+  if (allowBlank && !trimmed) return true
+  const parsed = Number(trimmed)
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 10
+}
+
+function isGradeSelectedTemplateValid(template: TeacherAssignmentGradeTemplate | null): boolean {
+  if (!template) return false
+
+  const allowBlank = template.gradeMode === 'draft'
+  return [
+    template.scoreCompletion,
+    template.scoreThinking,
+    template.scoreWorkflow,
+  ].every((value) => isGradeSelectedScoreValueValid(value, allowBlank))
 }
 
 function summarizeAssignmentAiGradingErrors(run: AssignmentAiGradingRunSummary): string {
@@ -273,10 +299,15 @@ export function TeacherClassroomView({
 
   // Batch grading state
   const [isAutoGrading, setIsAutoGrading] = useState(false)
+  const [isGradeSelectedSaving, setIsGradeSelectedSaving] = useState(false)
   const [isArtifactRepoAnalyzing, setIsArtifactRepoAnalyzing] = useState(false)
   const [isReturning, setIsReturning] = useState(false)
   const [batchProgressCount, setBatchProgressCount] = useState(0)
   const [showReturnConfirm, setShowReturnConfirm] = useState(false)
+  const [showGradeSelectedConfirm, setShowGradeSelectedConfirm] = useState(false)
+  const [gradeSelectedTemplate, setGradeSelectedTemplate] =
+    useState<TeacherAssignmentGradeTemplate | null>(null)
+  const [gradeSelectedRefreshCounter, setGradeSelectedRefreshCounter] = useState(0)
   const [refreshCounter, setRefreshCounter] = useState(0)
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const wasActiveRef = useRef(isActive)
@@ -732,6 +763,9 @@ export function TeacherClassroomView({
     setSelection: batchSetSelection,
     selectedCount: batchSelectedCount,
   } = useStudentSelection(studentRowIds)
+  const handleGradeTemplateChange = useCallback((template: TeacherAssignmentGradeTemplate | null) => {
+    setGradeSelectedTemplate(template)
+  }, [])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
@@ -1001,6 +1035,82 @@ export function TeacherClassroomView({
     }
   }
 
+  async function handleGradeSelected() {
+    if (!selectedAssignmentData || !gradeSelectedTemplate || batchSelectedCount === 0) return
+
+    if (!isGradeSelectedTemplateValid(gradeSelectedTemplate)) {
+      setError('Scores must be blank or integers 0–10')
+      return
+    }
+
+    const studentIds = Array.from(batchSelectedIds)
+    setBatchProgressCount(studentIds.length)
+    setIsGradeSelectedSaving(true)
+    setError('')
+    setInfo('')
+    try {
+      const res = await fetch(`/api/teacher/assignments/${selectedAssignmentData.assignment.id}/grade-selected`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          student_ids: studentIds,
+          score_completion: gradeSelectedTemplate.scoreCompletion,
+          score_thinking: gradeSelectedTemplate.scoreThinking,
+          score_workflow: gradeSelectedTemplate.scoreWorkflow,
+          feedback: gradeSelectedTemplate.feedbackDraft,
+          save_mode: gradeSelectedTemplate.gradeMode,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to copy grade')
+
+      const updatedDocs: GradeSelectedUpdatedDoc[] = Array.isArray(data.docs)
+        ? data.docs.filter((doc: unknown): doc is GradeSelectedUpdatedDoc =>
+            !!doc && typeof doc === 'object' && typeof (doc as { student_id?: unknown }).student_id === 'string'
+          )
+        : []
+      const docsByStudentId = new Map<string, GradeSelectedUpdatedDoc>(
+        updatedDocs.map((doc) => [doc.student_id, doc])
+      )
+
+      if (docsByStudentId.size > 0) {
+        setSelectedAssignmentData((prev) => {
+          if (!prev || prev.assignment.id !== selectedAssignmentData.assignment.id) return prev
+
+          const nextStudents = prev.students.map((student) => {
+            const updatedDoc = docsByStudentId.get(student.student_id)
+            if (!updatedDoc) return student
+
+            return {
+              ...student,
+              doc: {
+                ...(student.doc ?? {}),
+                ...updatedDoc,
+              },
+              status: calculateAssignmentStatus(prev.assignment, updatedDoc as any),
+              student_updated_at: updatedDoc.updated_at ?? student.student_updated_at,
+            }
+          })
+
+          return { ...prev, students: nextStudents }
+        })
+      }
+
+      const updatedCount = Number(data.updated_count ?? docsByStudentId.size)
+      setInfo(`Copied grade to ${updatedCount} selected student${updatedCount === 1 ? '' : 's'}`)
+      setShowGradeSelectedConfirm(false)
+      batchClearSelection()
+
+      if (activeSelectedStudentId && docsByStudentId.has(activeSelectedStudentId)) {
+        setGradeSelectedRefreshCounter((count) => count + 1)
+      }
+    } catch (err: any) {
+      setError(err.message || 'Failed to copy grade')
+    } finally {
+      setIsGradeSelectedSaving(false)
+    }
+  }
+
   const selectedStudentIndex = useMemo(() => {
     if (!selectedStudentId) return -1
     return currentStudentRows.findIndex((student) => student.student_id === selectedStudentId)
@@ -1261,7 +1371,22 @@ export function TeacherClassroomView({
   const hasReturnableSelection =
     batchSelectedReturnSummary.returnableCount + batchSelectedReturnSummary.missingCount > 0
   const isReturnDisabled =
-    isReturning || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
+    isReturning || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
+  const returnTooltipContent =
+    batchSelectedCount > 0 && !hasReturnableSelection
+      ? 'Nothing returnable selected'
+      : `Return${workspaceActionLabelSuffix}`
+  const gradeSelectedTemplateIsValid = isGradeSelectedTemplateValid(gradeSelectedTemplate)
+  const isGradeSelectedDisabled =
+    isGradeSelectedSaving ||
+    isAutoGrading ||
+    hasActiveAssignmentAiRun ||
+    isArtifactRepoAnalyzing ||
+    isReturning ||
+    isReadOnly ||
+    batchSelectedCount === 0 ||
+    !gradeSelectedTemplate ||
+    !gradeSelectedTemplateIsValid
   const showAssignmentAiRunOverlay = isAutoGrading || hasActiveAssignmentAiRun
   const assignmentAiRunOverlayLabel = hasActiveAssignmentAiRun && activeAssignmentAiRun
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
@@ -1272,7 +1397,9 @@ export function TeacherClassroomView({
       ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
       : isReturning
         ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-        : ''
+        : isGradeSelectedSaving
+          ? `Copying grade to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+          : ''
   useOverlayMessage(!!activeWorkMessage, activeWorkMessage, { tone: 'loading' })
 
   const studentBusyOverlay = activeWorkMessage ? (
@@ -1308,52 +1435,73 @@ export function TeacherClassroomView({
 
   const workspaceModeCenter = assignmentWorkspaceMode === 'overview' ? (
     <>
-      <SplitButton
-        label={
-          <span className="inline-flex items-center gap-2">
-            <Check className="h-4 w-4" aria-hidden="true" />
-            <span>AI Grade</span>
-          </span>
-        }
-        onPrimaryClick={() => {
-          void handleBatchAutoGrade()
-        }}
-        options={[
-          {
-            id: 'repo-analysis',
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                <span>Repo analysis</span>
-              </span>
-            ),
-            onSelect: () => {
-              void handleBatchArtifactRepoAnalyze()
+      <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
+        <SplitButton
+          label={
+            <span className="inline-flex items-center gap-2">
+              <Check className="h-4 w-4" aria-hidden="true" />
+              <span>AI Grade</span>
+            </span>
+          }
+          onPrimaryClick={() => {
+            void handleBatchAutoGrade()
+          }}
+          options={[
+            {
+              id: 'grade-selected',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                  <span>Copy Grade</span>
+                </span>
+              ),
+              onSelect: () => {
+                setShowGradeSelectedConfirm(true)
+              },
+              disabled: isGradeSelectedDisabled,
             },
-            disabled: isArtifactRepoAnalyzing || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
-          },
-          {
-            id: 'return',
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <Send className="h-4 w-4" aria-hidden="true" />
-                <span>Return</span>
-              </span>
-            ),
-            onSelect: () => {
+            {
+              id: 'repo-analysis',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                  <span>Repo analysis</span>
+                </span>
+              ),
+              onSelect: () => {
+                void handleBatchArtifactRepoAnalyze()
+              },
+              disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+            },
+          ]}
+          disabled={isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
+          className="inline-flex"
+          toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+          menuPlacement="down"
+          primaryButtonProps={{
+            'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+          }}
+        />
+      </Tooltip>
+
+      <Tooltip content={returnTooltipContent}>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="subtle"
+            size="sm"
+            className="px-4"
+            onClick={() => {
               setShowReturnConfirm(true)
-            },
-            disabled: isReturnDisabled,
-          },
-        ]}
-        disabled={isAutoGrading || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
-        className="inline-flex"
-        toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
-        menuPlacement="down"
-        primaryButtonProps={{
-          'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-        }}
-      />
+            }}
+            disabled={isReturnDisabled}
+            aria-label={`Return${workspaceActionLabelSuffix}`}
+          >
+            <Send className="h-4 w-4" aria-hidden="true" />
+            <span>Return</span>
+          </Button>
+        </span>
+      </Tooltip>
     </>
   ) : (
     <>
@@ -1582,12 +1730,14 @@ export function TeacherClassroomView({
           classroomId={classroom.id}
           assignmentId={selectedAssignmentId}
           studentId={activeSelectedStudentId}
+          refreshKey={gradeSelectedRefreshCounter}
           mode="overview"
           inspectorCollapsed={false}
           inspectorWidth={activeWorkspaceLayout.inspectorWidth}
           totalWidth={workspaceWidth}
           inspectorEditMode={assignmentEditMode}
           onLoadingStateChange={setWorkspaceLoading}
+          onGradeTemplateChange={handleGradeTemplateChange}
         />
       }
     />
@@ -1622,6 +1772,18 @@ export function TeacherClassroomView({
         onConfirm={deleteAssignment}
       />
 
+
+      <ConfirmDialog
+        isOpen={showGradeSelectedConfirm}
+        title={`Copy grade to ${batchSelectedCount} selected student(s)?`}
+        description={`This copies the open student's scores and feedback draft to the checked student(s), overwriting their saved scores and feedback drafts. It will not return feedback to students.`}
+        confirmLabel={isGradeSelectedSaving ? 'Copying...' : 'Copy Grade'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedDisabled}
+        isCancelDisabled={isGradeSelectedSaving}
+        onCancel={() => (isGradeSelectedSaving ? null : setShowGradeSelectedConfirm(false))}
+        onConfirm={handleGradeSelected}
+      />
 
       <ConfirmDialog
         isOpen={showReturnConfirm}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -700,6 +700,7 @@ export function TeacherClassroomView({
     options: { updateUrl?: boolean; replace?: boolean } = {},
   ) => {
     setSelectedStudentId(studentId)
+    setGradeSelectedConfirmTarget(null)
     if (options.updateUrl === false || !updateSearchParams || selection.mode !== 'assignment') return
 
     updateSearchParams((params) => {
@@ -1041,6 +1042,12 @@ export function TeacherClassroomView({
 
   async function handleGradeSelected(applyTarget: GradeSelectedApplyTarget) {
     if (!selectedAssignmentData || !gradeSelectedTemplate || batchSelectedCount === 0) return
+
+    if (gradeSelectedTemplate.studentId !== activeSelectedStudentId || gradeSelectedTemplate.studentId !== selectedStudentId) {
+      setGradeSelectedTemplate(null)
+      setGradeSelectedConfirmTarget(null)
+      return
+    }
 
     if (applyTarget === 'grade' && !isGradeSelectedTemplateValid(gradeSelectedTemplate)) {
       setError('Scores must be blank or integers 0–10')
@@ -1388,7 +1395,12 @@ export function TeacherClassroomView({
     batchSelectedReturnSummary.returnableCount + batchSelectedReturnSummary.missingCount > 0
   const isReturnDisabled =
     isReturning || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
-  const gradeSelectedTemplateIsValid = isGradeSelectedTemplateValid(gradeSelectedTemplate)
+  const activeGradeSelectedTemplate =
+    gradeSelectedTemplate?.studentId === activeSelectedStudentId &&
+    gradeSelectedTemplate.studentId === selectedStudentId
+      ? gradeSelectedTemplate
+      : null
+  const gradeSelectedTemplateIsValid = isGradeSelectedTemplateValid(activeGradeSelectedTemplate)
   const isApplyGradeSelectedDisabled =
     isGradeSelectedSaving ||
     isAutoGrading ||
@@ -1397,7 +1409,7 @@ export function TeacherClassroomView({
     isReturning ||
     isReadOnly ||
     batchSelectedCount === 0 ||
-    !gradeSelectedTemplate ||
+    !activeGradeSelectedTemplate ||
     !gradeSelectedTemplateIsValid
   const isApplyCommentsSelectedDisabled =
     isGradeSelectedSaving ||
@@ -1407,7 +1419,7 @@ export function TeacherClassroomView({
     isReturning ||
     isReadOnly ||
     batchSelectedCount === 0 ||
-    !gradeSelectedTemplate
+    !activeGradeSelectedTemplate
   const isGradeSelectedConfirmDisabled =
     gradeSelectedConfirmTarget === 'grade'
       ? isApplyGradeSelectedDisabled

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1829,9 +1829,7 @@ export function TeacherClassroomView({
         confirmLabel={
           isGradeSelectedSaving
             ? 'Applying...'
-            : gradeSelectedConfirmTarget === 'comments'
-              ? 'Apply Comments to Selected Students'
-              : 'Apply Grade to Selected Students'
+            : 'Apply'
         }
         cancelLabel="Cancel"
         isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedConfirmDisabled}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1783,7 +1783,7 @@ export function TeacherClassroomView({
       <ConfirmDialog
         isOpen={showGradeSelectedConfirm}
         title={`Apply grade to ${batchSelectedCount} selected student(s)?`}
-        description={`This applies the open student's scores and feedback draft to the checked student(s), overwriting their saved scores and feedback drafts. It will not return feedback to students.`}
+        description={`This applies the open student's scores and comment draft to the checked student(s), overwriting their saved scores and comment drafts. It will not return comments to students.`}
         confirmLabel={isGradeSelectedSaving ? 'Applying...' : 'Apply Grade to Selected Students'}
         cancelLabel="Cancel"
         isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedDisabled}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1062,7 +1062,7 @@ export function TeacherClassroomView({
         }),
       })
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to copy grade')
+      if (!res.ok) throw new Error(data.error || 'Failed to apply grade')
 
       const updatedDocs: GradeSelectedUpdatedDoc[] = Array.isArray(data.docs)
         ? data.docs.filter((doc: unknown): doc is GradeSelectedUpdatedDoc =>
@@ -1097,7 +1097,7 @@ export function TeacherClassroomView({
       }
 
       const updatedCount = Number(data.updated_count ?? docsByStudentId.size)
-      setInfo(`Copied grade to ${updatedCount} selected student${updatedCount === 1 ? '' : 's'}`)
+      setInfo(`Applied grade to ${updatedCount} selected student${updatedCount === 1 ? '' : 's'}`)
       setShowGradeSelectedConfirm(false)
       batchClearSelection()
 
@@ -1105,7 +1105,7 @@ export function TeacherClassroomView({
         setGradeSelectedRefreshCounter((count) => count + 1)
       }
     } catch (err: any) {
-      setError(err.message || 'Failed to copy grade')
+      setError(err.message || 'Failed to apply grade')
     } finally {
       setIsGradeSelectedSaving(false)
     }
@@ -1398,7 +1398,7 @@ export function TeacherClassroomView({
       : isReturning
         ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
         : isGradeSelectedSaving
-          ? `Copying grade to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+          ? `Applying grade to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
           : ''
   useOverlayMessage(!!activeWorkMessage, activeWorkMessage, { tone: 'loading' })
 
@@ -1452,7 +1452,7 @@ export function TeacherClassroomView({
               label: (
                 <span className="inline-flex items-center gap-2">
                   <Copy className="h-4 w-4" aria-hidden="true" />
-                  <span>Copy Grade</span>
+                  <span>Apply Grade</span>
                 </span>
               ),
               onSelect: () => {
@@ -1775,9 +1775,9 @@ export function TeacherClassroomView({
 
       <ConfirmDialog
         isOpen={showGradeSelectedConfirm}
-        title={`Copy grade to ${batchSelectedCount} selected student(s)?`}
-        description={`This copies the open student's scores and feedback draft to the checked student(s), overwriting their saved scores and feedback drafts. It will not return feedback to students.`}
-        confirmLabel={isGradeSelectedSaving ? 'Copying...' : 'Copy Grade'}
+        title={`Apply grade to ${batchSelectedCount} selected student(s)?`}
+        description={`This applies the open student's scores and feedback draft to the checked student(s), overwriting their saved scores and feedback drafts. It will not return feedback to students.`}
+        confirmLabel={isGradeSelectedSaving ? 'Applying...' : 'Apply Grade'}
         cancelLabel="Cancel"
         isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedDisabled}
         isCancelDisabled={isGradeSelectedSaving}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -305,6 +305,7 @@ export function TeacherClassroomView({
   const [batchProgressCount, setBatchProgressCount] = useState(0)
   const [showReturnConfirm, setShowReturnConfirm] = useState(false)
   const [showGradeSelectedConfirm, setShowGradeSelectedConfirm] = useState(false)
+  const [isApplyGradeOptionHighlighted, setIsApplyGradeOptionHighlighted] = useState(false)
   const [gradeSelectedTemplate, setGradeSelectedTemplate] =
     useState<TeacherAssignmentGradeTemplate | null>(null)
   const [gradeSelectedRefreshCounter, setGradeSelectedRefreshCounter] = useState(0)
@@ -1363,6 +1364,9 @@ export function TeacherClassroomView({
   const showOverviewInspector =
     assignmentWorkspaceMode === 'overview' &&
     !!activeSelectedStudentId
+  const highlightedInspectorSections = isApplyGradeOptionHighlighted
+    ? (['grades', 'comments'] as const)
+    : undefined
   const canOpenDetails =
     selection.mode === 'assignment' &&
     !selectedAssignmentLoading &&
@@ -1450,12 +1454,14 @@ export function TeacherClassroomView({
             {
               id: 'grade-selected',
               label: (
-                <span className="inline-flex items-center gap-2">
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
                   <Copy className="h-4 w-4" aria-hidden="true" />
-                  <span>Apply Grade</span>
+                  <span>Apply Grade to Selected Students</span>
                 </span>
               ),
+              onHoverChange: setIsApplyGradeOptionHighlighted,
               onSelect: () => {
+                setIsApplyGradeOptionHighlighted(false)
                 setShowGradeSelectedConfirm(true)
               },
               disabled: isGradeSelectedDisabled,
@@ -1732,6 +1738,7 @@ export function TeacherClassroomView({
           studentId={activeSelectedStudentId}
           refreshKey={gradeSelectedRefreshCounter}
           mode="overview"
+          highlightedInspectorSections={highlightedInspectorSections}
           inspectorCollapsed={false}
           inspectorWidth={activeWorkspaceLayout.inspectorWidth}
           totalWidth={workspaceWidth}
@@ -1777,7 +1784,7 @@ export function TeacherClassroomView({
         isOpen={showGradeSelectedConfirm}
         title={`Apply grade to ${batchSelectedCount} selected student(s)?`}
         description={`This applies the open student's scores and feedback draft to the checked student(s), overwriting their saved scores and feedback drafts. It will not return feedback to students.`}
-        confirmLabel={isGradeSelectedSaving ? 'Applying...' : 'Apply Grade'}
+        confirmLabel={isGradeSelectedSaving ? 'Applying...' : 'Apply Grade to Selected Students'}
         cancelLabel="Cancel"
         isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedDisabled}
         isCancelDisabled={isGradeSelectedSaving}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -28,7 +28,7 @@ import {
   Plus,
   Send,
 } from 'lucide-react'
-import { Button, ConfirmDialog, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { ConfirmDialog, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -1388,10 +1388,6 @@ export function TeacherClassroomView({
     batchSelectedReturnSummary.returnableCount + batchSelectedReturnSummary.missingCount > 0
   const isReturnDisabled =
     isReturning || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
-  const returnTooltipContent =
-    batchSelectedCount > 0 && !hasReturnableSelection
-      ? 'Nothing returnable selected'
-      : `Return${workspaceActionLabelSuffix}`
   const gradeSelectedTemplateIsValid = isGradeSelectedTemplateValid(gradeSelectedTemplate)
   const isApplyGradeSelectedDisabled =
     isGradeSelectedSaving ||
@@ -1523,6 +1519,19 @@ export function TeacherClassroomView({
               },
               disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
             },
+            {
+              id: 'return',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <Send className="h-4 w-4" aria-hidden="true" />
+                  <span>Return</span>
+                </span>
+              ),
+              onSelect: () => {
+                setShowReturnConfirm(true)
+              },
+              disabled: isReturnDisabled,
+            },
           ]}
           disabled={isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
           className="inline-flex"
@@ -1532,25 +1541,6 @@ export function TeacherClassroomView({
             'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
           }}
         />
-      </Tooltip>
-
-      <Tooltip content={returnTooltipContent}>
-        <span className="inline-flex">
-          <Button
-            type="button"
-            variant="subtle"
-            size="sm"
-            className="px-4"
-            onClick={() => {
-              setShowReturnConfirm(true)
-            }}
-            disabled={isReturnDisabled}
-            aria-label={`Return${workspaceActionLabelSuffix}`}
-          >
-            <Send className="h-4 w-4" aria-hidden="true" />
-            <span>Return</span>
-          </Button>
-        </span>
       </Tooltip>
     </>
   ) : (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1823,8 +1823,8 @@ export function TeacherClassroomView({
         }
         description={
           gradeSelectedConfirmTarget === 'comments'
-            ? `This applies the open student's comment draft to the checked student(s), overwriting their saved comment drafts. It will not return comments to students.`
-            : `This applies the open student's scores to the checked student(s), overwriting their saved scores. It will not change comment drafts or return comments to students.`
+            ? `The current student's comments will be applied to the selected students.`
+            : `The current student's grading will be applied to the selected students.`
         }
         confirmLabel={
           isGradeSelectedSaving

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -23,6 +23,7 @@ import {
   ChevronRight,
   Copy,
   LoaderCircle,
+  MessageSquare,
   Pencil,
   Plus,
   Send,
@@ -95,6 +96,7 @@ type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
   student_id: string
   updated_at?: string | null
 }
+type GradeSelectedApplyTarget = 'grade' | 'comments'
 type UpdateSearchParamsFn = (
   updater: (params: URLSearchParams) => void,
   options?: { replace?: boolean },
@@ -304,8 +306,9 @@ export function TeacherClassroomView({
   const [isReturning, setIsReturning] = useState(false)
   const [batchProgressCount, setBatchProgressCount] = useState(0)
   const [showReturnConfirm, setShowReturnConfirm] = useState(false)
-  const [showGradeSelectedConfirm, setShowGradeSelectedConfirm] = useState(false)
-  const [isApplyGradeOptionHighlighted, setIsApplyGradeOptionHighlighted] = useState(false)
+  const [gradeSelectedConfirmTarget, setGradeSelectedConfirmTarget] =
+    useState<GradeSelectedApplyTarget | null>(null)
+  const [highlightedApplyTarget, setHighlightedApplyTarget] = useState<GradeSelectedApplyTarget | null>(null)
   const [gradeSelectedTemplate, setGradeSelectedTemplate] =
     useState<TeacherAssignmentGradeTemplate | null>(null)
   const [gradeSelectedRefreshCounter, setGradeSelectedRefreshCounter] = useState(0)
@@ -1036,10 +1039,10 @@ export function TeacherClassroomView({
     }
   }
 
-  async function handleGradeSelected() {
+  async function handleGradeSelected(applyTarget: GradeSelectedApplyTarget) {
     if (!selectedAssignmentData || !gradeSelectedTemplate || batchSelectedCount === 0) return
 
-    if (!isGradeSelectedTemplateValid(gradeSelectedTemplate)) {
+    if (applyTarget === 'grade' && !isGradeSelectedTemplateValid(gradeSelectedTemplate)) {
       setError('Scores must be blank or integers 0–10')
       return
     }
@@ -1055,15 +1058,21 @@ export function TeacherClassroomView({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           student_ids: studentIds,
-          score_completion: gradeSelectedTemplate.scoreCompletion,
-          score_thinking: gradeSelectedTemplate.scoreThinking,
-          score_workflow: gradeSelectedTemplate.scoreWorkflow,
-          feedback: gradeSelectedTemplate.feedbackDraft,
-          save_mode: gradeSelectedTemplate.gradeMode,
+          apply_target: applyTarget,
+          ...(applyTarget === 'grade'
+            ? {
+                score_completion: gradeSelectedTemplate.scoreCompletion,
+                score_thinking: gradeSelectedTemplate.scoreThinking,
+                score_workflow: gradeSelectedTemplate.scoreWorkflow,
+                save_mode: gradeSelectedTemplate.gradeMode,
+              }
+            : {
+                feedback: gradeSelectedTemplate.feedbackDraft,
+              }),
         }),
       })
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to apply grade')
+      if (!res.ok) throw new Error(data.error || `Failed to apply ${applyTarget}`)
 
       const updatedDocs: GradeSelectedUpdatedDoc[] = Array.isArray(data.docs)
         ? data.docs.filter((doc: unknown): doc is GradeSelectedUpdatedDoc =>
@@ -1098,15 +1107,15 @@ export function TeacherClassroomView({
       }
 
       const updatedCount = Number(data.updated_count ?? docsByStudentId.size)
-      setInfo(`Applied grade to ${updatedCount} selected student${updatedCount === 1 ? '' : 's'}`)
-      setShowGradeSelectedConfirm(false)
+      setInfo(`Applied ${applyTarget} to ${updatedCount} selected student${updatedCount === 1 ? '' : 's'}`)
+      setGradeSelectedConfirmTarget(null)
       batchClearSelection()
 
       if (activeSelectedStudentId && docsByStudentId.has(activeSelectedStudentId)) {
         setGradeSelectedRefreshCounter((count) => count + 1)
       }
     } catch (err: any) {
-      setError(err.message || 'Failed to apply grade')
+      setError(err.message || `Failed to apply ${applyTarget}`)
     } finally {
       setIsGradeSelectedSaving(false)
     }
@@ -1364,9 +1373,12 @@ export function TeacherClassroomView({
   const showOverviewInspector =
     assignmentWorkspaceMode === 'overview' &&
     !!activeSelectedStudentId
-  const highlightedInspectorSections = isApplyGradeOptionHighlighted
-    ? (['grades', 'comments'] as const)
-    : undefined
+  const highlightedInspectorSections =
+    highlightedApplyTarget === 'grade'
+      ? (['grades'] as const)
+      : highlightedApplyTarget === 'comments'
+        ? (['comments'] as const)
+        : undefined
   const canOpenDetails =
     selection.mode === 'assignment' &&
     !selectedAssignmentLoading &&
@@ -1381,7 +1393,7 @@ export function TeacherClassroomView({
       ? 'Nothing returnable selected'
       : `Return${workspaceActionLabelSuffix}`
   const gradeSelectedTemplateIsValid = isGradeSelectedTemplateValid(gradeSelectedTemplate)
-  const isGradeSelectedDisabled =
+  const isApplyGradeSelectedDisabled =
     isGradeSelectedSaving ||
     isAutoGrading ||
     hasActiveAssignmentAiRun ||
@@ -1391,10 +1403,27 @@ export function TeacherClassroomView({
     batchSelectedCount === 0 ||
     !gradeSelectedTemplate ||
     !gradeSelectedTemplateIsValid
+  const isApplyCommentsSelectedDisabled =
+    isGradeSelectedSaving ||
+    isAutoGrading ||
+    hasActiveAssignmentAiRun ||
+    isArtifactRepoAnalyzing ||
+    isReturning ||
+    isReadOnly ||
+    batchSelectedCount === 0 ||
+    !gradeSelectedTemplate
+  const isGradeSelectedConfirmDisabled =
+    gradeSelectedConfirmTarget === 'grade'
+      ? isApplyGradeSelectedDisabled
+      : gradeSelectedConfirmTarget === 'comments'
+        ? isApplyCommentsSelectedDisabled
+        : true
   const showAssignmentAiRunOverlay = isAutoGrading || hasActiveAssignmentAiRun
   const assignmentAiRunOverlayLabel = hasActiveAssignmentAiRun && activeAssignmentAiRun
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
     : `Starting grading for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+  const gradeSelectedSavingLabel =
+    gradeSelectedConfirmTarget === 'comments' ? 'Applying comments' : 'Applying grade'
   const activeWorkMessage = showAssignmentAiRunOverlay
     ? assignmentAiRunOverlayLabel
     : isArtifactRepoAnalyzing
@@ -1402,7 +1431,7 @@ export function TeacherClassroomView({
       : isReturning
         ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
         : isGradeSelectedSaving
-          ? `Applying grade to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+          ? `${gradeSelectedSavingLabel} to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
           : ''
   useOverlayMessage(!!activeWorkMessage, activeWorkMessage, { tone: 'loading' })
 
@@ -1459,12 +1488,27 @@ export function TeacherClassroomView({
                   <span>Apply Grade to Selected Students</span>
                 </span>
               ),
-              onHoverChange: setIsApplyGradeOptionHighlighted,
+              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'grade' : null),
               onSelect: () => {
-                setIsApplyGradeOptionHighlighted(false)
-                setShowGradeSelectedConfirm(true)
+                setHighlightedApplyTarget(null)
+                setGradeSelectedConfirmTarget('grade')
               },
-              disabled: isGradeSelectedDisabled,
+              disabled: isApplyGradeSelectedDisabled,
+            },
+            {
+              id: 'comments-selected',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <MessageSquare className="h-4 w-4" aria-hidden="true" />
+                  <span>Apply Comments to Selected Students</span>
+                </span>
+              ),
+              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'comments' : null),
+              onSelect: () => {
+                setHighlightedApplyTarget(null)
+                setGradeSelectedConfirmTarget('comments')
+              },
+              disabled: isApplyCommentsSelectedDisabled,
             },
             {
               id: 'repo-analysis',
@@ -1781,15 +1825,32 @@ export function TeacherClassroomView({
 
 
       <ConfirmDialog
-        isOpen={showGradeSelectedConfirm}
-        title={`Apply grade to ${batchSelectedCount} selected student(s)?`}
-        description={`This applies the open student's scores and comment draft to the checked student(s), overwriting their saved scores and comment drafts. It will not return comments to students.`}
-        confirmLabel={isGradeSelectedSaving ? 'Applying...' : 'Apply Grade to Selected Students'}
+        isOpen={!!gradeSelectedConfirmTarget}
+        title={
+          gradeSelectedConfirmTarget === 'comments'
+            ? `Apply comments to ${batchSelectedCount} selected student(s)?`
+            : `Apply grade to ${batchSelectedCount} selected student(s)?`
+        }
+        description={
+          gradeSelectedConfirmTarget === 'comments'
+            ? `This applies the open student's comment draft to the checked student(s), overwriting their saved comment drafts. It will not return comments to students.`
+            : `This applies the open student's scores to the checked student(s), overwriting their saved scores. It will not change comment drafts or return comments to students.`
+        }
+        confirmLabel={
+          isGradeSelectedSaving
+            ? 'Applying...'
+            : gradeSelectedConfirmTarget === 'comments'
+              ? 'Apply Comments to Selected Students'
+              : 'Apply Grade to Selected Students'
+        }
         cancelLabel="Cancel"
-        isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedDisabled}
+        isConfirmDisabled={isGradeSelectedSaving || isGradeSelectedConfirmDisabled}
         isCancelDisabled={isGradeSelectedSaving}
-        onCancel={() => (isGradeSelectedSaving ? null : setShowGradeSelectedConfirm(false))}
-        onConfirm={handleGradeSelected}
+        onCancel={() => (isGradeSelectedSaving ? null : setGradeSelectedConfirmTarget(null))}
+        onConfirm={() => {
+          if (!gradeSelectedConfirmTarget) return
+          void handleGradeSelected(gradeSelectedConfirmTarget)
+        }}
       />
 
       <ConfirmDialog

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1781,7 +1781,7 @@ export function TeacherTestsTab({
               setShowClearOpenGradesConfirm(true)
             }}
           >
-            Clear Open Scores/Feedback
+            Clear Open Scores/Comments
           </Button>
         </div>
         <div className="mt-5 flex justify-end gap-2">

--- a/src/components/QuizIndividualResponses.tsx
+++ b/src/components/QuizIndividualResponses.tsx
@@ -339,7 +339,7 @@ export function QuizIndividualResponses({
                           onChange={(event) => updateDraft(answer.response_id, { feedback: event.target.value })}
                           rows={3}
                           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-xs text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-                          placeholder="Feedback (optional)"
+                          placeholder="Comment (optional)"
                         />
                       </div>
                       <div className="flex items-center gap-2">

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -810,10 +810,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         </div>
       </ContentDialog>
 
-      {/* Feedback panel */}
+      {/* Comments panel */}
       {feedbackVisible && (
         <div className="bg-surface rounded-lg shadow-sm border border-border p-4 space-y-3">
-          <h3 className="text-sm font-semibold text-text-default">Feedback</h3>
+          <h3 className="text-sm font-semibold text-text-default">Comments</h3>
           <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
             <div className="space-y-2 text-sm md:pr-4 md:border-r md:border-border">
               {doc?.returned_at && hasCompletionScore && (
@@ -878,7 +878,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 displayedFeedbackEntries.map((entry) => (
                   <div key={entry.id} className="rounded-md border border-border bg-page px-3 py-2">
                     <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-text-muted">
-                      {entry.entry_kind === 'grading_feedback' ? 'Grade Return' : 'Returned Feedback'} . {' '}
+                      {entry.entry_kind === 'grading_feedback' ? 'Grade Return' : 'Returned Comments'} . {' '}
                       {formatInTimeZone(new Date(entry.returned_at), 'America/Toronto', 'MMM d, h:mm a')}
                     </div>
                     <div className="text-sm text-text-default whitespace-pre-wrap">
@@ -888,7 +888,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 ))
               ) : (
                 <div className="text-sm text-text-default whitespace-pre-wrap">
-                  {doc?.feedback?.trim() || 'No feedback provided yet.'}
+                  {doc?.feedback?.trim() || 'No comments provided yet.'}
                 </div>
               )}
             </div>

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -14,6 +14,7 @@ import {
   type AssignmentWorkspacePaneLayout,
 } from '@/lib/assignment-grading-layout'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
+import type { InspectorSectionId } from '@/components/assignment-workspace/types'
 
 interface TeacherStudentWorkPanelProps {
   classroomId: string
@@ -37,6 +38,7 @@ interface TeacherStudentWorkPanelProps {
   inspectorEditMode?: boolean
   onDetailsMetaChange?: (meta: { studentName: string; characterCount: number } | null) => void
   onGradeTemplateChange?: (template: TeacherAssignmentGradeTemplate | null) => void
+  highlightedInspectorSections?: readonly InspectorSectionId[]
 }
 
 export interface TeacherAssignmentGradeTemplate {
@@ -66,6 +68,7 @@ export function TeacherStudentWorkPanel({
   inspectorEditMode = false,
   onDetailsMetaChange,
   onGradeTemplateChange,
+  highlightedInspectorSections = [],
 }: TeacherStudentWorkPanelProps) {
   const {
     data,
@@ -248,6 +251,7 @@ export function TeacherStudentWorkPanel({
       gradeSaving={gradeSaving}
       showDraftAutosavedNotice={showDraftAutosavedNotice}
       repoAnalyzing={repoAnalyzing}
+      highlightedSections={highlightedInspectorSections}
       expandedSections={expandedSections}
       visibleSections={visibleSections}
       editMode={inspectorEditMode}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -19,6 +19,7 @@ interface TeacherStudentWorkPanelProps {
   classroomId: string
   assignmentId: string
   studentId: string
+  refreshKey?: number
   mode?: AssignmentWorkspaceMode
   inspectorCollapsed?: boolean
   inspectorWidth?: number
@@ -35,12 +36,23 @@ interface TeacherStudentWorkPanelProps {
   canGoNextStudent?: boolean
   inspectorEditMode?: boolean
   onDetailsMetaChange?: (meta: { studentName: string; characterCount: number } | null) => void
+  onGradeTemplateChange?: (template: TeacherAssignmentGradeTemplate | null) => void
+}
+
+export interface TeacherAssignmentGradeTemplate {
+  studentId: string
+  scoreCompletion: string
+  scoreThinking: string
+  scoreWorkflow: string
+  feedbackDraft: string
+  gradeMode: 'draft' | 'graded'
 }
 
 export function TeacherStudentWorkPanel({
   classroomId,
   assignmentId,
   studentId,
+  refreshKey = 0,
   mode = 'details',
   inspectorCollapsed = false,
   inspectorWidth = ASSIGNMENT_GRADING_LAYOUT.defaultInspectorWidth,
@@ -53,6 +65,7 @@ export function TeacherStudentWorkPanel({
   canGoNextStudent = false,
   inspectorEditMode = false,
   onDetailsMetaChange,
+  onGradeTemplateChange,
 }: TeacherStudentWorkPanelProps) {
   const {
     data,
@@ -100,6 +113,7 @@ export function TeacherStudentWorkPanel({
     classroomId,
     assignmentId,
     studentId,
+    refreshKey,
     onLoadingStateChange,
   })
   const previousInspectorEditModeRef = useRef(inspectorEditMode)
@@ -152,6 +166,38 @@ export function TeacherStudentWorkPanel({
       characterCount: nextCharacterCount,
     })
   }, [data, error, mode, onDetailsMetaChange, previewContent, showInitialSpinner])
+
+  useEffect(() => {
+    return () => onGradeTemplateChange?.(null)
+  }, [onGradeTemplateChange])
+
+  useEffect(() => {
+    if (mode !== 'overview' || showInitialSpinner || error || !data) {
+      onGradeTemplateChange?.(null)
+      return
+    }
+
+    onGradeTemplateChange?.({
+      studentId,
+      scoreCompletion,
+      scoreThinking,
+      scoreWorkflow,
+      feedbackDraft,
+      gradeMode,
+    })
+  }, [
+    data,
+    error,
+    feedbackDraft,
+    gradeMode,
+    mode,
+    onGradeTemplateChange,
+    scoreCompletion,
+    scoreThinking,
+    scoreWorkflow,
+    showInitialSpinner,
+    studentId,
+  ])
 
   if (showInitialSpinner) {
     return (

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -175,7 +175,7 @@ export function TeacherStudentWorkPanel({
   }, [onGradeTemplateChange])
 
   useEffect(() => {
-    if (mode !== 'overview' || showInitialSpinner || error || !data) {
+    if (mode !== 'overview' || showInitialSpinner || error || !data || data.student.id !== studentId) {
       onGradeTemplateChange?.(null)
       return
     }

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -675,7 +675,7 @@ export function TestStudentGradingPanel({
                       onBlur={flushAutosave}
                       rows={1}
                       className="h-9 w-full overflow-hidden resize-none rounded-md border border-border bg-surface px-3 py-1 text-base leading-tight text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-                      placeholder="Feedback (optional)"
+                      placeholder="Comment (optional)"
                     />
                     <SplitScoreInput
                       ariaLabel={`Q${index + 1} score`}

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -437,7 +437,7 @@ function AutoGrowFeedbackTextarea({
         'min-h-[10rem] w-full overflow-hidden rounded border px-2 py-1 text-sm text-text-default',
         hasFreshAIDraft ? 'border-primary bg-info-bg' : 'border-border bg-surface',
       ].join(' ')}
-      placeholder="Teacher feedback draft"
+      placeholder="Teacher comment draft"
     />
   )
 }
@@ -733,7 +733,7 @@ export function TeacherWorkInspector({
     },
     {
       id: 'comments',
-      title: 'Feedback',
+      title: 'Comments',
       summary: null,
       content: (
         <div className="space-y-3">
@@ -765,7 +765,7 @@ export function TeacherWorkInspector({
                 ) : (
                   <>
                     <Send className="h-3.5 w-3.5" aria-hidden="true" />
-                    <span>Send feedback</span>
+                    <span>Send comment</span>
                   </>
                 )}
               </Button>
@@ -775,7 +775,7 @@ export function TeacherWorkInspector({
           {feedbackEntries.length > 0 ? (
             <div className="space-y-2">
               <div className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                Feedback Sent
+                Comments Sent
               </div>
               <div className="rounded border border-border bg-surface p-3">
                 <div className="space-y-3">

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -177,6 +177,7 @@ function InspectorSection({
   onToggle,
   onVisibleChange,
   action,
+  highlighted = false,
   children,
 }: {
   id: InspectorSectionId
@@ -188,10 +189,12 @@ function InspectorSection({
   onToggle: () => void
   onVisibleChange: () => void
   action?: ReactNode
+  highlighted?: boolean
   children?: ReactNode
 }) {
   const contentId = `assignment-inspector-section-${id}`
   const effectiveExpanded = visible && expanded
+  const isHighlighted = visible && highlighted
   const handleHeaderToggle = () => {
     if (!visible) return
     onToggle()
@@ -200,11 +203,14 @@ function InspectorSection({
   return (
     <section
       data-testid={`inspector-section-${id}`}
+      data-highlighted={isHighlighted ? 'true' : undefined}
       className={[
-        'overflow-hidden rounded-lg border transition-colors',
-        visible
-          ? 'border-border bg-surface'
-          : 'border-dashed border-border bg-surface-2',
+        'overflow-hidden rounded-lg border transition-[border-color,background-color,box-shadow]',
+        isHighlighted
+          ? 'border-primary bg-info-bg shadow-sm ring-1 ring-primary/30'
+          : visible
+            ? 'border-border bg-surface'
+            : 'border-dashed border-border bg-surface-2',
       ].join(' ')}
     >
       <div
@@ -491,6 +497,7 @@ export function TeacherWorkInspector({
   gradeSaving,
   showDraftAutosavedNotice,
   repoAnalyzing,
+  highlightedSections = [],
   expandedSections,
   visibleSections,
   editMode = false,
@@ -530,6 +537,7 @@ export function TeacherWorkInspector({
   gradeSaving: boolean
   showDraftAutosavedNotice: boolean
   repoAnalyzing: boolean
+  highlightedSections?: readonly InspectorSectionId[]
   expandedSections: InspectorSectionId[]
   visibleSections: InspectorSectionId[]
   editMode?: boolean
@@ -814,6 +822,7 @@ export function TeacherWorkInspector({
                   expanded={expandedSections.includes(section.id)}
                   visible={visible}
                   editMode={editMode}
+                  highlighted={highlightedSections.includes(section.id)}
                   summary={section.summary}
                   action={section.action}
                   onToggle={() => onToggleSection(section.id)}

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -763,7 +763,7 @@ export function useTeacherStudentWorkController({
 
     const trimmed = feedbackDraft.trim()
     if (!trimmed) {
-      setGradeError('Feedback draft is required before returning feedback')
+      setGradeError('Comment draft is required before returning comments')
       return
     }
 
@@ -779,7 +779,7 @@ export function useTeacherStudentWorkController({
         }),
       })
       const result = await response.json()
-      if (!response.ok) throw new Error(result.error || 'Failed to return feedback')
+      if (!response.ok) throw new Error(result.error || 'Failed to return comments')
 
       setData((current) =>
         current
@@ -793,7 +793,7 @@ export function useTeacherStudentWorkController({
       populateGradeForm(result.doc)
       dispatchGradeUpdated(result.doc)
     } catch (err: any) {
-      setGradeError(err.message || 'Failed to return feedback')
+      setGradeError(err.message || 'Failed to return comments')
     } finally {
       setFeedbackReturning(false)
     }

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -225,11 +225,13 @@ export function useTeacherStudentWorkController({
   classroomId,
   assignmentId,
   studentId,
+  refreshKey = 0,
   onLoadingStateChange,
 }: {
   classroomId: string
   assignmentId: string
   studentId: string
+  refreshKey?: number
   onLoadingStateChange?: (loading: boolean) => void
 }): TeacherStudentWorkController {
   const studentLoadRequestIdRef = useRef(0)
@@ -478,7 +480,7 @@ export function useTeacherStudentWorkController({
 
   useEffect(() => {
     void loadStudentWork()
-  }, [loadStudentWork])
+  }, [loadStudentWork, refreshKey])
 
   useEffect(() => {
     const requestId = ++historyLoadRequestIdRef.current

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -1,0 +1,193 @@
+import { ApiError, apiErrors } from '@/lib/api-handler'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export type AssignmentGradeSaveMode = 'draft' | 'graded'
+
+export interface ParsedAssignmentGradePayload {
+  score_completion: number | null
+  score_thinking: number | null
+  score_workflow: number | null
+  feedback: string
+  save_mode: AssignmentGradeSaveMode
+  shouldMarkGraded: boolean
+}
+
+interface AssignmentGradeBody {
+  score_completion: unknown
+  score_thinking: unknown
+  score_workflow: unknown
+  feedback: unknown
+  save_mode?: unknown
+}
+
+type SupabaseClient = ReturnType<typeof getServiceRoleClient>
+
+function parseDraftScore(value: unknown): number | null | typeof Number.NaN {
+  if (value === '' || value === null || value === undefined) return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 10) return Number.NaN
+  return parsed
+}
+
+export function normalizeAssignmentGradeStudentIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  return Array.from(
+    new Set(value.filter((studentId): studentId is string => typeof studentId === 'string')),
+  )
+}
+
+export function parseAssignmentGradePayload(body: AssignmentGradeBody): ParsedAssignmentGradePayload {
+  const {
+    score_completion,
+    score_thinking,
+    score_workflow,
+    feedback,
+    save_mode,
+  } = body
+
+  if (typeof feedback !== 'string') {
+    throw apiErrors.badRequest('feedback must be a string')
+  }
+
+  if (save_mode !== undefined && save_mode !== 'draft' && save_mode !== 'graded') {
+    throw apiErrors.badRequest('save_mode must be "draft" or "graded"')
+  }
+
+  const selectedSaveMode: AssignmentGradeSaveMode = save_mode === 'draft' ? 'draft' : 'graded'
+  const shouldMarkGraded = selectedSaveMode === 'graded'
+  const parsedScores = {
+    score_completion: shouldMarkGraded ? Number(score_completion) : parseDraftScore(score_completion),
+    score_thinking: shouldMarkGraded ? Number(score_thinking) : parseDraftScore(score_thinking),
+    score_workflow: shouldMarkGraded ? Number(score_workflow) : parseDraftScore(score_workflow),
+  }
+
+  for (const [name, value] of Object.entries(parsedScores)) {
+    if (shouldMarkGraded) {
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
+        throw apiErrors.badRequest(`${name} must be an integer 0–10`)
+      }
+      continue
+    }
+
+    if (Number.isNaN(value)) {
+      throw apiErrors.badRequest(`${name} must be blank or an integer 0–10`)
+    }
+  }
+
+  return {
+    ...parsedScores,
+    feedback,
+    save_mode: selectedSaveMode,
+    shouldMarkGraded,
+  }
+}
+
+export async function loadTeacherOwnedAssignmentForGrade(opts: {
+  supabase: SupabaseClient
+  assignmentId: string
+  teacherId: string
+}) {
+  const { supabase, assignmentId, teacherId } = opts
+  const { data: assignment, error: assignmentError } = await supabase
+    .from('assignments')
+    .select(`
+      *,
+      classrooms!inner (
+        teacher_id
+      )
+    `)
+    .eq('id', assignmentId)
+    .single()
+
+  if (assignmentError || !assignment) {
+    throw apiErrors.notFound('Assignment not found')
+  }
+
+  if (assignment.classrooms.teacher_id !== teacherId) {
+    throw new ApiError(403, 'Unauthorized')
+  }
+
+  return assignment
+}
+
+export async function assertStudentsEnrolledForAssignmentGrade(opts: {
+  supabase: SupabaseClient
+  classroomId: string
+  studentIds: string[]
+}) {
+  const { supabase, classroomId, studentIds } = opts
+
+  if (studentIds.length === 1) {
+    const { data: enrollment, error } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', classroomId)
+      .eq('student_id', studentIds[0])
+      .maybeSingle()
+
+    if (error) {
+      throw new Error('Failed to validate student enrollment')
+    }
+    if (!enrollment) {
+      throw apiErrors.badRequest('Student is not enrolled in this classroom')
+    }
+    return
+  }
+
+  const { data: enrollments, error } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', classroomId)
+    .in('student_id', studentIds)
+
+  if (error) {
+    throw new Error('Failed to validate student enrollment')
+  }
+
+  if (((enrollments as Array<{ student_id: string }> | null) ?? []).length !== studentIds.length) {
+    throw apiErrors.badRequest('Student is not enrolled in this classroom')
+  }
+}
+
+export function buildAssignmentGradeRows(opts: {
+  assignmentId: string
+  studentIds: string[]
+  grade: ParsedAssignmentGradePayload
+  now: string
+}) {
+  const { assignmentId, studentIds, grade, now } = opts
+
+  return studentIds.map((studentId) => ({
+    assignment_id: assignmentId,
+    student_id: studentId,
+    score_completion: grade.score_completion,
+    score_thinking: grade.score_thinking,
+    score_workflow: grade.score_workflow,
+    teacher_feedback_draft: grade.feedback,
+    teacher_feedback_draft_updated_at: now,
+    graded_at: grade.shouldMarkGraded ? now : null,
+    graded_by: grade.shouldMarkGraded ? 'teacher' : null,
+  }))
+}
+
+export async function upsertAssignmentGradeRows(opts: {
+  supabase: SupabaseClient
+  assignmentId: string
+  studentIds: string[]
+  grade: ParsedAssignmentGradePayload
+}) {
+  const { supabase, assignmentId, studentIds, grade } = opts
+  const now = new Date().toISOString()
+  const rows = buildAssignmentGradeRows({
+    assignmentId,
+    studentIds,
+    grade,
+    now,
+  })
+
+  return supabase
+    .from('assignment_docs')
+    .upsert(rows, { onConflict: 'assignment_id,student_id' })
+    .select()
+}

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -2,6 +2,7 @@ import { ApiError, apiErrors } from '@/lib/api-handler'
 import { getServiceRoleClient } from '@/lib/supabase'
 
 export type AssignmentGradeSaveMode = 'draft' | 'graded'
+export type AssignmentGradeApplyTarget = 'grade' | 'comments' | 'grade-and-comments'
 
 export interface ParsedAssignmentGradePayload {
   score_completion: number | null
@@ -10,6 +11,7 @@ export interface ParsedAssignmentGradePayload {
   feedback: string
   save_mode: AssignmentGradeSaveMode
   shouldMarkGraded: boolean
+  apply_target: AssignmentGradeApplyTarget
 }
 
 interface AssignmentGradeBody {
@@ -18,6 +20,7 @@ interface AssignmentGradeBody {
   score_workflow: unknown
   feedback: unknown
   save_mode?: unknown
+  apply_target?: unknown
 }
 
 type SupabaseClient = ReturnType<typeof getServiceRoleClient>
@@ -37,6 +40,12 @@ export function normalizeAssignmentGradeStudentIds(value: unknown): string[] {
   )
 }
 
+function parseAssignmentGradeApplyTarget(value: unknown): AssignmentGradeApplyTarget {
+  if (value === undefined) return 'grade-and-comments'
+  if (value === 'grade' || value === 'comments' || value === 'grade-and-comments') return value
+  throw apiErrors.badRequest('apply_target must be "grade", "comments", or "grade-and-comments"')
+}
+
 export function parseAssignmentGradePayload(body: AssignmentGradeBody): ParsedAssignmentGradePayload {
   const {
     score_completion,
@@ -44,10 +53,18 @@ export function parseAssignmentGradePayload(body: AssignmentGradeBody): ParsedAs
     score_workflow,
     feedback,
     save_mode,
+    apply_target,
   } = body
+  const selectedApplyTarget = parseAssignmentGradeApplyTarget(apply_target)
+  const shouldApplyGrade = selectedApplyTarget === 'grade' || selectedApplyTarget === 'grade-and-comments'
+  const shouldApplyComments = selectedApplyTarget === 'comments' || selectedApplyTarget === 'grade-and-comments'
 
-  if (typeof feedback !== 'string') {
-    throw apiErrors.badRequest('feedback must be a string')
+  let parsedFeedback = ''
+  if (shouldApplyComments) {
+    if (typeof feedback !== 'string') {
+      throw apiErrors.badRequest('feedback must be a string')
+    }
+    parsedFeedback = feedback
   }
 
   if (save_mode !== undefined && save_mode !== 'draft' && save_mode !== 'graded') {
@@ -56,30 +73,34 @@ export function parseAssignmentGradePayload(body: AssignmentGradeBody): ParsedAs
 
   const selectedSaveMode: AssignmentGradeSaveMode = save_mode === 'draft' ? 'draft' : 'graded'
   const shouldMarkGraded = selectedSaveMode === 'graded'
+  const parseScore = (value: unknown) => shouldMarkGraded ? Number(value) : parseDraftScore(value)
   const parsedScores = {
-    score_completion: shouldMarkGraded ? Number(score_completion) : parseDraftScore(score_completion),
-    score_thinking: shouldMarkGraded ? Number(score_thinking) : parseDraftScore(score_thinking),
-    score_workflow: shouldMarkGraded ? Number(score_workflow) : parseDraftScore(score_workflow),
+    score_completion: shouldApplyGrade ? parseScore(score_completion) : null,
+    score_thinking: shouldApplyGrade ? parseScore(score_thinking) : null,
+    score_workflow: shouldApplyGrade ? parseScore(score_workflow) : null,
   }
 
-  for (const [name, value] of Object.entries(parsedScores)) {
-    if (shouldMarkGraded) {
-      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
-        throw apiErrors.badRequest(`${name} must be an integer 0–10`)
+  if (shouldApplyGrade) {
+    for (const [name, value] of Object.entries(parsedScores)) {
+      if (shouldMarkGraded) {
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
+          throw apiErrors.badRequest(`${name} must be an integer 0–10`)
+        }
+        continue
       }
-      continue
-    }
 
-    if (Number.isNaN(value)) {
-      throw apiErrors.badRequest(`${name} must be blank or an integer 0–10`)
+      if (Number.isNaN(value)) {
+        throw apiErrors.badRequest(`${name} must be blank or an integer 0–10`)
+      }
     }
   }
 
   return {
     ...parsedScores,
-    feedback,
+    feedback: parsedFeedback,
     save_mode: selectedSaveMode,
     shouldMarkGraded,
+    apply_target: selectedApplyTarget,
   }
 }
 
@@ -158,17 +179,30 @@ export function buildAssignmentGradeRows(opts: {
 }) {
   const { assignmentId, studentIds, grade, now } = opts
 
-  return studentIds.map((studentId) => ({
-    assignment_id: assignmentId,
-    student_id: studentId,
-    score_completion: grade.score_completion,
-    score_thinking: grade.score_thinking,
-    score_workflow: grade.score_workflow,
-    teacher_feedback_draft: grade.feedback,
-    teacher_feedback_draft_updated_at: now,
-    graded_at: grade.shouldMarkGraded ? now : null,
-    graded_by: grade.shouldMarkGraded ? 'teacher' : null,
-  }))
+  const shouldApplyGrade = grade.apply_target === 'grade' || grade.apply_target === 'grade-and-comments'
+  const shouldApplyComments = grade.apply_target === 'comments' || grade.apply_target === 'grade-and-comments'
+
+  return studentIds.map((studentId) => {
+    const row: Record<string, string | number | null> = {
+      assignment_id: assignmentId,
+      student_id: studentId,
+    }
+
+    if (shouldApplyGrade) {
+      row.score_completion = grade.score_completion
+      row.score_thinking = grade.score_thinking
+      row.score_workflow = grade.score_workflow
+      row.graded_at = grade.shouldMarkGraded ? now : null
+      row.graded_by = grade.shouldMarkGraded ? 'teacher' : null
+    }
+
+    if (shouldApplyComments) {
+      row.teacher_feedback_draft = grade.feedback
+      row.teacher_feedback_draft_updated_at = now
+    }
+
+    return row
+  })
 }
 
 export async function upsertAssignmentGradeRows(opts: {

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown } from 'lucide-react'
 import {
+  useCallback,
   useEffect,
   useId,
   useRef,
@@ -17,6 +18,7 @@ export interface SplitButtonOption {
   label: ReactNode
   onSelect: () => void
   disabled?: boolean
+  onHoverChange?: (hovered: boolean) => void
 }
 
 export interface SplitButtonProps {
@@ -49,19 +51,28 @@ export function SplitButton({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const menuId = useId()
 
+  const clearOptionHover = useCallback(() => {
+    options.forEach((option) => option.onHoverChange?.(false))
+  }, [options])
+
+  const closeMenu = useCallback(() => {
+    clearOptionHover()
+    setIsOpen(false)
+  }, [clearOptionHover])
+
   useEffect(() => {
     if (!isOpen) return
 
     function handleClickOutside(event: MouseEvent) {
       if (!containerRef.current) return
       if (!containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
+        closeMenu()
       }
     }
 
     function handleEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        setIsOpen(false)
+        closeMenu()
       }
     }
 
@@ -71,10 +82,10 @@ export function SplitButton({
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleEscape)
     }
-  }, [isOpen])
+  }, [closeMenu, isOpen])
 
   function handleOptionSelect(onSelect: () => void) {
-    setIsOpen(false)
+    closeMenu()
     onSelect()
   }
 
@@ -101,7 +112,10 @@ export function SplitButton({
         aria-label={toggleAriaLabel}
         onClick={(event) => {
           event.stopPropagation()
-          setIsOpen((prev) => !prev)
+          setIsOpen((prev) => {
+            if (prev) clearOptionHover()
+            return !prev
+          })
         }}
         disabled={disabled || options.length === 0}
         className="rounded-l-none border-l border-black/15 px-3"
@@ -125,6 +139,10 @@ export function SplitButton({
               type="button"
               role="menuitem"
               disabled={option.disabled}
+              onMouseEnter={() => option.onHoverChange?.(true)}
+              onMouseLeave={() => option.onHoverChange?.(false)}
+              onFocus={() => option.onHoverChange?.(true)}
+              onBlur={() => option.onHoverChange?.(false)}
               onClick={(event) => {
                 event.stopPropagation()
                 handleOptionSelect(option.onSelect)

--- a/tests/api/teacher/assignments-grade-selected.test.ts
+++ b/tests/api/teacher/assignments-grade-selected.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/assignments/[id]/grade-selected/route'
+
+vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
+vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
+
+const mockSupabaseClient = { from: vi.fn() }
+
+function buildAssignmentTable() {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: 'assignment-1',
+            classroom_id: 'classroom-1',
+            classrooms: { teacher_id: 'teacher-1' },
+          },
+          error: null,
+        }),
+      })),
+    })),
+  }
+}
+
+function buildEnrollmentsTable(studentIds: string[]) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn().mockResolvedValue({
+          data: studentIds.map((student_id) => ({ student_id })),
+          error: null,
+        }),
+      })),
+    })),
+  }
+}
+
+function buildAssignmentDocsTable(capturedRows: Array<Record<string, unknown>[]>) {
+  return {
+    upsert: vi.fn((rows: Array<Record<string, unknown>>) => {
+      capturedRows.push(rows)
+      return {
+        select: vi.fn().mockResolvedValue({
+          data: rows.map((row, index) => ({
+            id: `doc-${index + 1}`,
+            ...row,
+            updated_at: '2026-04-12T12:00:00Z',
+          })),
+          error: null,
+        }),
+      }
+    }),
+  }
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade-selected', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 400 when student_ids is missing', async () => {
+    const response = await POST(makeRequest({
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      feedback: 'Shared feedback',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('student_ids array is required')
+  })
+
+  it('returns 400 when more than 100 unique students are selected', async () => {
+    const response = await POST(makeRequest({
+      student_ids: Array.from({ length: 101 }, (_, index) => `student-${index}`),
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      feedback: 'Shared feedback',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('Cannot grade more than 100 students at once')
+  })
+
+  it('returns 400 for invalid final scores', async () => {
+    const response = await POST(makeRequest({
+      student_ids: ['student-1'],
+      score_completion: 11,
+      score_thinking: 8,
+      score_workflow: 9,
+      feedback: 'Shared feedback',
+      save_mode: 'graded',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('score_completion must be an integer 0–10')
+  })
+
+  it('rejects selected students outside the assignment classroom', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return buildAssignmentTable()
+      if (table === 'classroom_enrollments') return buildEnrollmentsTable(['student-1'])
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const response = await POST(makeRequest({
+      student_ids: ['student-1', 'student-2'],
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      feedback: 'Shared feedback',
+      save_mode: 'graded',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('Student is not enrolled in this classroom')
+  })
+
+  it('upserts the same final grade for unique selected students without returning feedback', async () => {
+    const capturedRows: Array<Record<string, unknown>[]> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return buildAssignmentTable()
+      if (table === 'classroom_enrollments') return buildEnrollmentsTable(['student-1', 'student-2'])
+      if (table === 'assignment_docs') return buildAssignmentDocsTable(capturedRows)
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const response = await POST(makeRequest({
+      student_ids: ['student-1', 'student-2', 'student-1'],
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      feedback: 'Shared feedback',
+      save_mode: 'graded',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.updated_count).toBe(2)
+    expect(body.updated_student_ids).toEqual(['student-1', 'student-2'])
+    expect(capturedRows[0]).toHaveLength(2)
+    expect(capturedRows[0][0]).toEqual(expect.objectContaining({
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      teacher_feedback_draft: 'Shared feedback',
+      teacher_feedback_draft_updated_at: expect.any(String),
+      graded_at: expect.any(String),
+      graded_by: 'teacher',
+    }))
+    expect(capturedRows[0][0]).not.toHaveProperty('feedback')
+    expect(capturedRows[0][0]).not.toHaveProperty('feedback_returned_at')
+    expect(capturedRows[0][0]).not.toHaveProperty('returned_at')
+  })
+
+  it('allows draft batch grades with blank scores and does not mark graded', async () => {
+    const capturedRows: Array<Record<string, unknown>[]> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return buildAssignmentTable()
+      if (table === 'classroom_enrollments') return buildEnrollmentsTable(['student-1', 'student-2'])
+      if (table === 'assignment_docs') return buildAssignmentDocsTable(capturedRows)
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const response = await POST(makeRequest({
+      student_ids: ['student-1', 'student-2'],
+      score_completion: '',
+      score_thinking: 8,
+      score_workflow: null,
+      feedback: 'Draft feedback',
+      save_mode: 'draft',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(capturedRows[0][0]).toEqual(expect.objectContaining({
+      score_completion: null,
+      score_thinking: 8,
+      score_workflow: null,
+      teacher_feedback_draft: 'Draft feedback',
+      graded_at: null,
+      graded_by: null,
+    }))
+  })
+})

--- a/tests/api/teacher/assignments-grade-selected.test.ts
+++ b/tests/api/teacher/assignments-grade-selected.test.ts
@@ -170,6 +170,69 @@ describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
     expect(capturedRows[0][0]).not.toHaveProperty('returned_at')
   })
 
+  it('applies only scores when apply_target is grade', async () => {
+    const capturedRows: Array<Record<string, unknown>[]> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return buildAssignmentTable()
+      if (table === 'classroom_enrollments') return buildEnrollmentsTable(['student-1', 'student-2'])
+      if (table === 'assignment_docs') return buildAssignmentDocsTable(capturedRows)
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const response = await POST(makeRequest({
+      student_ids: ['student-1', 'student-2'],
+      apply_target: 'grade',
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      save_mode: 'graded',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(capturedRows[0][0]).toEqual(expect.objectContaining({
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      score_completion: 7,
+      score_thinking: 8,
+      score_workflow: 9,
+      graded_at: expect.any(String),
+      graded_by: 'teacher',
+    }))
+    expect(capturedRows[0][0]).not.toHaveProperty('teacher_feedback_draft')
+    expect(capturedRows[0][0]).not.toHaveProperty('teacher_feedback_draft_updated_at')
+  })
+
+  it('applies only comments when apply_target is comments', async () => {
+    const capturedRows: Array<Record<string, unknown>[]> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return buildAssignmentTable()
+      if (table === 'classroom_enrollments') return buildEnrollmentsTable(['student-1', 'student-2'])
+      if (table === 'assignment_docs') return buildAssignmentDocsTable(capturedRows)
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const response = await POST(makeRequest({
+      student_ids: ['student-1', 'student-2'],
+      apply_target: 'comments',
+      feedback: 'Shared comments',
+    }), { params: Promise.resolve({ id: 'assignment-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(capturedRows[0][0]).toEqual(expect.objectContaining({
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      teacher_feedback_draft: 'Shared comments',
+      teacher_feedback_draft_updated_at: expect.any(String),
+    }))
+    expect(capturedRows[0][0]).not.toHaveProperty('score_completion')
+    expect(capturedRows[0][0]).not.toHaveProperty('score_thinking')
+    expect(capturedRows[0][0]).not.toHaveProperty('score_workflow')
+    expect(capturedRows[0][0]).not.toHaveProperty('graded_at')
+    expect(capturedRows[0][0]).not.toHaveProperty('graded_by')
+  })
+
   it('allows draft batch grades with blank scores and does not mark graded', async () => {
     const capturedRows: Array<Record<string, unknown>[]> = []
 

--- a/tests/api/teacher/assignments-id-grade.test.ts
+++ b/tests/api/teacher/assignments-id-grade.test.ts
@@ -46,9 +46,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
       if (table === 'assignment_docs') {
         return {
           upsert: vi.fn(() => ({
-            select: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: {
+            select: vi.fn().mockResolvedValue({
+              data: [
+                {
                   id: 'doc-1',
                   assignment_id: 'assignment-1',
                   student_id: 'student-1',
@@ -56,9 +56,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
                   score_thinking: 0,
                   score_workflow: 0,
                 },
-                error: null,
-              }),
-            })),
+              ],
+              error: null,
+            }),
           })),
         }
       }
@@ -174,12 +174,12 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
 
       if (table === 'assignment_docs') {
         return {
-          upsert: vi.fn((payload: Record<string, unknown>) => {
-            capturedUpsertPayload = payload
+          upsert: vi.fn((payload: Record<string, unknown> | Array<Record<string, unknown>>) => {
+            capturedUpsertPayload = Array.isArray(payload) ? payload[0] : payload
             return {
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: {
+              select: vi.fn().mockResolvedValue({
+                data: [
+                  {
                     id: 'doc-1',
                     assignment_id: 'assignment-1',
                     student_id: 'student-1',
@@ -190,9 +190,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
                     graded_at: null,
                     graded_by: null,
                   },
-                  error: null,
-                }),
-              })),
+                ],
+                error: null,
+              }),
             }
           }),
         }
@@ -259,12 +259,12 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
 
       if (table === 'assignment_docs') {
         return {
-          upsert: vi.fn((payload: Record<string, unknown>) => {
-            capturedUpsertPayload = payload
+          upsert: vi.fn((payload: Record<string, unknown> | Array<Record<string, unknown>>) => {
+            capturedUpsertPayload = Array.isArray(payload) ? payload[0] : payload
             return {
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: {
+              select: vi.fn().mockResolvedValue({
+                data: [
+                  {
                     id: 'doc-1',
                     assignment_id: 'assignment-1',
                     student_id: 'student-1',
@@ -275,9 +275,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
                     graded_at: null,
                     graded_by: null,
                   },
-                  error: null,
-                }),
-              })),
+                ],
+                error: null,
+              }),
             }
           }),
         }

--- a/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
+++ b/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
@@ -105,7 +105,7 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     })
   }
 
-  it('shows returned feedback card for feedback-only (no scores)', async () => {
+  it('shows returned comments card for comments-only (no scores)', async () => {
     mockLoadResponses(
       makeDoc({
         feedback: 'Teacher comment only.',
@@ -119,7 +119,7 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Feedback')).toBeInTheDocument()
+      expect(screen.getByText('Comments')).toBeInTheDocument()
     })
     expect(screen.getByText('Teacher comment only.')).toBeInTheDocument()
     expect(screen.getByText('Grades will appear after your teacher returns them.')).toBeInTheDocument()
@@ -139,13 +139,13 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Feedback')).toBeInTheDocument()
+      expect(screen.getByText('Comments')).toBeInTheDocument()
     })
     expect(screen.getByText('Completion')).toBeInTheDocument()
     expect(screen.queryByText('Thinking')).not.toBeInTheDocument()
     expect(screen.queryByText('Workflow')).not.toBeInTheDocument()
     expect(screen.queryByText('Total')).not.toBeInTheDocument()
-    expect(screen.getByText('No feedback provided yet.')).toBeInTheDocument()
+    expect(screen.getByText('No comments provided yet.')).toBeInTheDocument()
   })
 
   it('shows full score set and total percent when all scores exist', async () => {
@@ -161,7 +161,7 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Feedback')).toBeInTheDocument()
+      expect(screen.getByText('Comments')).toBeInTheDocument()
     })
     expect(screen.getByText('Completion')).toBeInTheDocument()
     expect(screen.getByText('Thinking')).toBeInTheDocument()

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -956,7 +956,12 @@ describe('TeacherClassroomView', () => {
       save_mode: 'graded',
     })
     expect(mockClearSelection).toHaveBeenCalled()
-    expect(await screen.findByText('Applied grade to 2 selected students')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(mockShowMessage).toHaveBeenCalledWith({
+        text: 'Applied grade to 2 selected students',
+        tone: 'info',
+      })
+    })
   })
 
   it('highlights grade and feedback cards while hovering Apply Grade to Selected Students', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -936,8 +936,7 @@ describe('TeacherClassroomView', () => {
 
     fireEvent.click(gradeSelectedOption)
     expect(screen.getByText('Apply grade to 2 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText(/applies the open student's scores to the checked student/)).toBeInTheDocument()
-    expect(screen.getByText(/It will not change comment drafts or return comments to students/)).toBeInTheDocument()
+    expect(screen.getByText("The current student's grading will be applied to the selected students.")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
@@ -1038,7 +1037,7 @@ describe('TeacherClassroomView', () => {
 
     fireEvent.click(commentsSelectedOption)
     expect(screen.getByText('Apply comments to 2 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText(/applies the open student's comment draft/)).toBeInTheDocument()
+    expect(screen.getByText("The current student's comments will be applied to the selected students.")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -939,8 +939,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByText(/applies the open student's scores to the checked student/)).toBeInTheDocument()
     expect(screen.getByText(/It will not change comment drafts or return comments to students/)).toBeInTheDocument()
 
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
-    fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
     await waitFor(() => {
       expect(gradeSelectedBodies).toHaveLength(1)
@@ -1041,8 +1040,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByText('Apply comments to 2 selected student(s)?')).toBeInTheDocument()
     expect(screen.getByText(/applies the open student's comment draft/)).toBeInTheDocument()
 
-    const commentsSelectedButtons = screen.getAllByRole('button', { name: 'Apply Comments to Selected Students' })
-    fireEvent.click(commentsSelectedButtons[commentsSelectedButtons.length - 1])
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
     await waitFor(() => {
       expect(gradeSelectedBodies).toHaveLength(1)
@@ -1155,8 +1153,7 @@ describe('TeacherClassroomView', () => {
 
     mockClearSelection.mockClear()
     fireEvent.click(screen.getByRole('button', { name: 'Apply Grade to Selected Students' }))
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
-    fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
 
     expect(await screen.findByText('Batch save failed')).toBeInTheDocument()
     expect(mockClearSelection).not.toHaveBeenCalled()

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -918,17 +918,17 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
     })
 
-    const gradeSelectedOption = screen.getByRole('button', { name: 'Copy Grade' })
+    const gradeSelectedOption = screen.getByRole('button', { name: 'Apply Grade' })
     await waitFor(() => {
       expect(gradeSelectedOption).not.toBeDisabled()
     })
 
     fireEvent.click(gradeSelectedOption)
-    expect(screen.getByText('Copy grade to 2 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText(/copies the open student's scores and feedback draft/)).toBeInTheDocument()
+    expect(screen.getByText('Apply grade to 2 selected student(s)?')).toBeInTheDocument()
+    expect(screen.getByText(/applies the open student's scores and feedback draft/)).toBeInTheDocument()
     expect(screen.getByText(/It will not return feedback to students/)).toBeInTheDocument()
 
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Copy Grade' })
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
 
     await waitFor(() => {
@@ -944,10 +944,10 @@ describe('TeacherClassroomView', () => {
       save_mode: 'graded',
     })
     expect(mockClearSelection).toHaveBeenCalled()
-    expect(await screen.findByText('Copied grade to 2 selected students')).toBeInTheDocument()
+    expect(await screen.findByText('Applied grade to 2 selected students')).toBeInTheDocument()
   })
 
-  it('keeps checked students selected when Copy Grade fails', async () => {
+  it('keeps checked students selected when Apply Grade fails', async () => {
     mockStudentSelectionState.selectedIds = new Set(['student-1'])
     mockStudentSelectionState.selectedCount = 1
 
@@ -983,8 +983,8 @@ describe('TeacherClassroomView', () => {
     })
 
     mockClearSelection.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'Copy Grade' }))
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Copy Grade' })
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Grade' }))
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
 
     expect(await screen.findByText('Batch save failed')).toBeInTheDocument()

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -907,7 +907,6 @@ describe('TeacherClassroomView', () => {
               score_completion: 7,
               score_thinking: 8,
               score_workflow: 9,
-              teacher_feedback_draft: 'Use this feedback for the selected students.',
               graded_at: '2026-04-12T12:00:00Z',
               graded_by: 'teacher',
               updated_at: '2026-04-12T12:00:00Z',
@@ -937,8 +936,8 @@ describe('TeacherClassroomView', () => {
 
     fireEvent.click(gradeSelectedOption)
     expect(screen.getByText('Apply grade to 2 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText(/applies the open student's scores and comment draft/)).toBeInTheDocument()
-    expect(screen.getByText(/It will not return comments to students/)).toBeInTheDocument()
+    expect(screen.getByText(/applies the open student's scores to the checked student/)).toBeInTheDocument()
+    expect(screen.getByText(/It will not change comment drafts or return comments to students/)).toBeInTheDocument()
 
     const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
@@ -949,10 +948,10 @@ describe('TeacherClassroomView', () => {
 
     expect(gradeSelectedBodies[0]).toEqual({
       student_ids: ['student-1', 'student-2'],
+      apply_target: 'grade',
       score_completion: '7',
       score_thinking: '8',
       score_workflow: '9',
-      feedback: 'Use this feedback for the selected students.',
       save_mode: 'graded',
     })
     expect(mockClearSelection).toHaveBeenCalled()
@@ -964,7 +963,106 @@ describe('TeacherClassroomView', () => {
     })
   })
 
-  it('highlights grade and comments cards while hovering Apply Grade to Selected Students', async () => {
+  it('copies the active inspector comments to checked students after confirmation', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
+    mockStudentSelectionState.selectedCount = 2
+
+    const gradeSelectedBodies: Array<Record<string, unknown>> = []
+    const details = makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1')
+    details.students.push({
+      student_id: 'student-2',
+      student_email: 'student-2@example.com',
+      student_first_name: 'student-2',
+      student_last_name: 'Student',
+      status: 'submitted_on_time',
+      student_updated_at: '2026-04-10T12:00:00Z',
+      artifacts: [],
+      doc: {
+        submitted_at: '2026-04-10T12:00:00Z',
+        updated_at: '2026-04-10T12:00:00Z',
+        score_completion: null,
+        score_thinking: null,
+        score_workflow: null,
+        graded_at: null,
+        returned_at: null,
+        feedback_returned_at: null,
+      },
+    })
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => details,
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/grade-selected') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        gradeSelectedBodies.push(body)
+        const studentIds = body.student_ids as string[]
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            updated_count: studentIds.length,
+            updated_student_ids: studentIds,
+            docs: studentIds.map((studentId) => ({
+              student_id: studentId,
+              teacher_feedback_draft: 'Use this feedback for the selected students.',
+              teacher_feedback_draft_updated_at: '2026-04-12T12:00:00Z',
+              updated_at: '2026-04-12T12:00:00Z',
+            })),
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    const commentsSelectedOption = screen.getByRole('button', { name: 'Apply Comments to Selected Students' })
+    await waitFor(() => {
+      expect(commentsSelectedOption).not.toBeDisabled()
+    })
+
+    fireEvent.click(commentsSelectedOption)
+    expect(screen.getByText('Apply comments to 2 selected student(s)?')).toBeInTheDocument()
+    expect(screen.getByText(/applies the open student's comment draft/)).toBeInTheDocument()
+
+    const commentsSelectedButtons = screen.getAllByRole('button', { name: 'Apply Comments to Selected Students' })
+    fireEvent.click(commentsSelectedButtons[commentsSelectedButtons.length - 1])
+
+    await waitFor(() => {
+      expect(gradeSelectedBodies).toHaveLength(1)
+    })
+
+    expect(gradeSelectedBodies[0]).toEqual({
+      student_ids: ['student-1', 'student-2'],
+      apply_target: 'comments',
+      feedback: 'Use this feedback for the selected students.',
+    })
+    expect(mockClearSelection).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockShowMessage).toHaveBeenCalledWith({
+        text: 'Applied comments to 2 selected students',
+        tone: 'info',
+      })
+    })
+  })
+
+  it('highlights the matching inspector card while hovering apply menu actions', async () => {
     mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
     mockStudentSelectionState.selectedCount = 2
 
@@ -1001,14 +1099,22 @@ describe('TeacherClassroomView', () => {
 
     const workPanel = await screen.findByTestId('teacher-work-panel')
     const applyGradeOption = screen.getByRole('button', { name: 'Apply Grade to Selected Students' })
+    const applyCommentsOption = screen.getByRole('button', { name: 'Apply Comments to Selected Students' })
     await waitFor(() => {
       expect(applyGradeOption).not.toBeDisabled()
+      expect(applyCommentsOption).not.toBeDisabled()
     })
 
     fireEvent.mouseEnter(applyGradeOption)
-    expect(workPanel).toHaveAttribute('data-highlighted-sections', 'grades,comments')
+    expect(workPanel).toHaveAttribute('data-highlighted-sections', 'grades')
 
     fireEvent.mouseLeave(applyGradeOption)
+    expect(workPanel).toHaveAttribute('data-highlighted-sections', '')
+
+    fireEvent.mouseEnter(applyCommentsOption)
+    expect(workPanel).toHaveAttribute('data-highlighted-sections', 'comments')
+
+    fireEvent.mouseLeave(applyCommentsOption)
     expect(workPanel).toHaveAttribute('data-highlighted-sections', '')
   })
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -126,14 +126,35 @@ vi.mock('@/components/AssignmentArtifactsCell', () => ({
 }))
 
 vi.mock('@/components/TeacherStudentWorkPanel', () => ({
-  TeacherStudentWorkPanel: ({ assignmentId, studentId, mode, onDetailsMetaChange }: any) => {
+  TeacherStudentWorkPanel: ({
+    assignmentId,
+    studentId,
+    mode,
+    onDetailsMetaChange,
+    onGradeTemplateChange,
+  }: any) => {
     useEffect(() => {
       onDetailsMetaChange?.(
         mode === 'details'
-          ? { studentName: `${studentId} Student`, characterCount: 17 }
-          : null,
+        ? { studentName: `${studentId} Student`, characterCount: 17 }
+        : null,
       )
     }, [mode, onDetailsMetaChange, studentId])
+
+    useEffect(() => {
+      onGradeTemplateChange?.(
+        mode === 'overview'
+          ? {
+              studentId,
+              scoreCompletion: '7',
+              scoreThinking: '8',
+              scoreWorkflow: '9',
+              feedbackDraft: 'Use this feedback for the selected students.',
+              gradeMode: 'graded',
+            }
+          : null,
+      )
+    }, [mode, onGradeTemplateChange, studentId])
 
     return <div data-testid="teacher-work-panel">{`${mode}:${assignmentId}:${studentId}`}</div>
   },
@@ -822,6 +843,152 @@ describe('TeacherClassroomView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
 
     expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
+  })
+
+  it('copies the active inspector grade to checked students after confirmation', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
+    mockStudentSelectionState.selectedCount = 2
+
+    const gradeSelectedBodies: Array<Record<string, unknown>> = []
+    const details = makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1')
+    details.students.push({
+      student_id: 'student-2',
+      student_email: 'student-2@example.com',
+      student_first_name: 'student-2',
+      student_last_name: 'Student',
+      status: 'submitted_on_time',
+      student_updated_at: '2026-04-10T12:00:00Z',
+      artifacts: [],
+      doc: {
+        submitted_at: '2026-04-10T12:00:00Z',
+        updated_at: '2026-04-10T12:00:00Z',
+        score_completion: null,
+        score_thinking: null,
+        score_workflow: null,
+        graded_at: null,
+        returned_at: null,
+        feedback_returned_at: null,
+      },
+    })
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => details,
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/grade-selected') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        gradeSelectedBodies.push(body)
+        const studentIds = body.student_ids as string[]
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            updated_count: studentIds.length,
+            updated_student_ids: studentIds,
+            docs: studentIds.map((studentId) => ({
+              student_id: studentId,
+              score_completion: 7,
+              score_thinking: 8,
+              score_workflow: 9,
+              teacher_feedback_draft: 'Use this feedback for the selected students.',
+              graded_at: '2026-04-12T12:00:00Z',
+              graded_by: 'teacher',
+              updated_at: '2026-04-12T12:00:00Z',
+            })),
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    const gradeSelectedOption = screen.getByRole('button', { name: 'Copy Grade' })
+    await waitFor(() => {
+      expect(gradeSelectedOption).not.toBeDisabled()
+    })
+
+    fireEvent.click(gradeSelectedOption)
+    expect(screen.getByText('Copy grade to 2 selected student(s)?')).toBeInTheDocument()
+    expect(screen.getByText(/copies the open student's scores and feedback draft/)).toBeInTheDocument()
+    expect(screen.getByText(/It will not return feedback to students/)).toBeInTheDocument()
+
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Copy Grade' })
+    fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
+
+    await waitFor(() => {
+      expect(gradeSelectedBodies).toHaveLength(1)
+    })
+
+    expect(gradeSelectedBodies[0]).toEqual({
+      student_ids: ['student-1', 'student-2'],
+      score_completion: '7',
+      score_thinking: '8',
+      score_workflow: '9',
+      feedback: 'Use this feedback for the selected students.',
+      save_mode: 'graded',
+    })
+    expect(mockClearSelection).toHaveBeenCalled()
+    expect(await screen.findByText('Copied grade to 2 selected students')).toBeInTheDocument()
+  })
+
+  it('keeps checked students selected when Copy Grade fails', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1'])
+    mockStudentSelectionState.selectedCount = 1
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/grade-selected') {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ error: 'Batch save failed' }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+    })
+
+    mockClearSelection.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Grade' }))
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Copy Grade' })
+    fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
+
+    expect(await screen.findByText('Batch save failed')).toBeInTheDocument()
+    expect(mockClearSelection).not.toHaveBeenCalled()
   })
 
   it('switches to individual mode with student controls in the action bar', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -63,6 +63,10 @@ vi.mock('@/ui', () => ({
           type="button"
           onClick={option.onSelect}
           disabled={option.disabled}
+          onMouseEnter={() => option.onHoverChange?.(true)}
+          onMouseLeave={() => option.onHoverChange?.(false)}
+          onFocus={() => option.onHoverChange?.(true)}
+          onBlur={() => option.onHoverChange?.(false)}
         >
           {option.label}
         </button>
@@ -132,6 +136,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
     mode,
     onDetailsMetaChange,
     onGradeTemplateChange,
+    highlightedInspectorSections = [],
   }: any) => {
     useEffect(() => {
       onDetailsMetaChange?.(
@@ -156,7 +161,14 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
       )
     }, [mode, onGradeTemplateChange, studentId])
 
-    return <div data-testid="teacher-work-panel">{`${mode}:${assignmentId}:${studentId}`}</div>
+    return (
+      <div
+        data-testid="teacher-work-panel"
+        data-highlighted-sections={highlightedInspectorSections.join(',')}
+      >
+        {`${mode}:${assignmentId}:${studentId}`}
+      </div>
+    )
   },
 }))
 
@@ -918,7 +930,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
     })
 
-    const gradeSelectedOption = screen.getByRole('button', { name: 'Apply Grade' })
+    const gradeSelectedOption = screen.getByRole('button', { name: 'Apply Grade to Selected Students' })
     await waitFor(() => {
       expect(gradeSelectedOption).not.toBeDisabled()
     })
@@ -928,7 +940,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByText(/applies the open student's scores and feedback draft/)).toBeInTheDocument()
     expect(screen.getByText(/It will not return feedback to students/)).toBeInTheDocument()
 
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade' })
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
 
     await waitFor(() => {
@@ -947,7 +959,55 @@ describe('TeacherClassroomView', () => {
     expect(await screen.findByText('Applied grade to 2 selected students')).toBeInTheDocument()
   })
 
-  it('keeps checked students selected when Apply Grade fails', async () => {
+  it('highlights grade and feedback cards while hovering Apply Grade to Selected Students', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
+    mockStudentSelectionState.selectedCount = 2
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        const details = makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1')
+        details.students.push({
+          student_id: 'student-2',
+          student_email: 'student-2@example.com',
+          student_first_name: 'student-2',
+          student_last_name: 'Student',
+          status: 'submitted_on_time',
+          student_updated_at: '2026-04-10T12:00:00Z',
+          artifacts: [],
+          doc: null,
+        })
+        return Promise.resolve({
+          ok: true,
+          json: async () => details,
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    const workPanel = await screen.findByTestId('teacher-work-panel')
+    const applyGradeOption = screen.getByRole('button', { name: 'Apply Grade to Selected Students' })
+    await waitFor(() => {
+      expect(applyGradeOption).not.toBeDisabled()
+    })
+
+    fireEvent.mouseEnter(applyGradeOption)
+    expect(workPanel).toHaveAttribute('data-highlighted-sections', 'grades,comments')
+
+    fireEvent.mouseLeave(applyGradeOption)
+    expect(workPanel).toHaveAttribute('data-highlighted-sections', '')
+  })
+
+  it('keeps checked students selected when Apply Grade to Selected Students fails', async () => {
     mockStudentSelectionState.selectedIds = new Set(['student-1'])
     mockStudentSelectionState.selectedCount = 1
 
@@ -983,8 +1043,8 @@ describe('TeacherClassroomView', () => {
     })
 
     mockClearSelection.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Grade' }))
-    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade' })
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Grade to Selected Students' }))
+    const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
 
     expect(await screen.findByText('Batch save failed')).toBeInTheDocument()

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -937,8 +937,8 @@ describe('TeacherClassroomView', () => {
 
     fireEvent.click(gradeSelectedOption)
     expect(screen.getByText('Apply grade to 2 selected student(s)?')).toBeInTheDocument()
-    expect(screen.getByText(/applies the open student's scores and feedback draft/)).toBeInTheDocument()
-    expect(screen.getByText(/It will not return feedback to students/)).toBeInTheDocument()
+    expect(screen.getByText(/applies the open student's scores and comment draft/)).toBeInTheDocument()
+    expect(screen.getByText(/It will not return comments to students/)).toBeInTheDocument()
 
     const gradeSelectedButtons = screen.getAllByRole('button', { name: 'Apply Grade to Selected Students' })
     fireEvent.click(gradeSelectedButtons[gradeSelectedButtons.length - 1])
@@ -964,7 +964,7 @@ describe('TeacherClassroomView', () => {
     })
   })
 
-  it('highlights grade and feedback cards while hovering Apply Grade to Selected Students', async () => {
+  it('highlights grade and comments cards while hovering Apply Grade to Selected Students', async () => {
     mockStudentSelectionState.selectedIds = new Set(['student-1', 'student-2'])
     mockStudentSelectionState.selectedCount = 2
 

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -296,11 +296,11 @@ describe('TeacherStudentWorkPanel', () => {
     expect(within(gradesSection).getByText('0%')).toBeInTheDocument()
     expect(within(gradesSection).getByText('Total')).toBeInTheDocument()
     expect(within(gradesSection).getByText('30')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Feedback' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument()
     expect(screen.queryByText('No draft')).not.toBeInTheDocument()
 
     expect(screen.getByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
@@ -311,7 +311,7 @@ describe('TeacherStudentWorkPanel', () => {
     expect(within(gradeModeToggle).getByRole('button', { name: 'Final' })).toHaveAttribute('aria-pressed', 'true')
     expect(within(gradesSection).queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
     const feedbackSection = screen.getByTestId('inspector-section-comments')
-    expect(within(feedbackSection).getByRole('button', { name: 'Send feedback' })).toBeInTheDocument()
+    expect(within(feedbackSection).getByRole('button', { name: 'Send comment' })).toBeInTheDocument()
   })
 
   it('uses edit-mode checkboxes to hide inspector cards outside edit mode', async () => {
@@ -389,7 +389,7 @@ describe('TeacherStudentWorkPanel', () => {
     const { rerender } = render(<TeacherStudentWorkPanel {...panelProps} />)
 
     expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
 
     rerender(
       <TeacherStudentWorkPanel
@@ -399,11 +399,11 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Grade' })).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.getByRole('button', { name: 'Feedback' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: 'Comments' })).toHaveAttribute('aria-expanded', 'false')
     await waitFor(() => {
       expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
     })
-    expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Teacher comment draft')).not.toBeInTheDocument()
   })
 
   it('autosaves valid grading edits as final by default without a save button', async () => {
@@ -470,7 +470,7 @@ describe('TeacherStudentWorkPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Set Completion score to 6' }))
     await user.click(screen.getByRole('button', { name: 'Set Thinking score to 7' }))
     await user.click(screen.getByRole('button', { name: 'Set Workflow score to 8' }))
-    fireEvent.change(screen.getByPlaceholderText('Teacher feedback draft'), {
+    fireEvent.change(screen.getByPlaceholderText('Teacher comment draft'), {
       target: { value: 'Teacher note' },
     })
 
@@ -493,7 +493,7 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
   })
 
-  it('autosaves feedback-only edits after switching to draft', async () => {
+  it('autosaves comment-only edits after switching to draft', async () => {
     const gradeBodies: Array<Record<string, unknown>> = []
 
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -552,7 +552,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await screen.findByPlaceholderText('Teacher feedback draft')
+    await screen.findByPlaceholderText('Teacher comment draft')
     await user.click(screen.getByRole('button', { name: 'Draft' }))
 
     await waitFor(() => {
@@ -560,7 +560,7 @@ describe('TeacherStudentWorkPanel', () => {
     })
     gradeBodies.length = 0
 
-    await user.type(screen.getByPlaceholderText('Teacher feedback draft'), 'Teacher note')
+    await user.type(screen.getByPlaceholderText('Teacher comment draft'), 'Teacher note')
 
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1100))
@@ -639,7 +639,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    await screen.findByPlaceholderText('Teacher feedback draft')
+    await screen.findByPlaceholderText('Teacher comment draft')
     await user.click(screen.getByRole('button', { name: 'Draft' }))
 
     await waitFor(() => {
@@ -647,7 +647,7 @@ describe('TeacherStudentWorkPanel', () => {
     })
     gradeBodies.length = 0
 
-    await user.type(screen.getByPlaceholderText('Teacher feedback draft'), 'Teacher note')
+    await user.type(screen.getByPlaceholderText('Teacher comment draft'), 'Teacher note')
 
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1100))
@@ -804,7 +804,7 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
   })
@@ -828,7 +828,7 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
   })
 
@@ -1001,16 +1001,16 @@ describe('TeacherStudentWorkPanel', () => {
     expect(await screen.findByText('Returned feedback body')).toBeInTheDocument()
     expect(screen.getByText('Returned feedback body')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Feedback' }))
+    await user.click(screen.getByRole('button', { name: 'Comments' }))
 
     await waitFor(() => {
-      expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
+      expect(screen.queryByPlaceholderText('Teacher comment draft')).not.toBeInTheDocument()
     })
     expect(screen.queryByText('Draft present')).not.toBeInTheDocument()
     expect(screen.queryByText('1 returned')).not.toBeInTheDocument()
   })
 
-  it('prepends AI feedback suggestion into the feedback draft and marks it as an AI draft until focus', async () => {
+  it('prepends AI comment suggestion into the comment draft and marks it as an AI draft until focus', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -1051,7 +1051,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const draft = await screen.findByPlaceholderText('Teacher feedback draft')
+    const draft = await screen.findByPlaceholderText('Teacher comment draft')
     expect(draft).toHaveValue('AI feedback suggestion\n\nTeacher note')
     expect(draft).toHaveClass('border-primary')
     expect(draft).toHaveClass('bg-info-bg')

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -1109,6 +1109,94 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.getByTestId('inspector-section-comments')).toHaveAttribute('data-highlighted', 'true')
   })
 
+  it('clears the grade template while the next overview student loads', async () => {
+    const deferredStudent2 = createDeferred<any>()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.includes('/api/teacher/assignments/assignment-1/students/student-1')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeStudentWork('student-1', {
+            graded: true,
+            teacherFeedbackDraft: 'Student 1 feedback',
+          }),
+        })
+      }
+
+      if (url.includes('/api/teacher/assignments/assignment-1/students/student-2')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => deferredStudent2.promise,
+        })
+      }
+
+      if (url.includes('/api/assignment-docs/') && url.includes('/history')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ history: [] }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch in test: ${url}` }),
+      })
+    })
+
+    const onGradeTemplateChange = vi.fn()
+    const { rerender } = render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="overview"
+        onGradeTemplateChange={onGradeTemplateChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(onGradeTemplateChange).toHaveBeenCalledWith(expect.objectContaining({
+        studentId: 'student-1',
+        feedbackDraft: 'Student 1 feedback',
+      }))
+    })
+
+    onGradeTemplateChange.mockClear()
+
+    rerender(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-2"
+        mode="overview"
+        onGradeTemplateChange={onGradeTemplateChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(onGradeTemplateChange).toHaveBeenLastCalledWith(null)
+    })
+
+    expect(onGradeTemplateChange).not.toHaveBeenCalledWith(expect.objectContaining({
+      studentId: 'student-2',
+      feedbackDraft: 'Student 1 feedback',
+    }))
+
+    deferredStudent2.resolve(makeStudentWork('student-2', {
+      graded: true,
+      teacherFeedbackDraft: 'Student 2 feedback',
+    }))
+
+    await waitFor(() => {
+      expect(onGradeTemplateChange).toHaveBeenCalledWith(expect.objectContaining({
+        studentId: 'student-2',
+        feedbackDraft: 'Student 2 feedback',
+      }))
+    })
+  })
+
   it('keeps prior content visible while the next student loads', async () => {
     const deferredStudent2 = createDeferred<any>()
 

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -1086,6 +1086,29 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByTestId('rich-text-viewer')).not.toBeInTheDocument()
   })
 
+  it('highlights requested inspector sections', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="overview"
+        highlightedInspectorSections={['grades', 'comments']}
+      />,
+    )
+
+    await screen.findByTestId('grading-inspector-pane')
+
+    expect(screen.getByTestId('inspector-section-history')).not.toHaveAttribute('data-highlighted')
+    expect(screen.getByTestId('inspector-section-repo')).not.toHaveAttribute('data-highlighted')
+    expect(screen.getByTestId('inspector-section-grades')).toHaveAttribute('data-highlighted', 'true')
+    expect(screen.getByTestId('inspector-section-comments')).toHaveAttribute('data-highlighted', 'true')
+  })
+
   it('keeps prior content visible while the next student loads', async () => {
     const deferredStudent2 = createDeferred<any>()
 

--- a/tests/ui/SplitButton.test.tsx
+++ b/tests/ui/SplitButton.test.tsx
@@ -63,4 +63,28 @@ describe('SplitButton', () => {
     expect(menu.className).toContain('top-full')
     expect(menu.className).not.toContain('bottom-full')
   })
+
+  it('notifies option hover state and clears it when selected', () => {
+    const onHoverChange = vi.fn()
+
+    render(
+      <SplitButton
+        label="Post"
+        onPrimaryClick={vi.fn()}
+        options={[
+          { id: 'schedule', label: 'Schedule', onSelect: vi.fn(), onHoverChange },
+        ]}
+        toggleAriaLabel="Choose action"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose action' }))
+    const option = screen.getByRole('menuitem', { name: 'Schedule' })
+
+    fireEvent.mouseEnter(option)
+    expect(onHoverChange).toHaveBeenLastCalledWith(true)
+
+    fireEvent.click(option)
+    expect(onHoverChange).toHaveBeenLastCalledWith(false)
+  })
 })


### PR DESCRIPTION
## Summary
- Add an `Apply Grade to Selected Students` option to the teacher assignment `AI Grade` split-button menu.
- Apply the active right-pane grader scores, draft/final mode, and feedback draft to all checked students after confirmation.
- Highlight the grade and feedback inspector cards while the batch action is hovered or focused so teachers can see the source fields being applied.
- Add a batch save API and shared server-side grade parsing/upsert helper used by both single-student and batch grade saves.
- Patch assignment rows locally after success, refresh the active inspector, and keep feedback return fields untouched.

## Validation
- `pnpm test` during session start: 235 files / 1955 tests.
- `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm lint`
- `pnpm build`
- Visual verification reviewed for `/classrooms`:
  - `/tmp/pika-teacher.png`
  - `/tmp/pika-student.png`
  - `/tmp/pika-teacher-mobile.png`
- Manual Playwright assignment workspace screenshots:
  - `/tmp/pika-apply-grade-menu.png`
  - `/tmp/pika-apply-grade-dialog.png`
  - `/tmp/pika-apply-grade-selected-hover-highlight.png`

## Review Notes
- The batch route intentionally saves only score fields plus teacher feedback draft metadata. It does not set `feedback`, `feedback_returned_at`, `returned_at`, or submission/mailbox state.
- The API caps requests at 100 unique enrolled students and reuses the single-grade score validation rules.