### PR TITLE
[codex] Block assignment schedule after due date

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -10802,3 +10802,17 @@
 - Targeted Playwright screenshots:
   - `/tmp/pika-student-exam-docs-chevron.png`
   - `/tmp/pika-teacher-test-preview-docs-chevron.png`
+## 2026-05-05 — Block assignment scheduled release after due date
+
+**Completed:**
+- Added shared assignment schedule-vs-due-date validation with the canonical error message.
+- Blocked draft release, scheduled rescheduling, and due-date edits that would leave a future scheduled release after the due date.
+- Added inline schedule-dialog validation so teachers see the issue before an API request is sent.
+- Covered helper, API, and assignment modal behavior.
+
+**Validation:**
+- `pnpm test -- tests/lib/assignment-schedule-validation.test.ts tests/api/teacher/assignments-draft.test.ts tests/api/teacher/assignments-id.test.ts tests/components/AssignmentModal.test.tsx` (Vitest ran the broad suite: 243 files, 2033 tests)
+- `pnpm lint`
+- Manual Playwright visual verification on port 3003:
+  - `/tmp/pika-issue-547-teacher-schedule-validation.png`
+  - `/tmp/pika-issue-547-student-classrooms-smoke.png`

--- a/src/app/api/teacher/assignments/[id]/release/route.ts
+++ b/src/app/api/teacher/assignments/[id]/release/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
+import {
+  ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
+  isScheduledReleaseOnOrBeforeDueDate,
+} from '@/lib/assignment-schedule-validation'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -68,6 +72,12 @@ export const POST = withErrorHandler('PostTeacherAssignmentRelease', async (requ
     if (parsed <= new Date()) {
       return NextResponse.json(
         { error: 'Release date must be in the future' },
+        { status: 400 }
+      )
+    }
+    if (!isScheduledReleaseOnOrBeforeDueDate(parsed, existing.due_at)) {
+      return NextResponse.json(
+        { error: ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR },
         { status: 400 }
       )
     }

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -6,6 +6,10 @@ import { extractAssignmentArtifacts } from '@/lib/assignment-artifacts'
 import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { withErrorHandler } from '@/lib/api-handler'
 import { getActiveAssignmentAiGradingRunSummary } from '@/lib/server/assignment-ai-grading-runs'
+import {
+  ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
+  isScheduledReleaseOnOrBeforeDueDate,
+} from '@/lib/assignment-schedule-validation'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -293,6 +297,25 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
     } else if (existingIsScheduled) {
       updates.released_at = parsedReleasedAt ?? now.toISOString()
     }
+  }
+
+  const effectiveDueAt = due_at ?? existing.due_at
+  const effectiveReleaseAt = updates.released_at ?? existing.released_at
+  const effectiveReleaseDate = effectiveReleaseAt ? new Date(effectiveReleaseAt) : null
+  const isFutureScheduledRelease =
+    updates.is_draft !== true &&
+    !!effectiveReleaseDate &&
+    !Number.isNaN(effectiveReleaseDate.getTime()) &&
+    effectiveReleaseDate > now
+
+  if (
+    isFutureScheduledRelease &&
+    !isScheduledReleaseOnOrBeforeDueDate(effectiveReleaseDate, effectiveDueAt)
+  ) {
+    return NextResponse.json(
+      { error: ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR },
+      { status: 400 }
+    )
   }
 
   if (Object.keys(updates).length === 0) {

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -7,7 +7,7 @@ import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions
 import { getRelativeDueDate } from '@/lib/assignment-relative-date'
 import { ConfirmDialog, DialogPanel, SplitButton } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
-import { format } from 'date-fns'
+import { format, isValid, parse } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
 import { useAssignmentDateValidation } from '@/hooks/useAssignmentDateValidation'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
@@ -30,7 +30,13 @@ function getDisplayedAssignmentTitle(title: string): string {
 }
 
 function validateAssignmentValues(values: AssignmentEditorValues): string | null {
-  void values
+  if (!values.dueAt) return 'Due date is required.'
+
+  const parsedDueAt = parse(values.dueAt, 'yyyy-MM-dd', new Date())
+  if (!isValid(parsedDueAt) || format(parsedDueAt, 'yyyy-MM-dd') !== values.dueAt) {
+    return 'Enter a valid due date.'
+  }
+
   return null
 }
 
@@ -508,7 +514,10 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   function handleDueAtChange(newDueAt: string) {
     updateDueDate(newDueAt)
-    const validationError = getScheduledAssignmentDueDateValidationMessage(currentAssignment, newDueAt)
+    const validationError = validateAssignmentEditorValues(
+      { title, instructionsMarkdown, dueAt: newDueAt },
+      currentAssignment
+    )
     if (validationError) {
       setError(validationError)
     }

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -13,6 +13,7 @@ import { useAssignmentDateValidation } from '@/hooks/useAssignmentDateValidation
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
 import { DEFAULT_SCHEDULE_TIME, getDefaultScheduleDateInSchedulingTimezone, getTodayInSchedulingTimezone, isVisibleAtNow, parseScheduleIsoToParts } from '@/lib/scheduling'
 import { useAssignmentScheduling, type CreateSubmitAction } from '@/hooks/useAssignmentScheduling'
+import { getScheduledReleaseDueDateError } from '@/lib/assignment-schedule-validation'
 
 const AUTOSAVE_DEBOUNCE_MS = 3000
 const AUTOSAVE_MIN_INTERVAL_MS = 10000
@@ -34,6 +35,16 @@ function validateAssignmentValues(values: AssignmentEditorValues): string | null
 }
 
 const RELEASE_TITLE_ERROR = 'Add a title before posting or scheduling this assignment.'
+
+function getScheduleDueDateValidationMessage(scheduleIso: string, dueAt: string, isScheduleValid: boolean): string | null {
+  if (!scheduleIso || !dueAt || !isScheduleValid) return null
+
+  try {
+    return getScheduledReleaseDueDateError(scheduleIso, toTorontoEndOfDayIso(dueAt))
+  } catch {
+    return null
+  }
+}
 
 interface AssignmentModalProps {
   isOpen: boolean
@@ -616,6 +627,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       ? 'warning'
       : 'primary'
     : 'muted'
+  const scheduleDueDateValidationMessage = getScheduleDueDateValidationMessage(scheduleIso, dueAt, isScheduleValid)
 
   return (
     <>
@@ -719,6 +731,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           time={scheduleTime}
           minDate={getTodayInSchedulingTimezone()}
           isFutureValid={isScheduleValid}
+          validationMessage={scheduleDueDateValidationMessage}
           onDateChange={setScheduleDate}
           onTimeChange={setScheduleTime}
           onCancel={

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -36,6 +36,30 @@ function validateAssignmentValues(values: AssignmentEditorValues): string | null
 
 const RELEASE_TITLE_ERROR = 'Add a title before posting or scheduling this assignment.'
 
+function getScheduledAssignmentDueDateValidationMessage(
+  assignment: Assignment | null,
+  dueAt: string
+): string | null {
+  if (!assignment || assignment.is_draft || !assignment.released_at || !dueAt) return null
+
+  const releaseDate = new Date(assignment.released_at)
+  if (Number.isNaN(releaseDate.getTime()) || releaseDate <= new Date()) return null
+
+  try {
+    return getScheduledReleaseDueDateError(releaseDate, toTorontoEndOfDayIso(dueAt))
+  } catch {
+    return null
+  }
+}
+
+function validateAssignmentEditorValues(
+  values: AssignmentEditorValues,
+  assignment: Assignment | null
+): string | null {
+  return validateAssignmentValues(values)
+    ?? getScheduledAssignmentDueDateValidationMessage(assignment, values.dueAt)
+}
+
 function getScheduleDueDateValidationMessage(scheduleIso: string, dueAt: string, isScheduleValid: boolean): string | null {
   if (!scheduleIso || !dueAt || !isScheduleValid) return null
 
@@ -322,7 +346,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     values: AssignmentEditorValues,
     options?: { closeAfter?: boolean }
   ) => {
-    const validationError = validateAssignmentValues(values)
+    const validationError = validateAssignmentEditorValues(values, currentAssignment)
     if (validationError) {
       setError(validationError)
       setSaveStatus('unsaved')
@@ -455,7 +479,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   function handleTitleChange(newTitle: string) {
     setTitle(newTitle)
-    if (newTitle.trim()) {
+    if (newTitle.trim() && error === RELEASE_TITLE_ERROR) {
       setError('')
     }
     scheduleAutosave({ title: newTitle, instructionsMarkdown, dueAt })
@@ -484,6 +508,10 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
   function handleDueAtChange(newDueAt: string) {
     updateDueDate(newDueAt)
+    const validationError = getScheduledAssignmentDueDateValidationMessage(currentAssignment, newDueAt)
+    if (validationError) {
+      setError(validationError)
+    }
     scheduleAutosave({ title, instructionsMarkdown, dueAt: newDueAt })
   }
 
@@ -524,6 +552,13 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
     if ((saveStatus === 'unsaved' || pendingValuesRef.current) && currentAssignment) {
       const valuesToSave = pendingValuesRef.current ?? { title, instructionsMarkdown, dueAt }
+      const validationError = validateAssignmentEditorValues(valuesToSave, currentAssignment)
+      if (validationError) {
+        setError(validationError)
+        setSaveStatus('unsaved')
+        throw new Error(validationError)
+      }
+
       const changedFields = getChangedFields(valuesToSave)
 
       if (changedFields) {

--- a/src/components/ScheduleDateTimePicker.tsx
+++ b/src/components/ScheduleDateTimePicker.tsx
@@ -24,6 +24,7 @@ interface ScheduleDateTimePickerProps {
   className?: string
   contextLabel?: string | null
   contextTone?: 'primary' | 'warning' | 'muted'
+  validationMessage?: string | null
 }
 
 export function ScheduleDateTimePicker({
@@ -46,6 +47,7 @@ export function ScheduleDateTimePicker({
   className = '',
   contextLabel,
   contextTone = 'muted',
+  validationMessage,
 }: ScheduleDateTimePickerProps) {
   const dateInputId = useId()
   const timeInputId = useId()
@@ -104,6 +106,10 @@ export function ScheduleDateTimePicker({
         <p className="text-xs text-danger mt-2">Schedule must be in the future</p>
       )}
 
+      {validationMessage && (
+        <p className="text-xs text-danger mt-2">{validationMessage}</p>
+      )}
+
       <div className="mt-3 flex items-center gap-2">
         {onCancel && (
           <Button variant={cancelVariant} size="sm" className="flex-1" onClick={onCancel}>
@@ -115,7 +121,7 @@ export function ScheduleDateTimePicker({
           size="sm"
           className={onCancel ? 'flex-1' : 'w-full'}
           onClick={onConfirm}
-          disabled={!date || !isFutureValid}
+          disabled={!date || !isFutureValid || !!validationMessage}
         >
           {confirmLabel}
         </Button>

--- a/src/lib/assignment-schedule-validation.ts
+++ b/src/lib/assignment-schedule-validation.ts
@@ -1,0 +1,25 @@
+export const ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR = 'Scheduled release must be on or before the due date.'
+
+type DateLike = Date | string | null | undefined
+
+function toValidTime(value: DateLike): number | null {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isNaN(time) ? null : time
+}
+
+export function isScheduledReleaseOnOrBeforeDueDate(releaseAt: DateLike, dueAt: DateLike): boolean {
+  const releaseTime = toValidTime(releaseAt)
+  const dueTime = toValidTime(dueAt)
+
+  if (releaseTime === null || dueTime === null) return true
+
+  return releaseTime <= dueTime
+}
+
+export function getScheduledReleaseDueDateError(releaseAt: DateLike, dueAt: DateLike): string | null {
+  return isScheduledReleaseOnOrBeforeDueDate(releaseAt, dueAt)
+    ? null
+    : ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR
+}

--- a/tests/api/teacher/assignments-draft.test.ts
+++ b/tests/api/teacher/assignments-draft.test.ts
@@ -204,6 +204,41 @@ describe('POST /api/teacher/assignments/[id]/release', () => {
       expect(response.status).toBe(400)
       expect(data.error).toBe('Release date must be in the future')
     })
+
+    it('should return 400 when scheduled release is after the due date', async () => {
+      const mockFrom = vi.fn((table: string) => {
+        if (table === 'assignments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'assignment-1',
+                    is_draft: true,
+                    due_at: '2099-03-01T23:59:00.000Z',
+                    classrooms: { teacher_id: 'teacher-1', archived_at: null },
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+      })
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/release', {
+        method: 'POST',
+        body: JSON.stringify({ release_at: '2099-03-02T00:00:00.000Z' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('Scheduled release must be on or before the due date.')
+    })
   })
 
   describe('successful release', () => {

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -264,6 +264,142 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     const response = await PATCH(request, { params: { id: 'a-1' } })
     expect(response.status).toBe(200)
   })
+
+  it('rejects rescheduling a scheduled assignment after the due date', async () => {
+    let updateCalled = false
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'a-1',
+                  is_draft: false,
+                  released_at: '2099-03-01T14:00:00.000Z',
+                  due_at: '2099-03-01T23:59:00.000Z',
+                  classrooms: { teacher_id: 'teacher-1', archived_at: null },
+                },
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn(() => {
+            updateCalled = true
+            return {
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: null, error: null }),
+                })),
+              })),
+            }
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ released_at: '2099-03-02T00:00:00.000Z' }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Scheduled release must be on or before the due date.')
+    expect(updateCalled).toBe(false)
+  })
+
+  it('rejects moving the due date before an existing scheduled release', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'a-1',
+                  is_draft: false,
+                  released_at: '2099-03-02T14:00:00.000Z',
+                  due_at: '2099-03-03T23:59:00.000Z',
+                  classrooms: { teacher_id: 'teacher-1', archived_at: null },
+                },
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn(() => {
+            throw new Error('Update should not be called')
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ due_at: '2099-03-01T23:59:00.000Z' }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Scheduled release must be on or before the due date.')
+  })
+
+  it('allows clearing a scheduled release back to draft', async () => {
+    let capturedUpdate: any = null
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'a-1',
+                  is_draft: false,
+                  released_at: '2099-03-02T14:00:00.000Z',
+                  due_at: '2099-03-01T23:59:00.000Z',
+                  classrooms: { teacher_id: 'teacher-1', archived_at: null },
+                },
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn((updateData) => {
+            capturedUpdate = updateData
+            return {
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: { id: 'a-1', ...updateData },
+                    error: null,
+                  }),
+                })),
+              })),
+            }
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_draft: true, released_at: null }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(200)
+    expect(capturedUpdate).toEqual({ is_draft: true, released_at: null })
+  })
 })
 
 describe('DELETE /api/teacher/assignments/[id]', () => {

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -736,6 +736,107 @@ describe('AssignmentModal', () => {
       })
     })
 
