### PR TITLE
[codex] Add transient app message overlay

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9666,3 +9666,37 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-29 — Top-center transient app messages
+
+**Completed:**
+- Added the shared `AppMessageProvider` overlay primitive in `/ui` and mounted it from the root layout.
+- Migrated transient success, copy, refreshing, auth resend, and grading progress/completion messages out of inline page flow.
+- Repositioned the message pill into the center of the 48px global title bar and added animated ellipsis dots for loading-tone messages.
+- Removed the attempted fade-in/fade-out animation after browser verification still did not produce a convincing visible effect in product use.
+- Opened follow-up issue https://github.com/codepetca/pika/issues/523 to revisit title-bar message animation separately.
+- Kept blocking errors, validation, empty states, confirmations, and editor save-state context inline.
+- Updated `/ui` docs and component tests for the overlay behavior.
+
+**Validation:**
+- `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)
+- Pika UI verification for classroom assignments and assignment grading workspace:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual auth resend overlay verification:
+  - `/tmp/pika-auth-resend-overlay.png`
+  - `/tmp/pika-auth-resend-overlay-mobile.png`
+- Manual title-bar overlay verification:
+  - `/tmp/pika-header-overlay-desktop.png`
+  - `/tmp/pika-header-overlay-mobile.png`
+  - `/tmp/pika-header-overlay-fade.png`
+  - `/tmp/pika-header-overlay-soft-fade.png`
+  - `/tmp/pika-header-overlay-extra-slow-fade.png`
+  - `/tmp/pika-header-overlay-slow-fade-working.png`
+- After removing the fade attempt:
+  - `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx tests/components/TeacherTestsTab.test.tsx`
+  - `pnpm lint`
+  - `pnpm exec tsc --noEmit --pretty false --project tsconfig.json --incremental false`

--- a/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { Copy } from 'lucide-react'
-import { Button, Tooltip } from '@/ui'
+import { Button, Tooltip, useAppMessage } from '@/ui'
 import { useClassDaysContext } from '@/hooks/useClassDays'
 import type { ClassDay, Classroom } from '@/types'
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, addMonths, parseISO } from 'date-fns'
@@ -20,11 +20,10 @@ export function TeacherCalendarTab({ classroom }: Props) {
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string>('')
-  const [success, setSuccess] = useState<string>('')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [saving, setSaving] = useState(false)
-  const [copyNotice, setCopyNotice] = useState<string>('')
+  const { showMessage } = useAppMessage()
 
   // Sync from shared context (used for initial load and after event-driven refreshes)
   useEffect(() => {
@@ -70,7 +69,6 @@ export function TeacherCalendarTab({ classroom }: Props) {
     if (isReadOnly) return
     setSaving(true)
     setError('')
-    setSuccess('')
     try {
       const res = await fetch(`/api/classrooms/${classroom.id}/class-days`, {
         method: 'POST',
@@ -84,7 +82,7 @@ export function TeacherCalendarTab({ classroom }: Props) {
       if (!res.ok) {
         throw new Error(data.error || 'Failed to generate class days')
       }
-      setSuccess(`Generated ${data.count ?? 0} class days.`)
+      showMessage({ text: `Generated ${data.count ?? 0} days`, tone: 'success' })
       // Notify context and other components to refresh class days
       window.dispatchEvent(new CustomEvent(CLASS_DAYS_UPDATED_EVENT, { detail: { classroomId: classroom.id } }))
     } catch (err: any) {
@@ -101,21 +99,18 @@ export function TeacherCalendarTab({ classroom }: Props) {
       .sort()
 
     if (activeClassDays.length === 0) {
-      setCopyNotice('No class days to copy')
-      setTimeout(() => setCopyNotice(''), 2000)
+      showMessage({ text: 'No class days to copy', tone: 'warning' })
       return
     }
 
     const markdown = activeClassDays.map(date => `- ${date}`).join('\n')
     await navigator.clipboard.writeText(markdown)
-    setCopyNotice('Copied!')
-    setTimeout(() => setCopyNotice(''), 2000)
+    showMessage({ text: 'Copied', tone: 'success' })
   }
 
   async function toggleDay(date: string, isClassDay: boolean) {
     if (isReadOnly) return
     setError('')
-    setSuccess('')
     try {
       const res = await fetch(`/api/classrooms/${classroom.id}/class-days`, {
         method: 'PATCH',
@@ -188,10 +183,9 @@ export function TeacherCalendarTab({ classroom }: Props) {
         </div>
       )}
 
-      {(error || success) && (
+      {error && (
         <div className="space-y-2 mb-4">
-          {error && <div className="text-sm text-danger">{error}</div>}
-          {success && <div className="text-sm text-success">{success}</div>}
+          <div className="text-sm text-danger">{error}</div>
         </div>
       )}
 
@@ -221,7 +215,7 @@ export function TeacherCalendarTab({ classroom }: Props) {
                   className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-default hover:bg-surface-hover rounded transition-colors"
                 >
                   <Copy className="w-3.5 h-3.5" />
-                  <span>{copyNotice || 'Copy'}</span>
+                  <span>Copy</span>
                 </button>
               </Tooltip>
             </div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -26,7 +26,7 @@ import {
   Plus,
   Send,
 } from 'lucide-react'
-import { Button, ConfirmDialog, SplitButton, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -206,9 +206,6 @@ function formatAssignmentAiGradingRunMessage(run: AssignmentAiGradingRunSummary)
   }
 }
 
-const ASSIGNMENT_AI_GRADING_RUN_NOTE =
-  'Keep this assignment open while grading runs. Reopening it resumes the current progress.'
-
 export function TeacherClassroomView({
   classroom,
   onSelectAssignment,
@@ -282,6 +279,7 @@ export function TeacherClassroomView({
   const wasActiveRef = useRef(isActive)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
   const showSummarySpinner = useDelayedBusy(loading && assignments.length === 0)
+  const { showMessage } = useAppMessage()
   const {
     layout: assignmentGradingLayout,
     updateModeLayout,
@@ -724,9 +722,9 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (!info) return
-    const timer = setTimeout(() => setInfo(''), 4000)
-    return () => clearTimeout(timer)
-  }, [info])
+    showMessage({ text: info, tone: 'info' })
+    setInfo('')
+  }, [info, showMessage])
 
   useEffect(() => {
     if (!selectedAssignmentKey || !activeAssignmentAiRunId || !hasActiveAssignmentAiRun) return
@@ -1222,27 +1220,17 @@ export function TeacherClassroomView({
   const assignmentAiRunOverlayLabel = hasActiveAssignmentAiRun && activeAssignmentAiRun
     ? `Grading ${Math.min(activeAssignmentAiRun.processed_count, activeAssignmentAiRun.requested_count)} of ${activeAssignmentAiRun.requested_count} students…`
     : `Starting grading for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+  const activeWorkMessage = showAssignmentAiRunOverlay
