### PR TITLE
[codex] Align gradebook and roster work surfaces

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -10816,3 +10816,52 @@
 - Manual Playwright visual verification on port 3003:
   - `/tmp/pika-issue-547-teacher-schedule-validation.png`
   - `/tmp/pika-issue-547-student-classrooms-smoke.png`
+
+---
+---
+## 2026-05-04 13:10 [AI - Codex]
+**Goal:** Align Gradebook and Roster with the Daily teacher work-surface shell.
+**Completed:** Moved Gradebook and Roster onto the floating center action cluster plus gapped split workspace used by Daily; kept student tables in the left pane and summary/student detail inspectors on the right; moved roster row removal into the selected-student detail pane and hid secondary roster columns on mobile.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx`, `src/app/classrooms/[classroomId]/TeacherRosterTab.tsx`, `.ai/JOURNAL.md`
+- Visual verification: `/tmp/pika-final-gradebook-teacher.png`, `/tmp/pika-final-roster-teacher-after.png`, `/tmp/pika-final-gradebook-mobile.png`, `/tmp/pika-final-roster-mobile-after.png`
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/api/teacher/roster.test.ts tests/api/teacher/gradebook.test.ts`
+- `pnpm build`
+**Next:** None
+**Blockers:** None
+
+---
+---
+## 2026-05-04 14:25 [AI - Codex]
+**Goal:** Make Gradebook's student table follow the Roster table pattern.
+**Completed:** Split Gradebook's single student-name column into sortable First and Last columns, added roster-style row and header checkboxes, sorted the displayed gradebook rows by first/last name, and hid category grade columns on mobile so the left table fits like Roster while preserving Final.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx`, `tests/components/TeacherGradebookTab.test.tsx`, `.ai/JOURNAL.md`
+- Visual verification: `/tmp/pika-gradebook-table-teacher.png`, `/tmp/pika-gradebook-table-mobile-after.png`
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/api/teacher/roster.test.ts tests/api/teacher/gradebook.test.ts`
+- `pnpm build`
+**Next:** None
+**Blockers:** None
+
+---
+---
+## 2026-05-04 14:30 [AI - Codex]
+**Goal:** Collapse Roster's floating actions into one split button.
+**Completed:** Replaced separate `+ Students`, `+ CSV`, and selected-email controls with a single `SplitButton`; primary action opens Add Students, menu contains `+ CSV` and email actions for the current selection.
+**Status:** completed
+**Artifacts:**
+- Files: `src/app/classrooms/[classroomId]/TeacherRosterTab.tsx`, `.ai/JOURNAL.md`
+- Visual verification: `/tmp/pika-roster-split-button-teacher.png`, `/tmp/pika-roster-split-button-mobile.png`, `/tmp/pika-roster-split-button-menu.png`
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/api/teacher/roster.test.ts`
+- `pnpm build`
+**Next:** None
+**Blockers:** None

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -9,9 +9,9 @@ import type {
 } from '@/types'
 import { Button, FormField, Input } from '@/ui'
 import { Spinner } from '@/components/Spinner'
