### PR TITLE
[codex] Polish teacher work action controls

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,102 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Simplify Syllabus tab embed
-
-**Completed:**
-- Removed the published-state top Course site/Syllabus card from teacher and student Syllabus tabs.
-- Published Syllabus now opens directly to the embedded in-Pika course syllabus frame.
-- Kept unpublished teacher/student fallback states so teachers can still reach Course Website Settings when there is no published site.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/ResourcesTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification for Syllabus on `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=resources`:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-
-## 2026-05-06 — Fill Syllabus main content frame
-
-**Completed:**
-- Updated teacher and student Syllabus tabs so the published embed container fills the available main content width and height instead of using a centered max-width wrapper.
-- Preserved stable mobile height for the iframe so the course syllabus remains usable inside the classroom shell.
-
-**Validation:**
-- `pnpm test tests/components/ResourcesTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification for Syllabus on `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=resources`:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-
-## 2026-05-07 — Strip Syllabus framing and simplify generated content
-
-**Completed:**
-- Removed the published Syllabus iframe wrapper/card from teacher and student classroom tabs so the iframe renders directly in the main content area.
-- Simplified `/actual/[slug]` by removing the Grading summary, Resources section, and Current Lesson Sequence.
-- Reduced Classwork rows to assignment title plus approximate course weight only.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/ResourcesTab.test.tsx tests/lib/server/course-sites.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification for Syllabus on `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=resources`:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Standalone syllabus screenshots:
-  - `/tmp/pika-actual-syllabus.png`
-  - `/tmp/pika-actual-syllabus-mobile.png`
-
-## 2026-05-07 — Match actual syllabus to blueprint-style overview
-
-**Completed:**
-- Confirmed the in-Pika course overview comes from `classrooms.course_overview_markdown`, which is seeded from `course_blueprints.overview_markdown` when a classroom is created from a blueprint and then editable per classroom in Settings.
-- Reworked `/actual/[slug]` into a simplified syllabus page with header, Course Overview when present, optional Test Docs, and one Assignments list using A/Q/T labels plus course-weight percentages.
-- Removed the unused Resources publish toggle from Public Syllabus settings and renamed remaining teacher/student-facing course-site labels to syllabus language.
-
-**Validation:**
-- `pnpm test tests/components/ResourcesTab.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/lib/server/course-sites.test.ts tests/lib/validations/teacher.test.ts tests/api/teacher/classrooms-id.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-- Pika UI verification for Syllabus on `/classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=resources`:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Settings screenshot for Public Syllabus labels:
-  - `/tmp/pika-settings-teacher-full.png`
-
-## 2026-05-07 — Harden student log summary privacy
-
-**Completed:**
-- Added direct-identifier redaction for nightly student log summary prompts.
-- Built summary redaction maps from the full classroom roster plus entry authors.
-
-## 2026-05-08 — Skill progression evidence review
-
-**Completed:**
-- Reviewed startup guidance, recent session continuity, and the latest merged PRs/review notes to identify repeated engineering friction.
-- Anchored next-skill recommendations to concrete recent patterns: post-PR coverage gate fixes, multi-pass UI verification, UI/API invariant drift, privacy redaction gaps, and migration rollout compatibility work.
-
-**Validation:**
-- Reviewed `.ai/CURRENT.md`, `docs/ai-instructions.md`, `docs/dev-workflow.md`, `.ai/SESSION-LOG.md`
-- Reviewed GitHub PRs `#559` through `#565` plus PR review notes for `#561` and `#563`
-- Sent OpenAI summary requests with `store: false` and removed model-output snippets from parse errors.
-- Added prompt/payload regression coverage for roster names and common direct identifiers.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/student-log-summary-privacy bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec vitest tests/unit/log-summary.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-06 — Center floating action cluster in shell content
 
 **Completed:**
@@ -328,6 +232,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm vitest run tests/api/student/entries.test.ts tests/components/StudentTodayTabHistory.test.tsx tests/unit/timezone.test.ts`
 - `pnpm test`
+
 ## 2026-05-09 — Test markdown creation defaults
 
 **Completed:**
@@ -449,3 +354,11 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
 - Targeted visual capture:
   - `/tmp/pika-test-edit-code.png`
+
+## 2026-05-11 — Trim session log for CI
+
+**Completed:**
+- Trimmed the rolling session log after PR work so it stays within the enforced 20-entry budget.
+
+**Validation:**
+- `pnpm test tests/unit/ai-startup-docs.test.ts`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -328,3 +328,106 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm vitest run tests/api/student/entries.test.ts tests/components/StudentTodayTabHistory.test.tsx tests/unit/timezone.test.ts`
 - `pnpm test`
+## 2026-05-09 — Test markdown creation defaults
+
+**Completed:**
+- New teacher tests now open directly in the edit dialog's Code view after creation.
+- The created-test Code view starts with markdown editing enabled, so no separate `Edit Markdown` click is required.
+- Draft summary/title changes from markdown now patch the parent tests list state immediately and survive in-flight list refreshes.
+- Added an `Edit Test` option to the selected-test actions dropdown to open the edit modal from the grading workspace.
+- Removed the standalone selected-test pen toggle and later removed the selected-test `Manage Attempts` option plus its row-level attempt-delete mode.
+- Removed the standalone tests-list pen toggle; list reordering now lives behind the tests-list gear FAB, which toggles drag handles and card-level trash buttons.
+- Moved whole-test deletion to the tests-list gear mode as a trash icon on each test card, using the existing confirmation flow.
+- Changed the selected-test actions dropdown delete option to `Delete Selected`, targeting selected student test work only and disabled until one or more student rows are selected.
+- Added a confirmation dialog before selected-test `Open All`/batch-open access updates run.
+- Removed the standalone selected-assignment pen toggle from the grading workspace.
+- Added `Edit Assignment` and `Delete Assignment` to the selected-assignment actions dropdown, with assignment deletion using the existing confirmation flow.
+- Kept the selected-assignment actions dropdown accessible even when no students are selected; only the primary `AI Grade` action is disabled by empty selection.
+- Added focused component coverage for markdown-first creation, editable markdown-only layout startup, title propagation back to the tests list, selected-workspace edit-menu launch, gear-mode card reorder/delete controls, selected-student work deletion, access-open confirmation, and the absence of selected-workspace attempt-management controls.
+- Added focused component coverage for selected-assignment dropdown editing and deletion.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash scripts/verify-env.sh`
+- Visual verification:
+  - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+  - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=assignments'`
+  - `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+  - `/tmp/pika-created-test-code-view.png`
+  - `/tmp/pika-applied-title-list.png`
+  - `/tmp/pika-selected-test-actions-edit-test.png`
+  - `/tmp/pika-test-list-actions-reorder.png`
+  - `/tmp/pika-selected-test-actions-no-manage-attempts.png`
+  - `/tmp/pika-open-all-confirm.png`
+  - `/tmp/pika-delete-test-confirm.png`
+  - `/tmp/pika-test-list-settings-gear-delete.png`
+  - `/tmp/pika-selected-test-actions-delete-selected.png`
+  - `/tmp/pika-delete-selected-test-work-confirm.png`
+  - `/tmp/pika-selected-assignment-detail-after-wait.png`
+  - `/tmp/pika-selected-assignment-actions-delete-loaded.png`
+  - `/tmp/pika-delete-assignment-confirm.png`
+
+## 2026-05-09 — Daily log summary collapse
+
+**Completed:**
+- Removed the Daily tab floating action cluster show/hide button for the class log summary.
+- Changed the class log summary from hidden/shown to expanded/collapsed states.
+- Double-clicking the bottom summary panel collapses it to a 40px bar labeled `Log Summary`.
+- Double-clicking the collapsed bar restores the summary to the standard 180px height.
+- Preserved handle resizing, including dragging upward from the collapsed bar to reopen and resize the panel.
+- Added focused component coverage for double-click collapse/restore and drag-reopen behavior.
+
+**Validation:**
+- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
+- `pnpm lint`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance'`
+- Targeted visual captures:
+  - `/tmp/pika-daily-log-summary-collapsed.png`
+  - `/tmp/pika-daily-log-summary-drag-reopened.png`
+- `pnpm build`
+
+## 2026-05-10 — Submitted-aware test unsubmit action
+
+**Completed:**
+- Confirmed selected-student test-work deletion does not close/open student access; it deletes attempt data only and leaves `test_student_availability` unchanged.
+- Changed the selected-test `Unsubmit Selected` action to enable only when selected rows include submitted work.
+- Filtered batch unsubmit requests so mixed selections submit only the selected students whose work is currently submitted.
+- Added focused component coverage for disabled no-submitted selection and mixed-selection submitted-only unsubmit requests.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+- Targeted visual captures:
+  - `/tmp/pika-unsubmit-disabled-no-submitted-selected.png`
+  - `/tmp/pika-unsubmit-enabled-submitted-selected.png`
+- `pnpm build`
+
+## 2026-05-10 — Test action menu counts
+
+**Completed:**
+- Added compact count badges to the selected-test dropdown items for `AI Grade`, `Unsubmit Selected`, `Return`, and `Delete Selected`.
+- Counts now reflect the current selected rows and action eligibility: selected rows for AI grading/deletion, submitted selected rows for unsubmit, and closed/returnable selected rows for return.
+- Added focused component assertions for the action menu count labels.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+- Targeted visual capture:
+  - `/tmp/pika-test-action-menu-counts.png`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -431,3 +431,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Targeted visual capture:
   - `/tmp/pika-test-action-menu-counts.png`
 - `pnpm build`
+
+## 2026-05-10 — Markdown-only test editor defaults
+
+**Completed:**
+- Made editable markdown-only test editor surfaces enter writable mode by default, including create-test Code view and existing-test Code view.
+- Removed the markdown `Copy` and `Schema` toolbar actions from `QuizDetailPanel`.
+- Removed the now-redundant `startMarkdownEditing` prop plumbing from the tests tab.
+- Updated focused component coverage for default editable markdown-only layout and absent copy/schema actions.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+- Targeted visual capture:
+  - `/tmp/pika-test-edit-code.png`

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -11,7 +11,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react'
-import { Eye, EyeOff, GripHorizontal } from 'lucide-react'
+import { GripHorizontal } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { CalendarDateNavigator } from '@/components/CalendarActionBar'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
@@ -24,7 +24,7 @@ import { addDaysToDateString } from '@/lib/date-string'
 import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
 import { entryHasContent, getAttendanceDotClass, getAttendanceLabel } from '@/lib/attendance'
 import { useClassDaysContext } from '@/hooks/useClassDays'
