### PR TITLE
[codex] Render exam markdown in documents and options

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9923,3 +9923,22 @@
   - `/tmp/pika-teacher-mobile.png`
   - `/tmp/pika-settings-show-markdown-off.png`
   - `/tmp/pika-settings-show-markdown-on.png`
+## 2026-04-29 — Exam markdown rendering fix
+
+**Completed:**
+- Made exam-mode text documents render through the shared limited markdown renderer instead of a raw `<pre>`, preserving document interaction suppression for focus telemetry.
+- Made multiple-choice options render markdown in the student test form and teacher preview, so inline code and fenced code blocks no longer show literal markdown backticks.
+- Added regression coverage for language-tagged fenced code, markdown MC options, and text-document markdown inside the student exam flow.
+
+**Validation:**
+- `pnpm test tests/components/QuestionMarkdown.test.tsx tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verification for `/classrooms/c2055846-3dab-41ef-acc7-e3d478ecf5c1?tab=tests` on this branch at `http://localhost:3010`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Focused markdown visual checks after seeding and then restoring the local active test with markdown document/option examples:
+  - `/tmp/pika-student-exam-markdown-3010.png`
+  - `/tmp/pika-teacher-preview-markdown-3010.png`
+- Follow-up: removed the `scripts/seed-tests.ts` smoke-data change to avoid seed failures in databases missing existing test document migrations; markdown smoke coverage remains in component tests and the local visual check.

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ClockAlert, LogOut, Maximize } from 'lucide-react'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { TestTextDocumentViewer } from '@/components/TestTextDocumentViewer'
 import {
   getQuizExitCount,
   getQuizStatusBadgeClass,
@@ -1321,15 +1322,11 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                             </div>
 
                             {activeDoc?.source === 'text' ? (
-                              <div
-                                className="scrollbar-hover min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3"
-                                onMouseUp={handleTextDocPointerUp}
+                              <TestTextDocumentViewer
+                                content={activeDoc.content || ''}
                                 onKeyUp={handleTextDocPointerUp}
-                              >
-                                <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
-                                  {activeDoc.content || ''}
-                                </pre>
-                              </div>
+                                onMouseUp={handleTextDocPointerUp}
+                              />
                             ) : iframeDocs.length > 0 ? (
                               <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
                                 {iframeDocs.map((doc) => {

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -2010,22 +2010,25 @@ function QuizPreview({ questions, isTestsView }: { questions: QuizQuestion[]; is
               {question.options.map((option, optionIndex) => {
                 const isSelected = selected[question.id] === optionIndex
                 return (
-                  <label
+                  <div
                     key={optionIndex}
                     className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
                       isSelected
                         ? 'border-primary bg-primary/5'
                         : 'border-border hover:bg-surface-hover'
                     }`}
+                    onClick={() => setSelected((prev) => ({ ...prev, [question.id]: optionIndex }))}
                   >
                     <input
                       type="radio"
                       name={`preview-${question.id}`}
                       checked={isSelected}
+                      aria-label={option}
                       onChange={() => setSelected((prev) => ({ ...prev, [question.id]: optionIndex }))}
                       className="sr-only"
                     />
                     <span
+                      aria-hidden="true"
                       className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
                         isSelected ? 'border-primary' : 'border-border'
                       }`}
@@ -2034,8 +2037,8 @@ function QuizPreview({ questions, isTestsView }: { questions: QuizQuestion[]; is
                         <span className="w-2.5 h-2.5 rounded-full bg-primary" />
                       )}
                     </span>
-                    <span className="text-text-default">{option}</span>
-                  </label>
+                    <QuestionMarkdown content={option} className="min-w-0 flex-1" />
+                  </div>
                 )
               })}
             </div>

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -525,23 +525,31 @@ export function StudentQuizForm({
                           const isSelected = selectedOption === optionIndex
 
                           return (
-                            <label
+                            <div
                               key={optionIndex}
+                              data-question-option
                               className={`relative flex items-center gap-3 p-3 rounded-lg border transition-colors ${
                                 isSelected
                                   ? 'border-primary bg-primary/5'
                                   : 'border-border hover:bg-surface-hover'
                               } ${isInteractionLocked ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'}`}
+                              onClick={() => {
+                                if (!isInteractionLocked) {
+                                  handleOptionSelect(question.id, optionIndex)
+                                }
+                              }}
                             >
                               <input
                                 type="radio"
                                 name={`question-${question.id}`}
                                 checked={isSelected}
                                 disabled={isInteractionLocked}
+                                aria-label={option}
                                 onChange={() => handleOptionSelect(question.id, optionIndex)}
                                 className="peer absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 cursor-pointer opacity-0 disabled:cursor-not-allowed"
                               />
                               <span
+                                aria-hidden="true"
                                 className={`w-5 h-5 rounded-full border-2 flex items-center justify-center peer-focus-visible:ring-2 peer-focus-visible:ring-primary peer-focus-visible:ring-offset-2 ${
                                   isSelected ? 'border-primary' : 'border-border'
                                 }`}
@@ -550,8 +558,8 @@ export function StudentQuizForm({
                                   <span className="w-2.5 h-2.5 rounded-full bg-primary" />
                                 )}
                               </span>
-                              <span className="text-text-default">{option}</span>
-                            </label>
+                              <QuestionMarkdown content={option} className="min-w-0 flex-1" />
+                            </div>
                           )
                         })}
                       </div>

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, Maximize, X } from 'lucide-react'
 import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
+import { TestTextDocumentViewer } from '@/components/TestTextDocumentViewer'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import type { QuizQuestion, TestDocument } from '@/types'
@@ -478,11 +479,10 @@ export function TeacherTestPreviewPage({
                   </div>
 
                   {activeDoc?.source === 'text' ? (
-                    <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3 scrollbar-none">
-                      <pre className="whitespace-pre-wrap break-words text-sm text-text-default">
-                        {activeDoc.content || ''}
-                      </pre>
-                    </div>
+                    <TestTextDocumentViewer
+                      className="scrollbar-none"
+                      content={activeDoc.content || ''}
+                    />
                   ) : iframeDocs.length > 0 ? (
                     <div className="relative min-h-0 flex-1 overflow-hidden bg-white">
                       {iframeDocs.map((doc) => {

--- a/src/components/TestTextDocumentViewer.tsx
+++ b/src/components/TestTextDocumentViewer.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import type { KeyboardEventHandler, MouseEventHandler } from 'react'
+import { QuestionMarkdown } from '@/components/QuestionMarkdown'
+
+interface TestTextDocumentViewerProps {
+  className?: string
+  content: string
+  onKeyUp?: KeyboardEventHandler<HTMLDivElement>
+  onMouseUp?: MouseEventHandler<HTMLDivElement>
+}
+
+export function TestTextDocumentViewer({
+  className = 'scrollbar-hover',
+  content,
+  onKeyUp,
+  onMouseUp,
+}: TestTextDocumentViewerProps) {
+  return (
+    <div
+      className={`min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-surface-2 p-3 ${className}`.trim()}
+      onKeyUp={onKeyUp}
+      onMouseUp={onMouseUp}
+    >
+      <QuestionMarkdown content={content || ''} className="break-words" />
+    </div>
+  )
+}

--- a/tests/components/QuestionMarkdown.test.tsx
+++ b/tests/components/QuestionMarkdown.test.tsx
@@ -27,6 +27,18 @@ describe('QuestionMarkdown', () => {
     expect(screen.getByText('const x = 42;')).toBeInTheDocument()
   })
 
+  it('renders language-tagged code blocks without showing fence markers', () => {
+    render(
+      <QuestionMarkdown
+        content={`\`\`\`java\npublic class Main {}\n\`\`\``}
+      />
+    )
+
+    expect(screen.getByText('public class Main {}')).toBeInTheDocument()
+    expect(screen.queryByText(/```/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/java/)).not.toBeInTheDocument()
+  })
+
   it('does not render unsafe links as anchors', () => {
     render(<QuestionMarkdown content="[click me](javascript:alert(1))" />)
 

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -173,7 +173,7 @@ describe('StudentQuizForm preview mode', () => {
     expect(within(actionPanel).getByText('Answer all questions to submit')).toBeInTheDocument()
   })
 
-  it('keeps multiple-choice radios anchored inside their option labels', async () => {
+  it('keeps multiple-choice radios anchored inside their option rows', async () => {
     const onSubmitted = vi.fn()
 
     render(
@@ -194,13 +194,42 @@ describe('StudentQuizForm preview mode', () => {
       />
     )
 
-    const optionLabel = screen.getByText('A').closest('label')
-    const radio = within(optionLabel!).getByRole('radio')
+    const optionRow = screen.getByText('A').closest('[data-question-option]')
+    const radio = within(optionRow as HTMLElement).getByRole('radio')
 
-    expect(optionLabel).toHaveClass('relative')
+    expect(optionRow).toHaveClass('relative')
     expect(radio).not.toHaveClass('sr-only')
     expect(radio).toHaveClass('absolute')
     expect(radio).toHaveClass('left-3')
+  })
+
+  it('renders markdown inside multiple-choice options', async () => {
+    const onSubmitted = vi.fn()
+
+    render(
+      <StudentQuizForm
+        quizId="test-markdown-options-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Which code compiles?',
+            options: [
+              '`public static void main`',
+              '```java\npublic class Main {}\n```',
+            ],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        assessmentType="test"
+        previewMode
+        onSubmitted={onSubmitted}
+      />
+    )
+
+    expect(screen.getByText('public static void main')).toHaveClass('font-mono')
+    expect(screen.getByText('public class Main {}')).toBeInTheDocument()
+    expect(screen.queryByText(/```/)).not.toBeInTheDocument()
   })
 
   it('keeps the sticky submit footer for quizzes', async () => {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -1284,7 +1284,7 @@ describe('StudentQuizzesTab exam mode', () => {
                 {
                   id: 'doc-1',
                   title: 'Formula Sheet',
-                  content: 'Solve using the quadratic formula.',
+                  content: 'Solve using `public static`.\n\n```java\npublic class Main {}\n```',
                   source: 'text',
                 },
               ],
@@ -1351,7 +1351,12 @@ describe('StudentQuizzesTab exam mode', () => {
       expect(screen.getByRole('button', { name: 'Back to documents list' })).toBeInTheDocument()
     })
 
-    fireEvent.mouseUp(screen.getByText('Solve using the quadratic formula.'))
+    expect(screen.getByText('public static')).toHaveClass('font-mono')
+    expect(screen.getByText('public class Main {}')).toBeInTheDocument()
+    expect(screen.queryByText(/```/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Solve using/).parentElement).toHaveClass('break-words')
+
+    fireEvent.mouseUp(screen.getByText(/Solve using/))
     fireEvent(window, new Event('blur'))
     visibilityState = 'hidden'
     fireEvent(document, new Event('visibilitychange'))
@@ -3330,7 +3335,7 @@ describe('StudentQuizzesTab exam mode', () => {
 
     expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
     expect(screen.getByText('2 + 2 = ?')).toBeVisible()
-    expect(screen.getByText('3').closest('label')).toHaveClass('border-primary')
+    expect(screen.getByText('3').closest('[data-question-option]')).toHaveClass('border-primary')
     expect(
       focusBodies.some(
         (body) =>
@@ -3524,7 +3529,7 @@ describe('StudentQuizzesTab exam mode', () => {
       })
 
       expect(screen.getByText('Which HTTP method is usually used for partial updates?')).toBeInTheDocument()
-      expect(screen.getByText('PATCH').closest('label')).toHaveClass('border-primary')
+      expect(screen.getByText('PATCH').closest('[data-question-option]')).toHaveClass('border-primary')
 
       fireEvent.click(screen.getByText('GET'))
 
@@ -3535,7 +3540,7 @@ describe('StudentQuizzesTab exam mode', () => {
 
       expect(screen.queryByTestId('exam-content-obscurer')).not.toBeInTheDocument()
       expect(screen.getByText('Which HTTP method is usually used for partial updates?')).toBeVisible()
-      expect(screen.getByText('GET').closest('label')).toHaveClass('border-primary')
+      expect(screen.getByText('GET').closest('[data-question-option]')).toHaveClass('border-primary')
 
       await act(async () => {
         vi.advanceTimersByTime(5_000)


### PR DESCRIPTION
## Summary
- render test text documents through the shared QuestionMarkdown renderer in student exam mode and teacher preview
- render multiple-choice option text as markdown in student and teacher/test previews
- add focused regression coverage for inline code and fenced code blocks in documents and MC options

## Validation
- pnpm test tests/components/QuestionMarkdown.test.tsx tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx
- pnpm lint
- pnpm build (before seed rollback/rebase)
- visual verification for student exam and teacher preview markdown rendering

## Notes
- No seed or migration files are changed in this PR.