+    it('updates a changed due date and closes on draft save', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const newAssignment = {
+        ...baseAssignment,
+        id: 'new-draft-1',
+        title: 'Untitled Assignment',
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
+      }
+      const updatedAssignment = {
+        ...newAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-04'),
+      }
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ assignment: newAssignment }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ assignment: updatedAssignment }),
+      })
+
+      const onSuccess = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Draft')).toBeInTheDocument()
+      })
+
+      fireEvent.change(screen.getByDisplayValue('2099-03-03'), { target: { value: '2099-03-04' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Draft' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Draft' }))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      })
+
+      const [url, options] = fetchMock.mock.calls[1]
+      expect(url).toBe('/api/teacher/assignments/new-draft-1')
+      expect(options.method).toBe('PATCH')
+      expect(JSON.parse(options.body)).toEqual({ due_at: toTorontoEndOfDayIso('2099-03-04') })
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled()
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
+
+    it('blocks closing a draft with an empty due date without throwing an invalid time error', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const newAssignment = {
+        ...baseAssignment,
+        id: 'new-draft-1',
+        title: 'Untitled Assignment',
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
+      }
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ assignment: newAssignment }),
+      })
+
+      const onSuccess = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Draft')).toBeInTheDocument()
+      })
+
+      fireEvent.change(screen.getByDisplayValue('2099-03-03'), { target: { value: '' } })
+
+      expect(screen.getByText('Due date is required.')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Draft' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Draft' }))
+
+      expect(screen.getByText('Due date is required.')).toBeInTheDocument()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
     it('opens schedule modal from split action and schedules release', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       const newAssignment = {

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -171,7 +171,12 @@ describe('AssignmentModal', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          assignment: { ...baseAssignment, is_draft: false, released_at: '2099-03-01T14:00:00.000Z' },
+          assignment: {
+            ...baseAssignment,
+            due_at: toTorontoEndOfDayIso('2099-03-03'),
+            is_draft: false,
+            released_at: '2099-03-01T14:00:00.000Z',
+          },
         }),
       })
 
