### PR TITLE
[codex] Tighten assignment edit chrome and modal layout

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -273,3 +273,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-split-teacher.png`
   - `/tmp/pika-test-grading-split-teacher.png`
 - Playwright assertion pass confirmed no document-level vertical scroll on the affected desktop split routes and a 126px resize-handle movement after drag.
+## 2026-05-06 — Make assignment edit mode modal-close ephemeral
+
+**Completed:**
+- Cleared teacher assignment edit mode whenever the assignment create/edit modal exits.
+- Preserved modal-internal updates that intentionally keep the modal open.
+- Added regression coverage for closing the create assignment modal after starting summary edit mode.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-actionbar-spacer bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Pika UI verification on the shared assignments page:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Focused Playwright flow: toggled assignment edit mode, opened New assignment, closed the create modal, confirmed Edit returned to `aria-pressed="false"`, and cleaned up the temporary draft.
+  - `/tmp/pika-assignment-edit-mode-before-create-modal.png`
+  - `/tmp/pika-assignment-create-modal-before-close-ephemeral.png`
+  - `/tmp/pika-assignment-edit-mode-after-create-close.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -169,6 +169,29 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-teacher-assignments.png`
   - `/tmp/pika-student-assignments.png`
 
+## 2026-05-06 — Tighten assignment edit chrome and modal height
+
+**Completed:**
+- Hid the app-header `Assignments` title while teacher assignment summary edit mode is active, leaving the floating assignment action cluster as the working control surface.
+- Made the assignment create/edit modal use the near-full viewport panel in both modes.
+- Removed the visible modal header row, kept an accessible hidden dialog title, and moved the close button into the form action row.
+- Let the assignment instructions editor and preview flex into the added modal height.
+- Fixed calendar clicks on unreleased assignments so the editor modal clears the stale `assignmentId` route selection and does not reopen after close.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-actionbar-spacer bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- Focused Playwright calendar flow: clicked unreleased assignment from Calendar, closed the editor modal, confirmed it stayed closed at `?tab=assignments`.
+- Pika UI verification on shared assignment page:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Focused Playwright screenshots:
+  - `/tmp/pika-assignment-edit-modal.png`
+  - `/tmp/pika-assignment-create-modal.png`
+  - `/tmp/pika-assignment-edit-modal-mobile.png`
+
 ## 2026-05-05 — Make exam documents visibly clickable
 
 **Completed:**

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -504,6 +504,8 @@ function ClassroomPageContent({
     }
 
     if (activeTab === 'assignments') {
+      if (assignmentEditMode) return undefined
+
       return assignmentViewMode === 'assignment'
         ? selectedAssignment?.title || 'Assignments'
         : 'Assignments'
@@ -524,6 +526,7 @@ function ClassroomPageContent({
     return undefined
   }, [
     activeTab,
+    assignmentEditMode,
     assignmentViewMode,
     isTeacher,
     quizIdParam,

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -476,11 +476,16 @@ export function TeacherClassroomView({
       setEditAssignment(assignment)
       writeCookie(cookieName, 'summary')
       setSelection({ mode: 'summary' })
+      updateSearchParams?.((params) => {
+        params.set('tab', 'assignments')
+        params.delete('assignmentId')
+        params.delete('assignmentStudentId')
+      }, { replace: true })
     } else {
       writeCookie(cookieName, value)
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp])
+  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp, updateSearchParams])
 
   useEffect(() => {
     function onSelectionEvent(e: Event) {

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -689,6 +689,12 @@ export function TeacherClassroomView({
     loadAssignments()
   }
 
+  const closeAssignmentModal = useCallback(() => {
+    setEditAssignment(null)
+    setIsCreateModalOpen(false)
+    setAssignmentEditMode(false)
+  }, [])
+
   const setSelectionAndPersist = useCallback((
     next: TeacherAssignmentSelection,
     options: { updateUrl?: boolean; replace?: boolean } = {},
@@ -1844,10 +1850,7 @@ export function TeacherClassroomView({
         classroomId={classroom.id}
         assignment={editAssignment}
         classDays={classDays}
-        onClose={() => {
-          setEditAssignment(null)
-          setIsCreateModalOpen(false)
-        }}
+        onClose={closeAssignmentModal}
         onSuccess={(assignment, options) => {
           if (editAssignment) {
             handleEditSuccess(assignment)
@@ -1857,8 +1860,7 @@ export function TeacherClassroomView({
           if (options?.closeModal === false) {
             return
           }
-          setEditAssignment(null)
-          setIsCreateModalOpen(false)
+          closeAssignmentModal()
         }}
       />
     </>

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -38,6 +38,7 @@ interface AssignmentFormProps {
   markdownWarning?: string | null
   canUndoInstructions?: boolean
   canRedoInstructions?: boolean
+  fillHeight?: boolean
 }
 
 export function AssignmentForm({
@@ -62,6 +63,7 @@ export function AssignmentForm({
   markdownWarning,
   canUndoInstructions = false,
   canRedoInstructions = false,
+  fillHeight = false,
 }: AssignmentFormProps) {
   const instructionsRef = useRef<HTMLTextAreaElement>(null)
   const titleFieldId = useId()
@@ -152,7 +154,7 @@ export function AssignmentForm({
   }
 
   return (
-    <div className="space-y-3 w-full">
+    <div className={fillHeight ? 'flex h-full min-h-0 w-full flex-col gap-3' : 'space-y-3 w-full'}>
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_auto] lg:items-end lg:gap-x-8">
         <div className="min-w-0 space-y-1">
           <label htmlFor={titleFieldId} className="block text-sm font-medium text-text-default">
@@ -206,7 +208,7 @@ export function AssignmentForm({
         )}
       </div>
 
-      <div className="space-y-1">
+      <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col space-y-1' : 'space-y-1'}>
         <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
           <label className="block text-sm font-medium text-text-default">
             Instructions
@@ -216,14 +218,14 @@ export function AssignmentForm({
           </div>
           <div aria-hidden="true" />
         </div>
-        <div className="rounded-lg border border-border-strong overflow-hidden">
+        <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border-strong' : 'rounded-lg border border-border-strong overflow-hidden'}>
           {markdownWarning && (
             <div className="border-b border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
               {markdownWarning}
             </div>
           )}
           {showMarkdown ? (
-            <div className="grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]">
+            <div className={fillHeight ? 'grid min-h-0 flex-1 gap-0 md:grid-cols-2' : 'grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]'}>
               <div className="flex h-full min-h-0 flex-col border-b border-border md:border-b-0 md:border-r md:border-border">
                 <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
                   <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
@@ -260,14 +262,14 @@ export function AssignmentForm({
                   placeholder="Assignment instructions"
                   disabled={disabled}
                   spellCheck={false}
-                  className="h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]"
+                  className={fillHeight ? 'h-full min-h-0 w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0' : 'h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]'}
                 />
               </div>
-              <div className="bg-page">
+              <div className="flex min-h-0 flex-col bg-page">
                 <div className="px-3 py-2 text-xs font-medium uppercase tracking-wide text-text-muted">
                   Preview
                 </div>
-                <div className="min-h-[360px] px-3 pb-3 lg:min-h-[420px]">
+                <div className={fillHeight ? 'min-h-0 flex-1 overflow-y-auto px-3 pb-3' : 'min-h-[360px] px-3 pb-3 lg:min-h-[420px]'}>
                   <LimitedMarkdown
                     content={instructionsMarkdown}
                     emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
@@ -276,7 +278,7 @@ export function AssignmentForm({
               </div>
             </div>
           ) : (
-            <div className="min-h-[400px] lg:min-h-[460px]">
+            <div className={fillHeight ? 'flex min-h-0 flex-1' : 'min-h-[400px] lg:min-h-[460px]'}>
               <textarea
                 ref={instructionsRef}
                 value={instructionsMarkdown}
@@ -285,7 +287,7 @@ export function AssignmentForm({
                 onBlur={onBlur}
                 placeholder="Assignment instructions"
                 disabled={disabled}
-                className="min-h-[400px] w-full resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0 lg:min-h-[460px]"
+                className={fillHeight ? 'min-h-0 w-full flex-1 resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0' : 'min-h-[400px] w-full resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0 lg:min-h-[460px]'}
               />
             </div>
           )}

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -673,40 +673,40 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       : 'primary'
     : 'muted'
   const scheduleDueDateValidationMessage = getScheduleDueDateValidationMessage(scheduleIso, dueAt, isScheduleValid)
-  const creationPanelClass =
+  const editorPanelClass =
     '!h-[calc(100dvh-0.5rem)] !max-h-[calc(100dvh-0.5rem)] !w-[calc(100vw-0.5rem)] !max-w-[calc(100vw-0.5rem)] overflow-hidden p-0 sm:!h-[calc(100dvh-1rem)] sm:!max-h-[calc(100dvh-1rem)] sm:!w-[calc(100vw-1rem)] sm:!max-w-[calc(100vw-1rem)]'
+  const closeAssignmentModalButton = (
+    <Button
+      type="button"
+      variant="surface"
+      size="sm"
+      className="h-9 w-9 flex-shrink-0 px-0"
+      onClick={() => {
+        void handleClose()
+      }}
+      disabled={saving || releasing}
+      aria-label="Close assignment modal"
+      title="Close"
+    >
+      <X className="h-4 w-4" aria-hidden="true" />
+    </Button>
+  )
 
   return (
     <>
       <DialogPanel
         isOpen={isOpen}
         onClose={handleClose}
-        maxWidth={isCreateMode ? 'max-w-none' : 'w-[min(90vw,56rem)]'}
-        className={isCreateMode ? creationPanelClass : 'max-h-[92vh] p-0'}
-        viewportPaddingClassName={isCreateMode ? 'p-1 sm:p-2' : undefined}
+        maxWidth="max-w-none"
+        className={editorPanelClass}
+        viewportPaddingClassName="p-1 sm:p-2"
         ariaLabelledBy="assignment-modal-title"
       >
-        <div className="flex flex-shrink-0 items-center gap-3 border-b border-border px-4 py-3">
-          <h2 id="assignment-modal-title" className="min-w-0 flex-1 truncate text-base font-semibold text-text-default">
-            {modalTitle}
-          </h2>
-          <Button
-            type="button"
-            variant="surface"
-            size="sm"
-            className="h-10 w-10 flex-shrink-0 px-0"
-            onClick={() => {
-              void handleClose()
-            }}
-            disabled={saving || releasing}
-            aria-label="Close assignment modal"
-            title="Close"
-          >
-            <X className="h-5 w-5" aria-hidden="true" />
-          </Button>
-        </div>
+        <h2 id="assignment-modal-title" className="sr-only">
+          {modalTitle}
+        </h2>
 
-        <div className="flex-1 min-h-0 overflow-y-auto p-4">
+        <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
           <AssignmentForm
             title={title}
             instructionsMarkdown={instructionsMarkdown}
@@ -726,6 +726,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             markdownWarning={markdownWarning}
             canUndoInstructions={instructionsHistoryIndexRef.current > 0}
             canRedoInstructions={instructionsHistoryIndexRef.current < instructionsHistoryRef.current.length - 1}
+            fillHeight
             statusContent={(
               <span
                 className={`text-xs ${
@@ -740,38 +741,37 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
               </span>
             )}
             topRowActions={
-              currentAssignment
-                ? (
-                    <div className="flex flex-col items-start gap-2">
-                      {isScheduled && currentAssignment.released_at && (
-                        <div className="text-xs font-medium text-warning">
-                          {formatReleaseDate(currentAssignment.released_at)}
-                        </div>
-                      )}
-                      <div className="flex">
-                        <SplitButton
-                          label={primaryLabel}
-                          onPrimaryClick={() => {
-                            void handleTriggerPrimaryAction()
-                          }}
-                          variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
-                          size="md"
-                          disabled={creating || releasing || saving || !currentAssignment}
-                        className="shadow-sm"
-                        toggleAriaLabel="Choose assignment action"
-                        menuPlacement="down"
-                        primaryButtonProps={{
-                          className: 'w-[9rem] justify-center font-semibold',
-                        }}
-                          options={splitOptions.map((option) => ({
-                            ...option,
-                            onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
-                          }))}
-                        />
-                      </div>
-                    </div>
-                  )
-                : undefined
+              <div className="flex flex-col items-start gap-2 lg:items-end">
+                {currentAssignment && isScheduled && currentAssignment.released_at && (
+                  <div className="text-xs font-medium text-warning">
+                    {formatReleaseDate(currentAssignment.released_at)}
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
+                  {currentAssignment ? (
+                    <SplitButton
+                      label={primaryLabel}
+                      onPrimaryClick={() => {
+                        void handleTriggerPrimaryAction()
+                      }}
+                      variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
+                      size="md"
+                      disabled={creating || releasing || saving || !currentAssignment}
+                      className="shadow-sm"
+                      toggleAriaLabel="Choose assignment action"
+                      menuPlacement="down"
+                      primaryButtonProps={{
+                        className: 'w-[9rem] justify-center font-semibold',
+                      }}
+                      options={splitOptions.map((option) => ({
+                        ...option,
+                        onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
+                      }))}
+                    />
+                  ) : null}
+                  {closeAssignmentModalButton}
+                </div>
+              </div>
             }
           />
         </div>

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -321,6 +321,14 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     expect(screen.getByTestId('app-shell-page-title')).toHaveTextContent('Assignments')
   })
 