-import { Button, RefreshingIndicator, Tooltip } from '@/ui'
+import { RefreshingIndicator, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import type { AttendanceStatus } from '@/types'
 import {
@@ -47,6 +47,7 @@ import { format, parseISO } from 'date-fns'
 type SortColumn = 'first_name' | 'last_name' | 'id' | 'status'
 
 const SUMMARY_PANEL_DEFAULT_HEIGHT = 180
+const SUMMARY_PANEL_COLLAPSED_HEIGHT = 40
 const SUMMARY_PANEL_MIN_HEIGHT = 140
 const SUMMARY_PANEL_MAX_HEIGHT = 420
 const SUMMARY_PANEL_KEYBOARD_STEP = 32
@@ -100,7 +101,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const selectedWorkspaceRef = useRef<HTMLDivElement | null>(null)
   const hasLoadedOnceRef = useRef(false)
   const [detailPaneWidth, setDetailPaneWidth] = useState(50)
-  const [summaryPanelVisible, setSummaryPanelVisible] = useState(true)
+  const [summaryPanelCollapsed, setSummaryPanelCollapsed] = useState(false)
   const [summaryPanelHeight, setSummaryPanelHeight] = useState(SUMMARY_PANEL_DEFAULT_HEIGHT)
   const showBlockingSpinner = useDelayedBusy(loading && logs.length === 0)
   const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
@@ -327,21 +328,31 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       selectedRow.email_username
     : ''
   const selectedDateLabel = selectedDate ? format(parseISO(selectedDate), 'EEE MMM d') : 'Select date'
-  const summaryToggleLabel = summaryPanelVisible ? 'Hide class log summary' : 'Show class log summary'
+
+  const handleSummaryPanelDoubleClick = useCallback(() => {
+    setSummaryPanelCollapsed((collapsed) => {
+      if (collapsed) {
+        setSummaryPanelHeight(SUMMARY_PANEL_DEFAULT_HEIGHT)
+      }
+      return !collapsed
+    })
+  }, [])
 
   const handleSummaryResizeStart = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
       event.preventDefault()
-      setSummaryPanelVisible(true)
 
       const startY = event.clientY
-      const startHeight = summaryPanelHeight
+      const collapsedAtStart = summaryPanelCollapsed
+      const startHeight = collapsedAtStart ? SUMMARY_PANEL_COLLAPSED_HEIGHT : summaryPanelHeight
       const previousCursor = document.body.style.cursor
       const previousUserSelect = document.body.style.userSelect
       document.body.style.cursor = 'ns-resize'
       document.body.style.userSelect = 'none'
 
       const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+        if (collapsedAtStart && moveEvent.clientY >= startY) return
+        setSummaryPanelCollapsed(false)
         setSummaryPanelHeight(clampSummaryPanelHeight(startHeight + startY - moveEvent.clientY))
       }
 
@@ -359,55 +370,40 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       window.addEventListener('pointercancel', handleResizeEnd)
       window.addEventListener('blur', handleResizeEnd)
     },
-    [summaryPanelHeight],
+    [summaryPanelCollapsed, summaryPanelHeight],
   )
 
   const handleSummaryResizeKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'ArrowUp') {
         event.preventDefault()
-        setSummaryPanelVisible(true)
-        setSummaryPanelHeight((height) => clampSummaryPanelHeight(height + SUMMARY_PANEL_KEYBOARD_STEP))
+        setSummaryPanelCollapsed(false)
+        setSummaryPanelHeight((height) =>
+          clampSummaryPanelHeight(
+            (summaryPanelCollapsed ? SUMMARY_PANEL_MIN_HEIGHT : height) + SUMMARY_PANEL_KEYBOARD_STEP
+          )
+        )
       } else if (event.key === 'ArrowDown') {
         event.preventDefault()
-        setSummaryPanelVisible(true)
-        setSummaryPanelHeight((height) => clampSummaryPanelHeight(height - SUMMARY_PANEL_KEYBOARD_STEP))
+        if (!summaryPanelCollapsed) {
+          setSummaryPanelHeight((height) => clampSummaryPanelHeight(height - SUMMARY_PANEL_KEYBOARD_STEP))
+        }
       } else if (event.key === 'Home') {
         event.preventDefault()
-        setSummaryPanelVisible(true)
+        setSummaryPanelCollapsed(false)
         setSummaryPanelHeight(SUMMARY_PANEL_MIN_HEIGHT)
       } else if (event.key === 'End') {
         event.preventDefault()
-        setSummaryPanelVisible(true)
+        setSummaryPanelCollapsed(false)
         setSummaryPanelHeight(getSummaryPanelMaxHeight())
       } else if (event.key === 'Enter') {
         event.preventDefault()
-        setSummaryPanelVisible(true)
+        setSummaryPanelCollapsed(false)
         setSummaryPanelHeight(SUMMARY_PANEL_DEFAULT_HEIGHT)
       }
     },
-    [],
+    [summaryPanelCollapsed],
   )
-
-  const summaryToggleButton = selectedDate && !selectedRow ? (
-    <Tooltip content={summaryToggleLabel}>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-9 w-9 px-0"
-        aria-label={summaryToggleLabel}
-        aria-pressed={summaryPanelVisible}
-        onClick={() => setSummaryPanelVisible((visible) => !visible)}
-      >
-        {summaryPanelVisible ? (
-          <EyeOff className="h-4 w-4" aria-hidden="true" />
-        ) : (
-          <Eye className="h-4 w-4" aria-hidden="true" />
-        )}
-      </Button>
-    </Tooltip>
-  ) : null
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
@@ -430,12 +426,6 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
             prevAriaLabel="Previous day"
             nextAriaLabel="Next day"
           />
-          {summaryToggleButton ? (
-            <>
-              <span className="mx-1 h-6 w-px bg-border" aria-hidden="true" />
-              {summaryToggleButton}
-            </>
-          ) : null}
         </div>
       }
       centerPlacement="floating"
@@ -655,39 +645,54 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
         <div className="min-h-[180px] flex-1 overflow-auto rounded-lg bg-surface">
           {renderStudentTable(true)}
         </div>
