### PR TITLE
Align calendar controls with floating pattern

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -273,6 +273,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-split-teacher.png`
   - `/tmp/pika-test-grading-split-teacher.png`
 - Playwright assertion pass confirmed no document-level vertical scroll on the affected desktop split routes and a 126px resize-handle movement after drag.
+
 ## 2026-05-06 — Make assignment edit mode modal-close ephemeral
 
 **Completed:**
@@ -294,6 +295,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-edit-mode-before-create-modal.png`
   - `/tmp/pika-assignment-create-modal-before-close-ephemeral.png`
   - `/tmp/pika-assignment-edit-mode-after-create-close.png`
+
 ## 2026-05-06 — Align calendar controls with floating tab pattern
 
 **Completed:**
@@ -305,6 +307,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Follow-up: moved teacher Edit into its own right-side floating FAB, kept the center FAB focused on date + view mode, and added bottom calendar padding so the last table row does not end at the viewport edge.
 - Made the mobile teacher edit FAB icon-only with an accessible label so the long All-date range does not collide with the right FAB.
 - Follow-up: replaced the far-right edit FAB with an inline Edit control beside Week/Month/All and added scroll docking so the calendar date navigator moves into the app header after scrolling, leaving a shorter selector/Edit floating cluster.
+- Rebase follow-up: rebased `codex/calendar-fab-pattern` onto latest `origin/main` without conflicts; branch has no added migrations to resequence and duplicate migration prefix check was clean.
 
 **Validation:**
 - `pnpm lint`
@@ -360,3 +363,9 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-calendar-scroll-teacher-initial-mobile.png`
   - `/tmp/pika-calendar-scroll-teacher-scrolled-mobile.png`
   - `/tmp/pika-calendar-scroll-student-scrolled-mobile.png`
+- Rebase validation:
+  - `pnpm lint`
+  - `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/LessonCalendar.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx`
+  - `pnpm build`
+  - `git -C "$PIKA_WORKTREE" diff --name-only --diff-filter=A origin/main -- supabase/migrations`
+  - duplicate migration prefix check returned no output

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -300,6 +300,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Moved the classroom calendar date navigator and Week/Month/All selector into the shared centered floating action cluster.
 - Replaced the teacher calendar markdown-sidebar icon with the shared Edit control and kept student calendar without teacher edit chrome.
 - Set the teacher calendar title-bar label to `Calendar` and added mobile spacing so the wrapped teacher FAB does not cover the calendar header.
+- Follow-up: stacked the Week/Month/All selector below the date navigator, with teacher Edit beside the lower selector row.
 
 **Validation:**
 - `pnpm lint`
@@ -317,3 +318,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-student-calendar-mobile-week.png`
   - `/tmp/pika-student-calendar-mobile-all.png`
   - `/tmp/pika-teacher-calendar-dark.png`
+- Follow-up validation:
+  - `pnpm lint`
+  - `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/LessonCalendar.test.tsx`
+  - `pnpm build`
+  - `/tmp/pika-teacher-calendar-selector-below.png`
+  - `/tmp/pika-teacher-calendar-mobile-selector-below.png`
+  - `/tmp/pika-teacher-calendar-mobile-all-selector-below.png`
+  - `/tmp/pika-student-calendar-mobile-selector-below.png`
+  - `/tmp/pika-student-calendar-mobile-all-selector-below.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -301,6 +301,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Replaced the teacher calendar markdown-sidebar icon with the shared Edit control and kept student calendar without teacher edit chrome.
 - Set the teacher calendar title-bar label to `Calendar` and added mobile spacing so the wrapped teacher FAB does not cover the calendar header.
 - Follow-up: stacked the Week/Month/All selector below the date navigator, with teacher Edit beside the lower selector row.
+- Follow-up: moved teacher Edit into the date navigator row and aligned it to the row's right edge while keeping Week/Month/All below.
 
 **Validation:**
 - `pnpm lint`
@@ -327,3 +328,11 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-teacher-calendar-mobile-all-selector-below.png`
   - `/tmp/pika-student-calendar-mobile-selector-below.png`
   - `/tmp/pika-student-calendar-mobile-all-selector-below.png`
+- Edit-row follow-up validation:
+  - `pnpm lint`
+  - `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/LessonCalendar.test.tsx`
+  - `pnpm build`
+  - `/tmp/pika-teacher-calendar-edit-top-right.png`
+  - `/tmp/pika-teacher-calendar-mobile-edit-top-right.png`
+  - `/tmp/pika-teacher-calendar-mobile-all-edit-top-right.png`
+  - `/tmp/pika-student-calendar-mobile-edit-top-right.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -304,6 +304,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Follow-up: moved teacher Edit into the date navigator row and aligned it to the row's right edge while keeping Week/Month/All below.
 - Follow-up: moved teacher Edit into its own right-side floating FAB, kept the center FAB focused on date + view mode, and added bottom calendar padding so the last table row does not end at the viewport edge.
 - Made the mobile teacher edit FAB icon-only with an accessible label so the long All-date range does not collide with the right FAB.
+- Follow-up: replaced the far-right edit FAB with an inline Edit control beside Week/Month/All and added scroll docking so the calendar date navigator moves into the app header after scrolling, leaving a shorter selector/Edit floating cluster.
 
 **Validation:**
 - `pnpm lint`
@@ -349,3 +350,13 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-student-calendar-valid.png`
   - `/tmp/pika-student-calendar-mobile-all-bottom-buffer.png`
   - `/tmp/pika-teacher-calendar-320-all-compact-edit.png`
