### PR TITLE
[codex] Share gapped teacher workspace split

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10055,6 +10055,154 @@
 - `pnpm lint`
 - `pnpm build`
 - Pika UI verification script for `/classrooms`:
+## 2026-04-30 - Assignment pane-local workspace toggles
+
+**Completed:**
+- Reworked the selected assignment teacher workspace from global top tabs to pane-local controls.
+- Added left-pane Class/Individual switching and right-pane Grade/Work switching, with duplicate work panes prevented.
+- Kept batch assignment actions with the class table and moved selected-student navigation into the individual pane header.
+- Documented the assignment-only pilot as an experimental work-surface pattern for later Tests/Quizzes alignment.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-right-work.png`
+  - `/tmp/pika-assignment-left-individual.png`
+  - `/tmp/pika-assignment-mobile-right-work.png`
+  - `/tmp/pika-assignment-mobile-left-individual.png`
+
+## 2026-04-30 - Assignment action-bar view toggle revision
+
+**Completed:**
+- Moved the assignment `AI Grade` split button back into the selected-assignment action-bar center.
+- Replaced pane-local text toggles with an icon-only Class/Individual action-bar toggle immediately left of `AI Grade`.
+- Removed the Grade/Work right-pane toggle; the right pane now stays fixed on the grading panel.
+- Updated assignment work-surface docs to reflect the action-bar toggle pilot.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3001`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-actionbar-individual.png`
+  - `/tmp/pika-assignment-actionbar-individual-mobile.png`
+
+## 2026-04-30 - Assignment updating indicator overlay
+
+**Completed:**
+- Replaced the transient action-bar `Updating` text with an absolutely
+  positioned circular spinner.
+- Kept the status available to screen readers without allowing it to shift the
+  Class/Individual toggle or `AI Grade` split button.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3001`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-updating-overlay.png`
+  - `/tmp/pika-assignment-updating-overlay-mobile.png`
+
+## 2026-04-30 - Assignment class-pane deselect expansion
+
+**Completed:**
+- Added an explicit blank class-table click target that clears the active
+  student without interfering with row selection or batch checkboxes.
+- Suppressed the remembered-student default after an intentional class-mode
+  deselect, so the URL can drop `assignmentStudentId` and the class table stays
+  expanded.
+- Kept row clicks in class mode selecting the clicked student and preserving the
+  grading pane.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3001`.
+- Targeted browser check confirmed class-pane width expanded from 695px to
+  1390px and selected rows dropped to 0 after clicking the blank area.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-class-selected.png`
+  - `/tmp/pika-assignment-class-deselected-expanded.png`
+
+## 2026-04-30 - Assignment selected-student persistence
+
+**Completed:**
+- Reverted the class-pane blank-area deselect behavior.
+- Removed the invisible class-table deselect target and the remembered-student
+  suppression logic.
+- Kept selected assignments anchored to an active student; Escape in class mode
+  no longer clears the grading pane.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Targeted browser check confirmed blank table space plus Escape kept the same
+  `assignmentStudentId` and preserved the grading panel.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-selection-persistent.png`
+
+## 2026-04-30 - Assignment action-bar toggle calendar styling
+
+**Completed:**
+- Restyled the icon-only Class/Individual assignment toggle to follow the
+  calendar view switcher treatment: soft segmented background, rounded-control
+  corners, and blue-tinted active segment.
+- Adjusted the icon segment dimensions so the toggle visually aligns with the
+  adjacent `AI Grade` split button.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Targeted browser screenshot confirmed the assignment toggle and `AI Grade`
+  split button both use 8px corner radii with close height alignment.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-toggle-calendar-style.png`
+
+## 2026-04-30 - Shared segmented control
+
+**Completed:**
+- Added a shared `SegmentedControl` UI primitive for app-wide segmented toggles,
+  including icon-only and text-label modes.
+- Replaced the assignment Class/Individual toggle, calendar Week/Month/All
+  controls, and assignment Draft/Final grade mode selector with the shared
+  component.
+- Kept test mocks aligned with the new shared UI export.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/calendar-view-persistence.test.tsx tests/components/LessonCalendar.test.tsx tests/components/StudentLessonCalendarTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=calendar` on `http://localhost:3002`.
+- Visual screenshots reviewed:
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
@@ -10124,3 +10272,91 @@
 **Validation:**
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
 - `pnpm lint`
+## 2026-04-30 - Edit toggle pressed state
+
+**Completed:**
+- Updated the shared teacher work-surface edit control so it stays as
+  pencil-icon `Edit` in both states instead of changing to `Done`.
+- Gave the active state a pressed button treatment while preserving
+  `aria-pressed` for accessibility.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherEditModeControls.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments` on `http://localhost:3002`.
+- Targeted browser screenshot confirmed the active edit toggle keeps the
+  pencil-icon `Edit` label and appears pressed.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-assignment-edit-pressed.png`
+
+## 2026-04-30 - Assignment work-surface action bar shell
+
+**Completed:**
+- Added a reusable teacher work-surface action-bar content component with
+  left label/context, centered primary controls, and right trailing controls.
+- Updated the Assignments summary state to show the `Assignments` tab label on
+  the left, `New` centered, and the edit toggle on the right.
+- Updated the selected-assignment state to keep the assignment title/context on
+  the left, class/individual plus grading actions centered, and edit on the
+  right in a single action bar.
+- Constrained long assignment titles so the one-bar mobile layout truncates
+  instead of overlapping controls.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-30 - Assignment standalone workspace spacing
+
+**Completed:**
+- Updated standalone teacher work-surface frames so the lower workspace uses
+  the standard page gutters and top spacing below the action bar.
+- Kept attached-tab workspaces gutterless so existing tabbed surfaces are not
+  unintentionally changed.
+- Verified the selected-assignment workspace now aligns with the action bar
+  instead of starting flush at the page edge.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Cleared stale generated `.next` cache after a dev-server vendor chunk error,
+  then reran Pika UI verification.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-30 - Smaller shared page spacing primitive
+
+**Completed:**
+- Standardized the shared page spacing primitive to smaller gutters and gaps:
+  `PageContent`/`PageActionBar` now use `px-3`, content starts at `pt-2`, and
+  `PageStack` uses `space-y-3`.
+- Reduced the compact header/action-bar spacing token to `0.5rem`.
+- Kept the assignment action-bar shell and standalone workspace aligned to the
+  same shared primitive so assignment summary and selected views use one rhythm.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/StudentLessonCalendarTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=calendar` on `http://localhost:3002`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9608,6 +9608,67 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-30 - Shared Daily and Assignment split primitive
+
+**Completed:**
+- Moved Daily's gapped table/detail resize behavior into `TeacherWorkspaceSplit`
+  as a reusable `gapped` split variant.
+- Kept the existing Assignment split on the same component's default `joined`
+  variant, so Assignments and Daily now share one pane resize primitive with
+  configurable middle treatment.
+- Added keyboard resize support and ARIA value metadata to the shared split
+  handle path.
+- Updated the attendance layout-config test to match the integrated Daily
+  workspace with no app-level right sidebar.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm vitest run tests/unit/layout-config.test.ts tests/components/TeacherWorkspaceSplit.test.tsx tests/components/WorkspaceSplitPane.test.tsx tests/components/SummaryDetailWorkspaceShell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`
+- Cleared stale generated `.next` cache after a dev-server vendor chunk error,
+  then reran Pika UI verification cleanly.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=attendance` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Daily drag probe verified the detail pane resized from 678px to 804px.
+- Visual screenshots reviewed:
+  - `/tmp/pika-daily-teacher-warm.png`
+  - `/tmp/pika-daily-teacher-mobile.png`
+  - `/tmp/pika-daily-student.png`
+  - `/tmp/pika-assignment-teacher.png`
+  - `/tmp/pika-assignment-teacher-mobile.png`
+  - `/tmp/pika-assignment-student.png`
+
+## 2026-04-30 - Assignment gapped split mode
+
+**Completed:**
+- Switched the Assignment student-work split to the shared `gapped`
+  `TeacherWorkspaceSplit` mode used by Daily.
+- Gave the Assignment primary and grading panes rounded surface treatment and
+  removed the selected-student workspace outer border so the middle gap reads
+  as page background.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkspaceSplit.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3002`.
+- Assignment drag probe verified the grading pane resized from 678px to 783px.
+- Visual screenshots reviewed:
+  - `/tmp/pika-assignment-gap-teacher-warm.png`
+  - `/tmp/pika-assignment-gap-teacher-mobile.png`
+  - `/tmp/pika-assignment-gap-student.png`
+
+## 2026-04-30 - Teacher work-surface shell guidance
+
+**Completed:**
+- Added the reusable selected-workspace shell template to
+  `docs/guidance/ui/teacher-work-surfaces.md`.
+- Documented the intended `TeacherWorkSurfaceShell` plus
+  `TeacherWorkspaceSplit splitVariant="gapped"` composition for future
+  Assignments, Quizzes, Tests, and nearby teacher tabs.
+
+**Validation:**
+- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`
   - `/tmp/pika-teacher-blueprint-selected.png`
   - `/tmp/pika-teacher-blueprint-selected-mobile.png`
   - `/tmp/pika-teacher-blueprint-selected-dark.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10360,3 +10360,33 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+
+## 2026-04-30 - Daily work-surface shell
+
+**Completed:**
+- Applied the teacher work-surface shell pattern to the Daily attendance tab.
+- Moved Daily's log summary/student history from the global right sidebar into
+  the Daily lower split pane so the action bar spans the full Daily workspace.
+- Disabled the attendance route's app-level right sidebar now that Daily owns
+  its table and detail panes internally.
+- Rounded the Daily table and detail panes while leaving the lower split wrapper
+  borderless.
+- Added a desktop drag-resize handle in the gap between Daily panes, with
+  keyboard resize support and double-click reset.
+- Extracted the Calendar action-bar date navigator into a reusable
+  `CalendarDateNavigator` and reused it for Daily so the date label and arrow
+  controls match Calendar.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm vitest run tests/components/TeacherWorkSurfaceShell.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=attendance` on `http://localhost:3002`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=calendar` on `http://localhost:3002`.
+- Drag probe verified the Daily detail pane resized from 678px to 804px; screenshot
+  saved at `/tmp/pika-daily-resized.png`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -9609,6 +9609,30 @@
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
 
+## 2026-05-01 - Assignment individual split layout review fix
+
+**Completed:**
+- Fixed the PR review finding where the assignment workspace always read and
+  wrote the `overview` split layout, even while the left pane was in individual
+  student work mode.
+- The assignment parent now derives the active workspace layout mode from the
+  class/individual pane toggle and writes resize changes back to the matching
+  `overview` or `details` layout bucket.
+- Added focused test coverage that switches to individual mode, verifies the
+  details split width is used, and confirms resize updates are written to
+  `details`.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=assignments&assignmentId=55cfe7c5-9f16-42ef-858a-364a2468e5b9` on `http://localhost:3000`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+
 ## 2026-04-30 - Shared Daily and Assignment split primitive
 
 **Completed:**

--- a/docs/guidance/assignment-ux-language.md
+++ b/docs/guidance/assignment-ux-language.md
@@ -139,6 +139,17 @@ Those modes:
 - do not appear before a selection exists
 - keep the same outer page-shell language
 
+The current assignments workspace pilots an action-bar view toggle instead of a
+single top tab strip. In that layout:
+
+- an icon-only class/individual toggle sits in the action-bar center beside
+  assignment batch actions
+- the left pane switches between the class student table and the selected
+  student's individual work
+- the right pane stays as the grading panel
+- the selected assignment action bar stays focused on assignment context rather
+  than workspace-mode tabs
+
 ### `inspector_active`
 
 The teacher workspace uses side-by-side review only when the current assignment mode and current student selection justify it.

--- a/docs/guidance/ui/experimental/2026-04-assignment-pane-toggles.md
+++ b/docs/guidance/ui/experimental/2026-04-assignment-pane-toggles.md
@@ -1,0 +1,46 @@
+---
+status: experimental
+scope:
+  - teacher-assignments
+  - teacher-work-surface
+source_files:
+  - src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+  - src/components/TeacherStudentWorkPanel.tsx
+human_review_required: true
+generated_at: 2026-04-30
+---
+
+# Assignment Pane Toggles
+
+## Summary
+
+Teacher assignments now pilot an untabbed selected-assignment workspace. Instead
+of a top `Class` / `Individual` tab strip, the action-bar center owns an
+icon-only class/individual toggle beside the assignment batch action split
+button. The left pane switches between class table and individual work, while
+the right pane remains the grading panel.
+
+## Pattern
+
+- Keep the assignment action bar for assignment context, status, edit mode, the
+  class/individual view switch, and batch actions.
+- Use icon-only class/individual controls to keep the action cluster compact.
+- Keep the student-work controller shared across the split so history preview
+  and grading state update the visible work pane.
+- Keep the right pane fixed on grading so the selected student's work and rubric
+  can be compared side by side.
+- Keep batch actions in the global selected-assignment action bar.
+
+## Why Experimental
+
+This has only been applied to teacher assignments. It should guide tests and
+quizzes exploration, but it is not yet stable family guidance until the
+assignment screenshots and teacher workflow are accepted.
+
+## Promotion Criteria
+
+- Assignment workspace screenshots pass visual review on desktop and mobile.
+- Teachers can quickly discover the icon-only view toggle without losing class
+  batch actions.
+- The pattern works for at least one of teacher tests or quizzes without
+  importing assignment-specific components or controller logic.

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -178,6 +178,58 @@ Advances when:
 - Workspace states may add contextual controls, but the shell should remain recognizable across nearby states.
 - Workspace-mode controls are justified only when they unlock genuinely different work.
 
+### Reusable selected-workspace shell template
+
+When a teacher tab needs the Daily/Assignment two-pane work surface, reuse the
+shared shell and split primitives instead of building feature-local layout and
+resize code.
+
+Use this composition as the default selected-workspace template for assignments,
+quizzes, tests, and nearby teacher work tabs when the workflow has an active
+primary pane plus an active inspector/detail pane:
+
+```tsx
+<TeacherWorkSurfaceShell
+  state="workspace"
+  primary={actionBar}
+  summary={null}
+  workspace={workspace}
+  workspaceFrame="standalone"
+  workspaceFrameClassName="border-0 bg-page"
+/>
+```
+
+Inside `workspace`, use the shared split:
+
+```tsx
+<TeacherWorkspaceSplit
+  splitVariant="gapped"
+  primary={primaryPane}
+  inspector={inspectorPane}
+  inspectorCollapsed={false}
+  inspectorWidth={inspectorWidth}
+  onInspectorWidthChange={setInspectorWidth}
+  primaryClassName="rounded-lg bg-surface"
+  inspectorClassName="rounded-lg bg-surface"
+  dividerLabel="Resize workspace panes"
+/>
+```
+
+Default shape:
+
+- `TeacherWorkSurfaceShell` owns the tab action bar and the lower workspace slot.
+- `workspaceFrame="standalone"` keeps the one-bar page shell.
+- `workspaceFrameClassName="border-0 bg-page"` removes extra outer framing so
+  the panes sit directly on the page background.
+- `TeacherWorkspaceSplit splitVariant="gapped"` provides the page-background
+  middle gap, drag resize behavior, keyboard resize behavior, and mobile stacked
+  layout.
+- Pane content remains feature-owned; pane sizing, resize mechanics, and the
+  outer split shape should not be reimplemented in each tab.
+
+Use `TeacherWorkspaceSplit` without `splitVariant="gapped"` only when preserving
+an older joined split is explicitly desired.
+
 ### Main-content width
 
 - Summary states use the available main-content width.

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -203,6 +203,16 @@ Advances when:
 - They must represent real workflow changes.
 - They should not be the first visual emphasis in a browsing state.
 
