### PR TITLE
[codex] Add classroom navigation feedback

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9709,3 +9709,20 @@
 
 **Validation:**
 - `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)
+## 2026-04-29 — Classroom navigation pending feedback
+
+**Completed:**
+- Added immediate `Opening classroom...` feedback after teacher and student classroom cards are clicked, with the selected row disabled while the route advances.
+- Added matching pending feedback to the classroom switch dropdown and prevented duplicate classroom-switch clicks during navigation.
+- Confirmed the classroom picker already navigates directly to `/classrooms/:id`, so the local `Compiling /classrooms` delay remains a `next dev` route compilation artifact.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-teacher-opening.png`
+  - `/tmp/pika-student-opening.png`

--- a/src/app/classrooms/StudentClassroomsIndex.tsx
+++ b/src/app/classrooms/StudentClassroomsIndex.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { LoaderCircle } from 'lucide-react'
 import { Button, Card, EmptyState } from '@/ui'
 import { PageActionBar, PageContent, PageLayout, type ActionBarItem } from '@/components/PageLayout'
 import type { Classroom } from '@/types'
@@ -13,10 +14,16 @@ interface Props {
 export function StudentClassroomsIndex({ initialClassrooms }: Props) {
   const router = useRouter()
   const [classrooms] = useState<Classroom[]>(initialClassrooms)
+  const [openingClassroomId, setOpeningClassroomId] = useState<string | null>(null)
 
   const sorted = useMemo(() => {
     return [...classrooms].sort((a, b) => b.updated_at.localeCompare(a.updated_at))
   }, [classrooms])
+
+  const openClassroom = useCallback((classroom: Classroom) => {
+    setOpeningClassroomId(classroom.id)
+    router.push(`/classrooms/${classroom.id}?tab=today`)
+  }, [router])
 
   return (
     <PageLayout className="mx-auto max-w-6xl">
@@ -48,8 +55,13 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
               <button
                 key={c.id}
                 data-testid="classroom-card"
-                onClick={() => router.push(`/classrooms/${c.id}?tab=today`)}
-                className="w-full cursor-pointer border-b border-border px-5 py-4 text-left transition-colors last:border-b-0 hover:bg-surface-accent"
+                onClick={() => openClassroom(c)}
+                disabled={openingClassroomId !== null}
+                aria-busy={openingClassroomId === c.id}
+                className={[
+                  'w-full border-b border-border px-5 py-4 text-left transition-colors last:border-b-0',
+                  openingClassroomId === c.id ? 'cursor-wait bg-surface-accent' : 'cursor-pointer hover:bg-surface-accent',
+                ].join(' ')}
               >
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                   <div className="text-base font-semibold text-text-default">{c.title}</div>
@@ -60,6 +72,12 @@ export function StudentClassroomsIndex({ initialClassrooms }: Props) {
                 <div className="mt-1 text-sm leading-6 text-text-muted">
                   Code: <span className="font-mono tracking-[0.18em]">{c.class_code}</span>
                 </div>
+                {openingClassroomId === c.id && (
+                  <div className="mt-2 inline-flex items-center gap-1.5 text-xs font-medium text-primary">
+                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                    Opening classroom...
+                  </div>
+                )}
               </button>
             ))}
           </Card>

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -19,7 +19,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { useRouter, usePathname } from 'next/navigation'
-import { Archive, CircleDot, Plus } from 'lucide-react'
+import { Archive, CircleDot, LoaderCircle, Plus } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
 import { Button, ConfirmDialog } from '@/ui'
 import { Spinner } from '@/components/Spinner'
@@ -50,6 +50,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const [isLoadingArchived, setIsLoadingArchived] = useState(false)
   const [isReordering, setIsReordering] = useState(false)
   const [draggingClassroomId, setDraggingClassroomId] = useState<string | null>(null)
+  const [openingClassroomId, setOpeningClassroomId] = useState<string | null>(null)
   const [error, setError] = useState('')
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -282,6 +283,11 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const hasActiveClassrooms = activeClassrooms.length > 0
   const showBottomCreateButton = hasActiveClassrooms || view === 'archived'
 
+  const openClassroom = useCallback((classroom: Classroom) => {
+    setOpeningClassroomId(classroom.id)
+    router.push(`/classrooms/${classroom.id}?tab=attendance`)
+  }, [router])
+
   return (
     <PageLayout className="mx-auto max-w-2xl">
       <PageContent className="pb-36">
@@ -339,8 +345,10 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                     <SortableClassroomRow
                       key={classroom.id}
                       classroom={classroom}
-                      isDragDisabled={isReordering}
-                      onOpen={() => router.push(`/classrooms/${classroom.id}?tab=attendance`)}
+                      isDragDisabled={isReordering || openingClassroomId !== null}
+                      isDisabled={openingClassroomId !== null}
+                      isOpening={openingClassroomId === classroom.id}
+                      onOpen={() => openClassroom(classroom)}
                       onArchive={() => setPendingAction({ mode: 'archive', classroom })}
                     />
                   ))}