+- Scroll-docked date follow-up validation:
+  - `pnpm lint`
+  - `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/LessonCalendar.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherEditModeControls.test.tsx`
+  - `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx`
+  - `pnpm build`
+  - `/tmp/pika-calendar-scroll-teacher-initial-desktop.png`
+  - `/tmp/pika-calendar-scroll-teacher-scrolled-desktop.png`
+  - `/tmp/pika-calendar-scroll-teacher-initial-mobile.png`
+  - `/tmp/pika-calendar-scroll-teacher-scrolled-mobile.png`
+  - `/tmp/pika-calendar-scroll-student-scrolled-mobile.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -294,3 +294,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-edit-mode-before-create-modal.png`
   - `/tmp/pika-assignment-create-modal-before-close-ephemeral.png`
   - `/tmp/pika-assignment-edit-mode-after-create-close.png`
+## 2026-05-06 — Align calendar controls with floating tab pattern
+
+**Completed:**
+- Moved the classroom calendar date navigator and Week/Month/All selector into the shared centered floating action cluster.
+- Replaced the teacher calendar markdown-sidebar icon with the shared Edit control and kept student calendar without teacher edit chrome.
+- Set the teacher calendar title-bar label to `Calendar` and added mobile spacing so the wrapped teacher FAB does not cover the calendar header.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/LessonCalendar.test.tsx`
+- `pnpm build`
+- `pnpm test`
+- Pika UI verification script for teacher/student calendar capture:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Manual Playwright screenshots after role-specific classroom routing and loaded-state waits:
+  - `/tmp/pika-teacher-calendar-week.png`
+  - `/tmp/pika-teacher-calendar-mobile-week-2.png`
+  - `/tmp/pika-teacher-calendar-mobile-all-2.png`
+  - `/tmp/pika-student-calendar-mobile-week.png`
+  - `/tmp/pika-student-calendar-mobile-all.png`
+  - `/tmp/pika-teacher-calendar-dark.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -302,6 +302,8 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Set the teacher calendar title-bar label to `Calendar` and added mobile spacing so the wrapped teacher FAB does not cover the calendar header.
 - Follow-up: stacked the Week/Month/All selector below the date navigator, with teacher Edit beside the lower selector row.
 - Follow-up: moved teacher Edit into the date navigator row and aligned it to the row's right edge while keeping Week/Month/All below.
+- Follow-up: moved teacher Edit into its own right-side floating FAB, kept the center FAB focused on date + view mode, and added bottom calendar padding so the last table row does not end at the viewport edge.
+- Made the mobile teacher edit FAB icon-only with an accessible label so the long All-date range does not collide with the right FAB.
 
 **Validation:**
 - `pnpm lint`
@@ -336,3 +338,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-teacher-calendar-mobile-edit-top-right.png`
   - `/tmp/pika-teacher-calendar-mobile-all-edit-top-right.png`
   - `/tmp/pika-student-calendar-mobile-edit-top-right.png`
+- Independent-FAB/bottom-buffer follow-up validation:
+  - `pnpm lint`
+  - `pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/LessonCalendar.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherEditModeControls.test.tsx`
+  - `pnpm build`
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-teacher-mobile-compact-edit-loaded.png`
+  - `/tmp/pika-teacher-calendar-mobile-all-bottom-compact-edit.png`
+  - `/tmp/pika-teacher-calendar-desktop-all-bottom.png`
+  - `/tmp/pika-student-calendar-valid.png`
+  - `/tmp/pika-student-calendar-mobile-all-bottom-buffer.png`
+  - `/tmp/pika-teacher-calendar-320-all-compact-edit.png`

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -12,6 +12,7 @@ import { TeacherGradebookTab } from './TeacherGradebookTab'
 import { TeacherSettingsTab } from './TeacherSettingsTab'
 import { TeacherLessonCalendarTab, TeacherLessonCalendarSidebar, CalendarSidebarState } from './TeacherLessonCalendarTab'
 import { StudentLessonCalendarTab } from './StudentLessonCalendarTab'
+import { CalendarDateNavigator, type CalendarHeaderControlsState } from '@/components/CalendarActionBar'
 import { TeacherResourcesTab } from './TeacherResourcesTab'
 import { StudentResourcesTab } from './StudentResourcesTab'
 import { TeacherAnnouncementsTab } from './TeacherAnnouncementsTab'
