### PR TITLE
[codex] Add CodePetPal companion integration

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Restore Daily class summary placement
-
-**Completed:**
-- Restored the cached class log summary in the deselected Daily state as a full-width panel below the full-width student log table.
-- Kept the selected-student state focused on the split table/history pane, with the class summary hidden until deselection.
-- Added regression coverage so the class summary remains visible in the deselected table state and disappears during student-history selection.
-
-**Validation:**
-- `pnpm exec vitest tests/components/TeacherAttendanceTab.test.tsx tests/api/teacher/log-summary.test.ts`
-- `pnpm lint && pnpm build`
-- Pika UI verification script for `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance` on port 3002:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Targeted Daily class summary screenshots/check:
-  - `/tmp/pika-teacher-summary-restored.png`
-  - `/tmp/pika-teacher-daily-summary-selected.png`
-  - `/tmp/pika-teacher-daily-summary-deselected.png`
-
 ## 2026-05-06 — Fix PR coverage gate
 
 **Completed:**
@@ -348,3 +329,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Visual hover verification on port 3011:
   - `/tmp/pika-classrooms-toggle-active-tooltip.png`
   - `/tmp/pika-classrooms-toggle-archived-tooltip.png`
+
+## 2026-05-07 — Add CodePetPal v1 integration
+
+**Completed:**
+- Added the CodePetPal classroom opt-in migration and service-role-only delivery outbox.
+- Added server-side event enqueueing for first daily entries and assignment submissions with HMAC-pseudonymous IDs.
+- Added the guarded CodePetPal drain and student world lookup proxy routes.
+- Added the student floating companion widget shell and teacher settings opt-in card.
+- Updated architecture/project docs, feature inventory, and focused API/lib coverage.
+- Tightened `.ai/START-HERE.md` wording to keep the default startup docs under the repo budget after the new feature entry.
+- Migration file is committed for human application; no Supabase migration command was run.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/lib/codepetpal.test.ts tests/api/student/entries.test.ts tests/api/assignment-docs/submit.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `node scripts/features.mjs validate`
+- `pnpm build`
+- `pnpm test`
+- `pnpm e2e:auth`
+- Playwright visual verification on the branch dev server at `127.0.0.1:3000`:
+  - teacher classroom settings shows the CodePetPal opt-in card
+  - student classroom mobile view stays uncluttered while CodePetPal is disabled by default

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -1,15 +1,15 @@
-# Pika — AI Agent Starting Ritual
+# Pika AI Start
 
-**CRITICAL:** Follow this checklist at the start of **every** AI session.
+Follow this at the start of every AI session.
 
-**Automated alternative:** Run `/session-start` (Claude Code) or paste `.codex/prompts/session-start.md` (Codex).
+Shortcut: run `/session-start` or paste `.codex/prompts/session-start.md`.
 
 ---
 
 ## Quick Checklist
 
 ```
-[ ] Verify worktree: echo $PIKA_WORKTREE (must NOT be $HOME/Repos/pika)
+[ ] Verify worktree: echo $PIKA_WORKTREE (must not be $HOME/Repos/pika)
 [ ] Run: bash "$PIKA_WORKTREE/scripts/verify-env.sh"
 [ ] Check status: git -C "$PIKA_WORKTREE" status
 [ ] Read: .ai/CURRENT.md
@@ -19,35 +19,34 @@
 [ ] Plan before coding: state task, propose approach, wait for approval
 ```
 
-Do not start coding if verification fails.
-Read `.ai/SESSION-LOG.md` only for recent handoff context; `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+Do not code if verification fails. Read `.ai/SESSION-LOG.md` only for recent handoff context; `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
 ---
 
-## Worktree Rules (MANDATORY)
+## Worktree Rules
 
-All agents are bound to exactly ONE worktree via `$PIKA_WORKTREE`.
+Agents are bound to one worktree via `$PIKA_WORKTREE`.
 
-- NEVER assume the shell cwd.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`.
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
+- Never assume shell cwd.
+- Git commands must use: `git -C "$PIKA_WORKTREE"`.
+- File paths must be absolute or prefixed with `$PIKA_WORKTREE`.
 - Never do branch work in `$HOME/Repos/pika/` (the hub).
-- Worktree creation, cleanup, and shared `.env.local` setup live in `docs/dev-workflow.md`.
-- For hub-level git commands (add/remove worktrees): `export PIKA_WORKTREE="$HOME/Repos/pika"`
+- Worktree/shared `.env.local` setup lives in `docs/dev-workflow.md`.
+- For hub-level worktree commands: `export PIKA_WORKTREE="$HOME/Repos/pika"`
 
 ---
 
-## End of Session (MANDATORY)
+## End Of Session
 
 1. Append a concise session entry to `$PIKA_WORKTREE/.ai/SESSION-LOG.md`.
-2. Run `node "$PIKA_WORKTREE/scripts/trim-session-log.mjs"` to keep only the latest 20 entries.
+2. Run `node "$PIKA_WORKTREE/scripts/trim-session-log.mjs"`.
 3. Update `.ai/features.json` if anything changed:
    ```bash
    node "$PIKA_WORKTREE/scripts/features.mjs" pass <feature-id>
    node "$PIKA_WORKTREE/scripts/features.mjs" fail <feature-id>
    ```
 4. Commit and push the session log + feature changes.
-5. If work was merged, clean up:
+5. If merged, clean up:
    ```bash
    export PIKA_WORKTREE="$HOME/Repos/pika"
    git -C "$PIKA_WORKTREE" fetch origin
@@ -58,16 +57,16 @@ All agents are bound to exactly ONE worktree via `$PIKA_WORKTREE`.
 
 ---
 
-## Document Hierarchy (When Conflicts Arise)
+## Source Order
 
 Trust in this order:
