### PR TITLE
Add Vercel deployment probe note

### DIFF
--- a/docs/deployment/deploy-probes.md
+++ b/docs/deployment/deploy-probes.md
@@ -1,0 +1,10 @@
+# Deployment Probes
+
+This file records intentional no-runtime-change deploy probes.
+
+## 2026-04-30 Vercel production trigger probe
+
+- Purpose: verify whether Vercel creates a production deployment after `main` is merged into `production`.
+- Baseline `origin/main`: `c84ad7e7f200`
+- Baseline `origin/production`: `97e0e4716562`
+- Expected app impact: none; this is a documentation-only change.


### PR DESCRIPTION
Adds a documentation-only deployment probe note so we can observe GitHub and Vercel behavior through main and production without changing runtime code.