+  it('clears the assignments summary label while assignment edit mode is active', () => {
+    renderClient()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+
+    expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
+  })
+
   it('passes the daily label to the app shell title slot', () => {
     window.history.replaceState({}, '', '/classrooms/classroom-1?tab=attendance')
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -633,6 +633,48 @@ describe('TeacherClassroomView', () => {
     expect(updateSearchParams).not.toHaveBeenCalled()
   })
 
+  it('clears URL selection after opening an unreleased assignment editor from a route selection', async () => {
+    mockIsVisibleAtNow.mockReturnValue(false)
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('scheduled-assignment', 'Scheduled Assignment', {
+              released_at: '2026-05-10T12:00:00Z',
+            }),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
+    })
+    const updateSearchParams = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="scheduled-assignment"
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toHaveTextContent('Editing Scheduled Assignment')
+    })
+
+    expect(updateSearchParams).toHaveBeenCalled()
+    const { params, options } = applySearchParamsUpdate(
+      updateSearchParams.mock.calls[0],
+      'tab=calendar&assignmentId=scheduled-assignment&assignmentStudentId=student-1',
+    )
+    expect(options?.replace).toBe(true)
+    expect(params.get('tab')).toBe('assignments')
+    expect(params.get('assignmentId')).toBeNull()
+    expect(params.get('assignmentStudentId')).toBeNull()
+  })
+
   it('pushes assignment selection into classroom history', async () => {
     const updateSearchParams = vi.fn()
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -120,10 +120,13 @@ vi.mock('@/components/Spinner', () => ({
 }))
 
 vi.mock('@/components/AssignmentModal', () => ({
-  AssignmentModal: ({ isOpen, assignment }: any) => (
+  AssignmentModal: ({ isOpen, assignment, onClose }: any) => (
     isOpen ? (
       <div role="dialog">
         {assignment ? `Editing ${assignment.title}` : 'New Assignment'}
+        <button type="button" onClick={onClose}>
+          Close assignment modal
+        </button>
       </div>
     ) : null
   ),
@@ -539,6 +542,35 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByRole('dialog')).toHaveTextContent('Editing Assignment One')
     expect(updateSearchParams).not.toHaveBeenCalled()
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('exits assignment edit mode when the create assignment modal closes', async () => {
+    const onEditModeChange = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        onEditModeChange={onEditModeChange}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New assignment' }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('New Assignment')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close assignment modal' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+    })
+    expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
 
   it('resets edit mode when the selected assignment workspace changes', async () => {


### PR DESCRIPTION
## Summary
- hide the redundant Assignments header label while assignment edit mode is active
- make assignment create/edit use a near-full viewport modal, with an accessible hidden title and close control in the form action row
- clear stale calendar assignment route selections for unreleased assignments so the edit modal stays closed after closing

## Validation
- pnpm test tests/components/AssignmentModal.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx
- pnpm lint
- git diff --check
- Pika UI verify on shared assignment page for teacher, student, and teacher mobile views
- Focused Playwright calendar flow: clicked an unreleased assignment from Calendar, closed the editor modal, and confirmed it stayed closed at ?tab=assignments