-import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
-import { TeacherWorkSurfaceModeBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   DataTable,
   DataTableBody,
@@ -21,14 +21,18 @@ import {
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
+  SortableHeaderCell,
   TableCard,
 } from '@/components/DataTable'
 import {
   fetchJSONWithCache,
   invalidateCachedJSONMatching,
 } from '@/lib/request-cache'
+import { compareByNameFields, toggleSort } from '@/lib/table-sort'
+import { useStudentSelection } from '@/hooks/useStudentSelection'
 
 type GradebookSection = 'grades' | 'settings'
+type GradebookSortColumn = 'first_name' | 'last_name'
 
 interface GradebookSettingsState {
   use_weights: boolean
@@ -373,8 +377,31 @@ export function TeacherGradebookTab({
   const [studentDetail, setStudentDetail] = useState<GradebookStudentDetail | null>(null)
   const [studentDetailLoading, setStudentDetailLoading] = useState(false)
   const [studentDetailError, setStudentDetailError] = useState('')
+  const [detailPaneWidth, setDetailPaneWidth] = useState(50)
+  const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
+    column: GradebookSortColumn
+    direction: 'asc' | 'desc'
+  }>({ column: 'last_name', direction: 'asc' })
 
-  const rowKeys = useMemo(() => students.map((student) => student.student_id), [students])
+  const sortedStudents = useMemo(() => {
+    const rows = [...students]
+    rows.sort((a, b) =>
+      compareByNameFields(
+        { firstName: a.student_first_name, lastName: a.student_last_name, id: a.student_email },
+        { firstName: b.student_first_name, lastName: b.student_last_name, id: b.student_email },
+        sortColumn,
+        sortDirection,
+      )
+    )
+    return rows
+  }, [students, sortColumn, sortDirection])
+
+  const rowKeys = useMemo(() => sortedStudents.map((student) => student.student_id), [sortedStudents])
+  const { selectedIds, toggleSelect, toggleSelectAll, allSelected } = useStudentSelection(rowKeys)
+
+  function handleSort(column: GradebookSortColumn) {
+    setSortState((previous) => toggleSort(previous, column))
+  }
 
   const loadGradebook = useCallback(async () => {
     setLoading(true)
@@ -489,19 +516,58 @@ export function TeacherGradebookTab({
     [settings.assignments_weight, settings.quizzes_weight, settings.tests_weight],
   )
 
+  const actionBar = (
+    <TeacherWorkSurfaceActionBar
+      center={
+        <div role="tablist" aria-label="Gradebook sections" className="flex items-center gap-1">
+          <Button
+            type="button"
+            role="tab"
+            aria-selected={section === 'grades'}
+            size="sm"
+            variant={section === 'grades' ? 'primary' : 'surface'}
+            onClick={() => onSectionChange('grades')}
+          >
+            Grades
+          </Button>
+          <Button
+            type="button"
+            role="tab"
+            aria-selected={section === 'settings'}
+            size="sm"
+            variant={section === 'settings' ? 'primary' : 'surface'}
+            onClick={() => onSectionChange('settings')}
+          >
+            Settings
+          </Button>
+        </div>
+      }
+      centerPlacement="floating"
+    />
+  )
+
   const gradesWorkspace = loading ? (
     <div className="flex flex-1 justify-center py-12">
       <Spinner size="lg" />
     </div>
   ) : (
-    <SummaryDetailWorkspaceShell
+    <TeacherWorkspaceSplit
       className="flex-1"
-      orientation="responsive"
-      leftPaneClassName="flex min-h-0 flex-col lg:basis-1/2"
-      rightPaneClassName="flex min-h-0 flex-col lg:basis-1/2"
-      left={
-        <div className="min-h-0 min-w-0 flex-1 overflow-auto">
-          <TableCard>
+      splitVariant="gapped"
+      primaryClassName="min-h-[200px] rounded-lg bg-surface"
+      inspectorClassName="flex flex-col rounded-lg bg-surface"
+      inspectorCollapsed={false}
+      inspectorWidth={detailPaneWidth}
+      minInspectorPx={280}
+      minPrimaryPx={320}
+      minInspectorPercent={28}
+      maxInspectorPercent={72}
+      defaultInspectorWidth={50}
+      onInspectorWidthChange={setDetailPaneWidth}
+      dividerLabel="Resize Gradebook panes"
+      primary={
+        <div className="h-full min-h-0 overflow-auto">
+          <TableCard chrome="flush">
             <KeyboardNavigableTable
               rowKeys={rowKeys}
               selectedKey={selectedStudent?.student_id ?? null}
@@ -514,16 +580,43 @@ export function TeacherGradebookTab({
               <DataTable density="tight">
                 <DataTableHead>
                   <DataTableRow>
-                    <DataTableHeaderCell className="text-xs sm:text-sm">Student</DataTableHeaderCell>
-                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Assignments">
+                    <DataTableHeaderCell className="w-10">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={toggleSelectAll}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                        aria-label="Select all students"
+                      />
+                    </DataTableHeaderCell>
+                    <SortableHeaderCell
+                      label="First"
+                      isActive={sortColumn === 'first_name'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('first_name')}
+                      density="tight"
+                      trailing={sortedStudents.length > 0 ? (
+                        <span className="ml-1 inline-flex min-w-6 items-center justify-center rounded-full border border-border bg-surface px-2 py-0.5 text-xs font-semibold text-text-muted">
+                          {sortedStudents.length}
+                        </span>
+                      ) : undefined}
+                    />
+                    <SortableHeaderCell
+                      label="Last"
+                      isActive={sortColumn === 'last_name'}
+                      direction={sortDirection}
+                      onClick={() => handleSort('last_name')}
+                      density="tight"
+                    />
+                    <DataTableHeaderCell align="right" className="hidden text-xs sm:text-sm md:table-cell" aria-label="Assignments">
                       <span className="hidden sm:inline">Assignments</span>
                       <span className="sm:hidden">Assign.</span>
                     </DataTableHeaderCell>
-                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Quizzes">
+                    <DataTableHeaderCell align="right" className="hidden text-xs sm:text-sm md:table-cell" aria-label="Quizzes">
                       <span className="hidden sm:inline">Quizzes</span>
                       <span className="sm:hidden">Quiz</span>
                     </DataTableHeaderCell>
-                    <DataTableHeaderCell align="right" className="text-xs sm:text-sm" aria-label="Tests">
+                    <DataTableHeaderCell align="right" className="hidden text-xs sm:text-sm md:table-cell" aria-label="Tests">
                       <span className="hidden sm:inline">Tests</span>
                       <span className="sm:hidden">Test</span>
                     </DataTableHeaderCell>
@@ -531,7 +624,7 @@ export function TeacherGradebookTab({
                   </DataTableRow>
                 </DataTableHead>
                 <DataTableBody>
-                  {students.map((student) => {
+                  {sortedStudents.map((student) => {
                     const isSelected = student.student_id === selectedStudent?.student_id
                     return (
                       <DataTableRow
@@ -540,18 +633,33 @@ export function TeacherGradebookTab({
                           'cursor-pointer transition-colors',
                           isSelected ? 'bg-surface-selected hover:bg-surface-selected' : 'hover:bg-surface-hover',
                         ].join(' ')}
-                        onClick={() => setSelectedStudent(isSelected ? null : student)}
+                        onClick={(event) => {
+                          if ((event.target as HTMLElement).closest('button,input,a')) return
+                          setSelectedStudent(isSelected ? null : student)
+                        }}
                       >
-                        <DataTableCell className="max-w-[7rem] text-xs sm:max-w-none sm:text-sm">
-                          {getStudentName(student)}
+                        <DataTableCell>
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(student.student_id)}
+                            onChange={() => toggleSelect(student.student_id)}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            aria-label={`Select ${getStudentName(student)}`}
+                          />
                         </DataTableCell>
-                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                        <DataTableCell className="max-w-[5.5rem] truncate text-xs sm:max-w-none sm:text-sm">
+                          {student.student_first_name || '—'}
+                        </DataTableCell>
+                        <DataTableCell className="max-w-[5.5rem] truncate text-xs sm:max-w-none sm:text-sm">
+                          {student.student_last_name || '—'}
+                        </DataTableCell>
+                        <DataTableCell align="right" className="hidden whitespace-nowrap text-xs sm:text-sm md:table-cell">
                           {formatPercent(student.assignments_percent)}
                         </DataTableCell>
-                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                        <DataTableCell align="right" className="hidden whitespace-nowrap text-xs sm:text-sm md:table-cell">
                           {formatPercent(student.quizzes_percent)}
                         </DataTableCell>
-                        <DataTableCell align="right" className="whitespace-nowrap text-xs sm:text-sm">
+                        <DataTableCell align="right" className="hidden whitespace-nowrap text-xs sm:text-sm md:table-cell">
                           {formatPercent(student.tests_percent)}
                         </DataTableCell>
                         <DataTableCell align="right" className="whitespace-nowrap text-xs font-semibold sm:text-sm">
@@ -561,8 +669,8 @@ export function TeacherGradebookTab({
                     )
                   })}
 
-                  {students.length === 0 && (
-                    <EmptyStateRow colSpan={5} message="No students enrolled yet" />
+                  {sortedStudents.length === 0 && (
+                    <EmptyStateRow colSpan={7} message="No students enrolled yet" />
                   )}
                 </DataTableBody>
               </DataTable>
@@ -570,24 +678,31 @@ export function TeacherGradebookTab({
           </TableCard>
         </div>
       }
-      right={
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {selectedStudent ? (
-            <StudentDetailPanel
-              detail={studentDetail}
-              loading={studentDetailLoading}
-              error={studentDetailError}
-            />
-          ) : (
-            <ClassSummaryPanel summary={classSummary} />
-          )}
-        </div>
+      inspector={
+        <>
+          <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
+            <span className="truncate text-sm font-semibold text-text-default">
+              {selectedStudent ? getStudentName(selectedStudent) : 'Class Summary'}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {selectedStudent ? (
+              <StudentDetailPanel
+                detail={studentDetail}
+                loading={studentDetailLoading}
+                error={studentDetailError}
+              />
+            ) : (
+              <ClassSummaryPanel summary={classSummary} />
+            )}
+          </div>
+        </>
       }
     />
   )
 
   const settingsWorkspace = (
-    <div className="min-h-0 flex-1 overflow-y-auto p-4">
+    <div className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface p-4">
       <div className="max-w-2xl space-y-5">
         <label className="inline-flex items-center gap-2 text-sm text-text-default">
           <input
@@ -657,18 +772,8 @@ export function TeacherGradebookTab({
   return (
     <TeacherWorkSurfaceShell
       state="workspace"
-      workspaceFrame="attachedTabs"
-      primary={
-        <TeacherWorkSurfaceModeBar
-          modes={[
-            { id: 'grades', label: 'Grades' },
-            { id: 'settings', label: 'Settings' },
-          ]}
-          activeMode={section}
-          onModeChange={(mode) => onSectionChange(mode as GradebookSection)}
-          ariaLabel="Gradebook sections"
-        />
-      }
+      workspaceFrame="standalone"
+      primary={actionBar}
       feedback={
         error ? (
           <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
@@ -678,7 +783,7 @@ export function TeacherGradebookTab({
       }
       summary={null}
       workspace={section === 'grades' ? gradesWorkspace : settingsWorkspace}
-      workspaceClassName="bg-surface"
+      workspaceFrameClassName="min-h-[360px] border-0 bg-page"
     />
   )
 }

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { Button, ConfirmDialog, useAppMessage } from '@/ui'
+import { Button, ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
-import { ACTIONBAR_BUTTON_SECONDARY_CLASSNAME, PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
   DataTable,
   DataTableBody,
@@ -14,11 +16,12 @@ import {
   DataTableRow,
   DataTableHeaderCell,
   EmptyStateRow,
+  KeyboardNavigableTable,
   SortableHeaderCell,
   TableCard,
 } from '@/components/DataTable'
 import type { Classroom } from '@/types'
-import { Check, ChevronRight, Copy, Mail, Pencil, Trash2, X } from 'lucide-react'
+import { Check, Pencil, X } from 'lucide-react'
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
@@ -61,6 +64,24 @@ function normalizeRosterRows(raw: any[]): RosterRow[] {
   })
 }
 
+function getRosterName(row: RosterRow): string {
+  return [row.first_name, row.last_name].filter(Boolean).join(' ') || row.email
+}
+
+function formatRosterDate(iso: string | null): string {
+  if (!iso) return '—'
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'America/Toronto',
+    }).format(new Date(iso))
+  } catch {
+    return iso
+  }
+}
+
 export function TeacherRosterTab({ classroom }: Props) {
   const isReadOnly = !!classroom.archived_at
   const [loading, setLoading] = useState(true)
@@ -80,9 +101,10 @@ export function TeacherRosterTab({ classroom }: Props) {
     joined: boolean
   } | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
+  const [selectedRosterId, setSelectedRosterId] = useState<string | null>(null)
+  const [detailPaneWidth, setDetailPaneWidth] = useState(50)
 
   // Selection state
-  const [isEmailMenuOpen, setEmailMenuOpen] = useState(false)
   const { showMessage } = useAppMessage()
 
   // Counselor email editing state
@@ -175,6 +197,13 @@ export function TeacherRosterTab({ classroom }: Props) {
   const selectedRows = sortedRoster.filter((r) => selectedIds.has(r.id))
   const selectedStudentEmails = selectedRows.map((r) => r.email)
   const selectedCounselorEmails = selectedRows.map((r) => r.counselor_email).filter(Boolean) as string[]
+  const selectedRosterRow = sortedRoster.find((row) => row.id === selectedRosterId) ?? null
+
+  useEffect(() => {
+    if (selectedRosterId && !roster.some((row) => row.id === selectedRosterId)) {
+      setSelectedRosterId(null)
+    }
+  }, [roster, selectedRosterId])
 
   async function copyToClipboard(emails: string[], label: string) {
     const text = emails.join(', ')
@@ -191,7 +220,6 @@ export function TeacherRosterTab({ classroom }: Props) {
       document.body.removeChild(textarea)
       showMessage({ text: `${label} copied`, tone: 'success' })
     }
-    setEmailMenuOpen(false)
   }
 
   function openGmail(emails: string[]) {
@@ -199,7 +227,6 @@ export function TeacherRosterTab({ classroom }: Props) {
     if (validEmails.length === 0) return
     const bcc = validEmails.join(',')
     window.open(`https://mail.google.com/mail/?view=cm&fs=1&bcc=${encodeURIComponent(bcc)}`, '_blank')
-    setEmailMenuOpen(false)
   }
 
   function openOutlook(emails: string[]) {
@@ -207,7 +234,12 @@ export function TeacherRosterTab({ classroom }: Props) {
     if (validEmails.length === 0) return
     const bcc = validEmails.join(',')
     window.open(`https://outlook.office.com/mail/deeplink/compose?bcc=${encodeURIComponent(bcc)}`, '_blank')
-    setEmailMenuOpen(false)
+  }
+
+  function openDefaultEmail(emails: string[]) {
+    const validEmails = emails.filter((e) => e && e.includes('@'))
+    if (validEmails.length === 0) return
+    window.location.href = `mailto:?bcc=${encodeURIComponent(validEmails.join(','))}`
   }
 
   // Counselor email editing
@@ -252,310 +284,385 @@ export function TeacherRosterTab({ classroom }: Props) {
     }
   }
 
-  if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Spinner size="lg" />
-      </div>
+  const rosterActionOptions: SplitButtonOption[] = someSelected
+    ? [
+        {
+          id: 'add-students',
+          label: '+ Students',
+          onSelect: () => setAddModalOpen(true),
+          disabled: isReadOnly || loading,
+        },
+        {
+          id: 'upload-csv',
+          label: '+ CSV',
+          onSelect: () => setUploadModalOpen(true),
+          disabled: isReadOnly || loading,
+        },
+      ]
+    : [
+        {
+          id: 'upload-csv',
+          label: '+ CSV',
+          onSelect: () => setUploadModalOpen(true),
+          disabled: isReadOnly || loading,
+        },
+      ]
+
+  if (!someSelected) {
+    rosterActionOptions.push({
+      id: 'email-placeholder',
+      label: 'Select students to email',
+      onSelect: () => {},
+      disabled: true,
+    })
+  } else {
+    rosterActionOptions.push(
+      {
+        id: 'copy-student-emails',
+        label: `Copy emails (${selectedStudentEmails.length})`,
+        onSelect: () => copyToClipboard(selectedStudentEmails, 'Student emails'),
+      },
+      {
+        id: 'gmail-students',
+        label: 'Gmail',
+        onSelect: () => openGmail(selectedStudentEmails),
+      },
+      {
+        id: 'outlook-students',
+        label: 'Outlook',
+        onSelect: () => openOutlook(selectedStudentEmails),
+      },
     )
+
+    if (selectedCounselorEmails.length > 0) {
+      const allEmails = [...selectedStudentEmails, ...selectedCounselorEmails]
+      rosterActionOptions.push(
+        {
+          id: 'copy-counselor-emails',
+          label: `Copy counselors (${selectedCounselorEmails.length})`,
+          onSelect: () => copyToClipboard(selectedCounselorEmails, 'Counselor emails'),
+        },
+        {
+          id: 'copy-all-emails',
+          label: `Copy all emails (${allEmails.length})`,
+          onSelect: () => copyToClipboard(allEmails, 'All emails'),
+        },
+        {
+          id: 'gmail-all',
+          label: 'Gmail all',
+          onSelect: () => openGmail(allEmails),
+        },
+        {
+          id: 'outlook-all',
+          label: 'Outlook all',
+          onSelect: () => openOutlook(allEmails),
+        },
+      )
+    }
   }
 
-  return (
-    <PageLayout>
-      <PageActionBar
-        primary={
-          <div className="flex gap-2 flex-wrap">
-            <Button onClick={() => setAddModalOpen(true)} disabled={isReadOnly}>
-              + Students
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={() => setUploadModalOpen(true)}
-              disabled={isReadOnly}
-            >
-              + CSV
-            </Button>
-            {someSelected && (
-              <div className="relative" onMouseLeave={() => setEmailMenuOpen(false)}>
-                <button
-                  type="button"
-                  className={`${ACTIONBAR_BUTTON_SECONDARY_CLASSNAME} flex items-center gap-1`}
-                  onClick={() => setEmailMenuOpen(!isEmailMenuOpen)}
-                >
-                  <Mail className="h-4 w-4" />
-                  Email ({selectedIds.size})
-                </button>
-                {isEmailMenuOpen && (
-                  <div className="absolute left-0 top-full pt-1 w-48 z-10">
-                    <div className="rounded-md border border-border bg-surface shadow-lg">
-                    {/* Students option with submenu */}
-                    <div className="group relative">
-                      <button
-                        type="button"
-                        className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center justify-between"
-                      >
-                        <span>Students ({selectedStudentEmails.length})</span>
-                        <ChevronRight className="h-4 w-4" />
-                      </button>
-                      <div className="absolute left-full top-0 w-36 rounded-md border border-border bg-surface shadow-lg hidden group-hover:block">
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center gap-2"
-                          onClick={() => copyToClipboard(selectedStudentEmails, 'Student emails')}
-                        >
-                          <Copy className="h-4 w-4" />
-                          Copy
-                        </button>
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                          onClick={() => openGmail(selectedStudentEmails)}
-                        >
-                          Gmail
-                        </button>
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                          onClick={() => openOutlook(selectedStudentEmails)}
-                        >
-                          Outlook
-                        </button>
-                      </div>
-                    </div>
+  const actionBar = (
+    <TeacherWorkSurfaceActionBar
+      center={
+        <SplitButton
+          label={someSelected ? `Email (${selectedStudentEmails.length})` : '+ Students'}
+          onPrimaryClick={() => {
+            if (someSelected) {
+              openDefaultEmail(selectedStudentEmails)
+              return
+            }
+            if (isReadOnly || loading) return
+            setAddModalOpen(true)
+          }}
+          options={rosterActionOptions}
+          disabled={!someSelected && (isReadOnly || loading)}
+          size="sm"
+          toggleAriaLabel="Roster actions"
+          menuPlacement="down"
+        />
+      }
+      centerPlacement="floating"
+    />
+  )
 
-                    {/* Counselors option with submenu (only if there are counselor emails) */}
-                    {selectedCounselorEmails.length > 0 && (
-                      <div className="group relative">
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center justify-between"
-                        >
-                          <span>Counselors ({selectedCounselorEmails.length})</span>
-                          <ChevronRight className="h-4 w-4" />
-                        </button>
-                        <div className="absolute left-full top-0 w-36 rounded-md border border-border bg-surface shadow-lg hidden group-hover:block">
-                          <button
-                            type="button"
-                            className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center gap-2"
-                            onClick={() => copyToClipboard(selectedCounselorEmails, 'Counselor emails')}
-                          >
-                            <Copy className="h-4 w-4" />
-                            Copy
-                          </button>
-                          <button
-                            type="button"
-                            className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                            onClick={() => openGmail(selectedCounselorEmails)}
-                          >
-                            Gmail
-                          </button>
-                          <button
-                            type="button"
-                            className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                            onClick={() => openOutlook(selectedCounselorEmails)}
-                          >
-                            Outlook
-                          </button>
-                        </div>
-                      </div>
-                    )}
+  const detailPane = selectedRosterRow ? (
+    <div className="space-y-4 p-4">
+      <div className="rounded-md border border-border bg-surface-2 p-3">
+        <div className="text-xs text-text-muted">Student email</div>
+        <div className="mt-1 break-all text-sm font-medium text-text-default">{selectedRosterRow.email}</div>
+      </div>
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <div className="text-xs text-text-muted">First</div>
+          <div className="text-text-default">{selectedRosterRow.first_name || '—'}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Last</div>
+          <div className="text-text-default">{selectedRosterRow.last_name || '—'}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Student number</div>
+          <div className="text-text-default">{selectedRosterRow.student_number || '—'}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Joined</div>
+          <div className="text-text-default">{selectedRosterRow.joined ? 'Yes' : 'No'}</div>
+        </div>
+      </div>
+      <div>
+        <div className="text-xs text-text-muted">Counselor</div>
+        <div className="break-all text-sm text-text-default">{selectedRosterRow.counselor_email || '—'}</div>
+      </div>
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <div className="text-xs text-text-muted">Added</div>
+          <div className="text-text-default">{formatRosterDate(selectedRosterRow.created_at)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Joined at</div>
+          <div className="text-text-default">{formatRosterDate(selectedRosterRow.joined_at)}</div>
+        </div>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="danger"
+        disabled={isReadOnly}
+        onClick={() => {
+          setPendingRemoval({
+            rosterId: selectedRosterRow.id,
+            email: selectedRosterRow.email,
+            firstName: selectedRosterRow.first_name,
+            lastName: selectedRosterRow.last_name,
+            joined: selectedRosterRow.joined,
+          })
+        }}
+      >
+        Remove
+      </Button>
+    </div>
+  ) : (
+    <div className="space-y-4 p-4">
+      <div className="rounded-md border border-border bg-surface-2 p-3">
+        <div className="text-xs text-text-muted">Roster size</div>
+        <div className="mt-1 text-lg font-semibold text-text-default">{sortedRoster.length}</div>
+      </div>
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <div className="text-xs text-text-muted">Joined</div>
+          <div className="text-text-default">{joinedCount}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Not joined</div>
+          <div className="text-text-default">{Math.max(sortedRoster.length - joinedCount, 0)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Selected</div>
+          <div className="text-text-default">{selectedIds.size}</div>
+        </div>
+        <div>
+          <div className="text-xs text-text-muted">Counselors</div>
+          <div className="text-text-default">{sortedRoster.filter((row) => row.counselor_email).length}</div>
+        </div>
+      </div>
+    </div>
+  )
 
-                    {/* All option with submenu */}
-                    <div className="group relative border-t border-border">
-                      <button
-                        type="button"
-                        className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center justify-between"
-                      >
-                        <span>All ({selectedStudentEmails.length + selectedCounselorEmails.length})</span>
-                        <ChevronRight className="h-4 w-4" />
-                      </button>
-                      <div className="absolute left-full top-0 w-36 rounded-md border border-border bg-surface shadow-lg hidden group-hover:block">
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default flex items-center gap-2"
-                          onClick={() => copyToClipboard([...selectedStudentEmails, ...selectedCounselorEmails], 'All emails')}
-                        >
-                          <Copy className="h-4 w-4" />
-                          Copy
-                        </button>
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                          onClick={() => openGmail([...selectedStudentEmails, ...selectedCounselorEmails])}
-                        >
-                          Gmail
-                        </button>
-                        <button
-                          type="button"
-                          className="w-full px-4 py-2 text-left text-sm hover:bg-surface-hover text-text-default"
-                          onClick={() => openOutlook([...selectedStudentEmails, ...selectedCounselorEmails])}
-                        >
-                          Outlook
-                        </button>
-                      </div>
-                    </div>
-                    </div>
-                  </div>
-                )}
+  const workspace = loading ? (
+    <div className="flex flex-1 justify-center py-12">
+      <Spinner size="lg" />
+    </div>
+  ) : (
+    <TeacherWorkspaceSplit
+      className="flex-1"
+      splitVariant="gapped"
+      primaryClassName="min-h-[200px] rounded-lg bg-surface"
+      inspectorClassName="flex flex-col rounded-lg bg-surface"
+      inspectorCollapsed={false}
+      inspectorWidth={detailPaneWidth}
+      minInspectorPx={280}
+      minPrimaryPx={320}
+      minInspectorPercent={28}
+      maxInspectorPercent={72}
+      defaultInspectorWidth={50}
+      onInspectorWidthChange={setDetailPaneWidth}
+      dividerLabel="Resize Roster panes"
+      primary={
+        <div className="h-full min-h-0 overflow-auto">
+          <TableCard chrome="flush" overflowX>
+            {error && (
+              <div className="p-3 border-b border-border">
+                <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+                  {error}
+                </div>
               </div>
             )}
-          </div>
-        }
-      />
 
-      <PageContent>
-        <TableCard>
-          {error && (
-            <div className="p-3 border-b border-border">
-              <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
-                {error}
-              </div>
-            </div>
-          )}
-
-          <DataTable>
-            <DataTableHead>
-              <DataTableRow>
-                <DataTableHeaderCell className="w-10">
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    onChange={toggleSelectAll}
-                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                    aria-label="Select all students"
-                  />
-                </DataTableHeaderCell>
-                <SortableHeaderCell
-                  label="First"
-                  isActive={sortColumn === 'first_name'}
-                  direction={sortDirection}
-                  onClick={() => onSort('first_name')}
-                  trailing={sortedRoster.length > 0 ? <StudentCountBadge count={sortedRoster.length} variant="neutral" /> : undefined}
-                />
-                <SortableHeaderCell
-                  label="Last"
-                  isActive={sortColumn === 'last_name'}
-                  direction={sortDirection}
-                  onClick={() => onSort('last_name')}
-                />
-                <DataTableHeaderCell>Email</DataTableHeaderCell>
-                <DataTableHeaderCell>Counselor</DataTableHeaderCell>
-                <DataTableHeaderCell align="center">
-                  <span className="flex items-center justify-center gap-2">
-                    Joined
-                    <CountBadge count={joinedCount} tooltip={`${joinedCount} ${joinedCount === 1 ? 'student' : 'students'} joined`} variant="success" />
-                  </span>
-                </DataTableHeaderCell>
-                <DataTableHeaderCell align="right">Actions</DataTableHeaderCell>
-              </DataTableRow>
-            </DataTableHead>
-            <DataTableBody>
-              {sortedRoster.map((row) => (
-                <DataTableRow key={row.id} className="hover:bg-surface-hover">
-                  <DataTableCell>
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(row.id)}
-                      onChange={() => toggleSelect(row.id)}
-                      className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                      aria-label={`Select ${row.first_name ?? ''} ${row.last_name ?? ''}`}
+            <KeyboardNavigableTable
+              rowKeys={rosterIds}
+              selectedKey={selectedRosterId}
+              onSelectKey={setSelectedRosterId}
+              onDeselect={() => setSelectedRosterId(null)}
+            >
+              <DataTable density="tight">
+                <DataTableHead>
+                  <DataTableRow>
+                    <DataTableHeaderCell className="w-10">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={toggleSelectAll}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                        aria-label="Select all students"
+                      />
+                    </DataTableHeaderCell>
+                    <SortableHeaderCell
+                      label="First"
+                      isActive={sortColumn === 'first_name'}
+                      direction={sortDirection}
+                      onClick={() => onSort('first_name')}
+                      trailing={sortedRoster.length > 0 ? <StudentCountBadge count={sortedRoster.length} variant="neutral" /> : undefined}
                     />
-                  </DataTableCell>
-                  <DataTableCell>{row.first_name ?? '—'}</DataTableCell>
-                  <DataTableCell>{row.last_name ?? '—'}</DataTableCell>
-                  <DataTableCell className="text-text-muted">{row.email}</DataTableCell>
-                  <DataTableCell className="text-text-muted">
-                    {editingCounselorId === row.id ? (
-                      <div className="flex items-center gap-1">
-                        <input
-                          type="email"
-                          value={editingCounselorValue}
-                          onChange={(e) => setEditingCounselorValue(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') saveCounselorEmail(row.id)
-                            if (e.key === 'Escape') cancelEditingCounselor()
-                          }}
-                          className="w-32 rounded border border-border bg-surface px-2 py-1 text-sm text-text-default"
-                          placeholder="counselor@..."
-                          autoFocus
-                          disabled={isSavingCounselor}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => saveCounselorEmail(row.id)}
-                          disabled={isSavingCounselor}
-                          className="text-success hover:text-success-hover"
-                          aria-label="Save"
-                        >
-                          <Check className="h-4 w-4" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={cancelEditingCounselor}
-                          disabled={isSavingCounselor}
-                          className="text-text-muted hover:text-text-default"
-                          aria-label="Cancel"
-                        >
-                          <X className="h-4 w-4" />
-                        </button>
-                      </div>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => startEditingCounselor(row)}
-                        disabled={isReadOnly}
-                        className={`flex items-center gap-1 text-left ${
-                          isReadOnly ? 'cursor-not-allowed opacity-50' : 'hover:text-text-default'
-                        }`}
+                    <SortableHeaderCell
+                      label="Last"
+                      isActive={sortColumn === 'last_name'}
+                      direction={sortDirection}
+                      onClick={() => onSort('last_name')}
+                    />
+                    <DataTableHeaderCell className="hidden md:table-cell">Email</DataTableHeaderCell>
+                    <DataTableHeaderCell className="hidden lg:table-cell">Counselor</DataTableHeaderCell>
+                    <DataTableHeaderCell align="center">
+                      <span className="flex items-center justify-center gap-2">
+                        Joined
+                        <CountBadge count={joinedCount} tooltip={`${joinedCount} ${joinedCount === 1 ? 'student' : 'students'} joined`} variant="success" />
+                      </span>
+                    </DataTableHeaderCell>
+                  </DataTableRow>
+                </DataTableHead>
+                <DataTableBody>
+                  {sortedRoster.map((row) => {
+                    const isSelected = row.id === selectedRosterId
+                    return (
+                      <DataTableRow
+                        key={row.id}
+                        className={[
+                          'cursor-pointer transition-colors',
+                          isSelected ? 'bg-info-bg hover:bg-info-bg-hover' : 'hover:bg-surface-hover',
+                        ].join(' ')}
+                        onClick={(event) => {
+                          if ((event.target as HTMLElement).closest('button,input,a')) return
+                          setSelectedRosterId(isSelected ? null : row.id)
+                        }}
                       >
-                        {row.counselor_email ? (
-                          <span className="truncate max-w-[120px]" title={row.counselor_email}>
-                            {row.counselor_email}
-                          </span>
-                        ) : (
-                          <span className="text-text-muted italic">Add</span>
-                        )}
-                        {!isReadOnly && <Pencil className="h-3 w-3 flex-shrink-0" />}
-                      </button>
-                    )}
-                  </DataTableCell>
-                  <DataTableCell align="center">
-                    {row.joined && (
-                      <Check className="mx-auto h-5 w-5 text-success" aria-hidden="true" />
-                    )}
-                  </DataTableCell>
-                  <DataTableCell align="right">
-                    <button
-                      type="button"
-                      className={[
-                        'text-danger hover:text-danger-hover',
-                        isReadOnly ? 'opacity-50 cursor-not-allowed' : '',
-                      ].join(' ')}
-                      onClick={() => {
-                        if (isReadOnly) return
-                        setPendingRemoval({
-                          rosterId: row.id,
-                          email: row.email,
-                          firstName: row.first_name,
-                          lastName: row.last_name,
-                          joined: row.joined,
-                        })
-                      }}
-                      aria-label={`Remove ${row.email}`}
-                      disabled={isReadOnly}
-                    >
-                      <Trash2 className="h-5 w-5" aria-hidden="true" />
-                    </button>
-                  </DataTableCell>
-                </DataTableRow>
-              ))}
-              {sortedRoster.length === 0 && (
-                <EmptyStateRow colSpan={7} message="No students on the roster" />
-              )}
-            </DataTableBody>
-          </DataTable>
-        </TableCard>
-      </PageContent>
+                        <DataTableCell>
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(row.id)}
+                            onChange={() => toggleSelect(row.id)}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            aria-label={`Select ${row.first_name ?? ''} ${row.last_name ?? ''}`}
+                          />
+                        </DataTableCell>
+                        <DataTableCell>{row.first_name ?? '—'}</DataTableCell>
+                        <DataTableCell>{row.last_name ?? '—'}</DataTableCell>
+                        <DataTableCell className="hidden text-text-muted md:table-cell">{row.email}</DataTableCell>
+                        <DataTableCell className="hidden text-text-muted lg:table-cell">
+                          {editingCounselorId === row.id ? (
+                            <div className="flex items-center gap-1">
+                              <input
+                                type="email"
+                                value={editingCounselorValue}
+                                onChange={(e) => setEditingCounselorValue(e.target.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') saveCounselorEmail(row.id)
+                                  if (e.key === 'Escape') cancelEditingCounselor()
+                                }}
+                                className="w-32 rounded border border-border bg-surface px-2 py-1 text-sm text-text-default"
+                                placeholder="counselor@..."
+                                autoFocus
+                                disabled={isSavingCounselor}
+                              />
+                              <button
+                                type="button"
+                                onClick={() => saveCounselorEmail(row.id)}
+                                disabled={isSavingCounselor}
+                                className="text-success hover:text-success-hover"
+                                aria-label="Save"
+                              >
+                                <Check className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={cancelEditingCounselor}
+                                disabled={isSavingCounselor}
+                                className="text-text-muted hover:text-text-default"
+                                aria-label="Cancel"
+                              >
+                                <X className="h-4 w-4" />
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => startEditingCounselor(row)}
+                              disabled={isReadOnly}
+                              className={`flex items-center gap-1 text-left ${
+                                isReadOnly ? 'cursor-not-allowed opacity-50' : 'hover:text-text-default'
+                              }`}
+                            >
+                              {row.counselor_email ? (
+                                <span className="truncate max-w-[120px]" title={row.counselor_email}>
+                                  {row.counselor_email}
+                                </span>
+                              ) : (
+                                <span className="text-text-muted italic">Add</span>
+                              )}
+                              {!isReadOnly && <Pencil className="h-3 w-3 flex-shrink-0" />}
+                            </button>
+                          )}
+                        </DataTableCell>
+                        <DataTableCell align="center">
+                          {row.joined && (
+                            <Check className="mx-auto h-5 w-5 text-success" aria-hidden="true" />
+                          )}
+                        </DataTableCell>
+                      </DataTableRow>
+                    )
+                  })}
+                  {sortedRoster.length === 0 && (
+                    <EmptyStateRow colSpan={6} message="No students on the roster" />
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </KeyboardNavigableTable>
+          </TableCard>
+        </div>
+      }
+      inspector={
+        <>
+          <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
+            <span className="truncate text-sm font-semibold text-text-default">
+              {selectedRosterRow ? getRosterName(selectedRosterRow) : 'Roster Summary'}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {detailPane}
+          </div>
+        </>
+      }
+    />
+  )
+
+  return (
+    <>
+      <TeacherWorkSurfaceShell
+        state="workspace"
+        workspaceFrame="standalone"
+        primary={actionBar}
+        summary={null}
+        workspace={workspace}
+        workspaceFrameClassName="min-h-[360px] border-0 bg-page"
+      />
 
       <AddStudentsModal
         isOpen={isAddModalOpen}
@@ -595,6 +702,6 @@ export function TeacherRosterTab({ classroom }: Props) {
         onCancel={() => (isRemoving ? null : setPendingRemoval(null))}
         onConfirm={confirmRemoveStudent}
       />
-    </PageLayout>
+    </>
   )
 }

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -72,8 +72,12 @@ describe('TeacherGradebookTab', () => {
       />,
     )
 
-    expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument()
+    expect(await screen.findByText('Ada')).toBeInTheDocument()
+    expect(screen.getByText('Lovelace')).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Grades' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('checkbox', { name: 'Select all students' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /First/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Last/ })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: 'Tests' })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Ada Lovelace .* 85\.0%/ })).toBeInTheDocument()
 


### PR DESCRIPTION
## Summary

- Move Gradebook and Roster onto the Daily-style teacher work-surface shell with a floating center action cluster and gapped split layout.
- Update Gradebook's student table to match Roster patterns with selection checkboxes, sortable first/last columns, and mobile-friendly columns.
- Update Roster with a split-pane summary/detail inspector and a single context-aware split button that defaults to Email when students are selected.

## Impact

Teachers get a more consistent classroom tab layout across Daily, Gradebook, and Roster. Roster actions are consolidated into one control, while selected-row email workflows remain available through the primary button and dropdown.

## Validation

- `pnpm lint`
- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/api/teacher/roster.test.ts`
- `pnpm build`
- Visual verification for Gradebook/Roster desktop and mobile states, including selected Roster rows and the split-button menu.