-        {selectedDate && summaryPanelVisible && (
+        {selectedDate && (
           <section
             role="region"
-            aria-labelledby="class-log-summary-heading"
-            className="flex min-h-[140px] shrink-0 flex-col overflow-hidden rounded-lg bg-surface"
-            style={{ height: `${summaryPanelHeight}px` }}
+            aria-label="Class Log Summary"
+            data-state={summaryPanelCollapsed ? 'collapsed' : 'expanded'}
+            className={
+              summaryPanelCollapsed
+                ? 'flex h-10 min-h-10 shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-surface'
+                : 'flex min-h-[140px] shrink-0 flex-col overflow-hidden rounded-lg bg-surface'
+            }
+            style={{ height: `${summaryPanelCollapsed ? SUMMARY_PANEL_COLLAPSED_HEIGHT : summaryPanelHeight}px` }}
+            onDoubleClick={handleSummaryPanelDoubleClick}
           >
             <div
               role="separator"
               aria-label="Resize class log summary"
               aria-orientation="horizontal"
-              aria-valuemin={SUMMARY_PANEL_MIN_HEIGHT}
+              aria-valuemin={summaryPanelCollapsed ? SUMMARY_PANEL_COLLAPSED_HEIGHT : SUMMARY_PANEL_MIN_HEIGHT}
               aria-valuemax={SUMMARY_PANEL_MAX_HEIGHT}
-              aria-valuenow={summaryPanelHeight}
+              aria-valuenow={summaryPanelCollapsed ? SUMMARY_PANEL_COLLAPSED_HEIGHT : summaryPanelHeight}
               tabIndex={0}
-              className="flex h-5 shrink-0 cursor-ns-resize items-center justify-center border-b border-border text-text-muted outline-none transition-colors hover:bg-surface-hover focus:bg-info-bg focus:text-text-default"
+              className={
+                summaryPanelCollapsed
+                  ? 'flex h-10 shrink-0 cursor-ns-resize items-center justify-center gap-2 px-3 text-sm font-semibold text-text-default outline-none transition-colors hover:bg-surface-hover focus:bg-info-bg'
+                  : 'flex h-5 shrink-0 cursor-ns-resize items-center justify-center border-b border-border text-text-muted outline-none transition-colors hover:bg-surface-hover focus:bg-info-bg focus:text-text-default'
+              }
               onPointerDown={handleSummaryResizeStart}
               onKeyDown={handleSummaryResizeKeyDown}
             >
               <GripHorizontal className="h-4 w-4" aria-hidden="true" />
+              {summaryPanelCollapsed ? <span>Log Summary</span> : null}
             </div>
-            <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
-              <h3 id="class-log-summary-heading" className="truncate text-sm font-semibold text-text-default">
-                Class Log Summary
-              </h3>
-            </div>
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <LogSummary
-                classroomId={classroom.id}
-                date={selectedDate}
-                onStudentClick={selectStudentByName}
-              />
-            </div>
+            {!summaryPanelCollapsed && (
+              <>
+                <div className="flex min-h-10 items-center border-b border-border px-3 py-2">
+                  <h3 className="truncate text-sm font-semibold text-text-default">
+                    Class Log Summary
+                  </h3>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <LogSummary
+                    classroomId={classroom.id}
+                    date={selectedDate}
+                    onStudentClick={selectStudentByName}
+                  />
+                </div>
+              </>
+            )}
           </section>
         )}
       </div>

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1765,6 +1765,39 @@ export function TeacherClassroomView({
         }}
         options={[
           {
+            id: 'edit-assignment',
+            label: (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <Pencil className="h-4 w-4" aria-hidden="true" />
+                <span>Edit Assignment</span>
+              </span>
+            ),
+            onSelect: () => {
+              if (activeSelectedAssignmentData) {
+                setEditAssignment(activeSelectedAssignmentData.assignment)
+              }
+            },
+            disabled: !canEditAssignment,
+          },
+          {
+            id: 'delete-assignment',
+            label: (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap text-danger">
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                <span>Delete Assignment</span>
+              </span>
+            ),
+            onSelect: () => {
+              if (activeSelectedAssignmentData) {
+                setPendingDelete({
+                  id: activeSelectedAssignmentData.assignment.id,
+                  title: activeSelectedAssignmentData.assignment.title,
+                })
+              }
+            },
+            disabled: !activeSelectedAssignmentData || selectedAssignmentLoading || isReadOnly || isDeleting,
+          },
+          {
             id: 'grade-selected',
             label: (
               <span className="inline-flex items-center gap-2 whitespace-nowrap">
@@ -1821,12 +1854,12 @@ export function TeacherClassroomView({
             disabled: isReturnDisabled,
           },
         ]}
-        disabled={isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0}
         className="inline-flex"
-        toggleAriaLabel={`More grading actions${workspaceActionLabelSuffix}`}
+        toggleAriaLabel={`More assignment actions${workspaceActionLabelSuffix}`}
         menuPlacement="down"
         primaryButtonProps={{
           'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+          disabled: isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
         }}
       />
     </Tooltip>
@@ -1878,34 +1911,6 @@ export function TeacherClassroomView({
     </div>
   ) : null
 
-  const editSelectedAssignmentAction = selection.mode === 'assignment' ? (
-    <Tooltip content="Edit assignment">
-      <button
-        type="button"
-        className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-        onClick={() => {
-          if (activeSelectedAssignmentData) {
-            setEditAssignment(activeSelectedAssignmentData.assignment)
-          }
-        }}
-        disabled={!canEditAssignment}
-        aria-label="Edit assignment"
-        title="Edit assignment"
-      >
-        <Pencil className="h-4 w-4" aria-hidden="true" />
-      </button>
-    </Tooltip>
-  ) : null
-
-  const assignmentEditControls = (
-    <TeacherEditModeControls
-      active={assignmentEditMode}
-      onActiveChange={setAssignmentEditMode}
-      disabled={isReadOnly}
-    >
-      {editSelectedAssignmentAction}
-    </TeacherEditModeControls>
-  )
   const assignmentSummaryEditControls = (
     <TeacherEditModeControls
       active={assignmentEditMode}
@@ -1936,7 +1941,6 @@ export function TeacherClassroomView({
         ]}
       />
       {classPaneActions}
-      {assignmentEditControls}
       {workspaceStatus}
     </div>
   ) : null

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -16,7 +16,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Check, ClockAlert, Code, ExternalLink, Lock, LogOut, Pencil, Plus, RotateCcw, Send, Trash2, Unlock } from 'lucide-react'
+import { Check, ClockAlert, Code, ExternalLink, Lock, LogOut, Pencil, Plus, RotateCcw, Send, Settings, Trash2, Unlock } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
@@ -27,7 +27,6 @@ import {
 } from '@/components/AssessmentStatusIndicator'
 import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
-import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
@@ -221,6 +220,40 @@ function formatTestAiGradingRunMessage(run: TestAiGradingRunSummary): {
   }
 }
 
+function withDefaultTestStats(test: Quiz): QuizWithStats {
+  return {
+    ...test,
+    assessment_type: 'test',
+    documents: test.documents,
+    stats: {
+      total_students: 0,
+      responded: 0,
+      submitted: 0,
+      open_access: 0,
+      closed_access: 0,
+      questions_count: 0,
+      ...((test as Partial<QuizWithStats>).stats ?? {}),
+    },
+  }
+}
+
+function applyTestSummaryPatchToTest(
+  test: QuizWithStats,
+  update: AssessmentWorkspaceSummaryPatch
+): QuizWithStats {
+  return {
+    ...test,
+    title: typeof update.title === 'string' ? update.title : test.title,
+    show_results: typeof update.show_results === 'boolean' ? update.show_results : test.show_results,
+    status: update.status ?? test.status,
+    stats: {
+      ...test.stats,
+      questions_count:
+        typeof update.questions_count === 'number' ? update.questions_count : test.stats.questions_count,
+    },
+  }
+}
+
 export function TeacherTestsTab({
   classroom,
   testsTabClickToken = 0,
@@ -247,6 +280,8 @@ export function TeacherTestsTab({
   })
   const latestGradingRequestIdRef = useRef(0)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
+  const selectedTestIdRef = useRef<string | null>(null)
+  const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(null)
 
   const [tests, setTests] = useState<QuizWithStats[]>([])
   const { showMessage } = useAppMessage()
@@ -260,6 +295,7 @@ export function TeacherTestsTab({
   const [showModal, setShowModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
   const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
+  const [startMarkdownEditingTestId, setStartMarkdownEditingTestId] = useState<string | null>(null)
   const [, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
   const [pendingDeleteTest, setPendingDeleteTest] = useState<QuizWithStats | null>(null)
   const [isDeletingTest, setIsDeletingTest] = useState(false)
@@ -307,10 +343,9 @@ export function TeacherTestsTab({
   const [pendingOpenAccessStudent, setPendingOpenAccessStudent] = useState<TestGradingStudentRow | null>(null)
   const [pendingCloseAccessStudent, setPendingCloseAccessStudent] = useState<TestGradingStudentRow | null>(null)
   const [showCloseAccessConfirm, setShowCloseAccessConfirm] = useState(false)
+  const [pendingOpenAccessStudentIds, setPendingOpenAccessStudentIds] = useState<string[] | null>(null)
   const [pendingCloseAccessStudentIds, setPendingCloseAccessStudentIds] = useState<string[] | null>(null)
   const [showBatchGradeModal, setShowBatchGradeModal] = useState(false)
-  const [studentAttemptEditMode, setStudentAttemptEditMode] = useState(false)
-  const [pendingDeleteStudentAttempt, setPendingDeleteStudentAttempt] = useState<TestGradingStudentRow | null>(null)
   const [pendingDeleteStudentAttemptIds, setPendingDeleteStudentAttemptIds] = useState<string[] | null>(null)
   const [isDeletingStudentAttempt, setIsDeletingStudentAttempt] = useState(false)
 
@@ -400,6 +435,15 @@ export function TeacherTestsTab({
     () => batchSelectedStudents.map((student) => student.student_id),
     [batchSelectedStudents]
   )
+  const batchSelectedSubmittedStudents = useMemo(
+    () => batchSelectedStudents.filter((student) => student.status === 'submitted'),
+    [batchSelectedStudents]
+  )
+  const batchSelectedSubmittedStudentIds = useMemo(
+    () => batchSelectedSubmittedStudents.map((student) => student.student_id),
+    [batchSelectedSubmittedStudents]
+  )
+  const batchSelectedSubmittedCount = batchSelectedSubmittedStudents.length
 
   const setSelectedStudentId = useCallback((nextStudentId: string | null) => {
     setInternalSelectedStudentId(nextStudentId)
@@ -478,21 +522,7 @@ export function TeacherTestsTab({
 
   const applyTestSummaryPatch = useCallback((testId: string, update: AssessmentWorkspaceSummaryPatch) => {
     setTests((prev) =>
-      prev.map((test) => {
-        if (test.id !== testId) return test
-
-        return {
-          ...test,
-          title: typeof update.title === 'string' ? update.title : test.title,
-          show_results: typeof update.show_results === 'boolean' ? update.show_results : test.show_results,
-          status: update.status ?? test.status,
-          stats: {
-            ...test.stats,
-            questions_count:
-              typeof update.questions_count === 'number' ? update.questions_count : test.stats.questions_count,
-          },
-        }
-      })
+      prev.map((test) => (test.id === testId ? applyTestSummaryPatchToTest(test, update) : test))
     )
   }, [])
 
@@ -500,14 +530,19 @@ export function TeacherTestsTab({
     (update: AssessmentEditorSummaryUpdate) => {
       if (!selectedTestId) return
 
+      selectedTestDraftSummaryRef.current = update
       setSelectedTestDraftSummary(update)
       applyTestSummaryPatch(selectedTestId, update)
     },
     [applyTestSummaryPatch, selectedTestId]
   )
   const handleSelectedTestDraftSummaryChange = useCallback((update: AssessmentEditorSummaryUpdate) => {
+    if (selectedTestId) {
+      applyTestSummaryPatch(selectedTestId, update)
+    }
+    selectedTestDraftSummaryRef.current = update
     setSelectedTestDraftSummary(update)
-  }, [])
+  }, [applyTestSummaryPatch, selectedTestId])
 
   const loadTests = useCallback(async () => {
     setLoading(true)
@@ -515,13 +550,32 @@ export function TeacherTestsTab({
       const query = new URLSearchParams({ classroom_id: classroom.id })
       const response = await fetch(`${apiBasePath}?${query.toString()}`)
       const data = await response.json()
-      setTests(data.tests || data.quizzes || [])
+      const loadedTests = (data.tests || data.quizzes || []) as QuizWithStats[]
+      const currentSelectedTestId = selectedTestIdRef.current
+      const currentDraftSummary = selectedTestDraftSummaryRef.current
+      setTests(
+        currentSelectedTestId && currentDraftSummary
+          ? loadedTests.map((test) =>
+              test.id === currentSelectedTestId
+                ? applyTestSummaryPatchToTest(test, currentDraftSummary)
+                : test
+            )
+          : loadedTests
+      )
     } catch (error) {
       console.error('Error loading tests:', error)
     } finally {
       setLoading(false)
     }
   }, [classroom.id])
+
+  useEffect(() => {
+    selectedTestIdRef.current = selectedTestId
+  }, [selectedTestId])
+
+  useEffect(() => {
+    selectedTestDraftSummaryRef.current = selectedTestDraftSummary
+  }, [selectedTestDraftSummary])
 
   const loadGradingRows = useCallback(async (options?: { preserveRows?: boolean }) => {
     if (!selectedTestId) {
@@ -636,14 +690,14 @@ export function TeacherTestsTab({
   }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, tests])
 
   useEffect(() => {
+    selectedTestDraftSummaryRef.current = null
     setSelectedTestDraftSummary(null)
-    setStudentAttemptEditMode(false)
-    setPendingDeleteStudentAttempt(null)
     setPendingUnsubmitStudent(null)
     setPendingOpenAccessStudent(null)
     setPendingCloseAccessStudent(null)
     setShowUnsubmitConfirm(false)
     setShowCloseAccessConfirm(false)
+    setPendingOpenAccessStudentIds(null)
     setPendingCloseAccessStudentIds(null)
     setPendingDeleteStudentAttemptIds(null)
   }, [selectedTestId])
@@ -681,7 +735,7 @@ export function TeacherTestsTab({
 
   useEffect(() => {
     if (workspaceState !== 'selected' || selectedWorkspaceTab !== 'grading') return
-    if (!studentAttemptEditMode && batchSelectedCount === 0 && !selectedStudentId) return
+    if (batchSelectedCount === 0 && !selectedStudentId) return
 
     function handleEscape(event: KeyboardEvent) {
       if (event.key !== 'Escape' || event.defaultPrevented) return
@@ -701,7 +755,6 @@ export function TeacherTestsTab({
       }
 
       event.preventDefault()
-      setStudentAttemptEditMode(false)
       clearBatchSelection()
       if (selectedStudentId) {
         selectGradingStudent(null)
@@ -716,7 +769,6 @@ export function TeacherTestsTab({
     selectGradingStudent,
     selectedStudentId,
     selectedWorkspaceTab,
-    studentAttemptEditMode,
     workspaceState,
   ])
 
@@ -991,6 +1043,7 @@ export function TeacherTestsTab({
   }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
   function handleOpenTest(test: QuizWithStats) {
+    setStartMarkdownEditingTestId(null)
     navigateTestWorkspace({ testId: test.id, mode: 'grading', studentId: null })
     setGradingError('')
     setGradingWarning('')
@@ -1001,6 +1054,7 @@ export function TeacherTestsTab({
   function handleEditTest(test: QuizWithStats) {
     handleOpenTest(test)
     setTestEditModalView('edit')
+    setStartMarkdownEditingTestId(null)
     setShowEditModal(true)
   }
 
@@ -1022,13 +1076,26 @@ export function TeacherTestsTab({
   }, [selectedTestId])
 
   function handleNewTest() {
+    setStartMarkdownEditingTestId(null)
     setShowModal(true)
   }
 
-  function handleTestCreated(_test: Quiz) {
+  function handleTestCreated(test: Quiz) {
+    const createdTest = withDefaultTestStats(test)
+
     setShowModal(false)
     setTestEditMode(false)
-    clearTestWorkspace({ replace: true })
+    setHasPendingMarkdownImport(false)
+    selectedTestDraftSummaryRef.current = null
+    setSelectedTestDraftSummary(null)
+    setTests((prev) => {
+      const next = prev.filter((existing) => existing.id !== createdTest.id)
+      return [createdTest, ...next]
+    })
+    navigateTestWorkspace({ testId: createdTest.id, mode: 'grading', studentId: null }, { replace: true })
+    setTestEditModalView('markdown')
+    setStartMarkdownEditingTestId(createdTest.id)
+    setShowEditModal(true)
     window.dispatchEvent(
       new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
     )
@@ -1241,6 +1308,7 @@ export function TeacherTestsTab({
       clearBatchSelection()
       setShowCloseAccessConfirm(false)
       setPendingOpenAccessStudent(null)
+      setPendingOpenAccessStudentIds(null)
       setPendingCloseAccessStudent(null)
       setPendingCloseAccessStudentIds(null)
       await loadGradingRows()
@@ -1255,7 +1323,7 @@ export function TeacherTestsTab({
   async function handleBatchUnsubmit() {
     const targetStudentIds = pendingUnsubmitStudent
       ? [pendingUnsubmitStudent.student_id]
-      : batchSelectedStudentIds
+      : batchSelectedSubmittedStudentIds
     if (!selectedTestId || targetStudentIds.length === 0) return
 
     setIsBatchUnsubmitting(true)
@@ -1292,56 +1360,16 @@ export function TeacherTestsTab({
     }
   }
 
-  async function handleDeleteStudentAttempt() {
-    if (!selectedTestId || !pendingDeleteStudentAttempt) return
-
-    const student = pendingDeleteStudentAttempt
-    setIsDeletingStudentAttempt(true)
-    setGradingError('')
-    setGradingInfo('')
-    try {
-      const response = await fetch(`${apiBasePath}/${selectedTestId}/students/${student.student_id}/attempt`, {
-        method: 'DELETE',
-      })
-      const data = await response.json()
-      if (!response.ok) {
-        throw new Error(data.error || 'Delete failed')
-      }
-
-      const deletedAttempts = Number(data.deleted_attempts ?? 0)
-      const deletedResponses = Number(data.deleted_responses ?? 0)
-      const studentLabel = student.name || student.email || 'student'
-      showMessage({
-        text: deletedAttempts > 0 || deletedResponses > 0
-          ? `Deleted ${studentLabel}'s test work`
-          : `No test work found for ${studentLabel}`,
-        tone: 'info',
-      })
-
-      if (selectedStudentId === student.student_id) {
-        selectGradingStudent(null)
-      }
-      clearBatchSelection()
-      setPendingDeleteStudentAttempt(null)
-      await loadGradingRows()
-      setTestGradingPanelRefreshToken((prev) => prev + 1)
-      onTestGradingDataRefresh?.()
-    } catch (error: any) {
-      setGradingError(error.message || 'Delete failed')
-    } finally {
-      setIsDeletingStudentAttempt(false)
-    }
-  }
-
   async function handleDeleteSelectedStudentAttempts() {
     if (!selectedTestId || !pendingDeleteStudentAttemptIds || pendingDeleteStudentAttemptIds.length === 0) return
 
+    const targetStudentIds = pendingDeleteStudentAttemptIds
     setIsDeletingStudentAttempt(true)
     setGradingError('')
     setGradingInfo('')
     try {
       let deletedCount = 0
-      for (const studentId of pendingDeleteStudentAttemptIds) {
+      for (const studentId of targetStudentIds) {
         const response = await fetch(`${apiBasePath}/${selectedTestId}/students/${studentId}/attempt`, {
           method: 'DELETE',
         })
@@ -1349,6 +1377,7 @@ export function TeacherTestsTab({
         if (!response.ok) {
           throw new Error(data.error || 'Delete failed')
         }
+
         const deletedAttempts = Number(data.deleted_attempts ?? 0)
         const deletedResponses = Number(data.deleted_responses ?? 0)
         if (deletedAttempts > 0 || deletedResponses > 0) {
@@ -1356,12 +1385,8 @@ export function TeacherTestsTab({
         }
       }
 
-      showMessage({
-        text: `Deleted test work for ${deletedCount} student${deletedCount === 1 ? '' : 's'}`,
-        tone: 'info',
-      })
-
-      if (selectedStudentId && pendingDeleteStudentAttemptIds.includes(selectedStudentId)) {
+      setGradingInfo(`Deleted test work for ${deletedCount} student${deletedCount === 1 ? '' : 's'}`)
+      if (selectedStudentId && targetStudentIds.includes(selectedStudentId)) {
         selectGradingStudent(null)
       }
       clearBatchSelection()
@@ -1489,6 +1514,10 @@ export function TeacherTestsTab({
     [sortedGradingStudents]
   )
   const selectedClosedAccessCount = batchSelectedCount - selectedOpenAccessCount
+  const selectedReturnableCount = batchSelectedStudents.filter((student) => {
+    const hasWork = student.status !== 'not_started'
+    return hasWork && getEffectiveStudentAccess(student) === 'closed' && student.ungraded_open_responses === 0
+  }).length
   const shouldOpenSelectedAccess = batchSelectedCount > 0 && selectedClosedAccessCount >= selectedOpenAccessCount
   const accessPrimaryState: 'open' | 'closed' =
     batchSelectedCount > 0
@@ -1497,12 +1526,13 @@ export function TeacherTestsTab({
   const accessPrimaryCount = batchSelectedCount > 0 ? batchSelectedCount : allStudentIds.length
   const accessPrimaryScope = batchSelectedCount > 0 ? 'Selected' : 'All'
   const accessAlternateState: 'open' | 'closed' = accessPrimaryState === 'open' ? 'closed' : 'open'
+  const openAccessConfirmCount = pendingOpenAccessStudentIds?.length ?? batchSelectedCount
   const closeAccessConfirmCount = pendingCloseAccessStudentIds?.length ?? batchSelectedCount
   const pendingCloseAccessStudentLabel =
     pendingCloseAccessStudent?.name || pendingCloseAccessStudent?.email || null
   const unsubmitConfirmTitle = pendingUnsubmitStudent
     ? `Mark ${pendingUnsubmitStudent.name || pendingUnsubmitStudent.email || 'this student'} unsubmitted?`
-    : `Mark ${batchSelectedCount} selected attempt${batchSelectedCount === 1 ? '' : 's'} unsubmitted?`
+    : `Mark ${batchSelectedSubmittedCount} selected attempt${batchSelectedSubmittedCount === 1 ? '' : 's'} unsubmitted?`
   const isAccessActionDisabled =
     !selectedTestWorkspace ||
     isReadOnly ||
@@ -1514,6 +1544,35 @@ export function TeacherTestsTab({
       selectedTestWorkspace.status === 'draft' &&
       (!selectedActivation.valid || checkingActivation || statusUpdating || hasPendingMarkdownImport)) ||
     (accessPrimaryState === 'closed' && allStudentIds.length === 0)
+
+  function renderCountedActionLabel({
+    icon,
+    label,
+    count,
+    danger = false,
+  }: {
+    icon: JSX.Element
+    label: string
+    count: number
+    danger?: boolean
+  }) {
+    return (
+      <span className={['inline-flex w-full items-center justify-between gap-3 whitespace-nowrap', danger ? 'text-danger' : ''].join(' ')}>
+        <span className="inline-flex min-w-0 items-center gap-2">
+          {icon}
+          <span>{label}</span>
+        </span>
+        <span
+          className={[
+            'ml-2 inline-flex min-w-5 justify-center rounded-badge px-1.5 py-0.5 text-xs font-semibold',
+            danger ? 'bg-danger-bg text-danger' : 'bg-surface-2 text-text-muted',
+          ].join(' ')}
+        >
+          {count}
+        </span>
+      </span>
+    )
+  }
 
   function getAccessActionLabel(state: 'open' | 'closed', scope: 'All' | 'Selected', count: number): string {
     const verb = state === 'open' ? 'Open' : 'Close'
@@ -1535,7 +1594,9 @@ export function TeacherTestsTab({
         void handleRequestSelectedTestActivate()
         return
       }
-      void handleBatchStudentAccess('open', { studentIds: targetStudentIds })
+      if (targetStudentIds.length === 0) return
+      setPendingOpenAccessStudent(null)
+      setPendingOpenAccessStudentIds(targetStudentIds)
       return
     }
 
@@ -1703,11 +1764,6 @@ export function TeacherTestsTab({
                     </span>
                   </Tooltip>
                 </th>
-                {studentAttemptEditMode ? (
-                  <th className="w-11 px-2 py-2 font-medium">
-                    <span className="sr-only">Delete student test</span>
-                  </th>
-                ) : null}
               </tr>
             </thead>
             <tbody>
@@ -1873,24 +1929,6 @@ export function TeacherTestsTab({
                         </span>
                       </Tooltip>
                     </td>
-                    {studentAttemptEditMode ? (
-                      <td className="px-2 py-2 text-right">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 px-0 text-danger"
-                          aria-label={`Delete ${student.name || student.email || 'student'} test`}
-                          disabled={isReadOnly || isCombinedTestActionsBusy || isDeletingStudentAttempt}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            setPendingDeleteStudentAttempt(student)
-                          }}
-                        >
-                          <Trash2 className="h-4 w-4" aria-hidden="true" />
-                        </Button>
-                      </td>
-                    ) : null}
                   </tr>
                 )
               })}
@@ -1914,7 +1952,7 @@ export function TeacherTestsTab({
         {
           id: `${accessAlternateState}-${accessPrimaryScope.toLowerCase()}`,
           label: (
-            <span className="inline-flex items-center gap-2">
+            <span className="inline-flex items-center gap-2 whitespace-nowrap">
               {getAccessActionIcon(accessAlternateState)}
               <span>{accessAlternateLabel}</span>
             </span>
@@ -1923,13 +1961,28 @@ export function TeacherTestsTab({
           disabled: accessAlternateDisabled,
         },
         {
-          id: 'ai-grade',
+          id: 'edit-test',
           label: (
-            <span className="inline-flex items-center gap-2">
-              <Check className="h-4 w-4" aria-hidden="true" />
-              <span>AI Grade</span>
+            <span className="inline-flex items-center gap-2 whitespace-nowrap">
+              <Pencil className="h-4 w-4" aria-hidden="true" />
+              <span>Edit Test</span>
             </span>
           ),
+          onSelect: () => {
+            setStartMarkdownEditingTestId(null)
+            setTestEditModalView('edit')
+            setHasPendingMarkdownImport(false)
+            setShowEditModal(true)
+          },
+          disabled: isReadOnly,
+        },
+        {
+          id: 'ai-grade',
+          label: renderCountedActionLabel({
+            icon: <Check className="h-4 w-4" aria-hidden="true" />,
+            label: 'AI Grade',
+            count: batchSelectedCount,
+          }),
           onSelect: () => {
             setShowBatchGradeModal(true)
           },
@@ -1939,32 +1992,30 @@ export function TeacherTestsTab({
         },
         {
           id: 'unsubmit-selected',
-          label: (
-            <span className="inline-flex items-center gap-2">
-              <RotateCcw className="h-4 w-4" aria-hidden="true" />
-              <span>Unsubmit Selected</span>
-            </span>
-          ),
+          label: renderCountedActionLabel({
+            icon: <RotateCcw className="h-4 w-4" aria-hidden="true" />,
+            label: 'Unsubmit Selected',
+            count: batchSelectedSubmittedCount,
+          }),
           onSelect: () => {
-            if (batchSelectedCount === 0) {
-              setGradingWarning('Select students to unsubmit')
+            if (batchSelectedSubmittedCount === 0) {
+              setGradingWarning('Select submitted students to unsubmit')
               return
             }
             setPendingUnsubmitStudent(null)
             setShowUnsubmitConfirm(true)
           },
           disabled:
-            batchSelectedCount === 0 ||
+            batchSelectedSubmittedCount === 0 ||
             isCombinedTestActionsBusy,
         },
         {
           id: 'return',
-          label: (
-            <span className="inline-flex items-center gap-2">
-              <Send className="h-4 w-4" aria-hidden="true" />
-              <span>Return</span>
-            </span>
-          ),
+          label: renderCountedActionLabel({
+            icon: <Send className="h-4 w-4" aria-hidden="true" />,
+            label: 'Return',
+            count: selectedReturnableCount,
+          }),
           onSelect: () => {
             if (batchSelectedCount === 0) {
               setGradingWarning('Select students to return')
@@ -1980,29 +2031,25 @@ export function TeacherTestsTab({
             batchSelectedCount === 0 ||
             isCombinedTestActionsBusy,
         },
-        ...(studentAttemptEditMode
-          ? [
-              {
-                id: 'delete-selected',
-                label: (
-                  <span className="inline-flex items-center gap-2 text-danger">
-                    <Trash2 className="h-4 w-4" aria-hidden="true" />
-                    <span>Delete Selected</span>
-                  </span>
-                ),
-                onSelect: () => {
-                  if (batchSelectedCount === 0) {
-                    setGradingWarning('Select students to delete')
-                    return
-                  }
-                  setPendingDeleteStudentAttemptIds(batchSelectedStudentIds)
-                },
-                disabled:
-                  batchSelectedCount === 0 ||
-                  isCombinedTestActionsBusy,
-              },
-            ]
-          : []),
+        {
+          id: 'delete-selected',
+          label: renderCountedActionLabel({
+            icon: <Trash2 className="h-4 w-4" aria-hidden="true" />,
+            label: 'Delete Selected',
+            count: batchSelectedCount,
+            danger: true,
+          }),
+          onSelect: () => {
+            if (batchSelectedCount === 0) {
+              setGradingWarning('Select students to delete')
+              return
+            }
+            setPendingDeleteStudentAttemptIds(batchSelectedStudentIds)
+          },
+          disabled:
+            batchSelectedCount === 0 ||
+            isCombinedTestActionsBusy,
+        },
       ]}
       variant="secondary"
       size="sm"
@@ -2039,19 +2086,6 @@ export function TeacherTestsTab({
   const selectedWorkspaceControls = workspaceState === 'selected' ? (
     <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
       {selectedTestActions}
-      <Button
-        type="button"
-        variant={studentAttemptEditMode ? 'secondary' : 'ghost'}
-        size="sm"
-        className="h-9 w-9 px-0"
-        aria-label="Edit"
-        title="Edit"
-        aria-pressed={studentAttemptEditMode}
-        disabled={isReadOnly}
-        onClick={() => setStudentAttemptEditMode((prev) => !prev)}
-      >
-        <Pencil className="h-4 w-4" aria-hidden="true" />
-      </Button>
       {workspaceModeStatus}
     </div>
   ) : null
@@ -2116,24 +2150,37 @@ export function TeacherTestsTab({
     <TeacherWorkSurfaceActionBar
       center={
         <div className="flex items-center justify-center gap-1.5">
-          <Tooltip content="Create a new test">
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleNewTest}
+            disabled={isReadOnly}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            <span>New</span>
+          </Button>
+          <Tooltip content={testEditMode ? 'Hide test list controls' : 'Show test list controls'}>
             <Button
-              onClick={handleNewTest}
-              variant="primary"
+              type="button"
+              variant="ghost"
               size="sm"
-              className="gap-1.5"
+              aria-label="Test list settings"
+              title="Test list settings"
+              aria-pressed={testEditMode}
+              className={[
+                'h-9 w-9 px-0',
+                testEditMode
+                  ? 'border-primary/40 bg-info-bg text-primary shadow-inner hover:bg-info-bg-hover hover:text-primary'
+                  : '',
+              ].join(' ')}
+              onClick={() => setTestEditMode((prev) => !prev)}
               disabled={isReadOnly}
             >
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              New
+              <Settings className="h-4 w-4" aria-hidden="true" />
             </Button>
           </Tooltip>
-          <TeacherEditModeControls
-            active={testEditMode}
-            onActiveChange={setTestEditMode}
-            disabled={isReadOnly}
-            variant="secondary"
-          />
         </div>
       }
       centerPlacement="floating"
@@ -2189,13 +2236,7 @@ export function TeacherTestsTab({
               isReadOnly={isReadOnly}
               isDragDisabled={isReorderingTests}
               editMode={testEditMode}
-              onSelect={() => {
-                if (testEditMode) {
-                  handleEditTest(test)
-                  return
-                }
-                handleOpenTest(test)
-              }}
+              onSelect={() => handleOpenTest(test)}
               onRequestPreview={() => handleOpenSavedTestPreview({ testId: test.id, title: test.title })}
               onRequestDelete={() => setPendingDeleteTest(test)}
             />
@@ -2264,6 +2305,7 @@ export function TeacherTestsTab({
           setShowEditModal(false)
           setTestEditModalView('edit')
           setHasPendingMarkdownImport(false)
+          setStartMarkdownEditingTestId(null)
         }}
         ariaLabelledBy="test-edit-title"
         maxWidth="max-w-6xl"
@@ -2313,6 +2355,7 @@ export function TeacherTestsTab({
               setShowEditModal(false)
               setTestEditModalView('edit')
               setHasPendingMarkdownImport(false)
+              setStartMarkdownEditingTestId(null)
             }}
           >
             Close
@@ -2337,6 +2380,7 @@ export function TeacherTestsTab({
               onRequestTestPreview={handleOpenSavedTestPreview}
               showInlineDeleteAction={false}
               testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
+              startMarkdownEditing={startMarkdownEditingTestId === selectedTestWorkspace.id}
               showPreviewButton={false}
               showResultsTab={false}
             />
@@ -2469,6 +2513,22 @@ export function TeacherTestsTab({
       />
 
       <ConfirmDialog
+        isOpen={!!pendingOpenAccessStudentIds}
+        title={`Open access for ${openAccessConfirmCount} student(s)?`}
+        description="Allows students to start or continue. Submission state is unchanged."
+        confirmLabel={isBatchUpdatingAccess ? 'Opening...' : 'Open Access'}
+        cancelLabel="Cancel"
+        isConfirmDisabled={isBatchUpdatingAccess}
+        isCancelDisabled={isBatchUpdatingAccess}
+        onCancel={() => setPendingOpenAccessStudentIds(null)}
+        onConfirm={() => {
+          void handleBatchStudentAccess('open', {
+            studentIds: pendingOpenAccessStudentIds ?? Array.from(batchSelectedIds),
+          })
+        }}
+      />
+
+      <ConfirmDialog
         isOpen={showUnsubmitConfirm}
         title={unsubmitConfirmTitle}
         description="Keeps draft answers. Clears submitted/returned state and finalized grades. Access is unchanged."
@@ -2482,21 +2542,6 @@ export function TeacherTestsTab({
         }}
         onConfirm={() => {
           void handleBatchUnsubmit()
-        }}
-      />
-
-      <ConfirmDialog
-        isOpen={!!pendingDeleteStudentAttempt}
-        title={`Delete ${pendingDeleteStudentAttempt?.name || pendingDeleteStudentAttempt?.email || 'this student'}'s test work?`}
-        description="Deletes answers, grades, and focus history for this student. Access is unchanged."
-        confirmLabel={isDeletingStudentAttempt ? 'Deleting...' : 'Delete Work'}
-        confirmVariant="danger"
-        cancelLabel="Cancel"
-        isConfirmDisabled={isDeletingStudentAttempt}
-        isCancelDisabled={isDeletingStudentAttempt}
-        onCancel={() => setPendingDeleteStudentAttempt(null)}
-        onConfirm={() => {
-          void handleDeleteStudentAttempt()
         }}
       />
 

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -295,7 +295,6 @@ export function TeacherTestsTab({
   const [showModal, setShowModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
   const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
-  const [startMarkdownEditingTestId, setStartMarkdownEditingTestId] = useState<string | null>(null)
   const [, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
   const [pendingDeleteTest, setPendingDeleteTest] = useState<QuizWithStats | null>(null)
   const [isDeletingTest, setIsDeletingTest] = useState(false)
@@ -1043,7 +1042,6 @@ export function TeacherTestsTab({
   }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
   function handleOpenTest(test: QuizWithStats) {
-    setStartMarkdownEditingTestId(null)
     navigateTestWorkspace({ testId: test.id, mode: 'grading', studentId: null })
     setGradingError('')
     setGradingWarning('')
@@ -1054,7 +1052,6 @@ export function TeacherTestsTab({
   function handleEditTest(test: QuizWithStats) {
     handleOpenTest(test)
     setTestEditModalView('edit')
-    setStartMarkdownEditingTestId(null)
     setShowEditModal(true)
   }
 
@@ -1076,7 +1073,6 @@ export function TeacherTestsTab({
   }, [selectedTestId])
 
   function handleNewTest() {
-    setStartMarkdownEditingTestId(null)
     setShowModal(true)
   }
 
@@ -1094,7 +1090,6 @@ export function TeacherTestsTab({
     })
     navigateTestWorkspace({ testId: createdTest.id, mode: 'grading', studentId: null }, { replace: true })
     setTestEditModalView('markdown')
-    setStartMarkdownEditingTestId(createdTest.id)
     setShowEditModal(true)
     window.dispatchEvent(
       new CustomEvent(TEACHER_QUIZZES_UPDATED_EVENT, { detail: { classroomId: classroom.id } })
@@ -1969,7 +1964,6 @@ export function TeacherTestsTab({
             </span>
           ),
           onSelect: () => {
-            setStartMarkdownEditingTestId(null)
             setTestEditModalView('edit')
             setHasPendingMarkdownImport(false)
             setShowEditModal(true)
@@ -2305,7 +2299,6 @@ export function TeacherTestsTab({
           setShowEditModal(false)
           setTestEditModalView('edit')
           setHasPendingMarkdownImport(false)
-          setStartMarkdownEditingTestId(null)
         }}
         ariaLabelledBy="test-edit-title"
         maxWidth="max-w-6xl"
@@ -2355,7 +2348,6 @@ export function TeacherTestsTab({
               setShowEditModal(false)
               setTestEditModalView('edit')
               setHasPendingMarkdownImport(false)
-              setStartMarkdownEditingTestId(null)
             }}
           >
             Close
@@ -2380,7 +2372,6 @@ export function TeacherTestsTab({
               onRequestTestPreview={handleOpenSavedTestPreview}
               showInlineDeleteAction={false}
               testQuestionLayout={testEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
-              startMarkdownEditing={startMarkdownEditingTestId === selectedTestWorkspace.id}
               showPreviewButton={false}
               showResultsTab={false}
             />

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -16,7 +16,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Check, ChevronDown, ChevronUp, Copy, ExternalLink, Plus, RotateCcw, X } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, ExternalLink, Plus, RotateCcw, X } from 'lucide-react'
 import { Button, EmptyState, SplitButton, Tooltip, cn } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { useRefRect } from '@/hooks/use-element-rect'
@@ -34,7 +34,7 @@ import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
-import { markdownToTest, testToMarkdown, TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
+import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
 import type {
   AssessmentEditorSummaryUpdate,
   JsonPatchOperation,
@@ -56,7 +56,6 @@ interface Props {
   onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
   showInlineDeleteAction?: boolean
   testQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
-  startMarkdownEditing?: boolean
   showPreviewButton?: boolean
   showResultsTab?: boolean
   previewRequestToken?: number
@@ -126,7 +125,6 @@ export function QuizDetailPanel({
   onSaveStatusChange,
   showInlineDeleteAction = true,
   testQuestionLayout = 'stacked',
-  startMarkdownEditing = false,
   showPreviewButton = true,
   showResultsTab,
   previewRequestToken = 0,
@@ -492,12 +490,12 @@ export function QuizDetailPanel({
   }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
 
   useEffect(() => {
-    if (!startMarkdownEditing || !isTestsView || !isMarkdownSurfaceEnabled || !isEditable) return
+    if (!usesMarkdownOnlyQuestions || !isEditable) return
 
     setIsMarkdownEditing(true)
     setMarkdownError('')
     setMarkdownInfo('')
-  }, [isEditable, isMarkdownSurfaceEnabled, isTestsView, quiz.id, startMarkdownEditing])
+  }, [isEditable, quiz.id, usesMarkdownOnlyQuestions])
 
   useEffect(() => {
     if (isMarkdownSurfaceEnabled) return
@@ -1217,31 +1215,11 @@ export function QuizDetailPanel({
 
   function handleUndoMarkdownChanges() {
     setMarkdownContent(currentTestMarkdown)
-    setIsMarkdownEditing(false)
+    setIsMarkdownEditing(usesMarkdownOnlyQuestions && isEditable)
     setMarkdownDirty(false)
     markdownDirtyRef.current = false
     setMarkdownError('')
     setMarkdownInfo('')
-  }
-
-  async function handleCopyMarkdown() {
-    try {
-      await navigator.clipboard.writeText(markdownContent)
-      setMarkdownError('')
-      setMarkdownInfo('Markdown copied to clipboard')
-    } catch {
-      setMarkdownError('Failed to copy markdown')
-    }
-  }
-
-  async function handleCopyMarkdownSchema() {
-    try {
-      await navigator.clipboard.writeText(TEST_MARKDOWN_AI_SCHEMA)
-      setMarkdownError('')
-      setMarkdownInfo('Markdown schema copied to clipboard')
-    } catch {
-      setMarkdownError('Failed to copy markdown schema')
-    }
   }
 
   async function handleApplyMarkdown() {
@@ -1311,7 +1289,7 @@ export function QuizDetailPanel({
     emitDraftSummaryChange(nextDraft)
     setMarkdownContent(nextDerivedMarkdown)
     savedMarkdownRef.current = nextDerivedMarkdown
-    setIsMarkdownEditing(false)
+    setIsMarkdownEditing(usesMarkdownOnlyQuestions && isEditable)
     setMarkdownDirty(false)
     markdownDirtyRef.current = false
     setMarkdownError('')
@@ -1407,31 +1385,7 @@ export function QuizDetailPanel({
           {markdownHelperStatus}
         </span>
         <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              void handleCopyMarkdown()
-            }}
-            className="gap-1.5"
-          >
-            <Copy className="h-4 w-4" />
-            Copy
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              void handleCopyMarkdownSchema()
-            }}
-            className="gap-1.5"
-          >
-            <Copy className="h-4 w-4" />
-            Schema
-          </Button>
-          {!isMarkdownEditing ? (
+          {!usesMarkdownOnlyQuestions && !isMarkdownEditing ? (
             <Button
               type="button"
               variant="secondary"

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -56,6 +56,7 @@ interface Props {
   onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
   showInlineDeleteAction?: boolean
   testQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
+  startMarkdownEditing?: boolean
   showPreviewButton?: boolean
   showResultsTab?: boolean
   previewRequestToken?: number
@@ -125,6 +126,7 @@ export function QuizDetailPanel({
   onSaveStatusChange,
   showInlineDeleteAction = true,
   testQuestionLayout = 'stacked',
+  startMarkdownEditing = false,
   showPreviewButton = true,
   showResultsTab,
   previewRequestToken = 0,
@@ -488,6 +490,14 @@ export function QuizDetailPanel({
     }
     savedMarkdownRef.current = currentTestMarkdown
   }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
+
+  useEffect(() => {
+    if (!startMarkdownEditing || !isTestsView || !isMarkdownSurfaceEnabled || !isEditable) return
+
+    setIsMarkdownEditing(true)
+    setMarkdownError('')
+    setMarkdownInfo('')
+  }, [isEditable, isMarkdownSurfaceEnabled, isTestsView, quiz.id, startMarkdownEditing])
 
   useEffect(() => {
     if (isMarkdownSurfaceEnabled) return

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -13,6 +13,7 @@ interface TeacherTestCardProps {
   isReadOnly: boolean
   isDragDisabled?: boolean
   editMode: boolean
+  showDeleteAction?: boolean
   onSelect: () => void
   onRequestPreview: () => void
   onRequestDelete: () => void
@@ -23,11 +24,13 @@ export function TeacherTestCard({
   isReadOnly,
   isDragDisabled = false,
   editMode,
+  showDeleteAction = true,
   onSelect,
   onRequestPreview,
   onRequestDelete,
 }: TeacherTestCardProps) {
   const showEditActions = editMode && !isReadOnly
+  const showDeleteButton = showEditActions && showDeleteAction
   const {
     attributes,
     listeners,
@@ -89,7 +92,7 @@ export function TeacherTestCard({
           type="button"
           onClick={onSelect}
           className="min-w-0 text-left"
-          aria-label={editMode ? `Edit ${test.title}` : test.title}
+          aria-label={editMode ? `Open ${test.title}` : test.title}
         >
           <h3 className={['truncate font-medium', isDraft ? 'text-text-muted' : 'text-text-default'].join(' ')}>
             {test.title}
@@ -131,7 +134,7 @@ export function TeacherTestCard({
               <span>Preview</span>
             </Button>
           </Tooltip>
-          {showEditActions ? (
+          {showDeleteButton ? (
             <Tooltip content="Delete test">
               <Button
                 variant="ghost"

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -1639,6 +1639,54 @@ Correct Option: 2
       })
     })
 
+    it('starts the markdown-only layout in editable mode when requested', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Markdown Creation Test',
+                show_results: false,
+                questions: sampleQuestions,
+              },
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            quiz: {
+              documents: [],
+            },
+          }),
+        })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Markdown Creation Test',
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="markdown-only"
+          startMarkdownEditing
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const textarea = await screen.findByTestId('test-markdown-editor')
+      expect(textarea).toHaveProperty('readOnly', false)
+      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Editing markdown')
+      expect(screen.queryByRole('button', { name: 'Edit Markdown' })).not.toBeInTheDocument()
+    })
+
     it('applies valid markdown and saves through draft endpoint', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       const onQuizUpdate = vi.fn()

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
-import { TEST_MARKDOWN_AI_SCHEMA } from '@/lib/test-markdown'
 import { TooltipProvider } from '@/ui'
 import { createMockQuiz, createMockQuizQuestion } from '../helpers/mocks'
 import type { QuizWithStats, QuizQuestion, QuizResultsAggregate } from '@/types'
@@ -482,9 +481,9 @@ describe('QuizDetailPanel', () => {
       expect(await screen.findByTestId('test-markdown-only-layout')).toBeInTheDocument()
       const markdownEditor = screen.getByTestId('test-markdown-editor') as HTMLTextAreaElement
       expect(markdownEditor.value).toContain('Explain the runtime complexity of your solution.')
-      expect(markdownEditor).toHaveProperty('readOnly', true)
-      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Markdown mirror')
-      expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
+      expect(markdownEditor).toHaveProperty('readOnly', false)
+      expect(screen.getByTestId('markdown-helper-status')).toHaveTextContent('Editing markdown')
+      expect(screen.queryByRole('button', { name: 'Edit Markdown' })).not.toBeInTheDocument()
       expect(screen.queryByTestId('test-editor-only-layout')).not.toBeInTheDocument()
       expect(screen.queryByTestId('test-question-editor-pane')).not.toBeInTheDocument()
       expect(screen.queryByText('Questions (2)')).not.toBeInTheDocument()
@@ -1639,7 +1638,7 @@ Correct Option: 2
       })
     })
 
-    it('starts the markdown-only layout in editable mode when requested', async () => {
+    it('starts the markdown-only layout in editable mode by default', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock
         .mockResolvedValueOnce({
@@ -1676,7 +1675,6 @@ Correct Option: 2
           apiBasePath="/api/teacher/tests"
           onQuizUpdate={vi.fn()}
           testQuestionLayout="markdown-only"
-          startMarkdownEditing
         />,
         { wrapper: Wrapper }
       )
@@ -1896,7 +1894,7 @@ Prompt:
       expect(patchCalls).toHaveLength(0)
     })
 
-    it('copies markdown schema to clipboard', async () => {
+    it('does not show markdown copy or schema actions', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock
         .mockResolvedValueOnce({
@@ -1921,12 +1919,6 @@ Prompt:
           }),
         })
 
-      const clipboardWriteText = vi.fn().mockResolvedValue(undefined)
-      Object.defineProperty(globalThis.navigator, 'clipboard', {
-        value: { writeText: clipboardWriteText },
-        configurable: true,
-      })
-
       const testQuiz = makeQuizWithStats({
         assessment_type: 'test',
         title: 'Markdown Test',
@@ -1947,12 +1939,9 @@ Prompt:
       })
 
       fireEvent.click(screen.getByText('Markdown'))
-      fireEvent.click(screen.getByRole('button', { name: 'Schema' }))
 
-      await waitFor(() => {
-        expect(clipboardWriteText).toHaveBeenCalledWith(TEST_MARKDOWN_AI_SCHEMA)
-      })
-      expect(screen.getByText('Markdown schema copied to clipboard')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Schema' })).not.toBeInTheDocument()
     })
   })
 

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -139,31 +139,34 @@ describe('TeacherAttendanceTab', () => {
     expect(logText).toHaveAttribute('title', longLogText)
     expect(screen.getByText('Class Log Summary')).toBeInTheDocument()
     expect(screen.getByTestId('class-log-summary')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Hide class log summary' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Hide class log summary' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Show class log summary' })).not.toBeInTheDocument()
     expect(screen.getByRole('separator', { name: 'Resize class log summary' })).toBeInTheDocument()
     expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
   })
 
-  it('hides and shows the class log summary from the floating action cluster', async () => {
+  it('collapses and restores the class log summary from a double click', async () => {
     mockLogsFetch()
 
     render(<TeacherAttendanceTab classroom={classroom} />)
 
+    const panel = await screen.findByRole('region', { name: 'Class Log Summary' })
     expect(await screen.findByTestId('class-log-summary')).toBeInTheDocument()
+    expect(panel).toHaveStyle({ height: '180px' })
+    expect(panel).toHaveAttribute('data-state', 'expanded')
 
-    const hideButton = screen.getByRole('button', { name: 'Hide class log summary' })
-    expect(hideButton).toHaveAttribute('aria-pressed', 'true')
-    fireEvent.click(hideButton)
+    fireEvent.doubleClick(panel)
 
     expect(screen.queryByTestId('class-log-summary')).not.toBeInTheDocument()
-    expect(screen.queryByRole('region', { name: 'Class Log Summary' })).not.toBeInTheDocument()
+    expect(panel).toHaveStyle({ height: '40px' })
+    expect(panel).toHaveAttribute('data-state', 'collapsed')
+    expect(screen.getByText('Log Summary')).toBeInTheDocument()
 
-    const showButton = screen.getByRole('button', { name: 'Show class log summary' })
-    expect(showButton).toHaveAttribute('aria-pressed', 'false')
-    fireEvent.click(showButton)
+    fireEvent.doubleClick(panel)
 
     expect(await screen.findByTestId('class-log-summary')).toBeInTheDocument()
-    expect(screen.getByRole('region', { name: 'Class Log Summary' })).toHaveStyle({ height: '180px' })
+    expect(panel).toHaveStyle({ height: '180px' })
+    expect(panel).toHaveAttribute('data-state', 'expanded')
   })
 
   it('resizes the class log summary card from the handle with keyboard controls', async () => {
@@ -186,6 +189,29 @@ describe('TeacherAttendanceTab', () => {
     fireEvent.keyDown(separator, { key: 'ArrowUp' })
     fireEvent.keyDown(separator, { key: 'Enter' })
     expect(panel).toHaveStyle({ height: '180px' })
+  })
+
+  it('reopens the collapsed class log summary by dragging the handle upward', async () => {
+    mockLogsFetch()
+
+    render(<TeacherAttendanceTab classroom={classroom} />)
+
+    const panel = await screen.findByRole('region', { name: 'Class Log Summary' })
+
+    fireEvent.doubleClick(panel)
+    expect(panel).toHaveStyle({ height: '40px' })
+    expect(panel).toHaveAttribute('data-state', 'collapsed')
+
+    fireEvent(
+      screen.getByRole('separator', { name: 'Resize class log summary' }),
+      new MouseEvent('pointerdown', { clientY: 300, bubbles: true })
+    )
+    window.dispatchEvent(new MouseEvent('pointermove', { clientY: 90, bubbles: true }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }))
+
+    expect(await screen.findByTestId('class-log-summary')).toBeInTheDocument()
+    expect(panel).toHaveStyle({ height: '250px' })
+    expect(panel).toHaveAttribute('data-state', 'expanded')
   })
 
   it('returns to the full-width log table after deselecting a selected student', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -647,7 +647,7 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
     })
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
@@ -1011,11 +1011,69 @@ describe('TeacherClassroomView', () => {
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
     expect(screen.getByTestId('assignment-workspace-actionbar-center').parentElement).toHaveClass('fixed')
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Edit assignment' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Edit Assignment' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete Assignment' })).toBeInTheDocument()
 
-    expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Assignment' }))
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Editing Assignment One')
+  })
+
+  it('deletes a selected assignment from the actions dropdown with confirmation', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1' && init?.method === 'DELETE') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Assignment' }))
+
+    expect(await screen.findByText('Delete assignment?')).toBeInTheDocument()
+    expect(screen.getByText(/Assignment One/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/teacher/assignments/assignment-1',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
   })
 
   it('copies the active inspector grade to checked students after confirmation', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -52,7 +52,6 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     onRequestTestPreview,
     onDraftSummaryChange,
     onQuizUpdate,
-    startMarkdownEditing,
   }: {
     quiz: QuizWithStats
     testQuestionLayout?: string
@@ -71,7 +70,6 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       show_results: boolean
       questions_count: number
     }) => void
-    startMarkdownEditing?: boolean
   }) => {
     const [pendingMarkdown, setPendingMarkdown] = useState(false)
 
@@ -81,7 +79,6 @@ vi.mock('@/components/QuizDetailPanel', () => ({
         data-question-layout={testQuestionLayout}
         data-show-preview={String(showPreviewButton)}
         data-show-results={String(showResultsTab)}
-        data-start-markdown-editing={String(startMarkdownEditing)}
       >
         Detail for {quiz.title}
         {showPreviewButton ? (
@@ -526,7 +523,6 @@ describe('TeacherTestsTab', () => {
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
     expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'markdown-only')
-    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-start-markdown-editing', 'true')
     expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Code' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
     onRequestTestPreview,
     onDraftSummaryChange,
     onQuizUpdate,
+    startMarkdownEditing,
   }: {
     quiz: QuizWithStats
     testQuestionLayout?: string
@@ -70,6 +71,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
       show_results: boolean
       questions_count: number
     }) => void
+    startMarkdownEditing?: boolean
   }) => {
     const [pendingMarkdown, setPendingMarkdown] = useState(false)
 
@@ -79,6 +81,7 @@ vi.mock('@/components/QuizDetailPanel', () => ({
         data-question-layout={testQuestionLayout}
         data-show-preview={String(showPreviewButton)}
         data-show-results={String(showResultsTab)}
+        data-start-markdown-editing={String(startMarkdownEditing)}
       >
         Detail for {quiz.title}
         {showPreviewButton ? (
@@ -318,13 +321,22 @@ describe('TeacherTestsTab', () => {
     )
   }
 
+  async function openEditModalFromSelectedTest(title = 'Unit Test') {
+    fireEvent.click(await screen.findByText(title))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit Test' }))
+    return screen.findByTestId('mock-test-detail')
+  }
+
   it('renders the tests list by default with no selected workspace', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     renderTab()
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'Test list settings' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
@@ -337,11 +349,7 @@ describe('TeacherTestsTab', () => {
     fetchMock.mockResolvedValueOnce(makeResultsResponse())
     renderTab({ onSelectTest })
 
-    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Unit Test' }))
-
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    await openEditModalFromSelectedTest()
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Grading' })).not.toBeInTheDocument()
 
@@ -364,15 +372,36 @@ describe('TeacherTestsTab', () => {
     )
   })
 
+  it('opens the edit modal from the selected test actions menu', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.queryByRole('menuitem', { name: 'Manage Attempts' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Delete Test' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit Test' }))
+
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'editor-only')
+    expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Code' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
   it('disables status actions while markdown edits are pending in the edit modal', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
     fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
     renderTab()
 
-    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Unit Test' }))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    await openEditModalFromSelectedTest()
     expect(screen.getByRole('button', { name: 'Open All' })).toBeEnabled()
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
@@ -416,10 +445,7 @@ describe('TeacherTestsTab', () => {
     fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
     renderTab({ onRequestTestPreview })
 
-    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Unit Test' }))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    await openEditModalFromSelectedTest()
     expect(await screen.findByTestId('mock-test-detail')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark editor unsaved' }))
@@ -440,10 +466,7 @@ describe('TeacherTestsTab', () => {
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
-    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Unit Test' }))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    await openEditModalFromSelectedTest()
     expect(screen.getByRole('button', { name: 'Open All' })).toBeEnabled()
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
@@ -466,10 +489,7 @@ describe('TeacherTestsTab', () => {
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
-    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Unit Test' }))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    await openEditModalFromSelectedTest()
     expect(screen.getByRole('button', { name: 'Open All' })).toBeEnabled()
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Unit Test')
@@ -487,21 +507,52 @@ describe('TeacherTestsTab', () => {
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
-  it('returns to the tests list after creating a test', async () => {
+  it('opens a created test in editable code view', async () => {
     mockTestsResponse([])
     renderTab()
 
     expect(await screen.findByText('No tests yet')).toBeInTheDocument()
 
     mockTestsResponse([makeTest({ id: 'created-test-id', title: 'Created Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({
+      quizId: 'created-test-id',
+      quizTitle: 'Created Test',
+      quizStatus: 'draft',
+      students: [],
+    }))
 
     fireEvent.click(screen.getByRole('button', { name: 'New' }))
     fireEvent.click(screen.getByTestId('mock-test-save'))
 
-    expect(await screen.findByText('Created Test')).toBeInTheDocument()
-    expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Created Test')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-question-layout', 'markdown-only')
+    expect(screen.getByTestId('mock-test-detail')).toHaveAttribute('data-start-markdown-editing', 'true')
+    expect(within(screen.getByRole('dialog')).getByRole('button', { name: 'Code' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+  })
+
+  it('updates the tests list from edit modal draft title changes', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    const view = renderTab({ testsTabClickToken: 0 })
+
+    expect(await openEditModalFromSelectedTest()).toHaveTextContent('Detail for Unit Test')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Simulate draft change' }))
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={classroom}
+        testsTabClickToken={1}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Unit Test Draft')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Unit Test')).not.toBeInTheDocument()
   })
 
   it('validates and activates a draft test from the selected test split button', async () => {
@@ -558,6 +609,79 @@ describe('TeacherTestsTab', () => {
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
+  it('confirms and opens access for all students from the selected test split button', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({
+        quizStatus: 'active',
+        students: [
+          {
+            student_id: 'student-1',
+            name: 'Alice Zephyr',
+            first_name: 'Alice',
+            last_name: 'Zephyr',
+            email: 'alice@example.com',
+            status: 'submitted',
+            submitted_at: null,
+            last_activity_at: '2026-04-17T18:15:00.000Z',
+            points_earned: 3,
+            points_possible: 5,
+            percent: 60,
+            graded_open_responses: 0,
+            ungraded_open_responses: 1,
+            access_state: 'closed',
+            effective_access: 'closed',
+            access_source: 'student',
+            focus_summary: null,
+          },
+        ],
+      }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ updated_count: 1, skipped_count: 0, state: 'open' }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'active' }))
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open All' }))
+    expect(await screen.findByText('Open access for 1 student(s)?')).toBeInTheDocument()
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/tests/test-1/student-access'
+      )
+    ).toBe(false)
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Open Access' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/teacher/tests/test-1/student-access',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    const accessCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/tests/test-1/student-access'
+    )
+    expect(accessCall).toBeTruthy()
+    expect(JSON.parse(accessCall?.[1]?.body as string)).toMatchObject({
+      student_ids: ['student-1'],
+      state: 'open',
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close All' })).toBeInTheDocument()
+    })
+    expect(listFetchCalls(fetchMock)).toHaveLength(1)
+  })
+
   it('confirms and closes access for all students from the selected test split button', async () => {
     fetchMock
       .mockResolvedValueOnce({
@@ -581,6 +705,25 @@ describe('TeacherTestsTab', () => {
             status: 'in_progress',
             submitted_at: null,
             last_activity_at: '2026-04-17T18:15:00.000Z',
+            points_earned: 0,
+            points_possible: 5,
+            percent: null,
+            graded_open_responses: 0,
+            ungraded_open_responses: 0,
+            access_state: 'closed',
+            effective_access: 'closed',
+            access_source: 'student',
+            focus_summary: null,
+          },
+          {
+            student_id: 'student-2',
+            name: 'Bob Yellow',
+            first_name: 'Bob',
+            last_name: 'Yellow',
+            email: 'bob@example.com',
+            status: 'in_progress',
+            submitted_at: null,
+            last_activity_at: '2026-04-17T18:10:00.000Z',
             points_earned: 0,
             points_possible: 5,
             percent: null,
@@ -664,18 +807,24 @@ describe('TeacherTestsTab', () => {
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
-  it('shows card reorder and delete controls in edit mode and resets edit mode when tests is revisited', async () => {
+  it('shows card reorder controls from the list actions menu and resets reorder mode when tests is revisited', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     const view = renderTab({ testsTabClickToken: 0 })
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.queryByRole('button', { name: 'Delete Unit Test' })).not.toBeInTheDocument()
+    const settingsButton = screen.getByRole('button', { name: 'Test list settings' })
+    expect(settingsButton).toHaveAttribute('aria-pressed', 'false')
+    fireEvent.click(settingsButton)
 
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: 'Drag to reorder Unit Test' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Delete Unit Test' })).toBeInTheDocument()
+    expect(settingsButton).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(settingsButton)
+    expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
     view.rerender(
       <TeacherTestsTab
         classroom={classroom}
@@ -684,18 +833,28 @@ describe('TeacherTestsTab', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
     })
     expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Delete Unit Test' })).not.toBeInTheDocument()
   })
 
-  it('deletes a test from the summary card edit mode with confirmation', async () => {
+  it('shows whole-test delete in list settings mode', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     renderTab()
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
+
+    expect(screen.getByRole('button', { name: 'Drag to reorder Unit Test' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete Unit Test' })).toBeInTheDocument()
+  })
+
+  it('deletes a test from the list settings card action with confirmation', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    renderTab()
+
+    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
 
     fetchMock
       .mockResolvedValueOnce({
@@ -707,6 +866,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ tests: [] }),
       })
 
+    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete Unit Test' }))
     expect(await screen.findByText('Delete test?')).toBeInTheDocument()
     fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))
@@ -1293,7 +1453,7 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Return' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /Return/ }))
 
     expect(await screen.findByText('Close selected students before returning')).toBeInTheDocument()
     expect(fetchMock.mock.calls.some(([url]) => url === '/api/teacher/tests/test-1/return')).toBe(false)
@@ -1496,6 +1656,25 @@ describe('TeacherTestsTab', () => {
             access_source: 'student',
             focus_summary: null,
           },
+          {
+            student_id: 'student-2',
+            name: 'Bob Yellow',
+            first_name: 'Bob',
+            last_name: 'Yellow',
+            email: 'bob@example.com',
+            status: 'in_progress',
+            submitted_at: null,
+            last_activity_at: '2026-04-17T18:10:00.000Z',
+            points_earned: 0,
+            points_possible: 5,
+            percent: null,
+            graded_open_responses: 0,
+            ungraded_open_responses: 0,
+            access_state: 'closed',
+            effective_access: 'closed',
+            access_source: 'student',
+            focus_summary: null,
+          },
         ],
       }))
       .mockResolvedValueOnce({
@@ -1533,8 +1712,14 @@ describe('TeacherTestsTab', () => {
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
+    fireEvent.click(screen.getByLabelText('Select Bob Yellow'))
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Unsubmit Selected' }))
+    expect(screen.getByRole('menuitem', { name: /AI Grade\s+2/ })).toBeEnabled()
+    expect(screen.getByRole('menuitem', { name: /Unsubmit Selected\s+1/ })).toBeEnabled()
+    expect(screen.getByRole('menuitem', { name: /Return\s+2/ })).toBeEnabled()
+    expect(screen.getByRole('menuitem', { name: /Delete Selected\s+2/ })).toBeEnabled()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Unsubmit Selected/ }))
+    expect(await screen.findByText('Mark 1 selected attempt unsubmitted?')).toBeInTheDocument()
     expect(await screen.findByText(/Access is unchanged/)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Mark Unsubmitted' }))
 
@@ -1552,6 +1737,44 @@ describe('TeacherTestsTab', () => {
     expect(JSON.parse(unsubmitCall?.[1]?.body as string)).toMatchObject({
       student_ids: ['student-1'],
     })
+  })
+
+  it('disables unsubmit selected when selected students have no submitted work', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({
+        students: [
+          {
+            student_id: 'student-1',
+            name: 'Alice Zephyr',
+            first_name: 'Alice',
+            last_name: 'Zephyr',
+            email: 'alice@example.com',
+            status: 'in_progress',
+            submitted_at: null,
+            last_activity_at: '2026-04-17T18:15:00.000Z',
+            points_earned: 0,
+            points_possible: 5,
+            percent: null,
+            graded_open_responses: 0,
+            ungraded_open_responses: 0,
+            focus_summary: null,
+          },
+        ],
+      }))
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+
+    expect(screen.getByRole('menuitem', { name: /Unsubmit Selected\s+0/ })).toBeDisabled()
   })
 
   it('marks one submitted student unsubmitted from the row submitted icon with confirmation', async () => {
@@ -1636,7 +1859,35 @@ describe('TeacherTestsTab', () => {
     })
   })
 
-  it('uses row edit mode to delete one student test with confirmation', async () => {
+  it('clears student selections with Escape while keeping selected-delete in the dropdown', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    const rowCheckbox = screen.getByLabelText('Select Alice Zephyr') as HTMLInputElement
+    fireEvent.click(rowCheckbox)
+
+    expect(rowCheckbox.checked).toBe(true)
+    expect(screen.queryByRole('button', { name: 'Delete Alice Zephyr test' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.queryByRole('menuitem', { name: 'Manage Attempts' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeEnabled()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(rowCheckbox.checked).toBe(false)
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+  })
+
+  it('deletes selected student test work from the selected test actions dropdown', async () => {
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
@@ -1679,13 +1930,16 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(await screen.findByText('Unit Test'))
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Delete Alice Zephyr test' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Delete Alice Zephyr test' }))
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
 
-    expect(await screen.findByText("Delete Alice Zephyr's test work?")).toBeInTheDocument()
-    expect(screen.getByText(/Access is unchanged/)).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete Selected/ }))
+
+    expect(await screen.findByText('Delete 1 selected test work item?')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }))
 
     await waitFor(() => {
@@ -1695,133 +1949,6 @@ describe('TeacherTestsTab', () => {
       )
     })
     expect(await screen.findByLabelText('Status Not started')).toBeInTheDocument()
-  })
-
-  it('shows delete selected in the action dropdown while row edit mode is active', async () => {
-    const students = [
-      {
-        student_id: 'student-1',
-        name: 'Alice Zephyr',
-        first_name: 'Alice',
-        last_name: 'Zephyr',
-        email: 'alice@example.com',
-        status: 'submitted',
-        submitted_at: null,
-        last_activity_at: '2026-04-17T18:15:00.000Z',
-        points_earned: 3,
-        points_possible: 5,
-        percent: 60,
-        graded_open_responses: 0,
-        ungraded_open_responses: 1,
-        effective_access: 'open',
-        access_source: 'test',
-        focus_summary: null,
-      },
-      {
-        student_id: 'student-2',
-        name: 'Bob Yellow',
-        first_name: 'Bob',
-        last_name: 'Yellow',
-        email: 'bob@example.com',
-        status: 'submitted',
-        submitted_at: null,
-        last_activity_at: '2026-04-17T18:16:00.000Z',
-        points_earned: 4,
-        points_possible: 5,
-        percent: 80,
-        graded_open_responses: 1,
-        ungraded_open_responses: 0,
-        effective_access: 'open',
-        access_source: 'test',
-        focus_summary: null,
-      },
-    ]
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
-      })
-      .mockResolvedValueOnce(makeResultsResponse({ students }))
-
-    renderTab()
-
-    fireEvent.click(await screen.findByText('Unit Test'))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
-    expect(await screen.findByText('Bob Yellow')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    expect(screen.queryByRole('menuitem', { name: 'Delete Selected' })).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
-    fireEvent.click(screen.getByLabelText('Select Bob Yellow'))
-
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          deleted_attempts: 1,
-          deleted_responses: 1,
-          deleted_focus_events: 1,
-          deleted_ai_grading_items: 0,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          deleted_attempts: 1,
-          deleted_responses: 1,
-          deleted_focus_events: 0,
-          deleted_ai_grading_items: 0,
-        }),
-      })
-      .mockResolvedValueOnce(makeResultsResponse({ students: [] }))
-
-    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete Selected' }))
-
-    expect(await screen.findByText('Delete 2 selected test work items?')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }))
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        '/api/teacher/tests/test-1/students/student-1/attempt',
-        expect.objectContaining({ method: 'DELETE' })
-      )
-      expect(fetchMock).toHaveBeenCalledWith(
-        '/api/teacher/tests/test-1/students/student-2/attempt',
-        expect.objectContaining({ method: 'DELETE' })
-      )
-    })
-  })
-
-  it('turns off row edit mode and clears student selections with Escape', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
-      })
-      .mockResolvedValueOnce(makeResultsResponse())
-
-    renderTab()
-
-    fireEvent.click(await screen.findByText('Unit Test'))
-    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
-
-    const rowCheckbox = screen.getByLabelText('Select Alice Zephyr') as HTMLInputElement
-    fireEvent.click(rowCheckbox)
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-
-    expect(rowCheckbox.checked).toBe(true)
-    expect(screen.getByRole('button', { name: 'Delete Alice Zephyr test' })).toBeInTheDocument()
-
-    fireEvent.keyDown(window, { key: 'Escape' })
-
-    expect(rowCheckbox.checked).toBe(false)
-    expect(screen.queryByRole('button', { name: 'Delete Alice Zephyr test' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('starts a background AI grading run, polls it, and refreshes rows on completion', async () => {
@@ -1911,7 +2038,7 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'AI Grade' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /AI Grade/ }))
     fireEvent.click(await screen.findByRole('button', { name: 'Grade with AI' }))
 
     await waitFor(() => {
@@ -1932,7 +2059,7 @@ describe('TeacherTestsTab', () => {
     )
   })
 
-  it('does not expose the AI prompt or whole-test delete options', async () => {
+  it('does not expose the AI prompt or legacy destructive options', async () => {
     const onRequestDelete = vi.fn()
     fetchMock
       .mockResolvedValueOnce({
@@ -1950,6 +2077,8 @@ describe('TeacherTestsTab', () => {
 
     expect(screen.queryByRole('menuitem', { name: 'AI Prompt' })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Delete Test' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
     expect(screen.queryByRole('menuitem', { name: 'Clear Open Grades' })).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Grading strategy')).not.toBeInTheDocument()
     expect(screen.queryByText('Grading strategy')).not.toBeInTheDocument()
@@ -1969,13 +2098,13 @@ describe('TeacherTestsTab', () => {
     await screen.findByText('Alice Zephyr')
 
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
-    expect(screen.getByRole('menuitem', { name: 'AI Grade' })).toBeDisabled()
+    expect(screen.getByRole('menuitem', { name: /AI Grade/ })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
     fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
 
-    expect(screen.getByRole('menuitem', { name: 'AI Grade' })).toBeEnabled()
+    expect(screen.getByRole('menuitem', { name: /AI Grade/ })).toBeEnabled()
   })
 
   it('reloads the list once when the update event fires', async () => {


### PR DESCRIPTION
## Summary
- Default new test markdown editing into Code view and keep markdown-applied titles reflected in the tests list.
- Move test and assignment destructive actions into their contextual dropdowns/list controls, with test card delete exposed from the gear-powered list settings mode.
- Make selected-test student actions clearer with selected-work deletion, submitted-aware unsubmit behavior, action count badges, and Open All confirmation.
- Update the Daily log summary panel so double-click collapses/restores it and remove the old FAB show/hide button.

## Validation
- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
- `pnpm test tests/components/TeacherClassroomView.test.tsx`
- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
- `pnpm test tests/components/TeacherTestsTab.test.tsx`
- `pnpm lint`
- `pnpm build`
- tests-tab and assignments-tab UI verification via `.codex/skills/pika-ui-verify/scripts/ui_verify.sh`
- targeted Playwright screenshots for markdown creation, action dropdowns, delete/open confirmations, daily log collapse, and counted test action menu states

## Notes
- This PR intentionally keeps selected-student test-work deletion from changing student access; the attempt deletion API continues to leave `test_student_availability` untouched.
- PR is draft for review pass and CI signal.