-1. `.ai/features.json` — status authority
-2. `.ai/CURRENT.md` — compact current-state context
-3. `docs/core/architecture.md` — architecture and invariants
-4. `docs/core/tests.md` — testing requirements
-5. `docs/core/design.md` — UI/UX rules
-6. `docs/core/project-context.md` — setup and commands
-7. `docs/core/roadmap.md` — phase strategy
-8. `docs/core/decision-log.md` — historical rationale
-9. `.ai/SESSION-LOG.md` — recent handoff history (on demand)
-10. `.ai/JOURNAL-ARCHIVE.md` — historical investigation only
+1. `.ai/features.json`
+2. `.ai/CURRENT.md`
+3. `docs/core/architecture.md`
+4. `docs/core/tests.md`
+5. `docs/core/design.md`
+6. `docs/core/project-context.md`
+7. `docs/core/roadmap.md`
+8. `docs/core/decision-log.md`
+9. `.ai/SESSION-LOG.md`
+10. `.ai/JOURNAL-ARCHIVE.md`

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,12 +1,12 @@
 {
   "meta": {
     "project": "pika",
-    "lastUpdated": "2026-04-26",
-    "phase": "Infrastructure — AI Effectiveness Layer",
+    "lastUpdated": "2026-05-07",
+    "phase": "Pika + CodePetPal companion integration",
     "DO_NOT_DELETE_FEATURES": "This inventory is APPEND-ONLY. Mark features as passing/failing, add new features, but NEVER DELETE FEATURES FROM THIS FILE. Deletion corrupts project history.",
     "deletionPolicy": "PROHIBITED",
-    "totalFeatures": 10,
-    "passing": 10,
+    "totalFeatures": 11,
+    "passing": 11,
     "failing": 0
   },
   "features": [
@@ -116,6 +116,17 @@
       "blockedBy": [],
       "addedDate": "2026-04-17",
       "completedDate": "2026-04-17"
+    },
+    {
+      "id": "epic-codepetpal-v1",
+      "phase": "Phase 9 — Companion Integration",
+      "description": "Classroom-level CodePetPal opt-in, pseudonymous event outbox, server-side world lookup proxy, and student companion widget",
+      "passes": true,
+      "verification": "Run: pnpm lint && pnpm build && pnpm test tests/lib/codepetpal.test.ts tests/api/student/entries.test.ts tests/api/assignment-docs/submit.test.ts",
+      "issueRefs": [],
+      "blockedBy": [],
+      "addedDate": "2026-05-07",
+      "completedDate": "2026-05-07"
     }
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ OPENAI_API_KEY=
 GITHUB_FEEDBACK_TOKEN=
 GITHUB_FEEDBACK_REPO=owner/pika
 
+# CodePetPal (optional student companion integration)
+# Server-side only. Do not prefix these with NEXT_PUBLIC_.
+CODEPETPAL_API_URL=
+CODEPETPAL_API_KEY=
+CODEPETPAL_PSEUDONYM_SECRET=
+
 # Dangerous operations (scripts)
 # Required to run `npm run seed:fresh` (it wipes data).
 ALLOW_DB_WIPE=false

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -114,6 +114,18 @@ tests/                             # Vitest unit + API suites
 - Student editor autosaves via `/api/assignment-docs/[id]` (PATCH), submit/unsubmit via `/submit` and `/unsubmit`.
 - Status helpers live in `src/lib/assignments.ts` (`calculateAssignmentStatus`, badge/label helpers).
 
+### CodePetPal Companion Integration
+- Classroom opt-in is stored on `classrooms.codepetpal_enabled`.
+- Student progress events are emitted only from server mutation routes, not UI-only code.
+- Pika stores delivery work in `integration_event_outbox`; CodePetPal receives only HMAC-pseudonymous student/classroom IDs and low-risk event metadata.
+- Current emitted v1 events:
+  - `daily_entry_created` from first daily entry creation
+  - `assignment_submitted` from assignment submission
+- Delivery drains through `/api/integrations/codepetpal/drain`, protected by `CRON_SECRET`.
+- Student world lookup goes through `/api/integrations/codepetpal/world`; Pika uses server-side CodePetPal credentials and returns `{ enabled: false }` when disabled, unconfigured, or temporarily unavailable.
+- CodePetPal owns XP, levels, achievements, pet state, rules, and asset URLs. Pika owns classroom opt-in, raw identities, outbox retries, and the local student widget shell.
+- Do not send names, emails, grades, scores, raw IDs, rankings, journal text, assignment content, or browsing/editor history to CodePetPal.
+
 ### Route Protection
 - Role check via `requireRole('student' | 'teacher')` in API routes.
 - Classroom ownership/enrollment enforced in route logic and RLS.

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -87,6 +87,7 @@ pnpm run lint
 - `ENABLE_MOCK_EMAIL` (`true` to log verification/reset codes)
 - `NEXT_PUBLIC_APP_URL`
 - `CRON_SECRET` (required for protected cron endpoints; Vercel sends `Authorization: Bearer <CRON_SECRET>`; cron schedules are configured in the Vercel dashboard; on the Hobby plan, schedules must run at most once per day)
+- `CODEPETPAL_API_URL`, `CODEPETPAL_API_KEY`, `CODEPETPAL_PSEUDONYM_SECRET` (optional; required only when classroom-level CodePetPal companion opt-in is used)
 
 Legacy anon/service keys are supported but publishable/secret are preferred.
 
@@ -103,6 +104,8 @@ Legacy anon/service keys are supported but publishable/secret are preferred.
 4) **Classrooms & Roster**: Create classes, share join code/link, upload roster CSV, manage enrollments.
 
 5) **Assignments**: Create assignments per classroom; students edit with autosave and submit/unsubmit; teachers view stats and read-only docs.
+
+6) **CodePetPal Companion**: Optional classroom-level student companion integration. Pika stores raw IDs locally, queues low-risk events in `integration_event_outbox`, sends HMAC-pseudonymous event data to CodePetPal, and renders a local student widget from the world lookup proxy.
 
 ---
 

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -6,6 +6,7 @@ import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { withErrorHandler } from '@/lib/api-handler'
+import { enqueueCodePetPalEvent } from '@/lib/codepetpal'
 import { hasAssignmentSubmissionContent } from '@/lib/assignments'
 import type { AssignmentDocHistoryEntry, TiptapContent } from '@/types'
 
@@ -105,6 +106,15 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   if (doc) {
     doc.content = parseContentField(doc.content)
   }