+    ? assignmentAiRunOverlayLabel
+    : isArtifactRepoAnalyzing
+      ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+      : isReturning
+        ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+        : ''
+  useOverlayMessage(!!activeWorkMessage, activeWorkMessage, { tone: 'loading' })
 
-  const studentBusyOverlay = showAssignmentAiRunOverlay || isArtifactRepoAnalyzing || isReturning ? (
-    <div className="absolute inset-0 z-10 flex items-start justify-center rounded-md bg-surface/70 px-4 pt-4">
-      <div className="flex max-w-[24rem] flex-col gap-1 rounded-2xl border border-border bg-surface px-3 py-2 text-xs leading-tight text-text-muted shadow-sm sm:max-w-[28rem] sm:text-sm">
-        <div className="flex items-center gap-2">
-          <Spinner />
-          <span>
-            {showAssignmentAiRunOverlay
-              ? assignmentAiRunOverlayLabel
-              : isArtifactRepoAnalyzing
-                ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-                : `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`}
-          </span>
-        </div>
-        {showAssignmentAiRunOverlay ? (
-          <p className="pl-6 text-[11px] leading-tight text-text-muted sm:text-xs">
-            {ASSIGNMENT_AI_GRADING_RUN_NOTE}
-          </p>
-        ) : null}
-      </div>
-    </div>
+  const studentBusyOverlay = activeWorkMessage ? (
+    <div className="absolute inset-0 z-10 rounded-md bg-surface/30" aria-hidden="true" />
   ) : null
 
   const studentTable = (
@@ -1426,11 +1414,6 @@ export function TeacherClassroomView({
       {error && (
         <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
           {error}
-        </div>
-      )}
-      {info && (
-        <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
-          {info}
         </div>
       )}
     </>

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { Button, ConfirmDialog } from '@/ui'
+import { Button, ConfirmDialog, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
 import { ACTIONBAR_BUTTON_SECONDARY_CLASSNAME, PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
@@ -83,7 +83,7 @@ export function TeacherRosterTab({ classroom }: Props) {
 
   // Selection state
   const [isEmailMenuOpen, setEmailMenuOpen] = useState(false)
-  const [copiedMessage, setCopiedMessage] = useState<string | null>(null)
+  const { showMessage } = useAppMessage()
 
   // Counselor email editing state
   const [editingCounselorId, setEditingCounselorId] = useState<string | null>(null)
@@ -180,8 +180,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     const text = emails.join(', ')
     try {
       await navigator.clipboard.writeText(text)
-      setCopiedMessage(`${label} copied!`)
-      setTimeout(() => setCopiedMessage(null), 2000)
+      showMessage({ text: `${label} copied`, tone: 'success' })
     } catch {
       // Fallback for older browsers
       const textarea = document.createElement('textarea')
@@ -190,8 +189,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       textarea.select()
       document.execCommand('copy')
       document.body.removeChild(textarea)
-      setCopiedMessage(`${label} copied!`)
-      setTimeout(() => setCopiedMessage(null), 2000)
+      showMessage({ text: `${label} copied`, tone: 'success' })
     }
     setEmailMenuOpen(false)
   }
@@ -397,11 +395,6 @@ export function TeacherRosterTab({ classroom }: Props) {
                       </div>
                     </div>
                     </div>
-                  </div>
-                )}
-                {copiedMessage && (
-                  <div className="absolute left-0 top-full mt-1 px-3 py-2 rounded-md bg-success-bg text-success text-sm z-20">
-                    {copiedMessage}
                   </div>
                 )}
               </div>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useId } from 'react'
 import { useRouter } from 'next/navigation'
 import { Info } from 'lucide-react'
-import { Button, ConfirmDialog, DialogPanel, FormField, Input, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, FormField, Input, Tooltip, useAppMessage } from '@/ui'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { DEFAULT_ACTUAL_COURSE_SITE_CONFIG, slugifyCourseSiteValue } from '@/lib/course-site-publishing'
 import { TeacherCalendarTab } from './TeacherCalendarTab'
@@ -41,22 +41,17 @@ export function TeacherSettingsTab({
   const [title, setTitle] = useState(classroom.title)
   const [titleSaving, setTitleSaving] = useState(false)
   const [titleError, setTitleError] = useState<string>('')
-  const [titleSuccess, setTitleSuccess] = useState<string>('')
   const [joinCode, setJoinCode] = useState(classroom.class_code)
   const [allowEnrollment, setAllowEnrollment] = useState<boolean>(classroom.allow_enrollment)
   const [saving, setSaving] = useState(false)
   const [enrollmentError, setEnrollmentError] = useState<string>('')
-  const [enrollmentSuccess, setEnrollmentSuccess] = useState<string>('')
   const [joinCodeError, setJoinCodeError] = useState<string>('')
-  const [joinCodeSuccess, setJoinCodeSuccess] = useState<string>('')
   const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false)
   const [isRegenerating, setIsRegenerating] = useState(false)
-  const [copyNotice, setCopyNotice] = useState<string>('')
   const [lessonPlanVisibility, setLessonPlanVisibility] = useState<LessonPlanVisibility>(
     classroom.lesson_plan_visibility || 'current_week'
   )
   const [visibilityError, setVisibilityError] = useState<string>('')
-  const [visibilitySuccess, setVisibilitySuccess] = useState<string>('')
   const [visibilitySaving, setVisibilitySaving] = useState(false)
   const visibilityId = useId()
   const [actualSiteSlug, setActualSiteSlug] = useState(classroom.actual_site_slug || '')
@@ -68,7 +63,6 @@ export function TeacherSettingsTab({
   const [courseOutlineMarkdown, setCourseOutlineMarkdown] = useState(classroom.course_outline_markdown || '')
   const [siteSaving, setSiteSaving] = useState(false)
   const [siteError, setSiteError] = useState('')
-  const [siteSuccess, setSiteSuccess] = useState('')
   const [showCreateBlueprintDialog, setShowCreateBlueprintDialog] = useState(false)
   const [blueprintTitle, setBlueprintTitle] = useState(classroom.title)
   const [blueprintBusy, setBlueprintBusy] = useState(false)
@@ -79,6 +73,7 @@ export function TeacherSettingsTab({
     return window.location.origin
   }, [])
   const joinLink = `${origin}/join/${joinCode}`
+  const { showMessage } = useAppMessage()
 
   async function copy(text: string) {
     try {
@@ -90,8 +85,7 @@ export function TeacherSettingsTab({
 
   async function copyWithNotice(label: string, text: string) {
     await copy(text)
-    setCopyNotice(`${label} copied to clipboard.`)
-    setTimeout(() => setCopyNotice(''), 2000)
+    showMessage({ text: `${label} copied`, tone: 'success' })
   }
 
   async function saveTitle() {
@@ -106,7 +100,6 @@ export function TeacherSettingsTab({
     }
     setTitleSaving(true)
     setTitleError('')
-    setTitleSuccess('')
     try {
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
         method: 'PATCH',
@@ -118,8 +111,7 @@ export function TeacherSettingsTab({
         throw new Error(data.error || 'Failed to update course name')
       }
       setTitle(data.classroom?.title || trimmed)
-      setTitleSuccess('Course name updated.')
-      setTimeout(() => setTitleSuccess(''), 2000)
+      showMessage({ text: 'Course name updated', tone: 'success' })
     } catch (err: any) {
       setTitleError(err.message || 'Failed to update course name')
     } finally {
@@ -131,7 +123,6 @@ export function TeacherSettingsTab({
     if (isReadOnly) return
     setSaving(true)
     setEnrollmentError('')
-    setEnrollmentSuccess('')
     try {
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
         method: 'PATCH',
@@ -143,8 +134,7 @@ export function TeacherSettingsTab({
         throw new Error(data.error || 'Failed to update settings')
       }
       setAllowEnrollment(!!data.classroom?.allow_enrollment)
-      setEnrollmentSuccess('Settings saved.')
-      setTimeout(() => setEnrollmentSuccess(''), 2000)
+      showMessage({ text: 'Settings saved', tone: 'success' })
     } catch (err: any) {
       setEnrollmentError(err.message || 'Failed to update settings')
     } finally {
@@ -156,7 +146,6 @@ export function TeacherSettingsTab({
     if (isReadOnly) return
     setIsRegenerating(true)
     setJoinCodeError('')
-    setJoinCodeSuccess('')
     try {
       const newCode = generateJoinCode()
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
@@ -169,7 +158,7 @@ export function TeacherSettingsTab({
         throw new Error(data.error || 'Failed to regenerate join code')
       }
       setJoinCode(data.classroom?.class_code || newCode)
-      setJoinCodeSuccess('Join code regenerated.')
+      showMessage({ text: 'Join code regenerated', tone: 'success' })
     } catch (err: any) {
       setJoinCodeError(err.message || 'Failed to regenerate join code')
     } finally {
@@ -182,7 +171,6 @@ export function TeacherSettingsTab({
     if (isReadOnly) return
     setVisibilitySaving(true)
     setVisibilityError('')
-    setVisibilitySuccess('')
     try {
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
         method: 'PATCH',
@@ -194,7 +182,7 @@ export function TeacherSettingsTab({
         throw new Error(data.error || 'Failed to update visibility setting')
       }
       setLessonPlanVisibility(data.classroom?.lesson_plan_visibility || value)
-      setVisibilitySuccess('Calendar visibility updated.')
+      showMessage({ text: 'Visibility updated', tone: 'success' })
     } catch (err: any) {
       setVisibilityError(err.message || 'Failed to update visibility setting')
     } finally {
@@ -206,7 +194,6 @@ export function TeacherSettingsTab({
     if (isReadOnly) return
     setSiteSaving(true)
     setSiteError('')
-    setSiteSuccess('')
     try {
       const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
         method: 'PATCH',
@@ -228,8 +215,7 @@ export function TeacherSettingsTab({
       setActualSiteConfig(data.classroom?.actual_site_config || actualSiteConfig)
       setCourseOverviewMarkdown(data.classroom?.course_overview_markdown || courseOverviewMarkdown)
       setCourseOutlineMarkdown(data.classroom?.course_outline_markdown || courseOutlineMarkdown)
-      setSiteSuccess('Actual course site settings saved.')
-      setTimeout(() => setSiteSuccess(''), 2000)
+      showMessage({ text: 'Website settings saved', tone: 'success' })
     } catch (err: any) {
       setSiteError(err.message || 'Failed to save actual course site settings')
     } finally {
@@ -332,7 +318,6 @@ export function TeacherSettingsTab({
                 {titleSaving && <span className="text-sm text-text-muted self-center">Saving...</span>}
               </div>
               {titleError && <div className="text-sm text-danger">{titleError}</div>}
-              {titleSuccess && <div className="text-sm text-success">{titleSuccess}</div>}
             </div>
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
@@ -391,10 +376,7 @@ export function TeacherSettingsTab({
               </div>
 
               {joinCodeError && <div className="text-sm text-danger">{joinCodeError}</div>}
-              {joinCodeSuccess && <div className="text-sm text-success">{joinCodeSuccess}</div>}
               {enrollmentError && <div className="text-sm text-danger">{enrollmentError}</div>}
-              {enrollmentSuccess && <div className="text-sm text-success">{enrollmentSuccess}</div>}
-              {copyNotice && <div className="text-xs text-info">{copyNotice}</div>}
             </div>
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
@@ -426,7 +408,6 @@ export function TeacherSettingsTab({
               </div>
 
               {visibilityError && <div className="text-sm text-danger">{visibilityError}</div>}
-              {visibilitySuccess && <div className="text-sm text-success">{visibilitySuccess}</div>}
             </div>
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-4">
@@ -572,7 +553,6 @@ export function TeacherSettingsTab({
               </div>
 
               {siteError && <div className="text-sm text-danger">{siteError}</div>}
-              {siteSuccess && <div className="text-sm text-success">{siteSuccess}</div>}
             </div>
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-3">

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -21,7 +21,7 @@ import { getQuizExitCount } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, RefreshingIndicator, Select, Tooltip } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, RefreshingIndicator, Select, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
   AssessmentWorkspaceSummaryPatch,
@@ -87,8 +87,6 @@ type WorkspaceTab = 'authoring' | 'grading'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
 const GRADING_POLL_INTERVAL_MS = 15_000
-const TEST_AI_GRADING_RUN_NOTE =
-  'Keep this test open while grading runs. Reopening it resumes the current progress.'
 
 const STATUS_META: Record<
   TestGradingStudentRow['status'],
@@ -235,6 +233,7 @@ export function TeacherTestsTab({
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
 
   const [tests, setTests] = useState<QuizWithStats[]>([])
+  const { showMessage } = useAppMessage()
   const [loading, setLoading] = useState(true)
   const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
   const [internalSelectedTestId, setInternalSelectedTestId] = useState<string | null>(null)
@@ -813,22 +812,6 @@ export function TeacherTestsTab({
   ])
 
   useEffect(() => {
-    if (!gradingWarning) return
-    if (batchSelectedCount > 0) {
-      setGradingWarning('')
-      return
-    }
-    const timer = window.setTimeout(() => setGradingWarning(''), 3000)
-    return () => window.clearTimeout(timer)
-  }, [batchSelectedCount, gradingWarning])
-
-  useEffect(() => {
-    if (!gradingInfo) return
-    const timer = window.setTimeout(() => setGradingInfo(''), 4000)
-    return () => window.clearTimeout(timer)
-  }, [gradingInfo])
-
-  useEffect(() => {
     if (
       workspaceState !== 'selected' ||
       selectedWorkspaceTab !== 'grading' ||
@@ -927,10 +910,11 @@ export function TeacherTestsTab({
       setGradingError(message.error)
       setGradingInfo('')
     } else {
-      setGradingInfo(message.info)
+      showMessage({ text: message.info, tone: 'info' })
+      setGradingInfo('')
       setGradingError('')
     }
-  }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh])
+  }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
   function handleOpenTest(test: QuizWithStats) {
     navigateTestWorkspace({ testId: test.id, mode: 'authoring', studentId: null })
@@ -985,7 +969,7 @@ export function TeacherTestsTab({
         if (!options?.preserveSelection) {
           clearBatchSelection()
         }
-        setGradingInfo('AI grading started')
+        showMessage({ text: 'Grading started', tone: 'info' })
         return
       }
       if (response.status === 409 && data.run) {
@@ -1009,7 +993,8 @@ export function TeacherTestsTab({
       if (Number(summary.skipped_already_graded_count ?? 0) > 0) {
         summaryParts.push(`${summary.skipped_already_graded_count} already graded`)
       }
-      setGradingInfo(summaryParts.join(' • ') || 'No AI grading was needed')
+      showMessage({ text: summaryParts.join(' • ') || 'No AI grading was needed', tone: 'info' })
+      setGradingInfo('')
       if (!options?.preserveSelection) {
         clearBatchSelection()
       }
@@ -1232,7 +1217,7 @@ export function TeacherTestsTab({
   const gradingTable = (
     <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       {gradingRefreshing ? (
-        <RefreshingIndicator label="Refreshing grading rows..." className="px-3 py-2" />
+        <RefreshingIndicator label="Refreshing grades" className="px-3 py-2" />
       ) : null}
       {gradingLoading && gradingStudents.length === 0 ? (
         <div className="flex justify-center py-10">
@@ -1563,6 +1548,53 @@ export function TeacherTestsTab({
       </span>
     ) : null
 
+  const activeTestGradingMessage =
+    workspaceState === 'selected' && selectedWorkspaceTab === 'grading'
+      ? hasActiveTestAiRun && activeTestAiRun
+        ? `Grading ${Math.min(activeTestAiRun.processed_count, activeTestAiRun.requested_count)} of ${activeTestAiRun.requested_count} students…`
+        : isBatchAutoGrading
+          ? 'Starting grading…'
+          : isBatchReturning
+            ? 'Returning work…'
+            : isBatchClearingOpenGrades
+              ? 'Clearing grades…'
+              : ''
+      : ''
+  useOverlayMessage(!!activeTestGradingMessage, activeTestGradingMessage, { tone: 'loading' })
+
+  useEffect(() => {
+    if (!gradingWarning) return
+    if (batchSelectedCount > 0) {
+      setGradingWarning('')
+      return
+    }
+    if (workspaceState === 'selected' && selectedWorkspaceTab === 'grading' && !activeTestGradingMessage) {
+      showMessage({ text: gradingWarning, tone: 'warning' })
+    }
+    setGradingWarning('')
+  }, [
+    activeTestGradingMessage,
+    batchSelectedCount,
+    gradingWarning,
+    selectedWorkspaceTab,
+    showMessage,
+    workspaceState,
+  ])
+
+  useEffect(() => {
+    if (!gradingInfo) return
+    if (workspaceState === 'selected' && selectedWorkspaceTab === 'grading' && !activeTestGradingMessage) {
+      showMessage({ text: gradingInfo, tone: 'info' })
+    }
+    setGradingInfo('')
+  }, [
+    activeTestGradingMessage,
+    gradingInfo,
+    selectedWorkspaceTab,
+    showMessage,
+    workspaceState,
+  ])
+
   const workspaceModeTrailing = (
     <div
       className="min-w-0 max-w-[22rem] truncate text-right text-sm font-medium text-text-default"
@@ -1607,21 +1639,6 @@ export function TeacherTestsTab({
       {gradingError && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
         <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
           {gradingError}
-        </div>
-      ) : null}
-      {gradingWarning && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-        <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-          {gradingWarning}
-        </div>
-      ) : null}
-      {gradingInfo && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-        <div className="rounded-md border border-primary bg-info-bg px-3 py-2 text-sm text-info">
-          {gradingInfo}
-        </div>
-      ) : null}
-      {hasActiveTestAiRun && workspaceState === 'selected' && selectedWorkspaceTab === 'grading' ? (
-        <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-muted">
-          {TEST_AI_GRADING_RUN_NOTE}
         </div>
       ) : null}
     </>

--- a/src/app/create-password/page.tsx
+++ b/src/app/create-password/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, FormEvent, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Input, Button, FormField } from '@/ui'
+import { AppMessageFallback, Input, Button, FormField } from '@/ui'
 
 function CreatePasswordForm() {
   const router = useRouter()
@@ -96,7 +96,7 @@ function CreatePasswordForm() {
 
 export default function CreatePasswordPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<AppMessageFallback />}>
       <CreatePasswordForm />
     </Suspense>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import './globals.scss'
 import { ThemeProvider } from '@/contexts/ThemeContext'
 import { ProgressBarProvider } from '@/components/ProgressBarProvider'
-import { TooltipProvider } from '@/ui'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
 
 export const metadata: Metadata = {
   title: 'Pika',
@@ -37,9 +37,11 @@ export default function RootLayout({
       <body className="min-h-screen bg-page">
         <ThemeProvider>
           <TooltipProvider>
-            <ProgressBarProvider>
-              {children}
-            </ProgressBarProvider>
+            <AppMessageProvider>
+              <ProgressBarProvider>
+                {children}
+              </ProgressBarProvider>
+            </AppMessageProvider>
           </TooltipProvider>
         </ThemeProvider>
       </body>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, FormEvent, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Input, Button, FormField, AlertDialog } from '@/ui'
+import { AppMessageFallback, Input, Button, FormField, AlertDialog } from '@/ui'
 import { useAlertDialog } from '@/hooks/useAlertDialog'
 
 function ResetPasswordForm() {
@@ -212,7 +212,7 @@ function ResetPasswordForm() {
 
 export default function ResetPasswordPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<AppMessageFallback />}>
       <ResetPasswordForm />
     </Suspense>
   )

--- a/src/app/verify-signup/page.tsx
+++ b/src/app/verify-signup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, FormEvent, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Input, Button, FormField } from '@/ui'
+import { AppMessageFallback, Input, Button, FormField, useAppMessage } from '@/ui'
 
 function VerifySignupForm() {
   const router = useRouter()
@@ -13,7 +13,7 @@ function VerifySignupForm() {
   const [code, setCode] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [resendSuccess, setResendSuccess] = useState(false)
+  const { showMessage } = useAppMessage()
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -48,9 +48,7 @@ function VerifySignupForm() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       })
-      setResendSuccess(true)
-      // Hide success message after 3 seconds
-      setTimeout(() => setResendSuccess(false), 3000)
+      showMessage({ text: 'Code sent', tone: 'success' })
     } catch (err) {
       setError('Failed to resend code')
     }
@@ -99,12 +97,6 @@ function VerifySignupForm() {
           </Button>
         </form>
 
-        {resendSuccess && (
-          <div className="mt-4 bg-success-bg border border-success text-text-default px-4 py-3 rounded-lg">
-            New verification code sent!
-          </div>
-        )}
-
         <div className="mt-4 text-center">
           <button
             onClick={handleResendCode}
@@ -120,7 +112,7 @@ function VerifySignupForm() {
 
 export default function VerifySignupPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<AppMessageFallback />}>
       <VerifySignupForm />
     </Suspense>
   )

--- a/src/hooks/useAlertDialog.ts
+++ b/src/hooks/useAlertDialog.ts
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import type { AlertDialogState, AlertDialogVariant } from '@/ui'
+import { useAppMessage, type AlertDialogState, type AlertDialogVariant } from '@/ui'
 
 const INITIAL_STATE: AlertDialogState = { isOpen: false, title: '' }
 
 export function useAlertDialog() {
   const [state, setState] = useState<AlertDialogState>(INITIAL_STATE)
+  const { showMessage } = useAppMessage()
 
   const showAlert = useCallback((
     title: string,
@@ -26,8 +27,11 @@ export function useAlertDialog() {
   }, [])
 
   const showSuccess = useCallback((title: string, description?: string) => {
-    showAlert(title, { description, variant: 'success', autoDismiss: true })
-  }, [showAlert])
+    showMessage({
+      text: title.trim() || description?.trim() || 'Done',
+      tone: 'success',
+    })
+  }, [showMessage])
 
   const showError = useCallback((title: string, description?: string) => {
     showAlert(title, { description, variant: 'error' })

--- a/src/ui/AppMessage.tsx
+++ b/src/ui/AppMessage.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { cn } from './utils'
+
+export type AppMessageTone = 'loading' | 'info' | 'success' | 'warning'
+
+export interface ShowAppMessageOptions {
+  text: string
+  tone?: AppMessageTone
+  /**
+   * Defaults to a short auto-dismiss. Pass 0 for state-driven messages that
+   * should stay visible until the caller clears or replaces them.
+   */
+  durationMs?: number
+}
+
+interface AppMessageState {
+  id: string
+  text: string
+  tone: AppMessageTone
+}
+
+interface AppMessageContextValue {
+  showMessage: (options: ShowAppMessageOptions) => string
+  clearMessage: (id?: string) => void
+}
+
+interface UseOverlayMessageOptions {
+  tone?: AppMessageTone
+  delayMs?: number
+}
+
+const DEFAULT_DURATION_MS = 1800
+const WARNING_DURATION_MS = 2400
+
+const AppMessageContext = createContext<AppMessageContextValue | null>(null)
+
+const toneClassNames: Record<AppMessageTone, string> = {
+  loading: 'border-border bg-surface text-text-default',
+  info: 'border-primary bg-info-bg text-info',
+  success: 'border-success bg-success-bg text-success',
+  warning: 'border-warning bg-warning-bg text-warning',
+}
+
+function getDefaultDurationMs(tone: AppMessageTone): number {
+  return tone === 'warning' ? WARNING_DURATION_MS : DEFAULT_DURATION_MS
+}
+
+function trimStaticEllipsis(text: string) {
+  return text.replace(/[\s.。…]+$/, '')
+}
+
+function LoadingMessageText({ text }: { text: string }) {
+  const [dotCount, setDotCount] = useState(1)
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setDotCount((current) => (current >= 3 ? 1 : current + 1))
+    }, 420)
+    return () => window.clearInterval(intervalId)
+  }, [])
+
+  return (
+    <span className="truncate">
+      {trimStaticEllipsis(text)}
+      <span aria-hidden="true">{'.'.repeat(dotCount)}</span>
+    </span>
+  )
+}
+
+export function AppMessageProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<AppMessageState | null>(null)
+  const messageRef = useRef<AppMessageState | null>(null)
+  const autoDismissTimerRef = useRef<number | null>(null)
+  const nextIdRef = useRef(0)
+
+  const clearAutoDismissTimer = useCallback(() => {
+    if (autoDismissTimerRef.current == null) return
+    window.clearTimeout(autoDismissTimerRef.current)
+    autoDismissTimerRef.current = null
+  }, [])
+
+  const dismissMessage = useCallback((id?: string) => {
+    const currentMessage = messageRef.current
+    if (id && currentMessage?.id !== id) return
+
+    clearAutoDismissTimer()
+    messageRef.current = null
+    setMessage(null)
+  }, [clearAutoDismissTimer])
+
+  const clearMessage = useCallback((id?: string) => {
+    dismissMessage(id)
+  }, [dismissMessage])
+
+  const showMessage = useCallback((options: ShowAppMessageOptions) => {
+    const text = options.text.trim()
+    if (!text) {
+      dismissMessage()
+      return ''
+    }
+
+    clearAutoDismissTimer()
+
+    const tone = options.tone ?? 'info'
+    const id = `app-message-${Date.now()}-${nextIdRef.current}`
+    nextIdRef.current += 1
+    const nextMessage = { id, text, tone }
+    messageRef.current = nextMessage
+    setMessage(nextMessage)
+
+    const durationMs = options.durationMs ?? getDefaultDurationMs(tone)
+    if (durationMs > 0) {
+      autoDismissTimerRef.current = window.setTimeout(() => {
+        dismissMessage(id)
+      }, durationMs)
+    }
+
+    return id
+  }, [
+    clearAutoDismissTimer,
+    dismissMessage,
+  ])
+
+  useEffect(() => () => {
+    clearAutoDismissTimer()
+  }, [clearAutoDismissTimer])
+
+  const value = useMemo<AppMessageContextValue>(
+    () => ({ showMessage, clearMessage }),
+    [clearMessage, showMessage],
+  )
+
+  return (
+    <AppMessageContext.Provider value={value}>
+      {children}
+      {message ? (
+        <div
+          data-testid="app-message-overlay"
+          className="pointer-events-none fixed left-1/2 top-6 z-[80] flex w-[calc(100%-8rem)] max-w-[14rem] -translate-x-1/2 -translate-y-1/2 justify-center sm:max-w-md"
+          aria-live="polite"
+          aria-atomic="true"
+          role="status"
+        >
+          <div
+            data-testid="app-message-pill"
+            className={cn(
+              'inline-flex min-h-8 max-w-full items-center truncate rounded-badge border px-3 py-1.5 text-sm font-medium leading-none shadow-elevated',
+              toneClassNames[message.tone],
+            )}
+          >
+            {message.tone === 'loading' ? (
+              <LoadingMessageText text={message.text} />
+            ) : (
+              <span className="truncate">{message.text}</span>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </AppMessageContext.Provider>
+  )
+}
+
+export function useAppMessage() {
+  const context = useContext(AppMessageContext)
+  if (!context) {
+    throw new Error('useAppMessage must be used within AppMessageProvider')
+  }
+  return context
+}
+
+export function useOverlayMessage(
+  active: boolean,
+  text: string,
+  options: UseOverlayMessageOptions = {},
+) {
+  const { showMessage, clearMessage } = useAppMessage()
+  const messageIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!active) {
+      if (messageIdRef.current) {
+        clearMessage(messageIdRef.current)
+        messageIdRef.current = null
+      }
+      return
+    }
+
+    const delayMs = options.delayMs ?? 180
+    const timeoutId = window.setTimeout(() => {
+      messageIdRef.current = showMessage({
+        text,
+        tone: options.tone ?? 'loading',
+        durationMs: 0,
+      })
+    }, delayMs)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+      if (messageIdRef.current) {
+        clearMessage(messageIdRef.current)
+        messageIdRef.current = null
+      }
+    }
+  }, [active, clearMessage, options.delayMs, options.tone, showMessage, text])
+}
+
+export function AppMessageFallback({
+  label = 'Loading',
+}: {
+  label?: string
+}) {
+  useOverlayMessage(true, label, { tone: 'loading', delayMs: 0 })
+  return null
+}

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -9,7 +9,7 @@ This directory contains the canonical UI primitives for the Pika application.
 ## Quick Start
 
 ```tsx
-import { Button, Input, Select, FormField, AlertDialog, ConfirmDialog, Card, Tooltip } from '@/ui'
+import { Button, Input, Select, FormField, AlertDialog, ConfirmDialog, Card, Tooltip, useAppMessage } from '@/ui'
 
 // Form controls are always wrapped by FormField
 <FormField label="Email" error={errors.email} required>
@@ -135,6 +135,38 @@ interface TooltipProps {
 }
 ```
 
+### AppMessage
+
+`AppMessageProvider` is mounted from the root layout and owns the one-at-a-time message overlay centered in the global title bar. Use it only for short transient feedback such as loading, refreshing, progress, copy, and success notices. Keep validation, blocking errors, empty states, confirmations, and persistent editor save state inline. Loading-tone messages animate a trailing ellipsis, so pass copy without static dots when possible.
+
+```typescript
+type AppMessageTone = 'loading' | 'info' | 'success' | 'warning'
+
+interface ShowAppMessageOptions {
+  text: string
+  tone?: AppMessageTone
+  durationMs?: number
+}
+
+function useAppMessage(): {
+  showMessage: (options: ShowAppMessageOptions) => string
+  clearMessage: (id?: string) => void
+}
+
+function useOverlayMessage(
+  active: boolean,
+  text: string,
+  options?: { tone?: AppMessageTone; delayMs?: number }
+): void
+```
+
+```tsx
+const { showMessage } = useAppMessage()
+showMessage({ text: 'Copied', tone: 'success' })
+
+useOverlayMessage(isRefreshing, 'Refreshing', { tone: 'loading' })
+```
+
 ---
 
 ## Design System Policies (AI Rails)
@@ -245,7 +277,8 @@ These are NOT part of the `/ui` design system:
 
 - **Tiptap primitives**: Stay in `tiptap-ui-primitive/`
 - **Textarea**: Use native `<textarea>` wrapped by FormField
-- **Toast/Tabs**: Not implemented yet
+- **Toast stacks**: Use `AppMessage` instead; stacked toasts are intentionally not implemented
+- **Tabs**: Not implemented yet
 - **App-specific components**: ClassroomDropdown, UserMenu, etc.
 
 ---

--- a/src/ui/RefreshingIndicator.tsx
+++ b/src/ui/RefreshingIndicator.tsx
@@ -1,21 +1,17 @@
 'use client'
 
+import { useOverlayMessage } from './AppMessage'
+
 interface RefreshingIndicatorProps {
   label?: string
   className?: string
 }
 
 export function RefreshingIndicator({
-  label = 'Refreshing...',
+  label = 'Refreshing',
   className = '',
 }: RefreshingIndicatorProps) {
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      className={['px-3 py-2 text-xs text-text-muted', className].filter(Boolean).join(' ')}
-    >
-      {label}
-    </div>
-  )
+  void className
+  useOverlayMessage(true, label, { tone: 'loading', delayMs: 0 })
+  return null
 }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -20,6 +20,14 @@ export { Tooltip, TooltipProvider, type TooltipProps } from './Tooltip'
 export { RefreshingIndicator } from './RefreshingIndicator'
 export { TabContentTransition } from './TabContentTransition'
 export { SplitButton, type SplitButtonProps, type SplitButtonOption } from './SplitButton'
+export {
+  AppMessageFallback,
+  AppMessageProvider,
+  useAppMessage,
+  useOverlayMessage,
+  type AppMessageTone,
+  type ShowAppMessageOptions,
+} from './AppMessage'
 
 // Utilities
 export { cn } from './utils'

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -10,6 +10,8 @@ const mockToggleSelect = vi.fn()
 const mockToggleSelectAll = vi.fn()
 const mockClearSelection = vi.fn()
 const mockSetSelection = vi.fn()
+const mockShowMessage = vi.fn()
+const mockUseOverlayMessage = vi.fn()
 const mockStudentSelectionState = {
   selectedIds: new Set<string>(),
   allSelected: false,
@@ -57,6 +59,8 @@ vi.mock('@/ui', () => ({
   Tooltip: ({ children, content }: any) => (
     <span data-tooltip={typeof content === 'string' ? content : undefined}>{children}</span>
   ),
+  useAppMessage: () => ({ showMessage: mockShowMessage, clearMessage: vi.fn() }),
+  useOverlayMessage: (...args: any[]) => mockUseOverlayMessage(...args),
 }))
 
 vi.mock('@/hooks/useDelayedBusy', () => ({
@@ -304,6 +308,8 @@ describe('TeacherClassroomView', () => {
     mockToggleSelectAll.mockReset()
     mockClearSelection.mockReset()
     mockSetSelection.mockReset()
+    mockShowMessage.mockReset()
+    mockUseOverlayMessage.mockReset()
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
     mockStudentSelectionState.selectedCount = 0
@@ -819,7 +825,7 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByText('Graded 1 • 1 missing')).toBeInTheDocument()
+      expect(mockShowMessage).toHaveBeenCalledWith({ text: 'Graded 1 • 1 missing', tone: 'info' })
     })
     expect(mockClearSelection).toHaveBeenCalled()
   })
@@ -1015,9 +1021,11 @@ describe('TeacherClassroomView', () => {
     await waitFor(() => {
       expect(statusFetchCount).toBeGreaterThan(0)
     })
-    expect(
-      screen.getByText('Keep this assignment open while grading runs. Reopening it resumes the current progress.'),
-    ).toBeInTheDocument()
+    expect(mockUseOverlayMessage).toHaveBeenCalledWith(
+      true,
+      expect.stringMatching(/Grading \d+ of 2 students/),
+      { tone: 'loading' },
+    )
     expect(tickFetchCount).toBe(0)
   })
 
@@ -1129,7 +1137,7 @@ describe('TeacherClassroomView', () => {
         await Promise.resolve()
       })
 
-      expect(screen.getByText('Graded 2')).toBeInTheDocument()
+      expect(mockShowMessage).toHaveBeenCalledWith({ text: 'Graded 2', tone: 'info' })
       expect(tickFetchCount).toBe(2)
     } finally {
       vi.useRealTimers()
@@ -1363,7 +1371,10 @@ describe('TeacherClassroomView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Return' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Returned 1 • Created 1 zero-grade return • Skipped 1 already returned • Blocked 1 partial-rubric draft')).toBeInTheDocument()
+      expect(mockShowMessage).toHaveBeenCalledWith({
+        text: 'Returned 1 • Created 1 zero-grade return • Skipped 1 already returned • Blocked 1 partial-rubric draft',
+        tone: 'info',
+      })
     })
     expect(mockSetSelection).toHaveBeenCalledWith(['student-2'])
   })

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react'
 import { TeacherSettingsTab } from '@/app/classrooms/[classroomId]/TeacherSettingsTab'
-import { TooltipProvider } from '@/ui'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
 import type { Classroom } from '@/types'
 import type { ReactNode } from 'react'
 
@@ -30,7 +30,11 @@ const mockClassroom: Classroom = {
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <TooltipProvider>{children}</TooltipProvider>
+  return (
+    <AppMessageProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </AppMessageProvider>
+  )
 }
 
 describe('TeacherSettingsTab - Course Name Editing', () => {
@@ -135,7 +139,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     fireEvent.blur(input)
 
     await waitFor(() => {
-      expect(screen.getByText('Course name updated.')).toBeInTheDocument()
+      expect(screen.getByText('Course name updated')).toBeInTheDocument()
     })
   })
 
@@ -153,7 +157,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     fireEvent.blur(input)
 
     await waitFor(() => {
-      expect(screen.getByText('Course name updated.')).toBeInTheDocument()
+      expect(screen.getByText('Course name updated')).toBeInTheDocument()
     })
     expect(mockRefresh).not.toHaveBeenCalled()
   })
@@ -266,7 +270,7 @@ describe('TeacherSettingsTab - Allow Joining', () => {
     fireEvent.click(checkbox)
 
     await waitFor(() => {
-      expect(screen.getByText('Settings saved.')).toBeInTheDocument()
+      expect(screen.getByText('Settings saved')).toBeInTheDocument()
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -355,21 +359,21 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
     fireEvent.change(input, { target: { value: 'New Name' } })
     fireEvent.blur(input)
 
-    // Advance microtasks to let the fetch resolve, but not the 2s timeout
+    // Advance microtasks to let the fetch resolve, but not the timeout
     await act(async () => {
       await Promise.resolve()
     })
 
     // Success message should appear
-    expect(screen.getByText('Course name updated.')).toBeInTheDocument()
+    expect(screen.getByText('Course name updated')).toBeInTheDocument()
 
-    // Advance time by 2 seconds to trigger the auto-clear
+    // Advance time to trigger the short auto-clear
     await act(async () => {
-      vi.advanceTimersByTime(2000)
+      vi.advanceTimersByTime(1800)
     })
 
     // Success message should be gone
-    expect(screen.queryByText('Course name updated.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Course name updated')).not.toBeInTheDocument()
   })
 
   it('auto-clears enrollment success message after 2 seconds', async () => {
@@ -384,20 +388,20 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
     const checkbox = screen.getByLabelText('Allow joining')
     fireEvent.click(checkbox)
 
-    // Advance microtasks to let the fetch resolve, but not the 2s timeout
+    // Advance microtasks to let the fetch resolve, but not the timeout
     await act(async () => {
       await Promise.resolve()
     })
 
     // Success message should appear
-    expect(screen.getByText('Settings saved.')).toBeInTheDocument()
+    expect(screen.getByText('Settings saved')).toBeInTheDocument()
 
-    // Advance time by 2 seconds to trigger the auto-clear
+    // Advance time to trigger the short auto-clear
     await act(async () => {
-      vi.advanceTimersByTime(2000)
+      vi.advanceTimersByTime(1800)
     })
 
     // Success message should be gone
-    expect(screen.queryByText('Settings saved.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Settings saved')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import { useEffect, type ReactNode } from 'react'
 import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
-import { TooltipProvider } from '@/ui'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
 import type { QuizWithStats } from '@/types'
@@ -135,7 +135,11 @@ vi.mock('@/components/TestStudentGradingPanel', () => ({
 }))
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <TooltipProvider>{children}</TooltipProvider>
+  return (
+    <AppMessageProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </AppMessageProvider>
+  )
 }
 
 function makeTest(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
@@ -832,7 +836,9 @@ describe('TeacherTestsTab', () => {
 
     expect(screen.getByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.getByText('3/5')).toBeInTheDocument()
-    expect(screen.getByRole('status')).toHaveTextContent('Refreshing grading rows...')
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('Refreshing grades')
+    })
 
     await act(async () => {
       resolvePoll?.(
@@ -863,7 +869,9 @@ describe('TeacherTestsTab', () => {
     await waitFor(() => {
       expect(screen.getByText('4/5')).toBeInTheDocument()
     })
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
   })
 
   it('does not start polling when the server reports the test is closed', async () => {
@@ -1185,7 +1193,7 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Grade with AI' }))
 
     await waitFor(() => {
-      expect(screen.getByText('AI grading started')).toBeInTheDocument()
+      expect(screen.getByRole('status')).toHaveTextContent(/grading/i)
     })
 
     await act(async () => {
@@ -1194,7 +1202,7 @@ describe('TeacherTestsTab', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Graded 1')).toBeInTheDocument()
+      expect(screen.getByRole('status')).toHaveTextContent('Graded 1')
     })
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/teacher/tests/test-1/auto-grade-runs/run-1/tick',

--- a/tests/ui/AppMessage.test.tsx
+++ b/tests/ui/AppMessage.test.tsx
@@ -1,0 +1,137 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AppMessageProvider, useAppMessage, useOverlayMessage } from '@/ui'
+
+function MessageButton({
+  text,
+  tone = 'info',
+}: {
+  text: string
+  tone?: 'loading' | 'info' | 'success' | 'warning'
+}) {
+  const { showMessage } = useAppMessage()
+  return (
+    <button type="button" onClick={() => showMessage({ text, tone })}>
+      Show
+    </button>
+  )
+}
+
+function ActiveOverlayMessage({ active }: { active: boolean }) {
+  useOverlayMessage(active, 'Refreshing', { tone: 'loading', delayMs: 0 })
+  return <div data-testid="stable-content">Content</div>
+}
+
+describe('AppMessageProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a fixed top-center polite status message and auto-dismisses it', () => {
+    vi.useFakeTimers()
+
+    const { container } = render(
+      <AppMessageProvider>
+        <MessageButton text="Saved" tone="success" />
+      </AppMessageProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+
+    const overlay = screen.getByTestId('app-message-overlay')
+    expect(overlay).toHaveAttribute('aria-live', 'polite')
+    expect(overlay).toHaveAttribute('aria-atomic', 'true')
+    expect(overlay).toHaveClass('fixed', 'left-1/2', 'top-6', '-translate-y-1/2', 'pointer-events-none')
+    expect(screen.getByTestId('app-message-pill')).not.toHaveClass('transition-[opacity,transform]')
+    expect(container.firstElementChild).toBe(screen.getByRole('button', { name: 'Show' }))
+    expect(screen.getByRole('status')).toHaveTextContent('Saved')
+
+    act(() => {
+      vi.advanceTimersByTime(1800)
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('replaces an older message instead of stacking messages', () => {
+    vi.useFakeTimers()
+
+    function Harness() {
+      const { showMessage } = useAppMessage()
+      return (
+        <>
+          <button type="button" onClick={() => showMessage({ text: 'First', tone: 'info' })}>
+            First
+          </button>
+          <button type="button" onClick={() => showMessage({ text: 'Second', tone: 'warning' })}>
+            Second
+          </button>
+        </>
+      )
+    }
+
+    render(
+      <AppMessageProvider>
+        <Harness />
+      </AppMessageProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'First' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Second' }))
+
+    expect(screen.getByRole('status')).toHaveTextContent('Second')
+    expect(screen.getByRole('status')).not.toHaveTextContent('First')
+    expect(screen.getAllByTestId('app-message-overlay')).toHaveLength(1)
+  })
+
+  it('lets state-driven messages render outside layout content and clear when inactive', () => {
+    vi.useFakeTimers()
+
+    const { rerender } = render(
+      <AppMessageProvider>
+        <ActiveOverlayMessage active />
+      </AppMessageProvider>,
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(screen.getByTestId('stable-content')).toHaveTextContent('Content')
+    expect(screen.getByRole('status')).toHaveTextContent('Refreshing')
+    expect(screen.getByTestId('app-message-overlay')).toHaveClass('fixed')
+
+    rerender(
+      <AppMessageProvider>
+        <ActiveOverlayMessage active={false} />
+      </AppMessageProvider>,
+    )
+
+    expect(screen.getByTestId('stable-content')).toHaveTextContent('Content')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('animates loading messages with cycling ellipsis dots', () => {
+    vi.useFakeTimers()
+
+    render(
+      <AppMessageProvider>
+        <MessageButton text="AI grading in progress..." tone="loading" />
+      </AppMessageProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+
+    expect(screen.getByRole('status')).toHaveTextContent('AI grading in progress.')
+
+    act(() => {
+      vi.advanceTimersByTime(420)
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('AI grading in progress..')
+
+    act(() => {
+      vi.advanceTimersByTime(420)
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('AI grading in progress...')
+  })
+})

--- a/tests/ui/StatusPrimitives.test.tsx
+++ b/tests/ui/StatusPrimitives.test.tsx
@@ -1,24 +1,32 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { RefreshingIndicator, TabContentTransition } from '@/ui'
+import { AppMessageProvider, RefreshingIndicator, TabContentTransition } from '@/ui'
 
 describe('status primitives', () => {
-  it('renders the refreshing indicator with the default polite status label', () => {
-    render(<RefreshingIndicator />)
+  it('renders the refreshing indicator through the fixed overlay status label', async () => {
+    render(
+      <AppMessageProvider>
+        <RefreshingIndicator />
+      </AppMessageProvider>,
+    )
 
-    const status = screen.getByRole('status')
+    const status = await screen.findByRole('status')
     expect(status).toHaveAttribute('aria-live', 'polite')
-    expect(status).toHaveTextContent('Refreshing...')
-    expect(status.className).toContain('text-text-muted')
+    expect(status).toHaveTextContent('Refreshing')
+    expect(screen.getByTestId('app-message-overlay')).toHaveClass('fixed', 'pointer-events-none')
   })
 
-  it('renders the refreshing indicator with a custom label and class name', () => {
-    render(<RefreshingIndicator label="Syncing grades..." className="mb-2" />)
+  it('renders the refreshing indicator with a custom overlay label without layout classes', async () => {
+    render(
+      <AppMessageProvider>
+        <RefreshingIndicator label="Syncing grades" className="mb-2" />
+      </AppMessageProvider>,
+    )
 
-    const status = screen.getByRole('status')
-    expect(status).toHaveTextContent('Syncing grades...')
-    expect(status.className).toContain('mb-2')
+    const status = await screen.findByRole('status')
+    expect(status).toHaveTextContent('Syncing grades')
+    expect(screen.getByTestId('app-message-overlay')).not.toHaveClass('mb-2')
   })
 
   it('shows active tab content with visible transition classes', () => {


### PR DESCRIPTION
## Summary
- Add a shared root-mounted `AppMessageProvider` for one-at-a-time, short-lived title-bar messages.
- Move transient copy/success/refreshing/loading/grading messages out of inline layout and into the overlay.
- Keep blocking errors, validation, empty states, confirmations, and persistent editor save-state context inline.
- Document the new `@/ui` primitive and remove the old toast-not-implemented guidance.

## Notes
- Toast stacking remains intentionally unsupported.
- Entry/exit animation was investigated and removed because it did not produce a convincing product-visible effect. Follow-up issue: #523.

## Validation
- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)
- `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx tests/components/TeacherTestsTab.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.json --incremental false`
- Pika UI verify screenshots for teacher desktop, student mobile, and teacher mobile settings views
- Manual smoke on copy-code overlay and auth resend overlay paths
