### PR TITLE
[codex] Extract assignment lifecycle invariants

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,40 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Fix PR coverage gate
-
-**Completed:**
-- Investigated the failed GitHub CI run on the first PR commit.
-- Found the failure was a per-file coverage threshold miss for `src/app/api/teacher/log-summary/route.ts`.
-- Added route tests for classroom-not-found, entry-stats failure, and entry-count failure to cover the cron-only summary endpoint error branches.
-
-**Validation:**
-- `pnpm run test:coverage`
-- `pnpm lint`
-
-## 2026-05-06 — Restrict nightly log summaries to class days
-
-**Completed:**
-- Tightened `/api/cron/nightly-log-summaries` eligibility so AI summaries only run for unarchived classrooms with entries on yesterday, yesterday inside the classroom semester range, and an explicit `class_days.is_class_day = true` row.
-- Added a per-classroom eligibility recheck before the OpenAI call to keep the guard close to generation.
-- Added cron route tests for outside-semester and non-class-day cases and asserted they do not call OpenAI.
-
-**Validation:**
-- `pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm lint`
-- `pnpm test -- tests/api/cron/nightly-log-summaries.test.ts` (ran full suite: 251 files, 2110 tests)
-
-## 2026-05-06 — Fix cron coverage gate
-
-**Completed:**
-- Addressed the latest CI failure for `src/app/api/cron/nightly-log-summaries/route.ts` per-file coverage.
-- Added cron route tests for entry discovery errors, class-day discovery errors, and eligibility recheck skip paths.
-
-**Validation:**
-- `pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm run test:coverage`
-- `pnpm lint`
-
 ## 2026-05-07 — Allow late assignment submissions with repo metadata
 
 **Completed:**
@@ -360,6 +326,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-log-summary-teacher-populated.png`
   - `/tmp/pika-log-summary-teacher-mobile.png`
   - `/tmp/pika-log-summary-student-mobile.png`
+
 ## 2026-05-08 — Extract assignment lifecycle invariants
 
 **Completed:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,20 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-07 — Allow late assignment submissions with repo metadata
-
-**Completed:**
-- Fixed assignment submit validation so saved repo metadata counts as submittable work, matching the student editor's Submit button rule.
-- Made the student assignment editor flush pending repo URL/GitHub username edits before calling the submit endpoint.
-- Added regression coverage for a past-due repo-only assignment submission.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test -- tests/api/assignment-docs/submit.test.ts` (ran full suite: 251 files, 2119 tests)
-- `pnpm test -- tests/unit/assignments.test.ts` (ran full suite: 251 files, 2119 tests)
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-05-07 — Compact MC answer review
 
 **Completed:**
@@ -353,3 +339,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - PR checks showed Vercel skipped by ignored build step, with preview comments passing.
+
+## 2026-05-08 — Unblock assignment invariant merge
+
+**Completed:**
+- Rebasing PR #570 onto `origin/main` exposed a CI branch-coverage failure in `src/lib/assignments.ts`.
+- Added focused release-state coverage for malformed comparison dates so the fail-safe `Date.now()` branch is exercised.
+- Kept the assignment lifecycle implementation behavior-preserving.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/.codex/worktrees/53f9/pika bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/assignments.test.ts`
+- `pnpm run test:coverage`
+- `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -375,3 +375,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-05-08 — Open assignment invariant PR
+
+**Completed:**
+- Created branch `codex/assignment-lifecycle-invariants`.
+- Committed assignment lifecycle invariant extraction as `37cd562`.
+- Opened draft PR #570 and added `codex` plus `codex-automation` labels.
+- Posted a self-review comment with no blocking findings.
+
+**Validation:**
+- PR checks showed Vercel skipped by ignored build step, with preview comments passing.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -199,6 +199,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Added direct-identifier redaction for nightly student log summary prompts.
 - Built summary redaction maps from the full classroom roster plus entry authors.
