### PR TITLE
[codex] Pilot teacher assignment edit mode

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9726,3 +9726,178 @@
   - `/tmp/pika-teacher-mobile.png`
   - `/tmp/pika-teacher-opening.png`
   - `/tmp/pika-student-opening.png`
+## 2026-04-28 — Teacher assignments edit-mode pilot
+
+**Completed:**
+- Added the shared `TeacherEditModeControls` action-bar control for temporary teacher work-surface edit mode.
+- Updated teacher assignments so normal mode keeps `New`, navigation, grading, return, and status workflows visible while hiding reorder, delete, and bulk markdown code affordances.
+- Moved assignment bulk markdown entry behind edit-mode `Code`, gated parent markdown/sidebar opening on assignment edit mode, and reset edit mode on assignment workspace/tab changes.
+- Updated assignment summary cards so normal clicks open the workspace when possible, draft/scheduled cards still open the editor, and edit-mode clicks open the assignment editor with drag/delete visible.
+- Hid the selected-assignment title edit affordance until edit mode is active.
+- Added experimental guidance for the reusable teacher edit-mode pattern.
+- Fixed a small mobile header overflow exposed during assignment mobile verification by hiding the date/time on narrow screens.
+
+**Validation:**
+- `pnpm test tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `bash scripts/verify-env.sh` (`pnpm test`: 237 files, 1958 tests)
+- `pnpm e2e:auth`
+- Applied pending local Supabase migrations 057-059 with `supabase db push --local` to unblock visual verification against the local dev DB.
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-teacher-assignments-summary-normal.png`
+  - `/tmp/pika-teacher-assignments-summary-edit.png`
+  - `/tmp/pika-teacher-assignments-code-sidebar.png`
+  - `/tmp/pika-teacher-assignments-code-sidebar-dark.png`
+  - `/tmp/pika-teacher-assignment-workspace-normal.png`
+  - `/tmp/pika-teacher-assignment-workspace-edit.png`
+  - `/tmp/pika-teacher-assignments-mobile-390-after-header-fix.png`
+  - `/tmp/pika-student-assignments-mobile-390-after-header-fix.png`
+
+## 2026-04-29 — Teacher assignment workspace edit refinements
+
+**Completed:**
+- Moved the selected-assignment Class-mode `Return` action into the centered `AI Grade` split-button menu and removed the standalone Return button.
+- Added edit-mode visibility checkboxes to the grading inspector cards so teachers can hide cards such as `Repo` from normal mode while keeping hidden card headers available in edit mode.
+- Persisted inspector card visibility per classroom in client cookies alongside the existing expanded-section state.
+- Updated the experimental teacher edit-mode guidance with the inspector card visibility rule.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm test tests/components/TeacherWorkSurfaceShell.test.tsx`
+- `pnpm lint`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-workspace-split-return.png`
+  - `/tmp/pika-assignment-workspace-edit-inspector.png`
+  - `/tmp/pika-assignment-workspace-hidden-repo.png`
+  - `/tmp/pika-assignment-workspace-repo-hidden-normal.png`
+  - `/tmp/pika-assignment-workspace-mobile.png`
+
+## 2026-04-29 — Center assignment summary New action
+
+**Completed:**
+- Centered the teacher assignment summary `+ New` button in the action bar while keeping edit controls anchored on the right.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx`
+- `pnpm lint`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-student.png`
+
+## 2026-04-29 — Inspector edit-mode collapse behavior
+
+**Completed:**
+- Collapsed all right-pane assignment inspector cards when entering assignment edit mode.
+- Expanded the inspector card header click target so clicking anywhere in the top card header area toggles collapse/expand, while visibility checkboxes and card actions keep their own behavior.
+
+**Validation:**
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-workspace-edit-collapsed.png`
+  - `/tmp/pika-assignment-workspace-header-click-expanded-after-wait.png`
+
+## 2026-04-29 — Assignment edit mode route and Escape reset
+
+**Completed:**
+- Reset assignment edit mode when the teacher leaves the assignments route/tab or the assignment workspace changes.
+- Added Escape handling so assignment edit mode exits from summary and selected-assignment workspace views, while preserving Escape behavior inside inputs and editors.
+- Kept assignment markdown/sidebar cleanup scoped to assignment markdown state so other tabs do not lose their own right-sidebar state after navigation.
+- Tightened the mobile assignment action bar by making the edit-mode Code action icon-only below the `sm` breakpoint.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Interactive Playwright checks for summary edit mode, Code sidebar, Escape reset, route-away reset, selected-assignment workspace edit mode, and mobile edit mode.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-teacher-edit-mode.png`
+  - `/tmp/pika-teacher-code-sidebar.png`
+  - `/tmp/pika-teacher-workspace-normal.png`
+  - `/tmp/pika-teacher-workspace-edit.png`
+  - `/tmp/pika-teacher-mobile-edit-mode.png`
+
+## 2026-04-29 — Assignment summary edit mode opens markdown by default
+
+**Completed:**
+- Removed the assignment-list edit-mode `Code` action.
+- Updated assignment summary edit mode so entering edit mode automatically opens the existing bulk markdown editor in the right split pane.
+- Kept Done, Escape, workspace changes, and route changes closing assignment markdown/edit state.
+- Updated experimental teacher edit-mode guidance to make the automatic markdown split the assignment pilot rule.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherEditModeControls.test.tsx`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Interactive Playwright checks for automatic desktop split, removed Code action, Escape reset, route-away reset, and mobile markdown drawer.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-teacher-edit-mode-auto-markdown.png`
+  - `/tmp/pika-teacher-mobile-edit-auto-markdown.png`
+
+## 2026-04-29 — Actionbar top spacing balance
+
+**Completed:**
+- Increased the shared compact header/actionbar top spacing token from 2px to 12px so the actionbar has symmetric visual breathing room above and below it.
+
+**Validation:**
+- `pnpm test tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-edit-spacing-auto-markdown.png`
+
+## 2026-04-29 — Global markdown visibility preference
+
+**Completed:**
+- Added a main user-menu `Show markdown` checkbox backed by local storage.
+- Gated markdown/source surfaces across assignment edit split view, assignment instruction modals, lesson calendar markdown sidebar, lesson calendar cell rendering/shortcuts, class-day markdown copy, quiz markdown tabs/splits, classroom website markdown fields, and teacher blueprint markdown editors/previews.
+- Kept assignment edit mode functional when markdown is hidden: edit affordances remain visible, but the markdown pane stays closed until the setting is re-enabled.
+
+**Validation:**
+- `pnpm test tests/components/UserMenu.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/LessonCalendar.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm test tests/components/UserMenu.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/LessonCalendar.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherSettingsTab.test.tsx` (124 tests)
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `git diff --check`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=assignments`.
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=calendar`.
+- Interactive Playwright checks for assignment edit mode with markdown hidden and re-enabled.
+- Interactive Playwright checks for hidden markdown in assignment instructions, classroom website settings, and lesson calendar cells.
+- Visual screenshots reviewed:
+  - `/tmp/pika-markdown-hidden-assignment-edit-clean.png`
+  - `/tmp/pika-markdown-shown-assignment-edit-clean.png`
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-modal-markdown-hidden.png`
+  - `/tmp/pika-settings-markdown-hidden.png`
+  - `/tmp/pika-calendar-markdown-hidden.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9901,3 +9901,25 @@
   - `/tmp/pika-assignment-modal-markdown-hidden.png`
   - `/tmp/pika-settings-markdown-hidden.png`
   - `/tmp/pika-calendar-markdown-hidden.png`
+
+## 2026-04-29 — Move markdown display setting into classroom settings
+
+**Completed:**
+- Moved the `Show markdown` preference out of the top-right account menu and into the teacher classroom Settings → General tab.
+- Added a compact Display card above Actual Course Website so the markdown setting lives with the classroom settings gear flow.
+- Updated hidden-markdown copy to refer to the display setting instead of the user menu.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/components/UserMenu.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `git diff --check`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=settings`.
+- Interactive Playwright check for toggling `Show markdown` off/on from Settings → General.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-settings-show-markdown-off.png`
+  - `/tmp/pika-settings-show-markdown-on.png`