+### Action-bar workspace toggles
+
+- Compact workspace toggles are allowed in the selected-workspace action bar
+  when they choose the primary workspace view.
+- They should replace, not duplicate, top workspace tabs.
+- Keep batch or grading actions in the same action cluster when they apply to
+  the selected workspace.
+- The assignment pane-toggle implementation is an experimental assignment-led
+  pattern until promoted after visual and workflow review.
+
 ### Hard failures
 
 Treat these as family-level hard failures:
@@ -379,6 +389,8 @@ Use this checklist when changing or reviewing teacher-family UX:
 - no passive inspector before selection
 - selected workspace earns complexity
 - workspace tabs only after selection
+- action-bar toggles replace workspace tabs when the selected workspace needs a
+  compact primary-view switch
 - inspector opens only for active comparative or review work
 - parent tab click returns to `summary`
 - page-shell primitives are reused

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -6,7 +6,7 @@ import { TeacherClassroomView, TeacherAssignmentsMarkdownSidebar, type Assignmen
 import { assignmentsToMarkdown, markdownToAssignments } from '@/lib/assignment-markdown'
 import { StudentTodayTab } from './StudentTodayTab'
 import { StudentAssignmentsTab } from './StudentAssignmentsTab'
-import { TeacherAttendanceTab, type TeacherAttendanceTabHandle } from './TeacherAttendanceTab'
+import { TeacherAttendanceTab } from './TeacherAttendanceTab'
 import { TeacherRosterTab } from './TeacherRosterTab'
 import { TeacherGradebookTab } from './TeacherGradebookTab'
 import { TeacherSettingsTab } from './TeacherSettingsTab'
@@ -42,8 +42,6 @@ import {
   TEACHER_QUIZZES_UPDATED_EVENT,
 } from '@/lib/events'
 import { TeacherTestPreviewPage } from '@/components/TeacherTestPreviewPage'
-import { StudentLogHistory } from '@/components/StudentLogHistory'
-import { LogSummary } from './LogSummary'
 import { ConfirmDialog, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
@@ -51,7 +49,6 @@ import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
 import type {
   Classroom,
-  Entry,
   LessonPlan,
   TiptapContent,
   Assignment,
@@ -417,14 +414,6 @@ function ClassroomPageContent({
     window.scrollTo({ top: nextScrollTop, left: 0, behavior: 'auto' })
   }, [activeTab])
 
-  // State for attendance date (teacher attendance tab)
-  const [attendanceDate, setAttendanceDate] = useState<string>('')
-  const attendanceTabRef = useRef<TeacherAttendanceTabHandle>(null)
-
-  // State for selected student log (teacher attendance tab)
-  const [selectedStudentName, setSelectedStudentName] = useState<string>('')
-  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
-
   // State for selected assignment instructions (assignments tab)
   const [selectedAssignment, setSelectedAssignment] = useState<SelectedAssignmentInstructions | null>(null)
 
@@ -488,15 +477,6 @@ function ClassroomPageContent({
   const prevAssignmentMarkdownAutoOpenReadyRef = useRef(false)
   const abortControllerRef = useRef<AbortController | null>(null)
   const markdownStaleRef = useRef(true) // Start stale so first open loads
-
-  const handleSelectEntry = useCallback((_entry: Entry | null, studentName: string, studentId: string | null) => {
-    setSelectedStudentName(studentName)
-    setSelectedStudentId(studentId)
-  }, [])
-
-  const handleSummaryStudentClick = useCallback((studentName: string) => {
-    attendanceTabRef.current?.selectStudentByName(studentName)
-  }, [])
 
   const handleSelectAssignment = useCallback((assignment: SelectedAssignmentInstructions | null) => {
     setSelectedAssignment(assignment)
@@ -1068,10 +1048,7 @@ function ClassroomPageContent({
                   {mountedTabs.attendance && (
                     <TabContentTransition isActive={activeTab === 'attendance'}>
                       <TeacherAttendanceTab
-                        ref={attendanceTabRef}
                         classroom={classroom}
-                        onSelectEntry={handleSelectEntry}
-                        onDateChange={setAttendanceDate}
                         isActive={activeTab === 'attendance'}
                       />
                     </TabContentTransition>
@@ -1270,7 +1247,7 @@ function ClassroomPageContent({
               ? (selectedAssignment?.title || 'Instructions')
               : activeTab === 'today'
               ? "Today's Plan"
-              : (selectedStudentName || 'Log Summary')
+              : 'Details'
           }
           headerActions={
             showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
@@ -1331,15 +1308,6 @@ function ClassroomPageContent({
           ) : activeTab === 'resources' ? (
             <StudentClassResourcesSidebar classroom={classroom} />
           ) : isTeacher && isAssessmentTab ? (
-            null
-          ) : isTeacher && activeTab === 'attendance' && selectedStudentId ? (
-            <StudentLogHistory
-              studentId={selectedStudentId}
-              classroomId={classroom.id}
-            />
-          ) : isTeacher && activeTab === 'attendance' && attendanceDate ? (
-            <LogSummary classroomId={classroom.id} date={attendanceDate} onStudentClick={handleSummaryStudentClick} />
-          ) : isTeacher && activeTab === 'attendance' ? (
             null
           ) : isTeacher && activeTab === 'assignments' ? (
             <div className="p-4">

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -8,14 +8,13 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
-  type PointerEvent as ReactPointerEvent,
 } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { CalendarDateNavigator } from '@/components/CalendarActionBar'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import { LogSummary } from './LogSummary'
 import { getTodayInToronto } from '@/lib/timezone'
 import { addDaysToDateString } from '@/lib/date-string'
@@ -30,7 +29,6 @@ import {
   DataTableBody,
   DataTableCell,
   DataTableHead,
-  DataTableHeaderCell,
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
@@ -64,11 +62,6 @@ export interface TeacherAttendanceTabHandle {
   selectStudentByName: (name: string) => void
 }
 
-function clampPaneWidth(value: number, min: number, max: number): number {
-  if (max <= min) return min
-  return Math.min(max, Math.max(min, value))
-}
-
 export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props>(function TeacherAttendanceTab({
   classroom,
   onSelectEntry,
@@ -82,7 +75,6 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const [selectedDate, setSelectedDate] = useState<string>('')
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
-  const splitRef = useRef<HTMLDivElement | null>(null)
   const dateInputRef = useRef<HTMLInputElement | null>(null)
   const [detailPaneWidth, setDetailPaneWidth] = useState(50)
   const showBlockingSpinner = useDelayedBusy(loading && logs.length === 0)
@@ -329,203 +321,150 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     </div>
   )
 
-  const handlePaneResizeStart = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const splitElement = splitRef.current
-    if (!splitElement) return
-
-    event.preventDefault()
-
-    const { right, width } = splitElement.getBoundingClientRect()
-    if (width <= 0) return
-
-    const minRightPercent = Math.max(28, (280 / width) * 100)
-    const maxRightPercent = Math.min(72, ((width - 320) / width) * 100)
-
-    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
-      const nextRightWidth = ((right - moveEvent.clientX) / width) * 100
-      setDetailPaneWidth(
-        Math.round(clampPaneWidth(nextRightWidth, minRightPercent, maxRightPercent) * 10) / 10
-      )
-    }
-
-    const handleResizeEnd = () => {
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handleResizeEnd)
-      window.removeEventListener('pointercancel', handleResizeEnd)
-      window.removeEventListener('blur', handleResizeEnd)
-    }
-
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handleResizeEnd)
-    window.addEventListener('pointercancel', handleResizeEnd)
-    window.addEventListener('blur', handleResizeEnd)
-  }, [])
-
-  const handlePaneResizeReset = useCallback(() => {
-    setDetailPaneWidth(50)
-  }, [])
-
-  const handlePaneResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'ArrowLeft') {
-      event.preventDefault()
-      setDetailPaneWidth((current) => clampPaneWidth(current + 5, 28, 72))
-    } else if (event.key === 'ArrowRight') {
-      event.preventDefault()
-      setDetailPaneWidth((current) => clampPaneWidth(current - 5, 28, 72))
-    } else if (event.key === 'Home') {
-      event.preventDefault()
-      setDetailPaneWidth(72)
-    } else if (event.key === 'End') {
-      event.preventDefault()
-      setDetailPaneWidth(28)
-    } else if (event.key === 'Enter') {
-      event.preventDefault()
-      setDetailPaneWidth(50)
-    }
-  }, [])
-
   const workspace = showBlockingSpinner ? (
     <div className="flex justify-center py-12">
       <Spinner size="lg" />
     </div>
   ) : (
-    <div ref={splitRef} className="flex min-h-0 flex-1 flex-col gap-3 bg-page lg:flex-row lg:gap-0">
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div className="min-h-[200px] min-w-0 flex-1 overflow-hidden rounded-lg bg-surface" onClick={(e) => {
-        // Deselect when clicking outside the table
-        if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {
-          handleDeselect()
-        }
-      }}>
-        <KeyboardNavigableTable
-          rowKeys={rowKeys}
-          selectedKey={selectedStudentId}
-          onSelectKey={handleKeyboardSelect}
-          onDeselect={handleDeselect}
-        >
-          <TableCard chrome="flush">
-            {refreshing && (
-              <RefreshingIndicator />
-            )}
-            <DataTable>
-            <DataTableHead>
-              <DataTableRow>
-                <SortableHeaderCell
-                  label="First"
-                  isActive={sortColumn === 'first_name'}
-                  direction={sortDirection}
-                  onClick={() => handleSort('first_name')}
-                  density="tight"
-                  trailing={isClassDay && rows.length > 0 ? <StudentCountBadge count={rows.length} variant="neutral" /> : undefined}
-                />
-                <SortableHeaderCell
-                  label="Last"
-                  isActive={sortColumn === 'last_name'}
-                  direction={sortDirection}
-                  onClick={() => handleSort('last_name')}
-                  density="tight"
-                />
-                <SortableHeaderCell
-                  label="ID"
-                  isActive={sortColumn === 'id'}
-                  direction={sortDirection}
-                  onClick={() => handleSort('id')}
-                  density="tight"
-                />
-                <SortableHeaderCell
-                  label={isClassDay ? '' : 'Status'}
-                  isActive={sortColumn === 'status'}
-                  direction={sortDirection}
-                  onClick={() => handleSort('status')}
-                  density="tight"
-                  align="center"
-                  trailing={isClassDay ? (
-                    <div className="flex items-center gap-2">
-                      <CountBadge count={presentCount} tooltip="Present" variant="success" />
-                      <CountBadge count={absentCount} tooltip="Absent" variant="danger" />
-                    </div>
-                  ) : undefined}
-                />
-              </DataTableRow>
-            </DataTableHead>
-            <DataTableBody>
-              {rows.map((row) => {
-                const isSelected = selectedStudentId === row.student_id
-                const status: AttendanceStatus = row.entry && entryHasContent(row.entry)
-                  ? 'present'
-                  : selectedDate >= today
-                    ? 'pending'
-                    : 'absent'
-                return (
-                  <DataTableRow
-                    key={row.student_id}
-                    className={[
-                      'cursor-pointer transition-colors',
-                      isSelected
-                        ? 'bg-info-bg hover:bg-info-bg-hover'
-                        : 'hover:bg-surface-hover',
-                    ].join(' ')}
-                    onClick={() => handleRowClick(row)}
-                  >
-                    <DataTableCell density="tight">{row.student_first_name || '—'}</DataTableCell>
-                    <DataTableCell density="tight">{row.student_last_name || '—'}</DataTableCell>
-                    <DataTableCell density="tight" className="text-text-muted">
-                      {row.email_username}
-                    </DataTableCell>
-                    <DataTableCell density="tight" align="center">
-                      {isClassDay ? (
-                        <Tooltip content={getAttendanceLabel(status)}>
-                          <span
-                            className={`inline-block w-3 h-3 rounded-full ${getAttendanceDotClass(status)}`}
-                          />
-                        </Tooltip>
-                      ) : (
-                        <span className="text-text-muted">—</span>
-                      )}
-                    </DataTableCell>
-                  </DataTableRow>
-                )
-              })}
-              {rows.length === 0 && (
-                <EmptyStateRow
-                  colSpan={4}
-                  message={isClassDay ? 'No students enrolled' : 'Not a class day'}
-                />
-              )}
-            </DataTableBody>
-            </DataTable>
-          </TableCard>
-        </KeyboardNavigableTable>
-      </div>
-      <div className="hidden w-3 shrink-0 self-stretch lg:flex">
+    <TeacherWorkspaceSplit
+      className="flex-1"
+      splitVariant="gapped"
+      primaryClassName="min-h-[200px] rounded-lg bg-surface"
+      inspectorClassName="flex flex-col rounded-lg bg-surface"
+      inspectorCollapsed={false}
+      inspectorWidth={detailPaneWidth}
+      minInspectorPx={280}
+      minPrimaryPx={320}
+      minInspectorPercent={28}
+      maxInspectorPercent={72}
+      defaultInspectorWidth={50}
+      onInspectorWidthChange={setDetailPaneWidth}
+      dividerLabel="Resize Daily panes"
+      primary={
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
-          role="separator"
-          aria-label="Resize Daily panes"
-          aria-orientation="vertical"
-          aria-valuemin={28}
-          aria-valuemax={72}
-          aria-valuenow={detailPaneWidth}
-          tabIndex={0}
-          className="min-h-full flex-1 cursor-col-resize rounded-full outline-none focus:bg-info-bg hover:bg-surface-hover"
-          onPointerDown={handlePaneResizeStart}
-          onDoubleClick={handlePaneResizeReset}
-          onKeyDown={handlePaneResizeKeyDown}
-        />
-      </div>
-      <aside
-        className="flex min-h-0 w-full flex-col overflow-hidden rounded-lg bg-surface lg:shrink-0 lg:basis-[var(--daily-detail-pane-width)]"
-        style={{ '--daily-detail-pane-width': `calc(${detailPaneWidth}% - 6px)` } as CSSProperties}
-      >
-        <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
-          <span className="truncate text-sm font-semibold text-text-default">
-            {selectedRow ? selectedStudentName : 'Log Summary'}
-          </span>
+          className="h-full"
+          onClick={(e) => {
+            // Deselect when clicking outside the table
+            if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {
+              handleDeselect()
+            }
+          }}
+        >
+          <KeyboardNavigableTable
+            rowKeys={rowKeys}
+            selectedKey={selectedStudentId}
+            onSelectKey={handleKeyboardSelect}
+            onDeselect={handleDeselect}
+          >
+            <TableCard chrome="flush">
+              {refreshing && (
+                <RefreshingIndicator />
+              )}
+              <DataTable>
+                <DataTableHead>
+                  <DataTableRow>
+                    <SortableHeaderCell
+                      label="First"
+                      isActive={sortColumn === 'first_name'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('first_name')}
+                      density="tight"
+                      trailing={isClassDay && rows.length > 0 ? <StudentCountBadge count={rows.length} variant="neutral" /> : undefined}
+                    />
+                    <SortableHeaderCell
+                      label="Last"
+                      isActive={sortColumn === 'last_name'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('last_name')}
+                      density="tight"
+                    />
+                    <SortableHeaderCell
+                      label="ID"
+                      isActive={sortColumn === 'id'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('id')}
+                      density="tight"
+                    />
+                    <SortableHeaderCell
+                      label={isClassDay ? '' : 'Status'}
+                      isActive={sortColumn === 'status'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('status')}
+                      density="tight"
+                      align="center"
+                      trailing={isClassDay ? (
+                        <div className="flex items-center gap-2">
+                          <CountBadge count={presentCount} tooltip="Present" variant="success" />
+                          <CountBadge count={absentCount} tooltip="Absent" variant="danger" />
+                        </div>
+                      ) : undefined}
+                    />
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {rows.map((row) => {
+                    const isSelected = selectedStudentId === row.student_id
+                    const status: AttendanceStatus = row.entry && entryHasContent(row.entry)
+                      ? 'present'
+                      : selectedDate >= today
+                        ? 'pending'
+                        : 'absent'
+                    return (
+                      <DataTableRow
+                        key={row.student_id}
+                        className={[
+                          'cursor-pointer transition-colors',
+                          isSelected
+                            ? 'bg-info-bg hover:bg-info-bg-hover'
+                            : 'hover:bg-surface-hover',
+                        ].join(' ')}
+                        onClick={() => handleRowClick(row)}
+                      >
+                        <DataTableCell density="tight">{row.student_first_name || '—'}</DataTableCell>
+                        <DataTableCell density="tight">{row.student_last_name || '—'}</DataTableCell>
+                        <DataTableCell density="tight" className="text-text-muted">
+                          {row.email_username}
+                        </DataTableCell>
+                        <DataTableCell density="tight" align="center">
+                          {isClassDay ? (
+                            <Tooltip content={getAttendanceLabel(status)}>
+                              <span
+                                className={`inline-block w-3 h-3 rounded-full ${getAttendanceDotClass(status)}`}
+                              />
+                            </Tooltip>
+                          ) : (
+                            <span className="text-text-muted">—</span>
+                          )}
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
+                  {rows.length === 0 && (
+                    <EmptyStateRow
+                      colSpan={4}
+                      message={isClassDay ? 'No students enrolled' : 'Not a class day'}
+                    />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </TableCard>
+          </KeyboardNavigableTable>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {detailPane}
-        </div>
-      </aside>
-    </div>
+      }
+      inspector={
+        <>
+          <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
+            <span className="truncate text-sm font-semibold text-text-default">
+              {selectedRow ? selectedStudentName : 'Log Summary'}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {detailPane}
+          </div>
+        </>
+      }
+    />
   )
 
   return (

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -1,9 +1,22 @@
 'use client'
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import { Spinner } from '@/components/Spinner'
-import { DateActionBar } from '@/components/DateActionBar'
-import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import { CalendarDateNavigator } from '@/components/CalendarActionBar'
+import { StudentLogHistory } from '@/components/StudentLogHistory'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { LogSummary } from './LogSummary'
 import { getTodayInToronto } from '@/lib/timezone'
 import { addDaysToDateString } from '@/lib/date-string'
 import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
@@ -27,6 +40,7 @@ import {
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { applyDirection, compareByNameFields, toggleSort } from '@/lib/table-sort'
 import type { Classroom, Entry } from '@/types'
+import { format, parseISO } from 'date-fns'
 
 type SortColumn = 'first_name' | 'last_name' | 'id' | 'status'
 
@@ -50,6 +64,11 @@ export interface TeacherAttendanceTabHandle {
   selectStudentByName: (name: string) => void
 }
 
+function clampPaneWidth(value: number, min: number, max: number): number {
+  if (max <= min) return min
+  return Math.min(max, Math.max(min, value))
+}
+
 export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props>(function TeacherAttendanceTab({
   classroom,
   onSelectEntry,
@@ -63,6 +82,9 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const [selectedDate, setSelectedDate] = useState<string>('')
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
+  const splitRef = useRef<HTMLDivElement | null>(null)
+  const dateInputRef = useRef<HTMLInputElement | null>(null)
+  const [detailPaneWidth, setDetailPaneWidth] = useState(50)
   const showBlockingSpinner = useDelayedBusy(loading && logs.length === 0)
   const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
     column: SortColumn
@@ -208,75 +230,180 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     onSelectEntry?.(null, '', null)
   }, [onSelectEntry])
 
-  // Keyboard navigation handler
-  const handleKeyboardSelect = useCallback(
-    (studentId: string) => {
-      const row = rows.find((r) => r.student_id === studentId)
-      if (!row) return
-
-      setSelectedStudentId(studentId)
+  const selectStudentByRow = useCallback(
+    (row: LogRow) => {
+      setSelectedStudentId(row.student_id)
       const studentName =
         [row.student_first_name, row.student_last_name].filter(Boolean).join(' ') ||
         row.email_username
       onSelectEntry?.(row.entry, studentName, row.student_id)
     },
-    [rows, onSelectEntry]
+    [onSelectEntry]
+  )
+
+  const selectStudentByName = useCallback(
+    (name: string) => {
+      const row = logs.find((logRow) => {
+        const fullName = [logRow.student_first_name, logRow.student_last_name]
+          .filter(Boolean)
+          .join(' ')
+        return fullName === name
+      })
+      if (row) {
+        selectStudentByRow(row)
+      }
+    },
+    [logs, selectStudentByRow]
+  )
+
+  // Keyboard navigation handler
+  const handleKeyboardSelect = useCallback(
+    (studentId: string) => {
+      const row = rows.find((r) => r.student_id === studentId)
+      if (!row) return
+      selectStudentByRow(row)
+    },
+    [rows, selectStudentByRow]
   )
 
   useImperativeHandle(ref, () => ({
     selectStudentByName(name: string) {
-      const row = logs.find((r) => {
-        const fullName = [r.student_first_name, r.student_last_name].filter(Boolean).join(' ')
-        return fullName === name
-      })
-      if (row) {
-        setSelectedStudentId(row.student_id)
-        const studentName = [row.student_first_name, row.student_last_name].filter(Boolean).join(' ') || row.email_username
-        onSelectEntry?.(row.entry, studentName, row.student_id)
-      }
+      selectStudentByName(name)
     },
-  }), [logs, onSelectEntry])
+  }), [selectStudentByName])
 
   // Row keys for keyboard navigation (in sorted order)
   const rowKeys = useMemo(() => rows.map((r) => r.student_id), [rows])
+  const selectedRow = useMemo(
+    () => rows.find((row) => row.student_id === selectedStudentId) ?? null,
+    [rows, selectedStudentId]
+  )
+  const selectedStudentName = selectedRow
+    ? [selectedRow.student_first_name, selectedRow.student_last_name].filter(Boolean).join(' ') ||
+      selectedRow.email_username
+    : ''
+  const selectedDateLabel = selectedDate ? format(parseISO(selectedDate), 'EEE MMM d') : 'Select date'
 
-  if (showBlockingSpinner) {
-    return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
-    )
-  }
-
-  return (
-    <PageLayout>
-      <PageActionBar
-        primary={
-          <DateActionBar
+  const actionBar = (
+    <TeacherWorkSurfaceActionBar
+      label={
+        <div className="truncate px-1 text-sm font-semibold text-text-default">
+          Daily
+        </div>
+      }
+      center={
+        <>
+          <input
+            ref={dateInputRef}
+            type="date"
             value={selectedDate}
-            onChange={setSelectedDate}
+            onChange={(event) => setSelectedDate(event.target.value)}
+            className="sr-only"
+            tabIndex={-1}
+          />
+          <CalendarDateNavigator
+            label={selectedDateLabel}
+            onLabelClick={() => dateInputRef.current?.showPicker()}
+            labelAriaLabel="Select attendance date"
             onPrev={() => moveDateBy(-1)}
             onNext={() => moveDateBy(1)}
+            prevAriaLabel="Previous day"
+            nextAriaLabel="Next day"
           />
-        }
-        trailing={null}
-      />
+        </>
+      }
+    />
+  )
 
-      <PageContent>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div className="min-h-[200px]" onClick={(e) => {
-          // Deselect when clicking outside the table
-          if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {
-            handleDeselect()
-          }
-        }}>
+  const detailPane = selectedRow ? (
+    <StudentLogHistory studentId={selectedRow.student_id} classroomId={classroom.id} />
+  ) : selectedDate ? (
+    <LogSummary
+      classroomId={classroom.id}
+      date={selectedDate}
+      onStudentClick={selectStudentByName}
+    />
+  ) : (
+    <div className="p-4 text-sm text-text-muted">
+      Select a date to view the log summary.
+    </div>
+  )
+
+  const handlePaneResizeStart = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const splitElement = splitRef.current
+    if (!splitElement) return
+
+    event.preventDefault()
+
+    const { right, width } = splitElement.getBoundingClientRect()
+    if (width <= 0) return
+
+    const minRightPercent = Math.max(28, (280 / width) * 100)
+    const maxRightPercent = Math.min(72, ((width - 320) / width) * 100)
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      const nextRightWidth = ((right - moveEvent.clientX) / width) * 100
+      setDetailPaneWidth(
+        Math.round(clampPaneWidth(nextRightWidth, minRightPercent, maxRightPercent) * 10) / 10
+      )
+    }
+
+    const handleResizeEnd = () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handleResizeEnd)
+      window.removeEventListener('pointercancel', handleResizeEnd)
+      window.removeEventListener('blur', handleResizeEnd)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handleResizeEnd)
+    window.addEventListener('pointercancel', handleResizeEnd)
+    window.addEventListener('blur', handleResizeEnd)
+  }, [])
+
+  const handlePaneResizeReset = useCallback(() => {
+    setDetailPaneWidth(50)
+  }, [])
+
+  const handlePaneResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setDetailPaneWidth((current) => clampPaneWidth(current + 5, 28, 72))
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setDetailPaneWidth((current) => clampPaneWidth(current - 5, 28, 72))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setDetailPaneWidth(72)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setDetailPaneWidth(28)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      setDetailPaneWidth(50)
+    }
+  }, [])
+
+  const workspace = showBlockingSpinner ? (
+    <div className="flex justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : (
+    <div ref={splitRef} className="flex min-h-0 flex-1 flex-col gap-3 bg-page lg:flex-row lg:gap-0">
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div className="min-h-[200px] min-w-0 flex-1 overflow-hidden rounded-lg bg-surface" onClick={(e) => {
+        // Deselect when clicking outside the table
+        if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {
+          handleDeselect()
+        }
+      }}>
         <KeyboardNavigableTable
           rowKeys={rowKeys}
           selectedKey={selectedStudentId}
           onSelectKey={handleKeyboardSelect}
           onDeselect={handleDeselect}
         >
-          <TableCard>
+          <TableCard chrome="flush">
             {refreshing && (
               <RefreshingIndicator />
             )}
@@ -369,8 +496,46 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
             </DataTable>
           </TableCard>
         </KeyboardNavigableTable>
+      </div>
+      <div className="hidden w-3 shrink-0 self-stretch lg:flex">
+        <div
+          role="separator"
+          aria-label="Resize Daily panes"
+          aria-orientation="vertical"
+          aria-valuemin={28}
+          aria-valuemax={72}
+          aria-valuenow={detailPaneWidth}
+          tabIndex={0}
+          className="min-h-full flex-1 cursor-col-resize rounded-full outline-none focus:bg-info-bg hover:bg-surface-hover"
+          onPointerDown={handlePaneResizeStart}
+          onDoubleClick={handlePaneResizeReset}
+          onKeyDown={handlePaneResizeKeyDown}
+        />
+      </div>
+      <aside
+        className="flex min-h-0 w-full flex-col overflow-hidden rounded-lg bg-surface lg:shrink-0 lg:basis-[var(--daily-detail-pane-width)]"
+        style={{ '--daily-detail-pane-width': `calc(${detailPaneWidth}% - 6px)` } as CSSProperties}
+      >
+        <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
+          <span className="truncate text-sm font-semibold text-text-default">
+            {selectedRow ? selectedStudentName : 'Log Summary'}
+          </span>
         </div>
-      </PageContent>
-    </PageLayout>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {detailPane}
+        </div>
+      </aside>
+    </div>
+  )
+
+  return (
+    <TeacherWorkSurfaceShell
+      state="workspace"
+      primary={actionBar}
+      summary={null}
+      workspace={workspace}
+      workspaceFrame="standalone"
+      workspaceFrameClassName="min-h-[360px] border-0 bg-page"
+    />
   )
 })

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -27,8 +27,10 @@ import {
   Pencil,
   Plus,
   Send,
+  User,
+  Users,
 } from 'lucide-react'
-import { ConfirmDialog, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { ConfirmDialog, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -42,10 +44,9 @@ import {
   TeacherStudentWorkPanel,
   type TeacherAssignmentGradeTemplate,
 } from '@/components/TeacherStudentWorkPanel'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
-import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
-import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
   ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
@@ -62,7 +63,6 @@ import {
   ASSIGNMENT_GRADING_LAYOUT,
   getAssignmentWorkspaceStudentCookieName,
   parseAssignmentWorkspaceStudentId,
-  type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import type {
@@ -97,6 +97,7 @@ type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
   updated_at?: string | null
 }
 type GradeSelectedApplyTarget = 'grade' | 'comments'
+type AssignmentLeftPaneView = 'class' | 'individual'
 type UpdateSearchParamsFn = (
   updater: (params: URLSearchParams) => void,
   options?: { replace?: boolean },
@@ -288,8 +289,7 @@ export function TeacherClassroomView({
     studentName: string
     characterCount: number
   } | null>(null)
-  const [assignmentWorkspaceMode, setAssignmentWorkspaceMode] =
-    useState<AssignmentWorkspaceMode>('overview')
+  const [leftPaneView, setLeftPaneView] = useState<AssignmentLeftPaneView>('class')
   const [editAssignment, setEditAssignment] = useState<Assignment | null>(null)
   const [error, setError] = useState('')
   const [info, setInfo] = useState('')
@@ -386,7 +386,7 @@ export function TeacherClassroomView({
 
     observer.observe(node)
     return () => observer.disconnect()
-  }, [selection.mode, assignmentWorkspaceMode, selectedStudentId])
+  }, [selection.mode, leftPaneView, selectedStudentId])
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
@@ -560,7 +560,7 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
-      setAssignmentWorkspaceMode('overview')
+      setLeftPaneView('class')
       setSelectedStudentId(null)
       setWorkspaceLoading(false)
       return
@@ -774,7 +774,7 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
-    setAssignmentWorkspaceMode('overview')
+    setLeftPaneView('class')
     setSelectedStudentId(null)
     setWorkspaceLoading(false)
     batchClearSelection()
@@ -1224,32 +1224,27 @@ export function TeacherClassroomView({
     return currentStudentRows[0]?.student_id ?? null
   }, [classroom.id, currentStudentRows, selectedStudentId, selection])
 
-  const handleSwitchWorkspaceMode = useCallback((nextMode: AssignmentWorkspaceMode) => {
-    if (nextMode === assignmentWorkspaceMode) return
+  const handleSwitchLeftPaneView = useCallback((nextView: AssignmentLeftPaneView) => {
+    if (nextView === leftPaneView) return
 
-    if (nextMode === 'details') {
+    if (nextView === 'individual') {
       const nextStudentId = resolveDetailsStudentId()
       if (!nextStudentId) return
       setIndividualHeaderMeta(null)
       setSelectedStudentAndNavigate(nextStudentId, { replace: true })
-    } else {
-      setIndividualHeaderMeta(null)
     }
 
-    updateModeLayout(nextMode, assignmentGradingLayout[assignmentWorkspaceMode])
-    setAssignmentWorkspaceMode(nextMode)
+    setLeftPaneView(nextView)
   }, [
-    assignmentGradingLayout,
-    assignmentWorkspaceMode,
+    leftPaneView,
     resolveDetailsStudentId,
     setSelectedStudentAndNavigate,
-    updateModeLayout,
   ])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
     if (!activeSelectedAssignmentData || selectedAssignmentLoading) return
-    const workspaceKey = `${selection.assignmentId}:${assignmentWorkspaceMode}`
+    const workspaceKey = selection.assignmentId
     if (defaultedWorkspaceKeyRef.current === workspaceKey) return
 
     if (activeSelectedStudentId) {
@@ -1265,28 +1260,11 @@ export function TeacherClassroomView({
   }, [
     activeSelectedAssignmentData,
     activeSelectedStudentId,
-    assignmentWorkspaceMode,
     resolveDetailsStudentId,
     selectedAssignmentLoading,
     setSelectedStudentAndNavigate,
     selection,
   ])
-
-  // Escape key to deselect student
-  useEffect(() => {
-    if (assignmentEditMode) return
-    if (assignmentWorkspaceMode !== 'overview') return
-    if (!selectedStudentId) return
-
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        setSelectedStudentAndNavigate(null)
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [assignmentEditMode, assignmentWorkspaceMode, selectedStudentId, setSelectedStudentAndNavigate])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
@@ -1376,17 +1354,14 @@ export function TeacherClassroomView({
         ? `${individualHeaderMeta.characterCount} chars`
         : 'Loading…'
       : null
-  const activeWorkspaceLayout = assignmentGradingLayout[assignmentWorkspaceMode]
-  const showOverviewInspector =
-    assignmentWorkspaceMode === 'overview' &&
-    !!activeSelectedStudentId
+  const activeWorkspaceLayout = assignmentGradingLayout.overview
   const highlightedInspectorSections =
     highlightedApplyTarget === 'grade'
       ? (['grades'] as const)
       : highlightedApplyTarget === 'comments'
         ? (['comments'] as const)
         : undefined
-  const canOpenDetails =
+  const canOpenIndividual =
     selection.mode === 'assignment' &&
     !selectedAssignmentLoading &&
     currentStudentRows.length > 0
@@ -1452,12 +1427,10 @@ export function TeacherClassroomView({
       rows={currentStudentRows}
       selectedStudentId={activeSelectedStudentId}
       onSelectStudent={(studentId) => {
-        if (assignmentWorkspaceMode === 'details') {
-          setIndividualHeaderMeta(null)
-        }
+        setIndividualHeaderMeta(null)
         setSelectedStudentAndNavigate(studentId)
       }}
-      onDeselectStudent={() => setSelectedStudentAndNavigate(null)}
+      onDeselectStudent={() => {}}
       tableRef={tableContainerRef}
       selectedIds={batchSelectedIds}
       onToggleSelect={batchToggleSelect}
@@ -1467,98 +1440,104 @@ export function TeacherClassroomView({
       sortDirection={sortDirection}
       onToggleSort={toggleSort}
       dueAtMs={dueAtMs}
-      density={showOverviewInspector ? 'tight' : 'compact'}
+      density={activeSelectedStudentId ? 'tight' : 'compact'}
       loading={selectedAssignmentLoading || (selection.mode === 'assignment' && !activeSelectedAssignmentData && !selectedAssignmentError)}
       error={selectedAssignmentError}
       busyOverlay={studentBusyOverlay}
     />
   )
 
-  const workspaceModeCenter = assignmentWorkspaceMode === 'overview' ? (
-    <>
-      <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
-        <SplitButton
-          label={
-            <span className="inline-flex items-center gap-2">
-              <Check className="h-4 w-4" aria-hidden="true" />
-              <span>AI Grade</span>
-            </span>
-          }
-          onPrimaryClick={() => {
-            void handleBatchAutoGrade()
-          }}
-          options={[
-            {
-              id: 'grade-selected',
-              label: (
-                <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <Copy className="h-4 w-4" aria-hidden="true" />
-                  <span>Apply Grade to Selected Students</span>
-                </span>
-              ),
-              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'grade' : null),
-              onSelect: () => {
-                setHighlightedApplyTarget(null)
-                setGradeSelectedConfirmTarget('grade')
-              },
-              disabled: isApplyGradeSelectedDisabled,
+  const classPane = (
+    <div className="h-full min-h-0">
+      {studentTable}
+    </div>
+  )
+
+  const classPaneActions = (
+    <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
+      <SplitButton
+        label={
+          <span className="inline-flex items-center gap-2">
+            <Check className="h-4 w-4" aria-hidden="true" />
+            <span>AI Grade</span>
+          </span>
+        }
+        onPrimaryClick={() => {
+          void handleBatchAutoGrade()
+        }}
+        options={[
+          {
+            id: 'grade-selected',
+            label: (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <Copy className="h-4 w-4" aria-hidden="true" />
+                <span>Apply Grade to Selected Students</span>
+              </span>
+            ),
+            onHoverChange: (active) => setHighlightedApplyTarget(active ? 'grade' : null),
+            onSelect: () => {
+              setHighlightedApplyTarget(null)
+              setGradeSelectedConfirmTarget('grade')
             },
-            {
-              id: 'comments-selected',
-              label: (
-                <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <MessageSquare className="h-4 w-4" aria-hidden="true" />
-                  <span>Apply Comments to Selected Students</span>
-                </span>
-              ),
-              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'comments' : null),
-              onSelect: () => {
-                setHighlightedApplyTarget(null)
-                setGradeSelectedConfirmTarget('comments')
-              },
-              disabled: isApplyCommentsSelectedDisabled,
+            disabled: isApplyGradeSelectedDisabled,
+          },
+          {
+            id: 'comments-selected',
+            label: (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <MessageSquare className="h-4 w-4" aria-hidden="true" />
+                <span>Apply Comments to Selected Students</span>
+              </span>
+            ),
+            onHoverChange: (active) => setHighlightedApplyTarget(active ? 'comments' : null),
+            onSelect: () => {
+              setHighlightedApplyTarget(null)
+              setGradeSelectedConfirmTarget('comments')
             },
-            {
-              id: 'repo-analysis',
-              label: (
-                <span className="inline-flex items-center gap-2">
-                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                  <span>Repo analysis</span>
-                </span>
-              ),
-              onSelect: () => {
-                void handleBatchArtifactRepoAnalyze()
-              },
-              disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+            disabled: isApplyCommentsSelectedDisabled,
+          },
+          {
+            id: 'repo-analysis',
+            label: (
+              <span className="inline-flex items-center gap-2">
+                <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                <span>Repo analysis</span>
+              </span>
+            ),
+            onSelect: () => {
+              void handleBatchArtifactRepoAnalyze()
             },
-            {
-              id: 'return',
-              label: (
-                <span className="inline-flex items-center gap-2">
-                  <Send className="h-4 w-4" aria-hidden="true" />
-                  <span>Return</span>
-                </span>
-              ),
-              onSelect: () => {
-                setShowReturnConfirm(true)
-              },
-              disabled: isReturnDisabled,
+            disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+          },
+          {
+            id: 'return',
+            label: (
+              <span className="inline-flex items-center gap-2">
+                <Send className="h-4 w-4" aria-hidden="true" />
+                <span>Return</span>
+              </span>
+            ),
+            onSelect: () => {
+              setShowReturnConfirm(true)
             },
-          ]}
-          disabled={isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
-          className="inline-flex"
-          toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
-          menuPlacement="down"
-          primaryButtonProps={{
-            'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-          }}
-        />
-      </Tooltip>
-    </>
-  ) : (
-    <>
+            disabled: isReturnDisabled,
+          },
+        ]}
+        disabled={isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
+        className="inline-flex"
+        toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+        menuPlacement="down"
+        primaryButtonProps={{
+          'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+        }}
+      />
+    </Tooltip>
+  )
+
+  const selectedStudentControls = (
+    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
       <div
-        className="min-w-0 max-w-[18rem] truncate text-center text-sm font-medium text-text-default"
+        className="min-w-0 max-w-[18rem] truncate text-sm font-medium text-text-default"
         title={selectedStudentDisplayName ?? undefined}
       >
         {selectedStudentDisplayName ?? 'No student selected'}
@@ -1588,21 +1567,24 @@ export function TeacherClassroomView({
           <ChevronRight className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
-    </>
+    </div>
   )
 
-  const workspaceModeStatus = workspaceLoading ? (
-    <div aria-live="polite" className="inline-flex items-center gap-1 text-xs text-text-muted">
-      <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-      <span>Updating</span>
+  const workspaceStatus = workspaceLoading ? (
+    <div
+      aria-live="polite"
+      className="pointer-events-none absolute -right-7 top-1/2 inline-flex -translate-y-1/2 items-center text-text-muted"
+    >
+      <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
+      <span className="sr-only">Updating assignment workspace</span>
     </div>
   ) : null
 
-  const workspaceModeTrailing = assignmentEditMode ? (
+  const workspaceTitleControl = assignmentEditMode ? (
     <Tooltip content="Edit assignment">
       <button
         type="button"
-        className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex max-w-[22rem] items-center gap-2`}
+        className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex w-full max-w-[22rem] items-center gap-2 overflow-hidden`}
         onClick={() => {
           if (activeSelectedAssignmentData) {
             setEditAssignment(activeSelectedAssignmentData.assignment)
@@ -1618,7 +1600,7 @@ export function TeacherClassroomView({
     </Tooltip>
   ) : (
     <div
-      className="inline-flex min-h-10 max-w-[22rem] items-center px-2 text-sm font-medium text-text-default"
+      className="inline-flex min-h-10 w-full max-w-[22rem] items-center overflow-hidden px-2 text-sm font-medium text-text-default"
       title={selectedAssignmentTitle}
     >
       <span className="truncate">{selectedAssignmentTitle}</span>
@@ -1633,37 +1615,59 @@ export function TeacherClassroomView({
     />
   )
 
+  const assignmentWorkspaceControls = selection.mode === 'assignment' ? (
+    <div
+      data-testid="assignment-workspace-actionbar-center"
+      className="relative flex min-w-0 items-center justify-center gap-2"
+    >
+      <SegmentedControl<AssignmentLeftPaneView>
+        ariaLabel="Assignment workspace view"
+        value={leftPaneView}
+        onChange={handleSwitchLeftPaneView}
+        iconOnly
+        options={[
+          { value: 'class', label: 'Class', icon: <Users className="h-4 w-4" /> },
+          {
+            value: 'individual',
+            label: 'Individual',
+            icon: <User className="h-4 w-4" />,
+            disabled: !canOpenIndividual,
+          },
+        ]}
+      />
+      {classPaneActions}
+      {workspaceStatus}
+    </div>
+  ) : null
+
   const primaryButtons =
     selection.mode === 'summary' ? (
-      <div
-        data-testid="assignment-summary-actionbar-center"
-        className="relative flex min-h-10 w-full items-center justify-center"
-      >
-        <button
-          type="button"
-          className={`${ACTIONBAR_BUTTON_PRIMARY_CLASSNAME} flex items-center gap-1`}
-          onClick={() => setIsCreateModalOpen(true)}
-          disabled={isReadOnly}
-          aria-label="New assignment"
-        >
-          <Plus className="h-5 w-5" aria-hidden="true" />
-          <span>New</span>
-        </button>
-        <div className="absolute right-0 top-1/2 -translate-y-1/2">
-          {assignmentEditControls}
-        </div>
-      </div>
+      <TeacherWorkSurfaceActionBar
+        testId="assignment-summary-actionbar-center"
+        label={
+          <div className="truncate px-1 text-sm font-semibold text-text-default">
+            Assignments
+          </div>
+        }
+        center={
+          <button
+            type="button"
+            className={`${ACTIONBAR_BUTTON_PRIMARY_CLASSNAME} flex items-center gap-1`}
+            onClick={() => setIsCreateModalOpen(true)}
+            disabled={isReadOnly}
+            aria-label="New assignment"
+          >
+            <Plus className="h-5 w-5" aria-hidden="true" />
+            <span>New</span>
+          </button>
+        }
+        trailing={assignmentEditControls}
+      />
     ) : (
-      <TeacherWorkSurfaceModeBar
-        modes={[
-          { id: 'overview', label: 'Class' },
-          { id: 'details', label: 'Individual', disabled: !canOpenDetails },
-        ]}
-        activeMode={assignmentWorkspaceMode}
-        onModeChange={(mode) => handleSwitchWorkspaceMode(mode as AssignmentWorkspaceMode)}
-        center={workspaceModeCenter}
-        status={workspaceModeStatus}
-        trailing={workspaceModeTrailing}
+      <TeacherWorkSurfaceActionBar
+        label={workspaceTitleControl}
+        center={assignmentWorkspaceControls}
+        trailing={assignmentEditControls}
       />
     )
 
@@ -1721,81 +1725,38 @@ export function TeacherClassroomView({
     </DndContext>
   )
 
-  const workspaceContent = selectedAssignmentId == null ? null : assignmentWorkspaceMode === 'details' ? (
-    activeSelectedStudentId ? (
-      <TeacherStudentWorkPanel
-        classroomId={classroom.id}
-        assignmentId={selectedAssignmentId}
-        studentId={activeSelectedStudentId}
-        mode="details"
-        inspectorCollapsed={false}
-        inspectorWidth={activeWorkspaceLayout.inspectorWidth}
-        totalWidth={workspaceWidth}
-        onLayoutChange={(next) => updateModeLayout('details', next)}
-        onLoadingStateChange={setWorkspaceLoading}
-        onGoPrevStudent={handleGoPrevStudent}
-        onGoNextStudent={handleGoNextStudent}
-        canGoPrevStudent={canGoPrevStudent}
-        canGoNextStudent={canGoNextStudent}
-        inspectorEditMode={assignmentEditMode}
-        onDetailsMetaChange={setIndividualHeaderMeta}
-      />
-    ) : selectedAssignmentLoading || (!activeSelectedAssignmentData && !selectedAssignmentError) ? (
-      <div className="flex flex-1 items-center justify-center py-12">
-        <Spinner />
-      </div>
-    ) : selectedAssignmentError ? (
-      <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
-        {selectedAssignmentError}
-      </div>
-    ) : (
-      <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
-        No student submissions yet.
-      </div>
-    )
-  ) : showOverviewInspector ? (
-    <TeacherWorkspaceSplit
-      className="flex-1"
-      primaryClassName="min-h-0"
-      inspectorClassName="min-h-0"
+  const leftPaneHeader = leftPaneView === 'individual' ? selectedStudentControls : null
+
+  const workspaceContent = selectedAssignmentId == null ? null : activeSelectedStudentId ? (
+    <TeacherStudentWorkPanel
+      classroomId={classroom.id}
+      assignmentId={selectedAssignmentId}
+      studentId={activeSelectedStudentId}
+      mode="workspace"
+      classPane={classPane}
+      leftPaneView={leftPaneView}
+      leftHeader={leftPaneHeader}
       inspectorCollapsed={false}
       inspectorWidth={activeWorkspaceLayout.inspectorWidth}
-      minInspectorPx={ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx}
-      minPrimaryPx={ASSIGNMENT_GRADING_LAYOUT.overviewPrimaryMinPx}
-      onInspectorCollapsedChange={(collapsed) => {
-        updateModeLayout('overview', (current) => ({
-          ...current,
-          inspectorCollapsed: collapsed,
-        }))
-      }}
-      onInspectorWidthChange={(nextInspectorWidth) => {
-        updateModeLayout('overview', (current) => ({
-          ...current,
-          inspectorCollapsed: false,
-          inspectorWidth: nextInspectorWidth,
-        }))
-      }}
-      dividerLabel="Resize table and grading panes"
-      primary={studentTable}
-      inspector={
-        <TeacherStudentWorkPanel
-          classroomId={classroom.id}
-          assignmentId={selectedAssignmentId}
-          studentId={activeSelectedStudentId}
-          refreshKey={gradeSelectedRefreshCounter}
-          mode="overview"
-          highlightedInspectorSections={highlightedInspectorSections}
-          inspectorCollapsed={false}
-          inspectorWidth={activeWorkspaceLayout.inspectorWidth}
-          totalWidth={workspaceWidth}
-          inspectorEditMode={assignmentEditMode}
-          onLoadingStateChange={setWorkspaceLoading}
-          onGradeTemplateChange={handleGradeTemplateChange}
-        />
-      }
+      refreshKey={gradeSelectedRefreshCounter}
+      highlightedInspectorSections={highlightedInspectorSections}
+      totalWidth={workspaceWidth}
+      onLayoutChange={(next) => updateModeLayout('overview', next)}
+      onLoadingStateChange={setWorkspaceLoading}
+      inspectorEditMode={assignmentEditMode}
+      onDetailsMetaChange={setIndividualHeaderMeta}
+      onGradeTemplateChange={handleGradeTemplateChange}
     />
+  ) : selectedAssignmentLoading || (!activeSelectedAssignmentData && !selectedAssignmentError) ? (
+    <div className="flex flex-1 items-center justify-center py-12">
+      <Spinner />
+    </div>
+  ) : selectedAssignmentError ? (
+    <div className="flex flex-1 items-center justify-center p-4 text-sm text-danger">
+      {selectedAssignmentError}
+    </div>
   ) : (
-    studentTable
+    classPane
   )
 
   return (
@@ -1804,11 +1765,12 @@ export function TeacherClassroomView({
         state={selection.mode === 'summary' ? 'summary' : 'workspace'}
         primary={primaryButtons}
         actions={[]}
-        trailing={selection.mode === 'summary' ? undefined : assignmentEditControls}
+        trailing={undefined}
         feedback={feedback}
         summary={summaryContent}
         workspace={workspaceContent}
-        workspaceFrame="attachedTabs"
+        workspaceFrame="standalone"
+        workspaceFrameClassName={activeSelectedStudentId ? 'border-0 bg-page' : undefined}
         workspaceRef={workspaceContainerRef}
       />
 

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -63,6 +63,7 @@ import {
   ASSIGNMENT_GRADING_LAYOUT,
   getAssignmentWorkspaceStudentCookieName,
   parseAssignmentWorkspaceStudentId,
+  type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import type {
@@ -1354,7 +1355,8 @@ export function TeacherClassroomView({
         ? `${individualHeaderMeta.characterCount} chars`
         : 'Loading…'
       : null
-  const activeWorkspaceLayout = assignmentGradingLayout.overview
+  const activeWorkspaceMode: AssignmentWorkspaceMode = leftPaneView === 'individual' ? 'details' : 'overview'
+  const activeWorkspaceLayout = assignmentGradingLayout[activeWorkspaceMode]
   const highlightedInspectorSections =
     highlightedApplyTarget === 'grade'
       ? (['grades'] as const)
@@ -1741,7 +1743,7 @@ export function TeacherClassroomView({
       refreshKey={gradeSelectedRefreshCounter}
       highlightedInspectorSections={highlightedInspectorSections}
       totalWidth={workspaceWidth}
-      onLayoutChange={(next) => updateModeLayout('overview', next)}
+      onLayoutChange={(next) => updateModeLayout(activeWorkspaceMode, next)}
       onLoadingStateChange={setWorkspaceLoading}
       inspectorEditMode={assignmentEditMode}
       onDetailsMetaChange={setIndividualHeaderMeta}

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react'
 import { format } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { Button, cn } from '@/ui'
+import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
 import type { CalendarViewMode } from '@/components/LessonCalendar'
 
@@ -88,42 +88,32 @@ export function CalendarActionBar({
             )}
           </div>
 
-          <div className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 sm:flex items-center gap-1 rounded-control bg-surface-2 p-0.5">
-            {(['week', 'month', 'all'] as CalendarViewMode[]).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => onViewModeChange(mode)}
-                className={cn(
-                  'rounded-control px-3 py-1 text-xs font-medium capitalize transition-colors sm:text-sm',
-                  viewMode === mode
-                    ? 'bg-info-bg text-primary'
-                    : 'text-text-muted hover:bg-surface-hover hover:text-text-default'
-                )}
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
+          <SegmentedControl<CalendarViewMode>
+            ariaLabel="Calendar view"
+            value={viewMode}
+            onChange={onViewModeChange}
+            capitalizeLabels
+            className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 sm:flex"
+            options={[
+              { value: 'week', label: 'Week' },
+              { value: 'month', label: 'Month' },
+              { value: 'all', label: 'All' },
+            ]}
+          />
 
           <div className="ml-auto flex items-center gap-2 sm:absolute sm:right-0 sm:top-1/2 sm:-translate-y-1/2">
-            <div className="flex items-center gap-1 rounded-control bg-surface-2 p-0.5 sm:hidden">
-              {(['week', 'month', 'all'] as CalendarViewMode[]).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => onViewModeChange(mode)}
-                  className={cn(
-                    'rounded-control px-3 py-1 text-xs font-medium capitalize transition-colors',
-                    viewMode === mode
-                      ? 'bg-info-bg text-primary'
-                      : 'text-text-muted hover:bg-surface-hover hover:text-text-default'
-                  )}
-                >
-                  {mode}
-                </button>
-              ))}
-            </div>
+            <SegmentedControl<CalendarViewMode>
+              ariaLabel="Calendar view"
+              value={viewMode}
+              onChange={onViewModeChange}
+              capitalizeLabels
+              className="sm:hidden"
+              options={[
+                { value: 'week', label: 'Week' },
+                { value: 'month', label: 'Month' },
+                { value: 'all', label: 'All' },
+              ]}
+            />
             {trailing}
           </div>
         </div>

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -20,6 +20,18 @@ interface CalendarActionBarProps {
   className?: string
 }
 
+interface CalendarDateNavigatorProps {
+  label: string
+  onPrev?: () => void
+  onNext?: () => void
+  onLabelClick?: () => void
+  showNavigation?: boolean
+  labelAriaLabel?: string
+  prevAriaLabel?: string
+  nextAriaLabel?: string
+  className?: string
+}
+
 function getHeaderLabel(viewMode: CalendarViewMode, currentDate: Date, rangeStart?: string | null, rangeEnd?: string | null) {
   if (viewMode === 'week' || viewMode === 'month') {
     return format(currentDate, 'MMMM yyyy')
@@ -30,6 +42,63 @@ function getHeaderLabel(viewMode: CalendarViewMode, currentDate: Date, rangeStar
   }
 
   return 'All Dates'
+}
+
+export function CalendarDateNavigator({
+  label,
+  onPrev,
+  onNext,
+  onLabelClick,
+  showNavigation = true,
+  labelAriaLabel = 'Go to today',
+  prevAriaLabel = 'Previous',
+  nextAriaLabel = 'Next',
+  className = '',
+}: CalendarDateNavigatorProps) {
+  return (
+    <div className={`flex min-w-0 items-center gap-1 sm:gap-2 ${className}`}>
+      {showNavigation && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-9 w-9 px-0"
+          onClick={onPrev}
+          aria-label={prevAriaLabel}
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      )}
+
+      {onLabelClick ? (
+        <button
+          type="button"
+          onClick={onLabelClick}
+          className="truncate rounded-control px-2 py-1 text-sm font-semibold text-text-default transition-colors hover:bg-surface-hover sm:text-base"
+          aria-label={labelAriaLabel}
+        >
+          {label}
+        </button>
+      ) : (
+        <span className="truncate px-2 py-1 text-sm font-semibold text-text-default sm:text-base">
+          {label}
+        </span>
+      )}
+
+      {showNavigation && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-9 w-9 px-0"
+          onClick={onNext}
+          aria-label={nextAriaLabel}
+        >
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      )}
+    </div>
+  )
 }
 
 export function CalendarActionBar({
@@ -51,42 +120,13 @@ export function CalendarActionBar({
       className={className}
       primary={
         <div className="relative flex min-h-9 w-full items-center">
-          <div className="flex min-w-0 items-center gap-1 sm:gap-2">
-            {viewMode !== 'all' && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 w-9 px-0"
-                onClick={onPrev}
-                aria-label="Previous"
-              >
-                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            )}
-
-            <button
-              type="button"
-              onClick={onToday}
-              className="truncate rounded-control px-2 py-1 text-sm font-semibold text-text-default transition-colors hover:bg-surface-hover sm:text-base"
-              aria-label="Go to today"
-            >
-              {headerLabel}
-            </button>
-
-            {viewMode !== 'all' && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 w-9 px-0"
-                onClick={onNext}
-                aria-label="Next"
-              >
-                <ChevronRight className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            )}
-          </div>
+          <CalendarDateNavigator
+            label={headerLabel}
+            onPrev={onPrev}
+            onNext={onNext}
+            onLabelClick={onToday}
+            showNavigation={viewMode !== 'all'}
+          />
 
           <SegmentedControl<CalendarViewMode>
             ariaLabel="Calendar view"

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -8,7 +8,7 @@ import { LessonDayCell } from './LessonDayCell'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { useKeyboardShortcutHint } from '@/hooks/use-keyboard-shortcut-hint'
-import { DialogPanel, Tooltip } from '@/ui'
+import { DialogPanel, SegmentedControl, Tooltip } from '@/ui'
 import type { Announcement, Assignment, ClassDay, Classroom, LessonPlan } from '@/types'
 
 const TIMEZONE = 'America/Toronto'
@@ -377,20 +377,18 @@ export function LessonCalendar({
           </div>
 
           {/* Center: View mode selector */}
-          <div className="flex items-center justify-center gap-1">
-            {(['week', 'month', 'all'] as CalendarViewMode[]).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => onViewModeChange(mode)}
-                className={`rounded-md border px-3 py-0.5 text-sm capitalize transition-colors ${
-                  viewMode === mode
-                    ? 'border-transparent bg-info-bg text-primary font-medium'
-                    : 'border-transparent text-text-muted hover:bg-surface-hover hover:text-text-default'
-                }`}
-              >
-                {mode}
-              </button>
-            ))}
+          <div className="flex items-center justify-center">
+            <SegmentedControl<CalendarViewMode>
+              ariaLabel="Calendar view"
+              value={viewMode}
+              onChange={onViewModeChange}
+              capitalizeLabels
+              options={[
+                { value: 'week', label: 'Week' },
+                { value: 'month', label: 'Month' },
+                { value: 'all', label: 'All' },
+              ]}
+            />
           </div>
 
           {/* Right: Actions */}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createContext, useEffect, useMemo, useRef, useState } from 'react'
 import { MoreVertical } from 'lucide-react'
 import { buttonVariants } from '@/ui/Button'
 import { cn } from '@/ui/utils'
@@ -9,6 +9,10 @@ import { cn } from '@/ui/utils'
 export type PageDensity = 'default' | 'teacher' | 'student'
 
 const PageDensityContext = createContext<PageDensity>('default')
+const PAGE_GUTTER_X_CLASS = 'px-3'
+const PAGE_GUTTER_X_BLEED_CLASS = '-mx-3'
+const PAGE_CONTENT_TOP_CLASS = 'pt-2'
+const PAGE_STACK_GAP_CLASS = 'space-y-3'
 
 export type ActionBarItem = {
   id: string
@@ -49,15 +53,7 @@ export function PageLayout({
   className?: string
   bleedX?: boolean
 }) {
-  const density = useContext(PageDensityContext)
-  const frameClass =
-    !bleedX
-      ? ''
-      : density === 'teacher'
-        ? '-mx-3'
-        : density === 'student'
-          ? '-mx-4'
-          : '-mx-4'
+  const frameClass = bleedX ? PAGE_GUTTER_X_BLEED_CLASS : ''
 
   return <div className={cn('w-auto flex flex-col', frameClass, className)}>{children}</div>
 }
@@ -83,15 +79,7 @@ export function PageContent({
   children: ReactNode
   className?: string
 }) {
-  const density = useContext(PageDensityContext)
-  const spacingClass =
-    density === 'teacher'
-      ? 'px-3 pt-3'
-      : density === 'student'
-        ? 'px-4 pt-4'
-        : 'px-4 pt-2'
-
-  return <div className={cn(spacingClass, className)}>{children}</div>
+  return <div className={cn(PAGE_GUTTER_X_CLASS, PAGE_CONTENT_TOP_CLASS, className)}>{children}</div>
 }
 
 export function PageStack({
@@ -101,11 +89,7 @@ export function PageStack({
   children: ReactNode
   className?: string
 }) {
-  const density = useContext(PageDensityContext)
-  const spacingClass =
-    density === 'teacher' ? 'space-y-3' : density === 'student' ? 'space-y-4' : 'space-y-4'
-
-  return <div className={cn(spacingClass, className)}>{children}</div>
+  return <div className={cn(PAGE_STACK_GAP_CLASS, className)}>{children}</div>
 }
 
 function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
@@ -215,16 +199,9 @@ export function PageActionBar({
   trailing?: ReactNode
   className?: string
 }) {
-  const density = useContext(PageDensityContext)
-  const frameClass =
-    density === 'teacher'
-      ? 'px-3'
-      : density === 'student'
-        ? 'px-4'
-        : 'px-4'
   const outerClass = cn(
     'mt-header-compact w-full bg-page',
-    frameClass,
+    PAGE_GUTTER_X_CLASS,
     className,
   )
 
@@ -232,11 +209,53 @@ export function PageActionBar({
     return (
       <div className={outerClass}>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-        <div className="min-w-0">{primary}</div>
+          <div className="min-w-0">{primary}</div>
+
+          {actions.length > 0 && (
+            <>
+              <div className="hidden sm:flex flex-wrap items-center justify-start gap-2">
+                {actions.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={cn(
+                      item.primary
+                        ? ACTIONBAR_BUTTON_PRIMARY_CLASSNAME
+                        : ACTIONBAR_BUTTON_CLASSNAME,
+                      item.primary
+                        ? ''
+                        : item.destructive
+                          ? 'border-danger bg-danger-bg text-danger hover:bg-danger-bg-hover'
+                          : ''
+                    )}
+                    onClick={item.onSelect}
+                    disabled={item.disabled}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+              <div className="sm:hidden">
+                <ActionBarMenu items={actions} />
+              </div>
+            </>
+          )}
+
+          <div className="flex-1" />
+          {trailing}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={outerClass}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+        <div className="min-w-0 flex-1">{primary}</div>
 
         {actions.length > 0 && (
           <>
-            <div className="hidden sm:flex flex-wrap items-center justify-start gap-2">
+            <div className="hidden sm:flex flex-wrap items-center justify-end gap-2">
               {actions.map((item) => (
                 <button
                   key={item.id}
@@ -245,11 +264,9 @@ export function PageActionBar({
                     item.primary
                       ? ACTIONBAR_BUTTON_PRIMARY_CLASSNAME
                       : ACTIONBAR_BUTTON_CLASSNAME,
-                    item.primary
-                      ? ''
-                      : item.destructive
-                        ? 'border-danger bg-danger-bg text-danger hover:bg-danger-bg-hover'
-                        : ''
+                    item.destructive
+                      ? 'border-danger bg-danger-bg text-danger hover:bg-danger-bg-hover'
+                      : '',
                   )}
                   onClick={item.onSelect}
                   disabled={item.disabled}
@@ -263,47 +280,7 @@ export function PageActionBar({
             </div>
           </>
         )}
-
-        <div className="flex-1" />
         {trailing}
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className={outerClass}>
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-      <div className="min-w-0 flex-1">{primary}</div>
-
-      {actions.length > 0 && (
-        <>
-          <div className="hidden sm:flex flex-wrap items-center justify-end gap-2">
-            {actions.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={cn(
-                  item.primary
-                    ? ACTIONBAR_BUTTON_PRIMARY_CLASSNAME
-                    : ACTIONBAR_BUTTON_CLASSNAME,
-                  item.destructive
-                    ? 'border-danger bg-danger-bg text-danger hover:bg-danger-bg-hover'
-                    : '',
-                )}
-                onClick={item.onSelect}
-                disabled={item.disabled}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
-          <div className="sm:hidden">
-            <ActionBarMenu items={actions} />
-          </div>
-        </>
-      )}
-      {trailing}
       </div>
     </div>
   )

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
@@ -21,7 +21,10 @@ interface TeacherStudentWorkPanelProps {
   assignmentId: string
   studentId: string
   refreshKey?: number
-  mode?: AssignmentWorkspaceMode
+  mode?: AssignmentWorkspaceMode | 'workspace'
+  classPane?: ReactNode
+  leftPaneView?: 'class' | 'individual'
+  leftHeader?: ReactNode
   inspectorCollapsed?: boolean
   inspectorWidth?: number
   totalWidth?: number
@@ -31,10 +34,6 @@ interface TeacherStudentWorkPanelProps {
       | ((current: AssignmentWorkspacePaneLayout) => AssignmentWorkspacePaneLayout),
   ) => void
   onLoadingStateChange?: (loading: boolean) => void
-  onGoPrevStudent?: () => void
-  onGoNextStudent?: () => void
-  canGoPrevStudent?: boolean
-  canGoNextStudent?: boolean
   inspectorEditMode?: boolean
   onDetailsMetaChange?: (meta: { studentName: string; characterCount: number } | null) => void
   onGradeTemplateChange?: (template: TeacherAssignmentGradeTemplate | null) => void
@@ -50,21 +49,41 @@ export interface TeacherAssignmentGradeTemplate {
   gradeMode: 'draft' | 'graded'
 }
 
+function AssignmentWorkspacePaneFrame({
+  header,
+  children,
+}: {
+  header?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {header ? (
+        <div className="shrink-0 border-b border-border bg-surface px-3 py-2">
+          {header}
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {children}
+      </div>
+    </div>
+  )
+}
+
 export function TeacherStudentWorkPanel({
   classroomId,
   assignmentId,
   studentId,
   refreshKey = 0,
   mode = 'details',
+  classPane,
+  leftPaneView = 'class',
+  leftHeader,
   inspectorCollapsed = false,
   inspectorWidth = ASSIGNMENT_GRADING_LAYOUT.defaultInspectorWidth,
   totalWidth = 0,
   onLayoutChange,
   onLoadingStateChange,
-  onGoPrevStudent,
-  onGoNextStudent,
-  canGoPrevStudent = false,
-  canGoNextStudent = false,
   inspectorEditMode = false,
   onDetailsMetaChange,
   onGradeTemplateChange,
@@ -120,6 +139,12 @@ export function TeacherStudentWorkPanel({
     onLoadingStateChange,
   })
   const previousInspectorEditModeRef = useRef(inspectorEditMode)
+  const layoutMode: AssignmentWorkspaceMode =
+    mode === 'workspace'
+      ? leftPaneView === 'individual'
+        ? 'details'
+        : 'overview'
+      : mode
   const layout = useMemo(
     () =>
       clampAssignmentWorkspacePaneLayout(
@@ -127,10 +152,10 @@ export function TeacherStudentWorkPanel({
           inspectorCollapsed,
           inspectorWidth,
         },
-        mode,
+        layoutMode,
         { totalWidth },
       ),
-    [inspectorCollapsed, inspectorWidth, mode, totalWidth],
+    [inspectorCollapsed, inspectorWidth, layoutMode, totalWidth],
   )
 
   const updateLayout = useCallback(
@@ -152,7 +177,7 @@ export function TeacherStudentWorkPanel({
   }, [collapseAllSections, inspectorEditMode])
 
   useEffect(() => {
-    if (mode !== 'details' || showInitialSpinner || error || !data) {
+    if (mode === 'overview' || showInitialSpinner || error || !data) {
       onDetailsMetaChange?.(null)
       return
     }
@@ -168,14 +193,15 @@ export function TeacherStudentWorkPanel({
       studentName: nextStudentDisplayName,
       characterCount: nextCharacterCount,
     })
-  }, [data, error, mode, onDetailsMetaChange, previewContent, showInitialSpinner])
+  }, [data, error, leftPaneView, mode, onDetailsMetaChange, previewContent, showInitialSpinner])
 
   useEffect(() => {
     return () => onGradeTemplateChange?.(null)
   }, [onGradeTemplateChange])
 
   useEffect(() => {
-    if (mode !== 'overview' || showInitialSpinner || error || !data || data.student.id !== studentId) {
+    const shouldReportGradeTemplate = mode === 'overview' || mode === 'workspace'
+    if (!shouldReportGradeTemplate || showInitialSpinner || error || !data || data.student.id !== studentId) {
       onGradeTemplateChange?.(null)
       return
     }
@@ -263,17 +289,91 @@ export function TeacherStudentWorkPanel({
     />
   )
 
+  const workPane = (
+    <div className="flex h-full min-h-0 flex-col">
+      {previewEntry && (
+        <div
+          data-testid="individual-content-header"
+          className="border-b border-border bg-surface px-4 py-2 text-sm"
+        >
+          <div className="text-xs font-medium text-primary">
+            Previewing save from{' '}
+            {formatInTimeZone(
+              new Date(previewEntry.created_at),
+              'America/Toronto',
+              'MMM d, h:mm a',
+            )}
+          </div>
+        </div>
+      )}
+      {displayContent && !isEmpty(displayContent) ? (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <RichTextViewer content={displayContent} fillHeight chrome="flush" />
+        </div>
+      ) : (
+        <div className="flex h-32 items-center justify-center text-text-muted">
+          No work submitted yet
+        </div>
+      )}
+    </div>
+  )
+
   if (mode === 'overview') {
     return inspector
+  }
+
+  if (mode === 'workspace') {
+    const primaryPane = leftPaneView === 'individual' ? workPane : classPane ?? workPane
+    const primaryMinPx = leftPaneView === 'individual'
+      ? ASSIGNMENT_GRADING_LAYOUT.detailsPrimaryMinPx
+      : ASSIGNMENT_GRADING_LAYOUT.overviewPrimaryMinPx
+
+    return (
+      <TeacherWorkspaceSplit
+        className="flex-1"
+        splitVariant="gapped"
+        primaryClassName="min-h-0 rounded-lg bg-surface"
+        inspectorClassName="min-h-0 rounded-lg bg-surface"
+        inspectorCollapsed={layout.inspectorCollapsed}
+        inspectorWidth={layout.inspectorWidth}
+        minInspectorPx={ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx}
+        minPrimaryPx={primaryMinPx}
+        onInspectorCollapsedChange={(collapsed) => {
+          updateLayout((current) => ({
+            ...current,
+            inspectorCollapsed: collapsed,
+          }))
+        }}
+        onInspectorWidthChange={(nextInspectorWidth) => {
+          updateLayout((current) => ({
+            ...current,
+            inspectorCollapsed: false,
+            inspectorWidth: nextInspectorWidth,
+          }))
+        }}
+        dividerLabel="Resize assignment workspace panes"
+        primary={
+          <AssignmentWorkspacePaneFrame header={leftHeader}>
+            {primaryPane}
+          </AssignmentWorkspacePaneFrame>
+        }
+        inspector={
+          <AssignmentWorkspacePaneFrame>
+            {inspector}
+          </AssignmentWorkspacePaneFrame>
+        }
+      />
+    )
   }
 
   return (
     <TeacherWorkspaceSplit
       className="flex-1"
-      primaryClassName={`flex min-h-0 flex-col ${
+      splitVariant="gapped"
+      primaryClassName={`flex min-h-0 flex-col rounded-lg bg-surface ${
         previewEntry ? 'outline outline-2 outline-primary outline-offset-[-2px]' : ''
       }`}
-      inspectorClassName="flex min-h-0 flex-col"
+      inspectorClassName="flex min-h-0 flex-col rounded-lg bg-surface"
       inspectorCollapsed={layout.inspectorCollapsed}
       inspectorWidth={layout.inspectorWidth}
       minInspectorPx={ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx}
@@ -292,34 +392,7 @@ export function TeacherStudentWorkPanel({
         }))
       }}
       dividerLabel="Resize content and grading panes"
-      primary={
-        <>
-          {previewEntry && (
-            <div
-              data-testid="individual-content-header"
-              className="border-b border-border bg-surface px-4 py-2 text-sm"
-            >
-              <div className="text-xs font-medium text-primary">
-                Previewing save from{' '}
-                {formatInTimeZone(
-                  new Date(previewEntry.created_at),
-                  'America/Toronto',
-                  'MMM d, h:mm a',
-                )}
-              </div>
-            </div>
-          )}
-          {displayContent && !isEmpty(displayContent) ? (
-            <div className="min-h-0 flex-1 overflow-auto">
-              <RichTextViewer content={displayContent} fillHeight chrome="flush" />
-            </div>
-          ) : (
-            <div className="flex h-32 items-center justify-center text-text-muted">
-              No work submitted yet
-            </div>
-          )}
-        </>
-      }
+      primary={workPane}
       inspector={inspector}
     />
   )

--- a/src/components/WorkspaceSplitPane.tsx
+++ b/src/components/WorkspaceSplitPane.tsx
@@ -1,14 +1,18 @@
 'use client'
 
-import type { CSSProperties, ReactNode, PointerEventHandler } from 'react'
+import type { CSSProperties, KeyboardEventHandler, ReactNode, PointerEventHandler } from 'react'
 import { cn } from '@/ui/utils'
 
 interface WorkspaceSplitDivider {
   label: string
   onPointerDown: PointerEventHandler<HTMLDivElement>
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement>
   onDoubleClick?: () => void
   className?: string
   lineClassName?: string
+  ariaValueMin?: number
+  ariaValueMax?: number
+  ariaValueNow?: number
 }
 
 interface WorkspaceSplitPaneProps {
@@ -60,12 +64,17 @@ export function WorkspaceSplitPane({
             role="separator"
             aria-orientation="vertical"
             aria-label={divider.label}
+            aria-valuemin={divider.ariaValueMin}
+            aria-valuemax={divider.ariaValueMax}
+            aria-valuenow={divider.ariaValueNow}
+            tabIndex={divider.onKeyDown ? 0 : undefined}
             className={cn(
-              'absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent',
+              'absolute inset-y-0 left-0 z-10 w-3 -translate-x-1/2 cursor-col-resize bg-transparent outline-none',
               divider.className,
             )}
             onPointerDown={divider.onPointerDown}
             onDoubleClick={divider.onDoubleClick}
+            onKeyDown={divider.onKeyDown}
           >
             <div
               className={cn(

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, ChevronRight, Send } from 'lucide-react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { HistoryList } from '@/components/HistoryList'
 import { Spinner } from '@/components/Spinner'
-import { Button, Tooltip } from '@/ui'
+import { Button, SegmentedControl, Tooltip } from '@/ui'
 import type {
   AssignmentDocHistoryEntry,
   AssignmentFeedbackEntry,
@@ -690,43 +690,18 @@ export function TeacherWorkInspector({
           </div>
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0 text-xs text-text-muted">{gradeStatusLabel ?? ''}</div>
-            <div
-              data-testid="grade-mode-toggle"
-              className="inline-flex rounded-full border border-border bg-surface-2 p-0.5"
-            >
-              <button
-                type="button"
-                className={[
-                  'inline-flex h-8 items-center justify-center rounded-full px-3 text-xs font-medium transition-colors',
-                  gradeMode === 'draft'
-                    ? 'bg-surface text-text-default shadow-sm'
-                    : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text-default',
-                ].join(' ')}
-                aria-pressed={gradeMode === 'draft'}
-                onClick={() => {
-                  void handleSetGradeMode('draft')
-                }}
-                disabled={gradeSaving}
-              >
-                Draft
-              </button>
-              <button
-                type="button"
-                className={[
-                  'inline-flex h-8 items-center justify-center rounded-full px-3 text-xs font-medium transition-colors',
-                  gradeMode === 'graded'
-                    ? 'bg-surface text-text-default shadow-sm'
-                    : 'bg-transparent text-text-muted hover:bg-surface-hover hover:text-text-default',
-                ].join(' ')}
-                aria-pressed={gradeMode === 'graded'}
-                onClick={() => {
-                  void handleSetGradeMode('graded')
-                }}
-                disabled={gradeSaving}
-              >
-                Final
-              </button>
-            </div>
+            <SegmentedControl<GradeSaveMode>
+              ariaLabel="Grade save mode"
+              value={gradeMode}
+              onChange={(nextMode) => {
+                void handleSetGradeMode(nextMode)
+              }}
+              testId="grade-mode-toggle"
+              options={[
+                { value: 'draft', label: 'Draft', disabled: gradeSaving },
+                { value: 'graded', label: 'Final', disabled: gradeSaving },
+              ]}
+            />
           </div>
         </div>
       ),

--- a/src/components/teacher-work-surface/TeacherEditModeControls.tsx
+++ b/src/components/teacher-work-surface/TeacherEditModeControls.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { Check, Pencil } from 'lucide-react'
+import { Pencil } from 'lucide-react'
 import { Button, Tooltip } from '@/ui'
 import { cn } from '@/ui/utils'
 
@@ -11,7 +11,6 @@ interface TeacherEditModeControlsProps {
   disabled?: boolean
   children?: ReactNode
   editLabel?: string
-  doneLabel?: string
   className?: string
 }
 
@@ -21,12 +20,8 @@ export function TeacherEditModeControls({
   disabled = false,
   children,
   editLabel = 'Edit',
-  doneLabel = 'Done',
   className,
 }: TeacherEditModeControlsProps) {
-  const Icon = active ? Check : Pencil
-  const label = active ? doneLabel : editLabel
-
   return (
     <div className={cn('flex flex-wrap items-center justify-end gap-1.5', className)}>
       {active && children ? (
@@ -38,15 +33,20 @@ export function TeacherEditModeControls({
       <Tooltip content={active ? 'Hide edit actions' : 'Show edit actions'}>
         <Button
           type="button"
-          variant={active ? 'secondary' : 'ghost'}
+          variant="ghost"
           size="sm"
-          className="min-h-10 px-3"
+          className={cn(
+            'min-h-10 px-3',
+            active
+              ? 'border-primary/40 bg-info-bg text-primary shadow-inner hover:bg-info-bg-hover hover:text-primary'
+              : '',
+          )}
           aria-pressed={active}
           disabled={disabled}
           onClick={() => onActiveChange(!active)}
         >
-          <Icon className="h-4 w-4" aria-hidden="true" />
-          <span>{label}</span>
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+          <span>{editLabel}</span>
         </Button>
       </Tooltip>
     </div>

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { cn } from '@/ui/utils'
+
+interface TeacherWorkSurfaceActionBarProps {
+  label?: ReactNode
+  center?: ReactNode
+  trailing?: ReactNode
+  className?: string
+  labelClassName?: string
+  centerClassName?: string
+  trailingClassName?: string
+  testId?: string
+}
+
+export function TeacherWorkSurfaceActionBar({
+  label,
+  center,
+  trailing,
+  className,
+  labelClassName,
+  centerClassName,
+  trailingClassName,
+  testId,
+}: TeacherWorkSurfaceActionBarProps) {
+  return (
+    <div
+      data-testid={testId}
+      className={cn(
+        'grid min-h-10 w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2',
+        className,
+      )}
+    >
+      <div className={cn('min-w-0 max-w-full overflow-hidden justify-self-start', labelClassName)}>
+        {label}
+      </div>
+      <div className={cn('min-w-0 justify-self-center', centerClassName)}>
+        {center}
+      </div>
+      <div className={cn('min-w-0 justify-self-end', trailingClassName)}>
+        {trailing}
+      </div>
+    </div>
+  )
+}

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceShell.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceShell.tsx
@@ -49,6 +49,7 @@ export function TeacherWorkSurfaceShell({
 }: TeacherWorkSurfaceShellProps) {
   const isSummary = state === 'summary'
   const usesAttachedTabsFrame = workspaceFrame === 'attachedTabs'
+  const usesStandaloneFrame = workspaceFrame === 'standalone'
 
   return (
     <PageLayout
@@ -65,7 +66,9 @@ export function TeacherWorkSurfaceShell({
         className={cn(
           isSummary
             ? 'flex flex-col gap-3'
-            : 'px-0 flex min-h-0 flex-1 flex-col gap-3 pt-0',
+            : usesStandaloneFrame
+              ? 'flex min-h-0 flex-1 flex-col gap-3'
+              : 'px-0 flex min-h-0 flex-1 flex-col gap-3 pt-0',
           contentClassName,
         )}
       >

--- a/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
@@ -1,13 +1,20 @@
 'use client'
 
-import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
 import { useWindowSize } from '@/hooks/use-window-size'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
+import { cn } from '@/ui/utils'
 
 const DEFAULT_MIN_INSPECTOR_PX = 320
 const DEFAULT_MIN_PRIMARY_PX = 320
+const GAPPED_SPLIT_HANDLE_WIDTH_PX = 12
 
 interface TeacherWorkspaceSplitProps {
   primary: ReactNode
@@ -25,6 +32,7 @@ interface TeacherWorkspaceSplitProps {
   minPrimaryPx?: number
   minInspectorPercent?: number
   maxInspectorPercent?: number
+  splitVariant?: 'joined' | 'gapped'
 }
 
 function roundPercent(value: number): number {
@@ -83,6 +91,7 @@ export function TeacherWorkspaceSplit({
   minPrimaryPx = DEFAULT_MIN_PRIMARY_PX,
   minInspectorPercent = 0,
   maxInspectorPercent = 100,
+  splitVariant = 'joined',
 }: TeacherWorkspaceSplitProps) {
   const splitRef = useRef<HTMLDivElement | null>(null)
   const [splitWidth, setSplitWidth] = useState(0)
@@ -145,13 +154,17 @@ export function TeacherWorkspaceSplit({
         )
       }
 
-      const handlePointerUp = () => {
+      const handleResizeEnd = () => {
         window.removeEventListener('pointermove', handlePointerMove)
-        window.removeEventListener('pointerup', handlePointerUp)
+        window.removeEventListener('pointerup', handleResizeEnd)
+        window.removeEventListener('pointercancel', handleResizeEnd)
+        window.removeEventListener('blur', handleResizeEnd)
       }
 
       window.addEventListener('pointermove', handlePointerMove)
-      window.addEventListener('pointerup', handlePointerUp)
+      window.addEventListener('pointerup', handleResizeEnd)
+      window.addEventListener('pointercancel', handleResizeEnd)
+      window.addEventListener('blur', handleResizeEnd)
     },
     [
       maxInspectorPercent,
@@ -186,6 +199,104 @@ export function TeacherWorkspaceSplit({
     splitWidth,
   ])
 
+  const handleResizeKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const baseWidth = splitWidth || splitRef.current?.getBoundingClientRect().width || 0
+      const getClampedWidth = (nextWidth: number) =>
+        clampInspectorWidthPercent(
+          nextWidth,
+          baseWidth,
+          {
+            minInspectorPx,
+            minPrimaryPx,
+            minInspectorPercent,
+            maxInspectorPercent,
+          },
+        )
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        onInspectorCollapsedChange?.(false)
+        onInspectorWidthChange(getClampedWidth(inspectorWidth + 5))
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        onInspectorCollapsedChange?.(false)
+        onInspectorWidthChange(getClampedWidth(inspectorWidth - 5))
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        onInspectorCollapsedChange?.(false)
+        onInspectorWidthChange(getClampedWidth(maxInspectorPercent))
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        onInspectorCollapsedChange?.(false)
+        onInspectorWidthChange(getClampedWidth(minInspectorPercent))
+      } else if (event.key === 'Enter') {
+        event.preventDefault()
+        handleResizeReset()
+      }
+    },
+    [
+      handleResizeReset,
+      inspectorWidth,
+      maxInspectorPercent,
+      minInspectorPercent,
+      minInspectorPx,
+      minPrimaryPx,
+      onInspectorCollapsedChange,
+      onInspectorWidthChange,
+      splitWidth,
+    ],
+  )
+
+  if (splitVariant === 'gapped') {
+    const inspectorPaneStyle = inspectorVisible && isDesktop
+      ? {
+          '--teacher-workspace-inspector-width': `calc(${constrainedInspectorWidth}% - ${GAPPED_SPLIT_HANDLE_WIDTH_PX / 2}px)`,
+        } as CSSProperties
+      : undefined
+
+    return (
+      <div
+        ref={splitRef}
+        className={cn('flex min-h-0 flex-1 flex-col gap-3 bg-page lg:flex-row lg:gap-0', className)}
+      >
+        <div className={cn('min-h-0 min-w-0 flex-1 overflow-hidden', primaryClassName)}>
+          {primary}
+        </div>
+
+        {inspectorVisible ? (
+          <div className="hidden w-3 shrink-0 self-stretch lg:flex">
+            <div
+              role="separator"
+              aria-label={dividerLabel}
+              aria-orientation="vertical"
+              aria-valuemin={minInspectorPercent}
+              aria-valuemax={maxInspectorPercent}
+              aria-valuenow={constrainedInspectorWidth}
+              tabIndex={0}
+              className="min-h-full flex-1 cursor-col-resize rounded-full outline-none hover:bg-surface-hover focus:bg-info-bg"
+              onPointerDown={handleResizeStart}
+              onDoubleClick={handleResizeReset}
+              onKeyDown={handleResizeKeyDown}
+            />
+          </div>
+        ) : null}
+
+        {inspectorVisible ? (
+          <div
+            className={cn(
+              'min-h-0 w-full overflow-hidden lg:shrink-0 lg:basis-[var(--teacher-workspace-inspector-width)]',
+              inspectorClassName,
+            )}
+            style={inspectorPaneStyle}
+          >
+            {inspector}
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
   return (
     <div ref={splitRef} className="flex h-full min-h-0 flex-1">
       <SummaryDetailWorkspaceShell
@@ -201,6 +312,10 @@ export function TeacherWorkspaceSplit({
                 label: dividerLabel,
                 onPointerDown: handleResizeStart,
                 onDoubleClick: handleResizeReset,
+                onKeyDown: handleResizeKeyDown,
+                ariaValueMin: minInspectorPercent,
+                ariaValueMax: maxInspectorPercent,
+                ariaValueNow: constrainedInspectorWidth,
               }
             : undefined
         }

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -93,7 +93,7 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   attendance: {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%' },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   roster: {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -72,7 +72,7 @@
   --space-section: 1.5rem;
   --space-field: 0.75rem;
   --space-control: 0.5rem;
-  --space-header-compact: 0.75rem;
+  --space-header-compact: 0.5rem;
 
   /* Border radius */
   --radius-control: 0.5rem;

--- a/src/ui/SegmentedControl.tsx
+++ b/src/ui/SegmentedControl.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { cn } from './utils'
+
+export interface SegmentedControlOption<TValue extends string> {
+  value: TValue
+  label: string
+  icon?: ReactNode
+  disabled?: boolean
+}
+
+export interface SegmentedControlProps<TValue extends string> {
+  ariaLabel: string
+  value: TValue
+  options: Array<SegmentedControlOption<TValue>>
+  onChange: (value: TValue) => void
+  iconOnly?: boolean
+  capitalizeLabels?: boolean
+  className?: string
+  testId?: string
+}
+
+export function SegmentedControl<TValue extends string>({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+  iconOnly = false,
+  capitalizeLabels = false,
+  className,
+  testId,
+}: SegmentedControlProps<TValue>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-control bg-surface-2 p-0.5',
+        className,
+      )}
+    >
+      {options.map((option) => {
+        const isActive = option.value === value
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={cn(
+              'inline-flex items-center justify-center gap-1.5 rounded-control text-xs font-medium transition-colors',
+              iconOnly ? 'h-8 w-8 px-0' : 'px-3 py-1 sm:text-sm',
+              capitalizeLabels && !iconOnly ? 'capitalize' : '',
+              isActive
+                ? 'bg-info-bg text-primary'
+                : 'text-text-muted hover:bg-surface-hover hover:text-text-default',
+              option.disabled ? 'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-text-muted' : '',
+            )}
+            onClick={() => onChange(option.value)}
+            disabled={option.disabled}
+            aria-pressed={isActive}
+            aria-label={option.label}
+            title={iconOnly ? option.label : undefined}
+          >
+            {option.icon ? (
+              <span className="inline-flex h-4 w-4 items-center justify-center" aria-hidden="true">
+                {option.icon}
+              </span>
+            ) : null}
+            {iconOnly ? <span className="sr-only">{option.label}</span> : <span>{option.label}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -19,6 +19,7 @@ export { EmptyState, type EmptyStateProps } from './EmptyState'
 export { Tooltip, TooltipProvider, type TooltipProps } from './Tooltip'
 export { RefreshingIndicator } from './RefreshingIndicator'
 export { TabContentTransition } from './TabContentTransition'
+export { SegmentedControl, type SegmentedControlOption, type SegmentedControlProps } from './SegmentedControl'
 export { SplitButton, type SplitButtonProps, type SplitButtonOption } from './SplitButton'
 export {
   AppMessageFallback,

--- a/tests/components/TeacherAssignmentStudentTable.test.tsx
+++ b/tests/components/TeacherAssignmentStudentTable.test.tsx
@@ -70,13 +70,14 @@ describe('TeacherAssignmentStudentTable', () => {
   it('keeps row selection and batch selection as separate behaviors', () => {
     const onSelectStudent = vi.fn()
     const onToggleSelect = vi.fn()
+    const onDeselectStudent = vi.fn()
 
     render(
       <TeacherAssignmentStudentTable
         rows={[row]}
         selectedStudentId={null}
         onSelectStudent={onSelectStudent}
-        onDeselectStudent={vi.fn()}
+        onDeselectStudent={onDeselectStudent}
         selectedIds={new Set()}
         onToggleSelect={onToggleSelect}
         onToggleSelectAll={vi.fn()}
@@ -93,6 +94,7 @@ describe('TeacherAssignmentStudentTable', () => {
 
     fireEvent.click(screen.getByText('Ada'))
     expect(onSelectStudent).toHaveBeenCalledWith('student-1')
+    expect(onDeselectStudent).not.toHaveBeenCalled()
 
     onSelectStudent.mockClear()
     fireEvent.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect } from 'react'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
@@ -73,6 +73,23 @@ vi.mock('@/ui', () => ({
       ))}
     </div>
   ),
+  SegmentedControl: ({ ariaLabel, value, options, onChange }: any) => (
+    <div role="group" aria-label={ariaLabel}>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          disabled={option.disabled}
+          aria-pressed={option.value === value}
+          aria-label={option.label}
+        >
+          {option.icon}
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
   Tooltip: ({ children, content }: any) => (
     <span data-tooltip={typeof content === 'string' ? content : undefined}>{children}</span>
   ),
@@ -134,21 +151,24 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
     assignmentId,
     studentId,
     mode,
+    classPane,
+    leftPaneView = 'class',
+    leftHeader,
     onDetailsMetaChange,
     onGradeTemplateChange,
     highlightedInspectorSections = [],
   }: any) => {
     useEffect(() => {
       onDetailsMetaChange?.(
-        mode === 'details'
-        ? { studentName: `${studentId} Student`, characterCount: 17 }
-        : null,
+        mode === 'details' || mode === 'workspace'
+          ? { studentName: `${studentId} Student`, characterCount: 17 }
+          : null,
       )
-    }, [mode, onDetailsMetaChange, studentId])
+    }, [leftPaneView, mode, onDetailsMetaChange, studentId])
 
     useEffect(() => {
       onGradeTemplateChange?.(
-        mode === 'overview'
+        mode === 'overview' || mode === 'workspace'
           ? {
               studentId,
               scoreCompletion: '7',
@@ -160,6 +180,24 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
           : null,
       )
     }, [mode, onGradeTemplateChange, studentId])
+
+    if (mode === 'workspace') {
+      return (
+        <div
+          data-testid="teacher-work-panel"
+          data-highlighted-sections={highlightedInspectorSections.join(',')}
+        >
+          <div>{`overview:${assignmentId}:${studentId}`}</div>
+          <div data-testid="assignment-left-pane">
+            {leftHeader}
+            {leftPaneView === 'class' ? classPane : <div>{`work:${assignmentId}:${studentId}`}</div>}
+          </div>
+          <div data-testid="assignment-right-pane">
+            <div>{`grading:${assignmentId}:${studentId}`}</div>
+          </div>
+        </div>
+      )
+    }
 
     return (
       <div
@@ -426,16 +464,17 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.getByRole('button', { name: 'New assignment' })).toBeInTheDocument()
-    expect(screen.getByTestId('assignment-summary-actionbar-center')).toHaveClass('justify-center')
+    expect(screen.getByTestId('assignment-summary-actionbar-center')).toHaveClass('grid')
+    expect(screen.getByText('Assignments')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
 
-    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
     expect(onEditModeChange).toHaveBeenLastCalledWith(true)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
   })
@@ -453,15 +492,14 @@ describe('TeacherClassroomView', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
     })
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
   })
 
   it('opens the assignment editor from summary cards while edit mode is active', async () => {
@@ -526,7 +564,7 @@ describe('TeacherClassroomView', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
 
     rerender(
       <TeacherClassroomView
@@ -537,9 +575,8 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
     })
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
 
@@ -663,7 +700,7 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     const replaceCall = updateSearchParams.mock.calls.find((call) => call[1]?.replace === true)
@@ -733,7 +770,7 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     updateSearchParams.mockClear()
@@ -786,7 +823,7 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     act(() => {
@@ -809,11 +846,11 @@ describe('TeacherClassroomView', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-2:student-2')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-2:student-2')
     })
   })
 
-  it('renders class-mode actions in the selected-assignment action bar without duplicating them in the table', async () => {
+  it('renders the class-individual switch and grading split button in the selected-assignment action bar', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -842,11 +879,15 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
+    const workspaceControls = within(screen.getByRole('group', { name: 'Assignment workspace view' }))
+    expect(workspaceControls.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
+    expect(workspaceControls.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByRole('group', { name: 'Left pane view' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('group', { name: 'Right pane view' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
     expect(screen.getByText('Assignment One')).toBeInTheDocument()
@@ -1187,17 +1228,18 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Individual' }))
+    fireEvent.click(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' }))
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('details:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('work:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.queryByRole('button', { name: /AI Grade/i })).not.toBeInTheDocument()
+    expect(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()
     expect(screen.getByText('student-1 Student')).toBeInTheDocument()
     await waitFor(() => {
@@ -1205,6 +1247,49 @@ describe('TeacherClassroomView', () => {
     })
     expect(screen.getByRole('button', { name: 'Previous student' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next student' })).toBeInTheDocument()
+  })
+
+  it('keeps the right pane on grading when switching the action bar view control', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    fireEvent.click(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('work:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    expect(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('student-1 Student')).toBeInTheDocument()
   })
 
   it('keeps class mode active when clicking a student row', async () => {
@@ -1260,17 +1345,58 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     fireEvent.click(screen.getAllByText('student-2')[0])
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-2')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-2')
     })
 
-    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
+    const leftPaneControls = within(screen.getByRole('group', { name: 'Assignment workspace view' }))
+    expect(leftPaneControls.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
+    expect(leftPaneControls.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('keeps the active student selected when Escape is pressed in class mode', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+    expect(screen.getByText('student-1')).toBeInTheDocument()
   })
 
   it('resumes an active assignment AI grading run and reports the final counts', async () => {
@@ -1760,7 +1886,7 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     const returnButton = screen.getByRole('button', { name: /Return/i })
@@ -1894,7 +2020,7 @@ describe('TeacherClassroomView', () => {
     render(<TeacherClassroomView classroom={classroom} />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('overview:assignment-1:student-1')
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Return/i }))

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -13,6 +13,7 @@ const mockSetSelection = vi.fn()
 const mockShowMessage = vi.fn()
 const mockUseOverlayMessage = vi.fn()
 const mockIsVisibleAtNow = vi.fn(() => true)
+const mockUpdateModeLayout = vi.fn()
 const mockStudentSelectionState = {
   selectedIds: new Set<string>(),
   allSelected: false,
@@ -154,6 +155,8 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
     classPane,
     leftPaneView = 'class',
     leftHeader,
+    inspectorWidth,
+    onLayoutChange,
     onDetailsMetaChange,
     onGradeTemplateChange,
     highlightedInspectorSections = [],
@@ -187,6 +190,13 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
           data-testid="teacher-work-panel"
           data-highlighted-sections={highlightedInspectorSections.join(',')}
         >
+          <div data-testid="assignment-workspace-inspector-width">{inspectorWidth}</div>
+          <button
+            type="button"
+            onClick={() => onLayoutChange?.({ inspectorCollapsed: false, inspectorWidth: 61 })}
+          >
+            Mock resize split
+          </button>
           <div>{`overview:${assignmentId}:${studentId}`}</div>
           <div data-testid="assignment-left-pane">
             {leftHeader}
@@ -254,9 +264,9 @@ vi.mock('@/hooks/use-assignment-grading-layout', () => ({
   useAssignmentGradingLayout: () => ({
     layout: {
       overview: { inspectorCollapsed: false, inspectorWidth: 50 },
-      details: { inspectorCollapsed: false, inspectorWidth: 50 },
+      details: { inspectorCollapsed: false, inspectorWidth: 64 },
     },
-    updateModeLayout: vi.fn(),
+    updateModeLayout: mockUpdateModeLayout,
   }),
 }))
 
@@ -409,6 +419,7 @@ describe('TeacherClassroomView', () => {
     mockShowMessage.mockReset()
     mockUseOverlayMessage.mockReset()
     mockIsVisibleAtNow.mockReset()
+    mockUpdateModeLayout.mockReset()
     mockIsVisibleAtNow.mockReturnValue(true)
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
@@ -1238,6 +1249,13 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
+    expect(screen.getByTestId('assignment-workspace-inspector-width')).toHaveTextContent('64')
+    fireEvent.click(screen.getByRole('button', { name: 'Mock resize split' }))
+
+    expect(mockUpdateModeLayout).toHaveBeenCalledWith('details', {
+      inspectorCollapsed: false,
+      inspectorWidth: 61,
+    })
     expect(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()

--- a/tests/components/TeacherEditModeControls.test.tsx
+++ b/tests/components/TeacherEditModeControls.test.tsx
@@ -40,7 +40,7 @@ describe('TeacherEditModeControls', () => {
   it('renders active state with edit-only children', () => {
     renderControls({ active: true })
 
-    const toggle = screen.getByRole('button', { name: 'Done' })
+    const toggle = screen.getByRole('button', { name: 'Edit' })
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument()
   })
@@ -63,6 +63,6 @@ describe('TeacherEditModeControls', () => {
       </TooltipProvider>,
     )
 
-    expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
   })
 })

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -34,6 +34,22 @@ vi.mock('@/components/HistoryList', () => ({
 
 vi.mock('@/ui', () => ({
   Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  SegmentedControl: ({ ariaLabel, value, options, onChange, testId }: any) => (
+    <div role="group" aria-label={ariaLabel} data-testid={testId}>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          disabled={option.disabled}
+          aria-pressed={option.value === value}
+          aria-label={option.label}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
   Tooltip: ({ children }: any) => <>{children}</>,
 }))
 

--- a/tests/components/TeacherWorkSurfaceShell.test.tsx
+++ b/tests/components/TeacherWorkSurfaceShell.test.tsx
@@ -50,7 +50,7 @@ describe('TeacherWorkSurfaceShell', () => {
     expect(frame).toHaveClass('rounded-b-lg', 'border', 'border-border', 'bg-surface')
   })
 
-  it('supports standalone selected-workspace frames for non-tabbed workspaces', () => {
+  it('supports standalone selected-workspace frames with standard page gutters', () => {
     render(
       <TeacherWorkSurfaceShell
         state="workspace"
@@ -64,6 +64,9 @@ describe('TeacherWorkSurfaceShell', () => {
     const frame = screen.getByText('Gradebook table').parentElement?.parentElement
     expect(frame).toHaveClass('rounded-lg', 'border', 'border-border', 'bg-surface')
     expect(frame).not.toHaveClass('rounded-b-lg')
+    const content = frame?.parentElement
+    expect(content).toHaveClass('px-3', 'pt-2', 'flex-1')
+    expect(content).not.toHaveClass('px-0', 'pt-0')
   })
 
   it('keeps workspace children mounted across non-destructive shell updates', () => {

--- a/tests/components/TeacherWorkspaceSplit.test.tsx
+++ b/tests/components/TeacherWorkspaceSplit.test.tsx
@@ -110,4 +110,51 @@ describe('TeacherWorkspaceSplit', () => {
     expect(onInspectorWidthChange).toHaveBeenNthCalledWith(2, 58)
     rectSpy.mockRestore()
   })
+
+  it('renders the shared gapped split variant for Daily-style panes', () => {
+    render(
+      <TeacherWorkspaceSplit
+        splitVariant="gapped"
+        primary={<div>Daily table</div>}
+        inspector={<div>Log summary</div>}
+        inspectorWidth={50}
+        inspectorCollapsed={false}
+        onInspectorWidthChange={vi.fn()}
+        primaryClassName="rounded-lg bg-surface"
+        inspectorClassName="rounded-lg bg-surface"
+        minInspectorPercent={28}
+        maxInspectorPercent={72}
+        dividerLabel="Resize Daily panes"
+      />,
+    )
+
+    const separator = screen.getByRole('separator', { name: 'Resize Daily panes' })
+    expect(screen.getByText('Daily table')).toBeInTheDocument()
+    expect(screen.getByText('Log summary')).toBeInTheDocument()
+    expect(separator).toHaveAttribute('aria-valuemin', '28')
+    expect(separator).toHaveAttribute('aria-valuemax', '72')
+  })
+
+  it('supports keyboard resizing for the shared resize handle', () => {
+    const onInspectorWidthChange = vi.fn()
+
+    render(
+      <TeacherWorkspaceSplit
+        primary={<div>Student table</div>}
+        inspector={<div>Inspector pane</div>}
+        inspectorWidth={50}
+        inspectorCollapsed={false}
+        onInspectorWidthChange={onInspectorWidthChange}
+        minInspectorPercent={28}
+        maxInspectorPercent={72}
+        dividerLabel="Resize panes"
+      />,
+    )
+
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize panes' }), { key: 'ArrowLeft' })
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize panes' }), { key: 'Enter' })
+
+    expect(onInspectorWidthChange).toHaveBeenNthCalledWith(1, 55)
+    expect(onInspectorWidthChange).toHaveBeenNthCalledWith(2, 50)
+  })
 })

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -22,10 +22,10 @@ describe('LEFT_SIDEBAR constants', () => {
 })
 
 describe('getLayoutConfig', () => {
-  it('should return config for valid route keys', () => {
+  it('should return disabled right sidebar for integrated attendance workspace', () => {
     const config = getLayoutConfig('attendance')
     expect(config).toBeDefined()
-    expect(config.rightSidebar.enabled).toBe(true)
+    expect(config.rightSidebar.enabled).toBe(false)
     expect(config.mainContent.maxWidth).toBe('full')
   })
 


### PR DESCRIPTION
## Summary

- Refines the teacher work-surface shell and selected Assignment workspace action bar from the PR 524 direction.
- Moves Daily onto the shared teacher work-surface shell with an internal two-pane log summary split.
- Extends `TeacherWorkspaceSplit` with a reusable `gapped` variant and uses it for both Daily and Assignment selected workspaces.
- Reuses the Calendar date navigator in Daily and documents the reusable selected-workspace shell template for future tabs like Quizzes and Tests.

## Validation

- `pnpm lint`
- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`
- `pnpm vitest run tests/unit/layout-config.test.ts tests/components/TeacherWorkspaceSplit.test.tsx tests/components/WorkspaceSplitPane.test.tsx tests/components/SummaryDetailWorkspaceShell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm vitest run tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkspaceSplit.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx`
- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`
- Pika UI verification for Daily, Calendar, Assignment summary, and selected Assignment on `http://localhost:3002`
- Drag probes verified Daily and Assignment panes resize through the shared split handle