### PR TITLE
[codex] Add compact MC answer review

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,29 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Tighten assignment edit chrome and modal height
-
-**Completed:**
-- Hid the app-header `Assignments` title while teacher assignment summary edit mode is active, leaving the floating assignment action cluster as the working control surface.
-- Made the assignment create/edit modal use the near-full viewport panel in both modes.
-- Removed the visible modal header row, kept an accessible hidden dialog title, and moved the close button into the form action row.
-- Let the assignment instructions editor and preview flex into the added modal height.
-- Fixed calendar clicks on unreleased assignments so the editor modal clears the stale `assignmentId` route selection and does not reopen after close.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-actionbar-spacer bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- Focused Playwright calendar flow: clicked unreleased assignment from Calendar, closed the editor modal, confirmed it stayed closed at `?tab=assignments`.
-- Pika UI verification on shared assignment page:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Focused Playwright screenshots:
-  - `/tmp/pika-assignment-edit-modal.png`
-  - `/tmp/pika-assignment-create-modal.png`
-  - `/tmp/pika-assignment-edit-modal-mobile.png`
-
 ## 2026-05-05 — Make exam documents visibly clickable
 
 **Completed:**
@@ -409,3 +386,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test -- tests/unit/assignments.test.ts` (ran full suite: 251 files, 2119 tests)
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-05-07 — Compact MC answer review
+
+**Completed:**
+- Added a shared compact multiple-choice option review component that preserves original option order and uses a fixed check/X gutter.
+- Replaced the separate student/correct answer blocks in returned student test results and teacher test grading with the compact full-option list.
+- Put unanswered MC state in the short question meta line as `No answer`.
+
+**Validation:**
+- `pnpm vitest run tests/components/StudentQuizResults.test.tsx tests/components/TestStudentGradingPanel.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual screenshots on port 3003:
+  - `/tmp/pika-compact-mc-teacher.png`
+  - `/tmp/pika-compact-mc-teacher-mobile.png`
+  - `/tmp/pika-compact-mc-student-mobile.png`
+- `pnpm test`