--- a/docs/guidance/ui/experimental/2026-04-teacher-edit-mode-controls.md
+++ b/docs/guidance/ui/experimental/2026-04-teacher-edit-mode-controls.md
@@ -1,0 +1,53 @@
+---
+status: experimental
+scope:
+  - teacher-assignments
+  - teacher-work-surface
+  - shared-shell
+source_files:
+  - src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+  - src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+  - src/components/SortableAssignmentCard.tsx
+  - src/components/TeacherStudentWorkPanel.tsx
+  - src/components/assignment-workspace/TeacherWorkInspector.tsx
+  - src/components/assignment-workspace/useTeacherStudentWorkController.ts
+  - src/components/teacher-work-surface/TeacherEditModeControls.tsx
+human_review_required: true
+generated_at: 2026-04-28
+---
+
+# Teacher Edit-Mode Controls
+
+## Summary
+
+Teacher assignments now pilot a temporary edit mode for work surfaces. The default surface stays workflow-first: create, navigation, grading, review, save, return, and status controls remain visible. Destructive, reorder, and source-edit affordances are revealed only after the teacher enables edit mode.
+
+## Pattern
+
+- Put the edit toggle in the teacher work-surface action bar `trailing` slot.
+- Keep edit mode local to the current tab or workspace state. Do not persist it.
+- Reset edit mode when the teacher leaves the tab or switches assignment workspaces.
+- Use edit-only action children only when a feature needs extra explicit commands. In the assignments pilot, the existing bulk markdown sidebar opens automatically when summary edit mode starts, so there is no separate `Code` action in the assignment list.
+- Keep feature behavior inside the feature. The shared control owns only placement, active styling, disabled state, labels, and the edit-only action group.
+
+## Assignments Pilot Rules
+
+- Normal assignment summary cards hide drag handles and delete.
+- Normal assignment summary cards open the assignment workspace when possible.
+- Draft and scheduled assignment cards continue to open the assignment editor in normal mode.
+- Edit-mode assignment summary cards show drag handles and delete, and the card click opens the assignment editor.
+- Edit-mode assignment summary opens the existing bulk markdown sidebar by default as the right-side split pane.
+- Selected assignment workspaces keep grading and return actions visible. Secondary workflow actions such as `Return` may live in the centered split-button menu when that keeps the action bar calmer.
+- The title edit affordance appears only while edit mode is active.
+- Inspector card visibility controls are edit-mode-only. Hidden inspector cards stay visible as unchecked card headers in edit mode so teachers can re-show them, and are removed from normal mode.
+
+## Why Experimental
+
+This has only been applied to teacher assignments. Other teacher classroom tabs should not adopt it automatically until the assignments screenshots, behavior, and tests have been reviewed.
+
+## Promotion Criteria
+
+- Assignment pilot is accepted after visual review on desktop and mobile.
+- Teachers can discover edit mode without losing access to primary workflows.
+- The pattern works for at least one more teacher tab without feature-specific leakage into the shared shell.
+- Human review approves promotion into stable teacher work-surface guidance.

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -485,6 +485,7 @@ function ClassroomPageContent({
 
   // Track previous states for detecting transitions
   const prevSidebarOpenRef = useRef(false)
+  const prevAssignmentMarkdownAutoOpenReadyRef = useRef(false)
   const abortControllerRef = useRef<AbortController | null>(null)
   const markdownStaleRef = useRef(true) // Start stale so first open loads
 
@@ -585,19 +586,10 @@ function ClassroomPageContent({
 
   const handleAssignmentsEditModeChange = useCallback((active: boolean) => {
     setAssignmentEditMode(active)
+  }, [])
 
-    if (!active || !showMarkdown || !isTeacher || activeTab !== 'assignments' || assignmentViewMode !== 'summary') {
-      return
-    }
-
-    openAssignmentsMarkdownPanel()
-  }, [
-    activeTab,
-    assignmentViewMode,
-    isTeacher,
-    openAssignmentsMarkdownPanel,
-    showMarkdown,
-  ])
+  const assignmentMarkdownAutoOpenReady =
+    showMarkdown && isTeacher && activeTab === 'assignments' && assignmentEditMode && assignmentViewMode === 'summary'
 
   // Detect sidebar close for assignments tab. Markdown mode opens by default when summary edit mode starts.
   useEffect(() => {
@@ -617,22 +609,12 @@ function ClassroomPageContent({
   }, [isRightSidebarOpen, isTeacher, activeTab, assignmentEditMode, assignmentViewMode, showMarkdown])
 
   useEffect(() => {
-    if (!showMarkdown) return
-    if (!isTeacher || activeTab !== 'assignments') return
-    if (!assignmentEditMode || assignmentViewMode !== 'summary') return
-    if (isMarkdownMode && isRightSidebarOpen) return
+    const wasReady = prevAssignmentMarkdownAutoOpenReadyRef.current
+    prevAssignmentMarkdownAutoOpenReadyRef.current = assignmentMarkdownAutoOpenReady
 
+    if (!assignmentMarkdownAutoOpenReady || wasReady) return
     openAssignmentsMarkdownPanel()
-  }, [
-    activeTab,
-    assignmentEditMode,
-    assignmentViewMode,
-    isMarkdownMode,
-    isRightSidebarOpen,
-    isTeacher,
-    openAssignmentsMarkdownPanel,
-    showMarkdown,
-  ])
+  }, [assignmentMarkdownAutoOpenReady, openAssignmentsMarkdownPanel])
 
   useEffect(() => {
     if (!isTeacher || activeTab === 'assignments') return

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -32,7 +32,7 @@ import {
   useMobileDrawer,
   useRightSidebar,
 } from '@/components/layout'
-import { getRouteKeyFromTab } from '@/lib/layout-config'
+import { DESKTOP_BREAKPOINT, getRouteKeyFromTab } from '@/lib/layout-config'
 import { RichTextViewer } from '@/components/editor'
 import { Spinner } from '@/components/Spinner'
 import {
@@ -46,6 +46,7 @@ import { StudentLogHistory } from '@/components/StudentLogHistory'
 import { LogSummary } from './LogSummary'
 import { ConfirmDialog, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
 import type {
@@ -222,8 +223,9 @@ function ClassroomPageContent({
   searchParams: URLSearchParams
   updateSearchParams: UpdateSearchParamsFn
 }) {
-  const { openLeft, close: closeMobileDrawer } = useMobileDrawer()
+  const { openLeft, openRight, close: closeMobileDrawer } = useMobileDrawer()
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
+  const { showMarkdown } = useMarkdownPreference()
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
   const assignmentStudentIdParam = searchParams.get('assignmentStudentId')
@@ -470,6 +472,7 @@ function ClassroomPageContent({
 
   // State for markdown mode (teacher assignments tab - summary view only)
   const [assignmentViewMode, setAssignmentViewMode] = useState<AssignmentViewMode>('summary')
+  const [assignmentEditMode, setAssignmentEditMode] = useState(false)
   const [isMarkdownMode, setIsMarkdownMode] = useState(false)
   const [markdownContent, setMarkdownContent] = useState('')
   const [markdownError, setMarkdownError] = useState<string | null>(null)
@@ -482,7 +485,6 @@ function ClassroomPageContent({
 
   // Track previous states for detecting transitions
   const prevSidebarOpenRef = useRef(false)
-  const prevViewModeRef = useRef<AssignmentViewMode>('summary')
   const abortControllerRef = useRef<AbortController | null>(null)
   const markdownStaleRef = useRef(true) // Start stale so first open loads
 
@@ -506,6 +508,7 @@ function ClassroomPageContent({
   const handleViewModeChange = useCallback((mode: AssignmentViewMode) => {
     setAssignmentViewMode(mode)
     if (mode === 'assignment') {
+      setAssignmentEditMode(false)
       setIsMarkdownMode(false)
       // Abort any in-flight markdown load to prevent it from re-enabling markdown mode
       abortControllerRef.current?.abort()
@@ -524,6 +527,7 @@ function ClassroomPageContent({
     setMarkdownWarning(null)
     setWarningsAcknowledged(false)
     setMarkdownLoading(true)
+    setIsMarkdownMode(true)
 
     try {
       const data = await fetchJSONWithCache<{ assignments?: Assignment[] }>(
@@ -543,7 +547,6 @@ function ClassroomPageContent({
       const result = assignmentsToMarkdown(assignments)
       setMarkdownContent(result.markdown)
       setHasRichContent(result.hasRichContent)
-      setIsMarkdownMode(true)
       setRightSidebarWidth('50%')
       markdownStaleRef.current = false
     } catch (err) {
@@ -557,33 +560,133 @@ function ClassroomPageContent({
     }
   }, [classroom.id, setRightSidebarWidth])
 
-  // Detect sidebar open/close and view mode transitions for assignments tab
+  const openAssignmentsMarkdownPanel = useCallback(() => {
+    if (!showMarkdown) return
+
+    setRightSidebarWidth('50%')
+    setRightSidebarOpen(true)
+    if (typeof window !== 'undefined' && window.innerWidth < DESKTOP_BREAKPOINT) {
+      openRight()
+    }
+
+    if (markdownStaleRef.current || !isMarkdownMode) {
+      loadAssignmentsMarkdown()
+    } else {
+      setIsMarkdownMode(true)
+    }
+  }, [
+    isMarkdownMode,
+    loadAssignmentsMarkdown,
+    openRight,
+    showMarkdown,
+    setRightSidebarOpen,
+    setRightSidebarWidth,
+  ])
+
+  const handleAssignmentsEditModeChange = useCallback((active: boolean) => {
+    setAssignmentEditMode(active)
+
+    if (!active || !showMarkdown || !isTeacher || activeTab !== 'assignments' || assignmentViewMode !== 'summary') {
+      return
+    }
+
+    openAssignmentsMarkdownPanel()
+  }, [
+    activeTab,
+    assignmentViewMode,
+    isTeacher,
+    openAssignmentsMarkdownPanel,
+    showMarkdown,
+  ])
+
+  // Detect sidebar close for assignments tab. Markdown mode opens by default when summary edit mode starts.
   useEffect(() => {
     const wasOpen = prevSidebarOpenRef.current
-    const wasViewMode = prevViewModeRef.current
     prevSidebarOpenRef.current = isRightSidebarOpen
-    prevViewModeRef.current = assignmentViewMode
 
     if (!isTeacher || activeTab !== 'assignments') return
 
-    const sidebarJustOpened = isRightSidebarOpen && !wasOpen
-    const returnedToSummary = assignmentViewMode === 'summary' && wasViewMode === 'assignment'
+    if (!showMarkdown || !assignmentEditMode || assignmentViewMode !== 'summary') {
+      setIsMarkdownMode(false)
+      return
+    }
 
-    if (assignmentViewMode === 'summary' && (sidebarJustOpened || (returnedToSummary && isRightSidebarOpen))) {
-      if (markdownStaleRef.current) {
-        loadAssignmentsMarkdown()
-      } else {
-        // Reuse cached markdown when returning from assignment detail.
-        setIsMarkdownMode(true)
-      }
-    } else if (!isRightSidebarOpen && wasOpen) {
+    if (!isRightSidebarOpen && wasOpen) {
       setIsMarkdownMode(false)
     }
-  }, [isRightSidebarOpen, isTeacher, activeTab, assignmentViewMode, loadAssignmentsMarkdown])
+  }, [isRightSidebarOpen, isTeacher, activeTab, assignmentEditMode, assignmentViewMode, showMarkdown])
+
+  useEffect(() => {
+    if (!showMarkdown) return
+    if (!isTeacher || activeTab !== 'assignments') return
+    if (!assignmentEditMode || assignmentViewMode !== 'summary') return
+    if (isMarkdownMode && isRightSidebarOpen) return
+
+    openAssignmentsMarkdownPanel()
+  }, [
+    activeTab,
+    assignmentEditMode,
+    assignmentViewMode,
+    isMarkdownMode,
+    isRightSidebarOpen,
+    isTeacher,
+    openAssignmentsMarkdownPanel,
+    showMarkdown,
+  ])
+
+  useEffect(() => {
+    if (!isTeacher || activeTab === 'assignments') return
+
+    if (assignmentEditMode) {
+      setAssignmentEditMode(false)
+    }
+    if (isMarkdownMode) {
+      setIsMarkdownMode(false)
+    }
+    if (assignmentEditMode || isMarkdownMode) {
+      abortControllerRef.current?.abort()
+    }
+    if (isMarkdownMode && isRightSidebarOpen) {
+      setRightSidebarOpen(false)
+      closeMobileDrawer()
+    }
+  }, [
+    activeTab,
+    assignmentEditMode,
+    closeMobileDrawer,
+    isMarkdownMode,
+    isRightSidebarOpen,
+    isTeacher,
+    setRightSidebarOpen,
+  ])
+
+  useEffect(() => {
+    if (!isTeacher || activeTab !== 'assignments') return
+    if (showMarkdown && assignmentEditMode && assignmentViewMode === 'summary') return
+
+    if (isMarkdownMode) {
+      setIsMarkdownMode(false)
+    }
+    abortControllerRef.current?.abort()
+    if (isRightSidebarOpen) {
+      setRightSidebarOpen(false)
+      closeMobileDrawer()
+    }
+  }, [
+    activeTab,
+    assignmentEditMode,
+    assignmentViewMode,
+    closeMobileDrawer,
+    isMarkdownMode,
+    isRightSidebarOpen,
+    isTeacher,
+    showMarkdown,
+    setRightSidebarOpen,
+  ])
 
   // Refresh markdown when assignments are updated
   useEffect(() => {
-    if (!isTeacher || activeTab !== 'assignments' || !isMarkdownMode) return
+    if (!showMarkdown || !isTeacher || activeTab !== 'assignments' || assignmentViewMode !== 'summary' || !assignmentEditMode || !isMarkdownMode) return
 
     const handleAssignmentsUpdated = () => {
       markdownStaleRef.current = true
@@ -594,7 +697,7 @@ function ClassroomPageContent({
     return () => {
       window.removeEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
     }
-  }, [isTeacher, activeTab, isMarkdownMode, loadAssignmentsMarkdown])
+  }, [showMarkdown, isTeacher, activeTab, assignmentEditMode, assignmentViewMode, isMarkdownMode, loadAssignmentsMarkdown])
 
   const handleMarkdownContentChange = useCallback((content: string) => {
     setMarkdownContent(content)
@@ -675,6 +778,7 @@ function ClassroomPageContent({
   useEffect(() => {
     if (!isTeacher || activeTab !== 'assignments') return
     if (assignmentViewMode !== 'assignment') return
+    setIsMarkdownMode(false)
     setRightSidebarOpen(false)
     closeMobileDrawer()
   }, [
@@ -1012,6 +1116,7 @@ function ClassroomPageContent({
                         classroom={classroom}
                         onSelectAssignment={handleSelectAssignment}
                         onViewModeChange={handleViewModeChange}
+                        onEditModeChange={handleAssignmentsEditModeChange}
                         isActive={activeTab === 'assignments'}
                         selectedAssignmentId={assignmentIdParam}
                         selectedAssignmentStudentId={assignmentStudentIdParam}
@@ -1171,7 +1276,7 @@ function ClassroomPageContent({
           hideDesktopHeader={activeTab === 'resources'}
           minimalMobileHeader={activeTab === 'resources'}
           title={
-            isTeacher && activeTab === 'assignments' && isMarkdownMode
+            showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode
               ? 'Assignments'
               : isTeacher && activeTab === 'calendar' && calendarSidebarState
               ? 'Calendar'
@@ -1188,7 +1293,7 @@ function ClassroomPageContent({
               : (selectedStudentName || 'Log Summary')
           }
           headerActions={
-            isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
+            showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
               markdownWarning && !warningsAcknowledged ? (
                 <button
                   type="button"
@@ -1223,7 +1328,7 @@ function ClassroomPageContent({
             ) : undefined
           }
         >
-          {isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
+          {showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
             markdownLoading ? (
               <div className="flex items-center justify-center h-32">
                 <Spinner />

--- a/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { Copy } from 'lucide-react'
 import { Button, Tooltip, useAppMessage } from '@/ui'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { useClassDaysContext } from '@/hooks/useClassDays'
 import type { ClassDay, Classroom } from '@/types'
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, addMonths, parseISO } from 'date-fns'
@@ -16,6 +17,7 @@ interface Props {
 
 export function TeacherCalendarTab({ classroom }: Props) {
   const isReadOnly = !!classroom.archived_at
+  const { showMarkdown } = useMarkdownPreference()
   const { classDays: contextClassDays, isLoading: contextLoading } = useClassDaysContext()
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
@@ -208,16 +210,18 @@ export function TeacherCalendarTab({ classroom }: Props) {
               <div className="text-xs text-text-muted">
                 {isReadOnly ? 'Read-only mode' : 'Click on date to toggle class days'}
               </div>
-              <Tooltip content="Copy class days as markdown">
-                <button
-                  type="button"
-                  onClick={copyClassDays}
-                  className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-default hover:bg-surface-hover rounded transition-colors"
-                >
-                  <Copy className="w-3.5 h-3.5" />
-                  <span>Copy</span>
-                </button>
-              </Tooltip>
+              {showMarkdown ? (
+                <Tooltip content="Copy class days as markdown">
+                  <button
+                    type="button"
+                    onClick={copyClassDays}
+                    className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-default hover:bg-surface-hover rounded transition-colors"
+                  >
+                    <Copy className="w-3.5 h-3.5" />
+                    <span>Copy</span>
+                  </button>
+                </Tooltip>
+              ) : null}
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/assignment-workspace/TeacherAssignmentStudentTable'
 import { TeacherStudentWorkPanel } from '@/components/TeacherStudentWorkPanel'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
@@ -46,7 +47,6 @@ import {
   ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
   PageStack,
 } from '@/components/PageLayout'
-import { RightSidebarToggle } from '@/components/layout'
 import {
   calculateAssignmentStatus,
   getAssignmentRubricState,
@@ -98,6 +98,7 @@ interface Props {
   classroom: Classroom
   onSelectAssignment?: (assignment: { title: string; instructions: TiptapContent | string | null } | null) => void
   onViewModeChange?: (mode: AssignmentViewMode) => void
+  onEditModeChange?: (active: boolean) => void
   isActive?: boolean
   selectedAssignmentId?: string | null
   selectedAssignmentStudentId?: string | null
@@ -210,6 +211,7 @@ export function TeacherClassroomView({
   classroom,
   onSelectAssignment,
   onViewModeChange,
+  onEditModeChange,
   isActive = true,
   selectedAssignmentId: selectedAssignmentIdProp,
   selectedAssignmentStudentId,
@@ -225,6 +227,7 @@ export function TeacherClassroomView({
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [selection, setSelection] = useState<TeacherAssignmentSelection>({ mode: 'summary' })
   const [isReordering, setIsReordering] = useState(false)
+  const [assignmentEditMode, setAssignmentEditMode] = useState(false)
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -353,7 +356,7 @@ export function TeacherClassroomView({
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event
-      if (!over || active.id === over.id || isReordering || isReadOnly) return
+      if (!over || active.id === over.id || isReordering || isReadOnly || !assignmentEditMode) return
 
       const oldIndex = assignments.findIndex((a) => a.id === active.id)
       const newIndex = assignments.findIndex((a) => a.id === over.id)
@@ -389,7 +392,7 @@ export function TeacherClassroomView({
         setIsReordering(false)
       }
     },
-    [assignments, classroom.id, isReordering, isReadOnly, loadAssignments]
+    [assignmentEditMode, assignments, classroom.id, isReordering, isReadOnly, loadAssignments]
   )
 
   useEffect(() => {
@@ -564,6 +567,52 @@ export function TeacherClassroomView({
   useEffect(() => {
     onViewModeChange?.(selection.mode)
   }, [selection.mode, onViewModeChange])
+
+  useEffect(() => {
+    onEditModeChange?.(assignmentEditMode)
+  }, [assignmentEditMode, onEditModeChange])
+
+  useEffect(() => {
+    return () => {
+      onEditModeChange?.(false)
+    }
+  }, [onEditModeChange])
+
+  const assignmentEditModeResetKey =
+    selection.mode === 'assignment' ? selection.assignmentId : 'summary'
+
+  useEffect(() => {
+    setAssignmentEditMode(false)
+  }, [assignmentEditModeResetKey, classroom.id])
+
+  useEffect(() => {
+    if (isActive && !isReadOnly) return
+    setAssignmentEditMode(false)
+  }, [isActive, isReadOnly])
+
+  useEffect(() => {
+    if (!assignmentEditMode) return
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Escape' || event.defaultPrevented) return
+      const target = event.target
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      setAssignmentEditMode(false)
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [assignmentEditMode])
 
   function handleCreateSuccess(created: Assignment) {
     // Optimistically add the new assignment to the list
@@ -1098,6 +1147,7 @@ export function TeacherClassroomView({
 
   // Escape key to deselect student
   useEffect(() => {
+    if (assignmentEditMode) return
     if (assignmentWorkspaceMode !== 'overview') return
     if (!selectedStudentId) return
 
@@ -1109,7 +1159,7 @@ export function TeacherClassroomView({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [assignmentWorkspaceMode, selectedStudentId, setSelectedStudentAndNavigate])
+  }, [assignmentEditMode, assignmentWorkspaceMode, selectedStudentId, setSelectedStudentAndNavigate])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
@@ -1212,10 +1262,6 @@ export function TeacherClassroomView({
     batchSelectedReturnSummary.returnableCount + batchSelectedReturnSummary.missingCount > 0
   const isReturnDisabled =
     isReturning || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0 || !hasReturnableSelection
-  const returnTooltipContent =
-    batchSelectedCount > 0 && !hasReturnableSelection
-      ? 'Nothing returnable selected'
-      : `Return${workspaceActionLabelSuffix}`
   const showAssignmentAiRunOverlay = isAutoGrading || hasActiveAssignmentAiRun
   const assignmentAiRunOverlayLabel = hasActiveAssignmentAiRun && activeAssignmentAiRun
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
@@ -1262,60 +1308,52 @@ export function TeacherClassroomView({
 
   const workspaceModeCenter = assignmentWorkspaceMode === 'overview' ? (
     <>
-      <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
-        <SplitButton
-          label={
-            <span className="inline-flex items-center gap-2">
-              <Check className="h-4 w-4" aria-hidden="true" />
-              <span>AI Grade</span>
-            </span>
-          }
-          onPrimaryClick={() => {
-            void handleBatchAutoGrade()
-          }}
-          options={[
-            {
-              id: 'repo-analysis',
-              label: (
-                <span className="inline-flex items-center gap-2">
-                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                  <span>Repo analysis</span>
-                </span>
-              ),
-              onSelect: () => {
-                void handleBatchArtifactRepoAnalyze()
-              },
-              disabled: isArtifactRepoAnalyzing || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+      <SplitButton
+        label={
+          <span className="inline-flex items-center gap-2">
+            <Check className="h-4 w-4" aria-hidden="true" />
+            <span>AI Grade</span>
+          </span>
+        }
+        onPrimaryClick={() => {
+          void handleBatchAutoGrade()
+        }}
+        options={[
+          {
+            id: 'repo-analysis',
+            label: (
+              <span className="inline-flex items-center gap-2">
+                <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                <span>Repo analysis</span>
+              </span>
+            ),
+            onSelect: () => {
+              void handleBatchArtifactRepoAnalyze()
             },
-          ]}
-          disabled={isAutoGrading || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
-          className="inline-flex"
-          toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
-          menuPlacement="down"
-          primaryButtonProps={{
-            'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-          }}
-        />
-      </Tooltip>
-
-      <Tooltip content={returnTooltipContent}>
-        <span className="inline-flex">
-          <Button
-            type="button"
-            variant="subtle"
-            size="sm"
-            className="px-4"
-            onClick={() => {
+            disabled: isArtifactRepoAnalyzing || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+          },
+          {
+            id: 'return',
+            label: (
+              <span className="inline-flex items-center gap-2">
+                <Send className="h-4 w-4" aria-hidden="true" />
+                <span>Return</span>
+              </span>
+            ),
+            onSelect: () => {
               setShowReturnConfirm(true)
-            }}
-            disabled={isReturnDisabled}
-            aria-label={`Return${workspaceActionLabelSuffix}`}
-          >
-            <Send className="h-4 w-4" aria-hidden="true" />
-            <span>Return</span>
-          </Button>
-        </span>
-      </Tooltip>
+            },
+            disabled: isReturnDisabled,
+          },
+        ]}
+        disabled={isAutoGrading || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
+        className="inline-flex"
+        toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+        menuPlacement="down"
+        primaryButtonProps={{
+          'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+        }}
+      />
     </>
   ) : (
     <>
@@ -1360,7 +1398,7 @@ export function TeacherClassroomView({
     </div>
   ) : null
 
-  const workspaceModeTrailing = (
+  const workspaceModeTrailing = assignmentEditMode ? (
     <Tooltip content="Edit assignment">
       <button
         type="button"
@@ -1378,20 +1416,43 @@ export function TeacherClassroomView({
         <Pencil className="h-4 w-4 shrink-0" aria-hidden="true" />
       </button>
     </Tooltip>
+  ) : (
+    <div
+      className="inline-flex min-h-10 max-w-[22rem] items-center px-2 text-sm font-medium text-text-default"
+      title={selectedAssignmentTitle}
+    >
+      <span className="truncate">{selectedAssignmentTitle}</span>
+    </div>
+  )
+
+  const assignmentEditControls = (
+    <TeacherEditModeControls
+      active={assignmentEditMode}
+      onActiveChange={setAssignmentEditMode}
+      disabled={isReadOnly}
+    />
   )
 
   const primaryButtons =
     selection.mode === 'summary' ? (
-      <button
-        type="button"
-        className={`${ACTIONBAR_BUTTON_PRIMARY_CLASSNAME} flex items-center gap-1`}
-        onClick={() => setIsCreateModalOpen(true)}
-        disabled={isReadOnly}
-        aria-label="New assignment"
+      <div
+        data-testid="assignment-summary-actionbar-center"
+        className="relative flex min-h-10 w-full items-center justify-center"
       >
-        <Plus className="h-5 w-5" aria-hidden="true" />
-        <span>New</span>
-      </button>
+        <button
+          type="button"
+          className={`${ACTIONBAR_BUTTON_PRIMARY_CLASSNAME} flex items-center gap-1`}
+          onClick={() => setIsCreateModalOpen(true)}
+          disabled={isReadOnly}
+          aria-label="New assignment"
+        >
+          <Plus className="h-5 w-5" aria-hidden="true" />
+          <span>New</span>
+        </button>
+        <div className="absolute right-0 top-1/2 -translate-y-1/2">
+          {assignmentEditControls}
+        </div>
+      </div>
     ) : (
       <TeacherWorkSurfaceModeBar
         modes={[
@@ -1406,7 +1467,6 @@ export function TeacherClassroomView({
       />
     )
 
-  const showMobileToggle = selection.mode === 'summary'
   const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
 
   const feedback = (
@@ -1444,7 +1504,8 @@ export function TeacherClassroomView({
               assignment={assignment}
               isReadOnly={isReadOnly}
               isDragDisabled={isReordering}
-              onSelect={() => {
+              editMode={assignmentEditMode}
+              onOpen={() => {
                 if (assignment.is_draft || isScheduledAssignment(assignment)) {
                   setEditAssignment(assignment)
                 } else {
@@ -1476,6 +1537,7 @@ export function TeacherClassroomView({
         onGoNextStudent={handleGoNextStudent}
         canGoPrevStudent={canGoPrevStudent}
         canGoNextStudent={canGoNextStudent}
+        inspectorEditMode={assignmentEditMode}
         onDetailsMetaChange={setIndividualHeaderMeta}
       />
     ) : selectedAssignmentLoading || (!activeSelectedAssignmentData && !selectedAssignmentError) ? (
@@ -1524,6 +1586,7 @@ export function TeacherClassroomView({
           inspectorCollapsed={false}
           inspectorWidth={activeWorkspaceLayout.inspectorWidth}
           totalWidth={workspaceWidth}
+          inspectorEditMode={assignmentEditMode}
           onLoadingStateChange={setWorkspaceLoading}
         />
       }
@@ -1538,7 +1601,7 @@ export function TeacherClassroomView({
         state={selection.mode === 'summary' ? 'summary' : 'workspace'}
         primary={primaryButtons}
         actions={[]}
-        trailing={showMobileToggle ? <RightSidebarToggle /> : undefined}
+        trailing={selection.mode === 'summary' ? undefined : assignmentEditControls}
         feedback={feedback}
         summary={summaryContent}
         workspace={workspaceContent}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -11,6 +11,7 @@ import { useRightSidebar } from '@/components/layout'
 import { applyPendingLessonPlanChanges, lessonPlansToMarkdown, markdownToLessonPlans } from '@/lib/lesson-plan-markdown'
 import { useClassDays } from '@/hooks/useClassDays'
 import { Button } from '@/ui'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import type { Classroom, LessonPlan, TiptapContent, Assignment, Announcement } from '@/types'
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
@@ -83,6 +84,7 @@ export function TeacherLessonCalendarTab({
   const [refreshKey, setRefreshKey] = useState(0)
 
   const { toggle: toggleSidebar, isOpen: isSidebarOpen, setOpen: setSidebarOpen } = useRightSidebar()
+  const { showMarkdown } = useMarkdownPreference()
 
   // Auto-save tracking
   const pendingChangesRef = useRef<Map<string, string>>(new Map())
@@ -367,8 +369,9 @@ export function TeacherLessonCalendarTab({
 
   // Handle markdown panel toggle - just toggle, effect handles loading
   const handleMarkdownToggle = useCallback(() => {
+    if (!showMarkdown) return
     toggleSidebar()
-  }, [toggleSidebar])
+  }, [showMarkdown, toggleSidebar])
 
   // Handle markdown content change - ref updates immediately, state updates debounced
   const handleMarkdownChange = useCallback((content: string) => {
@@ -390,10 +393,15 @@ export function TeacherLessonCalendarTab({
     prevSidebarOpenRef.current = isSidebarOpen
 
     // Only load when transitioning from closed to open AND we need a refresh
-    if (isSidebarOpen && !wasOpen && needsRefreshRef.current) {
+    if (showMarkdown && isSidebarOpen && !wasOpen && needsRefreshRef.current) {
       loadMarkdownContent()
     }
-  }, [isSidebarOpen, loadMarkdownContent])
+  }, [isSidebarOpen, loadMarkdownContent, showMarkdown])
+
+  useEffect(() => {
+    if (showMarkdown || !isSidebarOpen) return
+    setSidebarOpen(false)
+  }, [isSidebarOpen, setSidebarOpen, showMarkdown])
 
   // Handle markdown save
   const handleMarkdownSave = useCallback(async () => {
@@ -468,7 +476,7 @@ export function TeacherLessonCalendarTab({
   // Note: markdownContent IS included because the sidebar uses local state to avoid cursor jump.
   // TeacherLessonCalendarSidebar tracks isDirty and ignores external updates once user starts typing.
   useEffect(() => {
-    if (isSidebarOpen) {
+    if (showMarkdown && isSidebarOpen) {
       onSidebarStateChange?.({
         markdownContent,
         markdownError,
@@ -479,7 +487,7 @@ export function TeacherLessonCalendarTab({
     } else {
       onSidebarStateChange?.(null)
     }
-  }, [isSidebarOpen, markdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
+  }, [showMarkdown, isSidebarOpen, markdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
 
   if (loading && lessonPlans.length === 0) {
     return (
@@ -519,20 +527,22 @@ export function TeacherLessonCalendarTab({
         trailing={
           <div className="flex items-center gap-2">
             {saving && <span className="text-sm text-text-muted">Saving...</span>}
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-9 w-9 px-0"
-              onClick={handleMarkdownToggle}
-              aria-label={isSidebarOpen ? 'Close sidebar' : 'Edit as Markdown'}
-            >
-              {isSidebarOpen ? (
-                <PanelRightClose className="h-4 w-4" aria-hidden="true" />
-              ) : (
-                <PanelRight className="h-4 w-4" aria-hidden="true" />
-              )}
-            </Button>
+            {showMarkdown ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9 w-9 px-0"
+                onClick={handleMarkdownToggle}
+                aria-label={isSidebarOpen ? 'Close sidebar' : 'Edit as Markdown'}
+              >
+                {isSidebarOpen ? (
+                  <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <PanelRight className="h-4 w-4" aria-hidden="true" />
+                )}
+              </Button>
+            ) : null}
           </div>
         }
       />

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -38,8 +38,9 @@ export function TeacherSettingsTab({
   const actualSiteSlugId = useId()
   const actualOverviewId = useId()
   const actualOutlineId = useId()
+  const showMarkdownId = useId()
   const isReadOnly = !!classroom.archived_at
-  const { showMarkdown } = useMarkdownPreference()
+  const { showMarkdown, mounted: markdownMounted, setShowMarkdown } = useMarkdownPreference()
   const [title, setTitle] = useState(classroom.title)
   const [titleSaving, setTitleSaving] = useState(false)
   const [titleError, setTitleError] = useState<string>('')
@@ -412,6 +413,21 @@ export function TeacherSettingsTab({
               {visibilityError && <div className="text-sm text-danger">{visibilityError}</div>}
             </div>
 
+            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
+              <div className="text-sm font-semibold text-text-default">Display</div>
+
+              <label htmlFor={showMarkdownId} className="flex items-center gap-3 text-sm text-text-default">
+                <input
+                  id={showMarkdownId}
+                  type="checkbox"
+                  checked={markdownMounted ? showMarkdown : true}
+                  onChange={(event) => setShowMarkdown(event.target.checked)}
+                  className="h-4 w-4"
+                />
+                Show markdown
+              </label>
+            </div>
+
             <div className="bg-surface rounded-lg border border-border p-4 space-y-4">
               <div className="flex items-center gap-2">
                 <div className="text-sm font-semibold text-text-default">Actual Course Website</div>
@@ -538,7 +554,7 @@ export function TeacherSettingsTab({
                 </>
               ) : (
                 <div className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-muted">
-                  Website overview and outline editing is hidden by your user menu setting.
+                  Website overview and outline editing is hidden by your display setting.
                 </div>
               )}
 

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Info } from 'lucide-react'
 import { Button, ConfirmDialog, DialogPanel, FormField, Input, Tooltip, useAppMessage } from '@/ui'
 import { PageContent, PageLayout } from '@/components/PageLayout'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_ACTUAL_COURSE_SITE_CONFIG, slugifyCourseSiteValue } from '@/lib/course-site-publishing'
 import { TeacherCalendarTab } from './TeacherCalendarTab'
 import type { ActualCourseSiteConfig, Classroom, LessonPlanVisibility } from '@/types'
@@ -38,6 +39,7 @@ export function TeacherSettingsTab({
   const actualOverviewId = useId()
   const actualOutlineId = useId()
   const isReadOnly = !!classroom.archived_at
+  const { showMarkdown } = useMarkdownPreference()
   const [title, setTitle] = useState(classroom.title)
   const [titleSaving, setTitleSaving] = useState(false)
   const [titleError, setTitleError] = useState<string>('')
@@ -506,31 +508,39 @@ export function TeacherSettingsTab({
                 </select>
               </div>
 
-              <div>
-                <label htmlFor={actualOverviewId} className="mb-2 block text-sm text-text-muted">
-                  Website overview
-                </label>
-                <textarea
-                  id={actualOverviewId}
-                  value={courseOverviewMarkdown}
-                  onChange={(e) => setCourseOverviewMarkdown(e.target.value)}
-                  disabled={siteSaving || isReadOnly}
-                  className="min-h-[140px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
+              {showMarkdown ? (
+                <>
+                  <div>
+                    <label htmlFor={actualOverviewId} className="mb-2 block text-sm text-text-muted">
+                      Website overview
+                    </label>
+                    <textarea
+                      id={actualOverviewId}
+                      value={courseOverviewMarkdown}
+                      onChange={(e) => setCourseOverviewMarkdown(e.target.value)}
+                      disabled={siteSaving || isReadOnly}
+                      className="min-h-[140px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
 
-              <div>
-                <label htmlFor={actualOutlineId} className="mb-2 block text-sm text-text-muted">
-                  Website outline
-                </label>
-                <textarea
-                  id={actualOutlineId}
-                  value={courseOutlineMarkdown}
-                  onChange={(e) => setCourseOutlineMarkdown(e.target.value)}
-                  disabled={siteSaving || isReadOnly}
-                  className="min-h-[160px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
+                  <div>
+                    <label htmlFor={actualOutlineId} className="mb-2 block text-sm text-text-muted">
+                      Website outline
+                    </label>
+                    <textarea
+                      id={actualOutlineId}
+                      value={courseOutlineMarkdown}
+                      onChange={(e) => setCourseOutlineMarkdown(e.target.value)}
+                      disabled={siteSaving || isReadOnly}
+                      className="min-h-[160px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </>
+              ) : (
+                <div className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-muted">
+                  Website overview and outline editing is hidden by your user menu setting.
+                </div>
+              )}
 
               {actualSitePublished && actualSiteSlug ? (
                 <div className="text-sm text-text-muted">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.scss'
 import { ThemeProvider } from '@/contexts/ThemeContext'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
 import { ProgressBarProvider } from '@/components/ProgressBarProvider'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
 
@@ -36,13 +37,15 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen bg-page">
         <ThemeProvider>
-          <TooltipProvider>
-            <AppMessageProvider>
-              <ProgressBarProvider>
-                {children}
-              </ProgressBarProvider>
-            </AppMessageProvider>
-          </TooltipProvider>
+          <MarkdownPreferenceProvider>
+            <TooltipProvider>
+              <AppMessageProvider>
+                <ProgressBarProvider>
+                  {children}
+                </ProgressBarProvider>
+              </AppMessageProvider>
+            </TooltipProvider>
+          </MarkdownPreferenceProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -888,7 +888,7 @@ export default function TeacherBlueprintsPage() {
                       </div>
                     ) : aiPreview ? (
                       <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
-                        Markdown preview is hidden by your user menu setting.
+                        Markdown preview is hidden by your display setting.
                       </div>
                     ) : null}
                   </div>
@@ -908,7 +908,7 @@ export default function TeacherBlueprintsPage() {
                     </div>
                   ) : (
                     <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
-                      Markdown editing is hidden by your user menu setting.
+                      Markdown editing is hidden by your display setting.
                     </div>
                   )
                 )}

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -7,6 +7,7 @@ import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
 import { Spinner } from '@/components/Spinner'
 import { CreateBlueprintModal } from '@/components/CreateBlueprintModal'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import {
   courseBlueprintAssignmentsToMarkdown,
   markdownToCourseBlueprintAssignments,
@@ -74,6 +75,7 @@ function emptyDraftState(): DraftState {
 export default function TeacherBlueprintsPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { showMarkdown } = useMarkdownPreference()
   const importInputRef = useRef<HTMLInputElement | null>(null)
   const [blueprints, setBlueprints] = useState<CourseBlueprint[]>([])
   const [selectedBlueprintId, setSelectedBlueprintId] = useState<string | null>(null)
@@ -802,7 +804,7 @@ export default function TeacherBlueprintsPage() {
                                         </div>
                                       ))}
                                     </div>
-                                    {suggestion.preview_markdown ? (
+                                    {showMarkdown && suggestion.preview_markdown ? (
                                       <textarea
                                         readOnly
                                         value={suggestion.preview_markdown}
@@ -875,7 +877,7 @@ export default function TeacherBlueprintsPage() {
                       </div>
                     ) : null}
 
-                    {aiPreview ? (
+                    {aiPreview && showMarkdown ? (
                       <div className="space-y-2">
                         <div className="text-sm font-semibold text-text-default">Preview: {TAB_LABELS[aiPreview.target]}</div>
                         <textarea
@@ -884,21 +886,31 @@ export default function TeacherBlueprintsPage() {
                           className="min-h-[420px] w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
                         />
                       </div>
+                    ) : aiPreview ? (
+                      <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
+                        Markdown preview is hidden by your user menu setting.
+                      </div>
                     ) : null}
                   </div>
                 ) : (
-                  <div className="space-y-3">
-                    <textarea
-                      value={drafts[activeTab]}
-                      onChange={(e) => setDrafts((current) => ({ ...current, [activeTab]: e.target.value }))}
-                      className="min-h-[520px] w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
-                    />
-                    <div className="flex justify-end">
-                      <Button type="button" onClick={saveCurrentTab} disabled={saving}>
-                        {saving ? 'Saving...' : `Save ${TAB_LABELS[activeTab]}`}
-                      </Button>
+                  showMarkdown ? (
+                    <div className="space-y-3">
+                      <textarea
+                        value={drafts[activeTab]}
+                        onChange={(e) => setDrafts((current) => ({ ...current, [activeTab]: e.target.value }))}
+                        className="min-h-[520px] w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+                      />
+                      <div className="flex justify-end">
+                        <Button type="button" onClick={saveCurrentTab} disabled={saving}>
+                          {saving ? 'Saving...' : `Save ${TAB_LABELS[activeTab]}`}
+                        </Button>
+                      </div>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="rounded-card border border-border bg-surface-2 p-4 text-sm text-text-muted">
+                      Markdown editing is hidden by your user menu setting.
+                    </div>
+                  )
                 )}
               </div>
             )}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -170,7 +170,7 @@ export function AppHeader({
             </button>
           </Tooltip>
         )}
-        <span className="mr-2 whitespace-nowrap text-base font-semibold tabular-nums text-text-default">
+        <span className="mr-2 hidden whitespace-nowrap text-base font-semibold tabular-nums text-text-default sm:inline-flex">
           <span>{formatInTimeZone(now, 'America/Toronto', 'EEE MMM d')}</span>
           <span className="ml-2">{formatInTimeZone(now, 'America/Toronto', 'h:mm a')}</span>
         </span>

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -5,6 +5,7 @@ import type { KeyboardEvent, ReactNode, RefObject } from 'react'
 import { Input, Button } from '@/ui'
 import { DateActionBar } from '@/components/DateActionBar'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
 import { Code2Icon } from '@/components/tiptap-icons/code2-icon'
 import { ItalicIcon } from '@/components/tiptap-icons/italic-icon'
@@ -64,6 +65,7 @@ export function AssignmentForm({
 }: AssignmentFormProps) {
   const instructionsRef = useRef<HTMLTextAreaElement>(null)
   const titleFieldId = useId()
+  const { showMarkdown } = useMarkdownPreference()
 
   function applyWrapFormatting(prefix: string, suffix = prefix) {
     const textarea = instructionsRef.current
@@ -220,34 +222,61 @@ export function AssignmentForm({
               {markdownWarning}
             </div>
           )}
-          <div className="grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]">
-            <div className="flex h-full min-h-0 flex-col border-b border-border md:border-b-0 md:border-r md:border-border">
-              <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
-                <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
-                  <Undo2Icon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={onInstructionsRedo} disabled={disabled || !canRedoInstructions} className="h-8 w-8 px-0" aria-label="Redo" title="Redo">
-                  <Redo2Icon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('### ')} disabled={disabled} className="h-8 w-8 px-0 text-sm font-bold" aria-label="Heading" title="Heading">
-                  H
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('**')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bold" title="Bold">
-                  <BoldIcon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('*')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Italic" title="Italic">
-                  <ItalicIcon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('- ')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bullet list" title="Bullet list">
-                  <ListIcon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyLinkFormatting()} disabled={disabled} className="h-8 w-8 px-0" aria-label="Link" title="Link">
-                  <LinkIcon className="h-4 w-4" aria-hidden="true" />
-                </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('`')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Inline code" title="Inline code">
-                  <Code2Icon className="h-4 w-4" aria-hidden="true" />
-                </Button>
+          {showMarkdown ? (
+            <div className="grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]">
+              <div className="flex h-full min-h-0 flex-col border-b border-border md:border-b-0 md:border-r md:border-border">
+                <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
+                  <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
+                    <Undo2Icon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={onInstructionsRedo} disabled={disabled || !canRedoInstructions} className="h-8 w-8 px-0" aria-label="Redo" title="Redo">
+                    <Redo2Icon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('### ')} disabled={disabled} className="h-8 w-8 px-0 text-sm font-bold" aria-label="Heading" title="Heading">
+                    H
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('**')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bold" title="Bold">
+                    <BoldIcon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('*')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Italic" title="Italic">
+                    <ItalicIcon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('- ')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bullet list" title="Bullet list">
+                    <ListIcon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinkFormatting()} disabled={disabled} className="h-8 w-8 px-0" aria-label="Link" title="Link">
+                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('`')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Inline code" title="Inline code">
+                    <Code2Icon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+                <textarea
+                  ref={instructionsRef}
+                  value={instructionsMarkdown}
+                  onChange={(e) => onInstructionsMarkdownChange(e.target.value)}
+                  onKeyDown={handleInstructionsKeyDown}
+                  onBlur={onBlur}
+                  placeholder="Assignment instructions"
+                  disabled={disabled}
+                  spellCheck={false}
+                  className="h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]"
+                />
               </div>
+              <div className="bg-page">
+                <div className="px-3 py-2 text-xs font-medium uppercase tracking-wide text-text-muted">
+                  Preview
+                </div>
+                <div className="min-h-[360px] px-3 pb-3 lg:min-h-[420px]">
+                  <LimitedMarkdown
+                    content={instructionsMarkdown}
+                    emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="min-h-[400px] lg:min-h-[460px]">
               <textarea
                 ref={instructionsRef}
                 value={instructionsMarkdown}
@@ -256,22 +285,10 @@ export function AssignmentForm({
                 onBlur={onBlur}
                 placeholder="Assignment instructions"
                 disabled={disabled}
-                spellCheck={false}
-                className="h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]"
+                className="min-h-[400px] w-full resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0 lg:min-h-[460px]"
               />
             </div>
-            <div className="bg-page">
-              <div className="px-3 py-2 text-xs font-medium uppercase tracking-wide text-text-muted">
-                Preview
-              </div>
-              <div className="min-h-[360px] px-3 pb-3 lg:min-h-[420px]">
-                <LimitedMarkdown
-                  content={instructionsMarkdown}
-                  emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
-                />
-              </div>
-            </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -3,6 +3,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { format } from 'date-fns'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { Tooltip } from '@/ui'
 import type { Announcement, Assignment, LessonPlan } from '@/types'
@@ -142,9 +143,11 @@ export const LessonDayCell = memo(function LessonDayCell({
   onAnnouncementClick,
 }: LessonDayCellProps) {
   const markdown = useMemo(() => getLessonPlanMarkdown(lessonPlan).markdown, [lessonPlan])
+  const { showMarkdown } = useMarkdownPreference()
   const [isEditing, setIsEditing] = useState(false)
   const [localMarkdown, setLocalMarkdown] = useState(markdown)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const renderPlainText = plainTextOnly || !showMarkdown
 
   useEffect(() => {
     if (!isEditing) {
@@ -191,6 +194,14 @@ export const LessonDayCell = memo(function LessonDayCell({
   }, [handleMarkdownChange])
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!showMarkdown) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsEditing(false)
+      }
+      return
+    }
+
     if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'b') {
       event.preventDefault()
       applyShortcut('bold')
@@ -215,11 +226,11 @@ export const LessonDayCell = memo(function LessonDayCell({
       event.preventDefault()
       setIsEditing(false)
     }
-  }, [applyShortcut])
+  }, [applyShortcut, showMarkdown])
 
   const hasContent = markdown.trim().length > 0
   const plainText = useMemo(() => {
-    if (!plainTextOnly || !hasContent) return ''
+    if (!renderPlainText || !hasContent) return ''
     return markdown
       .replace(/^#{1,6}\s+/gm, '')
       .replace(/\*\*([^*]+)\*\*/g, '$1')
@@ -228,10 +239,13 @@ export const LessonDayCell = memo(function LessonDayCell({
       .replace(/^\s*[-*]\s+/gm, '')
       .replace(/\n{3,}/g, '\n\n')
       .trim()
-  }, [plainTextOnly, hasContent, markdown])
+  }, [renderPlainText, hasContent, markdown])
   const previewClassName = compact || plainTextOnly
     ? 'space-y-1 text-[10px] leading-tight [&_p]:text-[10px] [&_p]:leading-tight [&_ul]:text-[10px] [&_ol]:text-[10px] [&_blockquote]:text-[10px] [&_h1]:text-xs [&_h2]:text-[11px] [&_h3]:text-[10px]'
     : 'space-y-2 text-sm leading-snug [&_p]:text-sm [&_ul]:text-sm [&_ol]:text-sm [&_blockquote]:text-sm [&_h1]:text-base [&_h2]:text-sm [&_h3]:text-sm'
+  const plainTextClassName = compact || plainTextOnly
+    ? 'text-[10px] leading-tight text-text-muted line-clamp-3 whitespace-pre-wrap'
+    : 'text-sm leading-snug text-text-muted whitespace-pre-wrap'
 
   // Weekend cells are narrow and minimal
   if (isWeekend) {
@@ -392,7 +406,7 @@ export const LessonDayCell = memo(function LessonDayCell({
             onChange={(event) => handleMarkdownChange(event.target.value)}
             onKeyDown={handleKeyDown}
             onBlur={() => setIsEditing(false)}
-            className={`w-full h-full resize-none border-none bg-transparent font-mono text-text-default focus:outline-none ${compact ? 'text-[10px] leading-tight' : 'text-sm leading-snug'}`}
+            className={`w-full h-full resize-none border-none bg-transparent text-text-default focus:outline-none ${showMarkdown ? 'font-mono' : ''} ${compact ? 'text-[10px] leading-tight' : 'text-sm leading-snug'}`}
           />
         ) : (
           <button
@@ -401,8 +415,8 @@ export const LessonDayCell = memo(function LessonDayCell({
             className={`w-full text-left ${editable ? 'cursor-text' : 'cursor-default'}`}
           >
             {hasContent ? (
-              plainTextOnly ? (
-                <div className="text-[10px] leading-tight text-text-muted line-clamp-3 whitespace-pre-wrap">
+              renderPlainText ? (
+                <div className={plainTextClassName}>
                   {plainText}
                 </div>
               ) : (

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -28,6 +28,7 @@ import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
@@ -127,6 +128,7 @@ export function QuizDetailPanel({
   const AUTOSAVE_DEBOUNCE_MS = 3000
   const AUTOSAVE_MIN_INTERVAL_MS = 10_000
   const isTestsView = quiz.assessment_type === 'test' || apiBasePath.includes('/tests')
+  const { showMarkdown } = useMarkdownPreference()
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
   const [documents, setDocuments] = useState<TestDocument[]>(
     () => normalizeTestDocuments((quiz as { documents?: unknown }).documents)
@@ -406,7 +408,7 @@ export function QuizDetailPanel({
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
   const hasResponses = quiz.stats.responded > 0
   const isEditable = canEditQuizQuestions(quiz, hasResponses)
-  const hasPendingMarkdownImport = isTestsView && markdownDirty
+  const hasPendingMarkdownImport = isTestsView && showMarkdown && markdownDirty
   const isMarkdownEditable = isEditable && isMarkdownEditing
   const markdownHelperStatus = markdownSaving
     ? 'Applying markdown...'
@@ -415,7 +417,7 @@ export function QuizDetailPanel({
       : isMarkdownEditing
         ? 'Editing markdown'
         : 'Markdown mirror'
-  const usesSummaryDetailQuestions = isTestsView && testQuestionLayout === 'summary-detail'
+  const usesSummaryDetailQuestions = isTestsView && showMarkdown && testQuestionLayout === 'summary-detail'
   const { width: summaryDetailWorkspaceWidth } = useRefRect(summaryDetailWorkspaceRef, {
     enabled: usesSummaryDetailQuestions,
   })
@@ -458,6 +460,22 @@ export function QuizDetailPanel({
     }
     savedMarkdownRef.current = currentTestMarkdown
   }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
+
+  useEffect(() => {
+    if (showMarkdown) return
+    if (viewMode === 'markdown') {
+      setViewMode('questions')
+    }
+    if (markdownDirty) {
+      const fallbackMarkdown = savedMarkdownRef.current || currentTestMarkdown
+      setMarkdownContent(fallbackMarkdown)
+      setMarkdownDirty(false)
+      markdownDirtyRef.current = false
+    }
+    setIsMarkdownEditing(false)
+    setMarkdownError('')
+    setMarkdownInfo('')
+  }, [currentTestMarkdown, markdownDirty, showMarkdown, viewMode])
 
   useEffect(() => {
     onPendingMarkdownImportChange?.(isTestsView ? hasPendingMarkdownImport : false)
@@ -1678,7 +1696,7 @@ export function QuizDetailPanel({
             {documents.length > 0 ? `Documents (${documents.length})` : 'Documents'}
           </button>
         )}
-        {isTestsView && (
+        {isTestsView && showMarkdown && (
           <button
             type="button"
             onClick={() => setViewMode('markdown')}
@@ -1907,7 +1925,7 @@ export function QuizDetailPanel({
               headerTitle="Reference Documents"
             />
           </div>
-        ) : viewMode === 'markdown' && isTestsView ? (
+        ) : viewMode === 'markdown' && isTestsView && showMarkdown ? (
           testsMarkdownPanel
         ) : viewMode === 'preview' ? (
           <QuizPreview questions={questions} isTestsView={isTestsView} />

--- a/src/components/SortableAssignmentCard.tsx
+++ b/src/components/SortableAssignmentCard.tsx
@@ -2,7 +2,7 @@
 
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, PenSquare, Trash2 } from 'lucide-react'
+import { GripVertical, Trash2 } from 'lucide-react'
 import { formatDueDate } from '@/lib/assignments'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import { Button, Tooltip } from '@/ui'
@@ -16,7 +16,8 @@ interface SortableAssignmentCardProps {
   assignment: AssignmentWithStats
   isReadOnly: boolean
   isDragDisabled?: boolean
-  onSelect: () => void
+  editMode: boolean
+  onOpen: () => void
   onEdit: () => void
   onDelete: () => void
 }
@@ -38,10 +39,12 @@ export function SortableAssignmentCard({
   assignment,
   isReadOnly,
   isDragDisabled = false,
-  onSelect,
+  editMode,
+  onOpen,
   onEdit,
   onDelete,
 }: SortableAssignmentCardProps) {
+  const showEditActions = editMode && !isReadOnly
   const {
     attributes,
     listeners,
@@ -49,7 +52,7 @@ export function SortableAssignmentCard({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: assignment.id, disabled: isReadOnly || isDragDisabled })
+  } = useSortable({ id: assignment.id, disabled: isReadOnly || isDragDisabled || !editMode })
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -65,11 +68,19 @@ export function SortableAssignmentCard({
     isScheduled && assignment.released_at
       ? formatScheduledRelease(assignment.released_at)
       : ''
+  const handleCardAction = () => {
+    if (editMode) {
+      onEdit()
+    } else {
+      onOpen()
+    }
+  }
 
   return (
     <div
       ref={setNodeRef}
       style={style}
+      onClick={handleCardAction}
       className={[
         'w-full rounded-card border p-3.5 text-left shadow-elevated',
         isDraft || isScheduled
@@ -80,11 +91,18 @@ export function SortableAssignmentCard({
           : isDraft || isScheduled
             ? 'transition hover:border-border-strong hover:bg-surface-3'
             : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
+        'cursor-pointer',
       ].join(' ')}
     >
-      <div className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-3">
-        {/* Drag handle */}
-        {!isReadOnly && (
+      <div
+        className={[
+          'grid items-center gap-3',
+          showEditActions
+            ? 'grid-cols-[auto_minmax(0,1fr)_auto]'
+            : 'grid-cols-[minmax(0,1fr)]',
+        ].join(' ')}
+      >
+        {showEditActions && (
           <button
             type="button"
             className={[
@@ -97,65 +115,54 @@ export function SortableAssignmentCard({
             {...listeners}
             aria-label="Drag to reorder"
             disabled={isDragDisabled}
+            onClick={(e) => e.stopPropagation()}
           >
             <GripVertical className="h-5 w-5" aria-hidden="true" />
           </button>
         )}
 
-        {/* Left: Title and due date */}
         <button
           type="button"
-          onClick={onSelect}
-          className="min-w-0 text-left"
+          onClick={(e) => {
+            e.stopPropagation()
+            handleCardAction()
+          }}
+          className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-left"
+          aria-label={editMode ? `Edit ${assignment.title}` : assignment.title}
         >
-          <h3 className={[
-            'font-medium truncate',
-            isDraft || isScheduled ? 'text-text-muted' : 'text-text-default'
-          ].join(' ')}>
-            {assignment.title}
-          </h3>
-          <p className="text-xs text-text-muted">
-            Due: {formatDueDate(assignment.due_at)}
-          </p>
-          {isScheduled && (
-            <p className="text-xs text-warning">{scheduledOpenLabel}</p>
-          )}
+          <span className="min-w-0">
+            <span className={[
+              'block truncate font-medium',
+              isDraft || isScheduled ? 'text-text-muted' : 'text-text-default'
+            ].join(' ')}>
+              {assignment.title}
+            </span>
+            <span className="block text-xs text-text-muted">
+              Due: {formatDueDate(assignment.due_at)}
+            </span>
+            {isScheduled && (
+              <span className="block text-xs text-warning">{scheduledOpenLabel}</span>
+            )}
+          </span>
+
+          <span className="whitespace-nowrap px-2 text-center">
+            {isDraft ? (
+              <span className="inline-flex items-center rounded-badge bg-surface-3 px-2.5 py-1 text-xs font-semibold text-text-muted">
+                Draft
+              </span>
+            ) : isScheduled ? (
+              <span className="inline-flex items-center rounded-badge bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning">
+                Scheduled
+              </span>
+            ) : (
+              <span className="text-sm text-text-muted">
+                {assignment.stats.submitted}/{assignment.stats.total_students}
+              </span>
+            )}
+          </span>
         </button>
 
-        {/* Middle: Status */}
-        <div className="whitespace-nowrap px-4 text-center">
-          {isDraft ? (
-            <span className="inline-flex items-center rounded-badge bg-surface-3 px-2.5 py-1 text-xs font-semibold text-text-muted">
-              Draft
-            </span>
-          ) : isScheduled ? (
-            <span className="inline-flex items-center rounded-badge bg-warning-bg px-2.5 py-1 text-xs font-semibold text-warning">
-              Scheduled
-            </span>
-          ) : (
-            <span className="text-sm text-text-muted">
-              {assignment.stats.submitted}/{assignment.stats.total_students}
-            </span>
-          )}
-        </div>
-
-        {/* Right: Action buttons */}
-        <div className="flex items-center gap-1">
-          <Tooltip content="Edit assignment">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="p-1.5"
-              aria-label={`Edit ${assignment.title}`}
-              disabled={isReadOnly}
-              onClick={(e) => {
-                e.stopPropagation()
-                onEdit()
-              }}
-            >
-              <PenSquare className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          </Tooltip>
+        {showEditActions && (
           <Tooltip content="Delete assignment">
             <Button
               variant="ghost"
@@ -171,7 +178,7 @@ export function SortableAssignmentCard({
               <Trash2 className="h-4 w-4" aria-hidden="true" />
             </Button>
           </Tooltip>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
@@ -33,6 +33,7 @@ interface TeacherStudentWorkPanelProps {
   onGoNextStudent?: () => void
   canGoPrevStudent?: boolean
   canGoNextStudent?: boolean
+  inspectorEditMode?: boolean
   onDetailsMetaChange?: (meta: { studentName: string; characterCount: number } | null) => void
 }
 
@@ -50,6 +51,7 @@ export function TeacherStudentWorkPanel({
   onGoNextStudent,
   canGoPrevStudent = false,
   canGoNextStudent = false,
+  inspectorEditMode = false,
   onDetailsMetaChange,
 }: TeacherStudentWorkPanelProps) {
   const {
@@ -78,6 +80,7 @@ export function TeacherStudentWorkPanel({
     totalScore,
     totalPercent,
     expandedSections,
+    visibleSections,
     setScoreCompletion,
     setScoreThinking,
     setScoreWorkflow,
@@ -88,6 +91,8 @@ export function TeacherStudentWorkPanel({
     handleHistoryMouseLeave,
     handleAIDraftAcknowledge,
     toggleSection,
+    collapseAllSections,
+    toggleSectionVisibility,
     handleReturnFeedback,
     handleSetGradeMode,
     handleAnalyzeRepo,
@@ -97,6 +102,7 @@ export function TeacherStudentWorkPanel({
     studentId,
     onLoadingStateChange,
   })
+  const previousInspectorEditModeRef = useRef(inspectorEditMode)
   const layout = useMemo(
     () =>
       clampAssignmentWorkspacePaneLayout(
@@ -120,6 +126,13 @@ export function TeacherStudentWorkPanel({
     },
     [onLayoutChange],
   )
+
+  useEffect(() => {
+    if (!previousInspectorEditModeRef.current && inspectorEditMode) {
+      collapseAllSections()
+    }
+    previousInspectorEditModeRef.current = inspectorEditMode
+  }, [collapseAllSections, inspectorEditMode])
 
   useEffect(() => {
     if (mode !== 'details' || showInitialSpinner || error || !data) {
@@ -190,7 +203,10 @@ export function TeacherStudentWorkPanel({
       showDraftAutosavedNotice={showDraftAutosavedNotice}
       repoAnalyzing={repoAnalyzing}
       expandedSections={expandedSections}
+      visibleSections={visibleSections}
+      editMode={inspectorEditMode}
       onToggleSection={toggleSection}
+      onToggleSectionVisibility={toggleSectionVisibility}
       handleReturnFeedback={handleReturnFeedback}
       handleSetGradeMode={handleSetGradeMode}
       handleAnalyzeRepo={handleAnalyzeRepo}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useState } from 'react'
 import Link from 'next/link'
-import { Check, UserCircle, LogOut, Moon, Sun, Bug } from 'lucide-react'
+import { UserCircle, LogOut, Moon, Sun, Bug } from 'lucide-react'
 import { useTheme } from '@/contexts/ThemeContext'
-import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { useDropdownNav } from '@/hooks/use-dropdown-nav'
 import { FeedbackDialog } from '@/components/FeedbackDialog'
 
@@ -71,18 +70,12 @@ function getInitials(firstName?: string | null, lastName?: string | null): strin
  */
 export function UserMenu({ user }: UserMenuProps) {
   const { theme, mounted, toggleTheme } = useTheme()
-  const { showMarkdown, mounted: markdownMounted, toggleShowMarkdown } = useMarkdownPreference()
   const [showFeedback, setShowFeedback] = useState(false)
 
   const handleThemeToggle = useCallback(() => {
     toggleTheme()
     // Don't close menu when toggling theme
   }, [toggleTheme])
-
-  const handleMarkdownToggle = useCallback(() => {
-    toggleShowMarkdown()
-    // Keep the menu open while changing display preferences.
-  }, [toggleShowMarkdown])
 
   const {
     isOpen,
@@ -98,7 +91,7 @@ export function UserMenu({ user }: UserMenuProps) {
     itemRefs,
     containerRef,
   } = useDropdownNav({
-    itemCount: 4, // theme toggle, markdown visibility, feedback, logout
+    itemCount: 3, // theme toggle, feedback, logout
   })
 
   if (!user) {
@@ -198,44 +191,15 @@ export function UserMenu({ user }: UserMenuProps) {
           {mounted ? (theme === 'dark' ? 'Light mode' : 'Dark mode') : 'Toggle theme'}
         </button>
 
-        {/* Markdown visibility */}
+        {/* Send Feedback */}
         <button
           id={getItemId(1)}
           ref={(el) => { itemRefs.current[1] = el }}
-          onClick={handleMarkdownToggle}
+          onClick={() => { setIsOpen(false); setShowFeedback(true) }}
           onMouseEnter={() => setFocusedIndex(1)}
           onKeyDown={handleItemKeyDown}
           className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
             focusedIndex === 1
-              ? 'bg-surface-2'
-              : 'hover:bg-surface-hover'
-          }`}
-          role="menuitemcheckbox"
-          aria-checked={markdownMounted ? showMarkdown : true}
-          tabIndex={isOpen ? 0 : -1}
-        >
-          <span
-            className={`flex h-4 w-4 items-center justify-center rounded border ${
-              markdownMounted && showMarkdown
-                ? 'border-primary bg-primary text-text-inverse'
-                : 'border-border-strong bg-surface'
-            }`}
-            aria-hidden="true"
-          >
-            {markdownMounted && showMarkdown ? <Check className="h-3 w-3" /> : null}
-          </span>
-          Show markdown
-        </button>
-
-        {/* Send Feedback */}
-        <button
-          id={getItemId(2)}
-          ref={(el) => { itemRefs.current[2] = el }}
-          onClick={() => { setIsOpen(false); setShowFeedback(true) }}
-          onMouseEnter={() => setFocusedIndex(2)}
-          onKeyDown={handleItemKeyDown}
-          className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
-            focusedIndex === 2
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
           }`}
@@ -248,14 +212,14 @@ export function UserMenu({ user }: UserMenuProps) {
 
         {/* Logout */}
         <Link
-          id={getItemId(3)}
-          ref={(el) => { itemRefs.current[3] = el }}
+          id={getItemId(2)}
+          ref={(el) => { itemRefs.current[2] = el }}
           href="/logout"
           onClick={() => setIsOpen(false)}
-          onMouseEnter={() => setFocusedIndex(3)}
+          onMouseEnter={() => setFocusedIndex(2)}
           onKeyDown={handleItemKeyDown}
           className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
-            focusedIndex === 3
+            focusedIndex === 2
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
           }`}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useState } from 'react'
 import Link from 'next/link'
-import { UserCircle, LogOut, Moon, Sun, Bug } from 'lucide-react'
+import { Check, UserCircle, LogOut, Moon, Sun, Bug } from 'lucide-react'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { useDropdownNav } from '@/hooks/use-dropdown-nav'
 import { FeedbackDialog } from '@/components/FeedbackDialog'
 
@@ -70,12 +71,18 @@ function getInitials(firstName?: string | null, lastName?: string | null): strin
  */
 export function UserMenu({ user }: UserMenuProps) {
   const { theme, mounted, toggleTheme } = useTheme()
+  const { showMarkdown, mounted: markdownMounted, toggleShowMarkdown } = useMarkdownPreference()
   const [showFeedback, setShowFeedback] = useState(false)
 
   const handleThemeToggle = useCallback(() => {
     toggleTheme()
     // Don't close menu when toggling theme
   }, [toggleTheme])
+
+  const handleMarkdownToggle = useCallback(() => {
+    toggleShowMarkdown()
+    // Keep the menu open while changing display preferences.
+  }, [toggleShowMarkdown])
 
   const {
     isOpen,
@@ -91,7 +98,7 @@ export function UserMenu({ user }: UserMenuProps) {
     itemRefs,
     containerRef,
   } = useDropdownNav({
-    itemCount: 3, // theme toggle, feedback, logout
+    itemCount: 4, // theme toggle, markdown visibility, feedback, logout
   })
 
   if (!user) {
@@ -191,15 +198,44 @@ export function UserMenu({ user }: UserMenuProps) {
           {mounted ? (theme === 'dark' ? 'Light mode' : 'Dark mode') : 'Toggle theme'}
         </button>
 
-        {/* Send Feedback */}
+        {/* Markdown visibility */}
         <button
           id={getItemId(1)}
           ref={(el) => { itemRefs.current[1] = el }}
-          onClick={() => { setIsOpen(false); setShowFeedback(true) }}
+          onClick={handleMarkdownToggle}
           onMouseEnter={() => setFocusedIndex(1)}
           onKeyDown={handleItemKeyDown}
           className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
             focusedIndex === 1
+              ? 'bg-surface-2'
+              : 'hover:bg-surface-hover'
+          }`}
+          role="menuitemcheckbox"
+          aria-checked={markdownMounted ? showMarkdown : true}
+          tabIndex={isOpen ? 0 : -1}
+        >
+          <span
+            className={`flex h-4 w-4 items-center justify-center rounded border ${
+              markdownMounted && showMarkdown
+                ? 'border-primary bg-primary text-text-inverse'
+                : 'border-border-strong bg-surface'
+            }`}
+            aria-hidden="true"
+          >
+            {markdownMounted && showMarkdown ? <Check className="h-3 w-3" /> : null}
+          </span>
+          Show markdown
+        </button>
+
+        {/* Send Feedback */}
+        <button
+          id={getItemId(2)}
+          ref={(el) => { itemRefs.current[2] = el }}
+          onClick={() => { setIsOpen(false); setShowFeedback(true) }}
+          onMouseEnter={() => setFocusedIndex(2)}
+          onKeyDown={handleItemKeyDown}
+          className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
+            focusedIndex === 2
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
           }`}
@@ -212,14 +248,14 @@ export function UserMenu({ user }: UserMenuProps) {
 
         {/* Logout */}
         <Link
-          id={getItemId(2)}
-          ref={(el) => { itemRefs.current[2] = el }}
+          id={getItemId(3)}
+          ref={(el) => { itemRefs.current[3] = el }}
           href="/logout"
           onClick={() => setIsOpen(false)}
-          onMouseEnter={() => setFocusedIndex(2)}
+          onMouseEnter={() => setFocusedIndex(3)}
           onKeyDown={handleItemKeyDown}
           className={`w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted transition-colors focus:outline-none ${
-            focusedIndex === 2
+            focusedIndex === 3
               ? 'bg-surface-2'
               : 'hover:bg-surface-hover'
           }`}

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -171,54 +171,112 @@ function InspectorSection({
   id,
   title,
   expanded,
+  visible,
+  editMode,
   summary,
   onToggle,
+  onVisibleChange,
   action,
   children,
 }: {
   id: InspectorSectionId
   title: string
   expanded: boolean
+  visible: boolean
+  editMode: boolean
   summary?: ReactNode
   onToggle: () => void
+  onVisibleChange: () => void
   action?: ReactNode
   children?: ReactNode
 }) {
   const contentId = `assignment-inspector-section-${id}`
+  const effectiveExpanded = visible && expanded
+  const handleHeaderToggle = () => {
+    if (!visible) return
+    onToggle()
+  }
 
   return (
     <section
       data-testid={`inspector-section-${id}`}
-      className="overflow-hidden rounded-lg border border-border bg-surface"
+      className={[
+        'overflow-hidden rounded-lg border transition-colors',
+        visible
+          ? 'border-border bg-surface'
+          : 'border-dashed border-border bg-surface-2',
+      ].join(' ')}
     >
-      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,19rem)] items-center gap-3 p-3">
-        <button
-          type="button"
-          className="min-w-0 text-left"
-          aria-label={title}
-          aria-expanded={expanded}
-          aria-controls={contentId}
-          onClick={onToggle}
-        >
-          <div className="flex min-w-0 items-center gap-2">
-            {expanded ? (
-              <ChevronDown className="h-4 w-4 text-text-muted" aria-hidden="true" />
-            ) : (
-              <ChevronRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
-            )}
-            <span className="shrink-0 text-sm font-semibold text-text-default">{title}</span>
-          </div>
-        </button>
+      <div
+        role="button"
+        tabIndex={visible ? 0 : -1}
+        aria-label={title}
+        aria-expanded={effectiveExpanded}
+        aria-controls={contentId}
+        aria-disabled={!visible}
+        className={[
+          'grid grid-cols-[minmax(0,1fr)_minmax(0,19rem)] items-center gap-3 p-3',
+          visible ? 'cursor-pointer' : 'cursor-default',
+        ].join(' ')}
+        onClick={(event) => {
+          const target = event.target
+          if (
+            target instanceof HTMLElement &&
+            target.closest('[data-inspector-header-control="true"]')
+          ) {
+            return
+          }
+          handleHeaderToggle()
+        }}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return
+          if (event.key !== 'Enter' && event.key !== ' ') return
+          event.preventDefault()
+          handleHeaderToggle()
+        }}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {editMode ? (
+            <input
+              type="checkbox"
+              checked={visible}
+              onChange={onVisibleChange}
+              aria-label={`Show ${title} card`}
+              data-inspector-header-control="true"
+              className="h-4 w-4 shrink-0 rounded border-border text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          ) : null}
+          {effectiveExpanded ? (
+            <ChevronDown className="h-4 w-4 text-text-muted" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
+          )}
+          <span
+            className={[
+              'shrink-0 text-sm font-semibold',
+              visible ? 'text-text-default' : 'text-text-muted',
+            ].join(' ')}
+          >
+            {title}
+          </span>
+        </div>
         <div className="min-w-0">
-          {(summary || (expanded && action)) ? (
+          {visible && (summary || (effectiveExpanded && action)) ? (
             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
               <div className="min-w-0">{summary}</div>
-              {expanded && action ? <div className="shrink-0">{action}</div> : null}
+              {effectiveExpanded && action ? (
+                <div
+                  className="shrink-0"
+                  data-inspector-header-control="true"
+                >
+                  {action}
+                </div>
+              ) : null}
             </div>
           ) : null}
         </div>
       </div>
-      <AnimatedSectionContent id={contentId} expanded={expanded}>
+      <AnimatedSectionContent id={contentId} expanded={effectiveExpanded}>
         {children}
       </AnimatedSectionContent>
     </section>
@@ -434,7 +492,10 @@ export function TeacherWorkInspector({
   showDraftAutosavedNotice,
   repoAnalyzing,
   expandedSections,
+  visibleSections,
+  editMode = false,
   onToggleSection,
+  onToggleSectionVisibility,
   handleReturnFeedback,
   handleSetGradeMode,
   handleAnalyzeRepo,
@@ -470,7 +531,10 @@ export function TeacherWorkInspector({
   showDraftAutosavedNotice: boolean
   repoAnalyzing: boolean
   expandedSections: InspectorSectionId[]
+  visibleSections: InspectorSectionId[]
+  editMode?: boolean
   onToggleSection: (section: InspectorSectionId) => void
+  onToggleSectionVisibility: (section: InspectorSectionId) => void
   handleReturnFeedback: () => Promise<void>
   handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
   handleAnalyzeRepo: () => Promise<void>
@@ -737,19 +801,28 @@ export function TeacherWorkInspector({
     >
       <div className="flex-1 overflow-y-auto">
         <div>
-          {sections.map((section) => (
-            <InspectorSection
-              key={section.id}
-              id={section.id}
-              title={section.title}
-              expanded={expandedSections.includes(section.id)}
-              summary={section.summary}
-              action={section.action}
-              onToggle={() => onToggleSection(section.id)}
-            >
-              {section.content}
-            </InspectorSection>
-          ))}
+          {sections
+            .filter((section) => editMode || visibleSections.includes(section.id))
+            .map((section) => {
+              const visible = visibleSections.includes(section.id)
+
+              return (
+                <InspectorSection
+                  key={section.id}
+                  id={section.id}
+                  title={section.title}
+                  expanded={expandedSections.includes(section.id)}
+                  visible={visible}
+                  editMode={editMode}
+                  summary={section.summary}
+                  action={section.action}
+                  onToggle={() => onToggleSection(section.id)}
+                  onVisibleChange={() => onToggleSectionVisibility(section.id)}
+                >
+                  {section.content}
+                </InspectorSection>
+              )
+            })}
         </div>
       </div>
 

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -18,12 +18,18 @@ type GradeSaveMode = 'draft' | 'graded'
 
 const SECTION_ORDER: InspectorSectionId[] = ['history', 'repo', 'grades', 'comments']
 const DEFAULT_EXPANDED_SECTIONS: InspectorSectionId[] = ['grades', 'comments']
+const DEFAULT_VISIBLE_SECTIONS: InspectorSectionId[] = SECTION_ORDER
 const INSPECTOR_SECTIONS_COOKIE_PREFIX = 'pika_teacher_student_work_sections'
+const INSPECTOR_VISIBLE_SECTIONS_COOKIE_PREFIX = 'pika_teacher_student_work_visible_sections'
 const GRADE_AUTOSAVE_DELAY_MS = 900
 const DRAFT_AUTOSAVED_NOTICE_MS = 2500
 
 function getInspectorSectionsCookieName(classroomId: string) {
   return `${INSPECTOR_SECTIONS_COOKIE_PREFIX}:${classroomId}`
+}
+
+function getInspectorVisibleSectionsCookieName(classroomId: string) {
+  return `${INSPECTOR_VISIBLE_SECTIONS_COOKIE_PREFIX}:${classroomId}`
 }
 
 function parseExpandedSections(rawValue: string | null | undefined): InspectorSectionId[] {
@@ -53,6 +59,35 @@ function parseExpandedSections(rawValue: string | null | undefined): InspectorSe
 }
 
 function serializeExpandedSections(sections: InspectorSectionId[]): string {
+  return SECTION_ORDER.filter((section) => sections.includes(section)).join(',')
+}
+
+function parseVisibleSections(rawValue: string | null | undefined): InspectorSectionId[] {
+  if (rawValue == null) return DEFAULT_VISIBLE_SECTIONS
+  if (rawValue.trim() === '') return []
+
+  const parts = rawValue
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  const valid = new Set<InspectorSectionId>(SECTION_ORDER)
+  const nextSections: InspectorSectionId[] = []
+
+  for (const part of parts) {
+    if (!valid.has(part as InspectorSectionId)) {
+      return DEFAULT_VISIBLE_SECTIONS
+    }
+    const section = part as InspectorSectionId
+    if (!nextSections.includes(section)) {
+      nextSections.push(section)
+    }
+  }
+
+  return SECTION_ORDER.filter((section) => nextSections.includes(section))
+}
+
+function serializeVisibleSections(sections: InspectorSectionId[]): string {
   return SECTION_ORDER.filter((section) => sections.includes(section)).join(',')
 }
 
@@ -167,6 +202,7 @@ export interface TeacherStudentWorkController {
   totalScore: number
   totalPercent: number
   expandedSections: InspectorSectionId[]
+  visibleSections: InspectorSectionId[]
   setScoreCompletion: (value: string) => void
   setScoreThinking: (value: string) => void
   setScoreWorkflow: (value: string) => void
@@ -177,6 +213,8 @@ export interface TeacherStudentWorkController {
   handleHistoryMouseLeave: () => void
   handleAIDraftAcknowledge: () => void
   toggleSection: (section: InspectorSectionId) => void
+  collapseAllSections: () => void
+  toggleSectionVisibility: (section: InspectorSectionId) => void
   handleAutoGrade: () => Promise<void>
   handleReturnFeedback: () => Promise<void>
   handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
@@ -224,10 +262,14 @@ export function useTeacherStudentWorkController({
   const [expandedSections, setExpandedSections] = useState<InspectorSectionId[]>(() =>
     parseExpandedSections(readCookie(getInspectorSectionsCookieName(classroomId))),
   )
+  const [visibleSections, setVisibleSections] = useState<InspectorSectionId[]>(() =>
+    parseVisibleSections(readCookie(getInspectorVisibleSectionsCookieName(classroomId))),
+  )
   const showInitialSpinner = useDelayedBusy(loading && !data)
 
   useEffect(() => {
     setExpandedSections(parseExpandedSections(readCookie(getInspectorSectionsCookieName(classroomId))))
+    setVisibleSections(parseVisibleSections(readCookie(getInspectorVisibleSectionsCookieName(classroomId))))
   }, [classroomId])
 
   const persistExpandedSections = useCallback(
@@ -251,6 +293,35 @@ export function useTeacherStudentWorkController({
       })
     },
     [persistExpandedSections],
+  )
+
+  const collapseAllSections = useCallback(() => {
+    const next: InspectorSectionId[] = []
+    persistExpandedSections(next)
+    setExpandedSections(next)
+  }, [persistExpandedSections])
+
+  const persistVisibleSections = useCallback(
+    (sections: InspectorSectionId[]) => {
+      writeCookie(
+        getInspectorVisibleSectionsCookieName(classroomId),
+        serializeVisibleSections(sections),
+      )
+    },
+    [classroomId],
+  )
+
+  const toggleSectionVisibility = useCallback(
+    (section: InspectorSectionId) => {
+      setVisibleSections((current) => {
+        const next = current.includes(section)
+          ? current.filter((value) => value !== section)
+          : SECTION_ORDER.filter((value) => value === section || current.includes(value))
+        persistVisibleSections(next)
+        return next
+      })
+    },
+    [persistVisibleSections],
   )
 
   const clearDraftAutosavedNotice = useCallback(() => {
@@ -803,6 +874,7 @@ export function useTeacherStudentWorkController({
     totalScore,
     totalPercent,
     expandedSections,
+    visibleSections,
     setScoreCompletion: updateScoreCompletion,
     setScoreThinking: updateScoreThinking,
     setScoreWorkflow: updateScoreWorkflow,
@@ -813,6 +885,8 @@ export function useTeacherStudentWorkController({
     handleHistoryMouseLeave,
     handleAIDraftAcknowledge: () => setHasFreshAIDraft(false),
     toggleSection,
+    collapseAllSections,
+    toggleSectionVisibility,
     handleAutoGrade,
     handleReturnFeedback,
     handleSetGradeMode,

--- a/src/components/teacher-work-surface/TeacherEditModeControls.tsx
+++ b/src/components/teacher-work-surface/TeacherEditModeControls.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Check, Pencil } from 'lucide-react'
+import { Button, Tooltip } from '@/ui'
+import { cn } from '@/ui/utils'
+
+interface TeacherEditModeControlsProps {
+  active: boolean
+  onActiveChange: (active: boolean) => void
+  disabled?: boolean
+  children?: ReactNode
+  editLabel?: string
+  doneLabel?: string
+  className?: string
+}
+
+export function TeacherEditModeControls({
+  active,
+  onActiveChange,
+  disabled = false,
+  children,
+  editLabel = 'Edit',
+  doneLabel = 'Done',
+  className,
+}: TeacherEditModeControlsProps) {
+  const Icon = active ? Check : Pencil
+  const label = active ? doneLabel : editLabel
+
+  return (
+    <div className={cn('flex flex-wrap items-center justify-end gap-1.5', className)}>
+      {active && children ? (
+        <div className="flex flex-wrap items-center justify-end gap-1.5">
+          {children}
+        </div>
+      ) : null}
+
+      <Tooltip content={active ? 'Hide edit actions' : 'Show edit actions'}>
+        <Button
+          type="button"
+          variant={active ? 'secondary' : 'ghost'}
+          size="sm"
+          className="min-h-10 px-3"
+          aria-pressed={active}
+          disabled={disabled}
+          onClick={() => onActiveChange(!active)}
+        >
+          <Icon className="h-4 w-4" aria-hidden="true" />
+          <span>{label}</span>
+        </Button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/contexts/MarkdownPreferenceContext.tsx
+++ b/src/contexts/MarkdownPreferenceContext.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+
+const MARKDOWN_PREFERENCE_STORAGE_KEY = 'pika_show_markdown'
+
+interface MarkdownPreferenceContextValue {
+  showMarkdown: boolean
+  mounted: boolean
+  setShowMarkdown: (show: boolean) => void
+  toggleShowMarkdown: () => void
+}
+
+const MarkdownPreferenceContext = createContext<MarkdownPreferenceContextValue>({
+  showMarkdown: true,
+  mounted: false,
+  setShowMarkdown: () => {},
+  toggleShowMarkdown: () => {},
+})
+
+function readStoredShowMarkdown(): boolean {
+  try {
+    return localStorage.getItem(MARKDOWN_PREFERENCE_STORAGE_KEY) !== 'false'
+  } catch {
+    return true
+  }
+}
+
+export function MarkdownPreferenceProvider({ children }: { children: ReactNode }) {
+  const [showMarkdown, setShowMarkdownState] = useState(true)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setShowMarkdownState(readStoredShowMarkdown())
+    setMounted(true)
+  }, [])
+
+  const setShowMarkdown = (show: boolean) => {
+    setShowMarkdownState(show)
+    try {
+      localStorage.setItem(MARKDOWN_PREFERENCE_STORAGE_KEY, show ? 'true' : 'false')
+    } catch {
+      // Ignore storage errors; the in-memory preference still updates for this session.
+    }
+  }
+
+  const value = useMemo<MarkdownPreferenceContextValue>(
+    () => ({
+      showMarkdown,
+      mounted,
+      setShowMarkdown,
+      toggleShowMarkdown: () => setShowMarkdown(!showMarkdown),
+    }),
+    [mounted, showMarkdown],
+  )
+
+  return (
+    <MarkdownPreferenceContext.Provider value={value}>
+      {children}
+    </MarkdownPreferenceContext.Provider>
+  )
+}
+
+export function useMarkdownPreference() {
+  return useContext(MarkdownPreferenceContext)
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -72,7 +72,7 @@
   --space-section: 1.5rem;
   --space-field: 0.75rem;
   --space-control: 0.5rem;
-  --space-header-compact: 0.125rem;
+  --space-header-compact: 0.75rem;
 
   /* Border radius */
   --radius-control: 0.5rem;

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { AssignmentModal } from '@/components/AssignmentModal'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
 import { toTorontoEndOfDayIso } from '@/lib/timezone'
 import type { Assignment } from '@/types'
 
@@ -32,6 +33,7 @@ describe('AssignmentModal', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    window.localStorage.clear()
   })
 
   describe('edit mode', () => {
@@ -105,6 +107,29 @@ describe('AssignmentModal', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Redo' }))
 
       expect(instructions).toHaveValue('**Original** instructions')
+    })
+
+    it('hides markdown instruction tools when the user preference is off', async () => {
+      window.localStorage.setItem('pika_show_markdown', 'false')
+
+      render(
+        <MarkdownPreferenceProvider>
+          <AssignmentModal
+            isOpen={true}
+            classroomId="classroom-1"
+            assignment={baseAssignment}
+            onClose={vi.fn()}
+            onSuccess={vi.fn()}
+          />
+        </MarkdownPreferenceProvider>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: 'Heading' })).not.toBeInTheDocument()
+      })
+      expect(screen.queryByRole('button', { name: 'Bold' })).not.toBeInTheDocument()
+      expect(screen.queryByText('Preview')).not.toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Assignment instructions')).toHaveValue('Original instructions')
     })
 
     it('shows save status indicator', () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -60,10 +60,13 @@ vi.mock('@/components/layout', async () => {
     MainContent: ({ children }: any) => <main>{children}</main>,
     NavItems: () => <nav />,
     RightSidebar: ({ children, headerActions, title }: any) => {
-      const { isRightOpen } = useLayoutContext()
+      const { isRightOpen, setRightOpen } = useLayoutContext()
       if (!isRightOpen) return null
       return (
         <aside aria-label={title || 'Right sidebar'}>
+          <button type="button" onClick={() => setRightOpen(false)}>
+            Close panel
+          </button>
           {headerActions}
           {children}
         </aside>
@@ -261,6 +264,26 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     await waitFor(() => {
       expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
     })
+  })
+
+  it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {
+    renderClient()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+    expect(mockFetchJSONWithCache).toHaveBeenCalledTimes(1)
   })
 
   it('clears assignment edit and markdown mode when route navigation leaves assignments', async () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -1,0 +1,295 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClassroomPageClient } from '@/app/classrooms/[classroomId]/ClassroomPageClient'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
+import type { Classroom } from '@/types'
+
+const mockFetchJSONWithCache = vi.hoisted(() => vi.fn())
+const mockAssignmentsToMarkdown = vi.hoisted(() => vi.fn())
+
+vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
+  TeacherClassroomView: ({ onEditModeChange }: any) => (
+    <div>
+      <button type="button" onClick={() => onEditModeChange?.(true)}>
+        Set assignment edit active
+      </button>
+      <button type="button" onClick={() => onEditModeChange?.(false)}>
+        Set assignment edit inactive
+      </button>
+    </div>
+  ),
+  TeacherAssignmentsMarkdownSidebar: ({ markdownContent }: any) => (
+    <div>Markdown editor: {markdownContent}</div>
+  ),
+}))
+
+vi.mock('@/components/AppShell', () => ({
+  AppShell: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layout', async () => {
+  const React = await import('react')
+  const LayoutContext = React.createContext<any>(null)
+
+  function useLayoutContext() {
+    const value = React.useContext(LayoutContext)
+    if (!value) {
+      throw new Error('layout context missing')
+    }
+    return value
+  }
+
+  return {
+    ThreePanelProvider: ({ children }: any) => {
+      const [isRightOpen, setRightOpen] = React.useState(false)
+      const [rightWidth, setRightWidth] = React.useState(320)
+      const value = React.useMemo(
+        () => ({
+          isRightOpen,
+          rightWidth,
+          setRightOpen,
+          setRightWidth,
+        }),
+        [isRightOpen, rightWidth],
+      )
+
+      return <LayoutContext.Provider value={value}>{children}</LayoutContext.Provider>
+    },
+    ThreePanelShell: ({ children }: any) => <div>{children}</div>,
+    LeftSidebar: ({ children }: any) => <div>{children}</div>,
+    MainContent: ({ children }: any) => <main>{children}</main>,
+    NavItems: () => <nav />,
+    RightSidebar: ({ children, headerActions, title }: any) => {
+      const { isRightOpen } = useLayoutContext()
+      if (!isRightOpen) return null
+      return (
+        <aside aria-label={title || 'Right sidebar'}>
+          {headerActions}
+          {children}
+        </aside>
+      )
+    },
+    useLayoutInitialState: () => ({ leftSidebarExpanded: true }),
+    useMobileDrawer: () => {
+      const { setRightOpen } = useLayoutContext()
+      return {
+        openLeft: vi.fn(),
+        openRight: () => setRightOpen(true),
+        close: () => setRightOpen(false),
+      }
+    },
+    useRightSidebar: () => {
+      const { isRightOpen, setRightOpen, rightWidth, setRightWidth } = useLayoutContext()
+      return {
+        isOpen: isRightOpen,
+        setOpen: setRightOpen,
+        setWidth: setRightWidth,
+        enabled: true,
+        cssWidth: typeof rightWidth === 'number' ? `${rightWidth}px` : rightWidth,
+        desktopAlwaysOpen: false,
+      }
+    },
+  }
+})
+
+vi.mock('@/components/StudentNotificationsProvider', () => ({
+  StudentNotificationsProvider: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('@/hooks/useClassDays', () => ({
+  ClassDaysProvider: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('@/ui', () => ({
+  ConfirmDialog: () => null,
+  TabContentTransition: ({ children, isActive }: any) => (isActive ? <>{children}</> : null),
+}))
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: (...args: any[]) => mockFetchJSONWithCache(...args),
+  prefetchJSON: vi.fn(),
+}))
+
+vi.mock('@/lib/assignment-markdown', () => ({
+  assignmentsToMarkdown: (...args: any[]) => mockAssignmentsToMarkdown(...args),
+  markdownToAssignments: vi.fn(() => ({ assignments: [], errors: [], warnings: [] })),
+}))
+
+vi.mock('@/lib/classroom-ux-metrics', () => ({
+  markClassroomTabSwitchReady: vi.fn(),
+  markClassroomTabSwitchStart: vi.fn(),
+}))
+
+vi.mock('@/components/editor', () => ({
+  RichTextViewer: () => <div>Rich text</div>,
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}))
+
+vi.mock('@/components/TeacherTestPreviewPage', () => ({
+  TeacherTestPreviewPage: () => null,
+}))
+
+vi.mock('@/app/classrooms/[classroomId]/StudentTodayTab', () => ({
+  StudentTodayTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentAssignmentsTab', () => ({
+  StudentAssignmentsTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherAttendanceTab', () => ({
+  TeacherAttendanceTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherRosterTab', () => ({
+  TeacherRosterTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherGradebookTab', () => ({
+  TeacherGradebookTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherSettingsTab', () => ({
+  TeacherSettingsTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherLessonCalendarTab', () => ({
+  TeacherLessonCalendarTab: () => <div />,
+  TeacherLessonCalendarSidebar: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentLessonCalendarTab', () => ({
+  StudentLessonCalendarTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherClassResourcesSidebar', () => ({
+  TeacherClassResourcesSidebar: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherResourcesTab', () => ({
+  TeacherResourcesTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentClassResourcesSidebar', () => ({
+  StudentClassResourcesSidebar: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentResourcesTab', () => ({
+  StudentResourcesTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherQuizzesTab', () => ({
+  TeacherQuizzesTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/TeacherTestsTab', () => ({
+  TeacherTestsTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentQuizzesTab', () => ({
+  StudentQuizzesTab: () => <div />,
+}))
+vi.mock('@/components/StudentLogHistory', () => ({
+  StudentLogHistory: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/LogSummary', () => ({
+  LogSummary: () => <div />,
+}))
+vi.mock('@/components/PageLayout', () => ({
+  PageDensityProvider: ({ children }: any) => <>{children}</>,
+}))
+
+const classroom: Classroom = {
+  id: 'classroom-1',
+  teacher_id: 'teacher-1',
+  title: 'Physics',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'hidden',
+  archived_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function renderClient() {
+  return render(
+    <MarkdownPreferenceProvider>
+      <ClassroomPageClient
+        classroom={classroom}
+        user={{ id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' }}
+        teacherClassrooms={[classroom]}
+        initialTab="assignments"
+        initialSearchParams={{ tab: 'assignments' }}
+      />
+    </MarkdownPreferenceProvider>,
+  )
+}
+
+describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=assignments')
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true,
+    })
+    mockFetchJSONWithCache.mockReset()
+    mockAssignmentsToMarkdown.mockReset()
+    mockFetchJSONWithCache.mockResolvedValue({
+      assignments: [
+        {
+          id: 'assignment-1',
+          title: 'Assignment One',
+          instructions_markdown: 'Instructions',
+          rich_instructions: null,
+        },
+      ],
+    })
+    mockAssignmentsToMarkdown.mockReturnValue({
+      markdown: '## Assignment One',
+      hasRichContent: false,
+    })
+  })
+
+  it('opens assignment markdown when assignment edit mode activates and closes it when edit mode turns off', async () => {
+    renderClient()
+
+    expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+    expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
+    })
+    expect(mockFetchJSONWithCache).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit inactive' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('clears assignment edit and markdown mode when route navigation leaves assignments', async () => {
+    renderClient()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
+    })
+
+    window.history.pushState({}, '', '/classrooms/classroom-1?tab=resources')
+    window.dispatchEvent(new Event('popstate'))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Set assignment edit active' })).not.toBeInTheDocument()
+  })
+
+  it('does not open assignment markdown when the global markdown setting is hidden', async () => {
+    window.localStorage.setItem('pika_show_markdown', 'false')
+    renderClient()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+
+    await waitFor(() => {
+      expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/LessonCalendar.test.tsx
+++ b/tests/components/LessonCalendar.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { LessonCalendar } from '@/components/LessonCalendar'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
 import { TooltipProvider } from '@/ui'
 import type { Assignment, Classroom, LessonPlan, TiptapContent } from '@/types'
 import type { ReactNode } from 'react'
@@ -58,6 +59,18 @@ const allModeLessonPlan: LessonPlan = {
 function Wrapper({ children }: { children: ReactNode }) {
   return <TooltipProvider>{children}</TooltipProvider>
 }
+
+function MarkdownPreferenceWrapper({ children }: { children: ReactNode }) {
+  return (
+    <MarkdownPreferenceProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </MarkdownPreferenceProvider>
+  )
+}
+
+afterEach(() => {
+  window.localStorage.clear()
+})
 
 describe('LessonCalendar', () => {
   describe('All view row heights', () => {
@@ -193,5 +206,31 @@ describe('LessonCalendar', () => {
     fireEvent.click(screen.getByText('All mode lesson'))
 
     expect(screen.getByDisplayValue('All mode lesson')).toBeInTheDocument()
+  })
+
+  it('renders lesson markdown as plain text when the user preference is off', async () => {
+    window.localStorage.setItem('pika_show_markdown', 'false')
+    const markdownLessonPlan: LessonPlan = {
+      ...allModeLessonPlan,
+      content_markdown: '### Lesson title\n- **Read** `notes`',
+    }
+
+    const { container } = render(
+      <LessonCalendar
+        classroom={mockClassroom}
+        lessonPlans={[markdownLessonPlan]}
+        viewMode="week"
+        currentDate={new Date('2026-03-16T12:00:00')}
+        editable={false}
+        onDateChange={vi.fn()}
+        onViewModeChange={vi.fn()}
+      />,
+      { wrapper: MarkdownPreferenceWrapper }
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('h3')).toBeNull()
+    })
+    expect(screen.getAllByText((_, node) => node?.textContent === 'Lesson title\nRead notes').length).toBeGreaterThan(0)
   })
 })

--- a/tests/components/SortableAssignmentCard.test.tsx
+++ b/tests/components/SortableAssignmentCard.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
+import { TooltipProvider } from '@/ui'
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  })),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: vi.fn(() => undefined),
+    },
+  },
+}))
+
+const assignment = {
+  id: 'assignment-1',
+  classroom_id: 'classroom-1',
+  title: 'Assignment One',
+  description: 'Description',
+  instructions_markdown: 'Instructions',
+  rich_instructions: null,
+  due_at: '2026-04-20T12:00:00Z',
+  position: 0,
+  is_draft: false,
+  released_at: '2026-04-10T12:00:00Z',
+  created_by: 'teacher-1',
+  created_at: '2026-04-01T12:00:00Z',
+  updated_at: '2026-04-01T12:00:00Z',
+  stats: { total_students: 2, submitted: 1, late: 0 },
+}
+
+function renderCard({
+  editMode,
+  onOpen = vi.fn(),
+  onEdit = vi.fn(),
+  onDelete = vi.fn(),
+}: {
+  editMode: boolean
+  onOpen?: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+}) {
+  render(
+    <TooltipProvider>
+      <SortableAssignmentCard
+        assignment={assignment as any}
+        isReadOnly={false}
+        editMode={editMode}
+        onOpen={onOpen}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+    </TooltipProvider>,
+  )
+
+  return { onOpen, onEdit, onDelete }
+}
+
+describe('SortableAssignmentCard', () => {
+  it('hides drag and delete affordances in normal mode', () => {
+    renderCard({ editMode: false })
+
+    expect(screen.queryByRole('button', { name: 'Drag to reorder' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete Assignment One' })).not.toBeInTheDocument()
+  })
+
+  it('shows drag and delete affordances in edit mode', () => {
+    renderCard({ editMode: true })
+
+    expect(screen.getByRole('button', { name: 'Drag to reorder' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete Assignment One' })).toBeInTheDocument()
+  })
+
+  it('opens the workspace in normal mode and the editor in edit mode', () => {
+    const normal = renderCard({ editMode: false })
+    fireEvent.click(screen.getByRole('button', { name: 'Assignment One' }))
+    expect(normal.onOpen).toHaveBeenCalledTimes(1)
+    expect(normal.onEdit).not.toHaveBeenCalled()
+
+    const edit = renderCard({ editMode: true })
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Assignment One' }))
+    expect(edit.onEdit).toHaveBeenCalledTimes(1)
+    expect(edit.onOpen).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -12,6 +12,7 @@ const mockClearSelection = vi.fn()
 const mockSetSelection = vi.fn()
 const mockShowMessage = vi.fn()
 const mockUseOverlayMessage = vi.fn()
+const mockIsVisibleAtNow = vi.fn(() => true)
 const mockStudentSelectionState = {
   selectedIds: new Set<string>(),
   allSelected: false,
@@ -46,15 +47,27 @@ vi.mock('@/ui', () => ({
       </div>
     ) : null
   ),
-  SplitButton: ({ label, onPrimaryClick, disabled, primaryButtonProps }: any) => (
-    <button
-      type="button"
-      onClick={onPrimaryClick}
-      disabled={disabled}
-      {...primaryButtonProps}
-    >
-      {label}
-    </button>
+  SplitButton: ({ label, onPrimaryClick, disabled, primaryButtonProps, options = [] }: any) => (
+    <div>
+      <button
+        type="button"
+        onClick={onPrimaryClick}
+        disabled={disabled}
+        {...primaryButtonProps}
+      >
+        {label}
+      </button>
+      {options.map((option: any) => (
+        <button
+          key={option.id}
+          type="button"
+          onClick={option.onSelect}
+          disabled={option.disabled}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
   ),
   Tooltip: ({ children, content }: any) => (
     <span data-tooltip={typeof content === 'string' ? content : undefined}>{children}</span>
@@ -84,14 +97,27 @@ vi.mock('@/components/Spinner', () => ({
 }))
 
 vi.mock('@/components/AssignmentModal', () => ({
-  AssignmentModal: () => null,
+  AssignmentModal: ({ isOpen, assignment }: any) => (
+    isOpen ? (
+      <div role="dialog">
+        {assignment ? `Editing ${assignment.title}` : 'New Assignment'}
+      </div>
+    ) : null
+  ),
 }))
 
 vi.mock('@/components/SortableAssignmentCard', () => ({
-  SortableAssignmentCard: ({ assignment, onSelect }: any) => (
-    <button type="button" onClick={onSelect}>
-      {assignment.title}
-    </button>
+  SortableAssignmentCard: ({ assignment, editMode, onOpen, onEdit, onDelete }: any) => (
+    <div>
+      <button type="button" onClick={editMode ? onEdit : onOpen}>
+        {assignment.title}
+      </button>
+      {editMode ? (
+        <button type="button" onClick={onDelete} aria-label={`Delete ${assignment.title}`}>
+          Delete
+        </button>
+      ) : null}
+    </div>
   ),
 }))
 
@@ -164,7 +190,7 @@ vi.mock('@/hooks/use-assignment-grading-layout', () => ({
 }))
 
 vi.mock('@/lib/scheduling', () => ({
-  isVisibleAtNow: () => true,
+  isVisibleAtNow: (...args: any[]) => mockIsVisibleAtNow(...args),
 }))
 
 vi.mock('@/components/DataTable', () => ({
@@ -217,7 +243,7 @@ const classroom: Classroom = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
-function makeAssignmentSummary(id: string, title: string) {
+function makeAssignmentSummary(id: string, title: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
     classroom_id: classroom.id,
@@ -233,6 +259,7 @@ function makeAssignmentSummary(id: string, title: string) {
     created_at: '2026-04-01T12:00:00Z',
     updated_at: '2026-04-01T12:00:00Z',
     stats: { total_students: 1, submitted: 1, late: 0 },
+    ...overrides,
   }
 }
 
@@ -310,6 +337,8 @@ describe('TeacherClassroomView', () => {
     mockSetSelection.mockReset()
     mockShowMessage.mockReset()
     mockUseOverlayMessage.mockReset()
+    mockIsVisibleAtNow.mockReset()
+    mockIsVisibleAtNow.mockReturnValue(true)
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
     mockStudentSelectionState.selectedCount = 0
@@ -346,6 +375,176 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('keeps New visible without a Code action while edit mode is active', async () => {
+    const onEditModeChange = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        onEditModeChange={onEditModeChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: 'New assignment' })).toBeInTheDocument()
+    expect(screen.getByTestId('assignment-summary-actionbar-center')).toHaveClass('justify-center')
+    expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
+    expect(onEditModeChange).toHaveBeenLastCalledWith(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(onEditModeChange).toHaveBeenLastCalledWith(false)
+    expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
+  })
+
+  it('exits assignment edit mode on Escape', async () => {
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+  })
+
+  it('opens the assignment editor from summary cards while edit mode is active', async () => {
+    const updateSearchParams = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Assignment One' }))
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Editing Assignment One')
+    expect(updateSearchParams).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('resets edit mode when the selected assignment workspace changes', async () => {
+    const onEditModeChange = vi.fn()
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    const { rerender } = render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        onEditModeChange={onEditModeChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+
+    rerender(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="assignment-1"
+        onEditModeChange={onEditModeChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+    expect(onEditModeChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('keeps draft and scheduled assignments opening the editor in normal mode', async () => {
+    mockIsVisibleAtNow.mockReturnValue(false)
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('draft-assignment', 'Draft Assignment', { is_draft: true }),
+            makeAssignmentSummary('scheduled-assignment', 'Scheduled Assignment', {
+              released_at: '2026-05-10T12:00:00Z',
+            }),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
+    })
+    const updateSearchParams = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Draft Assignment' }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('Editing Draft Assignment')
+    expect(updateSearchParams).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scheduled Assignment' }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('Editing Scheduled Assignment')
+    expect(updateSearchParams).not.toHaveBeenCalled()
   })
 
   it('pushes assignment selection into classroom history', async () => {
@@ -616,7 +815,12 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
-    expect(screen.getByRole('button', { name: /Return/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
+    expect(screen.getByText('Assignment One')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit assignment' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
     expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
   })
 
@@ -1227,7 +1431,6 @@ describe('TeacherClassroomView', () => {
 
     const returnButton = screen.getByRole('button', { name: /Return/i })
     expect(returnButton).toBeDisabled()
-    expect(returnButton.closest('[data-tooltip]')).toHaveAttribute('data-tooltip', 'Nothing returnable selected')
 
     fireEvent.click(returnButton)
     expect(screen.queryByText(/Return work to 2 selected student/)).not.toBeInTheDocument()
@@ -1368,7 +1571,9 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByText(/create returned 0\/0\/0 documents/i)).toBeInTheDocument()
     expect(screen.getByText(/already returned and will be skipped/i)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Return' }))
+    const confirmReturnButton = screen.getAllByRole('button', { name: 'Return' }).at(-1)
+    expect(confirmReturnButton).toBeDefined()
+    fireEvent.click(confirmReturnButton!)
 
     await waitFor(() => {
       expect(mockShowMessage).toHaveBeenCalledWith({

--- a/tests/components/TeacherEditModeControls.test.tsx
+++ b/tests/components/TeacherEditModeControls.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
+import { TooltipProvider } from '@/ui'
+
+function renderControls({
+  active,
+  onActiveChange = vi.fn(),
+  disabled = false,
+}: {
+  active: boolean
+  onActiveChange?: (active: boolean) => void
+  disabled?: boolean
+}) {
+  return {
+    onActiveChange,
+    ...render(
+      <TooltipProvider>
+        <TeacherEditModeControls
+          active={active}
+          onActiveChange={onActiveChange}
+          disabled={disabled}
+        >
+          <button type="button">Code</button>
+        </TeacherEditModeControls>
+      </TooltipProvider>,
+    ),
+  }
+}
+
+describe('TeacherEditModeControls', () => {
+  it('renders inactive state without edit-only children', () => {
+    renderControls({ active: false })
+
+    const toggle = screen.getByRole('button', { name: 'Edit' })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByRole('button', { name: 'Code' })).not.toBeInTheDocument()
+  })
+
+  it('renders active state with edit-only children', () => {
+    renderControls({ active: true })
+
+    const toggle = screen.getByRole('button', { name: 'Done' })
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument()
+  })
+
+  it('toggles active state requests and supports disabled state', () => {
+    const { onActiveChange, rerender } = renderControls({ active: false })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(onActiveChange).toHaveBeenCalledWith(true)
+
+    rerender(
+      <TooltipProvider>
+        <TeacherEditModeControls
+          active
+          onActiveChange={onActiveChange}
+          disabled
+        >
+          <button type="button">Code</button>
+        </TeacherEditModeControls>
+      </TooltipProvider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled()
+  })
+})

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -69,7 +69,23 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
       expect(screen.queryByLabelText('Website overview')).not.toBeInTheDocument()
     })
     expect(screen.queryByLabelText('Website outline')).not.toBeInTheDocument()
-    expect(screen.getByText('Website overview and outline editing is hidden by your user menu setting.')).toBeInTheDocument()
+    expect(screen.getByText('Website overview and outline editing is hidden by your display setting.')).toBeInTheDocument()
+  })
+
+  it('persists the show markdown display setting from the general settings tab', async () => {
+    render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+    const markdownToggle = await screen.findByRole('checkbox', { name: 'Show markdown' })
+    expect(markdownToggle).toBeChecked()
+
+    fireEvent.click(markdownToggle)
+
+    await waitFor(() => {
+      expect(markdownToggle).not.toBeChecked()
+    })
+    expect(window.localStorage.getItem('pika_show_markdown')).toBe('false')
+    expect(screen.queryByLabelText('Website overview')).not.toBeInTheDocument()
+    expect(screen.getByText('Website overview and outline editing is hidden by your display setting.')).toBeInTheDocument()
   })
 
   it('saves on blur when value has changed', async () => {

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react'
 import { TeacherSettingsTab } from '@/app/classrooms/[classroomId]/TeacherSettingsTab'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
 import type { Classroom } from '@/types'
 import type { ReactNode } from 'react'
 
@@ -31,9 +32,11 @@ const mockClassroom: Classroom = {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
-    <AppMessageProvider>
-      <TooltipProvider>{children}</TooltipProvider>
-    </AppMessageProvider>
+    <MarkdownPreferenceProvider>
+      <AppMessageProvider>
+        <TooltipProvider>{children}</TooltipProvider>
+      </AppMessageProvider>
+    </MarkdownPreferenceProvider>
   )
 }
 
@@ -46,6 +49,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    window.localStorage.clear()
     cleanup()
   })
 
@@ -54,6 +58,18 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     const input = screen.getByLabelText('Course Name')
     expect(input).toHaveValue('Test Course')
+  })
+
+  it('hides website markdown fields when the user preference is off', async () => {
+    window.localStorage.setItem('pika_show_markdown', 'false')
+
+    render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Website overview')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByLabelText('Website outline')).not.toBeInTheDocument()
+    expect(screen.getByText('Website overview and outline editing is hidden by your user menu setting.')).toBeInTheDocument()
   })
 
   it('saves on blur when value has changed', async () => {

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -225,6 +225,8 @@ function mockFetchByStudent(
 function clearInspectorSectionsCookies() {
   document.cookie = 'pika_teacher_student_work_sections%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
   document.cookie = 'pika_teacher_student_work_sections%3Aclassroom-2=; Path=/; Max-Age=0; SameSite=Lax'
+  document.cookie = 'pika_teacher_student_work_visible_sections%3Aclassroom-1=; Path=/; Max-Age=0; SameSite=Lax'
+  document.cookie = 'pika_teacher_student_work_visible_sections%3Aclassroom-2=; Path=/; Max-Age=0; SameSite=Lax'
 }
 
 function writeInspectorSectionsCookie(classroomId: string, value: string) {
@@ -310,6 +312,98 @@ describe('TeacherStudentWorkPanel', () => {
     expect(within(gradesSection).queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
     const feedbackSection = screen.getByTestId('inspector-section-comments')
     expect(within(feedbackSection).getByRole('button', { name: 'Send feedback' })).toBeInTheDocument()
+  })
+
+  it('uses edit-mode checkboxes to hide inspector cards outside edit mode', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    const user = userEvent.setup()
+    const panelProps = {
+      classroomId: 'classroom-1',
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      mode: 'details' as const,
+      inspectorCollapsed: false,
+      inspectorWidth: 40,
+      totalWidth: 1200,
+    }
+    const { rerender } = render(
+      <TeacherStudentWorkPanel
+        {...panelProps}
+        inspectorEditMode
+      />,
+    )
+
+    const repoSection = await screen.findByTestId('inspector-section-repo')
+    const repoVisibility = within(repoSection).getByRole('checkbox', { name: 'Show Repo card' })
+    expect(repoVisibility).toBeChecked()
+    expect(within(repoSection).getByText('No repo linked')).toBeInTheDocument()
+
+    await user.click(repoVisibility)
+
+    expect(repoVisibility).not.toBeChecked()
+    expect(within(repoSection).queryByText('No repo linked')).not.toBeInTheDocument()
+
+    rerender(<TeacherStudentWorkPanel {...panelProps} />)
+
+    expect(screen.queryByTestId('inspector-section-repo')).not.toBeInTheDocument()
+
+    rerender(
+      <TeacherStudentWorkPanel
+        {...panelProps}
+        inspectorEditMode
+      />,
+    )
+
+    const hiddenRepoSection = screen.getByTestId('inspector-section-repo')
+    const hiddenRepoVisibility = within(hiddenRepoSection).getByRole('checkbox', {
+      name: 'Show Repo card',
+    })
+    expect(hiddenRepoVisibility).not.toBeChecked()
+
+    await user.click(hiddenRepoVisibility)
+
+    expect(hiddenRepoVisibility).toBeChecked()
+
+    rerender(<TeacherStudentWorkPanel {...panelProps} />)
+
+    expect(screen.getByTestId('inspector-section-repo')).toBeInTheDocument()
+  })
+
+  it('collapses inspector cards when edit mode is entered', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    const panelProps = {
+      classroomId: 'classroom-1',
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      mode: 'details' as const,
+      inspectorCollapsed: false,
+      inspectorWidth: 40,
+      totalWidth: 1200,
+    }
+    const { rerender } = render(<TeacherStudentWorkPanel {...panelProps} />)
+
+    expect(await screen.findByLabelText('Completion score')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Teacher feedback draft')).toBeInTheDocument()
+
+    rerender(
+      <TeacherStudentWorkPanel
+        {...panelProps}
+        inspectorEditMode
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Grade' })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: 'Feedback' })).toHaveAttribute('aria-expanded', 'false')
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Completion score')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByPlaceholderText('Teacher feedback draft')).not.toBeInTheDocument()
   })
 
   it('autosaves valid grading edits as final by default without a save button', async () => {
@@ -776,6 +870,32 @@ describe('TeacherStudentWorkPanel', () => {
     expect(within(repoSection).getByText('Contribution')).toBeInTheDocument()
     expect(within(repoSection).getByText('Consistency')).toBeInTheDocument()
     expect(within(repoSection).getByText('Iteration')).toBeInTheDocument()
+  })
+
+  it('toggles collapsed cards when clicking the header summary area', async () => {
+    mockFetchByStudent({
+      'student-1': { graded: false },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    const repoSection = await screen.findByTestId('inspector-section-repo')
+    expect(within(repoSection).queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
+
+    await user.click(within(repoSection).getByText('No repo linked'))
+
+    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
   })
 
   it('updates the individual-mode preview when hovering a history entry', async () => {

--- a/tests/components/UserMenu.test.tsx
+++ b/tests/components/UserMenu.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
+import { ThemeProvider } from '@/contexts/ThemeContext'
+import { UserMenu } from '@/components/UserMenu'
+
+function renderUserMenu() {
+  return render(
+    <ThemeProvider>
+      <MarkdownPreferenceProvider>
+        <UserMenu user={{ email: 'teacher@example.com', role: 'teacher' }} />
+      </MarkdownPreferenceProvider>
+    </ThemeProvider>,
+  )
+}
+
+describe('UserMenu', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('persists the show markdown checkbox preference', async () => {
+    renderUserMenu()
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    const markdownToggle = await screen.findByRole('menuitemcheckbox', { name: 'Show markdown' })
+    expect(markdownToggle).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(markdownToggle)
+
+    await waitFor(() => {
+      expect(markdownToggle).toHaveAttribute('aria-checked', 'false')
+    })
+    expect(window.localStorage.getItem('pika_show_markdown')).toBe('false')
+  })
+})

--- a/tests/components/UserMenu.test.tsx
+++ b/tests/components/UserMenu.test.tsx
@@ -1,37 +1,25 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
-import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
 import { ThemeProvider } from '@/contexts/ThemeContext'
 import { UserMenu } from '@/components/UserMenu'
 
 function renderUserMenu() {
   return render(
     <ThemeProvider>
-      <MarkdownPreferenceProvider>
-        <UserMenu user={{ email: 'teacher@example.com', role: 'teacher' }} />
-      </MarkdownPreferenceProvider>
+      <UserMenu user={{ email: 'teacher@example.com', role: 'teacher' }} />
     </ThemeProvider>,
   )
 }
 
 describe('UserMenu', () => {
-  beforeEach(() => {
-    window.localStorage.clear()
-  })
-
-  it('persists the show markdown checkbox preference', async () => {
+  it('keeps display preferences out of the account menu', async () => {
     renderUserMenu()
 
     fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
 
-    const markdownToggle = await screen.findByRole('menuitemcheckbox', { name: 'Show markdown' })
-    expect(markdownToggle).toHaveAttribute('aria-checked', 'true')
-
-    fireEvent.click(markdownToggle)
-
-    await waitFor(() => {
-      expect(markdownToggle).toHaveAttribute('aria-checked', 'false')
-    })
-    expect(window.localStorage.getItem('pika_show_markdown')).toBe('false')
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Show markdown' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /dark mode|light mode|toggle theme/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Send Feedback' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Logout' })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Adds the teacher assignments edit-mode pilot with shared `TeacherEditModeControls` and assignment card edit-mode affordances.
- Keeps assignment workflow actions visible in normal mode while hiding reorder, delete, title edit, and markdown/source actions behind edit mode.
- Moves the global `Show markdown` preference into teacher classroom Settings → General → Display, and gates markdown/source surfaces throughout the app when disabled.
- Adds experimental UI guidance for the teacher edit-mode pattern so future tabs can adopt it after the assignment pilot is reviewed.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test tests/components/UserMenu.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/LessonCalendar.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherSettingsTab.test.tsx`
- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/components/UserMenu.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
- Pika UI verification for teacher assignments, teacher settings, and teacher calendar views, including mobile teacher and student smoke screenshots.
- Interactive Playwright checks for assignment edit mode markdown gating and Settings → General `Show markdown` toggling.