+
+  await enqueueCodePetPalEvent(supabase, {
+    classroomId: assignment.classroom_id,
+    studentId: user.id,
+    eventType: 'assignment_submitted',
+    sourceId: existingDoc.id,
+    occurredAt: doc?.submitted_at || new Date().toISOString(),
+    payload: { source: 'pika' },
+  })
 
   try {
     await supabase.from('assignment_doc_history').insert({

--- a/src/app/api/integrations/codepetpal/drain/route.ts
+++ b/src/app/api/integrations/codepetpal/drain/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withErrorHandler } from '@/lib/api-handler'
+import { drainCodePetPalOutbox } from '@/lib/codepetpal'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const POST = withErrorHandler('PostCodePetPalOutboxDrain', async (request: NextRequest) => {
+  const cronSecret = process.env.CRON_SECRET
+  const authHeader = request.headers.get('authorization') || ''
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const result = await drainCodePetPalOutbox(supabase)
+  return NextResponse.json(result, { status: result.ok ? 200 : 503 })
+})

--- a/src/app/api/integrations/codepetpal/world/route.ts
+++ b/src/app/api/integrations/codepetpal/world/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { codePetPalLookupQuerySchema, isCodePetPalRuntimeConfigured, lookupCodePetPalWorld } from '@/lib/codepetpal'
+import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetCodePetPalWorld', async (request: NextRequest) => {
+  const user = await requireRole('student')
+  const { searchParams } = new URL(request.url)
+  const query = codePetPalLookupQuerySchema.parse({
+    classroom_id: searchParams.get('classroom_id') || '',
+  })
+
+  const access = await assertStudentCanAccessClassroom(user.id, query.classroom_id)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: classroom, error } = await supabase
+    .from('classrooms')
+    .select('codepetpal_enabled')
+    .eq('id', query.classroom_id)
+    .single()
+
+  if (error || !classroom?.codepetpal_enabled || !isCodePetPalRuntimeConfigured()) {
+    return NextResponse.json({ enabled: false })
+  }
+
+  const view = await lookupCodePetPalWorld({
+    classroomId: query.classroom_id,
+    studentId: user.id,
+  })
+
+  return NextResponse.json(view)
+})