@@ -179,7 +184,7 @@ describe('AssignmentModal', () => {
         <AssignmentModal
           isOpen={true}
           classroomId="classroom-1"
-          assignment={baseAssignment}
+          assignment={{ ...baseAssignment, due_at: toTorontoEndOfDayIso('2099-03-03') }}
           onClose={vi.fn()}
           onSuccess={vi.fn()}
         />
@@ -208,6 +213,38 @@ describe('AssignmentModal', () => {
       expect(options.method).toBe('POST')
       const payload = JSON.parse(options.body)
       expect(payload.release_at).toBeDefined()
+    })
+
+    it('blocks scheduled release after the due date', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={{ ...baseAssignment, due_at: toTorontoEndOfDayIso('2099-03-01') }}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Choose assignment action' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Schedule' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Schedule Release')).toBeInTheDocument()
+      })
+
+      const scheduleDialog = screen.getByRole('dialog', { name: 'Schedule Release' })
+      const scheduleScope = within(scheduleDialog)
+
+      fireEvent.change(scheduleScope.getByLabelText('Date'), { target: { value: '2099-03-02' } })
+      fireEvent.change(scheduleScope.getByLabelText('Time'), { target: { value: '09:00' } })
+
+      expect(scheduleScope.getByText('Scheduled release must be on or before the due date.')).toBeInTheDocument()
+      expect(scheduleScope.getByRole('button', { name: 'Schedule' })).toBeDisabled()
+      fireEvent.click(scheduleScope.getByRole('button', { name: 'Schedule' }))
+      expect(fetchMock).not.toHaveBeenCalled()
     })
 
     it('defaults the schedule dialog date to the next day for draft assignments', async () => {
@@ -347,6 +384,7 @@ describe('AssignmentModal', () => {
     it('opens mini schedule modal when scheduled assignment primary is clicked', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
         is_draft: false,
         released_at: '2099-03-01T14:00:00.000Z',
       }
@@ -382,6 +420,7 @@ describe('AssignmentModal', () => {
     it('closes both modals when save schedule is confirmed', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
         is_draft: false,
         released_at: '2099-03-01T14:00:00.000Z',
       }
@@ -432,6 +471,7 @@ describe('AssignmentModal', () => {
     it('clears scheduled release from the schedule modal cancel action', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
         is_draft: false,
         released_at: '2099-03-01T14:00:00.000Z',
       }
@@ -483,6 +523,7 @@ describe('AssignmentModal', () => {
     it('saves pending form edits before opening schedule modal from schedule action', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
         is_draft: false,
         released_at: '2099-03-01T14:00:00.000Z',
       }
@@ -662,7 +703,12 @@ describe('AssignmentModal', () => {
 
     it('opens schedule modal from split action and schedules release', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-      const newAssignment = { ...baseAssignment, id: 'new-draft-1', title: 'Essay outline' }
+      const newAssignment = {
+        ...baseAssignment,
+        id: 'new-draft-1',
+        title: 'Essay outline',
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
+      }
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
@@ -719,7 +765,12 @@ describe('AssignmentModal', () => {
 
     it('closes create modal when save schedule is confirmed', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-      const newAssignment = { ...baseAssignment, id: 'new-draft-1', title: 'Research summary' }
+      const newAssignment = {
+        ...baseAssignment,
+        id: 'new-draft-1',
+        title: 'Research summary',
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
+      }
       fetchMock
         .mockResolvedValueOnce({
           ok: true,

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -417,6 +417,41 @@ describe('AssignmentModal', () => {
       expect(onSuccess).not.toHaveBeenCalled()
     })
 
+    it('blocks moving the due date before an existing scheduled release without autosaving', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z'))
+
+      const scheduledAssignment: Assignment = {
+        ...baseAssignment,
+        due_at: toTorontoEndOfDayIso('2099-03-03'),
+        is_draft: false,
+        released_at: '2099-03-02T14:00:00.000Z',
+      }
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={scheduledAssignment}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      fireEvent.change(screen.getByDisplayValue('2099-03-03'), { target: { value: '2099-03-01' } })
+
+      expect(screen.getByText('Scheduled release must be on or before the due date.')).toBeInTheDocument()
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(screen.getByText('Scheduled release must be on or before the due date.')).toBeInTheDocument()
+    })
+
     it('closes both modals when save schedule is confirmed', async () => {
       const scheduledAssignment: Assignment = {
         ...baseAssignment,

--- a/tests/lib/assignment-schedule-validation.test.ts
+++ b/tests/lib/assignment-schedule-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
+  getScheduledReleaseDueDateError,
+  isScheduledReleaseOnOrBeforeDueDate,
+} from '@/lib/assignment-schedule-validation'
+
+describe('assignment schedule validation', () => {
+  it('allows scheduled release before the assignment due date', () => {
+    expect(
+      isScheduledReleaseOnOrBeforeDueDate(
+        '2099-03-01T14:00:00.000Z',
+        '2099-03-01T23:59:00.000Z'
+      )
+    ).toBe(true)
+  })
+
+  it('allows scheduled release exactly at the assignment due date', () => {
+    expect(
+      isScheduledReleaseOnOrBeforeDueDate(
+        '2099-03-01T23:59:00.000Z',
+        '2099-03-01T23:59:00.000Z'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects scheduled release after the assignment due date', () => {
+    expect(
+      isScheduledReleaseOnOrBeforeDueDate(
+        '2099-03-02T00:00:00.000Z',
+        '2099-03-01T23:59:00.000Z'
+      )
+    ).toBe(false)
+  })
+
+  it('returns the canonical validation message for invalid date order', () => {
+    expect(
+      getScheduledReleaseDueDateError(
+        '2099-03-02T00:00:00.000Z',
+        '2099-03-01T23:59:00.000Z'
+      )
+    ).toBe(ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR)
+  })
+
+  it('does not fail closed when one side is absent or malformed', () => {
+    expect(isScheduledReleaseOnOrBeforeDueDate(null, '2099-03-01T23:59:00.000Z')).toBe(true)
+    expect(isScheduledReleaseOnOrBeforeDueDate('not-a-date', '2099-03-01T23:59:00.000Z')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- block future scheduled assignment releases that are after the assignment due date
- apply the same rule in draft release, scheduled assignment updates, and due-date edits
- show the validation inline in the schedule dialog and disable the Schedule action before an API request is sent

## Root Cause
Assignments already validated scheduled release times against "future" but did not compare `released_at` to `due_at`. That allowed teachers to create or edit a scheduled assignment so it became available after it was already due.

## Validation
- `pnpm test -- tests/lib/assignment-schedule-validation.test.ts tests/api/teacher/assignments-draft.test.ts tests/api/teacher/assignments-id.test.ts tests/components/AssignmentModal.test.tsx` (Vitest ran broad suite: 243 files, 2033 tests)
- `pnpm lint`
- Manual Playwright visual verification:
  - `/tmp/pika-issue-547-teacher-schedule-validation.png`
  - `/tmp/pika-issue-547-student-classrooms-smoke.png`

Closes #547
