### PR TITLE
[codex] Allow repo metadata assignment submissions

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,26 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-04-30 — Refresh assignment counts after return
-
-**Completed:**
-- Fixed the teacher assignment list card counts staying stale after returning selected assignment work.
-- Invalidated and reloaded the teacher assignment summary cache after a successful batch return, while preserving the current workspace content.
-- Added component coverage for a resubmitted student changing the summary card from `1/31` to `0/31` after return.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx`
-- `pnpm test tests/api/teacher/assignments.test.ts tests/api/teacher/assignments-id-return.test.ts`
-- `pnpm lint`
-- `pnpm test`
-- Pika UI verification script for `/classrooms`:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Manual Playwright screenshots for assignment lists:
-  - `/tmp/pika-teacher-assignments.png`
-  - `/tmp/pika-student-assignments.png`
-
 ## 2026-05-06 — Tighten assignment edit chrome and modal height
 
 **Completed:**
@@ -415,3 +395,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts`
 - `pnpm run test:coverage`
 - `pnpm lint`
+
+## 2026-05-07 — Allow late assignment submissions with repo metadata
+
+**Completed:**
+- Fixed assignment submit validation so saved repo metadata counts as submittable work, matching the student editor's Submit button rule.
+- Made the student assignment editor flush pending repo URL/GitHub username edits before calling the submit endpoint.
+- Added regression coverage for a past-due repo-only assignment submission.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test -- tests/api/assignment-docs/submit.test.ts` (ran full suite: 251 files, 2119 tests)
+- `pnpm test -- tests/unit/assignments.test.ts` (ran full suite: 251 files, 2119 tests)
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { countCharacters, countWords, isEmpty, parseContentField } from '@/lib/tiptap-content'
+import { countCharacters, countWords, parseContentField } from '@/lib/tiptap-content'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { withErrorHandler } from '@/lib/api-handler'
+import { hasAssignmentSubmissionContent } from '@/lib/assignments'
 import type { AssignmentDocHistoryEntry, TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -49,7 +50,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   // Check if doc exists
   const { data: existingDoc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content')
+    .select('id, student_id, content, repo_url, github_username')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -74,7 +75,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
     existingDoc.content = parseContentField(existingDoc.content)
   }
 
-  if (!existingDoc || isEmpty(existingDoc.content)) {
+  if (!existingDoc || !hasAssignmentSubmissionContent(existingDoc)) {
     return NextResponse.json(
       { error: 'No work to submit. Please write something first.' },
       { status: 400 }

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -16,8 +16,8 @@ import {
   calculateAssignmentStatus,
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
+  hasAssignmentSubmissionContent,
 } from '@/lib/assignments'
-import { isEmpty } from '@/lib/tiptap-content'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
 import { formatInTimeZone } from 'date-fns-tz'
 import { HistoryList } from '@/components/HistoryList'
@@ -296,7 +296,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
 
   const handleSubmit = useCallback(async () => {
     // Save first if there are unsaved changes
-    if (JSON.stringify(content) !== lastSavedContentRef.current) {
+    if (
+      JSON.stringify(content) !== lastSavedContentRef.current
+      || repoUrl !== lastSavedRepoUrlRef.current
+      || githubUsername !== lastSavedGitHubUsernameRef.current
+    ) {
       await saveContent(content, repoUrl, githubUsername, { trigger: 'autosave' })
     }
 
@@ -449,7 +453,11 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
 
   // Compute state for imperative handle (before early returns)
   const isSubmitted = doc?.is_submitted || false
-  const canSubmit = (!isEmpty(content) || !!repoUrl.trim() || !!githubUsername.trim()) && !previewEntry
+  const canSubmit = hasAssignmentSubmissionContent({
+    content,
+    repo_url: repoUrl,
+    github_username: githubUsername,
+  }) && !previewEntry
   const hasRepoMetadata = !!repoUrl.trim() || !!githubUsername.trim()
 
   // Expose imperative handle for parent components

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -1,4 +1,5 @@
-import { Assignment, AssignmentDoc, AssignmentStatus, AssignmentStats } from '@/types'
+import { Assignment, AssignmentDoc, AssignmentStatus, AssignmentStats, TiptapContent } from '@/types'
+import { isEmpty } from '@/lib/tiptap-content'
 import { formatInTimeZone } from 'date-fns-tz'
 
 type AssignmentStatDoc = Pick<AssignmentDoc, 'is_submitted' | 'submitted_at' | 'returned_at' | 'teacher_cleared_at'>
@@ -48,6 +49,16 @@ export function isAssignmentReturnable(
 ): boolean {
   const rubricState = getAssignmentRubricState(doc)
   return rubricState === 'blank' || rubricState === 'complete'
+}
+
+export function hasAssignmentSubmissionContent(input: {
+  content: TiptapContent
+  repo_url?: string | null
+  github_username?: string | null
+}): boolean {
+  return !isEmpty(input.content)
+    || Boolean(input.repo_url?.trim())
+    || Boolean(input.github_username?.trim())
 }
 
 export function isAssignmentAlreadyReturnedWithoutResubmission(

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -117,6 +117,104 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     expect(response.status).toBe(400)
   })
 
+  it('allows late submission when the saved work is repo metadata only', async () => {
+    const historyInsert = vi.fn(async () => ({ error: null }))
+    const emptyContent = { type: 'doc', content: [] }
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: false,
+                  released_at: '2026-04-01T12:00:00.000Z',
+                  due_at: '2026-04-15T03:59:59.000Z',
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: emptyContent,
+                    repo_url: 'https://github.com/codepetca/student-work',
+                    github_username: 'student1',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: vi.fn((payload: Record<string, unknown>) => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: emptyContent,
+                    repo_url: 'https://github.com/codepetca/student-work',
+                    github_username: 'student1',
+                    is_submitted: true,
+                    submitted_at: payload.submitted_at,
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_doc_history') {
+        return {
+          insert: historyInsert,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+    }), { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.doc).toEqual(expect.objectContaining({
+      id: 'doc-1',
+      is_submitted: true,
+      submitted_at: expect.any(String),
+      repo_url: 'https://github.com/codepetca/student-work',
+    }))
+    expect(historyInsert).toHaveBeenCalledWith(expect.objectContaining({
+      assignment_doc_id: 'doc-1',
+      snapshot: emptyContent,
+      word_count: 0,
+      char_count: 0,
+      trigger: 'submit',
+    }))
+  })
+
   it('submits work, records history, and attaches authenticity results', async () => {
     const historyInsert = vi.fn(async () => ({ error: null }))
     const authenticityUpdate = vi.fn(async () => ({ error: null }))

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -15,6 +15,7 @@ import {
   hasDraftSavedGrade,
   isAssignmentAlreadyReturnedWithoutResubmission,
   isAssignmentReturnable,
+  hasAssignmentSubmissionContent,
   formatDueDate,
   isPastDue,
   formatRelativeDueDate,
@@ -396,6 +397,24 @@ describe('assignment utilities', () => {
       const status = calculateAssignmentStatus(assignment, doc)
 
       expect(status).toBe('in_progress')
+    })
+  })
+
+  describe('hasAssignmentSubmissionContent', () => {
+    it('allows repo metadata to count as submittable work', () => {
+      expect(hasAssignmentSubmissionContent({
+        content: { type: 'doc', content: [] },
+        repo_url: 'https://github.com/codepetca/pika-student',
+        github_username: null,
+      })).toBe(true)
+    })
+
+    it('rejects docs with no written work or repo metadata', () => {
+      expect(hasAssignmentSubmissionContent({
+        content: { type: 'doc', content: [] },
+        repo_url: '   ',
+        github_username: null,
+      })).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

This fixes a mismatch between the student assignment editor and the submit API. The UI already treated a GitHub repo link or GitHub username as valid assignment work, but the submit route only accepted non-empty written editor content.

Changes:
- Add a shared `hasAssignmentSubmissionContent()` helper for assignment submission eligibility.
- Use that helper in `POST /api/assignment-docs/[id]/submit` so repo metadata counts as submittable work.
- Make `StudentAssignmentEditor` flush pending repo URL/GitHub username edits before posting submit.
- Add regression coverage for a past-due repo-only assignment submission.

## Impact

Students can submit work that consists of repo metadata, including after the due date or after a teacher returned an empty document. Empty submissions still remain blocked.

## Review

Self-review found no blockers. The API still does not enforce a due-date cutoff; late status remains derived from `submitted_at > due_at` rather than blocking submission.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test -- tests/api/assignment-docs/submit.test.ts` (ran full suite: 251 files, 2119 tests)
- `pnpm test -- tests/unit/assignments.test.ts` (ran full suite: 251 files, 2119 tests)
- `pnpm lint`
- `pnpm build`