--- a/src/app/api/student/entries/route.ts
+++ b/src/app/api/student/entries/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { isOnTime, getTodayInToronto } from '@/lib/timezone'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+import { enqueueCodePetPalEvent } from '@/lib/codepetpal'
 import {
   countCharacters,
   extractPlainText,
@@ -298,6 +299,15 @@ export const POST = withErrorHandler('PostStudentEntry', async (request, context
     }
 
     entry = data
+
+    await enqueueCodePetPalEvent(supabase, {
+      classroomId: classroom_id,
+      studentId: user.id,
+      eventType: 'daily_entry_created',
+      sourceId: data.id,
+      occurredAt: data.created_at || new Date().toISOString(),
+      payload: { date, source: 'pika' },
+    })
   }
 
   return NextResponse.json({ entry })

--- a/src/app/api/teacher/classrooms/[id]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/route.ts
@@ -58,6 +58,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     actualSiteConfig,
     courseOverviewMarkdown,
     courseOutlineMarkdown,
+    codePetPalEnabled,
   } = body
 
   if (
@@ -71,7 +72,8 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     actualSitePublished === undefined &&
     actualSiteConfig === undefined &&
     courseOverviewMarkdown === undefined &&
-    courseOutlineMarkdown === undefined
+    courseOutlineMarkdown === undefined &&
+    codePetPalEnabled === undefined
   ) {
     return NextResponse.json(
       { error: 'No fields to update' },
@@ -101,7 +103,8 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     actualSitePublished !== undefined ||
     actualSiteConfig !== undefined ||
     courseOverviewMarkdown !== undefined ||
-    courseOutlineMarkdown !== undefined
+    courseOutlineMarkdown !== undefined ||
+    codePetPalEnabled !== undefined
 
   if (hasArchiveToggle && hasOtherUpdates) {
     return NextResponse.json(
@@ -140,6 +143,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
   if (actualSiteConfig !== undefined) updates.actual_site_config = normalizeActualCourseSiteConfig(actualSiteConfig)
   if (courseOverviewMarkdown !== undefined) updates.course_overview_markdown = courseOverviewMarkdown
   if (courseOutlineMarkdown !== undefined) updates.course_outline_markdown = courseOutlineMarkdown
+  if (codePetPalEnabled !== undefined) updates.codepetpal_enabled = codePetPalEnabled
   if (hasArchiveToggle) {
     if (archived && isArchived) {
       return NextResponse.json(

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AppShell } from '@/components/AppShell'
+import { CodePetPalWidget } from '@/components/CodePetPalWidget'
 import { TeacherClassroomView, TeacherAssignmentsMarkdownSidebar, type AssignmentViewMode } from './TeacherClassroomView'
 import { assignmentsToMarkdown, markdownToAssignments } from '@/lib/assignment-markdown'
 import { StudentTodayTab } from './StudentTodayTab'
@@ -1407,6 +1408,13 @@ function ClassroomPageContent({
           }}
         />
       ) : null}
+
+      {!isTeacher && (
+        <CodePetPalWidget
+          classroomId={classroom.id}
+          enabled={!!classroom.codepetpal_enabled}
+        />
+      )}
 
     </AppShell>
   )

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -39,6 +39,7 @@ export function TeacherSettingsTab({
   const actualOverviewId = useId()
   const actualOutlineId = useId()
   const showMarkdownId = useId()
+  const codePetPalId = useId()
   const isReadOnly = !!classroom.archived_at
   const { showMarkdown, mounted: markdownMounted, setShowMarkdown } = useMarkdownPreference()
   const [title, setTitle] = useState(classroom.title)
@@ -48,6 +49,9 @@ export function TeacherSettingsTab({
   const [allowEnrollment, setAllowEnrollment] = useState<boolean>(classroom.allow_enrollment)
   const [saving, setSaving] = useState(false)
   const [enrollmentError, setEnrollmentError] = useState<string>('')
+  const [codePetPalEnabled, setCodePetPalEnabled] = useState<boolean>(!!classroom.codepetpal_enabled)
+  const [codePetPalSaving, setCodePetPalSaving] = useState(false)
+  const [codePetPalError, setCodePetPalError] = useState<string>('')
   const [joinCodeError, setJoinCodeError] = useState<string>('')
   const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false)
   const [isRegenerating, setIsRegenerating] = useState(false)
@@ -190,6 +194,29 @@ export function TeacherSettingsTab({
       setVisibilityError(err.message || 'Failed to update visibility setting')
     } finally {
       setVisibilitySaving(false)
+    }
+  }
+
+  async function saveCodePetPalEnabled(nextValue: boolean) {
+    if (isReadOnly) return
+    setCodePetPalSaving(true)
+    setCodePetPalError('')
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ codePetPalEnabled: nextValue }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update CodePetPal')
+      }
+      setCodePetPalEnabled(!!data.classroom?.codepetpal_enabled)
+      showMessage({ text: 'CodePetPal setting saved', tone: 'success' })
+    } catch (err: any) {
+      setCodePetPalError(err.message || 'Failed to update CodePetPal')
+    } finally {
+      setCodePetPalSaving(false)
     }
   }
 
@@ -426,6 +453,32 @@ export function TeacherSettingsTab({
                 />
                 Show markdown
               </label>
+            </div>
+
+            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <div className="text-sm font-semibold text-text-default">CodePetPal Companion</div>
+                <Tooltip content="Student companion world powered by pseudonymous progress events" side="right">
+                  <span className="text-text-muted cursor-help">
+                    <Info size={14} />
+                  </span>
+                </Tooltip>
+              </div>
+
+              <label htmlFor={codePetPalId} className="flex items-center gap-3 text-sm text-text-default">
+                <input
+                  id={codePetPalId}
+                  type="checkbox"
+                  checked={codePetPalEnabled}
+                  onChange={(event) => saveCodePetPalEnabled(event.target.checked)}
+                  disabled={codePetPalSaving || isReadOnly}
+                  className="h-4 w-4"
+                />
+                Enable student companion
+              </label>
+
+              {codePetPalSaving && <div className="text-sm text-text-muted">Saving...</div>}
+              {codePetPalError && <div className="text-sm text-danger">{codePetPalError}</div>}
             </div>
 
             <div className="bg-surface rounded-lg border border-border p-4 space-y-4">

--- a/src/components/CodePetPalWidget.tsx
+++ b/src/components/CodePetPalWidget.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Lock, X } from 'lucide-react'
+import type { CodePetPalWorldView } from '@/lib/codepetpal'
+
+interface CodePetPalWidgetProps {
+  classroomId: string
+  enabled: boolean
+}
+
+export function CodePetPalWidget({ classroomId, enabled }: CodePetPalWidgetProps) {
+  const [view, setView] = useState<CodePetPalWorldView>({ enabled: false })
+  const [panelOpen, setPanelOpen] = useState(false)
+  const [reacting, setReacting] = useState(false)
+  const longPressTimer = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setView({ enabled: false })
+      return
+    }
+
+    let cancelled = false
+
+    async function loadWorld() {
+      try {
+        const response = await fetch(`/api/integrations/codepetpal/world?classroom_id=${encodeURIComponent(classroomId)}`)
+        const payload = await response.json()
+        if (!cancelled) setView(payload)
+      } catch {
+        if (!cancelled) setView({ enabled: false })
+      }
+    }
+
+    loadWorld()
+    const intervalId = window.setInterval(loadWorld, 60_000)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+    }
+  }, [classroomId, enabled])
+
+  useEffect(() => {
+    if (!reacting) return
+    const timeout = window.setTimeout(() => setReacting(false), 900)
+    return () => window.clearTimeout(timeout)
+  }, [reacting])
+
+  if (!enabled || !view.enabled) return null
+
+  const petAsset = reacting ? view.world.pet.happy_asset_url : view.world.pet.idle_asset_url
+  const xpProgressPercent = Math.max(0, Math.min(100, view.world.xp_progress_percent))
+
+  function startLongPress() {
+    clearLongPress()
+    longPressTimer.current = window.setTimeout(() => setPanelOpen(true), 550)
+  }
+
+  function clearLongPress() {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current)
+      longPressTimer.current = null
+    }
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-3">
+      {panelOpen && (
+        <div className="w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-border bg-surface p-4 text-text-default shadow-elevated">
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold">CodePetPal</h2>
+              <p className="text-xs text-text-muted">
+                Level {view.world.level} · {view.world.xp} XP · {view.world.mood}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setPanelOpen(false)}
+              className="grid h-8 w-8 place-items-center rounded-md text-text-muted hover:bg-surface-hover hover:text-text-default"
+              aria-label="Close CodePetPal panel"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="mb-3 h-2 overflow-hidden rounded-full bg-surface-2">
+            <div
+              className="h-full rounded-full bg-primary"
+              style={{ width: `${xpProgressPercent}%` }}
+              aria-hidden="true"
+            />
+          </div>
+
+          <div className="mb-3 grid grid-cols-2 gap-2 text-xs">
+            <div className="rounded-md border border-border bg-surface-2 p-2">
+              <span className="block text-text-muted">Streak</span>
+              <strong>{view.world.streak_days} days</strong>
+            </div>
+            <div className="rounded-md border border-border bg-surface-2 p-2">
+              <span className="block text-text-muted">Submissions</span>
+              <strong>{view.world.assignment_submission_count}</strong>
+            </div>
+          </div>
+
+          <p className="mb-3 text-sm text-text-muted">{view.next_nudge}</p>
+
+          <div className="grid gap-2">
+            <h3 className="text-xs font-semibold uppercase text-text-muted">Awards</h3>
+            <div className="grid gap-2">
+              {view.achievements.unlocked.slice(0, 4).map((achievement) => (
+                <div key={achievement.key} className="flex items-center gap-2 rounded-md bg-surface-2 p-2">
+                  <span
+                    className="h-8 w-8 flex-none rounded-md border border-border bg-surface bg-contain bg-center bg-no-repeat"
+                    style={{ backgroundImage: achievement.asset_url ? `url(${achievement.asset_url})` : undefined }}
+                    aria-hidden="true"
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{achievement.title}</div>
+                    <div className="truncate text-xs text-text-muted">{achievement.description}</div>
+                  </div>
+                </div>
+              ))}
+              {view.achievements.unlocked.length === 0 && (
+                <div className="rounded-md bg-surface-2 p-2 text-sm text-text-muted">No awards yet</div>
+              )}
+              {view.achievements.locked.slice(0, 2).map((achievement) => (
+                <div key={achievement.key} className="flex items-center gap-2 rounded-md bg-surface-2 p-2 opacity-70">
+                  <span
+                    className="grid h-8 w-8 flex-none place-items-center rounded-md border border-border bg-surface text-xs text-text-muted"
+                    aria-hidden="true"
+                  >
+                    <Lock size={14} />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{achievement.title}</div>
+                    <div className="truncate text-xs text-text-muted">Locked</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        aria-label="Open CodePetPal companion"
+        aria-expanded={panelOpen}
+        onClick={() => setReacting(true)}
+        onContextMenu={(event) => {
+          event.preventDefault()
+          setPanelOpen(true)
+        }}
+        onPointerDown={startLongPress}
+        onPointerUp={clearLongPress}
+        onPointerCancel={clearLongPress}
+        onPointerLeave={clearLongPress}
+        onBlur={clearLongPress}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            setPanelOpen((current) => !current)
+          }
+        }}
+        className="grid h-16 w-16 place-items-center rounded-full border border-border bg-surface shadow-elevated transition hover:-translate-y-0.5 hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <span
+          className="h-12 w-12 bg-contain bg-center bg-no-repeat"
+          style={{ backgroundImage: `url(${petAsset})` }}
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/lib/codepetpal.ts
+++ b/src/lib/codepetpal.ts
@@ -1,0 +1,354 @@
+import { createHmac } from 'node:crypto'
+import { z } from 'zod'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export const CODEPETPAL_EVENT_TYPES = [
+  'daily_entry_created',
+  'assignment_submitted',
+  'calendar_milestone_reached',
+  'resource_viewed',
+  'quiz_completed_without_score',
+] as const
+
+export type CodePetPalEventType = (typeof CODEPETPAL_EVENT_TYPES)[number]
+
+export type CodePetPalWorldView =
+  | { enabled: false; error?: string }
+  | {
+      enabled: true
+      world: {
+        external_student_id: string
+        external_classroom_id: string
+        level: number
+        xp: number
+        xp_to_next_level: number
+        xp_progress_percent: number
+        mood: string
+        streak_days: number
+        assignment_submission_count: number
+        pet: {
+          species: string
+          idle_asset_url: string
+          happy_asset_url: string
+        }
+      }
+      achievements: {
+        unlocked: Array<{
+          key: string
+          title: string
+          description: string
+          asset_url: string | null
+          unlocked_at: string
+        }>
+        locked: Array<{
+          key: string
+          title: string
+          description: string
+          asset_url: string | null
+        }>
+      }
+      recent_events: Array<{
+        id: string
+        type: string
+        occurred_at: string
+      }>
+      next_nudge: string
+    }
+
+type CodePetPalEventInput = {
+  idempotency_key: string
+  type: CodePetPalEventType
+  occurred_at: string
+  external_student_id: string
+  external_classroom_id: string
+  payload?: Record<string, unknown>
+}
+
+type CodePetPalOutboxRow = {
+  id: string
+  classroom_id: string
+  student_id: string
+  event_type: CodePetPalEventType
+  idempotency_key: string
+  occurred_at: string
+  payload: Record<string, unknown> | null
+  attempt_count: number
+}
+
+export const codePetPalLookupQuerySchema = z.object({
+  classroom_id: z.string().uuid(),
+})
+
+export function isCodePetPalRuntimeConfigured() {
+  return Boolean(getCodePetPalBaseUrl() && process.env.CODEPETPAL_API_KEY)
+}
+
+export async function enqueueCodePetPalEvent(
+  supabase: SupabaseClient,
+  input: {
+    classroomId: string
+    studentId: string
+    eventType: CodePetPalEventType
+    sourceId: string
+    occurredAt?: string
+    payload?: Record<string, unknown>
+  },
+) {
+  try {
+    const { data: classroom, error: classroomError } = await supabase
+      .from('classrooms')
+      .select('codepetpal_enabled')
+      .eq('id', input.classroomId)
+      .single()
+
+    if (classroomError || !classroom?.codepetpal_enabled) {
+      return { queued: false, reason: classroomError ? 'lookup_failed' : 'disabled' }
+    }
+
+    const idempotencyKey = buildCodePetPalIdempotencyKey(input.eventType, input.sourceId)
+    const { error } = await supabase
+      .from('integration_event_outbox')
+      .upsert({
+        integration_key: 'codepetpal',
+        classroom_id: input.classroomId,
+        student_id: input.studentId,
+        event_type: input.eventType,
+        idempotency_key: idempotencyKey,
+        occurred_at: input.occurredAt || new Date().toISOString(),
+        payload: input.payload || {},
+        status: 'pending',
+        next_attempt_at: new Date().toISOString(),
+      }, { onConflict: 'idempotency_key', ignoreDuplicates: true })
+
+    if (error) {
+      console.error('CodePetPal outbox enqueue failed:', error)
+      return { queued: false, reason: 'insert_failed' }
+    }
+
+    return { queued: true, idempotencyKey }
+  } catch (error) {
+    console.error('CodePetPal outbox enqueue failed:', error)
+    return { queued: false, reason: 'unexpected_error' }
+  }
+}
+
+export async function drainCodePetPalOutbox(
+  supabase: SupabaseClient,
+  options: { limit?: number } = {},
+) {
+  const baseUrl = getCodePetPalBaseUrl()
+  const apiKey = process.env.CODEPETPAL_API_KEY
+  if (!baseUrl || !apiKey) {
+    return { ok: false, status: 'unconfigured', selected: 0, sent: 0, failed: 0 }
+  }
+
+  const now = new Date().toISOString()
+  const { data: rows, error } = await supabase
+    .from('integration_event_outbox')
+    .select('id, classroom_id, student_id, event_type, idempotency_key, occurred_at, payload, attempt_count')
+    .eq('integration_key', 'codepetpal')
+    .in('status', ['pending', 'failed'])
+    .lte('next_attempt_at', now)
+    .order('created_at', { ascending: true })
+    .limit(options.limit || 50)
+
+  if (error) {
+    console.error('CodePetPal outbox select failed:', error)
+    return { ok: false, status: 'select_failed', selected: 0, sent: 0, failed: 0 }
+  }
+
+  const outboxRows = ((rows || []) as CodePetPalOutboxRow[])
+  if (outboxRows.length === 0) {
+    return { ok: true, status: 'empty', selected: 0, sent: 0, failed: 0 }
+  }
+
+  const batch = outboxRows.map(toCodePetPalEvent)
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/events`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ events: batch }),
+    })
+    const payload = await response.json().catch(() => null)
+    return markOutboxDeliveryResult(supabase, outboxRows, response.ok, payload)
+  } catch (sendError) {
+    const message = sendError instanceof Error ? sendError.message : 'CodePetPal delivery failed'
+    await markOutboxRowsFailed(supabase, outboxRows, message)
+    return {
+      ok: false,
+      status: 'send_failed',
+      selected: outboxRows.length,
+      sent: 0,
+      failed: outboxRows.length,
+    }
+  }
+}
+
+export async function lookupCodePetPalWorld(input: {
+  classroomId: string
+  studentId: string
+}): Promise<CodePetPalWorldView> {
+  const baseUrl = getCodePetPalBaseUrl()
+  const apiKey = process.env.CODEPETPAL_API_KEY
+  if (!baseUrl || !apiKey) {
+    return { enabled: false, error: 'unconfigured' }
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/worlds/lookup`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        external_student_id: pseudonymousExternalId('student', input.studentId),
+        external_classroom_id: pseudonymousExternalId('classroom', input.classroomId),
+      }),
+    })
+
+    if (!response.ok) {
+      return { enabled: false, error: `lookup_failed:${response.status}` }
+    }
+
+    return await response.json() as CodePetPalWorldView
+  } catch (error) {
+    console.error('CodePetPal world lookup failed:', error)
+    return { enabled: false, error: 'lookup_failed' }
+  }
+}
+
+function toCodePetPalEvent(row: CodePetPalOutboxRow): CodePetPalEventInput {
+  return {
+    idempotency_key: row.idempotency_key,
+    type: row.event_type,
+    occurred_at: row.occurred_at,
+    external_student_id: pseudonymousExternalId('student', row.student_id),
+    external_classroom_id: pseudonymousExternalId('classroom', row.classroom_id),
+    payload: row.payload || {},
+  }
+}
+
+async function markOutboxDeliveryResult(
+  supabase: SupabaseClient,
+  rows: CodePetPalOutboxRow[],
+  responseOk: boolean,
+  payload: any,
+) {
+  const resultRows = Array.isArray(payload?.results) ? payload.results : []
+  const resultByKey = new Map(resultRows.map((result: any) => [result.idempotency_key, result]))
+  let sent = 0
+  let failed = 0
+
+  for (const row of rows) {
+    const result = resultByKey.get(row.idempotency_key) as { status?: string; error?: string } | undefined
+    if (result?.status === 'failed') {
+      await markOutboxRowFailed(
+        supabase,
+        row,
+        result.error || payload?.error || `CodePetPal returned a retryable response`,
+      )
+      failed += 1
+      continue
+    }
+
+    if (result?.status === 'processed' || result?.status === 'duplicate') {
+      await markOutboxRowSent(supabase, row)
+      sent += 1
+      continue
+    }
+
+    await markOutboxRowFailed(
+      supabase,
+      row,
+      result?.error ||
+        payload?.error ||
+        (responseOk ? 'CodePetPal response omitted this event result' : 'CodePetPal returned a retryable response'),
+    )
+    failed += 1
+  }
+
+  return {
+    ok: failed === 0,
+    status: failed === 0 ? 'sent' : 'partial_failed',
+    selected: rows.length,
+    sent,
+    failed,
+  }
+}
+
+async function markOutboxRowSent(supabase: SupabaseClient, row: CodePetPalOutboxRow) {
+  const now = new Date().toISOString()
+  await supabase
+    .from('integration_event_outbox')
+    .update({
+      status: 'sent',
+      attempt_count: row.attempt_count + 1,
+      last_attempt_at: now,
+      last_error: null,
+      sent_at: now,
+    })
+    .eq('id', row.id)
+}
+
+async function markOutboxRowsFailed(
+  supabase: SupabaseClient,
+  rows: CodePetPalOutboxRow[],
+  message: string,
+) {
+  for (const row of rows) {
+    await markOutboxRowFailed(supabase, row, message)
+  }
+}
+
+async function markOutboxRowFailed(
+  supabase: SupabaseClient,
+  row: CodePetPalOutboxRow,
+  message: string,
+) {
+  const now = new Date().toISOString()
+  const nextAttempt = new Date(Date.now() + backoffMs(row.attempt_count + 1)).toISOString()
+  await supabase
+    .from('integration_event_outbox')
+    .update({
+      status: 'failed',
+      attempt_count: row.attempt_count + 1,
+      last_attempt_at: now,
+      last_error: message.slice(0, 1000),
+      next_attempt_at: nextAttempt,
+    })
+    .eq('id', row.id)
+}
+
+function getCodePetPalBaseUrl() {
+  return process.env.CODEPETPAL_API_URL?.replace(/\/+$/, '') || ''
+}
+
+function buildCodePetPalIdempotencyKey(eventType: CodePetPalEventType, sourceId: string) {
+  return `pika:${eventType}:${hmacDigest(`event:${eventType}:${sourceId}`)}`
+}
+
+function pseudonymousExternalId(kind: 'student' | 'classroom', rawId: string) {
+  return `pika_${kind}_${hmacDigest(`${kind}:${rawId}`)}`
+}
+
+function hmacDigest(value: string) {
+  return createHmac('sha256', codePetPalPseudonymSecret()).update(value).digest('hex').slice(0, 32)
+}
+
+function codePetPalPseudonymSecret() {
+  const secret = process.env.CODEPETPAL_PSEUDONYM_SECRET || process.env.SESSION_SECRET
+  if (!secret) {
+    throw new Error('CODEPETPAL_PSEUDONYM_SECRET or SESSION_SECRET is required for CodePetPal pseudonymous IDs')
+  }
+  return secret
+}
+
+function backoffMs(attemptCount: number) {
+  const minutes = Math.min(60, 2 ** Math.max(0, attemptCount - 1))
+  return minutes * 60_000
+}