@@ -360,8 +368,13 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                   <button
                     type="button"
                     data-testid="classroom-card"
-                    onClick={() => router.push(`/classrooms/${c.id}?tab=attendance`)}
-                    className="-m-1.5 min-w-0 rounded-control p-1.5 text-left transition-colors hover:bg-surface-accent"
+                    onClick={() => openClassroom(c)}
+                    disabled={openingClassroomId !== null}
+                    aria-busy={openingClassroomId === c.id}
+                    className={[
+                      '-m-1.5 min-w-0 rounded-control p-1.5 text-left transition-colors',
+                      openingClassroomId === c.id ? 'cursor-wait bg-surface-accent' : 'hover:bg-surface-accent',
+                    ].join(' ')}
                   >
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                       <div className="text-base font-semibold text-text-default">{c.title}</div>
@@ -372,6 +385,12 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                     <div className="mt-1 text-sm text-text-muted">
                       Code: <span className="font-mono tracking-[0.18em]">{c.class_code}</span>
                     </div>
+                    {openingClassroomId === c.id && (
+                      <div className="mt-2 inline-flex items-center gap-1.5 text-xs font-medium text-primary">
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                        Opening classroom...
+                      </div>
+                    )}
                   </button>
                   <div className="flex flex-wrap items-center gap-2 lg:justify-end">
                     <Button
@@ -379,6 +398,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                       variant="surface"
                       size="xs"
                       onClick={() => setPendingAction({ mode: 'restore', classroom: c })}
+                      disabled={openingClassroomId !== null}
                     >
                       Restore
                     </Button>
@@ -388,6 +408,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                       size="xs"
                       onClick={() => setPendingAction({ mode: 'delete', classroom: c })}
                       className="text-danger hover:bg-danger-bg"
+                      disabled={openingClassroomId !== null}
                     >
                       Delete
                     </Button>
