### PR TITLE
Add Gradex assignment grading flag

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,17 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Fix PR coverage gate
-
-**Completed:**
-- Investigated the failed GitHub CI run on the first PR commit.
-- Found the failure was a per-file coverage threshold miss for `src/app/api/teacher/log-summary/route.ts`.
-- Added route tests for classroom-not-found, entry-stats failure, and entry-count failure to cover the cron-only summary endpoint error branches.
-
-**Validation:**
-- `pnpm run test:coverage`
-- `pnpm lint`
-
 ## 2026-05-06 — Restrict nightly log summaries to class days
 
 **Completed:**
@@ -344,3 +333,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-05-08 — Stabilize Gradex assignment run provider
+
+**Completed:**
+- Made background assignment AI grading use the provider stored on the run model instead of rereading the live Gradex feature flag per item.
+- Kept single-student/direct assignment grading controlled by the live `GRADEX_ASSIGNMENT_GRADING_ENABLED` flag.
+- Added regression coverage for both flag-flip directions: persisted Gradex runs stay on Gradex and persisted Pika runs stay on Pika.
+- Added coverage that new Gradex-enabled assignment grading runs persist `gradex:pika-assignment-v1`.
+
+**Validation:**
+- `pnpm test tests/lib/assignment-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs-gradex.test.ts`
+- `pnpm test tests/lib/gradex-client.test.ts tests/lib/gradex-assignment-payload.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs-gradex.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
+- `pnpm lint`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Restore Daily class summary placement
-
-**Completed:**
-- Restored the cached class log summary in the deselected Daily state as a full-width panel below the full-width student log table.
-- Kept the selected-student state focused on the split table/history pane, with the class summary hidden until deselection.
-- Added regression coverage so the class summary remains visible in the deselected table state and disappears during student-history selection.
-
-**Validation:**
-- `pnpm exec vitest tests/components/TeacherAttendanceTab.test.tsx tests/api/teacher/log-summary.test.ts`
-- `pnpm lint && pnpm build`
-- Pika UI verification script for `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance` on port 3002:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Targeted Daily class summary screenshots/check:
-  - `/tmp/pika-teacher-summary-restored.png`
-  - `/tmp/pika-teacher-daily-summary-selected.png`
-  - `/tmp/pika-teacher-daily-summary-deselected.png`
-
 ## 2026-05-06 — Fix PR coverage gate
 
 **Completed:**
@@ -348,3 +329,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Visual hover verification on port 3011:
   - `/tmp/pika-classrooms-toggle-active-tooltip.png`
   - `/tmp/pika-classrooms-toggle-archived-tooltip.png`
+
+## 2026-05-08 — Add Gradex assignment grading flag
+
+**Completed:**
+- Added server-side Gradex sync grading client and sanitized Pika assignment payload builder.
+- Wired assignment AI grading to use Gradex only when `GRADEX_ASSIGNMENT_GRADING_ENABLED` is enabled, leaving the existing Pika/OpenAI grader as the default.
+- Pseudonymized Pika assignment, submission, and student IDs with a salt; redacted emails, phone-like values, URLs, exact artifact URLs, identity fields, raw history, patches, snapshots, and keystroke data from Gradex payloads.
+- Stored Gradex `pika_assignment_v1` compatibility scores and feedback into the existing assignment grade draft fields, with Gradex failures surfacing through the existing run/error behavior instead of writing partial grades.
+
+**Validation:**
+- `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-client.test.ts tests/lib/assignment-ai-grading-runs-gradex.test.ts`
+- `pnpm test tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/unit/ai-grading.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -79,7 +79,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
   const studentId = normalizedStudentIds[0]
   const { data: doc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content, feedback, authenticity_score')
+    .select('id, assignment_id, student_id, content, feedback, submitted_at, authenticity_score, authenticity_flags')
     .eq('assignment_id', id)
     .eq('student_id', studentId)
     .maybeSingle()

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -26,9 +26,12 @@ import type {
 } from '@/types'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
+const GRADEX_ASSIGNMENT_MODEL_ALIAS = 'gradex:pika-assignment-v1'
 const RETRY_BACKOFF_SECONDS = [15, 60, 180]
 const TIMEOUT_RETRY_BACKOFF_SECONDS = [7, 20, 45]
 const MISSING_ASSIGNMENT_GRADE_FEEDBACK = 'Missing'
+
+type AssignmentGraderProvider = 'pika' | 'gradex'
 
 export const ASSIGNMENT_AI_GRADING_RUN_CHUNK_SIZE = 4
 export const ASSIGNMENT_AI_GRADING_ITEM_CONCURRENCY = 2
@@ -58,6 +61,7 @@ type GradeAssignmentDocWithAiOptions = {
   }
   gradedBy?: string | null
   requestTimeoutMs?: number
+  graderProvider?: AssignmentGraderProvider
   telemetry?: {
     operation?: string
     requestedStrategy?: string | null
@@ -80,9 +84,19 @@ type SupabaseSchemaError = {
   hint?: string | null
 }
 
-function getModelAlias(): string {
-  if (isGradexAssignmentGradingEnabled()) {
-    return 'gradex:pika-assignment-v1'
+function getLiveAssignmentGraderProvider(): AssignmentGraderProvider {
+  return isGradexAssignmentGradingEnabled() ? 'gradex' : 'pika'
+}
+
+function getAssignmentGraderProviderFromRunModel(
+  model: string | null | undefined,
+): AssignmentGraderProvider {
+  return model?.startsWith('gradex:') ? 'gradex' : 'pika'
+}
+
+function getModelAlias(provider: AssignmentGraderProvider = getLiveAssignmentGraderProvider()): string {
+  if (provider === 'gradex') {
+    return GRADEX_ASSIGNMENT_MODEL_ALIAS
   }
   return process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
 }
@@ -356,6 +370,7 @@ export async function gradeAssignmentDocWithAi({
   assignmentDoc,
   gradedBy,
   requestTimeoutMs,
+  graderProvider,
   telemetry,
 }: GradeAssignmentDocWithAiOptions): Promise<void> {
   const studentWork = parseContentField(assignmentDoc.content)
@@ -369,7 +384,8 @@ export async function gradeAssignmentDocWithAi({
     return
   }
 
-  const result = isGradexAssignmentGradingEnabled()
+  const resolvedGraderProvider = graderProvider ?? getLiveAssignmentGraderProvider()
+  const result = resolvedGraderProvider === 'gradex'
     ? await (async () => {
         const gradexPayload = buildPikaAssignmentGradexPayload({
           assignment,
@@ -672,6 +688,7 @@ async function processAssignmentAiRunItem(opts: {
       assignmentDoc,
       gradedBy: run.triggered_by,
       requestTimeoutMs: ASSIGNMENT_AI_GRADING_REQUEST_TIMEOUT_MS,
+      graderProvider: getAssignmentGraderProviderFromRunModel(run.model),
       telemetry: {
         operation: 'background_batch_item',
         requestedStrategy: 'background_chunked',
@@ -830,7 +847,7 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
   const { data: run, error: runError } = await supabase.rpc('create_assignment_ai_grading_run_atomic', {
     p_assignment_id: opts.assignmentId,
     p_teacher_id: opts.teacherId,
-    p_model: getModelAlias(),
+    p_model: getModelAlias(getLiveAssignmentGraderProvider()),
     p_requested_student_ids: normalizedStudentIds,
     p_selection_hash: selectionHash,
     p_gradable_count: gradableCount,

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -7,6 +7,11 @@ import {
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
+import {
+  gradePikaAssignmentWithGradex,
+  isGradexAssignmentGradingEnabled,
+} from '@/lib/server/gradex-client'
+import { buildPikaAssignmentGradexPayload } from '@/lib/server/gradex-assignment-payload'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { parseContentField } from '@/lib/tiptap-content'
 import type {
@@ -17,6 +22,7 @@ import type {
   AssignmentAiGradingRunStatus,
   AssignmentAiGradingRunSummary,
   AssignmentDocHistoryEntry,
+  AuthenticityFlag,
 } from '@/types'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
@@ -42,10 +48,13 @@ type GradeAssignmentDocWithAiOptions = {
   assignment: Assignment
   assignmentDoc: {
     id: string
+    assignment_id?: string
     student_id: string
     content: unknown
     feedback: string | null
+    submitted_at?: string | null
     authenticity_score: number | null
+    authenticity_flags?: AuthenticityFlag[] | null
   }
   gradedBy?: string | null
   requestTimeoutMs?: number
@@ -72,6 +81,9 @@ type SupabaseSchemaError = {
 }
 
 function getModelAlias(): string {
+  if (isGradexAssignmentGradingEnabled()) {
+    return 'gradex:pika-assignment-v1'
+  }
   return process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
 }
 
@@ -89,6 +101,34 @@ function getAssignmentInstructionsText(assignment: Assignment): string {
   return limitedMarkdownToPlainText(
     getAssignmentInstructionsMarkdown(assignment).markdown,
   )
+}
+
+function appendPreviousFeedback(feedback: string, previousFeedback?: string | null): string {
+  const previous = previousFeedback?.trim()
+  if (!previous) return feedback
+  return `${previous}\n\n--- Resubmission ---\n\n${feedback}`
+}
+
+function isRetryableGradingError(error: unknown): boolean {
+  if (isRetryableAssignmentAiGradingError(error)) return true
+  return !!(
+    error &&
+    typeof error === 'object' &&
+    'retryable' in error &&
+    (error as { retryable?: unknown }).retryable === true
+  )
+}
+
+function getGradingErrorKind(error: unknown): string {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'kind' in error &&
+    typeof (error as { kind?: unknown }).kind === 'string'
+  ) {
+    return (error as { kind: string }).kind
+  }
+  return 'internal'
 }
 
 function mapErrorSamples(rawSamples: unknown): AssignmentAiGradingRunErrorSample[] {
@@ -329,23 +369,41 @@ export async function gradeAssignmentDocWithAi({
     return
   }
 
-  const result = await gradeStudentWork({
-    assignmentTitle: assignment.title,
-    instructions: getAssignmentInstructionsText(assignment),
-    studentWork,
-    previousFeedback: assignmentDoc.feedback,
-    requestTimeoutMs,
-    telemetry: {
-      feature: 'assignment_auto_grade',
-      operation: telemetry?.operation ?? 'single_grade',
-      promptProfile: 'default',
-      requestedStrategy: telemetry?.requestedStrategy ?? 'single',
-      resolvedStrategy: telemetry?.resolvedStrategy ?? 'single',
-      runId: telemetry?.runId ?? null,
-      studentId: telemetry?.studentId ?? assignmentDoc.student_id,
-      attempt: telemetry?.attempt ?? null,
-    },
-  })
+  const result = isGradexAssignmentGradingEnabled()
+    ? await (async () => {
+        const gradexPayload = buildPikaAssignmentGradexPayload({
+          assignment,
+          assignmentDoc,
+          requestTimeoutMs,
+        })
+        const gradexResult = await gradePikaAssignmentWithGradex(gradexPayload, {
+          requestTimeoutMs,
+        })
+        return {
+          score_completion: gradexResult.score_completion,
+          score_thinking: gradexResult.score_thinking,
+          score_workflow: gradexResult.score_workflow,
+          feedback: appendPreviousFeedback(gradexResult.feedback, assignmentDoc.feedback),
+          model: `gradex:${gradexResult.model}`,
+        }
+      })()
+    : await gradeStudentWork({
+        assignmentTitle: assignment.title,
+        instructions: getAssignmentInstructionsText(assignment),
+        studentWork,
+        previousFeedback: assignmentDoc.feedback,
+        requestTimeoutMs,
+        telemetry: {
+          feature: 'assignment_auto_grade',
+          operation: telemetry?.operation ?? 'single_grade',
+          promptProfile: 'default',
+          requestedStrategy: telemetry?.requestedStrategy ?? 'single',
+          resolvedStrategy: telemetry?.resolvedStrategy ?? 'single',
+          runId: telemetry?.runId ?? null,
+          studentId: telemetry?.studentId ?? assignmentDoc.student_id,
+          attempt: telemetry?.attempt ?? null,
+        },
+      })
 
   const now = new Date().toISOString()
   const { error: updateError } = await supabase
@@ -581,7 +639,7 @@ async function processAssignmentAiRunItem(opts: {
 
   const { data: assignmentDoc, error: assignmentDocError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content, feedback, authenticity_score')
+    .select('id, assignment_id, student_id, content, feedback, submitted_at, authenticity_score, authenticity_flags')
     .eq('id', item.assignment_doc_id)
     .maybeSingle()
 
@@ -635,15 +693,15 @@ async function processAssignmentAiRunItem(opts: {
     const message = error instanceof Error ? error.message : 'AI grading failed'
 
     if (
-      isRetryableAssignmentAiGradingError(error) &&
+      isRetryableGradingError(error) &&
       attemptCount < ASSIGNMENT_AI_GRADING_MAX_ATTEMPTS
     ) {
       await updateRunItem(supabase, item.id, {
         status: 'queued',
         attempt_count: attemptCount,
-        last_error_code: error.kind,
+        last_error_code: getGradingErrorKind(error),
         last_error_message: message,
-        next_retry_at: getNextRetryAt(attemptCount, error.kind),
+        next_retry_at: getNextRetryAt(attemptCount, getGradingErrorKind(error)),
       })
       return
     }
@@ -651,10 +709,7 @@ async function processAssignmentAiRunItem(opts: {
     await updateRunItem(supabase, item.id, {
       status: 'failed',
       attempt_count: attemptCount,
-      last_error_code:
-        error instanceof Error && 'kind' in error && typeof error.kind === 'string'
-          ? error.kind
-          : 'internal',
+      last_error_code: getGradingErrorKind(error),
       last_error_message: message,
       completed_at: now,
     })

--- a/src/lib/server/gradex-assignment-payload.ts
+++ b/src/lib/server/gradex-assignment-payload.ts
@@ -1,0 +1,341 @@
+import { createHmac } from 'node:crypto'
+import { extractAssignmentArtifacts, type AssignmentArtifactType } from '@/lib/assignment-artifacts'
+import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
+import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
+import { extractPlainText, parseContentField } from '@/lib/tiptap-content'
+import type { Assignment, AuthenticityFlag } from '@/types'
+
+export const GRADEX_PIKA_ASSIGNMENT_PROFILE = 'pika-assignment-v1'
+
+type GradexCriterionKind = 'content' | 'thinking' | 'communication' | 'workflow'
+
+export interface GradexRubricCriterion {
+  id: string
+  label: string
+  description: string
+  kind: GradexCriterionKind
+  scale: {
+    min: number
+    max: number
+  }
+  weight: number
+  feedback_required: boolean
+}
+
+export interface GradexRubric {
+  version: string
+  criteria: GradexRubricCriterion[]
+}
+
+export interface GradexWorkflowEvidence {
+  authenticity_score?: number | null
+  evidence_confidence: number
+  active_session_count?: number
+  active_day_count?: number
+  total_word_delta?: number
+  paste_event_count?: number
+  high_wps_flag_count?: number
+  summary?: string
+  flags?: Array<{
+    reason: 'paste' | 'high_wps' | 'other'
+    count?: number
+    summary: string
+  }>
+}
+
+export interface GradexGradeSyncRequest {
+  assignment: {
+    external_assignment_id: string
+    title: string
+    instructions: string
+    type: 'essay'
+  }
+  rubric: GradexRubric
+  settings: {
+    grading_profile: typeof GRADEX_PIKA_ASSIGNMENT_PROFILE
+    model_profile: 'default'
+    feedback_style: 'balanced'
+    confidence_threshold: number
+    request_timeout_ms: number
+  }
+  submission: {
+    external_submission_id: string
+    external_student_id: string
+    content_type: 'text'
+    content: string
+    submitted_at?: string
+  }
+  workflow_evidence: GradexWorkflowEvidence
+}
+
+type GradexAssignmentDocInput = {
+  id: string
+  student_id: string
+  content: unknown
+  submitted_at?: string | null
+  authenticity_score?: number | null
+  authenticity_flags?: AuthenticityFlag[] | null
+} & Record<string, unknown>
+
+export interface BuildPikaAssignmentGradexPayloadOptions {
+  assignment: Assignment
+  assignmentDoc: GradexAssignmentDocInput
+  pseudonymSalt?: string
+  requestTimeoutMs?: number
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 25_000
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
+const PHONE_PATTERN = /\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g
+const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/gi
+const IDENTITY_KEY_PATTERN = /(email|first_?name|last_?name|full_?name|display_?name|student_?name|teacher_?name)/i
+
+export const PIKA_ASSIGNMENT_GRADEX_RUBRIC: GradexRubric = {
+  version: 'pika-essay-ctw-v1',
+  criteria: [
+    {
+      id: 'completion',
+      label: 'Completion',
+      description: 'Did the student complete all parts of the assignment?',
+      kind: 'content',
+      scale: { min: 0, max: 10 },
+      weight: 1,
+      feedback_required: true,
+    },
+    {
+      id: 'thinking',
+      label: 'Thinking',
+      description: 'Does the work show depth of thought, analysis, or understanding?',
+      kind: 'thinking',
+      scale: { min: 0, max: 10 },
+      weight: 1,
+      feedback_required: true,
+    },
+    {
+      id: 'workflow',
+      label: 'Workflow',
+      description: 'Is the work organized, clear, well-presented, and supported by process evidence?',
+      kind: 'workflow',
+      scale: { min: 0, max: 10 },
+      weight: 1,
+      feedback_required: true,
+    },
+  ],
+}
+
+function getRequiredPseudonymSalt(explicitSalt?: string): string {
+  const salt = explicitSalt?.trim() || process.env.GRADEX_PIKA_PSEUDONYM_SALT?.trim()
+  if (!salt) {
+    throw new Error('GRADEX_PIKA_PSEUDONYM_SALT is not configured')
+  }
+  return salt
+}
+
+function pseudonymize(prefix: string, value: string, salt: string): string {
+  const digest = createHmac('sha256', salt)
+    .update(`${prefix}:${value}`)
+    .digest('hex')
+    .slice(0, 32)
+  return `pika-${prefix}-${digest}`
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  return value.slice(0, maxLength)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function collectIdentityTokens(record: Record<string, unknown>): string[] {
+  const tokens = new Set<string>()
+  for (const [key, value] of Object.entries(record)) {
+    if (!IDENTITY_KEY_PATTERN.test(key)) continue
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed.length < 2) continue
+    tokens.add(trimmed)
+  }
+  return Array.from(tokens)
+}
+
+function sanitizeText(value: string, identityTokens: string[]): string {
+  let sanitized = value
+    .replace(EMAIL_PATTERN, '[email redacted]')
+    .replace(PHONE_PATTERN, '[phone redacted]')
+    .replace(URL_PATTERN, '[link redacted]')
+
+  for (const token of identityTokens) {
+    sanitized = sanitized.replace(new RegExp(escapeRegExp(token), 'gi'), '[identity redacted]')
+  }
+
+  return sanitized
+}
+
+function buildArtifactSummary(content: unknown): string {
+  const artifacts = extractAssignmentArtifacts(content)
+  if (artifacts.length === 0) return ''
+
+  const counts = new Map<AssignmentArtifactType, number>()
+  for (const artifact of artifacts) {
+    counts.set(artifact.type, (counts.get(artifact.type) ?? 0) + 1)
+  }
+
+  const labelByType: Record<AssignmentArtifactType, string> = {
+    image: 'Image',
+    link: 'Link',
+    repo: 'Repository',
+  }
+
+  const lines: string[] = []
+  for (const type of ['repo', 'image', 'link'] as AssignmentArtifactType[]) {
+    const count = counts.get(type) ?? 0
+    if (count === 0) continue
+    const label = labelByType[type]
+    lines.push(
+      count === 1
+        ? `- ${label} artifact submitted`
+        : `- ${count} ${label.toLowerCase()} artifacts submitted`,
+    )
+  }
+
+  return lines.length > 0 ? `Attached Artifacts:\n${lines.join('\n')}` : ''
+}
+
+function normalizeSubmissionContent(
+  assignmentDoc: GradexAssignmentDocInput,
+  identityTokens: string[],
+): string {
+  const parsedContent = parseContentField(assignmentDoc.content)
+  const text = sanitizeText(extractPlainText(parsedContent).trim(), identityTokens)
+  const artifactSummary = buildArtifactSummary(parsedContent)
+  const sections = [text, artifactSummary].filter((section) => section.trim().length > 0)
+  const normalized = sections.join('\n\n').trim()
+
+  return truncateText(normalized || 'Submission artifact provided.', 120_000)
+}
+
+function normalizeIsoDate(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return undefined
+  return date.toISOString()
+}
+
+function countAuthenticityFlags(flags: AuthenticityFlag[] | null | undefined) {
+  let pasteEventCount = 0
+  let highWpsFlagCount = 0
+
+  for (const flag of flags ?? []) {
+    if (flag.reason === 'paste') pasteEventCount += 1
+    if (flag.reason === 'high_wps') highWpsFlagCount += 1
+  }
+
+  return { pasteEventCount, highWpsFlagCount }
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? `${count} ${singular}` : `${count} ${plural}`
+}
+
+function buildWorkflowEvidence(assignmentDoc: GradexAssignmentDocInput): GradexWorkflowEvidence {
+  const authenticityScore =
+    typeof assignmentDoc.authenticity_score === 'number' &&
+    Number.isInteger(assignmentDoc.authenticity_score) &&
+    assignmentDoc.authenticity_score >= 0 &&
+    assignmentDoc.authenticity_score <= 100
+      ? assignmentDoc.authenticity_score
+      : null
+  const { pasteEventCount, highWpsFlagCount } = countAuthenticityFlags(assignmentDoc.authenticity_flags)
+  const hasWorkflowEvidence =
+    authenticityScore != null || pasteEventCount > 0 || highWpsFlagCount > 0
+
+  if (!hasWorkflowEvidence) {
+    return {
+      authenticity_score: null,
+      evidence_confidence: 0,
+      summary: 'No sanitized workflow evidence was available.',
+    }
+  }
+
+  const flagSummaries: string[] = []
+  const flags: GradexWorkflowEvidence['flags'] = []
+
+  if (pasteEventCount > 0) {
+    const countLabel = pluralize(pasteEventCount, 'paste event')
+    flagSummaries.push(countLabel)
+    flags.push({
+      reason: 'paste',
+      count: pasteEventCount,
+      summary: `${countLabel} detected in sanitized workflow evidence.`,
+    })
+  }
+
+  if (highWpsFlagCount > 0) {
+    const countLabel = pluralize(highWpsFlagCount, 'high writing-speed flag')
+    flagSummaries.push(countLabel)
+    flags.push({
+      reason: 'high_wps',
+      count: highWpsFlagCount,
+      summary: `${countLabel} detected in sanitized workflow evidence.`,
+    })
+  }
+
+  const summaryParts = [
+    authenticityScore == null
+      ? 'Pika authenticity score was unavailable.'
+      : `Pika authenticity score: ${authenticityScore}/100.`,
+    flagSummaries.length > 0
+      ? `Sanitized workflow flags: ${flagSummaries.join(', ')}.`
+      : 'No sanitized workflow flags were detected.',
+  ]
+
+  return {
+    authenticity_score: authenticityScore,
+    evidence_confidence: 0.75,
+    paste_event_count: pasteEventCount,
+    high_wps_flag_count: highWpsFlagCount,
+    summary: truncateText(summaryParts.join(' '), 2000),
+    ...(flags.length > 0 ? { flags } : {}),
+  }
+}
+
+export function buildPikaAssignmentGradexPayload(
+  opts: BuildPikaAssignmentGradexPayloadOptions,
+): GradexGradeSyncRequest {
+  const salt = getRequiredPseudonymSalt(opts.pseudonymSalt)
+  const identityTokens = collectIdentityTokens(opts.assignmentDoc)
+  const instructions = limitedMarkdownToPlainText(
+    getAssignmentInstructionsMarkdown(opts.assignment).markdown,
+  )
+  const submittedAt = normalizeIsoDate(opts.assignmentDoc.submitted_at)
+
+  return {
+    assignment: {
+      external_assignment_id: pseudonymize('assignment', opts.assignment.id, salt),
+      title: truncateText(sanitizeText(opts.assignment.title, identityTokens).trim() || 'Untitled assignment', 240),
+      instructions: truncateText(
+        sanitizeText(instructions, identityTokens).trim() || 'No assignment instructions provided.',
+        20_000,
+      ),
+      type: 'essay',
+    },
+    rubric: PIKA_ASSIGNMENT_GRADEX_RUBRIC,
+    settings: {
+      grading_profile: GRADEX_PIKA_ASSIGNMENT_PROFILE,
+      model_profile: 'default',
+      feedback_style: 'balanced',
+      confidence_threshold: 0.65,
+      request_timeout_ms: opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    },
+    submission: {
+      external_submission_id: pseudonymize('submission', opts.assignmentDoc.id, salt),
+      external_student_id: pseudonymize('student', opts.assignmentDoc.student_id, salt),
+      content_type: 'text',
+      content: normalizeSubmissionContent(opts.assignmentDoc, identityTokens),
+      ...(submittedAt ? { submitted_at: submittedAt } : {}),
+    },
+    workflow_evidence: buildWorkflowEvidence(opts.assignmentDoc),
+  }
+}

--- a/src/lib/server/gradex-client.ts
+++ b/src/lib/server/gradex-client.ts
@@ -1,0 +1,214 @@
+import type { GradexGradeSyncRequest } from '@/lib/server/gradex-assignment-payload'
+
+export type GradexClientErrorKind =
+  | 'config'
+  | 'timeout'
+  | 'network'
+  | 'rate_limit'
+  | 'server'
+  | 'bad_response'
+  | 'invalid_response'
+
+export interface GradexPikaAssignmentResult {
+  score_completion: number
+  score_thinking: number
+  score_workflow: number
+  feedback: string
+  model: string
+  auditId: string | null
+  gradingProfileVersion: string | null
+}
+
+export class GradexClientError extends Error {
+  readonly kind: GradexClientErrorKind
+  readonly retryable: boolean
+  readonly statusCode: number | null
+
+  constructor(opts: {
+    kind: GradexClientErrorKind
+    message: string
+    retryable: boolean
+    statusCode?: number | null
+  }) {
+    super(opts.message)
+    this.name = 'GradexClientError'
+    this.kind = opts.kind
+    this.retryable = opts.retryable
+    this.statusCode = opts.statusCode ?? null
+  }
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 25_000
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504])
+
+export function isGradexAssignmentGradingEnabled(): boolean {
+  const value = process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED?.trim().toLowerCase()
+  return value === 'true' || value === '1' || value === 'yes'
+}
+
+function getRequiredEnv(name: 'GRADEX_API_URL' | 'GRADEX_API_KEY'): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new GradexClientError({
+      kind: 'config',
+      message: `${name} is not configured`,
+      retryable: false,
+    })
+  }
+  return value
+}
+
+function buildGradexSyncUrl(apiUrl: string): string {
+  const normalized = apiUrl.trim().replace(/\/+$/, '')
+
+  if (!normalized) {
+    throw new GradexClientError({
+      kind: 'config',
+      message: 'GRADEX_API_URL is not configured',
+      retryable: false,
+    })
+  }
+
+  if (normalized.endsWith('/api/v1/grade/sync')) {
+    return normalized
+  }
+
+  if (normalized.endsWith('/api/v1')) {
+    return `${normalized}/grade/sync`
+  }
+
+  return `${normalized}/api/v1/grade/sync`
+}
+
+function toHttpError(statusCode: number): GradexClientError {
+  const retryable = RETRYABLE_STATUS_CODES.has(statusCode)
+  const kind: GradexClientErrorKind =
+    statusCode === 429
+      ? 'rate_limit'
+      : statusCode === 401 || statusCode === 403
+        ? 'config'
+        : retryable
+          ? 'server'
+          : 'bad_response'
+
+  return new GradexClientError({
+    kind,
+    message: `Gradex request failed (${statusCode})`,
+    retryable,
+    statusCode,
+  })
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' || error.name === 'TimeoutError')
+  )
+}
+
+function coerceScore(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
+    throw new GradexClientError({
+      kind: 'invalid_response',
+      message: `Gradex response has invalid ${label}`,
+      retryable: false,
+    })
+  }
+  return value
+}
+
+function parsePikaAssignmentCompatibility(payload: unknown): GradexPikaAssignmentResult {
+  const record = payload && typeof payload === 'object' ? payload as Record<string, unknown> : null
+  const compatibility = record?.compatibility && typeof record.compatibility === 'object'
+    ? record.compatibility as Record<string, unknown>
+    : null
+  const pika = compatibility?.pika_assignment_v1 && typeof compatibility.pika_assignment_v1 === 'object'
+    ? compatibility.pika_assignment_v1 as Record<string, unknown>
+    : null
+
+  if (!pika) {
+    throw new GradexClientError({
+      kind: 'invalid_response',
+      message: 'Gradex response is missing Pika assignment compatibility data',
+      retryable: false,
+    })
+  }
+
+  const feedback = typeof pika.feedback === 'string' ? pika.feedback.trim() : ''
+  if (!feedback) {
+    throw new GradexClientError({
+      kind: 'invalid_response',
+      message: 'Gradex response has empty Pika assignment feedback',
+      retryable: false,
+    })
+  }
+
+  return {
+    score_completion: coerceScore(pika.score_completion, 'score_completion'),
+    score_thinking: coerceScore(pika.score_thinking, 'score_thinking'),
+    score_workflow: coerceScore(pika.score_workflow, 'score_workflow'),
+    feedback,
+    model: typeof record?.model === 'string' && record.model.trim() ? record.model.trim() : 'gradex',
+    auditId: typeof record?.audit_id === 'string' && record.audit_id.trim() ? record.audit_id.trim() : null,
+    gradingProfileVersion:
+      typeof record?.grading_profile_version === 'string' && record.grading_profile_version.trim()
+        ? record.grading_profile_version.trim()
+        : null,
+  }
+}
+
+export async function gradePikaAssignmentWithGradex(
+  payload: GradexGradeSyncRequest,
+  opts?: { requestTimeoutMs?: number },
+): Promise<GradexPikaAssignmentResult> {
+  const apiUrl = getRequiredEnv('GRADEX_API_URL')
+  const apiKey = getRequiredEnv('GRADEX_API_KEY')
+  const timeoutMs =
+    opts?.requestTimeoutMs && opts.requestTimeoutMs > 0
+      ? opts.requestTimeoutMs
+      : payload.settings.request_timeout_ms || DEFAULT_REQUEST_TIMEOUT_MS
+
+  let response: Response
+  try {
+    response = await fetch(buildGradexSyncUrl(apiUrl), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      throw new GradexClientError({
+        kind: 'timeout',
+        message: 'Gradex grading request timed out',
+        retryable: true,
+      })
+    }
+
+    throw new GradexClientError({
+      kind: 'network',
+      message: 'Gradex request failed before receiving a response',
+      retryable: true,
+    })
+  }
+
+  if (!response.ok) {
+    throw toHttpError(response.status)
+  }
+
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    throw new GradexClientError({
+      kind: 'invalid_response',
+      message: 'Gradex response was not valid JSON',
+      retryable: false,
+    })
+  }
+
+  return parsePikaAssignmentCompatibility(body)
+}

--- a/tests/lib/assignment-ai-grading-runs-gradex.test.ts
+++ b/tests/lib/assignment-ai-grading-runs-gradex.test.ts
@@ -9,6 +9,13 @@ const { gradePikaAssignmentWithGradex } = vi.hoisted(() => ({
   gradePikaAssignmentWithGradex: vi.fn(),
 }))
 
+const { mockServiceSupabase } = vi.hoisted(() => ({
+  mockServiceSupabase: {
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+}))
+
 vi.mock('@/lib/ai-grading', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/ai-grading')>()
   return {
@@ -23,7 +30,14 @@ vi.mock('@/lib/server/gradex-client', () => ({
     process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED?.trim().toLowerCase() === 'true',
 }))
 
-import { gradeAssignmentDocWithAi } from '@/lib/server/assignment-ai-grading-runs'
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockServiceSupabase),
+}))
+
+import {
+  gradeAssignmentDocWithAi,
+  tickAssignmentAiGradingRun,
+} from '@/lib/server/assignment-ai-grading-runs'
 
 const assignment: Assignment = {
   id: 'assignment-db-123',
@@ -83,12 +97,150 @@ function buildSupabaseUpdateHarness() {
   }
 }
 
+function buildBackgroundRunHarness(runModel: string) {
+  const run = {
+    id: 'run-1',
+    assignment_id: assignment.id,
+    status: 'queued',
+    triggered_by: 'teacher-1',
+    model: runModel,
+    selection_hash: 'selection-hash',
+    requested_student_ids_json: [assignmentDoc.student_id],
+    requested_count: 1,
+    gradable_count: 1,
+    processed_count: 0,
+    completed_count: 0,
+    skipped_missing_count: 0,
+    skipped_empty_count: 0,
+    failed_count: 0,
+    error_samples_json: [],
+    lease_token: null,
+    lease_expires_at: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-05-04T20:00:00.000Z',
+    updated_at: '2026-05-04T20:00:00.000Z',
+  }
+  const item = {
+    id: 'item-1',
+    run_id: run.id,
+    assignment_id: assignment.id,
+    student_id: assignmentDoc.student_id,
+    assignment_doc_id: assignmentDoc.id,
+    queue_position: 0,
+    status: 'queued',
+    skip_reason: null,
+    attempt_count: 0,
+    next_retry_at: null,
+    last_error_code: null,
+    last_error_message: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-05-04T20:00:00.000Z',
+    updated_at: '2026-05-04T20:00:00.000Z',
+  }
+  const docUpdates: Record<string, unknown>[] = []
+
+  mockServiceSupabase.rpc.mockImplementation(async (fn: string) => {
+    if (fn === 'claim_assignment_ai_grading_run') {
+      return { data: true, error: null }
+    }
+    throw new Error(`Unexpected rpc: ${fn}`)
+  })
+
+  mockServiceSupabase.from.mockImplementation((table: string) => {
+    if (table === 'assignment_ai_grading_runs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((field: string, value: string) => {
+            if (field !== 'id') throw new Error(`Unexpected run eq field: ${field}`)
+            return {
+              maybeSingle: vi.fn(async () => ({
+                data: value === run.id ? { ...run } : null,
+                error: null,
+              })),
+            }
+          }),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn((field: string, value: string) => ({
+            select: vi.fn(() => ({
+              single: vi.fn(async () => {
+                if (field !== 'id' || value !== run.id) return { data: null, error: null }
+                Object.assign(run, payload)
+                return { data: { ...run }, error: null }
+              }),
+            })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_ai_grading_run_items') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((field: string, value: string) => ({
+            order: vi.fn(async () => ({
+              data:
+                field === 'run_id' && value === run.id
+                  ? [{ ...item }]
+                  : [],
+              error: null,
+            })),
+          })),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn(async (field: string, value: string) => {
+            if (field === 'id' && value === item.id) Object.assign(item, payload)
+            return { error: null }
+          }),
+        })),
+      }
+    }
+
+    if (table === 'assignments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: assignment, error: null })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_docs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({
+              data: assignmentDoc,
+              error: null,
+            })),
+          })),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => {
+          docUpdates.push(payload)
+          return {
+            eq: vi.fn(async () => ({ error: null })),
+          }
+        }),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return { docUpdates, item, run }
+}
+
 describe('assignment AI grading Gradex feature flag', () => {
   const originalFlag = process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
   const originalSalt = process.env.GRADEX_PIKA_PSEUDONYM_SALT
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockServiceSupabase.from.mockReset()
+    mockServiceSupabase.rpc.mockReset()
     delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
     process.env.GRADEX_PIKA_PSEUDONYM_SALT = 'stable-test-salt'
     gradeStudentWork.mockResolvedValue({
@@ -204,5 +356,45 @@ describe('assignment AI grading Gradex feature flag', () => {
     })
 
     expect(harness.update).not.toHaveBeenCalled()
+  })
+
+  it('keeps using Gradex for a persisted Gradex background run if the live flag is later disabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'false'
+    const harness = buildBackgroundRunHarness('gradex:pika-assignment-v1')
+
+    const result = await tickAssignmentAiGradingRun({
+      assignmentId: assignment.id,
+      runId: 'run-1',
+    })
+
+    expect(result.run.status).toBe('completed')
+    expect(gradePikaAssignmentWithGradex).toHaveBeenCalledTimes(1)
+    expect(gradeStudentWork).not.toHaveBeenCalled()
+    expect(harness.docUpdates[0]).toEqual(expect.objectContaining({
+      score_completion: 6,
+      score_thinking: 7,
+      score_workflow: 8,
+      ai_feedback_model: 'gradex:gradex-model',
+    }))
+  })
+
+  it('keeps using Pika for a persisted Pika background run if the live flag is later enabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    const harness = buildBackgroundRunHarness('gpt-5-nano')
+
+    const result = await tickAssignmentAiGradingRun({
+      assignmentId: assignment.id,
+      runId: 'run-1',
+    })
+
+    expect(result.run.status).toBe('completed')
+    expect(gradeStudentWork).toHaveBeenCalledTimes(1)
+    expect(gradePikaAssignmentWithGradex).not.toHaveBeenCalled()
+    expect(harness.docUpdates[0]).toEqual(expect.objectContaining({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      ai_feedback_model: 'gpt-5-nano',
+    }))
   })
 })

--- a/tests/lib/assignment-ai-grading-runs-gradex.test.ts
+++ b/tests/lib/assignment-ai-grading-runs-gradex.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Assignment } from '@/types'
+
+const { gradeStudentWork } = vi.hoisted(() => ({
+  gradeStudentWork: vi.fn(),
+}))
+
+const { gradePikaAssignmentWithGradex } = vi.hoisted(() => ({
+  gradePikaAssignmentWithGradex: vi.fn(),
+}))
+
+vi.mock('@/lib/ai-grading', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ai-grading')>()
+  return {
+    ...actual,
+    gradeStudentWork,
+  }
+})
+
+vi.mock('@/lib/server/gradex-client', () => ({
+  gradePikaAssignmentWithGradex,
+  isGradexAssignmentGradingEnabled: () =>
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED?.trim().toLowerCase() === 'true',
+}))
+
+import { gradeAssignmentDocWithAi } from '@/lib/server/assignment-ai-grading-runs'
+
+const assignment: Assignment = {
+  id: 'assignment-db-123',
+  classroom_id: 'classroom-db-123',
+  title: 'Reflection',
+  description: 'Write a reflection.',
+  instructions_markdown: 'Write a reflection about your process.',
+  rich_instructions: null,
+  due_at: '2026-05-15T19:00:00.000Z',
+  position: 0,
+  is_draft: false,
+  released_at: '2026-05-01T12:00:00.000Z',
+  track_authenticity: true,
+  created_by: 'teacher-db-123',
+  created_at: '2026-05-01T12:00:00.000Z',
+  updated_at: '2026-05-02T12:00:00.000Z',
+}
+
+const assignmentDoc = {
+  id: 'assignment-doc-db-456',
+  assignment_id: 'assignment-db-123',
+  student_id: 'student-db-789',
+  submitted_at: '2026-05-04T20:00:00.000Z',
+  content: {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'I revised my work and explained my choices.' }],
+      },
+    ],
+  },
+  feedback: null,
+  authenticity_score: 90,
+  authenticity_flags: [],
+}
+
+function buildSupabaseUpdateHarness() {
+  const updates: Record<string, unknown>[] = []
+  const eq = vi.fn(async () => ({ error: null }))
+  const update = vi.fn((payload: Record<string, unknown>) => {
+    updates.push(payload)
+    return { eq }
+  })
+  const from = vi.fn((table: string) => {
+    if (table === 'assignment_docs') {
+      return { update }
+    }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return {
+    supabase: { from } as any,
+    updates,
+    update,
+    eq,
+  }
+}
+
+describe('assignment AI grading Gradex feature flag', () => {
+  const originalFlag = process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
+  const originalSalt = process.env.GRADEX_PIKA_PSEUDONYM_SALT
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
+    process.env.GRADEX_PIKA_PSEUDONYM_SALT = 'stable-test-salt'
+    gradeStudentWork.mockResolvedValue({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      feedback: 'Strength: Clear work. Next Step: Add one detail.',
+      model: 'gpt-5-nano',
+      attempts: 1,
+    })
+    gradePikaAssignmentWithGradex.mockResolvedValue({
+      score_completion: 6,
+      score_thinking: 7,
+      score_workflow: 8,
+      feedback: 'Strength: Gradex feedback. Next Step: Add one example.',
+      model: 'gradex-model',
+      auditId: 'audit-1',
+      gradingProfileVersion: 'pika-assignment-v1',
+    })
+  })
+
+  afterEach(() => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = originalFlag
+    process.env.GRADEX_PIKA_PSEUDONYM_SALT = originalSalt
+  })
+
+  it('uses the existing Pika grader when the Gradex assignment flag is missing', async () => {
+    const harness = buildSupabaseUpdateHarness()
+
+    await gradeAssignmentDocWithAi({
+      supabase: harness.supabase,
+      assignment,
+      assignmentDoc,
+      gradedBy: 'teacher-1',
+    })
+
+    expect(gradeStudentWork).toHaveBeenCalledTimes(1)
+    expect(gradePikaAssignmentWithGradex).not.toHaveBeenCalled()
+    expect(harness.updates[0]).toEqual(expect.objectContaining({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      teacher_feedback_draft: 'Strength: Clear work. Next Step: Add one detail.',
+      ai_feedback_suggestion: 'Strength: Clear work. Next Step: Add one detail.',
+      ai_feedback_model: 'gpt-5-nano',
+      graded_by: 'teacher-1',
+    }))
+    expect(harness.eq).toHaveBeenCalledWith('id', 'assignment-doc-db-456')
+  })
+
+  it('uses Gradex and stores the Pika compatibility projection when the flag is enabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    const harness = buildSupabaseUpdateHarness()
+
+    await gradeAssignmentDocWithAi({
+      supabase: harness.supabase,
+      assignment,
+      assignmentDoc: {
+        ...assignmentDoc,
+        feedback: 'Earlier returned feedback.',
+      },
+      gradedBy: 'teacher-1',
+      requestTimeoutMs: 12_000,
+    })
+
+    expect(gradeStudentWork).not.toHaveBeenCalled()
+    expect(gradePikaAssignmentWithGradex).toHaveBeenCalledTimes(1)
+    expect(gradePikaAssignmentWithGradex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ grading_profile: 'pika-assignment-v1' }),
+        assignment: expect.objectContaining({
+          external_assignment_id: expect.stringMatching(/^pika-assignment-[a-f0-9]{32}$/),
+        }),
+        submission: expect.objectContaining({
+          external_submission_id: expect.stringMatching(/^pika-submission-[a-f0-9]{32}$/),
+          external_student_id: expect.stringMatching(/^pika-student-[a-f0-9]{32}$/),
+        }),
+      }),
+      { requestTimeoutMs: 12_000 },
+    )
+    expect(JSON.stringify(gradePikaAssignmentWithGradex.mock.calls[0]?.[0])).not.toContain('student-db-789')
+    expect(harness.updates[0]).toEqual(expect.objectContaining({
+      score_completion: 6,
+      score_thinking: 7,
+      score_workflow: 8,
+      teacher_feedback_draft:
+        'Earlier returned feedback.\n\n--- Resubmission ---\n\nStrength: Gradex feedback. Next Step: Add one example.',
+      ai_feedback_suggestion:
+        'Earlier returned feedback.\n\n--- Resubmission ---\n\nStrength: Gradex feedback. Next Step: Add one example.',
+      ai_feedback_model: 'gradex:gradex-model',
+      graded_by: 'teacher-1',
+    }))
+  })
+
+  it('surfaces Gradex failures and does not write a partial grade', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    gradePikaAssignmentWithGradex.mockRejectedValueOnce(Object.assign(
+      new Error('Gradex request failed (503)'),
+      { kind: 'server', retryable: true, statusCode: 503 },
+    ))
+    const harness = buildSupabaseUpdateHarness()
+
+    await expect(gradeAssignmentDocWithAi({
+      supabase: harness.supabase,
+      assignment,
+      assignmentDoc,
+      gradedBy: 'teacher-1',
+    })).rejects.toMatchObject({
+      kind: 'server',
+      retryable: true,
+      statusCode: 503,
+      message: 'Gradex request failed (503)',
+    })
+
+    expect(harness.update).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockSupabaseClient } = vi.hoisted(() => ({
   mockSupabaseClient: {
@@ -253,9 +253,20 @@ function buildTickHarness(opts: {
 }
 
 describe('createOrResumeAssignmentAiGradingRun', () => {
+  const originalGradexAssignmentFlag = process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.rpc.mockReset()
+    delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
+  })
+
+  afterEach(() => {
+    if (originalGradexAssignmentFlag === undefined) {
+      delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
+    } else {
+      process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = originalGradexAssignmentFlag
+    }
   })
 
   it('creates the batch through the atomic RPC with queued and skipped item rows', async () => {
@@ -338,6 +349,57 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
             skip_reason: null,
           }),
         ],
+      }),
+    )
+  })
+
+  it('persists the Gradex assignment provider in the run model when the flag is enabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    const runsTable = buildRunsTable()
+    const assignmentDocsTable = buildAssignmentDocsTable([
+      {
+        id: 'doc-gradable',
+        student_id: 'student-gradable',
+        content: JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        }),
+      },
+    ])
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_docs') return assignmentDocsTable
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    mockSupabaseClient.rpc.mockResolvedValue({
+      data: {
+        id: 'run-1',
+        assignment_id: 'assignment-1',
+        status: 'queued',
+        model: 'gradex:pika-assignment-v1',
+        created_at: '2026-04-21T12:00:00.000Z',
+      },
+      error: null,
+    })
+
+    const result = await createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-gradable'],
+    })
+
+    expect(result.kind).toBe('created')
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'create_assignment_ai_grading_run_atomic',
+      expect.objectContaining({
+        p_model: 'gradex:pika-assignment-v1',
       }),
     )
   })