--- a/src/lib/server/classrooms.ts
+++ b/src/lib/server/classrooms.ts
@@ -25,6 +25,7 @@ export function hydrateClassroomRecord(row: Record<string, any>): Classroom {
     ),
     course_overview_markdown: row.course_overview_markdown ?? '',
     course_outline_markdown: row.course_outline_markdown ?? '',
+    codepetpal_enabled: !!row.codepetpal_enabled,
   }
 }
 

--- a/src/lib/validations/teacher.ts
+++ b/src/lib/validations/teacher.ts
@@ -98,6 +98,7 @@ export const updateClassroomPublishingSchema = z.object({
   actualSiteConfig: actualSiteConfigSchema.optional(),
   courseOverviewMarkdown: z.string().optional(),
   courseOutlineMarkdown: z.string().optional(),
+  codePetPalEnabled: z.boolean().optional(),
 }).superRefine((value, ctx) => {
   if (value.actualSitePublished && value.actualSiteSlug === null) {
     ctx.addIssue({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export interface Classroom {
   actual_site_config: ActualCourseSiteConfig
   course_overview_markdown: string
   course_outline_markdown: string
+  codepetpal_enabled: boolean
   archived_at: string | null
   created_at: string
   updated_at: string

--- a/supabase/migrations/066_codepetpal_integration.sql
+++ b/supabase/migrations/066_codepetpal_integration.sql
@@ -1,0 +1,59 @@
+-- CodePetPal v1 classroom opt-in and event outbox.
+-- Pika keeps raw classroom/student IDs locally and sends only pseudonymous IDs
+-- through the server-side CodePetPal proxy/outbox.
+
+alter table public.classrooms
+  add column if not exists codepetpal_enabled boolean not null default false;
+
+create table if not exists public.integration_event_outbox (
+  id uuid primary key default gen_random_uuid(),
+  integration_key text not null default 'codepetpal',
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  event_type text not null,
+  idempotency_key text not null unique,
+  occurred_at timestamptz not null,
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'pending',
+  attempt_count integer not null default 0,
+  next_attempt_at timestamptz not null default now(),
+  last_attempt_at timestamptz,
+  last_error text,
+  sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint integration_event_outbox_event_type_check check (
+    event_type in (
+      'daily_entry_created',
+      'assignment_submitted',
+      'calendar_milestone_reached',
+      'resource_viewed',
+      'quiz_completed_without_score'
+    )
+  ),
+  constraint integration_event_outbox_status_check check (
+    status in ('pending', 'sending', 'sent', 'failed')
+  )
+);
+
+create index if not exists idx_integration_event_outbox_drain
+  on public.integration_event_outbox (integration_key, status, next_attempt_at, created_at);
+
+create index if not exists idx_integration_event_outbox_classroom_student
+  on public.integration_event_outbox (classroom_id, student_id, created_at desc);
+
+create or replace function public.update_integration_event_outbox_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_integration_event_outbox_updated_at on public.integration_event_outbox;
+create trigger update_integration_event_outbox_updated_at
+  before update on public.integration_event_outbox
+  for each row
+  execute function public.update_integration_event_outbox_updated_at();
+
+alter table public.integration_event_outbox enable row level security;

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -17,6 +17,9 @@ vi.mock('@/lib/server/classrooms', () => ({
 vi.mock('@/lib/authenticity', () => ({
   analyzeAuthenticity: vi.fn(() => ({ score: 0.82, flags: ['steady_revision'] })),
 }))
+vi.mock('@/lib/codepetpal', () => ({
+  enqueueCodePetPalEvent: vi.fn(async () => ({ queued: true })),
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
 
@@ -314,6 +317,15 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
       char_count: 13,
       trigger: 'submit',
     }))
+    const { enqueueCodePetPalEvent } = await import('@/lib/codepetpal')
+    expect(enqueueCodePetPalEvent).toHaveBeenCalledWith(mockSupabaseClient, {
+      classroomId: 'class-1',
+      studentId: 'student-1',
+      eventType: 'assignment_submitted',
+      sourceId: 'doc-1',
+      occurredAt: expect.any(String),
+      payload: { source: 'pika' },
+    })
     expect(authenticityUpdate).toHaveBeenCalledWith('id', 'doc-1')
   })
 

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -38,6 +38,9 @@ vi.mock('@/lib/server/classrooms', () => ({
     classroom: { id: 'classroom-1', archived_at: null },
   })),
 }))
+vi.mock('@/lib/codepetpal', () => ({
+  enqueueCodePetPalEvent: vi.fn(async () => ({ queued: true })),
+}))
 
 const mockSupabaseClient = { from: vi.fn() }
 
@@ -527,6 +530,15 @@ describe('POST /api/student/entries', () => {
         mood: undefined,
         on_time: expect.any(Boolean),
       })
+      const { enqueueCodePetPalEvent } = await import('@/lib/codepetpal')
+      expect(enqueueCodePetPalEvent).toHaveBeenCalledWith(mockSupabaseClient, {
+        classroomId: 'classroom-1',
+        studentId: 'student-1',
+        eventType: 'daily_entry_created',
+        sourceId: 'entry-new-1',
+        occurredAt: expect.any(String),
+        payload: { date: '2024-10-15', source: 'pika' },
+      })
     })
 
     it('should update existing entry when one exists', async () => {
@@ -612,6 +624,8 @@ describe('POST /api/student/entries', () => {
         on_time: expect.any(Boolean),
         version: expect.any(Number),
       })
+      const { enqueueCodePetPalEvent } = await import('@/lib/codepetpal')
+      expect(enqueueCodePetPalEvent).not.toHaveBeenCalled()
     })
 
     it('should calculate on_time status using isOnTime', async () => {

--- a/tests/lib/codepetpal.test.ts
+++ b/tests/lib/codepetpal.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  drainCodePetPalOutbox,
+  enqueueCodePetPalEvent,
+  lookupCodePetPalWorld,
+} from '@/lib/codepetpal'
+
+describe('CodePetPal integration helpers', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.SESSION_SECRET = 'test-session-secret-with-enough-entropy'
+    process.env.CODEPETPAL_API_URL = 'https://codepetpal.example'
+    process.env.CODEPETPAL_API_KEY = 'codepetpal-key'
+    vi.restoreAllMocks()
+  })
+
+  it('queues enabled classroom events with pseudonymous idempotency keys', async () => {
+    const upsert = vi.fn(async () => ({ error: null }))
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classrooms') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: { codepetpal_enabled: true },
+                  error: null,
+                })),
+              })),
+            })),
+          }
+        }
+        if (table === 'integration_event_outbox') {
+          return { upsert }
+        }
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    const result = await enqueueCodePetPalEvent(supabase as any, {
+      classroomId: 'classroom-raw-id',
+      studentId: 'student-raw-id',
+      eventType: 'daily_entry_created',
+      sourceId: 'entry-raw-id',
+      occurredAt: '2026-05-07T12:00:00.000Z',
+      payload: { date: '2026-05-07' },
+    })
+
+    expect(result.queued).toBe(true)
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      classroom_id: 'classroom-raw-id',
+      student_id: 'student-raw-id',
+      event_type: 'daily_entry_created',
+      occurred_at: '2026-05-07T12:00:00.000Z',
+      payload: { date: '2026-05-07' },
+    }), { onConflict: 'idempotency_key', ignoreDuplicates: true })
+
+    const queued = upsert.mock.calls[0][0]
+    expect(queued.idempotency_key).toMatch(/^pika:daily_entry_created:[a-f0-9]{32}$/)
+    expect(queued.idempotency_key).not.toContain('entry-raw-id')
+  })
+
+  it('does not queue when the classroom has not opted in', async () => {
+    const upsert = vi.fn()
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classrooms') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: { codepetpal_enabled: false },
+                  error: null,
+                })),
+              })),
+            })),
+          }
+        }
+        return { upsert }
+      }),
+    }
+
+    const result = await enqueueCodePetPalEvent(supabase as any, {
+      classroomId: 'classroom-raw-id',
+      studentId: 'student-raw-id',
+      eventType: 'assignment_submitted',
+      sourceId: 'doc-raw-id',
+    })
+
+    expect(result).toEqual({ queued: false, reason: 'disabled' })
+    expect(upsert).not.toHaveBeenCalled()
+  })
+
+  it('drains due outbox rows without sending raw IDs to CodePetPal', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    const rows = [
+      {
+        id: 'outbox-1',
+        classroom_id: 'classroom-raw-id',
+        student_id: 'student-raw-id',
+        event_type: 'assignment_submitted',
+        idempotency_key: 'pika:assignment_submitted:pseudonymous-key',
+        occurred_at: '2026-05-07T12:00:00.000Z',
+        payload: { source: 'pika' },
+        attempt_count: 0,
+      },
+    ]
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(() => ({
+              lte: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(async () => ({ data: rows, error: null })),
+                })),
+              })),
+            })),
+          })),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn(async () => {
+            updates.push(payload)
+            return { error: null }
+          }),
+        })),
+      })),
+    }
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body))
+      expect(JSON.stringify(body)).not.toContain('student-raw-id')
+      expect(JSON.stringify(body)).not.toContain('classroom-raw-id')
+      expect(body.events[0]).toMatchObject({
+        idempotency_key: 'pika:assignment_submitted:pseudonymous-key',
+        type: 'assignment_submitted',
+        payload: { source: 'pika' },
+      })
+      expect(body.events[0].external_student_id).toMatch(/^pika_student_[a-f0-9]{32}$/)
+      expect(body.events[0].external_classroom_id).toMatch(/^pika_classroom_[a-f0-9]{32}$/)
+      return Response.json({
+        failed: 0,
+        results: [{ idempotency_key: 'pika:assignment_submitted:pseudonymous-key', status: 'processed' }],
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await drainCodePetPalOutbox(supabase as any)
+
+    expect(result).toMatchObject({ ok: true, selected: 1, sent: 1, failed: 0 })
+    expect(updates[0]).toMatchObject({ status: 'sent', attempt_count: 1, last_error: null })
+  })
+
+  it('keeps outbox rows retryable when CodePetPal omits per-event results', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    const rows = [
+      {
+        id: 'outbox-1',
+        classroom_id: 'classroom-raw-id',
+        student_id: 'student-raw-id',
+        event_type: 'daily_entry_created',
+        idempotency_key: 'pika:daily_entry_created:pseudonymous-key',
+        occurred_at: '2026-05-07T12:00:00.000Z',
+        payload: { source: 'pika' },
+        attempt_count: 0,
+      },
+    ]
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(() => ({
+              lte: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(async () => ({ data: rows, error: null })),
+                })),
+              })),
+            })),
+          })),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => ({
+          eq: vi.fn(async () => {
+            updates.push(payload)
+            return { error: null }
+          }),
+        })),
+      })),
+    }
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ failed: 0, results: [] })))
+
+    const result = await drainCodePetPalOutbox(supabase as any)
+
+    expect(result).toMatchObject({ ok: false, selected: 1, sent: 0, failed: 1 })
+    expect(updates[0]).toMatchObject({
+      status: 'failed',
+      attempt_count: 1,
+      last_error: 'CodePetPal response omitted this event result',
+    })
+  })
+
+  it('looks up worlds with pseudonymous IDs only', async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body))
+      expect(JSON.stringify(body)).not.toContain('student-raw-id')
+      expect(JSON.stringify(body)).not.toContain('classroom-raw-id')
+      expect(body.external_student_id).toMatch(/^pika_student_[a-f0-9]{32}$/)
+      expect(body.external_classroom_id).toMatch(/^pika_classroom_[a-f0-9]{32}$/)
+      return Response.json({ enabled: true, world: { level: 1 } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await lookupCodePetPalWorld({
+      classroomId: 'classroom-raw-id',
+      studentId: 'student-raw-id',
+    })
+
+    expect(result.enabled).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith('https://codepetpal.example/api/v1/worlds/lookup', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer codepetpal-key' }),
+    }))
+  })
+})