@@ -451,7 +472,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         onSuccess={(created) => {
           setShowCreate(false)
           setActiveClassrooms((prev) => [created, ...prev])
-          router.push(`/classrooms/${created.id}?tab=attendance`)
+          openClassroom(created)
         }}
       />
 

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
 import { useDropdownNav } from '@/hooks/use-dropdown-nav'
 
 interface ClassroomDropdownProps {
@@ -30,21 +31,26 @@ export function ClassroomDropdown({
 }: ClassroomDropdownProps) {
   const router = useRouter()
   const allowClickRef = useRef(false)
+  const closeDropdownRef = useRef<(() => void) | null>(null)
+  const [openingClassroomId, setOpeningClassroomId] = useState<string | null>(null)
 
   const currentClassroom = classrooms.find((c) => c.id === currentClassroomId) || classrooms[0]
+  const openingClassroom = classrooms.find((c) => c.id === openingClassroomId)
   const firstSelectableIndex = classrooms.findIndex((c) => c.id !== currentClassroom?.id)
 
   const handleSelect = useCallback((index: number) => {
     const classroomId = classrooms[index]?.id
-    if (!classroomId || classroomId === currentClassroom?.id) return
+    if (!classroomId || classroomId === currentClassroom?.id || openingClassroomId) return
 
     const nextUrl = currentTab
       ? `/classrooms/${classroomId}?tab=${encodeURIComponent(currentTab)}`
       : `/classrooms/${classroomId}`
     const allowNavigation = onBeforeNavigate?.(nextUrl)
     if (allowNavigation === false) return
+    setOpeningClassroomId(classroomId)
+    closeDropdownRef.current?.()
     router.push(nextUrl)
-  }, [classrooms, currentClassroom?.id, currentTab, onBeforeNavigate, router])
+  }, [classrooms, currentClassroom?.id, currentTab, onBeforeNavigate, openingClassroomId, router])
 
   const {
     isOpen,
@@ -57,12 +63,18 @@ export function ClassroomDropdown({
     handleTriggerClick,
     itemRefs,
     containerRef,
+    setIsOpen,
   } = useDropdownNav({
     itemCount: classrooms.length,
     onSelect: handleSelect,
     initialFocusedIndex: firstSelectableIndex >= 0 ? firstSelectableIndex : 0,
     isItemDisabled: (index) => classrooms[index]?.id === currentClassroom?.id,
   })
+  closeDropdownRef.current = () => setIsOpen(false)
+
+  useEffect(() => {
+    setOpeningClassroomId(null)
+  }, [currentClassroomId])
 
   if (classrooms.length === 0) {
     return null
@@ -87,21 +99,32 @@ export function ClassroomDropdown({
         id={triggerId}
         type="button"
         onPointerDown={() => {
+          if (openingClassroomId) return
           allowClickRef.current = true
         }}
         onClick={() => {
+          if (openingClassroomId) return
           if (!allowClickRef.current) return
           allowClickRef.current = false
           handleTriggerClick()
         }}
         onKeyDown={handleTriggerKeyDown}
+        disabled={openingClassroomId !== null}
+        aria-busy={openingClassroomId !== null}
         className="px-2 py-1 -mx-2 text-xl font-bold text-text-default truncate max-w-xs rounded-md transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-controls={menuId}
         aria-label="Select classroom"
       >
-        {currentClassroom?.title}
+        <span className="inline-flex min-w-0 items-center gap-2">
+          {openingClassroomId && (
+            <LoaderCircle className="h-4 w-4 shrink-0 animate-spin text-primary" aria-hidden="true" />
+          )}
+          <span className="truncate">
+            {openingClassroom ? `Opening ${openingClassroom.title}...` : currentClassroom?.title}
+          </span>
+        </span>
       </button>
 
       {/* Dropdown menu with animation */}
@@ -117,6 +140,7 @@ export function ClassroomDropdown({
       >
         {classrooms.map((classroom, index) => {
           const isCurrent = classroom.id === currentClassroom?.id
+          const isOpening = classroom.id === openingClassroomId
 
           return (
             <button
@@ -131,7 +155,7 @@ export function ClassroomDropdown({
                 if (!isCurrent) setFocusedIndex(index)
               }}
               onKeyDown={handleItemKeyDown}
-              disabled={isCurrent}
+              disabled={isCurrent || openingClassroomId !== null}
               className={`w-full px-3 py-2 text-left text-sm font-medium transition-colors focus:outline-none ${
                 isCurrent
                   ? 'cursor-default text-text-muted'
@@ -143,7 +167,14 @@ export function ClassroomDropdown({
               tabIndex={isOpen && !isCurrent ? 0 : -1}
             >
               <span className="flex items-center justify-between gap-3">
-                <span className="truncate">{classroom.title}</span>
+                <span className="inline-flex min-w-0 items-center gap-2">
+                  {isOpening && (
+                    <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" aria-hidden="true" />
+                  )}
+                  <span className="truncate">
+                    {isOpening ? `Opening ${classroom.title}...` : classroom.title}
+                  </span>
+                </span>
                 {isCurrent && (
                   <span className="shrink-0 rounded-badge bg-surface px-2 py-0.5 text-[11px] font-semibold text-text-muted">
                     Current

--- a/src/components/SortableClassroomRow.tsx
+++ b/src/components/SortableClassroomRow.tsx
@@ -3,12 +3,14 @@
 import type { ReactNode } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Archive, GripVertical } from 'lucide-react'
+import { Archive, GripVertical, LoaderCircle } from 'lucide-react'
 import type { Classroom } from '@/types'
 
 interface SortableClassroomRowProps {
   classroom: Classroom
   isDragDisabled?: boolean
+  isDisabled?: boolean
+  isOpening?: boolean
   onOpen: () => void
   onArchive: () => void
 }
@@ -18,6 +20,8 @@ interface ClassroomRowFrameProps {
   dragHandle: ReactNode
   action: ReactNode
   onOpen?: () => void
+  isDisabled?: boolean
+  isOpening?: boolean
   className?: string
 }
 
@@ -26,8 +30,12 @@ function ClassroomRowFrame({
   dragHandle,
   action,
   onOpen,
+  isDisabled = false,
+  isOpening = false,
   className = '',
 }: ClassroomRowFrameProps) {
+  const isOpenDisabled = isDisabled || isOpening
+
   return (
     <div
       className={[
@@ -42,7 +50,12 @@ function ClassroomRowFrame({
       <button
         type="button"
         onClick={onOpen}
-        className="col-start-2 row-start-1 min-w-0 rounded-control -m-1.5 ml-1 p-1.5 text-left transition-colors hover:bg-surface-accent sm:ml-2"
+        disabled={isOpenDisabled}
+        aria-busy={isOpening}
+        className={[
+          'col-start-2 row-start-1 min-w-0 rounded-control -m-1.5 ml-1 p-1.5 text-left transition-colors sm:ml-2',
+          isOpening ? 'cursor-wait bg-surface-accent' : isDisabled ? 'cursor-wait' : 'hover:bg-surface-accent',
+        ].join(' ')}
       >
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <div className="min-w-0 text-base font-semibold text-text-default">
@@ -55,6 +68,12 @@ function ClassroomRowFrame({
         <div className="mt-1 text-sm text-text-muted">
           Code: <span className="font-mono tracking-[0.18em]">{classroom.class_code}</span>
         </div>
+        {isOpening && (
+          <div className="mt-2 inline-flex items-center gap-1.5 text-xs font-medium text-primary">
+            <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            Opening classroom...
+          </div>
+        )}
       </button>
 
       <div className="col-start-3 row-start-1 flex items-center justify-end">
@@ -88,6 +107,8 @@ export function ClassroomRowGhost({ classroom }: { classroom: Classroom }) {
 export function SortableClassroomRow({
   classroom,
   isDragDisabled = false,
+  isDisabled = false,
+  isOpening = false,
   onOpen,
   onArchive,
 }: SortableClassroomRowProps) {
@@ -118,6 +139,8 @@ export function SortableClassroomRow({
       <ClassroomRowFrame
         classroom={classroom}
         onOpen={onOpen}
+        isDisabled={isDisabled}
+        isOpening={isOpening}
         dragHandle={
           <button
             type="button"
@@ -130,7 +153,7 @@ export function SortableClassroomRow({
             {...attributes}
             {...listeners}
             aria-label={`Drag to reorder ${classroom.title}`}
-            disabled={isDragDisabled}
+            disabled={isDragDisabled || isDisabled || isOpening}
           >
             <GripVertical className="h-5 w-5" aria-hidden="true" />
           </button>
@@ -142,6 +165,7 @@ export function SortableClassroomRow({
             className="inline-flex h-6 w-6 -mr-1 items-center justify-center rounded-control text-text-muted transition-colors hover:text-text-default"
             aria-label={`Archive ${classroom.title}`}
             title={`Archive ${classroom.title}`}
+            disabled={isDisabled || isOpening}
           >
             <Archive className="h-4 w-4" aria-hidden="true" />
           </button>

--- a/tests/components/ClassroomDropdown.test.tsx
+++ b/tests/components/ClassroomDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { ClassroomDropdown } from '@/components/ClassroomDropdown'
 
@@ -78,6 +78,23 @@ describe('ClassroomDropdown', () => {
     pointerClick(screen.getByRole('option', { name: /Gamma/ }))
 
     expect(push).toHaveBeenCalledWith('/classrooms/class-3?tab=attendance')
+  })
+
+  it('shows immediate feedback after selecting a classroom', () => {
+    render(
+      <ClassroomDropdown
+        classrooms={classrooms}
+        currentClassroomId="class-2"
+        currentTab="attendance"
+      />
+    )
+
+    pointerClick(screen.getByRole('button', { name: 'Select classroom' }))
+    pointerClick(screen.getByRole('option', { name: /Gamma/ }))
+
+    const trigger = screen.getByRole('button', { name: 'Select classroom' })
+    expect(within(trigger).getByText('Opening Gamma...')).toBeInTheDocument()
+    expect(trigger).toBeDisabled()
   })
 
   it('skips the current classroom during keyboard navigation', () => {

--- a/tests/components/StudentClassroomsIndex.test.tsx
+++ b/tests/components/StudentClassroomsIndex.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { StudentClassroomsIndex } from '@/app/classrooms/StudentClassroomsIndex'
+import { createMockClassroom } from '../helpers/mocks'
+
+const push = vi.hoisted(() => vi.fn())
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+describe('StudentClassroomsIndex', () => {
+  beforeEach(() => {
+    push.mockReset()
+  })
+
+  it('shows immediate feedback while opening a classroom', () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    render(<StudentClassroomsIndex initialClassrooms={classrooms} />)
+
+    const openButton = screen.getByRole('button', { name: /^Math 101/ })
+    fireEvent.click(openButton)
+
+    expect(push).toHaveBeenCalledWith('/classrooms/c1?tab=today')
+    expect(openButton).toBeDisabled()
+    expect(screen.getByText('Opening classroom...')).toBeInTheDocument()
+  })
+})

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -3,8 +3,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TeacherClassroomsIndex } from '@/app/classrooms/TeacherClassroomsIndex'
 import { createMockClassroom } from '../helpers/mocks'
 
+const push = vi.hoisted(() => vi.fn())
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push }),
   usePathname: () => '/classrooms',
 }))
 
@@ -13,6 +15,7 @@ describe('TeacherClassroomsIndex', () => {
 
   beforeEach(() => {
     fetchMock = vi.fn()
+    push.mockReset()
     vi.stubGlobal('fetch', fetchMock)
   })
 
@@ -58,5 +61,29 @@ describe('TeacherClassroomsIndex', () => {
 
     expect(screen.queryByRole('button', { name: 'Blueprints' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument()
+  })
+
+  it('shows immediate feedback while opening a classroom', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+
+    const openButton = screen.getByRole('button', { name: /^Math 101/ })
+    fireEvent.click(openButton)
+
+    expect(push).toHaveBeenCalledWith('/classrooms/c1?tab=attendance')
+    expect(openButton).toBeDisabled()
+    expect(screen.getByText('Opening classroom...')).toBeInTheDocument()
+  })
+
+  it('prevents opening another classroom while navigation is pending', async () => {
+    const classrooms = [
+      createMockClassroom({ id: 'c1', title: 'Math 101' }),
+      createMockClassroom({ id: 'c2', title: 'Science 101' }),
+    ]
+    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /^Math 101/ }))
+
+    expect(screen.getByRole('button', { name: /^Science 101/ })).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Summary
- Add immediate pending feedback when teacher or student classroom cards open a classroom.
- Add matching pending feedback for the classroom switch dropdown.
- Disable duplicate classroom navigation actions while a route transition is pending.

## Why
In local development the first `/classrooms` detail navigation can feel frozen while Next.js compiles the route. Production should not pay that lazy compile cost, but users still need immediate confirmation that their classroom click was accepted.

## Validation
- pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/components/ClassroomDropdown.test.tsx
- pnpm lint
- pnpm build
- Visual verification for `/classrooms` teacher/student states, including delayed-click pending screenshots.