### PR TITLE
[codex] Fix stale student log date

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-08 — Shared assessment status indicator mapping
-
-**Completed:**
-- Added `AssessmentStatusIndicator` with centralized student-work status display mappings for assignments, test grading rows, and gradebook assessment details.
-- Replaced local status/icon switches in the assignment student table, teacher test grading table, and gradebook student inspector.
-- Preserved the assignment resubmitted chip and submitted-test unsubmit button while routing both through the shared status mapping.
-
-**Validation:**
-- `pnpm test tests/components/AssessmentStatusIndicator.test.tsx tests/components/AssessmentStatusIcon.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3003 pnpm e2e:auth`
-- `git diff --check`
-- Pika UI verification script for `/classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=gradebook` on port 3003:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-
 ## 2026-05-06 — Simplify Syllabus tab embed
 
 **Completed:**
@@ -332,3 +314,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-teacher-mobile.png`
   - `/tmp/pika-student.png`
+
+## 2026-05-11 — Fix stale student log date
+
+**Completed:**
+- Fixed Student Today autosave so a stale mounted tab rechecks the current Toronto date before building the save payload.
+- Cleared stale entry identity/version state when the mounted date rolls over, preventing first/new saves from targeting an old day.
+- Added a regression test for a tab mounted on May 6 that saves after today advances to May 11.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm lint`
+- `pnpm vitest run tests/api/student/entries.test.ts tests/components/StudentTodayTabHistory.test.tsx tests/unit/timezone.test.ts`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -84,12 +84,14 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
   const pendingContentRef = useRef<TiptapContent | null>(null)
   const entryIdRef = useRef<string | null>(null)
   const entryVersionRef = useRef(1)
