### PR TITLE
[codex] Add student exam-mode e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,26 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-08 — Shared gradebook status icons
-
-**Completed:**
-- Swapped gradebook inspector status symbols to the shared `AssessmentStatusIcon` component used by assignments/tests.
-- `Submitted` now uses the shared submitted circle instead of the returned/send symbol.
-- Submitted-late, missing, not-submitted, started, and resubmitted statuses keep compact labels with shared icon states.
-
-**Validation:**
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/AssessmentStatusIcon.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3003 pnpm e2e:auth`
-- Pika UI verification script for `/classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=gradebook` on port 3003:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Targeted mocked-data captures for shared status icons:
-  - `/tmp/pika-gradebook-shared-status-icons-desktop.png`
-  - `/tmp/pika-gradebook-shared-status-icons-mobile.png`
-
 ## 2026-05-08 — Shared assessment status indicator mapping
 
 **Completed:**
@@ -261,6 +241,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Visual hover verification on port 3011:
   - `/tmp/pika-classrooms-toggle-active-tooltip.png`
   - `/tmp/pika-classrooms-toggle-archived-tooltip.png`
+
+## 2026-05-10 — Add student exam-mode e2e coverage
+
+**Completed:**
+- Added a focused Playwright flow for student test exam mode.
+- Seeds a unique active open-response test through existing teacher APIs against the shared seeded teacher/student classroom.
+- Verifies test start, transient window loss without lock, sustained window loss with content obscuring and interaction blocking, restoration, and open-response draft preservation after reload/restart.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm exec playwright test e2e/student-exam-mode.spec.ts`
+- `pnpm lint`
 
 ## 2026-05-08 — Add class log summary controls
 

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Browser, type Page } from '@playwright/test'
+
+const TEACHER_STORAGE = '.auth/teacher.json'
+const STUDENT_STORAGE = '.auth/student.json'
+
+interface ClassroomRecord {
+  id: string
+  title?: string | null
+}
+
+interface AssessmentRecord {
+  id: string
+  title: string
+}
+
+interface AssessmentDraftRecord {
+  version: number
+  content: {
+    title: string
+    show_results: boolean
+    questions: unknown[]
+  }
+}
+
+function uniqueTitle(): string {
+  return `Exam Mode E2E ${Date.now()}`
+}
+
+async function loadJson<T>(page: Page, path: string): Promise<T> {
+  return page.evaluate(async (apiPath) => {
+    const response = await fetch(apiPath)
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data?.error || `Failed to load ${apiPath}: ${response.status}`)
+    }
+    return data
+  }, path) as Promise<T>
+}
+
+async function sendJson<T>(
+  page: Page,
+  method: 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  return page.evaluate(async ({ apiPath, payload, requestMethod }) => {
+    const response = await fetch(apiPath, {
+      method: requestMethod,
+      headers: payload ? { 'Content-Type': 'application/json' } : undefined,
+      body: payload ? JSON.stringify(payload) : undefined,
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data?.error || `Failed to ${requestMethod} ${apiPath}: ${response.status}`)
+    }
+    return data
+  }, { apiPath: path, payload: body, requestMethod: method }) as Promise<T>
+}
+
+async function withTeacherPage<T>(
+  browser: Browser,
+  callback: (page: Page) => Promise<T>,
+): Promise<T> {
+  const context = await browser.newContext({ storageState: TEACHER_STORAGE })
+  const page = await context.newPage()
+  try {
+    await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+    return await callback(page)
+  } finally {
+    await context.close()
+  }
+}
+
+async function findSharedClassroom(studentPage: Page, teacherPage: Page): Promise<ClassroomRecord> {
+  const [studentData, teacherData] = await Promise.all([
+    loadJson<{ classrooms?: ClassroomRecord[] }>(studentPage, '/api/student/classrooms'),
+    loadJson<{ classrooms?: ClassroomRecord[] }>(teacherPage, '/api/teacher/classrooms'),
+  ])
+
+  const teacherClassroomIds = new Set((teacherData.classrooms || []).map((classroom) => classroom.id))
+  const sharedClassroom = (studentData.classrooms || []).find((classroom) =>
+    teacherClassroomIds.has(classroom.id)
+  )
+
+  expect(
+    sharedClassroom,
+    'Seed teacher and student auth users with at least one shared classroom before running student exam-mode e2e tests.',
+  ).toBeTruthy()
+  return sharedClassroom!
+}
+
+async function createActiveOpenResponseTest(
+  teacherPage: Page,
+  classroomId: string,
+  title: string,
+): Promise<AssessmentRecord> {
+  const created = await sendJson<{ quiz: AssessmentRecord }>(teacherPage, 'POST', '/api/teacher/tests', {
+    classroom_id: classroomId,
+    title,
+  })
+
+  const testRecord = created.quiz
+  const draft = await loadJson<{ draft: AssessmentDraftRecord }>(
+    teacherPage,
+    `/api/teacher/tests/${testRecord.id}/draft`,
+  )
+
+  const questionId = crypto.randomUUID()
+  const content = {
+    ...draft.draft.content,
+    title,
+    show_results: false,
+    questions: [
+      {
+        id: questionId,
+        question_type: 'open_response',
+        question_text: 'Explain how you would preserve draft work during exam-mode lock and restoration.',
+        options: [],
+        correct_option: null,
+        answer_key: 'Draft work should stay mounted or be restored from the saved attempt.',
+        sample_solution: null,
+        points: 5,
+        response_max_chars: 2000,
+        response_monospace: false,
+      },
+    ],
+  }
+
+  await sendJson(teacherPage, 'PATCH', `/api/teacher/tests/${testRecord.id}/draft`, {
+    version: draft.draft.version,
+    content,
+  })
+  await sendJson(teacherPage, 'PATCH', `/api/teacher/tests/${testRecord.id}`, {
+    status: 'active',
+  })
+
+  return testRecord
+}
+
+async function cleanupTest(browser: Browser, testId: string | null): Promise<void> {
+  if (!testId) return
+  await withTeacherPage(browser, async (teacherPage) => {
+    await sendJson(teacherPage, 'DELETE', `/api/teacher/tests/${testId}`).catch(() => undefined)
+  })
+}
+
+async function prepareExamWindowForViewportCompliance(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: () => Promise.resolve(),
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1440,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+  })
+}
+
+test.describe('student exam mode', () => {
+  test.use({ storageState: STUDENT_STORAGE })
+
+  test('locks content only after sustained window loss and preserves open-response drafts', async ({ browser, page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const classroom = await withTeacherPage(browser, async (teacherPage) => {
+        const shared = await findSharedClassroom(page, teacherPage)
+        const testRecord = await createActiveOpenResponseTest(teacherPage, shared.id, testTitle)
+        testId = testRecord.id
+        return shared
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      const testCard = page.getByRole('button', { name: new RegExp(testTitle) }).first()
+      await expect(testCard).toBeVisible({ timeout: 15_000 })
+      await testCard.click()
+      await prepareExamWindowForViewportCompliance(page)
+
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      const splitShell = page.locator('[data-testid="student-test-split-container"]')
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+      const responseBox = page.locator('textarea[placeholder="Write your response..."]')
+      await expect(responseBox).toBeVisible()
+      await responseBox.fill('Draft survives exam-mode lock and reload.')
+      await expect(page.getByText('Saved')).toBeVisible({ timeout: 20_000 })
+
+      await page.setViewportSize({ width: 900, height: 500 })
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await expect(page.locator('[data-testid="exam-content-obscurer"]')).toHaveCount(0)
+      await expect(responseBox).toHaveValue('Draft survives exam-mode lock and reload.')
+
+      await page.setViewportSize({ width: 900, height: 500 })
+      const obscurer = page.locator('[data-testid="exam-content-obscurer"]')
+      await expect(obscurer).toBeVisible({ timeout: 5_000 })
+      await expect(page.locator('[data-testid="exam-interaction-blocker"]')).toBeVisible()
+      await expect(responseBox).toBeHidden()
+
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await expect(obscurer).toHaveCount(0)
+      await expect(responseBox).toBeVisible()
+      await expect(responseBox).toHaveValue('Draft survives exam-mode lock and reload.')
+
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+      await expect(responseBox).toHaveValue('Draft survives exam-mode lock and reload.')
+    } finally {
+      await page.setViewportSize({ width: 1440, height: 900 }).catch(() => undefined)
+      await cleanupTest(browser, testId)
+    }
+  })
+})


### PR DESCRIPTION
## Selected flow

Student exam mode: start an active open-response test, verify transient window loss does not lock content, verify sustained window loss hides content and blocks interaction, restore the window, and confirm the saved draft survives reload/restart.

This was chosen because student exam mode is the highest-priority coverage target and currently has deep Vitest/API coverage but no focused Playwright flow for the real student UI.

## Risk profile

exam-mode. The spec covers the compliance grace window, lock/content hiding behavior, restoration, and open-response draft preservation.

## Tests added or updated

- Added `e2e/student-exam-mode.spec.ts`.
- The spec seeds one unique active open-response test through existing teacher API routes, runs the student UI flow, and deletes the seeded test in cleanup.

## Commands run

- `bash scripts/verify-env.sh`
- `pnpm exec playwright test e2e/student-exam-mode.spec.ts`
- `pnpm lint`

## Seeded-data assumptions

- `.auth/teacher.json` and `.auth/student.json` can be generated by the existing Playwright setup.
- The seeded teacher and student users share at least one classroom.
- Test draft, attempt, and selected-student access migrations used by the existing test APIs are applied in the target e2e environment.

## Residual coverage gaps

- Teacher-side exam access open/close and telemetry review still need a separate e2e flow.
- Route-exit telemetry and away/focus duration are still covered mainly by Vitest/API tests, not this Playwright flow.
- Submitted/returned test grading visibility remains outside this focused run.