--- a/src/components/MultipleChoiceOptionReview.tsx
+++ b/src/components/MultipleChoiceOptionReview.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { cn } from '@/ui/utils'
+
+interface MultipleChoiceOptionReviewProps {
+  options: string[]
+  selectedOption: number | null | undefined
+  correctOption: number | null | undefined
+  className?: string
+}
+
+export function normalizeMultipleChoiceOptionIndex(
+  value: number | null | undefined,
+  optionCount: number
+): number | null {
+  if (!Number.isInteger(value)) return null
+  const index = Number(value)
+  return index >= 0 && index < optionCount ? index : null
+}
+
+function getOptionLetter(index: number): string {
+  return String.fromCharCode(65 + index)
+}
+
+export function MultipleChoiceOptionReview({
+  options,
+  selectedOption,
+  correctOption,
+  className,
+}: MultipleChoiceOptionReviewProps) {
+  const normalizedSelected = normalizeMultipleChoiceOptionIndex(selectedOption, options.length)
+  const normalizedCorrect = normalizeMultipleChoiceOptionIndex(correctOption, options.length)
+
+  if (options.length === 0) return null
+
+  return (
+    <div
+      className={cn('space-y-1', className)}
+      role="list"
+      aria-label="Multiple choice answer options"
+    >
+      {options.map((option, optionIndex) => {
+        const isCorrect = normalizedCorrect === optionIndex
+        const isSelected = normalizedSelected === optionIndex
+        const isIncorrectSelection = isSelected && !isCorrect
+        const statusSymbol = isCorrect ? '✓' : isIncorrectSelection ? '✕' : ''
+        const statusLabel = isCorrect
+          ? isSelected
+            ? 'Your answer, correct'
+            : 'Correct answer'
+          : isIncorrectSelection
+            ? 'Your answer, incorrect'
+            : null
+
+        return (
+          <div
+            key={`${optionIndex}-${option}`}
+            role="listitem"
+            className={cn(
+              'grid grid-cols-[1rem_1.25rem_minmax(0,1fr)] items-start gap-1.5 rounded-md px-2.5 py-1.5 text-sm',
+              isCorrect
+                ? 'bg-success-bg-muted text-text-default'
+                : isIncorrectSelection
+                  ? 'bg-warning-bg text-text-default'
+                  : 'bg-surface-2 text-text-default'
+            )}
+          >
+            <span
+              className={cn(
+                'flex h-5 w-4 items-center justify-center text-xs font-bold leading-none',
+                isCorrect ? 'text-success' : isIncorrectSelection ? 'text-warning' : 'text-text-muted'
+              )}
+              aria-label={statusLabel || undefined}
+              aria-hidden={statusLabel ? undefined : true}
+            >
+              {statusSymbol}
+            </span>
+            <span
+              className={cn(
+                'flex h-5 w-5 items-center justify-center text-xs font-semibold leading-none',
+                isCorrect ? 'text-success' : isIncorrectSelection ? 'text-warning' : 'text-text-muted'
+              )}
+            >
+              {getOptionLetter(optionIndex)}
+            </span>
+            <span className="min-w-0 whitespace-pre-wrap leading-5">
+              {option}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/StudentQuizResults.tsx
+++ b/src/components/StudentQuizResults.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
+import {
+  MultipleChoiceOptionReview,
+  normalizeMultipleChoiceOptionIndex,
+} from '@/components/MultipleChoiceOptionReview'
 import type {
   QuizAssessmentType,
   QuizResultsAggregate,
@@ -152,16 +156,10 @@ export function StudentQuizResults({
         ? questionResults.map((result, index) => {
             const possible = Number(result.points || 0)
             const earned = result.score
-            const isIncorrectMultipleChoice =
-              result.question_type === 'multiple_choice' && result.is_correct === false
-            const selectedAnswer =
-              typeof result.selected_option === 'number'
-                ? (result.options[result.selected_option] || '—')
-                : 'No answer selected'
-            const correctAnswer =
-              typeof result.correct_option === 'number'
-                ? (result.options[result.correct_option] || '—')
-                : '—'
+            const selectedOption =
+              result.question_type === 'multiple_choice'
+                ? normalizeMultipleChoiceOptionIndex(result.selected_option, result.options.length)
+                : null
 
             return (
               <div
@@ -171,33 +169,19 @@ export function StudentQuizResults({
                 <div className="space-y-1">
                   <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">
                     Q{index + 1} · {possible} pts
+                    {result.question_type === 'multiple_choice' && selectedOption == null
+                      ? ' · No answer'
+                      : ''}
                   </p>
                   <QuestionMarkdown content={result.question_text} />
                 </div>
 
                 {result.question_type === 'multiple_choice' ? (
-                  <div className="space-y-1 text-sm">
-                    <div className="rounded-md bg-surface-2 px-3 py-2 text-text-default">
-                      <p
-                        className={`text-xs font-semibold uppercase tracking-wide ${
-                          isIncorrectMultipleChoice ? 'text-warning' : ''
-                        }`}
-                      >
-                        Your answer
-                      </p>
-                      <p className={`font-medium ${isIncorrectMultipleChoice ? 'text-warning' : ''}`}>
-                        {selectedAnswer}
-                      </p>
-                    </div>
-                    <div
-                      className="rounded-md bg-surface-2 px-3 py-2 text-text-muted"
-                    >
-                      <p className="text-xs font-semibold uppercase tracking-wide">
-                        Correct answer
-                      </p>
-                      <p className="font-medium">{correctAnswer}</p>
-                    </div>
-                  </div>
+                  <MultipleChoiceOptionReview
+                    options={result.options}
+                    selectedOption={selectedOption}
+                    correctOption={result.correct_option}
+                  />
                 ) : (
                   <div className="space-y-2">
                     <p className="whitespace-pre-wrap rounded-md bg-surface-2 px-3 py-2 text-sm text-text-default">

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import {
+  MultipleChoiceOptionReview,
+  normalizeMultipleChoiceOptionIndex,
+} from '@/components/MultipleChoiceOptionReview'
+import {
   TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
   type TeacherTestGradingRowUpdatedEventDetail,
 } from '@/lib/events'
@@ -576,46 +580,22 @@ export function TestStudentGradingPanel({
               const responseId = answer?.response_id || null
               const isGradeEditable = !!responseId && !answer?.is_draft
               const selectedOption =
-                typeof answer?.selected_option === 'number' ? answer.selected_option : null
-              const selectedText =
-                selectedOption != null ? question.options[selectedOption] || '—' : 'No response'
-              const correctText =
-                typeof question.correct_option === 'number'
-                  ? question.options[question.correct_option] || '—'
-                  : '—'
-              const isIncorrectMultipleChoice =
-                selectedOption != null &&
-                typeof question.correct_option === 'number' &&
-                selectedOption !== question.correct_option
+                normalizeMultipleChoiceOptionIndex(answer?.selected_option, question.options.length)
 
               return (
                 <div key={question.id} className="space-y-2 py-1">
                   <p className="inline-flex items-center rounded bg-primary/10 pl-0 pr-2 py-1 text-sm font-bold text-primary">
                     Q{index + 1} MC
+                    {answer?.is_draft ? ' · Draft' : ''}
+                    {selectedOption == null ? ' · No answer' : ''}
                   </p>
                   <QuestionMarkdown content={question.question_text} />
                   <div className="grid grid-cols-[minmax(0,1fr)_76px] items-start gap-2">
-                    <div className="space-y-1 text-sm">
-                      <div className="rounded-md bg-surface-2 px-3 py-2 text-text-default">
-                        <p
-                          className={`text-xs font-semibold uppercase tracking-wide ${
-                            isIncorrectMultipleChoice ? 'text-warning' : ''
-                          }`}
-                        >
-                          Student answer
-                        </p>
-                        <p className={`font-medium ${isIncorrectMultipleChoice ? 'text-warning' : ''}`}>
-                          {selectedText}
-                          {answer?.is_draft ? ' (Draft)' : ''}
-                        </p>
-                      </div>
-                      <div className="rounded-md bg-surface-2 px-3 py-2 text-text-muted">
-                        <p className="text-xs font-semibold uppercase tracking-wide">
-                          Correct answer
-                        </p>
-                        <p className="font-medium">{correctText}</p>
-                      </div>
-                    </div>
+                    <MultipleChoiceOptionReview
+                      options={question.options}
+                      selectedOption={selectedOption}
+                      correctOption={question.correct_option}
+                    />
                     <SplitScoreInput
                       ariaLabel={`Q${index + 1} score`}
                       maxPoints={points}

--- a/tests/components/StudentQuizResults.test.tsx
+++ b/tests/components/StudentQuizResults.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { StudentQuizResults } from '@/components/StudentQuizResults'
 import type { QuizResultsAggregate } from '@/types'
 
@@ -172,7 +172,7 @@ describe('StudentQuizResults', () => {
     expect(screen.queryByRole('heading', { name: 'Results' })).not.toBeInTheDocument()
   })
 
-  it('highlights incorrect multiple-choice test answers', async () => {
+  it('shows multiple-choice test options in original order with compact gutter markers', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -212,21 +212,73 @@ describe('StudentQuizResults', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Your answer')).toBeInTheDocument()
+      expect(screen.getByRole('list', { name: 'Multiple choice answer options' })).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Your answer')).toBeInTheDocument()
-    expect(screen.getByText('Correct answer')).toBeInTheDocument()
-    expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.queryByText('Your answer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Correct answer')).not.toBeInTheDocument()
 
-    const incorrectAnswerLabel = screen.getByText('Your answer')
-    const incorrectAnswerText = screen.getByText('3')
-    expect(incorrectAnswerLabel.className).toContain('text-warning')
-    expect(incorrectAnswerText.className).toContain('text-warning')
-    expect(container.querySelector('.bg-warning-bg')).toBeNull()
-    expect(container.querySelector('.border-warning')).toBeNull()
+    const optionList = screen.getByRole('list', { name: 'Multiple choice answer options' })
+    const optionRows = within(optionList).getAllByRole('listitem')
+    expect(optionRows).toHaveLength(2)
+    expect(within(optionRows[0]).getByText('A')).toBeInTheDocument()
+    expect(within(optionRows[0]).getByText('3')).toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('B')).toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('4')).toBeInTheDocument()
+
+    expect(within(optionRows[0]).getByText('✕')).toHaveClass('text-warning')
+    expect(within(optionRows[1]).getByText('✓')).toHaveClass('text-success')
+    expect(optionRows[0]).toHaveClass('bg-warning-bg')
+    expect(optionRows[1]).toHaveClass('bg-success-bg-muted')
     expect(container.querySelector('.border-danger.bg-danger-bg')).toBeNull()
+  })
+
+  it('shows unanswered multiple-choice test questions in the question meta line', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        question_results: [
+          {
+            question_id: 'q1',
+            question_type: 'multiple_choice',
+            question_text: 'What is 2 + 2?',
+            options: ['3', '4'],
+            points: 1,
+            response_max_chars: 5000,
+            correct_option: 1,
+            selected_option: null,
+            response_text: null,
+            score: 0,
+            feedback: null,
+            graded_at: '2026-03-06T10:00:00.000Z',
+            is_correct: false,
+          },
+        ],
+        summary: {
+          earned_points: 0,
+          possible_points: 1,
+          percent: 0,
+        },
+      }),
+    })
+
+    render(
+      <StudentQuizResults
+        quizId="quiz-1"
+        myResponses={{}}
+        assessmentType="test"
+        apiBasePath="/api/student/tests"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Q1 · 1 pts · No answer')).toBeInTheDocument()
+    })
+
+    const optionList = screen.getByRole('list', { name: 'Multiple choice answer options' })
+    expect(within(optionList).queryByText('✕')).not.toBeInTheDocument()
+    expect(within(optionList).getByText('✓')).toHaveClass('text-success')
   })
 
   it('uses muted bar color for non-selected options', async () => {

--- a/tests/components/TestStudentGradingPanel.test.tsx
+++ b/tests/components/TestStudentGradingPanel.test.tsx
@@ -329,7 +329,7 @@ describe('TestStudentGradingPanel save-all grading', () => {
     })
   })
 
-  it('highlights incorrect MC answers and shows the correct answer', async () => {
+  it('shows MC options in original order with compact gutter markers', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/api/teacher/tests/test-1/results')) {
@@ -352,22 +352,26 @@ describe('TestStudentGradingPanel save-all grading', () => {
       />
     )
 
-    await screen.findByText('Student answer')
+    const optionList = await screen.findByRole('list', { name: 'Multiple choice answer options' })
 
-    const studentAnswerLabel = screen.getByText('Student answer')
-    const studentAnswerBlock = studentAnswerLabel.closest('div')
-    const correctAnswerLabel = screen.getByText('Correct answer')
-    const correctAnswerBlock = correctAnswerLabel.closest('div')
+    expect(screen.queryByText('Student answer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Correct answer')).not.toBeInTheDocument()
 
-    expect(studentAnswerLabel.className).toContain('text-warning')
-    expect(studentAnswerBlock).not.toBeNull()
-    expect(correctAnswerBlock).not.toBeNull()
-    expect(within(studentAnswerBlock!).getByText('4').className).toContain('text-warning')
-    expect(correctAnswerLabel).toBeInTheDocument()
-    expect(within(correctAnswerBlock!).getByText('5')).toBeInTheDocument()
+    const optionRows = within(optionList).getAllByRole('listitem')
+    expect(optionRows).toHaveLength(3)
+    expect(within(optionRows[0]).getByText('A')).toBeInTheDocument()
+    expect(within(optionRows[0]).getByText('3')).toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('B')).toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('4')).toBeInTheDocument()
+    expect(within(optionRows[2]).getByText('C')).toBeInTheDocument()
+    expect(within(optionRows[2]).getByText('5')).toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('✕')).toHaveClass('text-warning')
+    expect(within(optionRows[2]).getByText('✓')).toHaveClass('text-success')
+    expect(optionRows[1]).toHaveClass('bg-warning-bg')
+    expect(optionRows[2]).toHaveClass('bg-success-bg-muted')
   })
 
-  it('does not highlight correct MC answers', async () => {
+  it('uses only the check marker for correct MC answers', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
       if (url.endsWith('/api/teacher/tests/test-1/results')) {
@@ -390,18 +394,12 @@ describe('TestStudentGradingPanel save-all grading', () => {
       />
     )
 
-    await screen.findByText('Student answer')
+    const optionList = await screen.findByRole('list', { name: 'Multiple choice answer options' })
+    const optionRows = within(optionList).getAllByRole('listitem')
 
-    const studentAnswerLabel = screen.getByText('Student answer')
-    const studentAnswerBlock = studentAnswerLabel.closest('div')
-    const correctAnswerLabel = screen.getByText('Correct answer')
-    const correctAnswerBlock = correctAnswerLabel.closest('div')
-
-    expect(studentAnswerLabel.className).not.toContain('text-warning')
-    expect(studentAnswerBlock).not.toBeNull()
-    expect(correctAnswerBlock).not.toBeNull()
-    expect(within(studentAnswerBlock!).getByText('4').className).not.toContain('text-warning')
-    expect(within(correctAnswerBlock!).getByText('4')).toBeInTheDocument()
+    expect(within(optionRows[1]).queryByText('✕')).not.toBeInTheDocument()
+    expect(within(optionRows[1]).getByText('✓')).toHaveClass('text-success')
+    expect(optionRows[1]).toHaveClass('bg-success-bg-muted')
   })
 
   it('saves cleared score/feedback as clear_grade through save-all handler', async () => {


### PR DESCRIPTION
## Summary

Adds a shared compact multiple-choice answer review component for returned tests and teacher grading. MC review now keeps answer options in their original order, uses a fixed check/X plus option-letter gutter, marks correct rows green, marks wrong selected rows with warning styling, and keeps unanswered state in the question meta line as `No answer`.

## Why

The previous returned test view only showed the student's selected answer and the correct answer as separate blocks. That was compact, but it removed distractor context. This keeps the full MC context without stretching option lines with inline labels.

## Validation

- `pnpm vitest run tests/components/StudentQuizResults.test.tsx tests/components/TestStudentGradingPanel.test.tsx`
- `pnpm lint`
- `pnpm build`
- Visual screenshots on port 3003:
  - `/tmp/pika-compact-mc-teacher.png`
  - `/tmp/pika-compact-mc-teacher-mobile.png`
  - `/tmp/pika-compact-mc-student-mobile.png`
- `pnpm test`