--- a/tests/lib/gradex-assignment-payload.test.ts
+++ b/tests/lib/gradex-assignment-payload.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPikaAssignmentGradexPayload,
+  GRADEX_PIKA_ASSIGNMENT_PROFILE,
+} from '@/lib/server/gradex-assignment-payload'
+import type { Assignment } from '@/types'
+
+const assignment: Assignment = {
+  id: 'assignment-db-123',
+  classroom_id: 'classroom-db-123',
+  title: 'Portfolio Reflection',
+  description: 'Fallback description',
+  instructions_markdown: 'Write a reflection about the portfolio. Contact teacher@example.com if stuck.',
+  rich_instructions: null,
+  due_at: '2026-05-15T19:00:00.000Z',
+  position: 0,
+  is_draft: false,
+  released_at: '2026-05-01T12:00:00.000Z',
+  track_authenticity: true,
+  created_by: 'teacher-db-123',
+  created_at: '2026-05-01T12:00:00.000Z',
+  updated_at: '2026-05-02T12:00:00.000Z',
+}
+
+describe('buildPikaAssignmentGradexPayload', () => {
+  it('maps assignment, rubric, submission, settings, and workflow evidence to the Gradex Pika profile', () => {
+    const payload = buildPikaAssignmentGradexPayload({
+      assignment,
+      assignmentDoc: {
+        id: 'assignment-doc-db-456',
+        assignment_id: 'assignment-db-123',
+        student_id: 'student-db-789',
+        submitted_at: '2026-05-04T20:00:00.000Z',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'I completed the portfolio and wrote about my design decisions. My email is student@example.com.',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'The repository is at https://github.com/jane-student/portfolio.',
+                },
+              ],
+            },
+          ],
+        },
+        authenticity_score: 83,
+        authenticity_flags: [
+          {
+            timestamp: '2026-05-03T12:00:00.000Z',
+            wordDelta: 30,
+            seconds: 5,
+            wps: 6,
+            reason: 'high_wps',
+          },
+          {
+            timestamp: '2026-05-03T12:10:00.000Z',
+            wordDelta: 12,
+            seconds: 2,
+            wps: 6,
+            reason: 'paste',
+          },
+        ],
+        student_name: 'Jane Student',
+        student_email: 'student@example.com',
+        roster_id: 'roster-db-123',
+        patch: [{ op: 'replace', path: '/content', value: [] }],
+        snapshot: { type: 'doc', content: [] },
+      } as any,
+      pseudonymSalt: 'stable-test-salt',
+      requestTimeoutMs: 12_000,
+    })
+
+    expect(payload.assignment).toEqual({
+      external_assignment_id: expect.stringMatching(/^pika-assignment-[a-f0-9]{32}$/),
+      title: 'Portfolio Reflection',
+      instructions: 'Write a reflection about the portfolio. Contact [email redacted] if stuck.',
+      type: 'essay',
+    })
+    expect(payload.rubric.criteria.map((criterion) => criterion.id)).toEqual([
+      'completion',
+      'thinking',
+      'workflow',
+    ])
+    expect(payload.rubric.criteria).toEqual([
+      expect.objectContaining({ id: 'completion', scale: { min: 0, max: 10 } }),
+      expect.objectContaining({ id: 'thinking', scale: { min: 0, max: 10 } }),
+      expect.objectContaining({ id: 'workflow', scale: { min: 0, max: 10 } }),
+    ])
+    expect(payload.settings).toEqual({
+      grading_profile: GRADEX_PIKA_ASSIGNMENT_PROFILE,
+      model_profile: 'default',
+      feedback_style: 'balanced',
+      confidence_threshold: 0.65,
+      request_timeout_ms: 12_000,
+    })
+    expect(payload.submission).toEqual({
+      external_submission_id: expect.stringMatching(/^pika-submission-[a-f0-9]{32}$/),
+      external_student_id: expect.stringMatching(/^pika-student-[a-f0-9]{32}$/),
+      content_type: 'text',
+      content: expect.stringContaining('I completed the portfolio'),
+      submitted_at: '2026-05-04T20:00:00.000Z',
+    })
+    expect(payload.submission.content).toContain('[email redacted]')
+    expect(payload.submission.content).toContain('[link redacted]')
+    expect(payload.submission.content).toContain('Attached Artifacts:')
+    expect(payload.submission.content).toContain('- Repository artifact submitted')
+    expect(payload.workflow_evidence).toEqual({
+      authenticity_score: 83,
+      evidence_confidence: 0.75,
+      paste_event_count: 1,
+      high_wps_flag_count: 1,
+      summary: 'Pika authenticity score: 83/100. Sanitized workflow flags: 1 paste event, 1 high writing-speed flag.',
+      flags: [
+        { reason: 'paste', count: 1, summary: '1 paste event detected in sanitized workflow evidence.' },
+        { reason: 'high_wps', count: 1, summary: '1 high writing-speed flag detected in sanitized workflow evidence.' },
+      ],
+    })
+  })
+
+  it('does not include raw Pika IDs, identity fields, raw history, patches, snapshots, or exact artifact URLs', () => {
+    const payload = buildPikaAssignmentGradexPayload({
+      assignment,
+      assignmentDoc: {
+        id: 'assignment-doc-db-456',
+        assignment_id: 'assignment-db-123',
+        student_id: 'student-db-789',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'Submitted site: https://student.example.com/portfolio',
+                },
+              ],
+            },
+          ],
+        },
+        authenticity_score: null,
+        authenticity_flags: null,
+        student_name: 'Jane Student',
+        email: 'student@example.com',
+        roster_id: 'roster-db-123',
+        assignment_doc_history: [{ id: 'history-db-123' }],
+        keystrokes: 42,
+        patch: [{ op: 'replace', path: '/content', value: [] }],
+        snapshot: { type: 'doc', content: [] },
+      } as any,
+      pseudonymSalt: 'stable-test-salt',
+    })
+
+    const serialized = JSON.stringify(payload)
+
+    expect(serialized).not.toContain('assignment-db-123')
+    expect(serialized).not.toContain('classroom-db-123')
+    expect(serialized).not.toContain('teacher-db-123')
+    expect(serialized).not.toContain('assignment-doc-db-456')
+    expect(serialized).not.toContain('student-db-789')
+    expect(serialized).not.toContain('Jane Student')
+    expect(serialized).not.toContain('student@example.com')
+    expect(serialized).not.toContain('roster-db-123')
+    expect(serialized).not.toContain('assignment_doc_history')
+    expect(serialized).not.toContain('history-db-123')
+    expect(serialized).not.toContain('keystroke')
+    expect(serialized).not.toContain('patch')
+    expect(serialized).not.toContain('snapshot')
+    expect(serialized).not.toContain('https://student.example.com/portfolio')
+  })
+
+  it('uses stable salted pseudonymous IDs and changes them when the salt changes', () => {
+    const first = buildPikaAssignmentGradexPayload({
+      assignment,
+      assignmentDoc: {
+        id: 'assignment-doc-db-456',
+        assignment_id: 'assignment-db-123',
+        student_id: 'student-db-789',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        },
+        authenticity_score: null,
+      },
+      pseudonymSalt: 'stable-test-salt',
+    })
+    const second = buildPikaAssignmentGradexPayload({
+      assignment,
+      assignmentDoc: {
+        id: 'assignment-doc-db-456',
+        assignment_id: 'assignment-db-123',
+        student_id: 'student-db-789',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        },
+        authenticity_score: null,
+      },
+      pseudonymSalt: 'stable-test-salt',
+    })
+    const changedSalt = buildPikaAssignmentGradexPayload({
+      assignment,
+      assignmentDoc: {
+        id: 'assignment-doc-db-456',
+        assignment_id: 'assignment-db-123',
+        student_id: 'student-db-789',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        },
+        authenticity_score: null,
+      },
+      pseudonymSalt: 'different-test-salt',
+    })
+
+    expect(second.assignment.external_assignment_id).toBe(first.assignment.external_assignment_id)
+    expect(second.submission.external_submission_id).toBe(first.submission.external_submission_id)
+    expect(second.submission.external_student_id).toBe(first.submission.external_student_id)
+    expect(changedSalt.submission.external_student_id).not.toBe(first.submission.external_student_id)
+  })
+})