+
+## 2026-05-08 — Skill progression evidence review
+
+**Completed:**
+- Reviewed startup guidance, recent session continuity, and the latest merged PRs/review notes to identify repeated engineering friction.
+- Anchored next-skill recommendations to concrete recent patterns: post-PR coverage gate fixes, multi-pass UI verification, UI/API invariant drift, privacy redaction gaps, and migration rollout compatibility work.
+
+**Validation:**
+- Reviewed `.ai/CURRENT.md`, `docs/ai-instructions.md`, `docs/dev-workflow.md`, `.ai/SESSION-LOG.md`
+- Reviewed GitHub PRs `#559` through `#565` plus PR review notes for `#561` and `#563`
 - Sent OpenAI summary requests with `store: false` and removed model-output snippets from parse errors.
 - Added prompt/payload regression coverage for roster names and common direct identifiers.
 
@@ -350,3 +360,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-log-summary-teacher-populated.png`
   - `/tmp/pika-log-summary-teacher-mobile.png`
   - `/tmp/pika-log-summary-student-mobile.png`
+## 2026-05-08 — Extract assignment lifecycle invariants
+
+**Completed:**
+- Added shared assignment release-state helpers for draft/live/scheduled visibility in `src/lib/assignments.ts`.
+- Moved student assignment visibility behind the shared helper while preserving the server import path.
+- Centralized future scheduled-release due-date validation and migrated assignment update/release routes plus scheduling UI callers.
+- Added release-state and future schedule validation tests, including malformed `released_at` fail-closed behavior.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/.codex/worktrees/53f9/pika bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/assignments.test.ts tests/lib/assignment-schedule-validation.test.ts tests/api/assignment-docs/submit.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-draft.test.ts tests/components/AssignmentModal.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm vitest run tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/student/assignments.test.ts tests/api/integration/assignment-draft-flow.test.ts tests/api/student/notifications.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/api/teacher/assignments/[id]/release/route.ts
+++ b/src/app/api/teacher/assignments/[id]/release/route.ts
@@ -3,8 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import {
-  ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
-  isScheduledReleaseOnOrBeforeDueDate,
+  getFutureScheduledReleaseDueDateError,
 } from '@/lib/assignment-schedule-validation'
 
 export const dynamic = 'force-dynamic'
@@ -75,9 +74,13 @@ export const POST = withErrorHandler('PostTeacherAssignmentRelease', async (requ
         { status: 400 }
       )
     }
-    if (!isScheduledReleaseOnOrBeforeDueDate(parsed, existing.due_at)) {
+    const scheduleDueDateError = getFutureScheduledReleaseDueDateError({
+      releaseAt: parsed,
+      dueAt: existing.due_at,
+    })
+    if (scheduleDueDateError) {
       return NextResponse.json(
-        { error: ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR },
+        { error: scheduleDueDateError },
         { status: 400 }
       )
     }

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { calculateAssignmentStatus } from '@/lib/assignments'
+import {
+  calculateAssignmentStatus,
+  isAssignmentLive,
+  isAssignmentScheduledForFuture,
+} from '@/lib/assignments'
 import { extractAssignmentArtifacts } from '@/lib/assignment-artifacts'
 import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { withErrorHandler } from '@/lib/api-handler'
 import { getActiveAssignmentAiGradingRunSummary } from '@/lib/server/assignment-ai-grading-runs'
 import {
   ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
-  isScheduledReleaseOnOrBeforeDueDate,
+  getFutureScheduledReleaseDueDateError,
 } from '@/lib/assignment-schedule-validation'
 
 export const dynamic = 'force-dynamic'
@@ -246,9 +250,8 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
   if (due_at !== undefined) updates.due_at = due_at
 
   const now = new Date()
-  const existingReleaseDate = existing.released_at ? new Date(existing.released_at) : null
-  const existingIsLive = !existing.is_draft && (!existingReleaseDate || existingReleaseDate <= now)
-  const existingIsScheduled = !existing.is_draft && !!existingReleaseDate && existingReleaseDate > now
+  const existingIsLive = isAssignmentLive(existing, now)
+  const existingIsScheduled = isAssignmentScheduledForFuture(existing, now)
 
   let parsedReleasedAt: string | null | undefined
   if (released_at !== undefined) {
@@ -301,17 +304,19 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
 
   const effectiveDueAt = due_at ?? existing.due_at
   const effectiveReleaseAt = updates.released_at ?? existing.released_at
-  const effectiveReleaseDate = effectiveReleaseAt ? new Date(effectiveReleaseAt) : null
-  const isFutureScheduledRelease =
-    updates.is_draft !== true &&
-    !!effectiveReleaseDate &&
-    !Number.isNaN(effectiveReleaseDate.getTime()) &&
-    effectiveReleaseDate > now
+  const effectiveIsScheduled = isAssignmentScheduledForFuture({
+    is_draft: updates.is_draft ?? existing.is_draft,
+    released_at: effectiveReleaseAt,
+  }, now)
+  const scheduleDueDateError = effectiveIsScheduled
+    ? getFutureScheduledReleaseDueDateError({
+        releaseAt: effectiveReleaseAt,
+        dueAt: effectiveDueAt,
+        now,
+      })
+    : null
 
-  if (
-    isFutureScheduledRelease &&
-    !isScheduledReleaseOnOrBeforeDueDate(effectiveReleaseDate, effectiveDueAt)
-  ) {
+  if (scheduleDueDateError) {
     return NextResponse.json(
       { error: ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR },
       { status: 400 }

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -57,6 +57,7 @@ import {
 import {
   calculateAssignmentStatus,
   getAssignmentRubricState,
+  isAssignmentScheduledForFuture,
   isAssignmentAlreadyReturnedWithoutResubmission,
 } from '@/lib/assignments'
 import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
@@ -66,7 +67,6 @@ import {
   parseAssignmentWorkspaceStudentId,
   type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
-import { isVisibleAtNow } from '@/lib/scheduling'
 import type {
   Classroom,
   Assignment,
@@ -123,7 +123,7 @@ interface Props {
 }
 
 function isScheduledAssignment(assignment: Assignment): boolean {
-  return !assignment.is_draft && !!assignment.released_at && !isVisibleAtNow(assignment.released_at)
+  return isAssignmentScheduledForFuture(assignment)
 }
 
 function MetricBar({ value }: { value: number }) {

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -12,9 +12,10 @@ import { format, isValid, parse } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
 import { useAssignmentDateValidation } from '@/hooks/useAssignmentDateValidation'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
-import { DEFAULT_SCHEDULE_TIME, getDefaultScheduleDateInSchedulingTimezone, getTodayInSchedulingTimezone, isVisibleAtNow, parseScheduleIsoToParts } from '@/lib/scheduling'
+import { DEFAULT_SCHEDULE_TIME, getDefaultScheduleDateInSchedulingTimezone, getTodayInSchedulingTimezone, parseScheduleIsoToParts } from '@/lib/scheduling'
 import { useAssignmentScheduling, type CreateSubmitAction } from '@/hooks/useAssignmentScheduling'
-import { getScheduledReleaseDueDateError } from '@/lib/assignment-schedule-validation'
+import { getFutureScheduledReleaseDueDateError } from '@/lib/assignment-schedule-validation'
+import { isAssignmentScheduledForFuture } from '@/lib/assignments'
 
 const AUTOSAVE_DEBOUNCE_MS = 3000
 const AUTOSAVE_MIN_INTERVAL_MS = 10000
@@ -49,11 +50,11 @@ function getScheduledAssignmentDueDateValidationMessage(
 ): string | null {
   if (!assignment || assignment.is_draft || !assignment.released_at || !dueAt) return null
 
-  const releaseDate = new Date(assignment.released_at)
-  if (Number.isNaN(releaseDate.getTime()) || releaseDate <= new Date()) return null
-
   try {
-    return getScheduledReleaseDueDateError(releaseDate, toTorontoEndOfDayIso(dueAt))
+    return getFutureScheduledReleaseDueDateError({
+      releaseAt: assignment.released_at,
+      dueAt: toTorontoEndOfDayIso(dueAt),
+    })
   } catch {
     return null
   }
@@ -71,7 +72,10 @@ function getScheduleDueDateValidationMessage(scheduleIso: string, dueAt: string,
   if (!scheduleIso || !dueAt || !isScheduleValid) return null
 
   try {
-    return getScheduledReleaseDueDateError(scheduleIso, toTorontoEndOfDayIso(dueAt))
+    return getFutureScheduledReleaseDueDateError({
+      releaseAt: scheduleIso,
+      dueAt: toTorontoEndOfDayIso(dueAt),
+    })
   } catch {
     return null
   }
@@ -191,7 +195,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           : null
       )
       setDueAt(nextDueAt)
-      if (assignment.released_at && !isVisibleAtNow(assignment.released_at)) {
+      if (assignment.released_at && isAssignmentScheduledForFuture(assignment)) {
         const scheduled = parseScheduleIsoToParts(assignment.released_at)
         setScheduleDate(scheduled.date)
         setScheduleTime(scheduled.time)

--- a/src/components/SortableAssignmentCard.tsx
+++ b/src/components/SortableAssignmentCard.tsx
@@ -4,8 +4,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Trash2 } from 'lucide-react'
 import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
-import { formatDueDate } from '@/lib/assignments'
-import { isVisibleAtNow } from '@/lib/scheduling'
+import { formatDueDate, isAssignmentScheduledForFuture } from '@/lib/assignments'
 import { Button, Tooltip } from '@/ui'
 import type { Assignment, AssignmentStats } from '@/types'
 
@@ -61,10 +60,7 @@ export function SortableAssignmentCard({
   }
 
   const isDraft = assignment.is_draft
-  const isScheduled =
-    !assignment.is_draft &&
-    !!assignment.released_at &&
-    !isVisibleAtNow(assignment.released_at)
+  const isScheduled = isAssignmentScheduledForFuture(assignment)
   const scheduledOpenLabel =
     isScheduled && assignment.released_at
       ? formatScheduledRelease(assignment.released_at)

--- a/src/hooks/useAssignmentScheduling.ts
+++ b/src/hooks/useAssignmentScheduling.ts
@@ -6,9 +6,9 @@ import {
   DEFAULT_SCHEDULE_TIME,
   getDefaultScheduleDateInSchedulingTimezone,
   isScheduleIsoInFuture,
-  isVisibleAtNow,
   parseScheduleIsoToParts,
 } from '@/lib/scheduling'
+import { isAssignmentLive, isAssignmentScheduledForFuture } from '@/lib/assignments'
 import type { Assignment } from '@/types'
 
 export type CreateSubmitAction = 'post' | 'schedule' | 'draft'
@@ -112,12 +112,8 @@ export function useAssignmentScheduling({
 
   // Derived status flags
   const isDraft = !currentAssignment || currentAssignment.is_draft
-  const isScheduled =
-    !!currentAssignment &&
-    !currentAssignment.is_draft &&
-    !!currentAssignment.released_at &&
-    !isVisibleAtNow(currentAssignment.released_at)
-  const isLive = !!currentAssignment && !currentAssignment.is_draft && !isScheduled
+  const isScheduled = !!currentAssignment && isAssignmentScheduledForFuture(currentAssignment)
+  const isLive = !!currentAssignment && isAssignmentLive(currentAssignment)
   const scheduleIso = scheduleDate ? combineScheduleDateTimeToIso(scheduleDate, scheduleTime) : ''
   const isScheduleValid = scheduleIso ? isScheduleIsoInFuture(scheduleIso) : false
   const effectivePrimaryAction: CreateSubmitAction = isScheduled ? 'schedule' : primaryAction
@@ -148,7 +144,7 @@ export function useAssignmentScheduling({
     setShowCreateScheduleModal(false)
     setReleasing(false)
 
-    if (assignment?.released_at && !isVisibleAtNow(assignment.released_at)) {
+    if (assignment?.released_at && isAssignmentScheduledForFuture(assignment)) {
       const scheduled = parseScheduleIsoToParts(assignment.released_at)
       setScheduleDate(scheduled.date)
       setScheduleTime(scheduled.time)
@@ -175,7 +171,7 @@ export function useAssignmentScheduling({
   }
 
   function syncScheduleInputsFromAssignment() {
-    if (currentAssignment?.released_at && !isVisibleAtNow(currentAssignment.released_at)) {
+    if (currentAssignment?.released_at && isAssignmentScheduledForFuture(currentAssignment)) {
       const parsed = parseScheduleIsoToParts(currentAssignment.released_at)
       setScheduleDate(parsed.date)
       setScheduleTime(parsed.time)

--- a/src/lib/assignment-schedule-validation.ts
+++ b/src/lib/assignment-schedule-validation.ts
@@ -23,3 +23,18 @@ export function getScheduledReleaseDueDateError(releaseAt: DateLike, dueAt: Date
     ? null
     : ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR
 }
+
+export function getFutureScheduledReleaseDueDateError(input: {
+  releaseAt: DateLike
+  dueAt: DateLike
+  now?: Date
+}): string | null {
+  const releaseTime = toValidTime(input.releaseAt)
+  const dueTime = toValidTime(input.dueAt)
+  const nowTime = toValidTime(input.now ?? new Date())
+
+  if (releaseTime === null || dueTime === null || nowTime === null) return null
+  if (releaseTime <= nowTime) return null
+
+  return releaseTime <= dueTime ? null : ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR
+}

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -16,6 +16,50 @@ type AssignmentReturnDoc = {
 }
 
 export type AssignmentRubricState = 'blank' | 'partial' | 'complete'
+export type AssignmentReleaseState = 'draft' | 'scheduled' | 'live'
+export type AssignmentReleaseInput = {
+  is_draft: boolean
+  released_at: string | null
+}
+
+function getComparableTime(date: Date): number {
+  const time = date.getTime()
+  return Number.isNaN(time) ? Date.now() : time
+}
+
+export function getAssignmentReleaseState(
+  input: AssignmentReleaseInput,
+  now: Date = new Date()
+): AssignmentReleaseState {
+  if (input.is_draft) return 'draft'
+  if (!input.released_at) return 'live'
+
+  const releaseTime = new Date(input.released_at).getTime()
+  if (Number.isNaN(releaseTime)) return 'scheduled'
+
+  return releaseTime > getComparableTime(now) ? 'scheduled' : 'live'
+}
+
+export function isAssignmentVisibleToStudents(
+  input: AssignmentReleaseInput,
+  now: Date = new Date()
+): boolean {
+  return getAssignmentReleaseState(input, now) === 'live'
+}
+
+export function isAssignmentScheduledForFuture(
+  input: AssignmentReleaseInput,
+  now: Date = new Date()
+): boolean {
+  return getAssignmentReleaseState(input, now) === 'scheduled'
+}
+
+export function isAssignmentLive(
+  input: AssignmentReleaseInput,
+  now: Date = new Date()
+): boolean {
+  return getAssignmentReleaseState(input, now) === 'live'
+}
 
 export function getAssignmentFullReturnAt(
   doc: Pick<AssignmentReturnDoc, 'teacher_cleared_at' | 'returned_at'>

--- a/src/lib/server/assignments.ts
+++ b/src/lib/server/assignments.ts
@@ -1,16 +1,4 @@
-type AssignmentVisibilityRecord = {
-  is_draft: boolean
-  released_at: string | null
-}
-
-export function isAssignmentVisibleToStudents(
-  assignment: AssignmentVisibilityRecord,
-  now: Date = new Date()
-): boolean {
-  if (assignment.is_draft) return false
-  if (!assignment.released_at) return true
-  return new Date(assignment.released_at).getTime() <= now.getTime()
-}
+export { isAssignmentVisibleToStudents } from '@/lib/assignments'
 
 export function isMissingAssignmentTeacherClearedAtColumnError(error: {
   code?: string | null

--- a/tests/api/integration/assignment-draft-flow.test.ts
+++ b/tests/api/integration/assignment-draft-flow.test.ts
@@ -56,6 +56,10 @@ vi.mock('@/lib/server/classrooms', () => ({
 // Mock assignment status calculation
 vi.mock('@/lib/assignments', () => ({
   calculateAssignmentStatus: vi.fn(() => 'not-started'),
+  isAssignmentVisibleToStudents: vi.fn((assignment) => (
+    !assignment.is_draft &&
+    (!assignment.released_at || new Date(assignment.released_at).getTime() <= Date.now())
+  )),
 }))
 
 describe('Assignment Draft Mode Integration', () => {

--- a/tests/api/student/assignments.test.ts
+++ b/tests/api/student/assignments.test.ts
@@ -33,6 +33,10 @@ vi.mock('@/lib/assignments', () => ({
     if (doc) return 'in-progress'
     return 'not-started'
   }),
+  isAssignmentVisibleToStudents: vi.fn((assignment) => (
+    !assignment.is_draft &&
+    (!assignment.released_at || new Date(assignment.released_at).getTime() <= Date.now())
+  )),
   sanitizeDocForStudent: vi.fn((doc) => doc),
 }))
 

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -278,6 +278,11 @@ vi.mock('@/lib/assignments', () => ({
     if (!doc.is_submitted || !doc.submitted_at) return true
     return new Date(doc.submitted_at).getTime() <= returnedAt
   }),
+  isAssignmentScheduledForFuture: vi.fn((assignment: any) => (
+    !assignment.is_draft &&
+    !!assignment.released_at &&
+    !mockIsVisibleAtNow(assignment.released_at)
+  )),
   getAssignmentStatusIconClass: vi.fn(() => ''),
   getAssignmentStatusLabel: vi.fn(() => 'Submitted'),
   hasDraftSavedGrade: vi.fn(() => false),

--- a/tests/lib/assignment-schedule-validation.test.ts
+++ b/tests/lib/assignment-schedule-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
+  getFutureScheduledReleaseDueDateError,
   getScheduledReleaseDueDateError,
   isScheduledReleaseOnOrBeforeDueDate,
 } from '@/lib/assignment-schedule-validation'
@@ -45,5 +46,65 @@ describe('assignment schedule validation', () => {
   it('does not fail closed when one side is absent or malformed', () => {
     expect(isScheduledReleaseOnOrBeforeDueDate(null, '2099-03-01T23:59:00.000Z')).toBe(true)
     expect(isScheduledReleaseOnOrBeforeDueDate('not-a-date', '2099-03-01T23:59:00.000Z')).toBe(true)
+  })
+
+  describe('getFutureScheduledReleaseDueDateError', () => {
+    const now = new Date('2099-03-01T13:00:00.000Z')
+
+    it('allows a future scheduled release before the assignment due date', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: '2099-03-01T14:00:00.000Z',
+        dueAt: '2099-03-01T23:59:00.000Z',
+        now,
+      })).toBeNull()
+    })
+
+    it('allows a future scheduled release exactly at the assignment due date', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: '2099-03-01T23:59:00.000Z',
+        dueAt: '2099-03-01T23:59:00.000Z',
+        now,
+      })).toBeNull()
+    })
+
+    it('rejects a future scheduled release after the assignment due date', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: '2099-03-02T00:00:00.000Z',
+        dueAt: '2099-03-01T23:59:00.000Z',
+        now,
+      })).toBe(ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR)
+    })
+
+    it('ignores past release dates even when they are after the due date', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: '2099-02-28T14:00:00.000Z',
+        dueAt: '2099-02-27T23:59:00.000Z',
+        now,
+      })).toBeNull()
+    })
+
+    it('ignores null release dates', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: null,
+        dueAt: '2099-03-01T23:59:00.000Z',
+        now,
+      })).toBeNull()
+    })
+
+    it('ignores malformed release dates', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: 'not-a-date',
+        dueAt: '2099-03-01T23:59:00.000Z',
+        now,
+      })).toBeNull()
+    })
+
+    it('ignores malformed due dates', () => {
+      expect(getFutureScheduledReleaseDueDateError({
+        releaseAt: '2099-03-01T14:00:00.000Z',
+        dueAt: 'not-a-date',
+        now,
+      })).toBeNull()
+    })
   })
 })

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -473,6 +473,16 @@ describe('assignment utilities', () => {
       expect(isAssignmentLive(assignment, now)).toBe(false)
     })
 
+    it('falls back to current time when the comparison date is malformed', () => {
+      vi.setSystemTime(now)
+      const assignment = {
+        is_draft: false,
+        released_at: '2026-03-01T13:00:01.000Z',
+      }
+
+      expect(getAssignmentReleaseState(assignment, new Date('not-a-date'))).toBe('scheduled')
+    })
+
     it('fails closed for non-draft assignments with malformed release dates', () => {
       const assignment = {
         is_draft: false,

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -12,9 +12,13 @@ import {
   getAssignmentStatusIconClass,
   getAssignmentRubricState,
   getAssignmentFullReturnAt,
+  getAssignmentReleaseState,
   hasDraftSavedGrade,
   isAssignmentAlreadyReturnedWithoutResubmission,
+  isAssignmentLive,
   isAssignmentReturnable,
+  isAssignmentScheduledForFuture,
+  isAssignmentVisibleToStudents,
   hasAssignmentSubmissionContent,
   formatDueDate,
   isPastDue,
@@ -415,6 +419,70 @@ describe('assignment utilities', () => {
         repo_url: '   ',
         github_username: null,
       })).toBe(false)
+    })
+  })
+
+  describe('assignment release state', () => {
+    const now = new Date('2026-03-01T13:00:00.000Z')
+
+    it('treats draft assignments as hidden regardless of release date', () => {
+      const assignment = {
+        is_draft: true,
+        released_at: '2026-03-02T13:00:00.000Z',
+      }
+
+      expect(getAssignmentReleaseState(assignment, now)).toBe('draft')
+      expect(isAssignmentVisibleToStudents(assignment, now)).toBe(false)
+      expect(isAssignmentScheduledForFuture(assignment, now)).toBe(false)
+      expect(isAssignmentLive(assignment, now)).toBe(false)
+    })
+
+    it('treats non-draft assignments with no release date as live', () => {
+      const assignment = {
+        is_draft: false,
+        released_at: null,
+      }
+
+      expect(getAssignmentReleaseState(assignment, now)).toBe('live')
+      expect(isAssignmentVisibleToStudents(assignment, now)).toBe(true)
+      expect(isAssignmentScheduledForFuture(assignment, now)).toBe(false)
+      expect(isAssignmentLive(assignment, now)).toBe(true)
+    })
+
+    it('treats non-draft assignments with a past release date as live', () => {
+      const assignment = {
+        is_draft: false,
+        released_at: '2026-03-01T12:59:59.000Z',
+      }
+
+      expect(getAssignmentReleaseState(assignment, now)).toBe('live')
+      expect(isAssignmentVisibleToStudents(assignment, now)).toBe(true)
+      expect(isAssignmentScheduledForFuture(assignment, now)).toBe(false)
+      expect(isAssignmentLive(assignment, now)).toBe(true)
+    })
+
+    it('treats non-draft assignments with a future release date as scheduled', () => {
+      const assignment = {
+        is_draft: false,
+        released_at: '2026-03-01T13:00:01.000Z',
+      }
+
+      expect(getAssignmentReleaseState(assignment, now)).toBe('scheduled')
+      expect(isAssignmentVisibleToStudents(assignment, now)).toBe(false)
+      expect(isAssignmentScheduledForFuture(assignment, now)).toBe(true)
+      expect(isAssignmentLive(assignment, now)).toBe(false)
+    })
+
+    it('fails closed for non-draft assignments with malformed release dates', () => {
+      const assignment = {
+        is_draft: false,
+        released_at: 'not-a-date',
+      }
+
+      expect(getAssignmentReleaseState(assignment, now)).toBe('scheduled')
+      expect(isAssignmentVisibleToStudents(assignment, now)).toBe(false)
+      expect(isAssignmentScheduledForFuture(assignment, now)).toBe(true)
+      expect(isAssignmentLive(assignment, now)).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary
- add shared assignment release-state helpers for draft/live/scheduled visibility
- preserve the server assignment visibility import path while moving the rule into `src/lib/assignments.ts`
- centralize future scheduled-release due-date validation and migrate assignment routes plus scheduling UI callers
- add coverage for release-state classification, future schedule validation, and malformed `released_at` fail-closed behavior

## Review
Self-review found no blocking issues. The refactor preserves existing route error messages and UI copy, keeps request parsing in the routes, and keeps malformed non-null `released_at` hidden from students rather than treating it as live.

## Validation
- `PIKA_WORKTREE=/Users/stew/.codex/worktrees/53f9/pika bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/unit/assignments.test.ts tests/lib/assignment-schedule-validation.test.ts tests/api/assignment-docs/submit.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-draft.test.ts tests/components/AssignmentModal.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
- `pnpm vitest run tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/student/assignments.test.ts tests/api/integration/assignment-draft-flow.test.ts tests/api/student/notifications.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test`