@@ -422,6 +423,7 @@ function ClassroomPageContent({
 
   // State for calendar sidebar (teacher calendar tab)
   const [calendarSidebarState, setCalendarSidebarState] = useState<CalendarSidebarState | null>(null)
+  const [calendarHeaderControls, setCalendarHeaderControls] = useState<CalendarHeaderControlsState | null>(null)
 
   // State for selected quiz (teacher quizzes tab)
   const [selectedQuiz, setSelectedQuiz] = useState<QuizWithStats | null>(null)
@@ -449,6 +451,12 @@ function ClassroomPageContent({
   useEffect(() => {
     if (activeTab !== 'tests') {
       setTeacherTestPreview(null)
+    }
+  }, [activeTab])
+
+  useEffect(() => {
+    if (activeTab !== 'calendar') {
+      setCalendarHeaderControls(null)
     }
   }, [activeTab])
 
@@ -538,6 +546,17 @@ function ClassroomPageContent({
     selectedQuiz,
     testIdParam,
   ])
+
+  const appHeaderTitle = activeTab === 'calendar' && calendarHeaderControls ? (
+    <CalendarDateNavigator
+      label={calendarHeaderControls.label}
+      onPrev={calendarHeaderControls.onPrev}
+      onNext={calendarHeaderControls.onNext}
+      onLabelClick={calendarHeaderControls.showNavigation ? calendarHeaderControls.onToday : undefined}
+      showNavigation={calendarHeaderControls.showNavigation}
+      className="max-w-full justify-center"
+    />
+  ) : selectedWorkTitle
 
   // Load assignments and generate markdown content
   const loadAssignmentsMarkdown = useCallback(async () => {
@@ -1075,7 +1094,7 @@ function ClassroomPageContent({
       mainClassName="max-w-none px-0 py-0"
       constrainToViewport={hasActiveTeacherSplitPanes}
       examModeHeader={examHeaderData}
-      pageTitle={selectedWorkTitle}
+      pageTitle={appHeaderTitle}
     >
       <ThreePanelShell leftWidthOverride={hideLeftRailForExamMode ? 0 : undefined}>
         {hideLeftRailForExamMode ? (
@@ -1177,6 +1196,7 @@ function ClassroomPageContent({
                       <TeacherLessonCalendarTab
                         classroom={classroom}
                         onSidebarStateChange={setCalendarSidebarState}
+                        onHeaderControlsChange={setCalendarHeaderControls}
                         onNavigateToAssignments={(assignmentId) =>
                           navigateInClassroom((params) => {
                             params.set('tab', 'assignments')
@@ -1263,6 +1283,7 @@ function ClassroomPageContent({
                     <TabContentTransition isActive={activeTab === 'calendar'}>
                       <StudentLessonCalendarTab
                         classroom={classroom}
+                        onHeaderControlsChange={setCalendarHeaderControls}
                         onNavigateToAssignments={(assignmentId) =>
                           navigateInClassroom((params) => {
                             params.set('tab', 'assignments')

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -523,6 +523,10 @@ function ClassroomPageContent({
         : 'Tests'
     }
 
+    if (activeTab === 'calendar') {
+      return 'Calendar'
+    }
+
     return undefined
   }, [
     activeTab,

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, startOfWeek, subMonths, subWeeks } from 'date-fns'
-import { CalendarActionBar } from '@/components/CalendarActionBar'
+import {
+  CalendarActionBar,
+  getCalendarHeaderLabel,
+  type CalendarHeaderControlsState,
+} from '@/components/CalendarActionBar'
 import { Spinner } from '@/components/Spinner'
 import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
@@ -12,12 +16,14 @@ import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 
 interface Props {
   classroom: Classroom
+  onHeaderControlsChange?: (state: CalendarHeaderControlsState | null) => void
   onNavigateToAssignments?: (assignmentId: string) => void
   onNavigateToAnnouncements?: () => void
 }
 
 export function StudentLessonCalendarTab({
   classroom,
+  onHeaderControlsChange,
   onNavigateToAssignments = () => {},
   onNavigateToAnnouncements = () => {},
 }: Props) {
@@ -36,6 +42,17 @@ export function StudentLessonCalendarTab({
   }, [classroom.id])
   const [currentDate, setCurrentDate] = useState(new Date())
   const [maxDate, setMaxDate] = useState<string | null>(null)
+  const [isDateDocked, setIsDateDocked] = useState(false)
+
+  useEffect(() => {
+    function updateDateDocking() {
+      setIsDateDocked(window.scrollY > 24)
+    }
+
+    updateDateDocking()
+    window.addEventListener('scroll', updateDateDocking, { passive: true })
+    return () => window.removeEventListener('scroll', updateDateDocking)
+  }, [])
 
   // Always fetch the full term - switching views is then instant
   const fetchRange = {
@@ -85,7 +102,7 @@ export function StudentLessonCalendarTab({
   }, [onNavigateToAnnouncements])
 
   // Prevent navigation beyond max date
-  const handleDateChange = (newDate: Date) => {
+  const handleDateChange = useCallback((newDate: Date) => {
     if (maxDate) {
       const newDateStr = format(startOfWeek(newDate, { weekStartsOn: 0 }), 'yyyy-MM-dd')
       if (newDateStr > maxDate) {
@@ -94,7 +111,56 @@ export function StudentLessonCalendarTab({
       }
     }
     setCurrentDate(newDate)
-  }
+  }, [maxDate])
+
+  const handlePreviousDate = useCallback(() => {
+    if (viewMode === 'week') {
+      handleDateChange(subWeeks(currentDate, 1))
+    } else if (viewMode === 'month') {
+      handleDateChange(subMonths(currentDate, 1))
+    }
+  }, [currentDate, handleDateChange, viewMode])
+
+  const handleNextDate = useCallback(() => {
+    if (viewMode === 'week') {
+      handleDateChange(addWeeks(currentDate, 1))
+    } else if (viewMode === 'month') {
+      handleDateChange(addMonths(currentDate, 1))
+    }
+  }, [currentDate, handleDateChange, viewMode])
+
+  const handleToday = useCallback(() => {
+    handleDateChange(new Date())
+  }, [handleDateChange])
+
+  const headerLabel = getCalendarHeaderLabel(viewMode, currentDate, classroom.start_date, classroom.end_date)
+
+  useEffect(() => {
+    if (!onHeaderControlsChange) return undefined
+
+    if (!isDateDocked) {
+      onHeaderControlsChange(null)
+      return undefined
+    }
+
+    onHeaderControlsChange({
+      label: headerLabel,
+      showNavigation: viewMode !== 'all',
+      onPrev: handlePreviousDate,
+      onNext: handleNextDate,
+      onToday: handleToday,
+    })
+
+    return () => onHeaderControlsChange(null)
+  }, [
+    handleNextDate,
+    handlePreviousDate,
+    handleToday,
+    headerLabel,
+    isDateDocked,
+    onHeaderControlsChange,
+    viewMode,
+  ])
 
   if (loading && lessonPlans.length === 0) {
     return (
@@ -115,22 +181,11 @@ export function StudentLessonCalendarTab({
         currentDate={currentDate}
         rangeStart={classroom.start_date}
         rangeEnd={classroom.end_date}
-        onPrev={() => {
-          if (viewMode === 'week') {
-            handleDateChange(subWeeks(currentDate, 1))
-          } else if (viewMode === 'month') {
-            handleDateChange(subMonths(currentDate, 1))
-          }
-        }}
-        onNext={() => {
-          if (viewMode === 'week') {
-            handleDateChange(addWeeks(currentDate, 1))
-          } else if (viewMode === 'month') {
-            handleDateChange(addMonths(currentDate, 1))
-          }
-        }}
-        onToday={() => handleDateChange(new Date())}
+        onPrev={handlePreviousDate}
+        onNext={handleNextDate}
+        onToday={handleToday}
         onViewModeChange={handleViewModeChange}
+        datePlacement={isDateDocked ? 'header' : 'cluster'}
       />
       <PageContent className="pb-24 pt-2">
         <div className="overflow-hidden rounded-lg border border-border bg-surface">

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -132,7 +132,7 @@ export function StudentLessonCalendarTab({
         onToday={() => handleDateChange(new Date())}
         onViewModeChange={handleViewModeChange}
       />
-      <PageContent className="pt-2">
+      <PageContent className="pb-24 pt-2">
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -2,15 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, subMonths, subWeeks } from 'date-fns'
-import { PanelRight, PanelRightClose } from 'lucide-react'
 import { CalendarActionBar } from '@/components/CalendarActionBar'
 import { Spinner } from '@/components/Spinner'
 import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useRightSidebar } from '@/components/layout'
+import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { applyPendingLessonPlanChanges, lessonPlansToMarkdown, markdownToLessonPlans } from '@/lib/lesson-plan-markdown'
 import { useClassDays } from '@/hooks/useClassDays'
-import { Button } from '@/ui'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import type { Classroom, LessonPlan, TiptapContent, Assignment, Announcement } from '@/types'
 import { readCookie, writeCookie } from '@/lib/cookies'
@@ -504,6 +503,7 @@ export function TeacherLessonCalendarTab({
   return (
     <PageLayout bleedX={false}>
       <CalendarActionBar
+        className="pb-10 sm:pb-0"
         viewMode={viewMode}
         currentDate={currentDate}
         rangeStart={classroom.start_date}
@@ -525,23 +525,15 @@ export function TeacherLessonCalendarTab({
         onToday={() => setCurrentDate(new Date())}
         onViewModeChange={handleViewModeChange}
         trailing={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             {saving && <span className="text-sm text-text-muted">Saving...</span>}
             {showMarkdown ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 w-9 px-0"
-                onClick={handleMarkdownToggle}
-                aria-label={isSidebarOpen ? 'Close sidebar' : 'Edit as Markdown'}
-              >
-                {isSidebarOpen ? (
-                  <PanelRightClose className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <PanelRight className="h-4 w-4" aria-hidden="true" />
-                )}
-              </Button>
+              <TeacherEditModeControls
+                active={isSidebarOpen}
+                onActiveChange={handleMarkdownToggle}
+                disabled={Boolean(classroom.archived_at)}
+                variant="secondary"
+              />
             ) : null}
           </div>
         }

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -503,7 +503,6 @@ export function TeacherLessonCalendarTab({
   return (
     <PageLayout bleedX={false}>
       <CalendarActionBar
-        className="pb-10 sm:pb-0"
         viewMode={viewMode}
         currentDate={currentDate}
         rangeStart={classroom.start_date}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -523,21 +523,22 @@ export function TeacherLessonCalendarTab({
         }}
         onToday={() => setCurrentDate(new Date())}
         onViewModeChange={handleViewModeChange}
-        trailing={
+        trailing={saving || showMarkdown ? (
           <div className="flex items-center gap-1.5">
-            {saving && <span className="text-sm text-text-muted">Saving...</span>}
+            {saving && <span className="hidden text-sm text-text-muted sm:inline">Saving...</span>}
             {showMarkdown ? (
               <TeacherEditModeControls
                 active={isSidebarOpen}
                 onActiveChange={handleMarkdownToggle}
                 disabled={Boolean(classroom.archived_at)}
                 variant="secondary"
+                className="[&>button>span]:sr-only sm:[&>button>span]:not-sr-only"
               />
             ) : null}
           </div>
-        }
+        ) : null}
       />
-      <PageContent className="pt-2">
+      <PageContent className="pb-24 pt-2">
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, subMonths, subWeeks } from 'date-fns'
-import { CalendarActionBar } from '@/components/CalendarActionBar'
+import {
+  CalendarActionBar,
+  getCalendarHeaderLabel,
+  type CalendarHeaderControlsState,
+} from '@/components/CalendarActionBar'
 import { Spinner } from '@/components/Spinner'
 import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
@@ -48,6 +52,7 @@ export interface CalendarSidebarState {
 interface Props {
   classroom: Classroom
   onSidebarStateChange?: (state: CalendarSidebarState | null) => void
+  onHeaderControlsChange?: (state: CalendarHeaderControlsState | null) => void
   onNavigateToAssignments?: (assignmentId?: string | null) => void
   onNavigateToAnnouncements?: () => void
 }
@@ -55,6 +60,7 @@ interface Props {
 export function TeacherLessonCalendarTab({
   classroom,
   onSidebarStateChange,
+  onHeaderControlsChange,
   onNavigateToAssignments = () => {},
   onNavigateToAnnouncements = () => {},
 }: Props) {
@@ -81,9 +87,20 @@ export function TeacherLessonCalendarTab({
   const [markdownError, setMarkdownError] = useState<string | null>(null)
   const [bulkSaving, setBulkSaving] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [isDateDocked, setIsDateDocked] = useState(false)
 
   const { toggle: toggleSidebar, isOpen: isSidebarOpen, setOpen: setSidebarOpen } = useRightSidebar()
   const { showMarkdown } = useMarkdownPreference()
+
+  useEffect(() => {
+    function updateDateDocking() {
+      setIsDateDocked(window.scrollY > 24)
+    }
+
+    updateDateDocking()
+    window.addEventListener('scroll', updateDateDocking, { passive: true })
+    return () => window.removeEventListener('scroll', updateDateDocking)
+  }, [])
 
   // Auto-save tracking
   const pendingChangesRef = useRef<Map<string, string>>(new Map())
@@ -471,6 +488,55 @@ export function TeacherLessonCalendarTab({
     onNavigateToAnnouncements()
   }, [onNavigateToAnnouncements])
 
+  const handlePreviousDate = useCallback(() => {
+    if (viewMode === 'week') {
+      setCurrentDate((prev) => subWeeks(prev, 1))
+    } else if (viewMode === 'month') {
+      setCurrentDate((prev) => subMonths(prev, 1))
+    }
+  }, [viewMode])
+
+  const handleNextDate = useCallback(() => {
+    if (viewMode === 'week') {
+      setCurrentDate((prev) => addWeeks(prev, 1))
+    } else if (viewMode === 'month') {
+      setCurrentDate((prev) => addMonths(prev, 1))
+    }
+  }, [viewMode])
+
+  const handleToday = useCallback(() => {
+    setCurrentDate(new Date())
+  }, [])
+
+  const headerLabel = getCalendarHeaderLabel(viewMode, currentDate, classroom.start_date, classroom.end_date)
+
+  useEffect(() => {
+    if (!onHeaderControlsChange) return undefined
+
+    if (!isDateDocked) {
+      onHeaderControlsChange(null)
+      return undefined
+    }
+
+    onHeaderControlsChange({
+      label: headerLabel,
+      showNavigation: viewMode !== 'all',
+      onPrev: handlePreviousDate,
+      onNext: handleNextDate,
+      onToday: handleToday,
+    })
+
+    return () => onHeaderControlsChange(null)
+  }, [
+    handleNextDate,
+    handlePreviousDate,
+    handleToday,
+    headerLabel,
+    isDateDocked,
+    onHeaderControlsChange,
+    viewMode,
+  ])
+
   // Notify parent when sidebar opens/closes, content changes, or error/saving state changes
   // Note: markdownContent IS included because the sidebar uses local state to avoid cursor jump.
   // TeacherLessonCalendarSidebar tracks isDirty and ignores external updates once user starts typing.
@@ -507,22 +573,11 @@ export function TeacherLessonCalendarTab({
         currentDate={currentDate}
         rangeStart={classroom.start_date}
         rangeEnd={classroom.end_date}
-        onPrev={() => {
-          if (viewMode === 'week') {
-            setCurrentDate((prev) => subWeeks(prev, 1))
-          } else if (viewMode === 'month') {
-            setCurrentDate((prev) => subMonths(prev, 1))
-          }
-        }}
-        onNext={() => {
-          if (viewMode === 'week') {
-            setCurrentDate((prev) => addWeeks(prev, 1))
-          } else if (viewMode === 'month') {
-            setCurrentDate((prev) => addMonths(prev, 1))
-          }
-        }}
-        onToday={() => setCurrentDate(new Date())}
+        onPrev={handlePreviousDate}
+        onNext={handleNextDate}
+        onToday={handleToday}
         onViewModeChange={handleViewModeChange}
+        datePlacement={isDateDocked ? 'header' : 'cluster'}
         trailing={saving || showMarkdown ? (
           <div className="flex items-center gap-1.5">
             {saving && <span className="hidden text-sm text-text-muted sm:inline">Saving...</span>}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { ClockAlert, LogOut, Maximize, Menu, Minimize } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ClassroomDropdown } from './ClassroomDropdown'
@@ -33,7 +34,7 @@ interface AppHeaderProps {
     exitsCount: number
     awayTotalSeconds: number
   } | null
-  pageTitle?: string
+  pageTitle?: ReactNode
 }
 
 function formatDuration(totalSeconds: number): string {
@@ -67,6 +68,7 @@ export function AppHeader({
   }, [])
 
   const isExamMode = Boolean(examModeHeader)
+  const isTextPageTitle = typeof pageTitle === 'string'
   const pageTitleClassName =
     pageTitle === 'Classrooms'
       ? 'text-base sm:text-lg'
@@ -151,8 +153,10 @@ export function AppHeader({
               </span>
             </div>
           </div>
-        ) : pageTitle ? (
+        ) : pageTitle && isTextPageTitle ? (
           <h1 className={`truncate font-semibold text-text-default ${pageTitleClassName}`}>{pageTitle}</h1>
+        ) : pageTitle ? (
+          <div className="min-w-0 max-w-full">{pageTitle}</div>
         ) : null}
       </div>
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { AppHeader } from './AppHeader'
 
 interface AppShellProps {
@@ -27,7 +27,7 @@ interface AppShellProps {
     exitsCount: number
     awayTotalSeconds: number
   } | null
-  pageTitle?: string
+  pageTitle?: ReactNode
 }
 
 /**

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -5,10 +5,7 @@ import { format } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
-import {
-  TeacherWorkSurfaceActionBar,
-  TeacherWorkSurfaceFloatingActionCluster,
-} from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import type { CalendarViewMode } from '@/components/LessonCalendar'
 import { cn } from '@/ui/utils'
 
@@ -21,8 +18,17 @@ interface CalendarActionBarProps {
   onNext: () => void
   onToday: () => void
   onViewModeChange: (mode: CalendarViewMode) => void
+  datePlacement?: 'cluster' | 'header'
   trailing?: ReactNode
   className?: string
+}
+
+export interface CalendarHeaderControlsState {
+  label: string
+  showNavigation: boolean
+  onPrev: () => void
+  onNext: () => void
+  onToday: () => void
 }
 
 interface CalendarDateNavigatorProps {
@@ -37,7 +43,12 @@ interface CalendarDateNavigatorProps {
   className?: string
 }
 
-function getHeaderLabel(viewMode: CalendarViewMode, currentDate: Date, rangeStart?: string | null, rangeEnd?: string | null) {
+export function getCalendarHeaderLabel(
+  viewMode: CalendarViewMode,
+  currentDate: Date,
+  rangeStart?: string | null,
+  rangeEnd?: string | null,
+) {
   if (viewMode === 'week' || viewMode === 'month') {
     return format(currentDate, 'MMMM yyyy')
   }
@@ -79,13 +90,13 @@ export function CalendarDateNavigator({
         <button
           type="button"
           onClick={onLabelClick}
-          className="truncate rounded-control px-2 py-1 text-sm font-semibold text-text-default transition-colors hover:bg-surface-hover sm:text-base"
+          className="min-w-0 truncate rounded-control px-2 py-1 text-sm font-semibold text-text-default transition-colors hover:bg-surface-hover sm:text-base"
           aria-label={labelAriaLabel}
         >
           {label}
         </button>
       ) : (
-        <span className="truncate px-2 py-1 text-sm font-semibold text-text-default sm:text-base">
+        <span className="min-w-0 truncate px-2 py-1 text-sm font-semibold text-text-default sm:text-base">
           {label}
         </span>
       )}
@@ -115,20 +126,21 @@ export function CalendarActionBar({
   onNext,
   onToday,
   onViewModeChange,
+  datePlacement = 'cluster',
   trailing,
   className = '',
 }: CalendarActionBarProps) {
-  const headerLabel = getHeaderLabel(viewMode, currentDate, rangeStart, rangeEnd)
-  const hasTrailing = Boolean(trailing)
+  const headerLabel = getCalendarHeaderLabel(viewMode, currentDate, rangeStart, rangeEnd)
+  const showDateInCluster = datePlacement === 'cluster'
 
   return (
     <PageActionBar
-      className={cn('pb-10', className)}
+      className={cn(showDateInCluster ? 'pb-10' : 'pb-2', className)}
       primary={
-        <>
-          <TeacherWorkSurfaceActionBar
-            center={
-              <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
+        <TeacherWorkSurfaceActionBar
+          center={
+            <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
+              {showDateInCluster ? (
                 <div className="flex w-full max-w-full items-center justify-center">
                   <CalendarDateNavigator
                     label={headerLabel}
@@ -139,32 +151,26 @@ export function CalendarActionBar({
                     className="max-w-full"
                   />
                 </div>
+              ) : null}
 
-                <div className="flex flex-wrap items-center justify-center gap-1.5">
-                  <SegmentedControl<CalendarViewMode>
-                    ariaLabel="Calendar view"
-                    value={viewMode}
-                    onChange={onViewModeChange}
-                    capitalizeLabels
-                    options={[
-                      { value: 'week', label: 'Week' },
-                      { value: 'month', label: 'Month' },
-                      { value: 'all', label: 'All' },
-                    ]}
-                  />
-                </div>
+              <div className="flex max-w-full flex-wrap items-center justify-center gap-1.5">
+                <SegmentedControl<CalendarViewMode>
+                  ariaLabel="Calendar view"
+                  value={viewMode}
+                  onChange={onViewModeChange}
+                  capitalizeLabels
+                  options={[
+                    { value: 'week', label: 'Week' },
+                    { value: 'month', label: 'Month' },
+                    { value: 'all', label: 'All' },
+                  ]}
+                />
+                {trailing}
               </div>
-            }
-            centerClassName={hasTrailing ? 'max-w-[calc(100vw-9rem)] sm:max-w-[calc(100vw-1rem)]' : undefined}
-            centerPlacement="floating"
-          />
-
-          {hasTrailing ? (
-            <TeacherWorkSurfaceFloatingActionCluster className="left-auto right-3 max-w-[calc(50vw-0.75rem)] translate-x-0 sm:right-4 sm:max-w-[calc(100vw-1rem)]">
-              {trailing}
-            </TeacherWorkSurfaceFloatingActionCluster>
-          ) : null}
-        </>
+            </div>
+          }
+          centerPlacement="floating"
+        />
       }
     />
   )

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -5,7 +5,10 @@ import { format } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
-import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import {
+  TeacherWorkSurfaceActionBar,
+  TeacherWorkSurfaceFloatingActionCluster,
+} from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import type { CalendarViewMode } from '@/components/LessonCalendar'
 import { cn } from '@/ui/utils'
 
@@ -116,44 +119,52 @@ export function CalendarActionBar({
   className = '',
 }: CalendarActionBarProps) {
   const headerLabel = getHeaderLabel(viewMode, currentDate, rangeStart, rangeEnd)
+  const hasTrailing = Boolean(trailing)
 
   return (
     <PageActionBar
       className={cn('pb-10', className)}
       primary={
-        <TeacherWorkSurfaceActionBar
-          center={
-            <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
-              <div className="flex w-full max-w-full items-center justify-between gap-3">
-                <CalendarDateNavigator
-                  label={headerLabel}
-                  onPrev={onPrev}
-                  onNext={onNext}
-                  onLabelClick={viewMode === 'all' ? undefined : onToday}
-                  showNavigation={viewMode !== 'all'}
-                  className="max-w-full"
-                />
+        <>
+          <TeacherWorkSurfaceActionBar
+            center={
+              <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
+                <div className="flex w-full max-w-full items-center justify-center">
+                  <CalendarDateNavigator
+                    label={headerLabel}
+                    onPrev={onPrev}
+                    onNext={onNext}
+                    onLabelClick={viewMode === 'all' ? undefined : onToday}
+                    showNavigation={viewMode !== 'all'}
+                    className="max-w-full"
+                  />
+                </div>
 
-                {trailing}
+                <div className="flex flex-wrap items-center justify-center gap-1.5">
+                  <SegmentedControl<CalendarViewMode>
+                    ariaLabel="Calendar view"
+                    value={viewMode}
+                    onChange={onViewModeChange}
+                    capitalizeLabels
+                    options={[
+                      { value: 'week', label: 'Week' },
+                      { value: 'month', label: 'Month' },
+                      { value: 'all', label: 'All' },
+                    ]}
+                  />
+                </div>
               </div>
+            }
+            centerClassName={hasTrailing ? 'max-w-[calc(100vw-9rem)] sm:max-w-[calc(100vw-1rem)]' : undefined}
+            centerPlacement="floating"
+          />
 
-              <div className="flex flex-wrap items-center justify-center gap-1.5">
-                <SegmentedControl<CalendarViewMode>
-                  ariaLabel="Calendar view"
-                  value={viewMode}
-                  onChange={onViewModeChange}
-                  capitalizeLabels
-                  options={[
-                    { value: 'week', label: 'Week' },
-                    { value: 'month', label: 'Month' },
-                    { value: 'all', label: 'All' },
-                  ]}
-                />
-              </div>
-            </div>
-          }
-          centerPlacement="floating"
-        />
+          {hasTrailing ? (
+            <TeacherWorkSurfaceFloatingActionCluster className="left-auto right-3 max-w-[calc(50vw-0.75rem)] translate-x-0 sm:right-4 sm:max-w-[calc(100vw-1rem)]">
+              {trailing}
+            </TeacherWorkSurfaceFloatingActionCluster>
+          ) : null}
+        </>
       }
     />
   )

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -124,14 +124,18 @@ export function CalendarActionBar({
         <TeacherWorkSurfaceActionBar
           center={
             <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
-              <CalendarDateNavigator
-                label={headerLabel}
-                onPrev={onPrev}
-                onNext={onNext}
-                onLabelClick={viewMode === 'all' ? undefined : onToday}
-                showNavigation={viewMode !== 'all'}
-                className="max-w-full"
-              />
+              <div className="flex w-full max-w-full items-center justify-between gap-3">
+                <CalendarDateNavigator
+                  label={headerLabel}
+                  onPrev={onPrev}
+                  onNext={onNext}
+                  onLabelClick={viewMode === 'all' ? undefined : onToday}
+                  showNavigation={viewMode !== 'all'}
+                  className="max-w-full"
+                />
+
+                {trailing}
+              </div>
 
               <div className="flex flex-wrap items-center justify-center gap-1.5">
                 <SegmentedControl<CalendarViewMode>
@@ -145,8 +149,6 @@ export function CalendarActionBar({
                     { value: 'all', label: 'All' },
                   ]}
                 />
-
-                {trailing}
               </div>
             </div>
           }

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
+import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import type { CalendarViewMode } from '@/components/LessonCalendar'
 
 interface CalendarActionBarProps {
@@ -119,44 +120,35 @@ export function CalendarActionBar({
     <PageActionBar
       className={className}
       primary={
-        <div className="relative flex min-h-9 w-full items-center">
-          <CalendarDateNavigator
-            label={headerLabel}
-            onPrev={onPrev}
-            onNext={onNext}
-            onLabelClick={onToday}
-            showNavigation={viewMode !== 'all'}
-          />
+        <TeacherWorkSurfaceActionBar
+          center={
+            <div className="flex max-w-full flex-wrap items-center justify-center gap-1.5">
+              <CalendarDateNavigator
+                label={headerLabel}
+                onPrev={onPrev}
+                onNext={onNext}
+                onLabelClick={viewMode === 'all' ? undefined : onToday}
+                showNavigation={viewMode !== 'all'}
+                className="max-w-full"
+              />
 
-          <SegmentedControl<CalendarViewMode>
-            ariaLabel="Calendar view"
-            value={viewMode}
-            onChange={onViewModeChange}
-            capitalizeLabels
-            className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 sm:flex"
-            options={[
-              { value: 'week', label: 'Week' },
-              { value: 'month', label: 'Month' },
-              { value: 'all', label: 'All' },
-            ]}
-          />
+              <SegmentedControl<CalendarViewMode>
+                ariaLabel="Calendar view"
+                value={viewMode}
+                onChange={onViewModeChange}
+                capitalizeLabels
+                options={[
+                  { value: 'week', label: 'Week' },
+                  { value: 'month', label: 'Month' },
+                  { value: 'all', label: 'All' },
+                ]}
+              />
 
-          <div className="ml-auto flex items-center gap-2 sm:absolute sm:right-0 sm:top-1/2 sm:-translate-y-1/2">
-            <SegmentedControl<CalendarViewMode>
-              ariaLabel="Calendar view"
-              value={viewMode}
-              onChange={onViewModeChange}
-              capitalizeLabels
-              className="sm:hidden"
-              options={[
-                { value: 'week', label: 'Week' },
-                { value: 'month', label: 'Month' },
-                { value: 'all', label: 'All' },
-              ]}
-            />
-            {trailing}
-          </div>
-        </div>
+              {trailing}
+            </div>
+          }
+          centerPlacement="floating"
+        />
       }
     />
   )

--- a/src/components/CalendarActionBar.tsx
+++ b/src/components/CalendarActionBar.tsx
@@ -7,6 +7,7 @@ import { Button, SegmentedControl } from '@/ui'
 import { PageActionBar } from '@/components/PageLayout'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import type { CalendarViewMode } from '@/components/LessonCalendar'
+import { cn } from '@/ui/utils'
 
 interface CalendarActionBarProps {
   viewMode: CalendarViewMode
@@ -118,11 +119,11 @@ export function CalendarActionBar({
 
   return (
     <PageActionBar
-      className={className}
+      className={cn('pb-10', className)}
       primary={
         <TeacherWorkSurfaceActionBar
           center={
-            <div className="flex max-w-full flex-wrap items-center justify-center gap-1.5">
+            <div className="flex max-w-full flex-col items-center justify-center gap-1.5">
               <CalendarDateNavigator
                 label={headerLabel}
                 onPrev={onPrev}
@@ -132,19 +133,21 @@ export function CalendarActionBar({
                 className="max-w-full"
               />
 
-              <SegmentedControl<CalendarViewMode>
-                ariaLabel="Calendar view"
-                value={viewMode}
-                onChange={onViewModeChange}
-                capitalizeLabels
-                options={[
-                  { value: 'week', label: 'Week' },
-                  { value: 'month', label: 'Month' },
-                  { value: 'all', label: 'All' },
-                ]}
-              />
+              <div className="flex flex-wrap items-center justify-center gap-1.5">
+                <SegmentedControl<CalendarViewMode>
+                  ariaLabel="Calendar view"
+                  value={viewMode}
+                  onChange={onViewModeChange}
+                  capitalizeLabels
+                  options={[
+                    { value: 'week', label: 'Week' },
+                    { value: 'month', label: 'Month' },
+                    { value: 'all', label: 'All' },
+                  ]}
+                />
 
-              {trailing}
+                {trailing}
+              </div>
             </div>
           }
           centerPlacement="floating"

--- a/tests/components/calendar-view-persistence.test.tsx
+++ b/tests/components/calendar-view-persistence.test.tsx
@@ -155,6 +155,16 @@ describe('Calendar view mode persistence', () => {
         expect(readCookieSpy).toHaveBeenCalledWith('calendarViewMode:cls-123')
       })
     })
+
+    it('renders the teacher edit control in the calendar action cluster', async () => {
+      readCookieSpy.mockReturnValue(null)
+
+      render(<TeacherLessonCalendarTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+      })
+    })
   })
 
   describe('StudentLessonCalendarTab', () => {
@@ -200,6 +210,17 @@ describe('Calendar view mode persistence', () => {
       await waitFor(() => {
         expectCalendarViewSelected('week')
       })
+    })
+
+    it('does not render the teacher edit control', async () => {
+      readCookieSpy.mockReturnValue(null)
+
+      render(<StudentLessonCalendarTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+      await waitFor(() => {
+        expectCalendarViewSelected('week')
+      })
+      expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- move calendar controls into the floating tab action pattern
- keep teacher Edit inline with Week/Month/All and dock the date navigator into the app header on scroll
- add bottom spacing so the calendar table does not end at the viewport edge

## Validation
- pnpm lint
- pnpm test tests/components/calendar-view-persistence.test.tsx tests/components/LessonCalendar.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherEditModeControls.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx
- pnpm build
- Playwright screenshots for teacher/student calendar initial and scrolled states