### PR TITLE
[codex] Add classroom dashboard edit mode

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10551,3 +10551,176 @@
 - `pnpm lint`
 - `git diff --check`
 - `pnpm build`
+
+## 2026-04-30 — Add classroom dashboard edit toggle
+
+**Completed:**
+- Added a footer Edit/Done toggle on the teacher classroom dashboard.
+- Hid classroom drag handles, per-classroom archive actions, and the Active/Archived footer toggle until edit mode is enabled.
+- Reset the dashboard back to Active view when leaving edit mode.
+- Added component coverage for the hidden/edit-mode controls.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- Pika UI verification script for `/classrooms`:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshot for teacher edit mode:
+  - `/tmp/pika-teacher-edit.png`
+
+## 2026-05-03 — Rebase classroom dashboard edit toggle
+
+**Completed:**
+- Rebasing `codex/classroom-dash-edit-toggle` onto `origin/main`.
+- Stashed and restored local classroom dashboard edit toggle changes without conflicts.
+- Confirmed no migration files were added or resequenced.
+
+**Validation:**
+- Session startup verification: `pnpm test`
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+
+## 2026-05-03 — Move classroom dashboard edit controls to top
+
+**Completed:**
+- Replaced the bespoke classroom dashboard footer edit toggle with the shared assignment-style `TeacherEditModeControls`.
+- Moved `New` and `Edit` controls above the classroom cards.
+- Kept classroom drag handles, row archive actions, and the Active/Archived toggle hidden until edit mode is enabled.
+- Removed the fixed bottom action bar.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`
+- `pnpm test`
+
+## 2026-05-03 — Reuse classroom dashboard FAB cluster
+
+**Completed:**
+- Reused the shared `TeacherWorkSurfaceFloatingActionCluster` for the classroom dashboard `New` and `Edit` controls.
+- Kept the action cluster horizontally centered across desktop and mobile.
+- Preserved the edit-mode behavior where drag handles, row archive actions, and the Active/Archived toggle only show after enabling Edit.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-classrooms-teacher-default.png`
+  - `/tmp/pika-classrooms-teacher-mobile-default.png`
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`
+
+## 2026-05-03 — Align classroom view toggle with FAB buttons
+
+**Completed:**
+- Replaced the custom Active/Archived classroom view pills with the shared `SegmentedControl`.
+- Moved the Active/Archived toggle to the left of the `New` button when classroom edit mode is enabled.
+- Added coverage for the edit-mode control ordering.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-classrooms-teacher-default.png`
+  - `/tmp/pika-classrooms-teacher-mobile-default.png`
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`
+
+## 2026-05-03 — Move classroom view toggle to bottom center
+
+**Completed:**
+- Moved the Active/Archived classroom view segmented control out of the top FAB cluster.
+- Rendered the view toggle fixed at the bottom center while classroom edit mode is enabled.
+- Kept `New` and `Edit` in the centered top FAB cluster.
+- Added bottom padding in edit mode so fixed controls do not cover classroom cards.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-classrooms-teacher-default.png`
+  - `/tmp/pika-classrooms-teacher-mobile-default.png`
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`
+
+## 2026-05-03 — Always show classroom view toggle
+
+**Completed:**
+- Kept the Active/Archived classroom view toggle visible at the bottom center in both normal and edit modes.
+- Preserved Edit as the gate for classroom drag handles and row archive actions.
+- Stopped resetting the classroom view to Active when turning Edit off.
+- Added coverage for the always-visible view toggle and retained Archived selection after edit mode is disabled.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-classrooms-teacher-default.png`
+  - `/tmp/pika-classrooms-teacher-mobile-default.png`
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`
+
+## 2026-05-03 — Clear classroom edit mode on escape and page restore
+
+**Completed:**
+- Added Escape handling to turn classroom edit mode off and clear any drag state.
+- Added `pageshow` handling so browser page restore after refresh/back-forward does not leave edit mode enabled.
+- Added component coverage for Escape and page-restore edit-mode clearing.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright interaction check:
+  - Escape clears classroom edit mode.
+  - `pageshow` clears classroom edit mode.
+  - `/tmp/pika-classrooms-after-edit-clear.png`
+
+## 2026-05-04 — Move classroom create action below list
+
+**Completed:**
+- Removed `New` from the top classroom FAB cluster so the cluster now only contains `Edit`.
+- Rendered `New` below the classroom list when there are no active classrooms or classroom edit mode is enabled.
+- Hid `New` after the first active classroom exists while edit mode is off.
+- Updated component coverage for the new create-button visibility and placement.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- Pika UI verification script for `/classrooms` on port 3003:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots:
+  - `/tmp/pika-classrooms-teacher-default.png`
+  - `/tmp/pika-classrooms-teacher-mobile-default.png`
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-mobile-edit.png`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -21,7 +21,9 @@ import {
 import { useRouter, usePathname } from 'next/navigation'
 import { Archive, CircleDot, LoaderCircle, Plus } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
-import { Button, ConfirmDialog } from '@/ui'
+import { TeacherWorkSurfaceFloatingActionCluster } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
+import { Button, ConfirmDialog, SegmentedControl } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { ClassroomRowGhost, SortableClassroomRow } from '@/components/SortableClassroomRow'
@@ -45,6 +47,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   const [archivedClassrooms, setArchivedClassrooms] = useState<Classroom[]>([])
   const [view, setView] = useState<ViewMode>('active')
   const [showCreate, setShowCreate] = useState(false)
+  const [isEditingClassrooms, setIsEditingClassrooms] = useState(false)
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
   const [isProcessing, setIsProcessing] = useState(false)
   const [isLoadingArchived, setIsLoadingArchived] = useState(false)
@@ -107,7 +110,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
   }, [])
 
   const handleDragEnd = useCallback(async (event: DragEndEvent) => {
-    if (view !== 'active' || isReordering) return
+    if (!isEditingClassrooms || view !== 'active' || isReordering) return
 
     const { active, over } = event
     if (!over || active.id === over.id) {
@@ -145,11 +148,12 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
       setIsReordering(false)
       setDraggingClassroomId(null)
     }
-  }, [activeClassrooms, isReordering, refreshActiveClassrooms, view])
+  }, [activeClassrooms, isEditingClassrooms, isReordering, refreshActiveClassrooms, view])
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    if (!isEditingClassrooms) return
     setDraggingClassroomId(String(event.active.id))