--- a/tests/lib/gradex-client.test.ts
+++ b/tests/lib/gradex-client.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  GradexClientError,
+  gradePikaAssignmentWithGradex,
+} from '@/lib/server/gradex-client'
+import type { GradexGradeSyncRequest } from '@/lib/server/gradex-assignment-payload'
+
+const payload: GradexGradeSyncRequest = {
+  assignment: {
+    external_assignment_id: 'pika-assignment-abc',
+    title: 'Reflection',
+    instructions: 'Write a reflection.',
+    type: 'essay',
+  },
+  rubric: {
+    version: 'pika-essay-ctw-v1',
+    criteria: [
+      {
+        id: 'completion',
+        label: 'Completion',
+        description: 'Did the student complete all parts of the assignment?',
+        kind: 'content',
+        scale: { min: 0, max: 10 },
+        weight: 1,
+        feedback_required: true,
+      },
+      {
+        id: 'thinking',
+        label: 'Thinking',
+        description: 'Does the work show depth of thought, analysis, or understanding?',
+        kind: 'thinking',
+        scale: { min: 0, max: 10 },
+        weight: 1,
+        feedback_required: true,
+      },
+      {
+        id: 'workflow',
+        label: 'Workflow',
+        description: 'Is the work organized, clear, well-presented, and supported by process evidence?',
+        kind: 'workflow',
+        scale: { min: 0, max: 10 },
+        weight: 1,
+        feedback_required: true,
+      },
+    ],
+  },
+  settings: {
+    grading_profile: 'pika-assignment-v1',
+    model_profile: 'default',
+    feedback_style: 'balanced',
+    confidence_threshold: 0.65,
+    request_timeout_ms: 25_000,
+  },
+  submission: {
+    external_submission_id: 'pika-submission-def',
+    external_student_id: 'pika-student-ghi',
+    content_type: 'text',
+    content: 'Final submission',
+  },
+  workflow_evidence: {
+    authenticity_score: null,
+    evidence_confidence: 0,
+    summary: 'No sanitized workflow evidence was available.',
+  },
+}
+
+describe('gradePikaAssignmentWithGradex', () => {
+  const originalApiUrl = process.env.GRADEX_API_URL
+  const originalApiKey = process.env.GRADEX_API_KEY
+
+  beforeEach(() => {
+    process.env.GRADEX_API_URL = 'https://gradex.test'
+    process.env.GRADEX_API_KEY = 'gx_secret'
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    process.env.GRADEX_API_URL = originalApiUrl
+    process.env.GRADEX_API_KEY = originalApiKey
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('sends the Gradex auth header, request body, timeout signal, and parses the Pika compatibility projection', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        model: 'gradex-test-model',
+        grading_profile_version: 'pika-assignment-v1',
+        audit_id: 'audit-1',
+        compatibility: {
+          pika_assignment_v1: {
+            score_completion: 8,
+            score_thinking: 7,
+            score_workflow: 9,
+            feedback: 'Strength: Clear work. Next Step: Add one detail.',
+          },
+        },
+      }),
+    })
+
+    const result = await gradePikaAssignmentWithGradex(payload, {
+      requestTimeoutMs: 12_000,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('https://gradex.test/api/v1/grade/sync')
+    expect(init).toEqual(expect.objectContaining({
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer gx_secret',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: expect.any(AbortSignal),
+    }))
+    expect(result).toEqual({
+      score_completion: 8,
+      score_thinking: 7,
+      score_workflow: 9,
+      feedback: 'Strength: Clear work. Next Step: Add one detail.',
+      model: 'gradex-test-model',
+      auditId: 'audit-1',
+      gradingProfileVersion: 'pika-assignment-v1',
+    })
+  })
+
+  it('supports a GRADEX_API_URL that already includes the API version path', async () => {
+    process.env.GRADEX_API_URL = 'https://gradex.test/api/v1/'
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        model: 'gradex-test-model',
+        grading_profile_version: 'pika-assignment-v1',
+        audit_id: 'audit-1',
+        compatibility: {
+          pika_assignment_v1: {
+            score_completion: 8,
+            score_thinking: 7,
+            score_workflow: 9,
+            feedback: 'Strength: Clear work. Next Step: Add one detail.',
+          },
+        },
+      }),
+    })
+
+    await gradePikaAssignmentWithGradex(payload)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://gradex.test/api/v1/grade/sync')
+  })
+
+  it('throws a structured non-retryable config error when Gradex credentials are missing', async () => {
+    delete process.env.GRADEX_API_KEY
+
+    await expect(gradePikaAssignmentWithGradex(payload)).rejects.toMatchObject({
+      name: 'GradexClientError',
+      kind: 'config',
+      retryable: false,
+      statusCode: null,
+    })
+  })
+
+  it('throws a structured retryable timeout error without including the request body', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const timeout = new Error('The operation timed out')
+    timeout.name = 'TimeoutError'
+    fetchMock.mockRejectedValueOnce(timeout)
+
+    try {
+      await gradePikaAssignmentWithGradex(payload)
+      throw new Error('Expected Gradex timeout to reject')
+    } catch (error) {
+      expect(error).toBeInstanceOf(GradexClientError)
+      expect(error).toMatchObject({
+        kind: 'timeout',
+        retryable: true,
+        statusCode: null,
+      })
+      expect(error.message).not.toContain('Final submission')
+      expect(error.message).not.toContain('pika-student-ghi')
+    }
+  })
+
+  it('throws a structured retryable server error without echoing the response body', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: async () => 'upstream included submitted work: Final submission',
+    })
+
+    await expect(gradePikaAssignmentWithGradex(payload)).rejects.toMatchObject({
+      kind: 'server',
+      retryable: true,
+      statusCode: 503,
+      message: 'Gradex request failed (503)',
+    })
+  })
+
+  it('throws a structured invalid-response error when the compatibility projection is missing', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        model: 'gradex-test-model',
+        grading_profile_version: 'essay-rubric-v1',
+        audit_id: 'audit-1',
+      }),
+    })
+
+    await expect(gradePikaAssignmentWithGradex(payload)).rejects.toMatchObject({
+      kind: 'invalid_response',
+      retryable: false,
+      statusCode: null,
+    })
+  })
+
+  it('rejects non-integer Pika compatibility scores before they reach Pika smallint grade fields', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        model: 'gradex-test-model',
+        grading_profile_version: 'pika-assignment-v1',
+        audit_id: 'audit-1',
+        compatibility: {
+          pika_assignment_v1: {
+            score_completion: 8.5,
+            score_thinking: 7,
+            score_workflow: 9,
+            feedback: 'Strength: Clear work. Next Step: Add one detail.',
+          },
+        },
+      }),
+    })
+
+    await expect(gradePikaAssignmentWithGradex(payload)).rejects.toMatchObject({
+      kind: 'invalid_response',
+      retryable: false,
+      message: 'Gradex response has invalid score_completion',
+    })
+  })
+
+  it('rejects stringified Pika compatibility scores instead of coercing malformed Gradex output', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        model: 'gradex-test-model',
+        grading_profile_version: 'pika-assignment-v1',
+        audit_id: 'audit-1',
+        compatibility: {
+          pika_assignment_v1: {
+            score_completion: '8',
+            score_thinking: 7,
+            score_workflow: 9,
+            feedback: 'Strength: Clear work. Next Step: Add one detail.',
+          },
+        },
+      }),
+    })
+
+    await expect(gradePikaAssignmentWithGradex(payload)).rejects.toMatchObject({
+      kind: 'invalid_response',
+      retryable: false,
+      message: 'Gradex response has invalid score_completion',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add a server-side Gradex sync grading client for Pika assignment grading.
- Add a sanitized `pika-assignment-v1` payload builder that pseudonymizes Pika IDs and excludes raw history, patches, snapshots, keystrokes, roster identifiers, names, emails, and raw artifact URLs.
- Route assignment AI grading through Gradex only when `GRADEX_ASSIGNMENT_GRADING_ENABLED` is enabled; otherwise keep the existing Pika/OpenAI grader.
- Store Gradex `compatibility.pika_assignment_v1` scores and feedback into the existing assignment grade draft/suggestion fields, preserving teacher review and publish/return workflows.

## Required environment variables
- `GRADEX_ASSIGNMENT_GRADING_ENABLED=true`
- `GRADEX_API_URL=https://...`
- `GRADEX_API_KEY=...`
- `GRADEX_PIKA_PSEUDONYM_SALT=...` stable per environment

## Failure behavior
- Gradex errors surface through the existing assignment auto-grade error/run state.
- Gradex failures do not write partial grade drafts.
- Retryable Gradex errors are retried by the existing background run retry flow.

## Validation
- `pnpm test tests/lib/gradex-client.test.ts tests/lib/gradex-assignment-payload.test.ts tests/lib/assignment-ai-grading-runs-gradex.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/unit/ai-grading.test.ts`
- `pnpm lint`
- `pnpm build`
- Earlier full suite on this branch: `pnpm test`