+  const todayRef = useRef('')
 
   useEffect(() => {
     async function load() {
       setLoading(true)
       try {
         const todayDate = getTodayInToronto()
+        todayRef.current = todayDate
         setToday(todayDate)
 
         const historyCacheKey = getStudentEntryHistoryCacheKey({
@@ -182,7 +184,18 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
     newContent: TiptapContent,
     options?: { forceFull?: boolean }
   ) => {
-    if (!today) return
+    const currentToday = getTodayInToronto()
+    const entryDate = currentToday || todayRef.current
+    if (!entryDate) return
+
+    if (todayRef.current !== entryDate) {
+      todayRef.current = entryDate
+      setToday(entryDate)
+      entryIdRef.current = null
+      entryVersionRef.current = 1
+      lastSavedContentRef.current = JSON.stringify(EMPTY_DOC)
+      setConflictEntry(null)
+    }
 
     // Don't create a new DB record for empty content (e.g. TipTap mount normalization)
     const newContentStr = JSON.stringify(newContent)
@@ -224,7 +237,7 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
       patch?: JsonPatchOperation[]
     } = {
       classroom_id: classroom.id,
-      date: today,
+      date: entryDate,
       entry_id: entryIdRef.current ?? undefined,
       version: entryVersionRef.current,
     }
@@ -284,7 +297,7 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
       setSaveStatus('unsaved')
       setSaveError(err.message || 'Failed to save')
     }
-  }, [MAX_CHARS, classroom.id, today, updateHistoryEntries, notifications])
+  }, [MAX_CHARS, classroom.id, updateHistoryEntries, notifications])
 
   const scheduleSave = useCallback((
     newContent: TiptapContent,

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -5,9 +5,43 @@ import { StudentTodayTab } from '@/app/classrooms/[classroomId]/StudentTodayTab'
 import { getStudentEntryHistoryCacheKey } from '@/lib/student-entry-history'
 import type { Classroom, Entry } from '@/types'
 
+const getTodayInTorontoMock = vi.hoisted(() => vi.fn(() => '2025-12-16'))
+
 vi.mock('@/lib/timezone', () => ({
-  getTodayInToronto: () => '2025-12-16',
+  getTodayInToronto: getTodayInTorontoMock,
 }))
+
+vi.mock('@/components/editor', async () => {
+  const React = await import('react')
+
+  function toContent(text: string) {
+    if (!text) return { type: 'doc', content: [] }
+    return {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text }],
+        },
+      ],
+    }
+  }
+
+  function toText(content: any): string {
+    return content?.content?.[0]?.content?.[0]?.text ?? ''
+  }
+
+  return {
+    RichTextEditor: ({ content, onBlur, onChange, placeholder }: any) =>
+      React.createElement('textarea', {
+        'aria-label': placeholder,
+        onBlur,
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+          onChange(toContent(event.currentTarget.value)),
+        value: toText(content),
+      }),
+  }
+})
 
 vi.mock('@/ui', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/ui')>()
@@ -21,6 +55,8 @@ vi.mock('@/hooks/useClassDays', () => ({
   useClassDaysContext: () => ({
     classDays: [
       { id: 'd1', classroom_id: 'c1', date: '2025-12-16', prompt_text: null, is_class_day: true },
+      { id: 'd2', classroom_id: 'c1', date: '2025-05-06', prompt_text: null, is_class_day: true },
+      { id: 'd3', classroom_id: 'c1', date: '2025-05-11', prompt_text: null, is_class_day: true },
     ],
     isLoading: false,
     refresh: vi.fn(),
@@ -79,9 +115,10 @@ function mockJson(data: any, ok = true) {
 
 describe('StudentTodayTab history section', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
+    getTodayInTorontoMock.mockReturnValue('2025-12-16')
     window.sessionStorage.clear()
     document.cookie = 'pika_student_today_history=; Max-Age=0; Path=/'
-    vi.restoreAllMocks()
   })
 
   afterEach(() => {
@@ -174,5 +211,61 @@ describe('StudentTodayTab history section', () => {
       )
       expect(entryFetchCalls).toHaveLength(0)
     })
+  })
+
+  it('saves against the current Toronto date when the mounted date is stale', async () => {
+    getTodayInTorontoMock.mockReturnValue('2025-05-06')
+
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        return mockJson({
+          entry: {
+            id: 'entry-today',
+            student_id: 's1',
+            classroom_id: classroom.id,
+            date: body.date,
+            text: 'Worked today',
+            rich_content: body.rich_content,
+            version: 1,
+            minutes_reported: null,
+            mood: null,
+            created_at: '2025-05-11T14:00:00Z',
+            updated_at: '2025-05-11T14:00:00Z',
+            on_time: true,
+          },
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    getTodayInTorontoMock.mockReturnValue('2025-05-11')
+
+    fireEvent.change(editor, { target: { value: 'Worked today' } })
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/student/entries',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+    })
+
+    const saveCall = fetchMock.mock.calls.find(([input, init]) =>
+      String(input) === '/api/student/entries' && init?.method === 'PATCH'
+    )
+    expect(saveCall).toBeDefined()
+    expect(JSON.parse(String(saveCall?.[1]?.body)).date).toBe('2025-05-11')
   })
 })


### PR DESCRIPTION
## Summary

Fixes a Student Today autosave bug where a tab mounted on an older date could keep saving new work to that old date. The save path now rechecks the current Toronto date immediately before building the `/api/student/entries` payload and clears stale entry identity/version state when the day has changed.

## Root Cause

`StudentTodayTab` computed `today` once during component load and reused that state in later autosaves. If a student kept the classroom tab open across days, a first or stale-entry save could still post to the date from when the tab mounted, for example May 6 instead of May 11.

## Impact

Students who have never written a log, or who have not written in a while and keep the tab open, should now save to the actual current Toronto day. Existing server-side class-day and future-date validation still applies.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx`
- `pnpm lint`
- `pnpm vitest run tests/api/student/entries.test.ts tests/components/StudentTodayTabHistory.test.tsx tests/unit/timezone.test.ts`
- `pnpm test`