### PR DESCRIPTION
## Summary
- Add the CodePetPal v1 classroom opt-in, migration, and service-role-only event outbox.
- Emit low-risk `daily_entry_created` and `assignment_submitted` events from server mutation routes only.
- Add cron-protected outbox drain and student world lookup proxy routes using HMAC-pseudonymous IDs.
- Add the local student companion widget shell and teacher settings opt-in card.
- Update Pika AI startup guidance, feature inventory, architecture docs, and env docs.

## Privacy and Deployment Notes
- Pika keeps raw student/classroom IDs locally; CodePetPal receives only pseudonymous IDs plus low-risk event metadata.
- No names, emails, grades, scores, writing, rankings, or browsing/editor history are sent.
- The Supabase migration is committed but was not applied by the agent; it must be applied before enabling the setting in a live environment.
- Required runtime env for enabled classrooms: `CODEPETPAL_API_URL`, `CODEPETPAL_API_KEY`, and `CODEPETPAL_PSEUDONYM_SECRET`.

## Validation
- `bash scripts/verify-env.sh`
- `pnpm vitest run tests/lib/codepetpal.test.ts tests/api/student/entries.test.ts tests/api/assignment-docs/submit.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `node scripts/features.mjs validate`
- `pnpm build`
- `pnpm test`
- `pnpm e2e:auth`
- Playwright visual verification on `127.0.0.1:3000`: teacher settings opt-in card and student mobile classroom default-disabled state