### PR TITLE
[codex] Add explicit source-visible license

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9700,3 +9700,12 @@
   - `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx tests/components/TeacherTestsTab.test.tsx`
   - `pnpm lint`
   - `pnpm exec tsc --noEmit --pretty false --project tsconfig.json --incremental false`
+
+## 2026-04-29 — Explicit source-visible license
+
+**Completed:**
+- Added a root `LICENSE` file reserving all rights to Stewart Chan and identifying Pika as a CodePet project.
+- Added a README license section that states the repository is publicly visible for review/evaluation only and links to `LICENSE`.
+
+**Validation:**
+- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Pika Source Code License
+
+Copyright (c) 2026 Stewart Chan. All rights reserved.
+
+Pika is a CodePet project.
+
+This repository and its contents are publicly visible for review and evaluation
+only. Except for rights expressly granted by GitHub's Terms of Service for use
+of the GitHub platform, no license or permission is granted to any person or
+entity to use, copy, modify, merge, publish, distribute, sublicense, host,
+operate, sell, commercialize, or create derivative works from this software or
+any part of this repository.
+
+Any use of this software requires prior written permission from Stewart Chan.
+
+All intellectual property rights in and to this repository, including source
+code, documentation, designs, product concepts expressed in copyrightable form,
+and related materials, are reserved by Stewart Chan.
+
+The names "Pika" and "CodePet", and any associated branding, logos, or marks,
+may not be used without prior written permission.
+
+Third-party software, packages, libraries, and dependencies referenced by this
+repository remain subject to their own separate license terms.
+
+This software is provided for review and evaluation only, without warranty of
+any kind, express or implied, including but not limited to warranties of
+merchantability, fitness for a particular purpose, and noninfringement. In no
+event shall the copyright holder be liable for any claim, damages, or other
+liability arising from or related to this repository or its contents.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ node scripts/features.mjs next
 - **Styling**: Tailwind CSS
 - **Testing**: Vitest + React Testing Library
 
+## License
+
+Copyright (c) 2026 Stewart Chan. All rights reserved.
+
+Pika is a CodePet project. This repository is publicly visible for review and
+evaluation only. No permission is granted to use, copy, modify, distribute,
+host, commercialize, or create derivative works without prior written
+permission. See [LICENSE](./LICENSE).
+
 ## Prerequisites
 
 - Node.js 24.x


### PR DESCRIPTION
## Summary

- Add a root `LICENSE` reserving all rights to Stewart Chan and identifying Pika as a CodePet project.
- Add a README license section explaining the repo is publicly visible for review/evaluation only and linking to the full license.
- Record the session in `.ai/JOURNAL.md`.

## Notes

This is intentionally not an open-source license. It preserves public visibility while making clear that use, copying, modification, distribution, hosting, commercialization, and derivative works require prior written permission.

## Validation

- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` passed: 235 files, 1951 tests
- `git diff --check` passed