### PR TITLE
[codex] Make app message popup background solid

### DIFF
--- a/.ai/JOURNAL.md
+++ b/.ai/JOURNAL.md
@@ -10747,3 +10747,19 @@
 - Manual mobile drawer captures:
   - `/tmp/pika-teacher-mobile-drawer.png`
   - `/tmp/pika-student-mobile-drawer.png`
+## 2026-05-04 — Make message popup background solid
+
+**Completed:**
+- Changed global app message popup tones to use the solid semantic surface background.
+- Kept tone-specific border and text colors for info, success, and warning messages.
+- Added test coverage so success messages keep `bg-surface` instead of the translucent success background token.
+
+**Validation:**
+- `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx`
+- `pnpm lint`
+- Manual Playwright screenshots on `http://localhost:3100/verify-signup?email=teacher%40example.com`:
+  - `/tmp/pika-message-popup-light.png`
+  - `/tmp/pika-message-popup-dark.png`
+- Computed popup backgrounds verified as opaque:
+  - Light: `rgb(255, 255, 255)`
+  - Dark: `rgb(17, 24, 39)`

--- a/src/ui/AppMessage.tsx
+++ b/src/ui/AppMessage.tsx
@@ -47,9 +47,9 @@ const AppMessageContext = createContext<AppMessageContextValue | null>(null)
 
 const toneClassNames: Record<AppMessageTone, string> = {
   loading: 'border-border bg-surface text-text-default',
-  info: 'border-primary bg-info-bg text-info',
-  success: 'border-success bg-success-bg text-success',
-  warning: 'border-warning bg-warning-bg text-warning',
+  info: 'border-primary bg-surface text-info',
+  success: 'border-success bg-surface text-success',
+  warning: 'border-warning bg-surface text-warning',
 }
 
 function getDefaultDurationMs(tone: AppMessageTone): number {

--- a/tests/ui/AppMessage.test.tsx
+++ b/tests/ui/AppMessage.test.tsx
@@ -42,7 +42,8 @@ describe('AppMessageProvider', () => {
     expect(overlay).toHaveAttribute('aria-live', 'polite')
     expect(overlay).toHaveAttribute('aria-atomic', 'true')
     expect(overlay).toHaveClass('fixed', 'left-1/2', 'top-6', '-translate-y-1/2', 'pointer-events-none')
-    expect(screen.getByTestId('app-message-pill')).not.toHaveClass('transition-[opacity,transform]')
+    expect(screen.getByTestId('app-message-pill')).toHaveClass('bg-surface', 'text-success')
+    expect(screen.getByTestId('app-message-pill')).not.toHaveClass('bg-success-bg', 'transition-[opacity,transform]')
     expect(container.firstElementChild).toBe(screen.getByRole('button', { name: 'Show' }))
     expect(screen.getByRole('status')).toHaveTextContent('Saved')
 


### PR DESCRIPTION
## Summary
- Make global app message popup info, success, and warning tones use the solid semantic surface background.
- Preserve tone-specific border and text colors so status meaning remains visible.
- Add focused AppMessage coverage and log the session validation.

## Why
Dark-mode status background tokens are translucent, so message popups could appear see-through. The popup should render on a solid surface in both light and dark mode.

## Validation
- `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx`
- `pnpm lint`
- Manual Playwright visual verification on `http://localhost:3100/verify-signup?email=teacher%40example.com`
  - `/tmp/pika-message-popup-light.png`
  - `/tmp/pika-message-popup-dark.png`
- Computed popup backgrounds verified opaque:
  - Light: `rgb(255, 255, 255)`
  - Dark: `rgb(17, 24, 39)`

## Review
No issues found in self-review. Scope is limited to the shared app message primitive, its focused UI test, and the required journal entry.