### PR TITLE
[codex] Align teacher work surfaces across tabs

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10515,3 +10515,23 @@
 - `git diff --check`
 - Visual screenshot reviewed:
   - `/tmp/pika-daily-title-floating-date-fab.png`
+
+## 2026-05-03 - Quizzes shell alignment
+
+**Completed:**
+- Applied the shared teacher work-surface shell convention to Quizzes.
+- Moved Quizzes summary and selected quiz titles into the global app-header title slot.
+- Moved Quizzes summary and selected quiz actions into the shared floating center action cluster.
+- Removed the selected quiz workspace border frame and tightened mobile header truncation so the centered title does not overlap the classroom selector.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=quizzes`.
+- Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=quizzes&quizId=1cf70f6b-9b78-4cad-8ce5-26fd7da9fdb9`.
+- Visual screenshots reviewed:
+  - `/tmp/pika-quizzes-summary-teacher.png`
+  - `/tmp/pika-quizzes-selected-teacher.png`
+  - `/tmp/pika-quizzes-summary-teacher-mobile.png`
+  - `/tmp/pika-quizzes-selected-teacher-mobile.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10475,3 +10475,29 @@
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
   - `/tmp/pika-teacher-mobile.png`
+
+## 2026-05-02 - Assessment tab shell follow-ups
+
+**Completed:**
+- Applied the teacher work-surface shell and gapped split shape to Tests.
+- Standardized assignment, quiz, and test list cards through shared teacher
+  work-item primitives.
+- Moved Assignments and selected assignment/test titles into the global app
+  header title slot.
+- Added a shared floating center action cluster and used it for Assignments
+  summary controls, selected assignment controls, and selected test controls.
+- Consolidated selected Tests grading actions into the center split button.
+- Updated teacher work-surface guidance for title placement, floating actions,
+  and list/card reuse.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm lint`
+- `git diff --check`
+- `pnpm vitest run tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherWorkItemPrimitives.test.tsx tests/ui/SplitButton.test.tsx`
+- `pnpm vitest run tests/components/TeacherEditModeControls.test.tsx`
+- Visual screenshots reviewed:
+  - `/tmp/pika-assignments-summary-fab-standard-height.png`
+  - `/tmp/pika-assignments-fab-centered-actionbar.png`
+  - `/tmp/pika-selected-assignment-edit-in-fab.png`
+  - `/tmp/pika-tests-grading-floating-cluster-menu.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10501,3 +10501,17 @@
   - `/tmp/pika-assignments-fab-centered-actionbar.png`
   - `/tmp/pika-selected-assignment-edit-in-fab.png`
   - `/tmp/pika-tests-grading-floating-cluster-menu.png`
+
+## 2026-05-02 - Daily title and floating action alignment
+
+**Completed:**
+- Applied the latest assignment shell convention to Daily.
+- Moved the Daily label into the global app-header title slot.
+- Moved Daily's date navigator into the shared floating center action cluster.
+
+**Validation:**
+- `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherWorkspaceSplit.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Visual screenshot reviewed:
+  - `/tmp/pika-daily-title-floating-date-fab.png`

--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10535,3 +10535,19 @@
   - `/tmp/pika-quizzes-selected-teacher.png`
   - `/tmp/pika-quizzes-summary-teacher-mobile.png`
   - `/tmp/pika-quizzes-selected-teacher-mobile.png`