-  }, [])
+  }, [isEditingClassrooms])
 
   const handleDragCancel = useCallback(() => {
     setDraggingClassroomId(null)
@@ -170,6 +174,27 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     if (view !== 'archived') return
     loadArchived()
   }, [loadArchived, view])
+
+  useEffect(() => {
+    function clearEditMode() {
+      setIsEditingClassrooms(false)
+      setDraggingClassroomId(null)
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        clearEditMode()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('pageshow', clearEditMode)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('pageshow', clearEditMode)
+    }
+  }, [])
 
   async function archiveClassroom(classroom: Classroom) {
     setIsProcessing(true)
@@ -279,9 +304,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     : 'Confirm'
 
   const dialogVariant = pendingAction?.mode === 'delete' ? 'danger' : 'default'
-
-  const hasActiveClassrooms = activeClassrooms.length > 0
-  const showBottomCreateButton = hasActiveClassrooms || view === 'archived'
+  const showCreateClassroomButton = activeClassrooms.length === 0 || isEditingClassrooms
 
   const openClassroom = useCallback((classroom: Classroom) => {
     setOpeningClassroomId(classroom.id)
@@ -290,7 +313,23 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
   return (
     <PageLayout className="mx-auto max-w-2xl">
-      <PageContent className="pb-36">
+      <TeacherWorkSurfaceFloatingActionCluster>
+        <div className="flex flex-wrap items-center justify-center gap-1.5">
+          <TeacherEditModeControls
+            active={isEditingClassrooms}
+            onActiveChange={(active) => {
+              setIsEditingClassrooms(active)
+              if (!active) {
+                setDraggingClassroomId(null)
+              }
+            }}
+            disabled={openingClassroomId !== null}
+            variant="secondary"
+          />
+        </div>
+      </TeacherWorkSurfaceFloatingActionCluster>
+
+      <PageContent className="pb-24 pt-16">
         {error && (
           <div className="mb-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {error}
@@ -309,15 +348,17 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
           view === 'active' ? (
             /* Empty active: center the CTA on screen */
             <div className="flex flex-col items-center justify-center" style={{ minHeight: 'calc(100dvh - 12rem)' }}>
-              <p className="mb-4 text-sm text-text-muted">Create your first classroom</p>
-              <button
+              <p className="text-sm text-text-muted">Create your first classroom</p>
+              <Button
                 type="button"
+                variant="primary"
+                size="sm"
+                className="mt-4"
                 onClick={() => setShowCreate(true)}
-                className="inline-flex items-center gap-2 rounded-control bg-primary px-6 py-3 text-sm font-semibold text-text-inverse shadow-sm transition-colors hover:bg-primary-hover"
               >
-                <Plus className="h-5 w-5" aria-hidden="true" />
-                New classroom
-              </button>
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                <span>New</span>
+              </Button>
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center py-16 text-center">
@@ -325,6 +366,18 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
               <p className="mt-1 text-sm text-text-muted">
                 Archived classrooms will appear here so you can restore or permanently remove them later.
               </p>
+              {showCreateClassroomButton ? (
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  className="mt-4"
+                  onClick={() => setShowCreate(true)}
+                >
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  <span>New</span>
+                </Button>
+              ) : null}
             </div>
           )
         ) : (
@@ -345,6 +398,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
                     <SortableClassroomRow
                       key={classroom.id}
                       classroom={classroom}
+                      showEditControls={isEditingClassrooms}
                       isDragDisabled={isReordering || openingClassroomId !== null}
                       isDisabled={openingClassroomId !== null}
                       isOpening={openingClassroomId === classroom.id}
@@ -418,52 +472,41 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
             )}
           </div>
         )}
+
+        {visibleClassrooms.length > 0 && showCreateClassroomButton ? (
+          <div className="flex justify-center pt-3">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => setShowCreate(true)}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span>New</span>
+            </Button>
+          </div>
+        ) : null}
       </PageContent>
 
-      {/* Fixed bottom bar: Active/Archived toggle with inline create CTA */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-page/90 pb-4 pt-3 backdrop-blur-sm">
-        <div className="mx-auto flex w-full max-w-2xl items-center justify-center px-4">
-          <div className="flex items-center gap-2">
-            <div className="inline-flex items-stretch rounded-full border border-border bg-surface-2 p-0.5 shadow-sm">
-              <button
-                type="button"
-                onClick={() => setView('active')}
-                className={[
-                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
-                  view === 'active'
-                    ? 'bg-surface text-text-default shadow-sm'
-                    : 'text-text-muted hover:bg-surface-accent',
-                ].join(' ')}
-              >
-                <CircleDot className="h-3.5 w-3.5" aria-hidden="true" />
-                Active
-              </button>
-              <button
-                type="button"
-                onClick={() => setView('archived')}
-                className={[
-                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
-                  view === 'archived'
-                    ? 'bg-surface text-text-default shadow-sm'
-                    : 'text-text-muted hover:bg-surface-accent',
-                ].join(' ')}
-              >
-                <Archive className="h-3.5 w-3.5" aria-hidden="true" />
-                Archived
-              </button>
-            </div>
-            <button
-              type="button"
-              onClick={() => setShowCreate(true)}
-              className={[
-                'rounded-control bg-primary px-4 py-1.5 text-sm font-semibold text-text-inverse shadow-sm transition-colors hover:bg-primary-hover',
-                showBottomCreateButton ? 'inline-flex items-center' : 'hidden',
-              ].join(' ')}
-            >
-              + New
-            </button>
-          </div>
-        </div>
+      <div className="fixed bottom-4 left-1/2 z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur">
+        <SegmentedControl<ViewMode>
+          ariaLabel="Classroom view"
+          value={view}
+          onChange={setView}
+          className="border border-border shadow-sm"
+          options={[
+            {
+              value: 'active',
+              label: 'Active',
+              icon: <CircleDot className="h-3.5 w-3.5" />,
+            },
+            {
+              value: 'archived',
+              label: 'Archived',
+              icon: <Archive className="h-3.5 w-3.5" />,
+            },
+          ]}
+        />
       </div>
 
       <CreateClassroomModal

--- a/src/components/SortableClassroomRow.tsx
+++ b/src/components/SortableClassroomRow.tsx
@@ -11,6 +11,7 @@ interface SortableClassroomRowProps {
   isDragDisabled?: boolean
   isDisabled?: boolean
   isOpening?: boolean
+  showEditControls?: boolean
   onOpen: () => void
   onArchive: () => void
 }
@@ -109,6 +110,7 @@ export function SortableClassroomRow({
   isDragDisabled = false,
   isDisabled = false,
   isOpening = false,
+  showEditControls = true,
   onOpen,
   onArchive,
 }: SortableClassroomRowProps) {
@@ -119,7 +121,7 @@ export function SortableClassroomRow({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: classroom.id, disabled: isDragDisabled })
+  } = useSortable({ id: classroom.id, disabled: isDragDisabled || !showEditControls })
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -141,7 +143,7 @@ export function SortableClassroomRow({
         onOpen={onOpen}
         isDisabled={isDisabled}
         isOpening={isOpening}
-        dragHandle={
+        dragHandle={showEditControls ? (
           <button
             type="button"
             className={[
@@ -157,8 +159,8 @@ export function SortableClassroomRow({
           >
             <GripVertical className="h-5 w-5" aria-hidden="true" />
           </button>
-        }
-        action={
+        ) : null}
+        action={showEditControls ? (
           <button
             type="button"
             onClick={onArchive}
@@ -169,7 +171,7 @@ export function SortableClassroomRow({
           >
             <Archive className="h-4 w-4" aria-hidden="true" />
           </button>
-        }
+        ) : null}
       />
     </div>
   )

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { TeacherClassroomsIndex } from '@/app/classrooms/TeacherClassroomsIndex'
+import { TooltipProvider } from '@/ui'
 import { createMockClassroom } from '../helpers/mocks'
+import type { Classroom } from '@/types'
 
 const push = vi.hoisted(() => vi.fn())
 
@@ -9,6 +11,14 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
   usePathname: () => '/classrooms',
 }))
+
+function renderTeacherClassroomsIndex(initialClassrooms: Classroom[]) {
+  return render(
+    <TooltipProvider>
+      <TeacherClassroomsIndex initialClassrooms={initialClassrooms} />
+    </TooltipProvider>
+  )
+}
 
 describe('TeacherClassroomsIndex', () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -26,7 +36,7 @@ describe('TeacherClassroomsIndex', () => {
 
   it('does not refetch classrooms on initial mount (#302)', async () => {
     const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
-    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+    renderTeacherClassroomsIndex(classrooms)
 
     // Show the server-provided data
     expect(await waitFor(() => document.querySelector('[data-testid="classroom-card"]'))).toBeTruthy()
@@ -40,7 +50,7 @@ describe('TeacherClassroomsIndex', () => {
     expect(classroomFetchCalls).toHaveLength(0)
   })
 
-  it('keeps the bottom create button available in archived view when there are no active classrooms', async () => {
+  it('keeps the create button available in archived view when there are no active classrooms', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -48,24 +58,107 @@ describe('TeacherClassroomsIndex', () => {
       }),
     })
 
-    render(<TeacherClassroomsIndex initialClassrooms={[]} />)
+    renderTeacherClassroomsIndex([])
 
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
 
-    expect(await screen.findByText('Archived')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /^Archived/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
   })
 
-  it('does not show a Blueprints button in the bottom action bar', async () => {
-    render(<TeacherClassroomsIndex initialClassrooms={[]} />)
+  it('hides the create button after the first classroom unless edit mode is enabled', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    renderTeacherClassroomsIndex(classrooms)
+
+    const editButton = screen.getByRole('button', { name: 'Edit' })
+    const card = screen.getByTestId('classroom-card')
+
+    expect(editButton.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+
+    fireEvent.click(editButton)
+
+    const newButton = screen.getByRole('button', { name: 'New' })
+    expect(card.compareDocumentPosition(newButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('always shows the classroom view toggle while hiding row edit controls until edit is enabled', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    renderTeacherClassroomsIndex(classrooms)
+
+    expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Archived' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Drag to reorder Math 101' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Archive Math 101' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    const activeButton = screen.getByRole('button', { name: 'Active' })
+    const archivedButton = screen.getByRole('button', { name: 'Archived' })
+
+    expect(activeButton).toBeInTheDocument()
+    expect(archivedButton).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Drag to reorder Math 101' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Archive Math 101' })).toBeInTheDocument()
+  })
+
+  it('keeps the selected classroom view when edit mode is turned off', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        classrooms: [createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' })],
+      }),
+    })
+
+    renderTeacherClassroomsIndex([])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
+    expect(await screen.findByRole('button', { name: /^Archived/ })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(
+      within(screen.getByRole('group', { name: 'Classroom view' })).getByRole('button', { name: 'Archived' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('turns classroom edit mode off when Escape is pressed', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    renderTeacherClassroomsIndex(classrooms)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Archive Math 101' })).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(screen.queryByRole('button', { name: 'Archive Math 101' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('turns classroom edit mode off when the page is restored', async () => {
+    const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
+    renderTeacherClassroomsIndex(classrooms)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Archive Math 101' })).toBeInTheDocument()
+
+    fireEvent(window, new Event('pageshow'))
+
+    expect(screen.queryByRole('button', { name: 'Archive Math 101' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('does not show a Blueprints button in the classroom action bar', async () => {
+    renderTeacherClassroomsIndex([])
 
     expect(screen.queryByRole('button', { name: 'Blueprints' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '+ New' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
   })
 
   it('shows immediate feedback while opening a classroom', async () => {
     const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
-    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+    renderTeacherClassroomsIndex(classrooms)
 
     const openButton = screen.getByRole('button', { name: /^Math 101/ })
     fireEvent.click(openButton)
@@ -80,7 +173,7 @@ describe('TeacherClassroomsIndex', () => {
       createMockClassroom({ id: 'c1', title: 'Math 101' }),
       createMockClassroom({ id: 'c2', title: 'Science 101' }),
     ]
-    render(<TeacherClassroomsIndex initialClassrooms={classrooms} />)
+    renderTeacherClassroomsIndex(classrooms)
 
     fireEvent.click(screen.getByRole('button', { name: /^Math 101/ }))
 


### PR DESCRIPTION
## Summary

Adds an explicit classroom dashboard edit mode for teacher classroom management.

- Reuses the shared teacher work surface floating action cluster for the `Edit` control.
- Keeps the Active/Archived classroom view toggle always visible at the bottom center with the shared `SegmentedControl`.
- Hides classroom drag handles and row archive actions until edit mode is enabled.
- Moves `New` below the classroom list, hides it after the first active classroom unless edit mode is on, and keeps it available for the empty classroom state.
- Clears edit mode on Escape and browser page restore.

## Validation

- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
- `pnpm lint`
- `git diff --check`
- Pika UI verification for `/classrooms` on port 3003
- Manual desktop/mobile screenshots for classroom default and edit modes
- Manual Playwright interaction check for Escape and `pageshow` clearing edit mode