### PR TITLE
[codex] Split announcements from resources tab

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10724,3 +10724,26 @@
   - `/tmp/pika-classrooms-teacher-mobile-default.png`
   - `/tmp/pika-teacher-edit.png`
   - `/tmp/pika-teacher-mobile-edit.png`
+
+## 2026-05-04 — Split announcements from resources tab
+
+**Completed:**
+- Added a dedicated `Announcements` classroom tab for teachers and students.
+- Moved announcement feeds into the new tab and made `Resources` show only class resources.
+- Routed unread announcement activity to the Announcements nav item.
+- Updated calendar announcement links, layout route keys, UI gallery links, and focused coverage.
+
+**Validation:**
+- `pnpm test tests/components/ResourcesTab.test.tsx tests/components/NavItems.test.tsx tests/unit/layout-config.test.ts tests/components/ThreePanelProvider.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- Pika UI verification script on port 3010:
+  - `classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=resources`
+  - `classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=announcements`
+- Manual Playwright student captures for the student-accessible classroom:
+  - `/tmp/pika-student-resources-accessible.png`
+  - `/tmp/pika-student-announcements-accessible.png`
+- Manual mobile drawer captures:
+  - `/tmp/pika-teacher-mobile-drawer.png`
+  - `/tmp/pika-student-mobile-drawer.png`

--- a/src/app/__ui/UiGallery.tsx
+++ b/src/app/__ui/UiGallery.tsx
@@ -58,6 +58,7 @@ export function UiGallery({ role }: Props) {
         { label: 'Roster', href: `/classrooms/${c.id}?tab=roster` },
         { label: 'Calendar', href: `/classrooms/${c.id}?tab=calendar` },
         { label: 'Resources', href: `/classrooms/${c.id}?tab=resources` },
+        { label: 'Announcements', href: `/classrooms/${c.id}?tab=announcements` },
         { label: 'Settings', href: `/classrooms/${c.id}?tab=settings` },
       ],
     }))
@@ -74,6 +75,7 @@ export function UiGallery({ role }: Props) {
         { label: 'Tests', href: `/classrooms/${c.id}?tab=tests` },
         { label: 'Calendar', href: `/classrooms/${c.id}?tab=calendar` },
         { label: 'Resources', href: `/classrooms/${c.id}?tab=resources` },
+        { label: 'Announcements', href: `/classrooms/${c.id}?tab=announcements` },
       ],
     }))
   }, [classrooms])

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -12,10 +12,10 @@ import { TeacherGradebookTab } from './TeacherGradebookTab'
 import { TeacherSettingsTab } from './TeacherSettingsTab'
 import { TeacherLessonCalendarTab, TeacherLessonCalendarSidebar, CalendarSidebarState } from './TeacherLessonCalendarTab'
 import { StudentLessonCalendarTab } from './StudentLessonCalendarTab'
-import { TeacherClassResourcesSidebar } from './TeacherClassResourcesSidebar'
 import { TeacherResourcesTab } from './TeacherResourcesTab'
-import { StudentClassResourcesSidebar } from './StudentClassResourcesSidebar'
 import { StudentResourcesTab } from './StudentResourcesTab'
+import { TeacherAnnouncementsTab } from './TeacherAnnouncementsTab'
+import { StudentAnnouncementsTab } from './StudentAnnouncementsTab'
 import { TeacherQuizzesTab } from './TeacherQuizzesTab'
 import { TeacherTestsTab } from './TeacherTestsTab'
 import { StudentQuizzesTab } from './StudentQuizzesTab'
@@ -117,8 +117,8 @@ export function ClassroomPageClient({
   const validTabs = useMemo(
     () =>
       isTeacher
-        ? (['attendance', 'gradebook', 'assignments', 'quizzes', 'tests', 'calendar', 'resources', 'roster', 'settings'] as const)
-        : (['today', 'assignments', 'quizzes', 'tests', 'calendar', 'resources'] as const),
+        ? (['attendance', 'gradebook', 'assignments', 'quizzes', 'tests', 'calendar', 'resources', 'announcements', 'roster', 'settings'] as const)
+        : (['today', 'assignments', 'quizzes', 'tests', 'calendar', 'resources', 'announcements'] as const),
     [isTeacher]
   )
 
@@ -764,8 +764,6 @@ function ClassroomPageContent({
   useEffect(() => {
     if (isTeacher && activeTab === 'assignments') {
       setRightSidebarWidth('50%')
-    } else if (activeTab === 'resources') {
-      setRightSidebarWidth('50%')
     }
   }, [
     isTeacher,
@@ -835,15 +833,6 @@ function ClassroomPageContent({
             },
             20_000,
           )
-          prefetchJSON(
-            `teacher-announcements:${classroom.id}`,
-            async () => {
-              const response = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
-              if (!response.ok) throw new Error('Prefetch failed')
-              return response.json()
-            },
-            20_000,
-          )
         } else {
           prefetchJSON(
             `student-resources:${classroom.id}`,
@@ -854,6 +843,21 @@ function ClassroomPageContent({
             },
             20_000,
           )
+        }
+      }
+
+      if (tab === 'announcements') {
+        if (isTeacher) {
+          prefetchJSON(
+            `teacher-announcements:${classroom.id}`,
+            async () => {
+              const response = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
+              if (!response.ok) throw new Error('Prefetch failed')
+              return response.json()
+            },
+            20_000,
+          )
+        } else {
           prefetchJSON(
             `student-announcements:${classroom.id}`,
             async () => {
@@ -877,6 +881,7 @@ function ClassroomPageContent({
         () => {
           prefetchTabData('assignments')
           prefetchTabData('resources')
+          prefetchTabData('announcements')
         },
         { timeout: 1200 },
       )
@@ -889,6 +894,7 @@ function ClassroomPageContent({
     const timer = window.setTimeout(() => {
       prefetchTabData('assignments')
       prefetchTabData('resources')
+      prefetchTabData('announcements')
     }, 350)
     return () => window.clearTimeout(timer)
   }, [prefetchTabData])
@@ -905,7 +911,7 @@ function ClassroomPageContent({
           params.delete('assignmentId')
           params.delete('assignmentStudentId')
         }
-        if (tab !== 'resources' && tab !== 'settings') {
+        if (tab !== 'settings') {
           params.delete('section')
         }
         if (tab !== 'tests' || activeTab === 'tests') {
@@ -1167,7 +1173,7 @@ function ClassroomPageContent({
                         }
                         onNavigateToAnnouncements={() =>
                           navigateInClassroom((params) => {
-                            params.set('tab', 'resources')
+                            params.set('tab', 'announcements')
                             params.delete('section')
                             params.delete('assignmentId')
                             params.delete('assignmentStudentId')
@@ -1179,6 +1185,11 @@ function ClassroomPageContent({
                   {mountedTabs.resources && (
                     <TabContentTransition isActive={activeTab === 'resources'}>
                       <TeacherResourcesTab classroom={classroom} />
+                    </TabContentTransition>
+                  )}
+                  {mountedTabs.announcements && (
+                    <TabContentTransition isActive={activeTab === 'announcements'}>
+                      <TeacherAnnouncementsTab classroom={classroom} />
                     </TabContentTransition>
                   )}
                   {mountedTabs.roster && (
@@ -1248,7 +1259,7 @@ function ClassroomPageContent({
                         }
                         onNavigateToAnnouncements={() =>
                           navigateInClassroom((params) => {
-                            params.set('tab', 'resources')
+                            params.set('tab', 'announcements')
                             params.delete('section')
                             params.delete('assignmentId')
                           })
@@ -1261,6 +1272,11 @@ function ClassroomPageContent({
                       <StudentResourcesTab classroom={classroom} />
                     </TabContentTransition>
                   )}
+                  {mountedTabs.announcements && (
+                    <TabContentTransition isActive={activeTab === 'announcements'}>
+                      <StudentAnnouncementsTab classroom={classroom} />
+                    </TabContentTransition>
+                  )}
                 </>
               )}
             </div>
@@ -1268,8 +1284,8 @@ function ClassroomPageContent({
         </MainContent>
 
         <RightSidebar
-          hideDesktopHeader={activeTab === 'resources'}
-          minimalMobileHeader={activeTab === 'resources'}
+          hideDesktopHeader={false}
+          minimalMobileHeader={false}
           title={
             showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode
               ? 'Assignments'
@@ -1279,8 +1295,6 @@ function ClassroomPageContent({
               ? ''
               : isTeacher && activeTab === 'assignments'
               ? ''
-              : activeTab === 'resources'
-              ? 'Class Resources'
               : activeTab === 'assignments'
               ? (selectedAssignment?.title || 'Instructions')
               : activeTab === 'today'
@@ -1341,10 +1355,6 @@ function ClassroomPageContent({
             )
           ) : isTeacher && activeTab === 'calendar' && calendarSidebarState ? (
             <TeacherLessonCalendarSidebar {...calendarSidebarState} />
-          ) : isTeacher && activeTab === 'resources' ? (
-            <TeacherClassResourcesSidebar classroom={classroom} />
-          ) : activeTab === 'resources' ? (
-            <StudentClassResourcesSidebar classroom={classroom} />
           ) : isTeacher && isAssessmentTab ? (
             null
           ) : isTeacher && activeTab === 'assignments' ? (

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsTab.tsx
@@ -1,18 +1,18 @@
 'use client'
 
 import { PageContent, PageLayout } from '@/components/PageLayout'
-import { StudentClassResourcesSidebar } from './StudentClassResourcesSidebar'
+import { StudentAnnouncementsSection } from './StudentAnnouncementsSection'
 import type { Classroom } from '@/types'
 
 interface Props {
   classroom: Classroom
 }
 
-export function StudentResourcesTab({ classroom }: Props) {
+export function StudentAnnouncementsTab({ classroom }: Props) {
   return (
     <PageLayout>
       <PageContent>
-        <StudentClassResourcesSidebar classroom={classroom} />
+        <StudentAnnouncementsSection classroom={classroom} className="mx-0 max-w-none" />
       </PageContent>
     </PageLayout>
   )

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -79,7 +79,7 @@ export function StudentLessonCalendarTab({
     [onNavigateToAssignments]
   )
 
-  // Handle announcement click - navigate to Resources > Announcements
+  // Handle announcement click - navigate to Announcements
   const handleAnnouncementClick = useCallback(() => {
     onNavigateToAnnouncements()
   }, [onNavigateToAnnouncements])

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsTab.tsx
@@ -1,18 +1,18 @@
 'use client'
 
 import { PageContent, PageLayout } from '@/components/PageLayout'
-import { StudentClassResourcesSidebar } from './StudentClassResourcesSidebar'
+import { TeacherAnnouncementsSection } from './TeacherAnnouncementsSection'
 import type { Classroom } from '@/types'
 
 interface Props {
   classroom: Classroom
 }
 
-export function StudentResourcesTab({ classroom }: Props) {
+export function TeacherAnnouncementsTab({ classroom }: Props) {
   return (
     <PageLayout>
       <PageContent>
-        <StudentClassResourcesSidebar classroom={classroom} />
+        <TeacherAnnouncementsSection classroom={classroom} className="mx-0 max-w-none" />
       </PageContent>
     </PageLayout>
   )

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -467,7 +467,7 @@ export function TeacherLessonCalendarTab({
     [onNavigateToAssignments, classroom.id]
   )
 
-  // Handle announcement click - navigate to Resources > Announcements
+  // Handle announcement click - navigate to Announcements
   const handleAnnouncementClick = useCallback(() => {
     onNavigateToAnnouncements()
   }, [onNavigateToAnnouncements])

--- a/src/app/classrooms/[classroomId]/TeacherResourcesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherResourcesTab.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { PageContent, PageLayout } from '@/components/PageLayout'
-import { RightSidebarToggle } from '@/components/layout'
-import { TeacherAnnouncementsSection } from './TeacherAnnouncementsSection'
+import { TeacherClassResourcesSidebar } from './TeacherClassResourcesSidebar'
 import type { Classroom } from '@/types'
 
 interface Props {
@@ -13,10 +12,7 @@ export function TeacherResourcesTab({ classroom }: Props) {
   return (
     <PageLayout>
       <PageContent>
-        <div className="mb-3 flex justify-end lg:hidden">
-          <RightSidebarToggle />
-        </div>
-        <TeacherAnnouncementsSection classroom={classroom} className="mx-0 max-w-none" />
+        <TeacherClassResourcesSidebar classroom={classroom} />
       </PageContent>
     </PageLayout>
   )

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -8,6 +8,7 @@ import {
   ClipboardList,
   LibraryBig,
   FileCheck,
+  Megaphone,
   Settings,
   PenSquare,
   SquarePercent,
@@ -32,6 +33,7 @@ export type ClassroomNavItemId =
   | 'tests'
   | 'calendar'
   | 'resources'
+  | 'announcements'
   | 'roster'
   | 'settings'
   | 'today'
@@ -54,6 +56,7 @@ const teacherItems: NavItem[] = [
   { id: 'gradebook', label: 'Gradebook', icon: SquarePercent },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: LibraryBig },
+  { id: 'announcements', label: 'Announcements', icon: Megaphone },
   { id: 'roster', label: 'Roster', icon: Users },
   { id: 'settings', label: 'Settings', icon: Settings },
 ]
@@ -65,6 +68,7 @@ const studentItems: NavItem[] = [
   { id: 'tests', label: 'Tests', icon: FileCheck },
   { id: 'calendar', label: 'Calendar', icon: Calendar },
   { id: 'resources', label: 'Resources', icon: LibraryBig },
+  { id: 'announcements', label: 'Announcements', icon: Megaphone },
 ]
 
 // ============================================================================
@@ -139,7 +143,7 @@ export function NavItems({
     role === 'student' &&
     !notifications?.loading &&
     (notifications?.activeTestsCount ?? 0) > 0
-  const showResourcesPulse =
+  const showAnnouncementsPulse =
     role === 'student' &&
     !notifications?.loading &&
     (notifications?.unreadAnnouncementsCount ?? 0) > 0
@@ -207,7 +211,7 @@ export function NavItems({
           (item.id === 'assignments' && showAssignmentsPulse) ||
           (item.id === 'quizzes' && showQuizzesPulse) ||
           (item.id === 'tests' && showTestsPulse) ||
-          (item.id === 'resources' && showResourcesPulse)
+          (item.id === 'announcements' && showAnnouncementsPulse)
         const ariaLabel = shouldPulse ? `${item.label} (new activity)` : item.label
 
         const navLink = (

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -54,6 +54,8 @@ export type RouteKey =
   | 'calendar-student'
   | 'resources-teacher'
   | 'resources-student'
+  | 'announcements-teacher'
+  | 'announcements-student'
 
 // ============================================================================
 // Constants
@@ -145,11 +147,19 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   'resources-teacher': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%', desktopAlwaysOpen: true },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   'resources-student': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%', desktopAlwaysOpen: true },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
+    mainContent: { maxWidth: 'full' },
+  },
+  'announcements-teacher': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
+    mainContent: { maxWidth: 'full' },
+  },
+  'announcements-student': {
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 320 },
     mainContent: { maxWidth: 'full' },
   },
 }
@@ -226,6 +236,10 @@ export function getRouteKeyFromTab(
 
   if (tab === 'resources') {
     return role === 'teacher' ? 'resources-teacher' : 'resources-student'
+  }
+
+  if (tab === 'announcements') {
+    return role === 'teacher' ? 'announcements-teacher' : 'announcements-student'
   }
 
   if (tab === 'assignments') {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -186,6 +186,12 @@ vi.mock('@/app/classrooms/[classroomId]/StudentClassResourcesSidebar', () => ({
 vi.mock('@/app/classrooms/[classroomId]/StudentResourcesTab', () => ({
   StudentResourcesTab: () => <div />,
 }))
+vi.mock('@/app/classrooms/[classroomId]/TeacherAnnouncementsTab', () => ({
+  TeacherAnnouncementsTab: () => <div />,
+}))
+vi.mock('@/app/classrooms/[classroomId]/StudentAnnouncementsTab', () => ({
+  StudentAnnouncementsTab: () => <div />,
+}))
 vi.mock('@/app/classrooms/[classroomId]/TeacherQuizzesTab', () => ({
   TeacherQuizzesTab: ({ onSelectQuiz }: any) => (
     <div>

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -102,6 +102,15 @@ describe('NavItems notification dots', () => {
     expect(screen.queryByRole('button', { name: /assignment/i })).toBeNull()
   })
 
+  it('puts unread announcement activity on the announcements nav item', () => {
+    mockNotifications = baseNotifications({ unreadAnnouncementsCount: 4 })
+    renderNav('student', 'announcements')
+
+    const announcementsLink = screen.getByRole('link', { name: 'Announcements (new activity)' })
+    expect(announcementsLink.querySelector('[data-new-activity-dot="true"]')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Resources' }).querySelector('[data-new-activity-dot="true"]')).toBeNull()
+  })
+
   it('does not render notification dots for teacher nav items', () => {
     mockNotifications = baseNotifications({
       hasTodayEntry: false,

--- a/tests/components/ResourcesTab.test.tsx
+++ b/tests/components/ResourcesTab.test.tsx
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { TeacherResourcesTab } from '@/app/classrooms/[classroomId]/TeacherResourcesTab'
 import { StudentResourcesTab } from '@/app/classrooms/[classroomId]/StudentResourcesTab'
+import { TeacherAnnouncementsTab } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsTab'
+import { StudentAnnouncementsTab } from '@/app/classrooms/[classroomId]/StudentAnnouncementsTab'
+
+vi.mock('@/app/classrooms/[classroomId]/TeacherClassResourcesSidebar', () => ({
+  TeacherClassResourcesSidebar: () => <div>Teacher resources content</div>,
+}))
+
+vi.mock('@/app/classrooms/[classroomId]/StudentClassResourcesSidebar', () => ({
+  StudentClassResourcesSidebar: () => <div>Student resources content</div>,
+}))
 
 vi.mock('@/app/classrooms/[classroomId]/TeacherAnnouncementsSection', () => ({
   TeacherAnnouncementsSection: () => <div>Teacher announcements content</div>,
@@ -9,10 +19,6 @@ vi.mock('@/app/classrooms/[classroomId]/TeacherAnnouncementsSection', () => ({
 
 vi.mock('@/app/classrooms/[classroomId]/StudentAnnouncementsSection', () => ({
   StudentAnnouncementsSection: () => <div>Student announcements content</div>,
-}))
-
-vi.mock('@/components/layout', () => ({
-  RightSidebarToggle: () => <button type="button">Open panel</button>,
 }))
 
 const classroom = {
@@ -32,21 +38,31 @@ const classroom = {
 } as const
 
 describe('ResourcesTab', () => {
-  it('renders teacher resources as announcements plus a panel toggle', () => {
+  it('renders teacher resources without announcements content', () => {
     render(<TeacherResourcesTab classroom={classroom} />)
 
-    expect(screen.getByText('Teacher announcements content')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Open panel' })).toBeInTheDocument()
-    expect(screen.queryByText('Announcements')).toBeNull()
-    expect(screen.queryByRole('button', { name: 'Class Resources' })).toBeNull()
+    expect(screen.getByText('Teacher resources content')).toBeInTheDocument()
+    expect(screen.queryByText('Teacher announcements content')).toBeNull()
   })
 
-  it('renders student resources as announcements plus a panel toggle', () => {
+  it('renders student resources without announcements content', () => {
     render(<StudentResourcesTab classroom={classroom} />)
 
+    expect(screen.getByText('Student resources content')).toBeInTheDocument()
+    expect(screen.queryByText('Student announcements content')).toBeNull()
+  })
+
+  it('renders teacher announcements in the announcements tab', () => {
+    render(<TeacherAnnouncementsTab classroom={classroom} />)
+
+    expect(screen.getByText('Teacher announcements content')).toBeInTheDocument()
+    expect(screen.queryByText('Teacher resources content')).toBeNull()
+  })
+
+  it('renders student announcements in the announcements tab', () => {
+    render(<StudentAnnouncementsTab classroom={classroom} />)
+
     expect(screen.getByText('Student announcements content')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Open panel' })).toBeInTheDocument()
-    expect(screen.queryByText('Announcements')).toBeNull()
-    expect(screen.queryByRole('button', { name: 'Class Resources' })).toBeNull()
+    expect(screen.queryByText('Student resources content')).toBeNull()
   })
 })

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -20,8 +20,8 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
     <>
       <button onClick={() => setRouteKey('today')}>go-today</button>
       <button onClick={() => setRouteKey('assignments-student')}>go-assignments</button>
+      <button onClick={() => setRouteKey('assignments-teacher-viewing')}>go-teacher-viewing</button>
       <button onClick={() => setRouteKey('quizzes-teacher')}>go-quizzes</button>
-      <button onClick={() => setRouteKey('resources-teacher')}>go-resources</button>
       <button onClick={() => setRouteKey('roster')}>go-roster</button>
       <ThreePanelProvider
         routeKey={routeKey}
@@ -102,9 +102,9 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
     expect(screen.getByTestId('open').textContent).toBe('false')
 
-    // Go to resources-teacher (enabled, defaultOpen: true)
+    // Go to teacher assignment viewing (enabled, defaultOpen: true)
     act(() => {
-      screen.getByText('go-resources').click()
+      screen.getByText('go-teacher-viewing').click()
     })
     expect(screen.getByTestId('enabled').textContent).toBe('true')
     expect(screen.getByTestId('open').textContent).toBe('true')

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -53,19 +53,25 @@ describe('getLayoutConfig', () => {
     expect(viewingConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
   })
 
-  it('should use a persistent two-pane layout for resources tabs', () => {
+  it('should use single-pane layouts for resources and announcements tabs', () => {
     const teacherConfig = getLayoutConfig('resources-teacher')
     const studentConfig = getLayoutConfig('resources-student')
+    const teacherAnnouncementsConfig = getLayoutConfig('announcements-teacher')
+    const studentAnnouncementsConfig = getLayoutConfig('announcements-student')
 
-    expect(teacherConfig.rightSidebar.enabled).toBe(true)
-    expect(teacherConfig.rightSidebar.defaultOpen).toBe(true)
-    expect(teacherConfig.rightSidebar.defaultWidth).toBe('50%')
-    expect(teacherConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
+    expect(teacherConfig.rightSidebar.enabled).toBe(false)
+    expect(teacherConfig.rightSidebar.defaultOpen).toBe(false)
+    expect(teacherConfig.mainContent.maxWidth).toBe('full')
 
-    expect(studentConfig.rightSidebar.enabled).toBe(true)
-    expect(studentConfig.rightSidebar.defaultOpen).toBe(true)
-    expect(studentConfig.rightSidebar.defaultWidth).toBe('50%')
-    expect(studentConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
+    expect(studentConfig.rightSidebar.enabled).toBe(false)
+    expect(studentConfig.rightSidebar.defaultOpen).toBe(false)
+    expect(studentConfig.mainContent.maxWidth).toBe('full')
+
+    expect(teacherAnnouncementsConfig.rightSidebar.enabled).toBe(false)
+    expect(teacherAnnouncementsConfig.mainContent.maxWidth).toBe('full')
+
+    expect(studentAnnouncementsConfig.rightSidebar.enabled).toBe(false)
+    expect(studentAnnouncementsConfig.mainContent.maxWidth).toBe('full')
   })
 
   it('should not reserve external sidebars for teacher gradebook, quizzes, and tests', () => {
@@ -162,11 +168,13 @@ describe('getRouteKeyFromTab', () => {
     expect(getRouteKeyFromTab('gradebook', 'teacher')).toBe('gradebook')
     expect(getRouteKeyFromTab('roster', 'teacher')).toBe('roster')
     expect(getRouteKeyFromTab('settings', 'teacher')).toBe('settings')
+    expect(getRouteKeyFromTab('announcements', 'teacher')).toBe('announcements-teacher')
   })
 
   it('should return correct route key for student tabs', () => {
     expect(getRouteKeyFromTab('today', 'student')).toBe('today')
     expect(getRouteKeyFromTab('tests', 'student')).toBe('tests-student')
+    expect(getRouteKeyFromTab('announcements', 'student')).toBe('announcements-student')
   })
 
   it('should return assignments-student for student assignments', () => {
@@ -213,6 +221,8 @@ describe('ROUTE_CONFIGS', () => {
       'calendar-student',
       'resources-teacher',
       'resources-student',
+      'announcements-teacher',
+      'announcements-student',
     ]
 
     expectedKeys.forEach((key) => {


### PR DESCRIPTION
## Summary

- Adds a dedicated Announcements classroom tab for teachers and students.
- Moves announcement feeds out of Resources so Resources shows only class resources.
- Routes unread announcement activity and calendar announcement links to the new tab.
- Updates layout route keys, UI gallery links, and focused component/unit coverage.

## Validation

- `pnpm test tests/components/ResourcesTab.test.tsx tests/components/NavItems.test.tsx tests/unit/layout-config.test.ts tests/components/ThreePanelProvider.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- Pika UI verification on port 3010 for teacher/student Resources and Announcements views.
- Manual mobile drawer screenshots confirmed Resources and Announcements are separate nav items.