+
+## 2026-05-03 - Tests preview save guard follow-up
+
+**Completed:**
+- Fixed the Tests Preview menu path so an open editor owns preview requests and
+  force-saves the current draft before showing preview.
+- Guarded `QuizDetailPanel` autosave completion with a draft revision so stale
+  in-flight saves cannot publish `saved` over newer local edits.
+- Kept pending markdown state active while a selected test is in grading mode,
+  since authoring now lives in the edit modal.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/api/teacher/tests-draft-route.test.ts`
+- `pnpm lint`
+- `git diff --check`
+- `pnpm build`

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -262,6 +262,13 @@ an older joined split is explicitly desired.
 - They should replace, not duplicate, top workspace tabs.
 - Keep batch or grading actions in the same action cluster when they apply to
   the selected workspace.
+- Summary states should put the tab label, such as `Assignments`, in the global
+  app-header title slot instead of duplicating it in the page action bar.
+- In selected workspaces, place the selected item title in the global app-header
+  title slot rather than inside the page action bar.
+- Render central summary or selected-workspace actions through the floating
+  center action cluster so the controls stay anchored under the app header while
+  the teacher scrolls the workspace.
 - The assignment pane-toggle implementation is an experimental assignment-led
   pattern until promoted after visual and workflow review.
 

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -499,6 +499,10 @@ function ClassroomPageContent({
   const selectedWorkTitle = useMemo(() => {
     if (!isTeacher) return undefined
 
+    if (activeTab === 'attendance') {
+      return 'Daily'
+    }
+
     if (activeTab === 'assignments') {
       return assignmentViewMode === 'assignment'
         ? selectedAssignment?.title || 'Assignments'

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1142,6 +1142,7 @@ function ClassroomPageContent({
                         selectedTestStudentId={testStudentIdParam}
                         updateSearchParams={navigateInClassroom}
                         onSelectTest={handleSelectQuiz}
+                        onRequestTestPreview={setTeacherTestPreview}
                         onRequestDelete={() => {
                           void handleRequestAssessmentDelete()
                         }}

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -515,8 +515,10 @@ function ClassroomPageContent({
         : 'Quizzes'
     }
 
-    if (activeTab === 'tests' && testIdParam && selectedQuiz?.id === testIdParam) {
-      return selectedQuiz.title
+    if (activeTab === 'tests') {
+      return testIdParam && selectedQuiz?.id === testIdParam
+        ? selectedQuiz.title
+        : 'Tests'
     }
 
     return undefined

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -496,6 +496,29 @@ function ClassroomPageContent({
     }
   }, [])
 
+  const selectedWorkTitle = useMemo(() => {
+    if (!isTeacher) return undefined
+
+    if (activeTab === 'assignments') {
+      return assignmentViewMode === 'assignment'
+        ? selectedAssignment?.title || 'Assignments'
+        : 'Assignments'
+    }
+
+    if (activeTab === 'tests' && testIdParam && selectedQuiz?.id === testIdParam) {
+      return selectedQuiz.title
+    }
+
+    return undefined
+  }, [
+    activeTab,
+    assignmentViewMode,
+    isTeacher,
+    selectedAssignment?.title,
+    selectedQuiz,
+    testIdParam,
+  ])
+
   // Load assignments and generate markdown content
   const loadAssignmentsMarkdown = useCallback(async () => {
     if (abortControllerRef.current) {
@@ -1016,6 +1039,7 @@ function ClassroomPageContent({
       onNavigateClassroom={handleClassroomNavigationAttempt}
       mainClassName="max-w-none px-0 py-0"
       examModeHeader={examHeaderData}
+      pageTitle={selectedWorkTitle}
     >
       <ThreePanelShell leftWidthOverride={hideLeftRailForExamMode ? 0 : undefined}>
         {hideLeftRailForExamMode ? (

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -509,6 +509,12 @@ function ClassroomPageContent({
         : 'Assignments'
     }
 
+    if (activeTab === 'quizzes') {
+      return quizIdParam && selectedQuiz?.id === quizIdParam
+        ? selectedQuiz.title
+        : 'Quizzes'
+    }
+
     if (activeTab === 'tests' && testIdParam && selectedQuiz?.id === testIdParam) {
       return selectedQuiz.title
     }
@@ -518,6 +524,7 @@ function ClassroomPageContent({
     activeTab,
     assignmentViewMode,
     isTeacher,
+    quizIdParam,
     selectedAssignment?.title,
     selectedQuiz,
     testIdParam,

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -278,11 +278,6 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
-      label={
-        <div className="truncate px-1 text-sm font-semibold text-text-default">
-          Daily
-        </div>
-      }
       center={
         <>
           <input
@@ -304,6 +299,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
           />
         </>
       }
+      centerPlacement="floating"
     />
   )
 

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -30,7 +30,7 @@ import {
   User,
   Users,
 } from 'lucide-react'
-import { ConfirmDialog, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -46,12 +46,10 @@ import {
 } from '@/components/TeacherStudentWorkPanel'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
-  ACTIONBAR_BUTTON_PRIMARY_CLASSNAME,
-  ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME,
-  PageStack,
 } from '@/components/PageLayout'
 import {
   calculateAssignmentStatus,
@@ -583,6 +581,9 @@ export function TeacherClassroomView({
   }, [assignmentAiGradingRun, selection])
   const activeAssignmentAiRunId = activeAssignmentAiRun?.id ?? null
   const hasActiveAssignmentAiRun = isAssignmentAiGradingRunActive(activeAssignmentAiRun)
+  const selectedAssignmentSummary = selection.mode === 'assignment'
+    ? assignments.find((item) => item.id === selection.assignmentId) ?? null
+    : null
 
   // Notify parent about selected assignment for sidebar
   useEffect(() => {
@@ -594,10 +595,18 @@ export function TeacherClassroomView({
         title: assignment.title,
         instructions: assignment.instructions_markdown || assignment.rich_instructions || assignment.description,
       })
+    } else if (selectedAssignmentSummary) {
+      onSelectAssignment?.({
+        title: selectedAssignmentSummary.title,
+        instructions:
+          selectedAssignmentSummary.instructions_markdown ||
+          selectedAssignmentSummary.rich_instructions ||
+          selectedAssignmentSummary.description,
+      })
     } else {
       onSelectAssignment?.(null)
     }
-  }, [activeSelectedAssignmentData, onSelectAssignment, selection.mode])
+  }, [activeSelectedAssignmentData, onSelectAssignment, selectedAssignmentSummary, selection.mode])
 
   // Notify parent of view mode changes
   useEffect(() => {
@@ -1340,13 +1349,6 @@ export function TeacherClassroomView({
 
   const canEditAssignment =
     selection.mode === 'assignment' && !!activeSelectedAssignmentData && !selectedAssignmentLoading && !isReadOnly
-  const selectedAssignmentSummary = selection.mode === 'assignment'
-    ? assignments.find((item) => item.id === selection.assignmentId) ?? null
-    : null
-  const selectedAssignmentTitle =
-    activeSelectedAssignmentData?.assignment.title ??
-    selectedAssignmentSummary?.title ??
-    'Assignment'
   const selectedStudentDisplayName =
     individualHeaderMeta?.studentName ?? getStudentDisplayName(selectedStudentRow)
   const individualCharacterCountLabel =
@@ -1582,11 +1584,11 @@ export function TeacherClassroomView({
     </div>
   ) : null
 
-  const workspaceTitleControl = assignmentEditMode ? (
+  const editSelectedAssignmentAction = selection.mode === 'assignment' ? (
     <Tooltip content="Edit assignment">
       <button
         type="button"
-        className={`${ACTIONBAR_ICON_BUTTON_WIDE_CLASSNAME} inline-flex w-full max-w-[22rem] items-center gap-2 overflow-hidden`}
+        className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
         onClick={() => {
           if (activeSelectedAssignmentData) {
             setEditAssignment(activeSelectedAssignmentData.assignment)
@@ -1594,26 +1596,28 @@ export function TeacherClassroomView({
         }}
         disabled={!canEditAssignment}
         aria-label="Edit assignment"
-        title={selectedAssignmentTitle}
+        title="Edit assignment"
       >
-        <span className="truncate">{selectedAssignmentTitle}</span>
-        <Pencil className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <Pencil className="h-4 w-4" aria-hidden="true" />
       </button>
     </Tooltip>
-  ) : (
-    <div
-      className="inline-flex min-h-10 w-full max-w-[22rem] items-center overflow-hidden px-2 text-sm font-medium text-text-default"
-      title={selectedAssignmentTitle}
-    >
-      <span className="truncate">{selectedAssignmentTitle}</span>
-    </div>
-  )
+  ) : null
 
   const assignmentEditControls = (
     <TeacherEditModeControls
       active={assignmentEditMode}
       onActiveChange={setAssignmentEditMode}
       disabled={isReadOnly}
+    >
+      {editSelectedAssignmentAction}
+    </TeacherEditModeControls>
+  )
+  const assignmentSummaryEditControls = (
+    <TeacherEditModeControls
+      active={assignmentEditMode}
+      onActiveChange={setAssignmentEditMode}
+      disabled={isReadOnly}
+      variant="secondary"
     />
   )
 
@@ -1638,6 +1642,7 @@ export function TeacherClassroomView({
         ]}
       />
       {classPaneActions}
+      {assignmentEditControls}
       {workspaceStatus}
     </div>
   ) : null
@@ -1646,30 +1651,28 @@ export function TeacherClassroomView({
     selection.mode === 'summary' ? (
       <TeacherWorkSurfaceActionBar
         testId="assignment-summary-actionbar-center"
-        label={
-          <div className="truncate px-1 text-sm font-semibold text-text-default">
-            Assignments
+        center={
+          <div className="flex items-center justify-center gap-1.5">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => setIsCreateModalOpen(true)}
+              disabled={isReadOnly}
+              aria-label="New assignment"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span>New</span>
+            </Button>
+            {assignmentSummaryEditControls}
           </div>
         }
-        center={
-          <button
-            type="button"
-            className={`${ACTIONBAR_BUTTON_PRIMARY_CLASSNAME} flex items-center gap-1`}
-            onClick={() => setIsCreateModalOpen(true)}
-            disabled={isReadOnly}
-            aria-label="New assignment"
-          >
-            <Plus className="h-5 w-5" aria-hidden="true" />
-            <span>New</span>
-          </button>
-        }
-        trailing={assignmentEditControls}
+        centerPlacement="floating"
       />
     ) : (
       <TeacherWorkSurfaceActionBar
-        label={workspaceTitleControl}
         center={assignmentWorkspaceControls}
-        trailing={assignmentEditControls}
+        centerPlacement="floating"
       />
     )
 
@@ -1703,7 +1706,7 @@ export function TeacherClassroomView({
         items={assignments.map((assignment) => assignment.id)}
         strategy={verticalListSortingStrategy}
       >
-        <PageStack>
+        <TeacherWorkItemList>
           {assignments.map((assignment) => (
             <SortableAssignmentCard
               key={assignment.id}
@@ -1722,7 +1725,7 @@ export function TeacherClassroomView({
               onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
             />
           ))}
-        </PageStack>
+        </TeacherWorkItemList>
       </SortableContext>
     </DndContext>
   )

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -7,6 +7,7 @@ import { QuizModal } from '@/components/QuizModal'
 import { QuizCard } from '@/components/QuizCard'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { Button, EmptyState } from '@/ui'
@@ -188,30 +189,39 @@ export function TeacherQuizzesTab({
   }
 
   const primaryContent = selectedQuizWorkspace ? (
-    <div className="flex min-w-0 flex-wrap items-center gap-2">
-      <div className="min-w-0 flex-1">
-        <h2 className="truncate text-sm font-semibold text-text-default" title={selectedQuizWorkspace.title}>
-          {selectedQuizWorkspace.title}
-        </h2>
-      </div>
-      {onRequestDelete ? (
+    <TeacherWorkSurfaceActionBar
+      center={
+        onRequestDelete ? (
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            onClick={onRequestDelete}
+            disabled={isReadOnly}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete Quiz
+          </Button>
+        ) : null
+      }
+      centerPlacement="floating"
+    />
+  ) : (
+    <TeacherWorkSurfaceActionBar
+      center={
         <Button
-          type="button"
-          variant="danger"
+          onClick={handleNewQuiz}
+          variant="primary"
           size="sm"
-          onClick={onRequestDelete}
+          className="gap-1.5"
           disabled={isReadOnly}
         >
-          <Trash2 className="h-4 w-4" />
-          Delete Quiz
+          <Plus className="h-4 w-4" />
+          New Quiz
         </Button>
-      ) : null}
-    </div>
-  ) : (
-    <Button onClick={handleNewQuiz} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
-      <Plus className="h-4 w-4" />
-      New Quiz
-    </Button>
+      }
+      centerPlacement="floating"
+    />
   )
 
   const summaryContent = loading ? (
@@ -274,6 +284,7 @@ export function TeacherQuizzesTab({
         summary={summaryContent}
         workspace={workspaceContent}
         workspaceFrame="standalone"
+        workspaceFrameClassName="min-h-[360px] border-0 bg-page"
       />
 
       <QuizModal

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizCard } from '@/components/QuizCard'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
-import { PageStack } from '@/components/PageLayout'
+import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { Button, EmptyState } from '@/ui'
@@ -226,7 +226,7 @@ export function TeacherQuizzesTab({
       className="mx-auto w-full max-w-3xl"
     />
   ) : (
-    <PageStack className="w-full">
+    <TeacherWorkItemList>
       {quizzes.map((quiz) => (
         <QuizCard
           key={quiz.id}
@@ -240,7 +240,7 @@ export function TeacherQuizzesTab({
           }}
         />
       ))}
-    </PageStack>
+    </TeacherWorkItemList>
   )
 
   const workspaceContent = selectedQuizWorkspace ? (

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Check, ClockAlert, LogOut, Play, Plus, Send, Square, Trash2 } from 'lucide-react'
+import { Check, ClockAlert, ExternalLink, FileText, LogOut, Pencil, Play, Plus, Send, Square, Trash2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
@@ -84,6 +84,7 @@ interface TestGradingQuestionSummary {
 
 type WorkspaceState = 'list' | 'selected'
 type WorkspaceTab = 'authoring' | 'grading'
+type TestEditModalView = 'edit' | 'markdown'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
 const GRADING_POLL_INTERVAL_MS = 15_000
@@ -226,7 +227,7 @@ export function TeacherTestsTab({
     selectedTestId: string | null
   }>({
     workspaceState: 'list',
-    selectedWorkspaceTab: 'authoring',
+    selectedWorkspaceTab: 'grading',
     selectedTestId: null,
   })
   const latestGradingRequestIdRef = useRef(0)
@@ -235,13 +236,14 @@ export function TeacherTestsTab({
   const [tests, setTests] = useState<QuizWithStats[]>([])
   const { showMessage } = useAppMessage()
   const [loading, setLoading] = useState(true)
-  const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('authoring')
+  const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('grading')
   const [internalSelectedTestId, setInternalSelectedTestId] = useState<string | null>(null)
   const [selectedTestDraftSummary, setSelectedTestDraftSummary] = useState<AssessmentEditorSummaryUpdate | null>(null)
   const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [showModal, setShowModal] = useState(false)
+  const [showEditModal, setShowEditModal] = useState(false)
+  const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
-  const [testPreviewRequestToken, setTestPreviewRequestToken] = useState(0)
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
   const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
@@ -268,7 +270,7 @@ export function TeacherTestsTab({
   const selectedTestId =
     selectedTestIdProp !== undefined ? selectedTestIdProp : internalSelectedTestId
   const selectedWorkspaceTab =
-    selectedTestMode === 'authoring' || selectedTestMode === 'grading'
+    selectedTestMode === 'grading'
       ? selectedTestMode
       : internalSelectedWorkspaceTab
   const selectedStudentId =
@@ -375,15 +377,15 @@ export function TeacherTestsTab({
     options?: UpdateSearchOptions,
   ) => {
     setInternalSelectedTestId(next.testId)
-    setInternalSelectedWorkspaceTab(next.mode === 'grading' ? 'grading' : 'authoring')
+    setInternalSelectedWorkspaceTab('grading')
     setInternalSelectedStudentId(next.studentId ?? null)
 
     updateSearchParams?.((params) => {
       params.set('tab', 'tests')
       if (next.testId) {
         params.set('testId', next.testId)
-        params.set('testMode', next.mode === 'grading' ? 'grading' : 'authoring')
-        if (next.mode === 'grading' && next.studentId) {
+        params.set('testMode', 'grading')
+        if (next.studentId) {
           params.set('testStudentId', next.studentId)
         } else {
           params.delete('testStudentId')
@@ -399,14 +401,6 @@ export function TeacherTestsTab({
   const clearTestWorkspace = useCallback((options?: UpdateSearchOptions) => {
     navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
   }, [navigateTestWorkspace])
-
-  const switchTestWorkspaceMode = useCallback((nextMode: WorkspaceTab) => {
-    if (!selectedTestId) return
-    navigateTestWorkspace(
-      { testId: selectedTestId, mode: nextMode, studentId: null },
-      { replace: true },
-    )
-  }, [navigateTestWorkspace, selectedTestId])
 
   const selectGradingStudent = useCallback((studentId: string | null) => {
     setInternalSelectedStudentId(studentId)
@@ -612,7 +606,9 @@ export function TeacherTestsTab({
     if (!pendingCreatedTestId) return
     if (!tests.some((test) => test.id === pendingCreatedTestId)) return
 
-    navigateTestWorkspace({ testId: pendingCreatedTestId, mode: 'authoring', studentId: null })
+    navigateTestWorkspace({ testId: pendingCreatedTestId, mode: 'grading', studentId: null })
+    setTestEditModalView('edit')
+    setShowEditModal(true)
     setPendingCreatedTestId(null)
   }, [navigateTestWorkspace, pendingCreatedTestId, tests])
 
@@ -917,11 +913,20 @@ export function TeacherTestsTab({
   }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
   function handleOpenTest(test: QuizWithStats) {
-    navigateTestWorkspace({ testId: test.id, mode: 'authoring', studentId: null })
+    navigateTestWorkspace({ testId: test.id, mode: 'grading', studentId: null })
     setGradingError('')
     setGradingWarning('')
     setGradingInfo('')
     clearBatchSelection()
+  }
+
+  function handlePreviewSelectedTest() {
+    if (!selectedTestId) return
+    const previewWindow = window.open(
+      `/classrooms/${classroom.id}/tests/${selectedTestId}/preview`,
+      '_blank',
+    )
+    previewWindow?.focus()
   }
 
   function handleNewTest() {
@@ -1176,8 +1181,7 @@ export function TeacherTestsTab({
     return { valid: true }
   }
 
-  const returnWillCloseActiveTest =
-    selectedWorkspaceTab === 'grading' && selectedTestWorkspace?.status === 'active'
+  const returnWillCloseActiveTest = selectedTestWorkspace?.status === 'active'
   const selectedActivation = selectedTestWorkspace
     ? validateSelectedTestActivation(selectedTestWorkspace.stats.questions_count || 0)
     : { valid: false }
@@ -1400,77 +1404,82 @@ export function TeacherTestsTab({
     </div>
   )
 
-  const workspaceModeCenter = selectedWorkspaceTab === 'authoring' ? (
-    <>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={() => setTestPreviewRequestToken((value) => value + 1)}
-        disabled={hasPendingMarkdownImport}
-      >
-        Preview
-      </Button>
-      {selectedTestWorkspace?.status === 'draft' ? (
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            void handleRequestSelectedTestActivate()
-          }}
-          disabled={
-            !selectedActivation.valid ||
-            isReadOnly ||
-            statusUpdating ||
-            checkingActivation ||
-            hasPendingMarkdownImport
-          }
-        >
-          <Play className="h-4 w-4" />
-          Open
-        </Button>
-      ) : null}
-      {selectedTestWorkspace?.status === 'active' ? (
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => setShowCloseConfirm(true)}
-          disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
-        >
-          <Square className="h-4 w-4" />
-          Close
-        </Button>
-      ) : null}
-      {selectedTestWorkspace?.status === 'closed' ? (
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => {
+  const selectedTestLifecycleAction = selectedTestWorkspace?.status === 'active'
+    ? {
+        label: 'Close',
+        icon: <Square className="h-4 w-4" aria-hidden="true" />,
+        onPrimaryClick: () => setShowCloseConfirm(true),
+        disabled: isReadOnly || statusUpdating || hasPendingMarkdownImport,
+      }
+    : {
+        label: 'Open',
+        icon: <Play className="h-4 w-4" aria-hidden="true" />,
+        onPrimaryClick: () => {
+          if (selectedTestWorkspace?.status === 'closed') {
             void handleSelectedTestStatusChange('active')
-          }}
-          disabled={isReadOnly || statusUpdating || hasPendingMarkdownImport}
-        >
-          <Play className="h-4 w-4" />
-          Reopen
-        </Button>
-      ) : null}
-      {onRequestDelete ? (
-        <Button
-          type="button"
-          variant="danger"
-          size="sm"
-          onClick={onRequestDelete}
-          disabled={isReadOnly}
-        >
-          <Trash2 className="h-4 w-4" />
-          Delete
-        </Button>
-      ) : null}
-    </>
-  ) : (
+            return
+          }
+          void handleRequestSelectedTestActivate()
+        },
+        disabled:
+          !selectedTestWorkspace ||
+          (selectedTestWorkspace.status === 'draft' && !selectedActivation.valid) ||
+          isReadOnly ||
+          statusUpdating ||
+          checkingActivation ||
+          hasPendingMarkdownImport,
+      }
+
+  const selectedTestLifecycleSplit = selectedTestWorkspace ? (
+    <SplitButton
+      label={
+        <span className="inline-flex items-center gap-2">
+          {selectedTestLifecycleAction.icon}
+          <span>{selectedTestLifecycleAction.label}</span>
+        </span>
+      }
+      onPrimaryClick={selectedTestLifecycleAction.onPrimaryClick}
+      options={[
+        {
+          id: 'preview',
+          label: (
+            <span className="inline-flex items-center gap-2">
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              <span>Preview</span>
+            </span>
+          ),
+          onSelect: handlePreviewSelectedTest,
+          disabled: hasPendingMarkdownImport,
+        },
+        ...(onRequestDelete
+          ? [
+              {
+                id: 'delete',
+                label: (
+                  <span className="inline-flex items-center gap-2 text-danger">
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    <span>Delete</span>
+                  </span>
+                ),
+                onSelect: onRequestDelete,
+                disabled: isReadOnly,
+              },
+            ]
+          : []),
+      ]}
+      variant="secondary"
+      size="sm"
+      className="inline-flex"
+      toggleAriaLabel="More test actions"
+      menuPlacement="down"
+      primaryButtonProps={{
+        'aria-label': `${selectedTestLifecycleAction.label} test`,
+        disabled: selectedTestLifecycleAction.disabled,
+      }}
+    />
+  ) : null
+
+  const gradingActions = (
     <SplitButton
       label={
         <span className="inline-flex items-center gap-2">
@@ -1564,6 +1573,27 @@ export function TeacherTestsTab({
       </span>
     ) : null
 
+  const selectedWorkspaceControls = workspaceState === 'selected' ? (
+    <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          setTestEditModalView('edit')
+          setShowEditModal(true)
+        }}
+        disabled={!selectedTestWorkspace || isReadOnly}
+      >
+        <Pencil className="h-4 w-4" aria-hidden="true" />
+        Edit
+      </Button>
+      {selectedTestLifecycleSplit}
+      {gradingActions}
+      {workspaceModeStatus}
+    </div>
+  ) : null
+
   const activeTestGradingMessage =
     workspaceState === 'selected' && selectedWorkspaceTab === 'grading'
       ? hasActiveTestAiRun && activeTestAiRun
@@ -1611,54 +1641,37 @@ export function TeacherTestsTab({
     workspaceState,
   ])
 
-  const workspaceModeSwitcher = workspaceState === 'selected' ? (
-    <SegmentedControl<WorkspaceTab>
-      ariaLabel="Test workspace mode"
-      value={selectedWorkspaceTab}
-      onChange={switchTestWorkspaceMode}
-      capitalizeLabels
-      options={[
-        { value: 'authoring', label: 'Authoring' },
-        { value: 'grading', label: 'Grading' },
-      ]}
-    />
-  ) : null
-
   const primaryContent = workspaceState === 'selected' ? (
     <TeacherWorkSurfaceActionBar
-      center={
-        <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
-          {workspaceModeSwitcher}
-          {workspaceModeCenter}
-          {workspaceModeStatus}
-        </div>
-      }
+      center={selectedWorkspaceControls}
       centerPlacement="floating"
     />
   ) : (
     <TeacherWorkSurfaceActionBar
-      label={
-        <div className="truncate px-1 text-sm font-semibold text-text-default">
-          Tests
-        </div>
-      }
       center={
-        <Button onClick={handleNewTest} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
+        <Button
+          onClick={handleNewTest}
+          variant="primary"
+          size="sm"
+          className="gap-1.5"
+          disabled={isReadOnly}
+        >
           <Plus className="h-4 w-4" />
           New Test
         </Button>
       }
+      centerPlacement="floating"
     />
   )
 
   const feedback = (
     <>
-      {statusActionError && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+      {statusActionError && workspaceState === 'selected' ? (
         <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
           {statusActionError}
         </div>
       ) : null}
-      {hasPendingMarkdownImport && workspaceState === 'selected' && selectedWorkspaceTab === 'authoring' ? (
+      {hasPendingMarkdownImport && workspaceState === 'selected' ? (
         <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
           Apply or undo markdown changes before previewing or changing the test status.
         </div>
@@ -1710,28 +1723,6 @@ export function TeacherTestsTab({
     <div className="flex flex-1 justify-center py-12">
       <Spinner size="lg" />
     </div>
-  ) : selectedWorkspaceTab === 'authoring' ? (
-    <div className="flex min-h-0 flex-1 overflow-hidden rounded-lg bg-surface">
-      <QuizDetailPanel
-        quiz={selectedTest}
-        classroomId={classroom.id}
-        apiBasePath={apiBasePath}
-        onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
-        onQuizUpdate={(update) => {
-          if (update) {
-            applySelectedTestDraftSummary(update)
-            return
-          }
-          void loadTests()
-        }}
-        onPendingMarkdownImportChange={setHasPendingMarkdownImport}
-        showInlineDeleteAction={false}
-        testQuestionLayout="summary-detail"
-        showPreviewButton={false}
-        showResultsTab={false}
-        previewRequestToken={testPreviewRequestToken}
-      />
-    </div>
   ) : (
     <TeacherWorkspaceSplit
       className="flex-1"
@@ -1770,6 +1761,75 @@ export function TeacherTestsTab({
         onClose={() => setShowModal(false)}
         onSuccess={handleTestCreated}
       />
+
+      <DialogPanel
+        isOpen={showEditModal && !!selectedTestWorkspace}
+        onClose={() => {
+          setShowEditModal(false)
+          setTestEditModalView('edit')
+          setHasPendingMarkdownImport(false)
+        }}
+        ariaLabelledBy="test-edit-title"
+        maxWidth="max-w-6xl"
+        className="h-[85vh] overflow-hidden p-0"
+      >
+        <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+          <h2 id="test-edit-title" className="min-w-0 basis-full truncate text-base font-semibold text-text-default sm:basis-auto sm:flex-1">
+            {selectedTestWorkspace ? `Edit ${selectedTestWorkspace.title}` : 'Edit test'}
+          </h2>
+          <SegmentedControl<TestEditModalView>
+            ariaLabel="Test edit modal view"
+            value={testEditModalView}
+            onChange={setTestEditModalView}
+            options={[
+              {
+                value: 'edit',
+                label: 'Edit',
+                icon: <Pencil className="h-4 w-4" aria-hidden="true" />,
+              },
+              {
+                value: 'markdown',
+                label: 'Markdown',
+                icon: <FileText className="h-4 w-4" aria-hidden="true" />,
+              },
+            ]}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setShowEditModal(false)
+              setTestEditModalView('edit')
+              setHasPendingMarkdownImport(false)
+            }}
+          >
+            Close
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          {selectedTestWorkspace ? (
+            <QuizDetailPanel
+              quiz={selectedTestWorkspace}
+              classroomId={classroom.id}
+              apiBasePath={apiBasePath}
+              onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
+              onQuizUpdate={(update) => {
+                if (update) {
+                  applySelectedTestDraftSummary(update)
+                  return
+                }
+                void loadTests()
+              }}
+              onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+              showInlineDeleteAction={false}
+              testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
+              showPreviewButton={false}
+              showResultsTab={false}
+            />
+          ) : null}
+        </div>
+      </DialogPanel>
 
       <DialogPanel
         isOpen={showBatchGradeModal}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -85,6 +85,7 @@ interface TestGradingQuestionSummary {
 type WorkspaceState = 'list' | 'selected'
 type WorkspaceTab = 'authoring' | 'grading'
 type TestEditModalView = 'edit' | 'markdown'
+type TestEditSaveStatus = 'saved' | 'saving' | 'unsaved'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
 const GRADING_POLL_INTERVAL_MS = 15_000
@@ -243,6 +244,7 @@ export function TeacherTestsTab({
   const [showModal, setShowModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
   const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
+  const [testEditSaveStatus, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
@@ -922,12 +924,17 @@ export function TeacherTestsTab({
 
   function handlePreviewSelectedTest() {
     if (!selectedTestId) return
+    if (hasPendingMarkdownImport || testEditSaveStatus !== 'saved') return
     const previewWindow = window.open(
       `/classrooms/${classroom.id}/tests/${selectedTestId}/preview`,
       '_blank',
     )
     previewWindow?.focus()
   }
+
+  useEffect(() => {
+    setTestEditSaveStatus('saved')
+  }, [selectedTestId])
 
   function handleNewTest() {
     setShowModal(true)
@@ -1449,7 +1456,7 @@ export function TeacherTestsTab({
             </span>
           ),
           onSelect: handlePreviewSelectedTest,
-          disabled: hasPendingMarkdownImport,
+          disabled: hasPendingMarkdownImport || testEditSaveStatus !== 'saved',
         },
         ...(onRequestDelete
           ? [
@@ -1822,6 +1829,7 @@ export function TeacherTestsTab({
                 void loadTests()
               }}
               onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+              onSaveStatusChange={setTestEditSaveStatus}
               showInlineDeleteAction={false}
               testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
               showPreviewButton={false}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -6,11 +6,11 @@ import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
 import { TeacherTestCard } from '@/components/TeacherTestCard'
-import { PageStack } from '@/components/PageLayout'
 import { AssessmentStatusIcon, type AssessmentStatusIconState } from '@/components/AssessmentStatusIcon'
 import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
-import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   TEACHER_QUIZZES_UPDATED_EVENT,
@@ -21,7 +21,7 @@ import { getQuizExitCount } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, RefreshingIndicator, Select, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, FormField, RefreshingIndicator, SegmentedControl, Select, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
   AssessmentWorkspaceSummaryPatch,
@@ -1178,7 +1178,6 @@ export function TeacherTestsTab({
 
   const returnWillCloseActiveTest =
     selectedWorkspaceTab === 'grading' && selectedTestWorkspace?.status === 'active'
-  const selectedTestTitle = selectedTestWorkspace?.title || 'Test'
   const selectedActivation = selectedTestWorkspace
     ? validateSelectedTestActivation(selectedTestWorkspace.stats.questions_count || 0)
     : { valid: false }
@@ -1472,60 +1471,77 @@ export function TeacherTestsTab({
       ) : null}
     </>
   ) : (
-    <>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={openBatchPromptGuidelineModal}
-        disabled={isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades}
-      >
-        AI Prompt
-      </Button>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={() => {
-          if (batchSelectedCount === 0) {
-            setGradingWarning('Select students to grade')
-            return
-          }
-          setShowBatchGradeModal(true)
-        }}
-        disabled={
-          batchSelectedCount === 0 ||
-          hasActiveTestAiRun ||
-          isBatchAutoGrading ||
-          isBatchReturning ||
-          isBatchClearingOpenGrades
+    <SplitButton
+      label={
+        <span className="inline-flex items-center gap-2">
+          <Check className="h-4 w-4" aria-hidden="true" />
+          <span>AI Grade</span>
+        </span>
+      }
+      onPrimaryClick={() => {
+        if (batchSelectedCount === 0) {
+          setGradingWarning('Select students to grade')
+          return
         }
-      >
-        <Check className="h-4 w-4" />
-        AI Grade
-      </Button>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={() => {
-          if (batchSelectedCount === 0) {
-            setGradingWarning('Select students to return')
-            return
-          }
-          setShowReturnConfirm(true)
-        }}
-        disabled={
-          batchSelectedCount === 0 ||
-          isBatchAutoGrading ||
-          isBatchReturning ||
-          isBatchClearingOpenGrades
-        }
-      >
-        <Send className="h-4 w-4" />
-        Return
-      </Button>
-    </>
+        setShowBatchGradeModal(true)
+      }}
+      options={[
+        {
+          id: 'ai-prompt',
+          label: 'AI Prompt',
+          onSelect: openBatchPromptGuidelineModal,
+          disabled: isBatchAutoGrading || isBatchReturning || isBatchClearingOpenGrades,
+        },
+        {
+          id: 'clear-open-grades',
+          label: (
+            <span className="inline-flex items-center gap-2">
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+              <span>Clear Open Grades</span>
+            </span>
+          ),
+          onSelect: () => setShowClearOpenGradesConfirm(true),
+          disabled:
+            batchSelectedCount === 0 ||
+            isBatchAutoGrading ||
+            isBatchReturning ||
+            isBatchClearingOpenGrades,
+        },
+        {
+          id: 'return',
+          label: (
+            <span className="inline-flex items-center gap-2">
+              <Send className="h-4 w-4" aria-hidden="true" />
+              <span>Return</span>
+            </span>
+          ),
+          onSelect: () => {
+            if (batchSelectedCount === 0) {
+              setGradingWarning('Select students to return')
+              return
+            }
+            setShowReturnConfirm(true)
+          },
+          disabled:
+            batchSelectedCount === 0 ||
+            isBatchAutoGrading ||
+            isBatchReturning ||
+            isBatchClearingOpenGrades,
+        },
+      ]}
+      disabled={
+        hasActiveTestAiRun ||
+        isBatchAutoGrading ||
+        isBatchReturning ||
+        isBatchClearingOpenGrades
+      }
+      variant="secondary"
+      size="sm"
+      className="inline-flex"
+      toggleAriaLabel="More test grading actions"
+      menuPlacement="down"
+      primaryButtonProps={{ 'aria-label': 'AI Grade' }}
+    />
   )
 
   const workspaceModeStatus =
@@ -1595,33 +1611,44 @@ export function TeacherTestsTab({
     workspaceState,
   ])
 
-  const workspaceModeTrailing = (
-    <div
-      className="min-w-0 max-w-[22rem] truncate text-right text-sm font-medium text-text-default"
-      title={selectedTestTitle}
-    >
-      {selectedTestTitle}
-    </div>
-  )
+  const workspaceModeSwitcher = workspaceState === 'selected' ? (
+    <SegmentedControl<WorkspaceTab>
+      ariaLabel="Test workspace mode"
+      value={selectedWorkspaceTab}
+      onChange={switchTestWorkspaceMode}
+      capitalizeLabels
+      options={[
+        { value: 'authoring', label: 'Authoring' },
+        { value: 'grading', label: 'Grading' },
+      ]}
+    />
+  ) : null
 
   const primaryContent = workspaceState === 'selected' ? (
-    <TeacherWorkSurfaceModeBar
-      modes={[
-        { id: 'authoring', label: 'Authoring' },
-        { id: 'grading', label: 'Grading' },
-      ]}
-      activeMode={selectedWorkspaceTab}
-      onModeChange={(mode) => switchTestWorkspaceMode(mode as WorkspaceTab)}
-      center={workspaceModeCenter}
-      status={workspaceModeStatus}
-      trailing={workspaceModeTrailing}
-      ariaLabel="Test workspace modes"
+    <TeacherWorkSurfaceActionBar
+      center={
+        <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
+          {workspaceModeSwitcher}
+          {workspaceModeCenter}
+          {workspaceModeStatus}
+        </div>
+      }
+      centerPlacement="floating"
     />
   ) : (
-    <Button onClick={handleNewTest} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
-      <Plus className="h-4 w-4" />
-      New Test
-    </Button>
+    <TeacherWorkSurfaceActionBar
+      label={
+        <div className="truncate px-1 text-sm font-semibold text-text-default">
+          Tests
+        </div>
+      }
+      center={
+        <Button onClick={handleNewTest} variant="primary" className="gap-1.5 shadow-sm" disabled={isReadOnly}>
+          <Plus className="h-4 w-4" />
+          New Test
+        </Button>
+      }
+    />
   )
 
   const feedback = (
@@ -1656,7 +1683,7 @@ export function TeacherTestsTab({
       className="mx-auto w-full max-w-3xl"
     />
   ) : (
-    <PageStack className="mx-auto w-full max-w-6xl">
+    <TeacherWorkItemList>
       {tests.map((test) => (
         <TeacherTestCard
           key={test.id}
@@ -1666,7 +1693,7 @@ export function TeacherTestsTab({
           onUpdate={(update) => applyTestSummaryPatch(test.id, update)}
         />
       ))}
-    </PageStack>
+    </TeacherWorkItemList>
   )
 
   const gradingInspector = selectedTest && selectedStudentId ? (
@@ -1684,38 +1711,42 @@ export function TeacherTestsTab({
       <Spinner size="lg" />
     </div>
   ) : selectedWorkspaceTab === 'authoring' ? (
-    <QuizDetailPanel
-      quiz={selectedTest}
-      classroomId={classroom.id}
-      apiBasePath={apiBasePath}
-      onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
-      onQuizUpdate={(update) => {
-        if (update) {
-          applySelectedTestDraftSummary(update)
-          return
-        }
-        void loadTests()
-      }}
-      onPendingMarkdownImportChange={setHasPendingMarkdownImport}
-      showInlineDeleteAction={false}
-      testQuestionLayout="summary-detail"
-      showPreviewButton={false}
-      showResultsTab={false}
-      previewRequestToken={testPreviewRequestToken}
-    />
-  ) : gradingInspector ? (
+    <div className="flex min-h-0 flex-1 overflow-hidden rounded-lg bg-surface">
+      <QuizDetailPanel
+        quiz={selectedTest}
+        classroomId={classroom.id}
+        apiBasePath={apiBasePath}
+        onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
+        onQuizUpdate={(update) => {
+          if (update) {
+            applySelectedTestDraftSummary(update)
+            return
+          }
+          void loadTests()
+        }}
+        onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+        showInlineDeleteAction={false}
+        testQuestionLayout="summary-detail"
+        showPreviewButton={false}
+        showResultsTab={false}
+        previewRequestToken={testPreviewRequestToken}
+      />
+    </div>
+  ) : (
     <TeacherWorkspaceSplit
+      className="flex-1"
+      splitVariant="gapped"
       primary={gradingTable}
-      inspector={gradingInspector}
+      inspector={gradingInspector ? <div className="h-full overflow-y-auto">{gradingInspector}</div> : undefined}
       inspectorWidth={gradingInspectorWidth}
       inspectorCollapsed={false}
       onInspectorWidthChange={setGradingInspectorWidth}
       dividerLabel="Resize grading and student response panes"
+      primaryClassName="min-h-[200px] rounded-lg bg-surface"
+      inspectorClassName="rounded-lg bg-surface"
       minPrimaryPx={420}
       minInspectorPx={360}
     />
-  ) : (
-    gradingTable
   )
 
   return (
@@ -1726,7 +1757,8 @@ export function TeacherTestsTab({
         feedback={feedback}
         summary={summaryContent}
         workspace={workspaceContent}
-        workspaceFrame="attachedTabs"
+        workspaceFrame="standalone"
+        workspaceFrameClassName="min-h-[360px] border-0 bg-page"
       />
 
       <QuizModal

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -47,6 +47,7 @@ interface Props {
     studentId: string | null
     studentName: string | null
   }) => void
+  onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onRequestDelete?: () => void
 }
 
@@ -217,6 +218,7 @@ export function TeacherTestsTab({
   onSelectTest,
   onTestGradingDataRefresh,
   onTestGradingContextChange,
+  onRequestTestPreview,
   onRequestDelete,
 }: Props) {
   const apiBasePath = '/api/teacher/tests'
@@ -245,6 +247,7 @@ export function TeacherTestsTab({
   const [showEditModal, setShowEditModal] = useState(false)
   const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
   const [testEditSaveStatus, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
+  const [testPreviewRequestToken, setTestPreviewRequestToken] = useState(0)
   const [pendingCreatedTestId, setPendingCreatedTestId] = useState<string | null>(null)
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
@@ -684,10 +687,10 @@ export function TeacherTestsTab({
   ])
 
   useEffect(() => {
-    if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'authoring') {
+    if (workspaceState !== 'selected') {
       setHasPendingMarkdownImport(false)
     }
-  }, [selectedWorkspaceTab, workspaceState])
+  }, [workspaceState])
 
   useEffect(() => {
     if (
@@ -922,14 +925,33 @@ export function TeacherTestsTab({
     clearBatchSelection()
   }
 
-  function handlePreviewSelectedTest() {
-    if (!selectedTestId) return
-    if (hasPendingMarkdownImport || testEditSaveStatus !== 'saved') return
+  function handleOpenSavedTestPreview(preview: { testId: string; title: string }) {
+    if (onRequestTestPreview) {
+      onRequestTestPreview(preview)
+      return
+    }
+
     const previewWindow = window.open(
-      `/classrooms/${classroom.id}/tests/${selectedTestId}/preview`,
+      `/classrooms/${classroom.id}/tests/${preview.testId}/preview`,
       '_blank',
     )
     previewWindow?.focus()
+  }
+
+  function handlePreviewSelectedTest() {
+    if (!selectedTestId) return
+    if (hasPendingMarkdownImport) return
+
+    if (showEditModal && selectedTestWorkspace) {
+      setTestPreviewRequestToken((value) => value + 1)
+      return
+    }
+
+    if (testEditSaveStatus !== 'saved') return
+    handleOpenSavedTestPreview({
+      testId: selectedTestId,
+      title: selectedTestWorkspace?.title || 'Test',
+    })
   }
 
   useEffect(() => {
@@ -1456,7 +1478,7 @@ export function TeacherTestsTab({
             </span>
           ),
           onSelect: handlePreviewSelectedTest,
-          disabled: hasPendingMarkdownImport || testEditSaveStatus !== 'saved',
+          disabled: hasPendingMarkdownImport || (!showEditModal && testEditSaveStatus !== 'saved'),
         },
         ...(onRequestDelete
           ? [
@@ -1830,6 +1852,8 @@ export function TeacherTestsTab({
               }}
               onPendingMarkdownImportChange={setHasPendingMarkdownImport}
               onSaveStatusChange={setTestEditSaveStatus}
+              onRequestTestPreview={handleOpenSavedTestPreview}
+              previewRequestToken={testPreviewRequestToken}
               showInlineDeleteAction={false}
               testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
               showPreviewButton={false}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -91,7 +91,7 @@ export function AppHeader({
   return (
     <header className="sticky top-0 z-50 h-12 bg-surface border-b border-border grid grid-cols-[1fr_minmax(0,1fr)_1fr] items-center px-4">
       {/* Left section */}
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         {/* Mobile sidebar trigger (classroom pages) */}
         {onOpenSidebar && (
           <Tooltip content="Open navigation">
@@ -126,7 +126,7 @@ export function AppHeader({
         {/* Classroom Selector (teachers with multiple classrooms, or when explicitly provided) */}
         {classrooms && classrooms.length > 0 && (
           <ClassroomDropdown
-            className="ml-4"
+            className="ml-1 min-w-0 sm:ml-4"
             classrooms={classrooms}
             currentClassroomId={currentClassroomId}
             currentTab={currentTab}

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -83,7 +83,7 @@ export function ClassroomDropdown({
   // If only one classroom, show as plain text
   if (classrooms.length === 1) {
     return (
-      <div className={`text-xl font-bold text-text-default truncate max-w-xs ${className}`}>
+      <div className={`max-w-full truncate text-xl font-bold text-text-default sm:max-w-xs ${className}`}>
         {classrooms[0].title}
       </div>
     )
@@ -92,7 +92,7 @@ export function ClassroomDropdown({
   return (
     <div
       ref={containerRef}
-      className={`relative ${className}`}
+      className={`relative max-w-full ${className}`}
     >
       {/* Trigger */}
       <button
@@ -111,13 +111,13 @@ export function ClassroomDropdown({
         onKeyDown={handleTriggerKeyDown}
         disabled={openingClassroomId !== null}
         aria-busy={openingClassroomId !== null}
-        className="px-2 py-1 -mx-2 text-xl font-bold text-text-default truncate max-w-xs rounded-md transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+        className="min-w-0 max-w-full truncate rounded-md px-2 py-1 -mx-2 text-xl font-bold text-text-default transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface sm:max-w-xs"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-controls={menuId}
         aria-label="Select classroom"
       >
-        <span className="inline-flex min-w-0 items-center gap-2">
+        <span className="inline-flex min-w-0 max-w-full items-center gap-2">
           {openingClassroomId && (
             <LoaderCircle className="h-4 w-4 shrink-0 animate-spin text-primary" aria-hidden="true" />
           )}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -200,7 +200,7 @@ export function PageActionBar({
   className?: string
 }) {
   const outerClass = cn(
-    'mt-header-compact w-full bg-page',
+    'w-full bg-page',
     PAGE_GUTTER_X_CLASS,
     className,
   )

--- a/src/components/QuizCard.tsx
+++ b/src/components/QuizCard.tsx
@@ -11,6 +11,7 @@ import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
+import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
 import {
   combineScheduleDateTimeToIso,
   DEFAULT_SCHEDULE_TIME,
@@ -207,26 +208,17 @@ export function QuizCard({
   const statusBadgeClass = isScheduled
     ? 'bg-warning-bg text-warning'
     : getQuizStatusBadgeClass(quiz.status)
+  const cardTone = isSelected
+    ? 'selected'
+    : isScheduled
+      ? 'scheduled'
+      : isDraft
+        ? 'muted'
+        : 'default'
 
   return (
     <>
-      <div
-        className={[
-          'w-full rounded-card border p-3.5 text-left shadow-elevated',
-          isDraft
-            ? 'border-border-strong bg-surface-2'
-            : isScheduled
-              ? 'border-warning bg-warning-bg'
-              : 'border-border bg-surface-panel',
-          isSelected
-            ? 'border-primary bg-surface-selected shadow-panel'
-            : isDraft
-              ? 'transition hover:border-border-strong hover:bg-surface-3'
-              : isScheduled
-                ? 'transition hover:border-warning hover:bg-warning-bg'
-                : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
-        ].join(' ')}
-      >
+      <TeacherWorkItemCardFrame tone={cardTone}>
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
           <button
             type="button"
@@ -423,7 +415,7 @@ export function QuizCard({
             />
           </div>
         )}
-      </div>
+      </TeacherWorkItemCardFrame>
 
       <ConfirmDialog
         isOpen={showActivateConfirm}

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -54,7 +54,7 @@ interface Props {
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onPendingMarkdownImportChange?: (pending: boolean) => void
   showInlineDeleteAction?: boolean
-  testQuestionLayout?: 'stacked' | 'summary-detail'
+  testQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
   showPreviewButton?: boolean
   showResultsTab?: boolean
   previewRequestToken?: number
@@ -410,7 +410,9 @@ export function QuizDetailPanel({
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
   const hasResponses = quiz.stats.responded > 0
   const isEditable = canEditQuizQuestions(quiz, hasResponses)
-  const hasPendingMarkdownImport = isTestsView && showMarkdown && markdownDirty
+  const usesMarkdownOnlyQuestions = isTestsView && testQuestionLayout === 'markdown-only'
+  const isMarkdownSurfaceEnabled = showMarkdown || usesMarkdownOnlyQuestions
+  const hasPendingMarkdownImport = isTestsView && isMarkdownSurfaceEnabled && markdownDirty
   const isMarkdownEditable = isEditable && isMarkdownEditing
   const markdownHelperStatus = markdownSaving
     ? 'Applying markdown...'
@@ -420,11 +422,12 @@ export function QuizDetailPanel({
         ? 'Editing markdown'
         : 'Markdown mirror'
   const usesSummaryDetailQuestions = isTestsView && showMarkdown && testQuestionLayout === 'summary-detail'
+  const usesEditorOnlyQuestions = isTestsView && testQuestionLayout === 'editor-only'
   const { width: summaryDetailWorkspaceWidth } = useRefRect(summaryDetailWorkspaceRef, {
     enabled: usesSummaryDetailQuestions,
   })
   const { width: viewportWidth } = useWindowSize()
-  const hasInlineDocumentsCard = usesSummaryDetailQuestions
+  const hasInlineDocumentsCard = usesSummaryDetailQuestions || usesEditorOnlyQuestions
   const resolvedShowResultsTab = showResultsTab ?? !isTestsView
   const totalQuestionPoints = useMemo(
     () =>
@@ -472,7 +475,7 @@ export function QuizDetailPanel({
   }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
 
   useEffect(() => {
-    if (showMarkdown) return
+    if (isMarkdownSurfaceEnabled) return
     if (viewMode === 'markdown') {
       setViewMode('questions')
     }
@@ -485,7 +488,7 @@ export function QuizDetailPanel({
     setIsMarkdownEditing(false)
     setMarkdownError('')
     setMarkdownInfo('')
-  }, [currentTestMarkdown, markdownDirty, showMarkdown, viewMode])
+  }, [currentTestMarkdown, isMarkdownSurfaceEnabled, markdownDirty, viewMode])
 
   useEffect(() => {
     onPendingMarkdownImportChange?.(isTestsView ? hasPendingMarkdownImport : false)
@@ -1561,6 +1564,87 @@ export function QuizDetailPanel({
     </div>
   )
 
+  const testQuestionEditorPane = (
+    <div data-testid="test-question-editor-pane" className="flex h-full min-h-0 flex-col">
+      <div className="border-b border-border px-3 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-muted">
+            <span>
+              {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
+            </span>
+            <span aria-hidden="true">•</span>
+            <span data-testid="test-question-editor-header-summary">
+              {questions.length} question{questions.length === 1 ? '' : 's'} • {totalQuestionPoints} pts
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={areAllEditorSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+            onClick={handleToggleAllQuestions}
+            disabled={!hasCollapsibleEditorSections}
+            className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
+          >
+            {areAllEditorSectionsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </Button>
+        </div>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        <div className={cn('flex h-full min-h-0 flex-col', hasPendingMarkdownImport && 'opacity-60')}>
+          <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-accordion-list">
+            <div className="space-y-3">
+              {testsInlineDocumentsCard}
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={questions.map((question) => question.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-3">
+                    {questions.map((question, index) => (
+                      <TestQuestionEditor
+                        key={question.id}
+                        question={question}
+                        questionNumber={index + 1}
+                        isEditable={isEditable}
+                        onChange={handleQuestionChange}
+                        onDuplicate={handleDuplicateQuestion}
+                        onDelete={handleQuestionDelete}
+                        variant="accordion"
+                        isExpanded={expandedQuestionIds.includes(question.id)}
+                        onToggleExpanded={() => handleToggleQuestionExpanded(question.id)}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            </div>
+          </div>
+
+          {isEditable ? (
+            <div className="border-t border-border p-3">
+              {renderTestAddQuestionSplitButton()}
+            </div>
+          ) : null}
+        </div>
+        {hasPendingMarkdownImport ? (
+          <div
+            data-testid="markdown-pending-lock"
+            className="absolute inset-0 z-10 flex items-center justify-center bg-surface/75 px-6 text-center"
+          >
+            <div className="max-w-sm rounded-md border border-warning bg-surface px-4 py-3 text-sm text-text-default shadow-lg">
+              Apply or undo markdown changes to continue editing questions.
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+
   const testsSummaryDetailPanel = (
     <div
       ref={summaryDetailWorkspaceRef}
@@ -1578,92 +1662,13 @@ export function QuizDetailPanel({
           onPointerDown: handleSummaryDetailResizeStart,
           onDoubleClick: handleSummaryDetailResizeReset,
         }}
-        left={
-        <div data-testid="test-question-editor-pane" className="flex h-full min-h-0 flex-col">
-          <div className="border-b border-border px-3 py-3">
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-muted">
-                <span>
-                  {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'unsaved' ? 'Unsaved changes' : 'Saved'}
-                </span>
-                <span aria-hidden="true">•</span>
-                <span data-testid="test-question-editor-header-summary">
-                  {questions.length} question{questions.length === 1 ? '' : 's'} • {totalQuestionPoints} pts
-                </span>
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                aria-label={areAllEditorSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
-                onClick={handleToggleAllQuestions}
-                disabled={!hasCollapsibleEditorSections}
-                className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
-              >
-                {areAllEditorSectionsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              </Button>
-            </div>
-          </div>
-          <div className="relative min-h-0 flex-1">
-            <div className={cn('flex h-full min-h-0 flex-col', hasPendingMarkdownImport && 'opacity-60')}>
-              <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-accordion-list">
-                <div className="space-y-3">
-                  {testsInlineDocumentsCard}
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                  >
-                    <SortableContext
-                      items={questions.map((question) => question.id)}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      <div className="space-y-3">
-                        {questions.map((question, index) => (
-                          <TestQuestionEditor
-                            key={question.id}
-                            question={question}
-                            questionNumber={index + 1}
-                            isEditable={isEditable}
-                            onChange={handleQuestionChange}
-                            onDuplicate={handleDuplicateQuestion}
-                            onDelete={handleQuestionDelete}
-                            variant="accordion"
-                            isExpanded={expandedQuestionIds.includes(question.id)}
-                            onToggleExpanded={() => handleToggleQuestionExpanded(question.id)}
-                          />
-                        ))}
-                      </div>
-                    </SortableContext>
-                  </DndContext>
-                </div>
-              </div>
-
-              {isEditable ? (
-                <div className="border-t border-border p-3">
-                  {renderTestAddQuestionSplitButton()}
-                </div>
-              ) : null}
-            </div>
-            {hasPendingMarkdownImport ? (
-              <div
-                data-testid="markdown-pending-lock"
-                className="absolute inset-0 z-10 flex items-center justify-center bg-surface/75 px-6 text-center"
-              >
-                <div className="max-w-sm rounded-md border border-warning bg-surface px-4 py-3 text-sm text-text-default shadow-lg">
-                  Apply or undo markdown changes to continue editing questions.
-                </div>
-              </div>
-            ) : null}
-          </div>
-        </div>
-        }
+        left={testQuestionEditorPane}
         right={
-        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col" data-testid="test-question-markdown-pane">
-          <div className="flex min-h-0 flex-1 flex-col p-4">
-            {testsMarkdownPanel}
+          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col" data-testid="test-question-markdown-pane">
+            <div className="flex min-h-0 flex-1 flex-col p-4">
+              {testsMarkdownPanel}
+            </div>
           </div>
-        </div>
         }
       />
     </div>
@@ -1680,7 +1685,7 @@ export function QuizDetailPanel({
   return (
     <div className="flex h-full w-full min-w-0 flex-col">
       {/* Tabs */}
-      {!usesSummaryDetailQuestions && (
+      {!usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions && (
         <div className="flex border-b border-border shrink-0">
         <button
           type="button"
@@ -1780,7 +1785,9 @@ export function QuizDetailPanel({
       <div
         className={[
           'flex-1',
-          usesSummaryDetailQuestions ? 'min-h-0 overflow-hidden p-0' : 'overflow-y-auto p-4',
+          usesSummaryDetailQuestions || usesEditorOnlyQuestions || usesMarkdownOnlyQuestions
+            ? 'min-h-0 overflow-hidden p-0'
+            : 'overflow-y-auto p-4',
         ].join(' ')}
       >
         {error && (
@@ -1795,7 +1802,15 @@ export function QuizDetailPanel({
           </div>
         )}
 
-        {usesSummaryDetailQuestions ? (
+        {usesEditorOnlyQuestions ? (
+          <div data-testid="test-editor-only-layout" className="h-full min-h-0 bg-surface-2">
+            {testQuestionEditorPane}
+          </div>
+        ) : usesMarkdownOnlyQuestions ? (
+          <div data-testid="test-markdown-only-layout" className="flex h-full min-h-0 flex-col p-4">
+            {testsMarkdownPanel}
+          </div>
+        ) : usesSummaryDetailQuestions ? (
           testsSummaryDetailPanel
         ) : viewMode === 'questions' ? (
           <div className="space-y-3">

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -20,6 +20,8 @@ import { Check, ChevronDown, ChevronUp, Copy, ExternalLink, Plus, RotateCcw, X }
 import { Button, EmptyState, SplitButton, Tooltip, cn } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { useRefRect } from '@/hooks/use-element-rect'
+import { useWindowSize } from '@/hooks/use-window-size'
+import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 import { canEditQuizQuestions } from '@/lib/quizzes'
 import { QuizQuestionEditor } from '@/components/QuizQuestionEditor'
 import { TestQuestionEditor } from '@/components/TestQuestionEditor'
@@ -421,6 +423,7 @@ export function QuizDetailPanel({
   const { width: summaryDetailWorkspaceWidth } = useRefRect(summaryDetailWorkspaceRef, {
     enabled: usesSummaryDetailQuestions,
   })
+  const { width: viewportWidth } = useWindowSize()
   const hasInlineDocumentsCard = usesSummaryDetailQuestions
   const resolvedShowResultsTab = showResultsTab ?? !isTestsView
   const totalQuestionPoints = useMemo(
@@ -447,6 +450,13 @@ export function QuizDetailPanel({
       ),
     [summaryDetailMarkdownWidthPercent, summaryDetailWorkspaceWidth]
   )
+  const usesWideSummaryDetailLayout =
+    (viewportWidth === 0 || viewportWidth >= DESKTOP_BREAKPOINT) &&
+    (summaryDetailWorkspaceWidth === 0 ||
+      summaryDetailWorkspaceWidth >=
+        TEST_SUMMARY_DETAIL_LAYOUT.minEditorWidthPx +
+          TEST_SUMMARY_DETAIL_LAYOUT.minMarkdownWidthPx +
+          48)
   const hasCollapsibleEditorSections = questions.length > 0 || hasInlineDocumentsCard
   const areAllEditorSectionsExpanded =
     (questions.length === 0 || areAllQuestionsExpanded) &&
@@ -1559,10 +1569,10 @@ export function QuizDetailPanel({
     >
       <SummaryDetailWorkspaceShell
         className="flex-1"
-        orientation="row"
+        orientation={usesWideSummaryDetailLayout ? 'row' : 'responsive'}
         leftPaneClassName="min-h-0 bg-surface-2"
         rightPaneClassName="min-h-0"
-        rightWidthPercent={clampedSummaryDetailMarkdownWidthPercent}
+        rightWidthPercent={usesWideSummaryDetailLayout ? clampedSummaryDetailMarkdownWidthPercent : undefined}
         divider={{
           label: 'Resize question and markdown panes',
           onPointerDown: handleSummaryDetailResizeStart,

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -53,6 +53,7 @@ interface Props {
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onPendingMarkdownImportChange?: (pending: boolean) => void
+  onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
   showInlineDeleteAction?: boolean
   testQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
   showPreviewButton?: boolean
@@ -121,6 +122,7 @@ export function QuizDetailPanel({
   onRequestDelete,
   onRequestTestPreview,
   onPendingMarkdownImportChange,
+  onSaveStatusChange,
   showInlineDeleteAction = true,
   testQuestionLayout = 'stacked',
   showPreviewButton = true,
@@ -195,6 +197,12 @@ export function QuizDetailPanel({
     TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
   )
   const loadedDraftQuizIdRef = useRef<string | null>(null)
+
+  const updateSaveStatus = useCallback((status: 'saved' | 'saving' | 'unsaved') => {
+    saveStatusRef.current = status
+    setSaveStatus(status)
+    onSaveStatusChange?.(status)
+  }, [onSaveStatusChange])
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -347,11 +355,11 @@ export function QuizDetailPanel({
       lastSavedDraftRef.current = JSON.stringify(nextSnapshot)
       pendingDraftRef.current = nextSnapshot
       loadedDraftQuizIdRef.current = quiz.id
-      setSaveStatus('saved')
+      updateSaveStatus('saved')
       setError('')
       setConflictDraft(null)
     },
-    [normalizeDraftQuestions, quiz.id, quiz.show_results, quiz.title]
+    [normalizeDraftQuestions, quiz.id, quiz.show_results, quiz.title, updateSaveStatus]
   )
 
   // Sync editTitle when quiz changes
@@ -533,11 +541,11 @@ export function QuizDetailPanel({
           : nextDraft
       const nextSerialized = JSON.stringify(contentDraft)
       if (!options?.forceFull && nextSerialized === lastSavedDraftRef.current) {
-        setSaveStatus('saved')
+        updateSaveStatus('saved')
         return true
       }
 
-      setSaveStatus('saving')
+      updateSaveStatus('saving')
       lastSaveAttemptAtRef.current = Date.now()
 
       let baseDraft = contentDraft
@@ -596,7 +604,7 @@ export function QuizDetailPanel({
               },
             })
           }
-          setSaveStatus('unsaved')
+          updateSaveStatus('unsaved')
           setError(data?.error || 'Draft updated elsewhere')
           return false
         }
@@ -630,7 +638,7 @@ export function QuizDetailPanel({
           draftVersionRef.current += 1
           lastSavedDraftRef.current = nextSerialized
           pendingDraftRef.current = nextDraft
-          setSaveStatus('saved')
+          updateSaveStatus('saved')
           setError('')
           setConflictDraft(null)
           onQuizUpdate(summarizeDraftContent(contentDraft))
@@ -638,12 +646,12 @@ export function QuizDetailPanel({
         return true
       } catch (saveError: any) {
         console.error('Error saving draft:', saveError)
-        setSaveStatus('unsaved')
+        updateSaveStatus('unsaved')
         setError(saveError?.message || 'Failed to save draft')
         return false
       }
     },
-    [apiBasePath, applyServerDraft, documents, isTestsView, normalizeDraftQuestions, onQuizUpdate, quiz.id]
+    [apiBasePath, applyServerDraft, documents, isTestsView, normalizeDraftQuestions, onQuizUpdate, quiz.id, updateSaveStatus]
   )
 
   const scheduleSave = useCallback(
@@ -685,7 +693,7 @@ export function QuizDetailPanel({
       if (conflictDraft) return
 
       pendingDraftRef.current = nextDraft
-      setSaveStatus('unsaved')
+      updateSaveStatus('unsaved')
       setError('')
 
       if (saveTimeoutRef.current) {
@@ -696,7 +704,7 @@ export function QuizDetailPanel({
         scheduleSave(nextDraft)
       }, AUTOSAVE_DEBOUNCE_MS)
     },
-    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, scheduleSave]
+    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, scheduleSave, updateSaveStatus]
   )
 
   const loadQuizDetails = useCallback(async () => {
@@ -887,7 +895,7 @@ export function QuizDetailPanel({
       questions,
     }
     pendingDraftRef.current = nextDraft
-    setSaveStatus('unsaved')
+    updateSaveStatus('unsaved')
     setError('')
     scheduleSave(nextDraft, { force: true })
   }

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -176,6 +176,7 @@ export function QuizDetailPanel({
   const throttledSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAttemptAtRef = useRef(0)
   const lastSavedDraftRef = useRef('')
+  const draftMutationRevisionRef = useRef(0)
   const saveStatusRef = useRef<'saved' | 'saving' | 'unsaved'>('saved')
   const pendingDraftRef = useRef<AssessmentEditorDraft | null>(null)
   const saveDraftRef = useRef<
@@ -203,6 +204,11 @@ export function QuizDetailPanel({
     setSaveStatus(status)
     onSaveStatusChange?.(status)
   }, [onSaveStatusChange])
+
+  const markDraftUnsaved = useCallback(() => {
+    draftMutationRevisionRef.current += 1
+    updateSaveStatus('unsaved')
+  }, [updateSaveStatus])
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -355,6 +361,7 @@ export function QuizDetailPanel({
       lastSavedDraftRef.current = JSON.stringify(nextSnapshot)
       pendingDraftRef.current = nextSnapshot
       loadedDraftQuizIdRef.current = quiz.id
+      draftMutationRevisionRef.current += 1
       updateSaveStatus('saved')
       setError('')
       setConflictDraft(null)
@@ -540,12 +547,18 @@ export function QuizDetailPanel({
             }
           : nextDraft
       const nextSerialized = JSON.stringify(contentDraft)
+      const saveRevision = draftMutationRevisionRef.current
+      const isLatestSave = () => saveRevision === draftMutationRevisionRef.current
       if (!options?.forceFull && nextSerialized === lastSavedDraftRef.current) {
-        updateSaveStatus('saved')
+        if (isLatestSave()) {
+          updateSaveStatus('saved')
+        }
         return true
       }
 
-      updateSaveStatus('saving')
+      if (isLatestSave()) {
+        updateSaveStatus('saving')
+      }
       lastSaveAttemptAtRef.current = Date.now()
 
       let baseDraft = contentDraft
@@ -591,6 +604,10 @@ export function QuizDetailPanel({
         const data = await response.json()
 
         if (response.status === 409) {
+          if (!isLatestSave()) {
+            return false
+          }
+
           const serverDraft = data?.draft as
             | { version: number; content: { title: string; show_results: boolean; questions: QuizQuestion[] } }
             | undefined
@@ -620,34 +637,42 @@ export function QuizDetailPanel({
             }
           | undefined
         if (serverDraft?.content) {
-          applyServerDraft(serverDraft)
-          onQuizUpdate({
-            title:
-              typeof serverDraft.content.title === 'string'
-                ? serverDraft.content.title
-                : contentDraft.title,
-            show_results:
-              typeof serverDraft.content.show_results === 'boolean'
-                ? serverDraft.content.show_results
-                : contentDraft.show_results,
-            questions_count: Array.isArray(serverDraft.content.questions)
-              ? serverDraft.content.questions.length
-              : contentDraft.questions.length,
-          })
+          draftVersionRef.current = serverDraft.version
+          lastSavedDraftRef.current = nextSerialized
+          if (isLatestSave()) {
+            applyServerDraft(serverDraft)
+            onQuizUpdate({
+              title:
+                typeof serverDraft.content.title === 'string'
+                  ? serverDraft.content.title
+                  : contentDraft.title,
+              show_results:
+                typeof serverDraft.content.show_results === 'boolean'
+                  ? serverDraft.content.show_results
+                  : contentDraft.show_results,
+              questions_count: Array.isArray(serverDraft.content.questions)
+                ? serverDraft.content.questions.length
+                : contentDraft.questions.length,
+            })
+          }
         } else {
           draftVersionRef.current += 1
           lastSavedDraftRef.current = nextSerialized
-          pendingDraftRef.current = nextDraft
-          updateSaveStatus('saved')
-          setError('')
-          setConflictDraft(null)
-          onQuizUpdate(summarizeDraftContent(contentDraft))
+          if (isLatestSave()) {
+            pendingDraftRef.current = nextDraft
+            updateSaveStatus('saved')
+            setError('')
+            setConflictDraft(null)
+            onQuizUpdate(summarizeDraftContent(contentDraft))
+          }
         }
         return true
       } catch (saveError: any) {
         console.error('Error saving draft:', saveError)
-        updateSaveStatus('unsaved')
-        setError(saveError?.message || 'Failed to save draft')
+        if (isLatestSave()) {
+          updateSaveStatus('unsaved')
+          setError(saveError?.message || 'Failed to save draft')
+        }
         return false
       }
     },
@@ -693,7 +718,7 @@ export function QuizDetailPanel({
       if (conflictDraft) return
 
       pendingDraftRef.current = nextDraft
-      updateSaveStatus('unsaved')
+      markDraftUnsaved()
       setError('')
 
       if (saveTimeoutRef.current) {
@@ -704,7 +729,7 @@ export function QuizDetailPanel({
         scheduleSave(nextDraft)
       }, AUTOSAVE_DEBOUNCE_MS)
     },
-    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, scheduleSave, updateSaveStatus]
+    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, markDraftUnsaved, scheduleSave]
   )
 
   const loadQuizDetails = useCallback(async () => {
@@ -895,7 +920,7 @@ export function QuizDetailPanel({
       questions,
     }
     pendingDraftRef.current = nextDraft
-    updateSaveStatus('unsaved')
+    markDraftUnsaved()
     setError('')
     scheduleSave(nextDraft, { force: true })
   }
@@ -996,6 +1021,8 @@ export function QuizDetailPanel({
     emitDraftSummaryChange(nextDraft)
 
     if (options?.force) {
+      pendingDraftRef.current = nextDraft
+      markDraftUnsaved()
       scheduleSave(nextDraft, { force: true })
       return
     }
@@ -1279,6 +1306,8 @@ export function QuizDetailPanel({
     markdownDirtyRef.current = false
     setMarkdownError('')
     setMarkdownInfo('')
+    pendingDraftRef.current = nextDraft
+    markDraftUnsaved()
 
     const saved = await saveDraft(nextDraft, {
       forceFull: true,

--- a/src/components/SortableAssignmentCard.tsx
+++ b/src/components/SortableAssignmentCard.tsx
@@ -3,6 +3,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Trash2 } from 'lucide-react'
+import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
 import { formatDueDate } from '@/lib/assignments'
 import { isVisibleAtNow } from '@/lib/scheduling'
 import { Button, Tooltip } from '@/ui'
@@ -77,22 +78,13 @@ export function SortableAssignmentCard({
   }
 
   return (
-    <div
+    <TeacherWorkItemCardFrame
       ref={setNodeRef}
       style={style}
       onClick={handleCardAction}
-      className={[
-        'w-full rounded-card border p-3.5 text-left shadow-elevated',
-        isDraft || isScheduled
-          ? 'border-border-strong bg-surface-2'
-          : 'border-border bg-surface-panel',
-        isDragging
-          ? 'z-50 scale-[1.02] border-primary opacity-95 shadow-panel'
-          : isDraft || isScheduled
-            ? 'transition hover:border-border-strong hover:bg-surface-3'
-            : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
-        'cursor-pointer',
-      ].join(' ')}
+      tone={isDraft || isScheduled ? 'muted' : 'default'}
+      dragging={isDragging}
+      className="cursor-pointer"
     >
       <div
         className={[
@@ -180,6 +172,6 @@ export function SortableAssignmentCard({
           </Tooltip>
         )}
       </div>
-    </div>
+    </TeacherWorkItemCardFrame>
   )
 }

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { Play, Square } from 'lucide-react'
+import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
 import { getAssessmentStatusLabel, getQuizStatusBadgeClass, canActivateQuiz } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { Button, ConfirmDialog, Tooltip } from '@/ui'
@@ -113,15 +114,7 @@ export function TeacherTestCard({
 
   return (
     <>
-      <div
-        className={[
-          'w-full rounded-card border p-3.5 text-left shadow-elevated',
-          isDraft ? 'border-border-strong bg-surface-2' : 'border-border bg-surface-panel',
-          isDraft
-            ? 'transition hover:border-border-strong hover:bg-surface-3'
-            : 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel',
-        ].join(' ')}
-      >
+      <TeacherWorkItemCardFrame tone={isDraft ? 'muted' : 'default'}>
         <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
           <button type="button" onClick={onSelect} className="min-w-0 text-left">
             <h3 className={['truncate font-medium', isDraft ? 'text-text-muted' : 'text-text-default'].join(' ')}>
@@ -203,7 +196,7 @@ export function TeacherTestCard({
             ) : null}
           </div>
         </div>
-      </div>
+      </TeacherWorkItemCardFrame>
 
       <ConfirmDialog
         isOpen={showActivateConfirm}

--- a/src/components/teacher-work-surface/TeacherEditModeControls.tsx
+++ b/src/components/teacher-work-surface/TeacherEditModeControls.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react'
 import { Pencil } from 'lucide-react'
-import { Button, Tooltip } from '@/ui'
+import { Button, Tooltip, type ButtonProps } from '@/ui'
 import { cn } from '@/ui/utils'
 
 interface TeacherEditModeControlsProps {
@@ -11,6 +11,7 @@ interface TeacherEditModeControlsProps {
   disabled?: boolean
   children?: ReactNode
   editLabel?: string
+  variant?: NonNullable<ButtonProps['variant']>
   className?: string
 }
 
@@ -20,6 +21,7 @@ export function TeacherEditModeControls({
   disabled = false,
   children,
   editLabel = 'Edit',
+  variant = 'ghost',
   className,
 }: TeacherEditModeControlsProps) {
   return (
@@ -33,10 +35,9 @@ export function TeacherEditModeControls({
       <Tooltip content={active ? 'Hide edit actions' : 'Show edit actions'}>
         <Button
           type="button"
-          variant="ghost"
+          variant={variant}
           size="sm"
           className={cn(
-            'min-h-10 px-3',
             active
               ? 'border-primary/40 bg-info-bg text-primary shadow-inner hover:bg-info-bg-hover hover:text-primary'
               : '',

--- a/src/components/teacher-work-surface/TeacherWorkItemCardFrame.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkItemCardFrame.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from 'react'
+import { forwardRef } from 'react'
+import { cn } from '@/ui/utils'
+
+export type TeacherWorkItemCardTone = 'default' | 'muted' | 'scheduled' | 'selected'
+
+interface TeacherWorkItemCardFrameProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode
+  tone?: TeacherWorkItemCardTone
+  interactive?: boolean
+  dragging?: boolean
+  className?: string
+  style?: CSSProperties
+}
+
+export const TeacherWorkItemCardFrame = forwardRef(function TeacherWorkItemCardFrame(
+  {
+    children,
+    tone = 'default',
+    interactive = true,
+    dragging = false,
+    className,
+    ...props
+  }: TeacherWorkItemCardFrameProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'w-full rounded-card border p-3.5 text-left shadow-elevated',
+        tone === 'selected'
+          ? 'border-primary bg-surface-selected shadow-panel'
+          : tone === 'scheduled'
+            ? 'border-warning bg-warning-bg'
+            : tone === 'muted'
+              ? 'border-border-strong bg-surface-2'
+              : 'border-border bg-surface-panel',
+        dragging
+          ? 'z-50 scale-[1.02] border-primary opacity-95 shadow-panel'
+          : interactive && tone === 'scheduled'
+            ? 'transition hover:border-warning hover:bg-warning-bg'
+            : interactive && tone === 'muted'
+              ? 'transition hover:border-border-strong hover:bg-surface-3'
+              : interactive && tone === 'default'
+                ? 'transition hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel'
+                : '',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+})

--- a/src/components/teacher-work-surface/TeacherWorkItemList.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkItemList.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { PageStack } from '@/components/PageLayout'
+import { cn } from '@/ui/utils'
+
+interface TeacherWorkItemListProps {
+  children: ReactNode
+  className?: string
+}
+
+export function TeacherWorkItemList({ children, className }: TeacherWorkItemListProps) {
+  return (
+    <PageStack className={cn('w-full', className)}>
+      {children}
+    </PageStack>
+  )
+}

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
@@ -3,6 +3,9 @@
 import type { ReactNode } from 'react'
 import { cn } from '@/ui/utils'
 
+const TEACHER_WORK_SURFACE_FLOATING_ACTION_CLUSTER_CLASS =
+  'fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur'
+
 interface TeacherWorkSurfaceActionBarProps {
   label?: ReactNode
   center?: ReactNode
@@ -10,8 +13,23 @@ interface TeacherWorkSurfaceActionBarProps {
   className?: string
   labelClassName?: string
   centerClassName?: string
+  centerPlacement?: 'inline' | 'floating'
   trailingClassName?: string
   testId?: string
+}
+
+export function TeacherWorkSurfaceFloatingActionCluster({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn(TEACHER_WORK_SURFACE_FLOATING_ACTION_CLUSTER_CLASS, className)}>
+      {children}
+    </div>
+  )
 }
 
 export function TeacherWorkSurfaceActionBar({
@@ -21,9 +39,12 @@ export function TeacherWorkSurfaceActionBar({
   className,
   labelClassName,
   centerClassName,
+  centerPlacement = 'inline',
   trailingClassName,
   testId,
 }: TeacherWorkSurfaceActionBarProps) {
+  const isCenterFloating = centerPlacement === 'floating'
+
   return (
     <div
       data-testid={testId}
@@ -35,9 +56,19 @@ export function TeacherWorkSurfaceActionBar({
       <div className={cn('min-w-0 max-w-full overflow-hidden justify-self-start', labelClassName)}>
         {label}
       </div>
-      <div className={cn('min-w-0 justify-self-center', centerClassName)}>
-        {center}
-      </div>
+      {center ? (
+        isCenterFloating ? (
+          <TeacherWorkSurfaceFloatingActionCluster className={centerClassName}>
+            {center}
+          </TeacherWorkSurfaceFloatingActionCluster>
+        ) : (
+          <div className={cn('min-w-0 justify-self-center', centerClassName)}>
+            {center}
+          </div>
+        )
+      ) : (
+        <div />
+      )}
       <div className={cn('min-w-0 justify-self-end', trailingClassName)}>
         {trailing}
       </div>

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -187,7 +187,16 @@ vi.mock('@/app/classrooms/[classroomId]/StudentResourcesTab', () => ({
   StudentResourcesTab: () => <div />,
 }))
 vi.mock('@/app/classrooms/[classroomId]/TeacherQuizzesTab', () => ({
-  TeacherQuizzesTab: () => <div />,
+  TeacherQuizzesTab: ({ onSelectQuiz }: any) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onSelectQuiz?.({ id: 'quiz-1', title: 'Quiz One' })}
+      >
+        Select quiz workspace
+      </button>
+    </div>
+  ),
 }))
 vi.mock('@/app/classrooms/[classroomId]/TeacherTestsTab', () => ({
   TeacherTestsTab: () => <div />,
@@ -303,6 +312,27 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     renderClient({ initialTab: 'attendance', initialSearchParams: { tab: 'attendance' } })
 
     expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Daily')
+  })
+
+  it('passes the quizzes summary label to the app shell title slot', () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=quizzes')
+
+    renderClient({ initialTab: 'quizzes', initialSearchParams: { tab: 'quizzes' } })
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Quizzes')
+  })
+
+  it('passes the selected quiz title to the app shell title slot', () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=quizzes&quizId=quiz-1')
+
+    renderClient({
+      initialTab: 'quizzes',
+      initialSearchParams: { tab: 'quizzes', quizId: 'quiz-1' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select quiz workspace' }))
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Quiz One')
   })
 
   it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -220,15 +220,18 @@ const classroom: Classroom = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
-function renderClient() {
+function renderClient(options?: { initialTab?: string; initialSearchParams?: Record<string, string | undefined> }) {
+  const initialTab = options?.initialTab ?? 'assignments'
+  const initialSearchParams = options?.initialSearchParams ?? { tab: initialTab }
+
   return render(
     <MarkdownPreferenceProvider>
       <ClassroomPageClient
         classroom={classroom}
         user={{ id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' }}
         teacherClassrooms={[classroom]}
-        initialTab="assignments"
-        initialSearchParams={{ tab: 'assignments' }}
+        initialTab={initialTab}
+        initialSearchParams={initialSearchParams}
       />
     </MarkdownPreferenceProvider>,
   )
@@ -292,6 +295,14 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     renderClient()
 
     expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Assignments')
+  })
+
+  it('passes the daily label to the app shell title slot', () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=attendance')
+
+    renderClient({ initialTab: 'attendance', initialSearchParams: { tab: 'attendance' } })
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Daily')
   })
 
   it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -199,7 +199,16 @@ vi.mock('@/app/classrooms/[classroomId]/TeacherQuizzesTab', () => ({
   ),
 }))
 vi.mock('@/app/classrooms/[classroomId]/TeacherTestsTab', () => ({
-  TeacherTestsTab: () => <div />,
+  TeacherTestsTab: ({ onSelectTest }: any) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onSelectTest?.({ id: 'test-1', title: 'Test One' })}
+      >
+        Select test workspace
+      </button>
+    </div>
+  ),
 }))
 vi.mock('@/app/classrooms/[classroomId]/StudentQuizzesTab', () => ({
   StudentQuizzesTab: () => <div />,
@@ -333,6 +342,27 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select quiz workspace' }))
 
     expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Quiz One')
+  })
+
+  it('passes the tests summary label to the app shell title slot', () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=tests')
+
+    renderClient({ initialTab: 'tests', initialSearchParams: { tab: 'tests' } })
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Tests')
+  })
+
+  it('passes the selected test title to the app shell title slot', () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=tests&testId=test-1')
+
+    renderClient({
+      initialTab: 'tests',
+      initialSearchParams: { tab: 'tests', testId: 'test-1' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select test workspace' }))
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Test One')
   })
 
   it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -8,13 +8,22 @@ const mockFetchJSONWithCache = vi.hoisted(() => vi.fn())
 const mockAssignmentsToMarkdown = vi.hoisted(() => vi.fn())
 
 vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
-  TeacherClassroomView: ({ onEditModeChange }: any) => (
+  TeacherClassroomView: ({ onEditModeChange, onSelectAssignment, onViewModeChange }: any) => (
     <div>
       <button type="button" onClick={() => onEditModeChange?.(true)}>
         Set assignment edit active
       </button>
       <button type="button" onClick={() => onEditModeChange?.(false)}>
         Set assignment edit inactive
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          onViewModeChange?.('assignment')
+          onSelectAssignment?.({ title: 'Assignment One', instructions: null })
+        }}
+      >
+        Select assignment workspace
       </button>
     </div>
   ),
@@ -24,7 +33,12 @@ vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
 }))
 
 vi.mock('@/components/AppShell', () => ({
-  AppShell: ({ children }: any) => <div>{children}</div>,
+  AppShell: ({ children, pageTitle }: any) => (
+    <div>
+      <div data-testid="app-shell-page-title">{pageTitle}</div>
+      {children}
+    </div>
+  ),
 }))
 
 vi.mock('@/components/layout', async () => {
@@ -264,6 +278,20 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     await waitFor(() => {
       expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
     })
+  })
+
+  it('passes the selected assignment title to the app shell title slot', () => {
+    renderClient()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select assignment workspace' }))
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Assignment One')
+  })
+
+  it('passes the assignments summary label to the app shell title slot', () => {
+    renderClient()
+
+    expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Assignments')
   })
 
   it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -849,6 +849,109 @@ describe('QuizDetailPanel', () => {
       expect(patchBody.content?.questions).toHaveLength(1)
     }, 10_000)
 
+    it('does not report saved when an older autosave finishes after a newer edit', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const onSaveStatusChange = vi.fn()
+      let resolveFirstPatch: ((response: Response) => void) | null = null
+
+      fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url === '/api/teacher/tests/quiz-stale-save-test/draft' && !options) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              draft: {
+                version: 1,
+                content: {
+                  title: 'Stale Save Test',
+                  show_results: false,
+                  questions: [],
+                },
+              },
+            }),
+          } as Response)
+        }
+
+        if (url === '/api/teacher/tests/quiz-stale-save-test' && !options) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              quiz: {
+                documents: [],
+              },
+            }),
+          } as Response)
+        }
+
+        if (url === '/api/teacher/tests/quiz-stale-save-test/draft' && options?.method === 'PATCH') {
+          return new Promise<Response>((resolve) => {
+            resolveFirstPatch = resolve
+          })
+        }
+
+        throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
+      })
+
+      const testQuiz = makeQuizWithStats({
+        id: 'quiz-stale-save-test',
+        assessment_type: 'test',
+        title: 'Stale Save Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          onSaveStatusChange={onSaveStatusChange}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const addQuestionButton = await screen.findByRole('button', { name: '+ MC Question' })
+      vi.useFakeTimers()
+
+      fireEvent.click(addQuestionButton)
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+
+      await act(async () => {
+        vi.advanceTimersByTime(3_100)
+      })
+
+      const patchCalls = fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')
+      expect(patchCalls).toHaveLength(1)
+      expect(resolveFirstPatch).toBeTruthy()
+
+      fireEvent.click(addQuestionButton)
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+      onSaveStatusChange.mockClear()
+
+      await act(async () => {
+        resolveFirstPatch?.({
+          ok: true,
+          json: async () => ({
+            draft: {
+              version: 2,
+              content: {
+                title: 'Stale Save Test',
+                show_results: false,
+                questions: [createMockQuizQuestion({ id: 'saved-q1' })],
+              },
+            },
+          }),
+        } as Response)
+        await Promise.resolve()
+      })
+
+      expect(onSaveStatusChange).not.toHaveBeenCalledWith('saved')
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+    })
+
     it('duplicates a test question immediately below the source in summary-detail mode', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -382,6 +382,115 @@ describe('QuizDetailPanel', () => {
       })
     })
 
+    it('renders tests in editor-only mode with the question editor pane and no tabs', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Editor Modal Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Editor Modal Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="editor-only"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByTestId('test-editor-only-layout')).toBeInTheDocument()
+      const editorPane = screen.getByTestId('test-question-editor-pane')
+      expect(editorPane).toBeInTheDocument()
+      expect(screen.queryByTestId('test-summary-detail-layout')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('test-question-markdown-pane')).not.toBeInTheDocument()
+      expect(screen.queryByText('Questions (2)')).not.toBeInTheDocument()
+      expect(screen.queryByText('Markdown')).not.toBeInTheDocument()
+      expect(within(editorPane).getByTestId('test-documents-card')).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: '+ MC Question' })).toBeInTheDocument()
+    })
+
+    it('renders tests in markdown-only mode with the markdown editor and no tabs', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Markdown Modal Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: {
+            documents: [],
+          },
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Markdown Modal Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="markdown-only"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByTestId('test-markdown-only-layout')).toBeInTheDocument()
+      const markdownEditor = screen.getByTestId('test-markdown-editor') as HTMLTextAreaElement
+      expect(markdownEditor.value).toContain('Explain the runtime complexity of your solution.')
+      expect(markdownEditor).toHaveProperty('readOnly', true)
+      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Markdown mirror')
+      expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
+      expect(screen.queryByTestId('test-editor-only-layout')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('test-question-editor-pane')).not.toBeInTheDocument()
+      expect(screen.queryByText('Questions (2)')).not.toBeInTheDocument()
+      expect(screen.queryByText('Markdown')).not.toBeInTheDocument()
+    })
+
     it('cleans up interrupted summary-detail drags and resets on double click', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -476,7 +476,7 @@ describe('TeacherClassroomView', () => {
 
     expect(screen.getByRole('button', { name: 'New assignment' })).toBeInTheDocument()
     expect(screen.getByTestId('assignment-summary-actionbar-center')).toHaveClass('grid')
-    expect(screen.getByText('Assignments')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New assignment' }).parentElement?.parentElement).toHaveClass('fixed')
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
@@ -901,7 +901,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
-    expect(screen.getByText('Assignment One')).toBeInTheDocument()
+    expect(screen.getByTestId('assignment-workspace-actionbar-center').parentElement).toHaveClass('fixed')
     expect(screen.queryByRole('button', { name: 'Edit assignment' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -285,7 +285,7 @@ describe('TeacherTestsTab', () => {
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
     expect(screen.getByText('New Test')).toBeInTheDocument()
-    expect(screen.queryByRole('tab', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
   })
@@ -302,8 +302,8 @@ describe('TeacherTestsTab', () => {
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'summary-detail')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
-    expect(screen.getByRole('tab', { name: 'Authoring' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByRole('tab', { name: 'Grading' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Grading' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.queryByRole('button', { name: 'Questions' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Documents' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Back to tests' })).not.toBeInTheDocument()
@@ -342,7 +342,8 @@ describe('TeacherTestsTab', () => {
 
   it('updates the authoring header and activation state immediately from local draft changes', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    renderTab()
+    const onSelectTest = vi.fn()
+    renderTab({ onSelectTest })
 
     fireEvent.click(await screen.findByText('Unit Test'))
 
@@ -353,7 +354,7 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Simulate draft change' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Unit Test Draft')).toBeInTheDocument()
+      expect(onSelectTest).toHaveBeenLastCalledWith(expect.objectContaining({ title: 'Unit Test Draft' }))
       expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
     })
 
@@ -363,7 +364,8 @@ describe('TeacherTestsTab', () => {
 
   it('keeps the selected workspace mounted and updates saved test metadata after autosave', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    renderTab()
+    const onSelectTest = vi.fn()
+    renderTab({ onSelectTest })
 
     fireEvent.click(await screen.findByText('Unit Test'))
 
@@ -375,7 +377,7 @@ describe('TeacherTestsTab', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test Updated')
-      expect(screen.getByText('Unit Test Updated')).toBeInTheDocument()
+      expect(onSelectTest).toHaveBeenLastCalledWith(expect.objectContaining({ title: 'Unit Test Updated' }))
       expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
     })
 
@@ -395,7 +397,7 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(screen.getByTestId('mock-test-save'))
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
-    expect(screen.getByRole('tab', { name: 'Authoring' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('validates and activates a draft test from authoring', async () => {
@@ -551,7 +553,7 @@ describe('TeacherTestsTab', () => {
       expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
     })
     expect(screen.getByText('Unit Test')).toBeInTheDocument()
-    expect(screen.queryByRole('tab', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(onSelectTest).toHaveBeenLastCalledWith(null)
   })
 
@@ -570,7 +572,7 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByText('Unit Test'))
     setOpenMock.mockClear()
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.queryByTestId('mock-test-grading-panel')).not.toBeInTheDocument()
@@ -634,7 +636,7 @@ describe('TeacherTestsTab', () => {
     await screen.findByTestId('mock-test-detail')
     updateSearchParams.mockClear()
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     await waitFor(() => {
       expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
@@ -748,7 +750,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -823,7 +825,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.getByText('3/5')).toBeInTheDocument()
@@ -897,7 +899,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -935,7 +937,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -973,7 +975,7 @@ describe('TeacherTestsTab', () => {
     const view = renderTab({ testsTabClickToken: 0 })
 
     fireEvent.click(await screen.findByText('Unit Test A'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     view.rerender(
       <TeacherTestsTab
@@ -987,7 +989,7 @@ describe('TeacherTestsTab', () => {
     })
 
     fireEvent.click(screen.getByText('Unit Test B'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     await act(async () => {
       resolveSecondResults?.(
@@ -1073,11 +1075,12 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
-    fireEvent.click(screen.getByRole('button', { name: 'Return' }))
+    fireEvent.click(screen.getByRole('button', { name: 'More test grading actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Return' }))
 
     expect(
       await screen.findByText('This test is still open. Confirming will close it for all students before returning selected work.')
@@ -1185,7 +1188,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
@@ -1221,10 +1224,11 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('tab', { name: 'Grading' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     await screen.findByText('Alice Zephyr')
 
-    fireEvent.click(screen.getByRole('button', { name: 'AI Prompt' }))
+    fireEvent.click(screen.getByRole('button', { name: 'More test grading actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'AI Prompt' }))
 
     expect(await screen.findByRole('heading', { name: 'AI Prompt' })).toBeInTheDocument()
     expect(screen.getByText(/Pika automatically uses the coding rubric/i)).toBeInTheDocument()

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -290,72 +290,87 @@ describe('TeacherTestsTab', () => {
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
   })
 
-  it('opens a selected test in authoring mode when the card is clicked', async () => {
+  it('opens a selected test in grading mode and edits in a modal', async () => {
     const onSelectTest = vi.fn()
 
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
     renderTab({ onSelectTest })
 
     fireEvent.click(await screen.findByText('Unit Test'))
 
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Grading' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
-    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'summary-detail')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'editor-only')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
-    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'Grading' })).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.queryByRole('button', { name: 'Questions' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Documents' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Back to tests' })).not.toBeInTheDocument()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Markdown' }))
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'markdown-only')
+    expect(within(dialog).getByRole('button', { name: 'Markdown' })).toHaveAttribute('aria-pressed', 'true')
     expect(onSelectTest).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'test-1', title: 'Unit Test' })
     )
   })
 
-  it('disables preview and status actions while markdown edits are pending', async () => {
+  it('disables status actions while markdown edits are pending in the edit modal', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
 
-    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'editor-only')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-preview', 'false')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-show-results', 'false')
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark pending markdown' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Open test' })).toBeDisabled()
       expect(
         screen.getByText('Apply or undo markdown changes before previewing or changing the test status.')
       ).toBeInTheDocument()
     })
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear pending markdown' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Preview' })).toBeEnabled()
-      expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
+      expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
     })
   })
 
-  it('updates the authoring header and activation state immediately from local draft changes', async () => {
+  it('updates the selected test header and activation state immediately from modal draft changes', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
     fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
 
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
-    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
 
     fireEvent.click(screen.getByRole('button', { name: 'Simulate draft change' }))
 
     await waitFor(() => {
       expect(onSelectTest).toHaveBeenLastCalledWith(expect.objectContaining({ title: 'Unit Test Draft' }))
-      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Open test' })).toBeDisabled()
     })
 
     expect(screen.getByTestId('mock-test-detail')).toBeInTheDocument()
@@ -364,13 +379,16 @@ describe('TeacherTestsTab', () => {
 
   it('keeps the selected workspace mounted and updates saved test metadata after autosave', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
     fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
 
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
-    expect(screen.getByRole('button', { name: 'Open' })).toBeEnabled()
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
 
     fireEvent.click(screen.getByRole('button', { name: 'Simulate autosave update' }))
@@ -378,34 +396,36 @@ describe('TeacherTestsTab', () => {
     await waitFor(() => {
       expect(screen.getByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test Updated')
       expect(onSelectTest).toHaveBeenLastCalledWith(expect.objectContaining({ title: 'Unit Test Updated' }))
-      expect(screen.getByRole('button', { name: 'Open' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Open test' })).toBeDisabled()
     })
 
     expect(screen.getByTestId('mock-test-detail')).toBeInTheDocument()
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
-  it('opens a newly created test directly into authoring mode', async () => {
+  it('opens a newly created test in grading with the edit modal open', async () => {
     mockTestsResponse([])
     renderTab()
 
     expect(await screen.findByText('No tests yet')).toBeInTheDocument()
 
     mockTestsResponse([makeTest({ id: 'created-test-id', title: 'Created Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizId: 'created-test-id', quizTitle: 'Created Test' }))
 
     fireEvent.click(screen.getByText('New Test'))
     fireEvent.click(screen.getByTestId('mock-test-save'))
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
-    expect(screen.getByRole('button', { name: 'Authoring' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
   })
 
-  it('validates and activates a draft test from authoring', async () => {
+  it('validates and activates a draft test from the selected test split button', async () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })] }),
       })
+      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -429,9 +449,9 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open test' }))
 
     expect(await screen.findByText('Activate test?')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Activate' }))
@@ -448,17 +468,18 @@ describe('TeacherTestsTab', () => {
     expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ status: 'active' })
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Close test' })).toBeInTheDocument()
     })
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
-  it('confirms and closes an active test from authoring', async () => {
+  it('confirms and closes an active test from the selected test split button', async () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
       })
+      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'active' }))
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ test: { id: 'test-1', status: 'closed' } }),
@@ -467,9 +488,9 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close test' }))
     expect(await screen.findByText('Close test?')).toBeInTheDocument()
 
     fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
@@ -486,7 +507,7 @@ describe('TeacherTestsTab', () => {
     expect(JSON.parse((patchCall?.[1] as RequestInit).body as string)).toEqual({ status: 'closed' })
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open test' })).toBeInTheDocument()
     })
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
@@ -536,10 +557,11 @@ describe('TeacherTestsTab', () => {
     const onSelectTest = vi.fn()
 
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
     const view = renderTab({ onSelectTest, testsTabClickToken: 0 })
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     view.rerender(
       <TeacherTestsTab
@@ -550,7 +572,7 @@ describe('TeacherTestsTab', () => {
     )
 
     await waitFor(() => {
-      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+      expect(screen.queryByText('Alice Zephyr')).not.toBeInTheDocument()
     })
     expect(screen.getByText('Unit Test')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
@@ -571,8 +593,6 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(await screen.findByText('Unit Test'))
     setOpenMock.mockClear()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.queryByTestId('mock-test-grading-panel')).not.toBeInTheDocument()
@@ -605,6 +625,7 @@ describe('TeacherTestsTab', () => {
     })
 
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
     renderTab({ selectedTestId: null, updateSearchParams })
 
     fireEvent.click(await screen.findByText('Unit Test'))
@@ -613,11 +634,11 @@ describe('TeacherTestsTab', () => {
     const params = new URLSearchParams('tab=tests')
     updateSearchParams.mock.calls[0][0](params)
     expect(params.get('testId')).toBe('test-1')
-    expect(params.get('testMode')).toBe('authoring')
+    expect(params.get('testMode')).toBe('grading')
     expect(params.get('testStudentId')).toBeNull()
   })
 
-  it('replaces the selected test history entry when switching workspace modes', async () => {
+  it('treats legacy authoring params as grading mode', async () => {
     const updateSearchParams = vi.fn()
 
     fetchMock
@@ -633,27 +654,17 @@ describe('TeacherTestsTab', () => {
       updateSearchParams,
     })
 
-    await screen.findByTestId('mock-test-detail')
-    updateSearchParams.mockClear()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
-
-    await waitFor(() => {
-      expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
-    })
-
-    const params = new URLSearchParams('tab=tests&testId=test-1&testMode=authoring')
-    updateSearchParams.mock.calls[0][0](params)
-    expect(params.get('testId')).toBe('test-1')
-    expect(params.get('testMode')).toBe('grading')
-    expect(params.get('testStudentId')).toBeNull()
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
+    expect(updateSearchParams).not.toHaveBeenCalled()
   })
 
   it('models Browser Back by following controlled test params back to summary', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
     const view = renderTab({ selectedTestId: 'test-1', selectedTestMode: 'authoring' })
 
-    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     view.rerender(
       <TeacherTestsTab
@@ -664,7 +675,7 @@ describe('TeacherTestsTab', () => {
     )
 
     await waitFor(() => {
-      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+      expect(screen.queryByText('Alice Zephyr')).not.toBeInTheDocument()
     })
     expect(screen.getByText('Unit Test')).toBeInTheDocument()
   })
@@ -681,6 +692,7 @@ describe('TeacherTestsTab', () => {
           resolveTests = resolve
         }) as unknown as Promise<Response>,
     )
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
 
     renderTab({
       selectedTestId: 'test-1',
@@ -702,7 +714,7 @@ describe('TeacherTestsTab', () => {
       await Promise.resolve()
     })
 
-    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(updateSearchParams).not.toHaveBeenCalled()
   })
 
@@ -750,7 +762,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -825,7 +836,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(screen.getByText('3/5')).toBeInTheDocument()
@@ -899,7 +909,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -937,7 +946,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
@@ -975,7 +983,6 @@ describe('TeacherTestsTab', () => {
     const view = renderTab({ testsTabClickToken: 0 })
 
     fireEvent.click(await screen.findByText('Unit Test A'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     view.rerender(
       <TeacherTestsTab
@@ -989,7 +996,6 @@ describe('TeacherTestsTab', () => {
     })
 
     fireEvent.click(screen.getByText('Unit Test B'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
 
     await act(async () => {
       resolveSecondResults?.(
@@ -1075,7 +1081,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
@@ -1188,7 +1193,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
@@ -1224,7 +1228,6 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     fireEvent.click(await screen.findByText('Unit Test'))
-    fireEvent.click(screen.getByRole('button', { name: 'Grading' }))
     await screen.findByText('Alice Zephyr')
 
     fireEvent.click(screen.getByRole('button', { name: 'More test grading actions' }))

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showPreviewButton,
     showResultsTab,
     onPendingMarkdownImportChange,
+    onSaveStatusChange,
     onDraftSummaryChange,
     onQuizUpdate,
   }: {
@@ -56,6 +57,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showPreviewButton?: boolean
     showResultsTab?: boolean
     onPendingMarkdownImportChange?: (pending: boolean) => void
+    onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
     onDraftSummaryChange?: (update: {
       title: string
       show_results: boolean
@@ -79,6 +81,12 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       </button>
       <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
         Clear pending markdown
+      </button>
+      <button type="button" onClick={() => onSaveStatusChange?.('unsaved')}>
+        Mark editor unsaved
+      </button>
+      <button type="button" onClick={() => onSaveStatusChange?.('saved')}>
+        Mark editor saved
       </button>
       <button
         type="button"
@@ -348,6 +356,18 @@ describe('TeacherTestsTab', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Open test' })).toBeEnabled()
+      expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark editor unsaved' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark editor saved' }))
+
+    await waitFor(() => {
       expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
     })
   })

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -49,6 +49,8 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showResultsTab,
     onPendingMarkdownImportChange,
     onSaveStatusChange,
+    onRequestTestPreview,
+    previewRequestToken,
     onDraftSummaryChange,
     onQuizUpdate,
   }: {
@@ -58,6 +60,8 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     showResultsTab?: boolean
     onPendingMarkdownImportChange?: (pending: boolean) => void
     onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
+    onRequestTestPreview?: (preview: { testId: string; title: string }) => void
+    previewRequestToken?: number
     onDraftSummaryChange?: (update: {
       title: string
       show_results: boolean
@@ -68,52 +72,59 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       show_results: boolean
       questions_count: number
     }) => void
-  }) => (
-    <div
-      data-testid="mock-test-detail"
-      data-question-layout={testQuestionLayout}
-      data-show-preview={String(showPreviewButton)}
-      data-show-results={String(showResultsTab)}
-    >
-      Detail for {quiz.title}
-      <button type="button" onClick={() => onPendingMarkdownImportChange?.(true)}>
-        Mark pending markdown
-      </button>
-      <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
-        Clear pending markdown
-      </button>
-      <button type="button" onClick={() => onSaveStatusChange?.('unsaved')}>
-        Mark editor unsaved
-      </button>
-      <button type="button" onClick={() => onSaveStatusChange?.('saved')}>
-        Mark editor saved
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          onDraftSummaryChange?.({
-            title: `${quiz.title} Draft`,
-            show_results: false,
-            questions_count: 0,
-          })
-        }
+  }) => {
+    useEffect(() => {
+      if (!previewRequestToken) return
+      onRequestTestPreview?.({ testId: quiz.id, title: quiz.title })
+    }, [onRequestTestPreview, previewRequestToken, quiz.id, quiz.title])
+
+    return (
+      <div
+        data-testid="mock-test-detail"
+        data-question-layout={testQuestionLayout}
+        data-show-preview={String(showPreviewButton)}
+        data-show-results={String(showResultsTab)}
       >
-        Simulate draft change
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          onQuizUpdate?.({
-            title: `${quiz.title} Updated`,
-            show_results: false,
-            questions_count: 0,
-          })
-        }
-      >
-        Simulate autosave update
-      </button>
-    </div>
-  ),
+        Detail for {quiz.title}
+        <button type="button" onClick={() => onPendingMarkdownImportChange?.(true)}>
+          Mark pending markdown
+        </button>
+        <button type="button" onClick={() => onPendingMarkdownImportChange?.(false)}>
+          Clear pending markdown
+        </button>
+        <button type="button" onClick={() => onSaveStatusChange?.('unsaved')}>
+          Mark editor unsaved
+        </button>
+        <button type="button" onClick={() => onSaveStatusChange?.('saved')}>
+          Mark editor saved
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            onDraftSummaryChange?.({
+              title: `${quiz.title} Draft`,
+              show_results: false,
+              questions_count: 0,
+            })
+          }
+        >
+          Simulate draft change
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            onQuizUpdate?.({
+              title: `${quiz.title} Updated`,
+              show_results: false,
+              questions_count: 0,
+            })
+          }
+        >
+          Simulate autosave update
+        </button>
+      </div>
+    )
+  },
 }))
 
 vi.mock('@/components/TestStudentGradingPanel', () => ({
@@ -265,6 +276,7 @@ describe('TeacherTestsTab', () => {
       options?: { replace?: boolean },
     ) => void
     onSelectTest?: (test: QuizWithStats | null) => void
+    onRequestTestPreview?: (preview: { testId: string; title: string }) => void
     onTestGradingContextChange?: (context: {
       mode: 'authoring' | 'grading'
       testId: string | null
@@ -281,6 +293,7 @@ describe('TeacherTestsTab', () => {
         selectedTestStudentId={options?.selectedTestStudentId}
         updateSearchParams={options?.updateSearchParams}
         onSelectTest={options?.onSelectTest}
+        onRequestTestPreview={options?.onRequestTestPreview}
         onTestGradingContextChange={options?.onTestGradingContextChange}
       />,
       { wrapper: Wrapper }
@@ -362,13 +375,37 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Mark editor unsaved' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeDisabled()
+      expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark editor saved' }))
 
     await waitFor(() => {
       expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
+    })
+  })
+
+  it('delegates preview from the selected test menu to the open editor', async () => {
+    const onRequestTestPreview = vi.fn()
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    renderTab({ onRequestTestPreview })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark editor unsaved' }))
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.getByRole('menuitem', { name: 'Preview' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Preview' }))
+
+    await waitFor(() => {
+      expect(onRequestTestPreview).toHaveBeenCalledWith({
+        testId: 'test-1',
+        title: 'Unit Test',
+      })
     })
   })
 

--- a/tests/components/TeacherWorkItemPrimitives.test.tsx
+++ b/tests/components/TeacherWorkItemPrimitives.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
+import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
+
+describe('TeacherWorkItem primitives', () => {
+  it('renders work-item lists at full available width', () => {
+    const { container } = render(
+      <TeacherWorkItemList>
+        <div>Item</div>
+      </TeacherWorkItemList>,
+    )
+
+    expect(container.firstElementChild).toHaveClass('w-full')
+    expect(container.firstElementChild).not.toHaveClass('max-w-6xl')
+  })
+
+  it('centralizes the shared card frame chrome and tones', () => {
+    const { rerender } = render(
+      <TeacherWorkItemCardFrame tone="default">Default card</TeacherWorkItemCardFrame>,
+    )
+
+    const defaultCard = screen.getByText('Default card')
+    expect(defaultCard).toHaveClass('w-full')
+    expect(defaultCard).toHaveClass('rounded-card')
+    expect(defaultCard).toHaveClass('bg-surface-panel')
+
+    rerender(
+      <TeacherWorkItemCardFrame tone="muted">Muted card</TeacherWorkItemCardFrame>,
+    )
+    expect(screen.getByText('Muted card')).toHaveClass('bg-surface-2')
+
+    rerender(
+      <TeacherWorkItemCardFrame tone="selected">Selected card</TeacherWorkItemCardFrame>,
+    )
+    expect(screen.getByText('Selected card')).toHaveClass('bg-surface-selected')
+  })
+})


### PR DESCRIPTION
## Summary
- applies the shared teacher work-surface shell to Daily, Quizzes, and Tests follow-up states
- standardizes assignment/test FAB action clusters and work-item list card framing
- changes Tests so selection opens grading by default, while editing opens a large modal with Edit and Markdown views
- adds reusable guidance for the selected-workspace split template

## Validation
- bash scripts/verify-env.sh
- pnpm vitest run tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
- pnpm lint
- git diff --check
- UI screenshots via pika-ui-verify for teacher/student selected Tests workspace plus edit modal desktop/mobile checks
