### PR TITLE
[codex] Constrain split-pane workspace scrolling

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -228,3 +228,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm test tests/components/AssignmentModal.test.tsx tests/lib/finalize-test-attempts.test.ts tests/api/teacher/tests-unsubmit.test.ts tests/api/teacher/tests-student-attempt-delete.test.ts tests/api/teacher/tests-return.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-student-access.test.ts tests/api/integration/test-return-visibility-flow.test.ts`
 - `pnpm lint`
+
+## 2026-05-06 — Independent split-pane scrolling
+
+**Completed:**
+- Added an opt-in viewport constraint to `AppShell` and enabled it for active desktop teacher split-pane workspaces.
+- Bounded the gapped teacher workspace split at desktop sizes without changing resize handlers or inspector-width state.
+- Moved overflowing table/content regions inside the affected split panes so attendance, roster, gradebook, assignment review, and test grading can scroll panes independently.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test -- tests/components/TeacherWorkspaceSplit.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx` (ran full suite: 249 files, 2091 tests)
+- `pnpm lint`
+- Pika UI verification for `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance`:
+  - `/tmp/pika-attendance-teacher.png`
+  - `/tmp/pika-attendance-student.png`
+  - `/tmp/pika-attendance-teacher-mobile.png`
+- Focused teacher split screenshots:
+  - `/tmp/pika-gradebook-teacher.png`
+  - `/tmp/pika-roster-teacher.png`
+  - `/tmp/pika-assignment-split-teacher.png`
+  - `/tmp/pika-test-grading-split-teacher.png`
+- Playwright assertion pass confirmed no document-level vertical scroll on the affected desktop split routes and a 126px resize-handle movement after drag.

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -971,6 +971,15 @@ function ClassroomPageContent({
       : activeTab === 'tests'
         ? 'pb-0'
         : ''
+  const hasActiveTeacherSplitPanes =
+    isTeacher &&
+    (
+      activeTab === 'attendance' ||
+      activeTab === 'roster' ||
+      (activeTab === 'gradebook' && gradebookSectionParam !== 'settings') ||
+      (activeTab === 'assignments' && !!assignmentIdParam && !!assignmentStudentIdParam) ||
+      (activeTab === 'tests' && !!testIdParam && testModeParam === 'grading' && !!testStudentIdParam)
+    )
 
   async function handleRequestAssessmentDelete() {
     if (!selectedQuiz) return
@@ -1057,6 +1066,7 @@ function ClassroomPageContent({
       onNavigateHome={handleHomeNavigationAttempt}
       onNavigateClassroom={handleClassroomNavigationAttempt}
       mainClassName="max-w-none px-0 py-0"
+      constrainToViewport={hasActiveTeacherSplitPanes}
       examModeHeader={examHeaderData}
       pageTitle={selectedWorkTitle}
     >

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -339,7 +339,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       primary={
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
-          className="h-full"
+          className="h-full min-h-0 overflow-auto"
           onClick={(e) => {
             // Deselect when clicking outside the table
             if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1454,7 +1454,7 @@ export function TeacherClassroomView({
   )
 
   const classPane = (
-    <div className="h-full min-h-0">
+    <div className="h-full min-h-0 overflow-auto">
       {studentTable}
     </div>
   )

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1648,7 +1648,7 @@ export function TeacherTestsTab({
           tone="muted"
         />
       ) : (
-        <div className="min-h-0 w-full overflow-hidden rounded-md border border-border bg-surface">
+        <div className="min-h-0 w-full overflow-auto rounded-md border border-border bg-surface">
           <table className="w-full text-sm">
             <thead>
               <tr className="bg-surface-hover text-left text-text-muted">
@@ -2228,7 +2228,7 @@ export function TeacherTestsTab({
       className="flex-1"
       splitVariant="gapped"
       primary={gradingTable}
-      inspector={gradingInspector ? <div className="h-full overflow-y-auto">{gradingInspector}</div> : undefined}
+      inspector={gradingInspector ? <div className="h-full min-h-0 overflow-y-auto">{gradingInspector}</div> : undefined}
       inspectorWidth={gradingInspectorWidth}
       inspectorCollapsed={false}
       onInspectorWidthChange={setGradingInspectorWidth}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -21,6 +21,7 @@ interface AppShellProps {
   onNavigateHome?: (href: string) => boolean
   onNavigateClassroom?: (href: string) => boolean
   mainClassName?: string
+  constrainToViewport?: boolean
   examModeHeader?: {
     testTitle: string
     exitsCount: number
@@ -44,11 +45,14 @@ export function AppShell({
   onNavigateHome,
   onNavigateClassroom,
   mainClassName,
+  constrainToViewport = false,
   examModeHeader,
   pageTitle,
 }: AppShellProps) {
+  const shouldConstrainViewport = constrainToViewport || !!examModeHeader
+
   return (
-    <div className={`flex min-h-dvh flex-col bg-page${examModeHeader ? ' lg:h-dvh lg:overflow-hidden' : ''}`}>
+    <div className={`flex min-h-dvh flex-col bg-page${shouldConstrainViewport ? ' lg:h-dvh lg:overflow-hidden' : ''}`}>
       {showHeader && (
         <AppHeader
           user={user}
@@ -65,8 +69,9 @@ export function AppShell({
       <main
         className={[
           'flex-1 min-h-0',
+          shouldConstrainViewport ? 'lg:overflow-hidden' : '',
           mainClassName || 'max-w-7xl mx-auto px-4 py-3',
-        ].join(' ')}
+        ].filter(Boolean).join(' ')}
       >
         {children}
       </main>

--- a/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkspaceSplit.tsx
@@ -258,7 +258,7 @@ export function TeacherWorkspaceSplit({
     return (
       <div
         ref={splitRef}
-        className={cn('flex min-h-0 flex-1 flex-col gap-3 bg-page lg:flex-row lg:gap-0', className)}
+        className={cn('flex min-h-0 flex-1 flex-col gap-3 bg-page lg:h-full lg:overflow-hidden lg:flex-row lg:gap-0', className)}
       >
         <div className={cn('min-h-0 min-w-0 flex-1 overflow-hidden', primaryClassName)}>
           {primary}


### PR DESCRIPTION
## Summary

- Add an opt-in viewport constraint to `AppShell` for active desktop teacher split-pane workspaces.
- Apply that constraint to attendance, roster, gradebook, assignment review with a selected student, and test grading with a selected student.
- Move overflow ownership into the active pane bodies so each pane scrolls independently while the shared split resize behavior remains unchanged.

## Why

Two-pane teacher workspaces could make the overall classroom shell vertically scroll. That made the split panes feel like one large page instead of two independent work surfaces. This keeps the shell bounded on desktop and lets the primary and inspector panes handle their own overflow.

## Review

Self-review found no code findings. The change is intentionally scoped to desktop teacher workspaces with active split panes; mobile stacked layouts and nested/editor split patterns are left unchanged.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test -- tests/components/TeacherWorkspaceSplit.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx` (ran full suite: 249 files, 2091 tests)
- `pnpm lint`
- Pika UI verification for `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance`
- Focused Playwright screenshots for attendance, roster, gradebook, assignment review, and test grading
- Browser assertion pass confirmed no document-level vertical scroll on affected desktop split routes and verified split-handle drag movement by 126px