### PR TITLE
[codex] Add mixed classwork material ordering

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,93 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-06 — Center floating action cluster in shell content
-
-**Completed:**
-- Added a shared shell CSS variable for the main content center based on current left and right panel widths.
-- Updated the teacher work-surface floating action cluster to center on that shell variable on desktop and animate with the shell timing.
-- Added focused coverage for the desktop centering contract.
-
-**Validation:**
-- `pnpm test tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/ThreePanelProvider.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification on port 3001:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student-today.png`
-  - `/tmp/pika-teacher-mobile.png`
-  - `/tmp/pika-teacher-expanded.png`
-
-## 2026-05-06 — Keep calendar date in action bar
-
-**Completed:**
-- Removed the pinned app-header title labels from teacher classroom tabs.
-- Kept the calendar date navigator in the PageActionBar left slot and removed the obsolete calendar titlebar docking path.
-- Left non-calendar teacher action bars without static tab labels.
-- Added mobile-only spacing so the fixed calendar control cluster does not overlap the left-side date navigator.
-
-**Validation:**
-- `pnpm test tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification on port 3001:
-  - `/tmp/pika-teacher-calendar-desktop.png`
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-  - `/tmp/pika-teacher-attendance-labels.png`
-
-## 2026-05-07 — Make edit controls icon-only
-
-**Completed:**
-- Removed visible `Edit` text from shared teacher edit-mode controls and the selected-test workspace edit toggle.
-- Kept accessible names and titles on the icon-only pencil buttons.
-- Added focused coverage that the shared edit toggle remains named `Edit` without visible button text.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fab-rail-centering bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherEditModeControls.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherAttendanceTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification on port 3001:
-  - `/tmp/pika-teacher-tests-edit-icon.png`
-  - `/tmp/pika-teacher-selected-test-edit-icon.png`
-  - `/tmp/pika-teacher-classrooms-edit-icon.png`
-
-## 2026-05-07 — Shorten assessment new labels
-
-**Completed:**
-- Changed teacher quiz and test summary action labels from `New Quiz` and `New Test` to `New`.
-- Kept the plus icon visible so the action reads as `+ New`.
-- Updated focused quiz/test component coverage for the shorter accessible button name.
-
-**Validation:**
-- `pnpm test tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification on port 3001:
-  - `/tmp/pika-teacher-tests-new-label.png`
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-
-## 2026-05-07 — Add create action tooltips
-
-**Completed:**
-- Added contextual tooltips to the compact teacher summary `+ New` buttons for assignments, quizzes, and tests.
-- Kept the visible button labels unchanged and preserved the assignment button's accessible name.
-- Updated the assignment action-bar test to assert the fixed floating cluster without depending on the tooltip-adjusted DOM parent chain.
-
-**Validation:**
-- `pnpm test tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verification on port 3001 for assignments, quizzes, and tests.
-- Hover screenshots:
-  - `/tmp/pika-teacher-assignments-new-tooltip.png`
-  - `/tmp/pika-teacher-quizzes-new-tooltip.png`
-  - `/tmp/pika-teacher-tests-new-tooltip.png`
-
 ## 2026-05-07 — Hide classroom view labels outside edit mode
 
 **Completed:**
@@ -362,3 +275,99 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/unit/ai-startup-docs.test.ts`
+
+## 2026-05-11 — Mixed classwork material ordering
+
+**Completed:**
+- Added material `position` migration and mixed assignment/material classwork ordering.
+- Added teacher classwork reorder API for `{ type, id }` item lists.
+- Moved classwork reorder persistence into transaction-backed Postgres RPC functions.
+- Hardened classwork reorder requests to reject stale partial lists while preserving assignment-only reorder around material position slots.
+- Made assignment/material create routes fail closed on unexpected mixed-order position lookup errors.
+- Preserved existing material positions when the assignment Markdown bulk-save path rewrites assignment positions.
+- Updated teacher classwork summary so materials are visually distinct and draggable in edit mode.
+- Updated student classwork summary to render the same mixed order with distinct material cards.
+- Refined material cards to use tint plus a left accent rail instead of an icon, keeping the Syllabus icon reserved for Syllabus.
+- Documented the material card/order behavior in assignment UX guidance.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classwork-material-order bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/lib/classwork-order.test.ts tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/api/teacher/assignments.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- Post-iconless refinement:
+  - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+  - `pnpm lint`
+- Final pre-push validation:
+  - `pnpm test tests/api/teacher/classwork-reorder.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm build`
+- Transactional reorder fix:
+  - `pnpm test tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/assignments-reorder.test.ts tests/api/teacher/assignments-bulk.test.ts tests/api/teacher/assignments.test.ts tests/api/teacher/materials.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+  - `pnpm lint`
+  - `pnpm build`
+  - `supabase db lint --local --schema public --fail-on error` (existing unrelated warning: `public.unsubmit_test_attempts_atomic` unused `p_updated_by`)
+  - `pnpm test`
+- Visual verification:
+  - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=assignments'`
+  - `/tmp/pika-teacher-material.png`
+  - `/tmp/pika-student-material.png`
+  - `/tmp/pika-teacher-material-dark.png`
+  - `/tmp/pika-student-material-dark.png`
+  - `/tmp/pika-teacher-material-tinted.png`
+  - `/tmp/pika-student-material-tinted.png`
+  - `/tmp/pika-student-material-tinted-dark.png`
+
+## 2026-05-11 — Classwork migration filename resequence
+
+**Completed:**
+- Renamed the mixed classwork material ordering migration from a timestamped filename to the next numeric-leading Pika migration slot, `067_classwork_mixed_ordering.sql`.
+
+**Validation:**
+- `bash scripts/verify-env.sh` exposed an unrelated session-log length failure before trimming.
+- `node scripts/trim-session-log.mjs`
+
+## 2026-05-11 — Remove material card outline highlight
+
+**Completed:**
+- Removed the primary outline and left accent rail from teacher and student material cards while keeping the soft tint and `Material` label.
+- Added component assertions to keep material cards on neutral borders without the primary rail.
+- Updated assignment UX guidance to describe tint-based material differentiation.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=assignments'` captured the route but local DB state returned "Classroom not found".
+- Supplemental CSS visual harness:
+  - `/tmp/pika-material-no-outline-harness.png`
+  - `/tmp/pika-material-no-outline-harness-dark.png`
+
+## 2026-05-11 — Smooth material drag treatment
+
+**Completed:**
+- Removed the material card's hover transition while it is actively dragging so dnd-kit owns transform movement like assignment cards.
+- Added a neutral drag-border option to the shared teacher work item frame and used it for material cards.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkItemPrimitives.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Pika UI verify captured the target route but local DB state still returned "Classroom not found".
+- Supplemental drag-state harness:
+  - `/tmp/pika-material-drag-state-harness.png`
+
+## 2026-05-11 — Restrict classwork reorder RPC execution
+
+**Completed:**
+- Added explicit `revoke all` from `public`, `anon`, and `authenticated` for the new classwork reorder RPCs.
+- Granted both reorder RPCs only to `service_role`, matching the API route authorization boundary.
+- Added a static migration regression test for the RPC grant contract.
+
+**Validation:**
+- `pnpm test tests/unit/classwork-migration-rpc-grants.test.ts tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/assignments-reorder.test.ts`
+- `pnpm lint`
+- `supabase db lint --local --schema public --fail-on error` (existing unrelated warning: `public.unsubmit_test_attempts_atomic` unused `p_updated_by`)
+- `pnpm build`

--- a/docs/guidance/assignment-ux-language.md
+++ b/docs/guidance/assignment-ux-language.md
@@ -209,6 +209,15 @@ What matters:
 - status is compact
 - actions do not dominate the row
 
+### Classwork materials
+
+Materials share the assignment summary stream but remain visually distinct:
+
+- materials can be interleaved with assignments and reordered in edit mode
+- material cards use the same compact card rhythm, plus a soft tint and `Material` label
+- material cards do not show due-date, submission, grading, or gradebook metadata
+- assignment and material domain behavior stays separate even when the list order is shared
+
 ### Student card structure
 
 The student assignment card is simpler:

--- a/src/app/api/student/classrooms/[id]/materials/route.ts
+++ b/src/app/api/student/classrooms/[id]/materials/route.ts
@@ -11,6 +11,11 @@ function isMissingMaterialsTableError(error: any) {
   return error?.code === 'PGRST205' || String(error?.message || '').includes('classwork_materials')
 }
 
+function isMissingMaterialsPositionError(error: any) {
+  const message = String(error?.message || '')
+  return error?.code === 'PGRST204' || (message.includes('position') && message.includes('classwork_materials'))
+}
+
 export const GET = withErrorHandler('GetStudentClassworkMaterials', async (_request, context) => {
   const user = await requireRole('student')
   const { id: classroomId } = await context.params
@@ -21,12 +26,27 @@ export const GET = withErrorHandler('GetStudentClassworkMaterials', async (_requ
   }
 
   const supabase = getServiceRoleClient()
-  const { data: materials, error } = await supabase
+  const ordered = await supabase
     .from('classwork_materials')
     .select('*')
     .eq('classroom_id', classroomId)
     .eq('is_draft', false)
-    .order('released_at', { ascending: false })
+    .order('position', { ascending: true })
+    .order('released_at', { ascending: true })
+
+  let materials = ordered.data
+  let error = ordered.error
+
+  if (error && isMissingMaterialsPositionError(error)) {
+    const fallback = await supabase
+      .from('classwork_materials')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .eq('is_draft', false)
+      .order('released_at', { ascending: false })
+    materials = fallback.data
+    error = fallback.error
+  }
 
   if (error) {
     if (isMissingMaterialsTableError(error)) {

--- a/src/app/api/teacher/assignments/bulk/route.ts
+++ b/src/app/api/teacher/assignments/bulk/route.ts
@@ -19,6 +19,16 @@ interface BulkAssignmentInput {
 
 const MAX_ASSIGNMENTS = 50
 
+function isMissingClassworkMaterialPositionError(error: any) {
+  const message = String(error?.message || '')
+  return (
+    error?.code === 'PGRST205' ||
+    error?.code === 'PGRST204' ||
+    message.includes('classwork_materials') ||
+    (message.includes('position') && message.includes('schema cache'))
+  )
+}
+
 function isLiveAssignment(
   assignment: { is_draft: boolean; released_at: string | null },
   now: Date = new Date()
@@ -37,6 +47,25 @@ function isLiveAssignment(
   }
 
   return releaseDate <= now
+}
+
+function buildAssignmentPositions(
+  inputAssignments: BulkAssignmentInput[],
+  reservedMaterialPositions: number[],
+) {
+  const reserved = new Set(reservedMaterialPositions)
+  const positions = new Map<BulkAssignmentInput, number>()
+  let nextPosition = 0
+
+  for (const assignment of inputAssignments) {
+    while (reserved.has(nextPosition)) {
+      nextPosition++
+    }
+    positions.set(assignment, nextPosition)
+    nextPosition++
+  }
+
+  return positions
 }
 
 /**
@@ -159,6 +188,27 @@ export const POST = withErrorHandler('PostTeacherAssignmentsBulk', async (reques
     return NextResponse.json({ errors }, { status: 400 })
   }
 
+  const materialPositionsResult = await supabase
+    .from('classwork_materials')
+    .select('position')
+    .eq('classroom_id', classroom_id)
+
+  if (
+    materialPositionsResult.error &&
+    !isMissingClassworkMaterialPositionError(materialPositionsResult.error)
+  ) {
+    console.error('Error fetching classwork material positions:', materialPositionsResult.error)
+    return NextResponse.json(
+      { error: 'Failed to save assignments' },
+      { status: 500 }
+    )
+  }
+
+  const materialPositions = (materialPositionsResult.data || [])
+    .map((material: { position?: number | null }) => material.position)
+    .filter((position: unknown): position is number => typeof position === 'number' && Number.isFinite(position))
+  const assignmentPositions = buildAssignmentPositions(inputAssignments, materialPositions)
+
   // Process assignments: separate creates and updates
   const toCreate: BulkAssignmentInput[] = []
   const toUpdate: BulkAssignmentInput[] = []
@@ -186,7 +236,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentsBulk', async (reques
         description: instructionFields.description,
         rich_instructions: instructionFields.rich_instructions,
         due_at: a.due_at,
-        position: a.position,
+        position: assignmentPositions.get(a) ?? a.position,
         is_draft: true, // New assignments are always drafts
         created_by: user.id,
       }
@@ -225,7 +275,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentsBulk', async (reques
       description: instructionFields.description,
       rich_instructions: instructionFields.rich_instructions,
       due_at: a.due_at,
-      position: a.position,
+      position: assignmentPositions.get(a) ?? a.position,
       is_draft: a.is_draft,
     }
 

--- a/src/app/api/teacher/assignments/reorder/route.ts
+++ b/src/app/api/teacher/assignments/reorder/route.ts
@@ -7,6 +7,25 @@ import { withErrorHandler } from '@/lib/api-handler'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+function getKnownAssignmentReorderError(error: any) {
+  const message = String(error?.message || '')
+
+  if (message === 'Assignment list changed. Refresh and try again.') {
+    return { status: 409, message }
+  }
+
+  if (
+    message === 'assignment_ids must be an array' ||
+    message === 'assignment_ids must include strings' ||
+    message === 'assignment_ids must be unique' ||
+    message === 'One or more assignments not found in classroom'
+  ) {
+    return { status: 400, message }
+  }
+
+  return null
+}
+
 // POST /api/teacher/assignments/reorder
 // body: { classroom_id: string, assignment_ids: string[] }
 export const POST = withErrorHandler('PostTeacherAssignmentsReorder', async (request, context) => {
@@ -33,31 +52,17 @@ export const POST = withErrorHandler('PostTeacherAssignmentsReorder', async (req
 
   const supabase = getServiceRoleClient()
 
-  // Verify all IDs belong to the classroom
-  const { data: assignments, error: assignmentsError } = await supabase
-    .from('assignments')
-    .select('id')
-    .eq('classroom_id', classroom_id)
-    .in('id', uniqueIds)
+  const { error } = await supabase.rpc('reorder_assignments_preserve_materials', {
+    p_classroom_id: classroom_id,
+    p_assignment_ids: uniqueIds,
+  })
 
-  if (assignmentsError) {
-    console.error('Error verifying assignments:', assignmentsError)
-    return NextResponse.json({ error: 'Failed to verify assignments' }, { status: 500 })
-  }
-
-  if ((assignments || []).length !== uniqueIds.length) {
-    return NextResponse.json({ error: 'One or more assignments not found in classroom' }, { status: 400 })
-  }
-
-  const results = await Promise.all(
-    uniqueIds.map((id, index) =>
-      supabase.from('assignments').update({ position: index }).eq('id', id)
-    )
-  )
-  const updateError = results.find((r) => r.error)?.error ?? null
-
-  if (updateError) {
-    console.error('Error reordering assignments:', updateError)
+  if (error) {
+    const knownError = getKnownAssignmentReorderError(error)
+    if (knownError) {
+      return NextResponse.json({ error: knownError.message }, { status: knownError.status })
+    }
+    console.error('Error reordering assignments:', error)
     return NextResponse.json({ error: 'Failed to reorder assignments' }, { status: 500 })
   }
 

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -10,6 +10,16 @@ import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/ass
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+function isMissingClassworkMaterialPositionError(error: any) {
+  const message = String(error?.message || '')
+  return (
+    error?.code === 'PGRST205' ||
+    error?.code === 'PGRST204' ||
+    message.includes('classwork_materials') ||
+    (message.includes('position') && message.includes('schema cache'))
+  )
+}
+
 // GET /api/teacher/assignments?classroom_id=xxx - List assignments for a classroom
 export const GET = withErrorHandler('GetTeacherAssignments', async (request, context) => {
   const user = await requireRole('teacher')
@@ -132,16 +142,41 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
 
   const supabase = getServiceRoleClient()
 
-  const lastAssignmentResult = await supabase
-    .from('assignments')
-    .select('position')
-    .eq('classroom_id', classroom_id)
-    .order('position', { ascending: false })
-    .limit(1)
-    .maybeSingle()
+  const [lastAssignmentResult, lastMaterialResult] = await Promise.all([
+    supabase
+      .from('assignments')
+      .select('position')
+      .eq('classroom_id', classroom_id)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('classwork_materials')
+      .select('position')
+      .eq('classroom_id', classroom_id)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ])
 
-  const nextPosition =
-    typeof lastAssignmentResult.data?.position === 'number' ? lastAssignmentResult.data.position + 1 : 0
+  const lastAssignmentPosition =
+    typeof lastAssignmentResult.data?.position === 'number' ? lastAssignmentResult.data.position : -1
+  const lastMaterialPosition =
+    !lastMaterialResult.error && typeof lastMaterialResult.data?.position === 'number'
+      ? lastMaterialResult.data.position
+      : -1
+
+  if (lastAssignmentResult.error) {
+    console.error('Error fetching last assignment position:', lastAssignmentResult.error)
+    return NextResponse.json({ error: 'Failed to create assignment' }, { status: 500 })
+  }
+
+  if (lastMaterialResult.error && !isMissingClassworkMaterialPositionError(lastMaterialResult.error)) {
+    console.error('Error fetching last material position:', lastMaterialResult.error)
+    return NextResponse.json({ error: 'Failed to create assignment' }, { status: 500 })
+  }
+
+  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition) + 1
 
   const instructionFields = buildAssignmentInstructionFields(
     typeof instructions_markdown === 'string'
@@ -163,7 +198,9 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
     track_authenticity: true,
   }
 
-  if (!lastAssignmentResult.error) {
+  if (isMissingClassworkMaterialPositionError(lastMaterialResult.error)) {
+    insertBody.position = lastAssignmentPosition + 1
+  } else {
     insertBody.position = nextPosition
   }
 

--- a/src/app/api/teacher/classrooms/[id]/classwork/reorder/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/classwork/reorder/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+type ReorderItem = {
+  type?: 'assignment' | 'material'
+  id?: string
+}
+
+function getUniqueItemKeys(items: ReorderItem[]) {
+  return items.map((item) => `${item.type}:${item.id}`)
+}
+
+function getKnownReorderError(error: any) {
+  const message = String(error?.message || '')
+
+  if (message === 'Classwork list changed. Refresh and try again.') {
+    return { status: 409, message }
+  }
+
+  if (
+    message === 'items must be an array' ||
+    message === 'items must include type and id' ||
+    message === 'items must be unique' ||
+    message === 'One or more classwork items not found in classroom'
+  ) {
+    return { status: 400, message }
+  }
+
+  return null
+}
+
+export const POST = withErrorHandler('PostTeacherClassworkReorder', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id: classroomId } = await context.params
+  const body = await request.json()
+  const items = (body as { items?: ReorderItem[] }).items
+
+  if (!Array.isArray(items)) {
+    return NextResponse.json({ error: 'items are required' }, { status: 400 })
+  }
+
+  const invalidItem = items.find((item) => (
+    !item ||
+    (item.type !== 'assignment' && item.type !== 'material') ||
+    typeof item.id !== 'string' ||
+    item.id.length === 0
+  ))
+  if (invalidItem) {
+    return NextResponse.json({ error: 'items must include type and id' }, { status: 400 })
+  }
+
+  const itemKeys = getUniqueItemKeys(items)
+  if (new Set(itemKeys).size !== itemKeys.length) {
+    return NextResponse.json({ error: 'items must be unique' }, { status: 400 })
+  }
+
+  const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
+  if (!ownership.ok) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { error } = await supabase.rpc('reorder_classwork_items', {
+    p_classroom_id: classroomId,
+    p_items: items,
+  })
+
+  if (error) {
+    const knownError = getKnownReorderError(error)
+    if (knownError) {
+      return NextResponse.json({ error: knownError.message }, { status: knownError.status })
+    }
+    console.error('Error reordering classwork:', error)
+    return NextResponse.json({ error: 'Failed to reorder classwork' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+})

--- a/src/app/api/teacher/classrooms/[id]/materials/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/materials/route.ts
@@ -16,6 +16,11 @@ function isMissingMaterialsTableError(error: any) {
   return error?.code === 'PGRST205' || String(error?.message || '').includes('classwork_materials')
 }
 
+function isMissingMaterialsPositionError(error: any) {
+  const message = String(error?.message || '')
+  return error?.code === 'PGRST204' || (message.includes('position') && message.includes('classwork_materials'))
+}
+
 export const GET = withErrorHandler('GetTeacherClassworkMaterials', async (_request, context) => {
   const user = await requireRole('teacher')
   const { id: classroomId } = await context.params
@@ -26,11 +31,25 @@ export const GET = withErrorHandler('GetTeacherClassworkMaterials', async (_requ
   }
 
   const supabase = getServiceRoleClient()
-  const { data: materials, error } = await supabase
+  const ordered = await supabase
     .from('classwork_materials')
     .select('*')
     .eq('classroom_id', classroomId)
-    .order('created_at', { ascending: false })
+    .order('position', { ascending: true })
+    .order('created_at', { ascending: true })
+
+  let materials = ordered.data
+  let error = ordered.error
+
+  if (error && isMissingMaterialsPositionError(error)) {
+    const fallback = await supabase
+      .from('classwork_materials')
+      .select('*')
+      .eq('classroom_id', classroomId)
+      .order('created_at', { ascending: false })
+    materials = fallback.data
+    error = fallback.error
+  }
 
   if (error) {
     if (isMissingMaterialsTableError(error)) {
@@ -68,16 +87,56 @@ export const POST = withErrorHandler('PostTeacherClassworkMaterial', async (requ
   }
 
   const supabase = getServiceRoleClient()
+  const [lastAssignmentResult, lastMaterialResult] = await Promise.all([
+    supabase
+      .from('assignments')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('classwork_materials')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ])
+  const lastAssignmentPosition = typeof lastAssignmentResult.data?.position === 'number'
+    ? lastAssignmentResult.data.position
+    : -1
+  const lastMaterialPosition = !lastMaterialResult.error && typeof lastMaterialResult.data?.position === 'number'
+    ? lastMaterialResult.data.position
+    : -1
+
+  if (lastAssignmentResult.error) {
+    console.error('Error fetching last assignment position:', lastAssignmentResult.error)
+    return NextResponse.json({ error: 'Failed to create material' }, { status: 500 })
+  }
+
+  if (lastMaterialResult.error && !isMissingMaterialsPositionError(lastMaterialResult.error)) {
+    console.error('Error fetching last material position:', lastMaterialResult.error)
+    return NextResponse.json({ error: 'Failed to create material' }, { status: 500 })
+  }
+
+  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition) + 1
+  const insertBody: Record<string, unknown> = {
+    classroom_id: classroomId,
+    title: cleanTitle,
+    content,
+    is_draft: !!isDraft,
+    released_at: isDraft ? null : new Date().toISOString(),
+    created_by: user.id,
+  }
+
+  if (!isMissingMaterialsPositionError(lastMaterialResult.error)) {
+    insertBody.position = nextPosition
+  }
+
   const { data: material, error } = await supabase
     .from('classwork_materials')
-    .insert({
-      classroom_id: classroomId,
-      title: cleanTitle,
-      content,
-      is_draft: !!isDraft,
-      released_at: isDraft ? null : new Date().toISOString(),
-      created_by: user.id,
-    })
+    .insert(insertBody)
     .select()
     .single()
 

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { BookOpen, Pencil } from 'lucide-react'
+import { Pencil } from 'lucide-react'
 import { Button, Card, ContentDialog, EmptyState, RefreshingIndicator } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
@@ -17,6 +17,7 @@ import { RichTextViewer } from '@/components/editor'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { fetchJSONWithCache } from '@/lib/request-cache'
+import { buildOrderedClassworkItems } from '@/lib/classwork-order'
 
 interface Props {
   classroom: Classroom
@@ -109,6 +110,11 @@ export function StudentAssignmentsTab({
     if (!selectedMaterialId) return null
     return materials.find((material) => material.id === selectedMaterialId) ?? null
   }, [materials, selectedMaterialId])
+
+  const classworkItems = useMemo(
+    () => buildOrderedClassworkItems(assignments, materials),
+    [assignments, materials],
+  )
 
   const view: StudentAssignmentsView = useMemo(() => {
     if (selectedMaterialId && selectedMaterial) return 'material'
@@ -268,58 +274,64 @@ export function StudentAssignmentsTab({
                 />
               ) : (
                 <PageStack>
-                  {materials.map((material) => (
-                    <button
-                      key={material.id}
-                      type="button"
-                      data-testid="material-card"
-                      onClick={() => navigate({ materialId: material.id })}
-                      className="block w-full rounded-card border border-border bg-surface-panel px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel"
-                    >
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0">
-                          <h3 className="truncate text-base font-semibold text-text-default">
-                            {material.title}
-                          </h3>
-                          <p className="mt-1 inline-flex items-center gap-1 text-sm text-text-muted">
-                            <BookOpen className="h-4 w-4" aria-hidden="true" />
-                            Material
-                          </p>
-                        </div>
-                        <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-primary">
-                          Posted
-                        </span>
-                      </div>
-                    </button>
-                  ))}
-                  {assignments.map((assignment) => (
-                    <button
-                      key={assignment.id}
-                      type="button"
-                      data-testid="assignment-card"
-                      onClick={() => navigate({ assignmentId: assignment.id })}
-                      className="block w-full rounded-card border border-border bg-surface-panel px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel"
-                    >
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0">
-                          <h3 className="truncate text-base font-semibold text-text-default">
-                            {assignment.title}
-                          </h3>
-                          <p className="mt-1 text-sm text-text-muted">
-                            {formatDueDate(assignment.due_at)}
-                          </p>
-                          <p className="mt-1 text-xs uppercase tracking-[0.16em] text-text-muted">
-                            {formatRelativeDueDate(assignment.due_at)}
-                          </p>
-                        </div>
-                        <span
-                          className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getAssignmentStatusBadgeClass(assignment.status)}`}
+                  {classworkItems.map((item) => {
+                    if (item.type === 'material') {
+                      const material = item.material
+                      return (
+                        <button
+                          key={material.id}
+                          type="button"
+                          data-testid="material-card"
+                          onClick={() => navigate({ materialId: material.id })}
+                          className="block w-full rounded-card border border-border bg-info-bg px-5 py-4 text-left transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-info-bg-hover hover:shadow-panel"
                         >
-                          {getAssignmentStatusLabel(assignment.status)}
-                        </span>
-                      </div>
-                    </button>
-                  ))}
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0">
+                              <h3 className="truncate text-base font-semibold text-text-default">
+                                {material.title}
+                              </h3>
+                              <p className="mt-1 text-sm text-primary">
+                                Material
+                              </p>
+                            </div>
+                            <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-primary">
+                              Posted
+                            </span>
+                          </div>
+                        </button>
+                      )
+                    }
+
+                    const assignment = item.assignment
+                    return (
+                      <button
+                        key={assignment.id}
+                        type="button"
+                        data-testid="assignment-card"
+                        onClick={() => navigate({ assignmentId: assignment.id })}
+                        className="block w-full rounded-card border border-border bg-surface-panel px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel"
+                      >
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0">
+                            <h3 className="truncate text-base font-semibold text-text-default">
+                              {assignment.title}
+                            </h3>
+                            <p className="mt-1 text-sm text-text-muted">
+                              {formatDueDate(assignment.due_at)}
+                            </p>
+                            <p className="mt-1 text-xs uppercase tracking-[0.16em] text-text-muted">
+                              {formatRelativeDueDate(assignment.due_at)}
+                            </p>
+                          </div>
+                          <span
+                            className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getAssignmentStatusBadgeClass(assignment.status)}`}
+                          >
+                            {getAssignmentStatusLabel(assignment.status)}
+                          </span>
+                        </div>
+                      </button>
+                    )
+                  })}
                 </PageStack>
               )
             ) : view === 'material' && selectedMaterial ? (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -14,14 +14,17 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
+  useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import {
   BarChart3,
   Check,
   ChevronLeft,
   ChevronRight,
   Copy,
+  GripVertical,
   LoaderCircle,
   MessageSquare,
   Pencil,
@@ -67,6 +70,7 @@ import {
   parseAssignmentWorkspaceStudentId,
   type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
+import { buildOrderedClassworkItems } from '@/lib/classwork-order'
 import type {
   Classroom,
   Assignment,
@@ -142,29 +146,77 @@ function TeacherMaterialCard({
   material,
   isReadOnly,
   editMode,
+  isDragDisabled,
   onOpen,
   onDelete,
 }: {
   material: ClassworkMaterial
   isReadOnly: boolean
   editMode: boolean
+  isDragDisabled: boolean
   onOpen: () => void
   onDelete: () => void
 }) {
   const showEditActions = editMode && !isReadOnly
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: material.id, disabled: isReadOnly || isDragDisabled || !editMode })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: isDragging ? undefined : transition,
+  }
 
   return (
     <TeacherWorkItemCardFrame
+      ref={setNodeRef}
+      style={style}
       onClick={onOpen}
       tone={material.is_draft ? 'muted' : 'default'}
-      className="cursor-pointer"
+      interactive={material.is_draft}
+      dragging={isDragging}
+      dragTone="neutral"
+      className={[
+        'cursor-pointer',
+        material.is_draft
+          ? ''
+          : isDragging
+            ? 'bg-info-bg'
+            : 'bg-info-bg transition hover:-translate-y-px hover:bg-info-bg-hover hover:shadow-panel',
+      ].join(' ')}
     >
       <div
         className={[
           'grid items-center gap-3',
-          showEditActions ? 'grid-cols-[minmax(0,1fr)_auto]' : 'grid-cols-[minmax(0,1fr)]',
+          showEditActions
+            ? 'grid-cols-[auto_minmax(0,1fr)_auto]'
+            : 'grid-cols-[minmax(0,1fr)]',
         ].join(' ')}
       >
+        {showEditActions && (
+          <button
+            type="button"
+            className={[
+              'p-1 -ml-1 touch-none transition-colors',
+              isDragDisabled
+                ? 'text-text-muted cursor-default'
+                : 'text-text-muted hover:text-text-default cursor-grab active:cursor-grabbing',
+            ].join(' ')}
+            {...attributes}
+            {...listeners}
+            aria-label="Drag to reorder material"
+            disabled={isDragDisabled}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <GripVertical className="h-5 w-5" aria-hidden="true" />
+          </button>
+        )}
+
         <button
           type="button"
           onClick={(event) => {
@@ -175,15 +227,17 @@ function TeacherMaterialCard({
           aria-label={`Open ${material.title}`}
         >
           <span className="min-w-0">
-            <span
-              className={[
-                'block truncate font-medium',
-                material.is_draft ? 'text-text-muted' : 'text-text-default',
-              ].join(' ')}
-            >
-              {material.title}
+            <span className="min-w-0">
+              <span
+                className={[
+                  'block truncate font-medium',
+                  material.is_draft ? 'text-text-muted' : 'text-text-default',
+                ].join(' ')}
+              >
+                {material.title}
+              </span>
+              <span className="block text-xs text-primary">Material</span>
             </span>
-            <span className="block text-xs text-text-muted">Material</span>
           </span>
 
           <span className="whitespace-nowrap px-2 text-center">
@@ -612,14 +666,9 @@ export function TeacherClassroomView({
     invalidateCachedJSON(`student-materials:${classroom.id}`)
     setMaterials((current) => {
       const exists = current.some((item) => item.id === material.id)
-      const next = exists
+      return exists
         ? current.map((item) => (item.id === material.id ? material : item))
         : [material, ...current]
-      return next.sort((a, b) => {
-        const aTime = new Date(a.created_at).getTime()
-        const bTime = new Date(b.created_at).getTime()
-        return bTime - aTime
-      })
     })
     setEditMaterial(null)
     setIsMaterialModalOpen(false)
@@ -668,30 +717,56 @@ export function TeacherClassroomView({
     return () => observer.disconnect()
   }, [selection.mode, leftPaneView, selectedStudentId])
 
+  const classworkItems = useMemo(
+    () => buildOrderedClassworkItems(assignments, materials),
+    [assignments, materials],
+  )
+
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event
       if (!over || active.id === over.id || isReordering || isReadOnly || !assignmentEditMode) return
 
-      const oldIndex = assignments.findIndex((a) => a.id === active.id)
-      const newIndex = assignments.findIndex((a) => a.id === over.id)
+      const oldIndex = classworkItems.findIndex((item) => item.id === active.id)
+      const newIndex = classworkItems.findIndex((item) => item.id === over.id)
 
       if (oldIndex === -1 || newIndex === -1) return
 
       // Optimistically update local state
-      const reordered = arrayMove(assignments, oldIndex, newIndex)
-      setAssignments(reordered)
+      const reordered = arrayMove(classworkItems, oldIndex, newIndex)
+      setAssignments(
+        reordered.flatMap((item, position) => (
+          item.type === 'assignment'
+            ? [{ ...item.assignment, position }]
+            : []
+        )),
+      )
+      setMaterials(
+        reordered.flatMap((item, position) => (
+          item.type === 'material'
+            ? [{ ...item.material, position }]
+            : []
+        )),
+      )
 
       // Persist to server
       setIsReordering(true)
       try {
-        const orderedIds = reordered.map((a) => a.id)
-        await fetch('/api/teacher/assignments/reorder', {
+        const response = await fetch(`/api/teacher/classrooms/${classroom.id}/classwork/reorder`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ classroom_id: classroom.id, assignment_ids: orderedIds }),
+          body: JSON.stringify({
+            items: reordered.map((item) => ({ type: item.type, id: item.id })),
+          }),
         })
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}))
+          throw new Error(data.error || 'Failed to save classwork order')
+        }
         invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+        invalidateCachedJSON(`teacher-materials:${classroom.id}`)
+        invalidateCachedJSON(`student-assignments:${classroom.id}`)
+        invalidateCachedJSON(`student-materials:${classroom.id}`)
         // Notify sidebar to refresh
         window.dispatchEvent(
           new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
@@ -699,15 +774,15 @@ export function TeacherClassroomView({
           })
         )
       } catch (err) {
-        console.error('Failed to reorder assignments:', err)
-        setError('Failed to save assignment order. Please try again.')
+        console.error('Failed to reorder classwork:', err)
+        setError('Failed to save classwork order. Please try again.')
         // Reload to restore server state on error
         loadAssignments()
       } finally {
         setIsReordering(false)
       }
     },
-    [assignmentEditMode, assignments, classroom.id, isReordering, isReadOnly, loadAssignments]
+    [assignmentEditMode, classroom.id, classworkItems, isReordering, isReadOnly, loadAssignments]
   )
 
   useEffect(() => {
@@ -2015,30 +2090,36 @@ export function TeacherClassroomView({
     </div>
   ) : (
     <TeacherWorkItemList>
-      {materials.map((material) => (
-        <TeacherMaterialCard
-          key={material.id}
-          material={material}
-          isReadOnly={isReadOnly}
-          editMode={assignmentEditMode}
-          onOpen={() => {
-            setEditMaterial(material)
-            setIsMaterialModalOpen(true)
-          }}
-          onDelete={() => setPendingMaterialDelete(material)}
-        />
-      ))}
-      {assignments.length > 0 ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={classworkItems.map((item) => item.id)}
+          strategy={verticalListSortingStrategy}
         >
-          <SortableContext
-            items={assignments.map((assignment) => assignment.id)}
-            strategy={verticalListSortingStrategy}
-          >
-            {assignments.map((assignment) => (
+          {classworkItems.map((item) => {
+            if (item.type === 'material') {
+              const material = item.material
+              return (
+                <TeacherMaterialCard
+                  key={material.id}
+                  material={material}
+                  isReadOnly={isReadOnly}
+                  isDragDisabled={isReordering}
+                  editMode={assignmentEditMode}
+                  onOpen={() => {
+                    setEditMaterial(material)
+                    setIsMaterialModalOpen(true)
+                  }}
+                  onDelete={() => setPendingMaterialDelete(material)}
+                />
+              )
+            }
+
+            const assignment = item.assignment
+            return (
               <SortableAssignmentCard
                 key={assignment.id}
                 assignment={assignment}
@@ -2055,10 +2136,10 @@ export function TeacherClassroomView({
                 onEdit={() => setEditAssignment(assignment)}
                 onDelete={() => setPendingDelete({ id: assignment.id, title: assignment.title })}
               />
-            ))}
-          </SortableContext>
-        </DndContext>
-      ) : null}
+            )
+          })}
+        </SortableContext>
+      </DndContext>
     </TeacherWorkItemList>
   )
 

--- a/src/components/teacher-work-surface/TeacherWorkItemCardFrame.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkItemCardFrame.tsx
@@ -11,6 +11,7 @@ interface TeacherWorkItemCardFrameProps extends HTMLAttributes<HTMLDivElement> {
   tone?: TeacherWorkItemCardTone
   interactive?: boolean
   dragging?: boolean
+  dragTone?: 'primary' | 'neutral'
   className?: string
   style?: CSSProperties
 }
@@ -21,6 +22,7 @@ export const TeacherWorkItemCardFrame = forwardRef(function TeacherWorkItemCardF
     tone = 'default',
     interactive = true,
     dragging = false,
+    dragTone = 'primary',
     className,
     ...props
   }: TeacherWorkItemCardFrameProps,
@@ -39,7 +41,10 @@ export const TeacherWorkItemCardFrame = forwardRef(function TeacherWorkItemCardF
               ? 'border-border-strong bg-surface-2'
               : 'border-border bg-surface-panel',
         dragging
-          ? 'z-50 scale-[1.02] border-primary opacity-95 shadow-panel'
+          ? [
+              'z-50 scale-[1.02] opacity-95 shadow-panel',
+              dragTone === 'neutral' ? 'border-border' : 'border-primary',
+            ].join(' ')
           : interactive && tone === 'scheduled'
             ? 'transition hover:border-warning hover:bg-warning-bg'
             : interactive && tone === 'muted'

--- a/src/lib/classwork-order.ts
+++ b/src/lib/classwork-order.ts
@@ -1,0 +1,75 @@
+export type OrderedClassworkItem<TAssignment, TMaterial> =
+  | {
+      id: string
+      type: 'assignment'
+      position: number
+      createdAt: string
+      title: string
+      assignment: TAssignment
+    }
+  | {
+      id: string
+      type: 'material'
+      position: number
+      createdAt: string
+      title: string
+      material: TMaterial
+    }
+
+type AssignmentLike = {
+  id: string
+  title: string
+  position?: number | null
+  created_at?: string | null
+}
+
+type MaterialLike = {
+  id: string
+  title: string
+  position?: number | null
+  created_at?: string | null
+}
+
+function normalizedPosition(position: number | null | undefined, fallback: number) {
+  return typeof position === 'number' && Number.isFinite(position) ? position : fallback
+}
+
+export function buildOrderedClassworkItems<
+  TAssignment extends AssignmentLike,
+  TMaterial extends MaterialLike,
+>(
+  assignments: TAssignment[],
+  materials: TMaterial[],
+): OrderedClassworkItem<TAssignment, TMaterial>[] {
+  const assignmentItems = assignments.map((assignment, index) => ({
+    id: assignment.id,
+    type: 'assignment' as const,
+    position: normalizedPosition(assignment.position, index),
+    createdAt: assignment.created_at || '',
+    title: assignment.title,
+    assignment,
+  }))
+
+  const materialOffset = assignments.length
+  const materialItems = materials.map((material, index) => ({
+    id: material.id,
+    type: 'material' as const,
+    position: normalizedPosition(material.position, materialOffset + index),
+    createdAt: material.created_at || '',
+    title: material.title,
+    material,
+  }))
+
+  return [...assignmentItems, ...materialItems].sort((left, right) => {
+    const positionDelta = left.position - right.position
+    if (positionDelta !== 0) return positionDelta
+
+    const createdDelta = left.createdAt.localeCompare(right.createdAt)
+    if (createdDelta !== 0) return createdDelta
+
+    const typeDelta = left.type.localeCompare(right.type)
+    if (typeDelta !== 0) return typeDelta
+
+    return left.id.localeCompare(right.id)
+  })
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -930,6 +930,7 @@ export interface ClassworkMaterial {
   content: TiptapContent
   is_draft: boolean
   released_at: string | null
+  position: number
   created_by: string
   created_at: string
   updated_at: string

--- a/supabase/migrations/067_classwork_mixed_ordering.sql
+++ b/supabase/migrations/067_classwork_mixed_ordering.sql
@@ -1,0 +1,345 @@
+-- Add ordering for ungraded classwork materials so assignments and materials
+-- can share one classroom classwork stream.
+
+alter table public.classwork_materials
+  add column if not exists position integer;
+
+with material_positions as (
+  select
+    material.id,
+    coalesce(
+      (
+        select max(assignment.position) + 1
+        from public.assignments assignment
+        where assignment.classroom_id = material.classroom_id
+      ),
+      0
+    )
+    + row_number() over (
+      partition by material.classroom_id
+      order by material.created_at asc, material.id asc
+    )
+    - 1 as position
+  from public.classwork_materials material
+  where material.position is null
+)
+update public.classwork_materials material
+set position = material_positions.position
+from material_positions
+where material.id = material_positions.id;
+
+alter table public.classwork_materials
+  alter column position set not null;
+
+create index if not exists idx_classwork_materials_classroom_position
+  on public.classwork_materials (classroom_id, position, created_at);
+
+create or replace function public.set_classwork_material_position()
+returns trigger as $$
+begin
+  if new.position is null then
+    select coalesce(max(existing.position), -1) + 1
+    into new.position
+    from (
+      select position
+      from public.assignments
+      where classroom_id = new.classroom_id
+
+      union all
+
+      select position
+      from public.classwork_materials
+      where classroom_id = new.classroom_id
+    ) existing;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_classwork_material_position on public.classwork_materials;
+create trigger set_classwork_material_position
+  before insert on public.classwork_materials
+  for each row
+  execute function public.set_classwork_material_position();
+
+create or replace function public.reorder_classwork_items(
+  p_classroom_id uuid,
+  p_items jsonb
+)
+returns void as $$
+declare
+  submitted_count integer;
+  current_count integer;
+begin
+  if p_items is null or jsonb_typeof(p_items) <> 'array' then
+    raise exception 'items must be an array' using errcode = '22023';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  select count(*) into submitted_count
+  from submitted;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    )
+    select 1
+    from submitted
+    where item_type not in ('assignment', 'material')
+      or item_id is null
+      or item_id = ''
+  ) then
+    raise exception 'items must include type and id' using errcode = '22023';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    )
+    select 1
+    from submitted
+    group by item_type, item_id
+    having count(*) > 1
+  ) then
+    raise exception 'items must be unique' using errcode = '22023';
+  end if;
+
+  with current_items as (
+    select 'assignment'::text as item_type, assignment.id::text as item_id
+    from public.assignments assignment
+    where assignment.classroom_id = p_classroom_id
+
+    union all
+
+    select 'material'::text as item_type, material.id::text as item_id
+    from public.classwork_materials material
+    where material.classroom_id = p_classroom_id
+  )
+  select count(*) into current_count
+  from current_items;
+
+  if submitted_count <> current_count then
+    raise exception 'Classwork list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    ),
+    current_items as (
+      select 'assignment'::text as item_type, assignment.id::text as item_id
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+
+      union all
+
+      select 'material'::text as item_type, material.id::text as item_id
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+    )
+    select 1
+    from submitted
+    left join current_items using (item_type, item_id)
+    where current_items.item_id is null
+  ) then
+    raise exception 'One or more classwork items not found in classroom' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    ),
+    current_items as (
+      select 'assignment'::text as item_type, assignment.id::text as item_id
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+
+      union all
+
+      select 'material'::text as item_type, material.id::text as item_id
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+    )
+    select 1
+    from current_items
+    left join submitted using (item_type, item_id)
+    where submitted.item_id is null
+  ) then
+    raise exception 'Classwork list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  update public.assignments assignment
+  set position = submitted.position
+  from submitted
+  where submitted.item_type = 'assignment'
+    and assignment.classroom_id = p_classroom_id
+    and assignment.id::text = submitted.item_id;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  update public.classwork_materials material
+  set position = submitted.position
+  from submitted
+  where submitted.item_type = 'material'
+    and material.classroom_id = p_classroom_id
+    and material.id::text = submitted.item_id;
+end;
+$$ language plpgsql;
+
+revoke all on function public.reorder_classwork_items(uuid, jsonb) from public, anon, authenticated;
+grant execute on function public.reorder_classwork_items(uuid, jsonb) to service_role;
+
+create or replace function public.reorder_assignments_preserve_materials(
+  p_classroom_id uuid,
+  p_assignment_ids jsonb
+)
+returns void as $$
+declare
+  submitted_count integer;
+  current_count integer;
+  next_position integer := 0;
+  submitted_assignment record;
+begin
+  if p_assignment_ids is null or jsonb_typeof(p_assignment_ids) <> 'array' then
+    raise exception 'assignment_ids must be an array' using errcode = '22023';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as submitted_position,
+      entry.value #>> '{}' as assignment_id,
+      jsonb_typeof(entry.value) as value_type
+    from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+  )
+  select count(*) into submitted_count
+  from submitted;
+
+  if exists (
+    with submitted as (
+      select
+        entry.value #>> '{}' as assignment_id,
+        jsonb_typeof(entry.value) as value_type
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    where value_type <> 'string'
+      or assignment_id is null
+      or assignment_id = ''
+  ) then
+    raise exception 'assignment_ids must include strings' using errcode = '22023';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    group by assignment_id
+    having count(*) > 1
+  ) then
+    raise exception 'assignment_ids must be unique' using errcode = '22023';
+  end if;
+
+  select count(*) into current_count
+  from public.assignments assignment
+  where assignment.classroom_id = p_classroom_id;
+
+  if submitted_count <> current_count then
+    raise exception 'Assignment list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    where not exists (
+      select 1
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+        and assignment.id::text = submitted.assignment_id
+    )
+  ) then
+    raise exception 'One or more assignments not found in classroom' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from public.assignments assignment
+    where assignment.classroom_id = p_classroom_id
+      and not exists (
+        select 1
+        from submitted
+        where submitted.assignment_id = assignment.id::text
+      )
+  ) then
+    raise exception 'Assignment list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  for submitted_assignment in
+    select
+      entry.value #>> '{}' as assignment_id
+    from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    order by entry.ordinality
+  loop
+    while exists (
+      select 1
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+        and material.position = next_position
+    ) loop
+      next_position := next_position + 1;
+    end loop;
+
+    update public.assignments assignment
+    set position = next_position
+    where assignment.classroom_id = p_classroom_id
+      and assignment.id::text = submitted_assignment.assignment_id;
+
+    next_position := next_position + 1;
+  end loop;
+end;
+$$ language plpgsql;
+
+revoke all on function public.reorder_assignments_preserve_materials(uuid, jsonb) from public, anon, authenticated;
+grant execute on function public.reorder_assignments_preserve_materials(uuid, jsonb) to service_role;

--- a/tests/api/student/materials.test.ts
+++ b/tests/api/student/materials.test.ts
@@ -15,9 +15,12 @@ describe('GET /api/student/classrooms/[id]/materials', () => {
     vi.clearAllMocks()
   })
 
-  it('returns only published materials for enrolled students', async () => {
-    const materials = [{ id: 'mat-1', title: 'Reference', is_draft: false }]
-    const order = vi.fn().mockResolvedValue({ data: materials, error: null })
+  it('returns only published materials for enrolled students in classwork order', async () => {
+    const materials = [{ id: 'mat-1', title: 'Reference', is_draft: false, position: 1 }]
+    const order = vi
+      .fn()
+      .mockImplementationOnce(() => ({ order }))
+      .mockResolvedValue({ data: materials, error: null })
     const eqDraft = vi.fn(() => ({ order }))
     const eqClassroom = vi.fn(() => ({ eq: eqDraft }))
     const select = vi.fn(() => ({ eq: eqClassroom }))
@@ -30,15 +33,19 @@ describe('GET /api/student/classrooms/[id]/materials', () => {
     expect(mockSupabaseClient.from).toHaveBeenCalledWith('classwork_materials')
     expect(eqClassroom).toHaveBeenCalledWith('classroom_id', 'c-1')
     expect(eqDraft).toHaveBeenCalledWith('is_draft', false)
-    expect(order).toHaveBeenCalledWith('released_at', { ascending: false })
+    expect(order).toHaveBeenNthCalledWith(1, 'position', { ascending: true })
+    expect(order).toHaveBeenNthCalledWith(2, 'released_at', { ascending: true })
     await expect(response.json()).resolves.toEqual({ materials })
   })
 
   it('returns an empty list before the materials migration is applied', async () => {
-    const order = vi.fn().mockResolvedValue({
-      data: null,
-      error: { code: 'PGRST205', message: "Could not find the table 'public.classwork_materials'" },
-    })
+    const order = vi
+      .fn()
+      .mockImplementationOnce(() => ({ order }))
+      .mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST205', message: "Could not find the table 'public.classwork_materials'" },
+      })
     const eqDraft = vi.fn(() => ({ order }))
     const eqClassroom = vi.fn(() => ({ eq: eqDraft }))
     const select = vi.fn(() => ({ eq: eqClassroom }))

--- a/tests/api/teacher/assignments-bulk.test.ts
+++ b/tests/api/teacher/assignments-bulk.test.ts
@@ -291,6 +291,71 @@ describe('POST /api/teacher/assignments/bulk', () => {
     expect(data.created).toBe(0)
   })
 
+  it('should preserve material positions when saving assignment markdown', async () => {
+    const updates: Array<{ id: string; payload: Record<string, any> }> = []
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'a-1', title: 'First', is_draft: true, released_at: null },
+                  { id: 'a-2', title: 'Second', is_draft: true, released_at: null },
+                ],
+                error: null,
+              }),
+            })),
+          })),
+          update: vi.fn((payload: Record<string, any>) => ({
+            eq: vi.fn((_column: string, id: string) => ({
+              select: vi.fn(async () => {
+                updates.push({ id, payload })
+                return { data: [{ id, ...payload }], error: null }
+              }),
+            })),
+          })),
+          insert: vi.fn(),
+        }
+      }
+
+      if (table === 'classwork_materials') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ position: 1 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const assignments = [
+      { id: 'a-2', title: 'Second', due_at: '2025-01-20T23:59:00Z', instructions: 'Second', is_draft: true, position: 0 },
+      { id: 'a-1', title: 'First', due_at: '2025-01-21T23:59:00Z', instructions: 'First', is_draft: true, position: 1 },
+    ]
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/assignments/bulk',
+      {
+        method: 'POST',
+        body: JSON.stringify({ classroom_id: 'c-1', assignments }),
+      }
+    )
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(updates.map((update) => ({ id: update.id, position: update.payload.position }))).toEqual([
+      { id: 'a-2', position: 0 },
+      { id: 'a-1', position: 2 },
+    ])
+  })
+
   it('should allow releasing a draft assignment', async () => {
     // Mock: existing draft assignment via select().eq().in()
     const mockIn = vi.fn().mockResolvedValue({

--- a/tests/api/teacher/assignments-reorder.test.ts
+++ b/tests/api/teacher/assignments-reorder.test.ts
@@ -16,12 +16,12 @@ vi.mock('@/lib/server/classrooms', () => ({
 import { POST } from '@/app/api/teacher/assignments/reorder/route'
 import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
 
-const mockSupabaseClient = { from: vi.fn() }
+const mockSupabaseClient = { rpc: vi.fn() }
 
 describe('POST /api/teacher/assignments/reorder', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockSupabaseClient.from.mockReset()
+    mockSupabaseClient.rpc.mockResolvedValue({ data: null, error: null })
   })
 
   it('rejects missing params and duplicate assignment ids', async () => {
@@ -51,15 +51,13 @@ describe('POST /api/teacher/assignments/reorder', () => {
     }))
 
     expect(response.status).toBe(403)
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
   })
 
   it('rejects ids that do not all belong to the classroom', async () => {
-    mockSupabaseClient.from.mockReturnValue({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          in: vi.fn(async () => ({ data: [{ id: 'a-1' }], error: null })),
-        })),
-      })),
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'One or more assignments not found in classroom' },
     })
 
     const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
@@ -70,67 +68,45 @@ describe('POST /api/teacher/assignments/reorder', () => {
     expect(response.status).toBe(400)
   })
 
-  it('persists each assignment position in submitted order', async () => {
-    const updates: unknown[] = []
-    mockSupabaseClient.from.mockImplementation((table: string) => {
-      if (table !== 'assignments') throw new Error(`Unexpected table: ${table}`)
-      return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            in: vi.fn(async () => ({
-              data: [{ id: 'a-2' }, { id: 'a-1' }],
-              error: null,
-            })),
-          })),
-        })),
-        update: vi.fn((payload: unknown) => {
-          updates.push(payload)
-          return {
-            eq: vi.fn(async () => ({ error: null })),
-          }
-        }),
-      }
-    })
-
+  it('persists each assignment position through the material-aware reorder RPC', async () => {
     const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
       method: 'POST',
       body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-2', 'a-1'] }),
     }))
 
     expect(response.status).toBe(200)
-    expect(updates).toEqual([{ position: 0 }, { position: 1 }])
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('reorder_assignments_preserve_materials', {
+      p_classroom_id: 'classroom-1',
+      p_assignment_ids: ['a-2', 'a-1'],
+    })
   })
 
-  it('returns 500 when verifying or updating assignments fails', async () => {
-    mockSupabaseClient.from.mockReturnValueOnce({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          in: vi.fn(async () => ({ data: null, error: { message: 'verify failed' } })),
-        })),
-      })),
+  it('returns 409 for stale assignment lists', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Assignment list changed. Refresh and try again.' },
     })
 
-    const verifyFailure = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+    const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
       method: 'POST',
       body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1'] }),
     }))
-    expect(verifyFailure.status).toBe(500)
 
-    mockSupabaseClient.from.mockReturnValue({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          in: vi.fn(async () => ({ data: [{ id: 'a-1' }], error: null })),
-        })),
-      })),
-      update: vi.fn(() => ({
-        eq: vi.fn(async () => ({ error: { message: 'update failed' } })),
-      })),
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Assignment list changed. Refresh and try again.' })
+  })
+
+  it('returns 500 when the material-aware reorder RPC fails unexpectedly', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'database unavailable' },
     })
 
-    const updateFailure = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
+    const response = await POST(new NextRequest('http://localhost/api/teacher/assignments/reorder', {
       method: 'POST',
       body: JSON.stringify({ classroom_id: 'classroom-1', assignment_ids: ['a-1'] }),
     }))
-    expect(updateFailure.status).toBe(500)
+
+    expect(response.status).toBe(500)
   })
 })

--- a/tests/api/teacher/assignments.test.ts
+++ b/tests/api/teacher/assignments.test.ts
@@ -275,6 +275,20 @@ describe('POST /api/teacher/assignments', () => {
         }
       }
 
+      if (table === 'classwork_materials') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { position: 2 }, error: null }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -289,5 +303,55 @@ describe('POST /api/teacher/assignments', () => {
 
     const response = await POST(request)
     expect(response.status).toBe(201)
+  })
+
+  it('fails assignment creation when mixed order lookup has an unexpected error', async () => {
+    const insert = vi.fn()
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { position: 1 }, error: null }),
+                })),
+              })),
+            })),
+          })),
+          insert,
+        }
+      }
+
+      if (table === 'classwork_materials') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'database unavailable' } }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments', {
+      method: 'POST',
+      body: JSON.stringify({
+        classroom_id: 'c1',
+        title: 'Essay Draft',
+        due_at: '2026-03-20T23:59:59.000Z',
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(500)
+    expect(insert).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/teacher/classwork-reorder.test.ts
+++ b/tests/api/teacher/classwork-reorder.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({ id: 'teacher-1', role: 'teacher' })),
+}))
+
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
+}))
+
+import { POST } from '@/app/api/teacher/classrooms/[id]/classwork/reorder/route'
+import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+
+const mockSupabaseClient = { rpc: vi.fn() }
+const params = { params: Promise.resolve({ id: 'classroom-1' }) }
+
+describe('POST /api/teacher/classrooms/[id]/classwork/reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.rpc.mockResolvedValue({ data: null, error: null })
+  })
+
+  it('rejects missing, invalid, and duplicate items', async () => {
+    const missing = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }), params)
+    expect(missing.status).toBe(400)
+
+    const invalid = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ items: [{ type: 'note', id: 'x-1' }] }),
+    }), params)
+    expect(invalid.status).toBe(400)
+
+    const duplicate = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ items: [{ type: 'material', id: 'm-1' }, { type: 'material', id: 'm-1' }] }),
+    }), params)
+    expect(duplicate.status).toBe(400)
+  })
+
+  it('returns classroom mutation failures before verifying items', async () => {
+    ;(assertTeacherCanMutateClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({ items: [{ type: 'assignment', id: 'a-1' }] }),
+    }), params)
+
+    expect(response.status).toBe(403)
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+  })
+
+  it('rejects classwork ids that do not belong to the classroom', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'One or more classwork items not found in classroom' },
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({
+        items: [
+          { type: 'assignment', id: 'a-1' },
+          { type: 'material', id: 'm-1' },
+        ],
+      }),
+    }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'One or more classwork items not found in classroom' })
+  })
+
+  it('rejects stale reorder requests that omit current classwork items', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Classwork list changed. Refresh and try again.' },
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({
+        items: [
+          { type: 'material', id: 'm-1' },
+          { type: 'assignment', id: 'a-1' },
+        ],
+      }),
+    }), params)
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({ error: 'Classwork list changed. Refresh and try again.' })
+  })
+
+  it('returns 500 without row writes when the transactional reorder fails unexpectedly', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'column classwork_materials.position does not exist' },
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({
+        items: [
+          { type: 'assignment', id: 'a-2' },
+          { type: 'assignment', id: 'a-1' },
+        ],
+      }),
+    }), params)
+
+    expect(response.status).toBe(500)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists mixed assignment and material positions transactionally', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/teacher/classrooms/classroom-1/classwork/reorder', {
+      method: 'POST',
+      body: JSON.stringify({
+        items: [
+          { type: 'material', id: 'm-1' },
+          { type: 'assignment', id: 'a-2' },
+          { type: 'assignment', id: 'a-1' },
+        ],
+      }),
+    }), params)
+
+    expect(response.status).toBe(200)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('reorder_classwork_items', {
+      p_classroom_id: 'classroom-1',
+      p_items: [
+        { type: 'material', id: 'm-1' },
+        { type: 'assignment', id: 'a-2' },
+        { type: 'assignment', id: 'a-1' },
+      ],
+    })
+  })
+})

--- a/tests/api/teacher/materials.test.ts
+++ b/tests/api/teacher/materials.test.ts
@@ -17,9 +17,12 @@ describe('GET /api/teacher/classrooms/[id]/materials', () => {
     vi.clearAllMocks()
   })
 
-  it('returns teacher materials newest first', async () => {
-    const materials = [{ id: 'mat-1', title: 'Reference', content: doc, is_draft: false }]
-    const order = vi.fn().mockResolvedValue({ data: materials, error: null })
+  it('returns teacher materials in classwork order', async () => {
+    const materials = [{ id: 'mat-1', title: 'Reference', content: doc, is_draft: false, position: 1 }]
+    const order = vi
+      .fn()
+      .mockImplementationOnce(() => ({ order }))
+      .mockResolvedValue({ data: materials, error: null })
     const eq = vi.fn(() => ({ order }))
     const select = vi.fn(() => ({ eq }))
     ;(mockSupabaseClient.from as any) = vi.fn(() => ({ select }))
@@ -30,15 +33,19 @@ describe('GET /api/teacher/classrooms/[id]/materials', () => {
     expect(response.status).toBe(200)
     expect(mockSupabaseClient.from).toHaveBeenCalledWith('classwork_materials')
     expect(eq).toHaveBeenCalledWith('classroom_id', 'c-1')
-    expect(order).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(order).toHaveBeenNthCalledWith(1, 'position', { ascending: true })
+    expect(order).toHaveBeenNthCalledWith(2, 'created_at', { ascending: true })
     await expect(response.json()).resolves.toEqual({ materials })
   })
 
   it('returns an empty list before the materials migration is applied', async () => {
-    const order = vi.fn().mockResolvedValue({
-      data: null,
-      error: { code: 'PGRST205', message: "Could not find the table 'public.classwork_materials'" },
-    })
+    const order = vi
+      .fn()
+      .mockImplementationOnce(() => ({ order }))
+      .mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST205', message: "Could not find the table 'public.classwork_materials'" },
+      })
     const eq = vi.fn(() => ({ order }))
     const select = vi.fn(() => ({ eq }))
     ;(mockSupabaseClient.from as any) = vi.fn(() => ({ select }))
@@ -64,6 +71,7 @@ describe('POST /api/teacher/classrooms/[id]/materials', () => {
       content: doc,
       is_draft: false,
       released_at: '2026-05-06T14:00:00.000Z',
+      position: 4,
       created_by: 'teacher-1',
     }
     const insert = vi.fn(() => ({
@@ -71,7 +79,36 @@ describe('POST /api/teacher/classrooms/[id]/materials', () => {
         single: vi.fn().mockResolvedValue({ data: material, error: null }),
       })),
     }))
-    ;(mockSupabaseClient.from as any) = vi.fn(() => ({ insert }))
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { position: 2 }, error: null }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+      if (table === 'classwork_materials') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { position: 3 }, error: null }),
+                })),
+              })),
+            })),
+          })),
+          insert,
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/materials', {
       method: 'POST',
@@ -86,9 +123,53 @@ describe('POST /api/teacher/classrooms/[id]/materials', () => {
       content: doc,
       is_draft: false,
       released_at: expect.any(String),
+      position: 4,
       created_by: 'teacher-1',
     }))
     await expect(response.json()).resolves.toEqual({ material })
+  })
+
+  it('fails material creation when mixed order lookup has an unexpected error', async () => {
+    const insert = vi.fn()
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'database unavailable' } }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+      if (table === 'classwork_materials') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: { position: 3 }, error: null }),
+                })),
+              })),
+            })),
+          })),
+          insert,
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/materials', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Reference', content: doc, is_draft: false }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+
+    expect(response.status).toBe(500)
+    expect(insert).not.toHaveBeenCalled()
   })
 
   it('rejects missing titles', async () => {

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { forwardRef, useEffect, useImperativeHandle } from 'react'
 import { StudentAssignmentsTab } from '@/app/classrooms/[classroomId]/StudentAssignmentsTab'
-import type { Classroom, AssignmentWithStatus } from '@/types'
+import type { Classroom, AssignmentWithStatus, ClassworkMaterial } from '@/types'
 
 // --- Mocks ---
 
@@ -68,6 +68,11 @@ function makeAssignment(overrides: Partial<AssignmentWithStatus> = {}): Assignme
     instructions_markdown: 'Write an essay',
     rich_instructions: null,
     due_at: '2025-06-01T00:00:00Z',
+    position: 0,
+    is_draft: false,
+    released_at: '2025-05-01T00:00:00Z',
+    track_authenticity: true,
+    created_by: 'teacher-1',
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     status: 'not_started',
@@ -76,7 +81,23 @@ function makeAssignment(overrides: Partial<AssignmentWithStatus> = {}): Assignme
   } as AssignmentWithStatus
 }
 
-function mockFetchAssignments(assignments: AssignmentWithStatus[]) {
+function makeMaterial(overrides: Partial<ClassworkMaterial> = {}): ClassworkMaterial {
+  return {
+    id: 'mat-1',
+    classroom_id: 'cls-1',
+    title: 'Reference Material',
+    content: { type: 'doc', content: [] },
+    is_draft: false,
+    released_at: '2025-05-01T00:00:00Z',
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function mockFetchClasswork(assignments: AssignmentWithStatus[], materials: ClassworkMaterial[] = []) {
   ;(global.fetch as ReturnType<typeof vi.fn>)
     .mockResolvedValueOnce({
       ok: true,
@@ -84,9 +105,11 @@ function mockFetchAssignments(assignments: AssignmentWithStatus[]) {
     })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ materials: [] }),
+      json: async () => ({ materials }),
     })
 }
+
+const mockFetchAssignments = mockFetchClasswork
 
 describe('StudentAssignmentsTab', () => {
   beforeEach(() => {
@@ -217,5 +240,33 @@ describe('StudentAssignmentsTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Repo' })).toBeInTheDocument()
     })
+  })
+
+  it('renders materials and assignments in shared classwork order', async () => {
+    const mixedClassroom = { ...classroom, id: 'cls-mixed' }
+    mockFetchClasswork(
+      [makeAssignment({ id: 'asgn-1', classroom_id: mixedClassroom.id, title: 'Essay Assignment', position: 2 })],
+      [makeMaterial({ id: 'mat-1', classroom_id: mixedClassroom.id, title: 'Opening Reading', position: 1 })],
+    )
+
+    render(<StudentAssignmentsTab classroom={mixedClassroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Opening Reading')).toBeInTheDocument()
+    })
+
+    const cards = [
+      ...screen.getAllByTestId('material-card'),
+      ...screen.getAllByTestId('assignment-card'),
+    ].sort((left, right) => {
+      const position = left.compareDocumentPosition(right)
+      return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+    })
+
+    expect(cards[0]).toHaveTextContent('Opening Reading')
+    expect(cards[1]).toHaveTextContent('Essay Assignment')
+    expect(cards[0]).toHaveClass('border-border')
+    expect(cards[0]).not.toHaveClass('border-primary/40')
+    expect(cards[0].querySelector('.border-l-2')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
-import type { Classroom } from '@/types'
+import type { Classroom, ClassworkMaterial } from '@/types'
 
 const mockFetchJSONWithCache = vi.fn()
 const mockInvalidateCachedJSON = vi.fn()
@@ -34,7 +34,23 @@ vi.mock('@dnd-kit/sortable', () => ({
   arrayMove: vi.fn((items) => items),
   SortableContext: ({ children }: any) => <div>{children}</div>,
   sortableKeyboardCoordinates: vi.fn(),
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  })),
   verticalListSortingStrategy: vi.fn(),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: vi.fn(() => undefined),
+    },
+  },
 }))
 
 vi.mock('@/ui', () => ({
@@ -372,6 +388,22 @@ function makeAssignmentSummary(id: string, title: string, overrides: Record<stri
   }
 }
 
+function makeMaterialSummary(id: string, title: string, overrides: Partial<ClassworkMaterial> = {}): ClassworkMaterial {
+  return {
+    id,
+    classroom_id: classroom.id,
+    title,
+    content: { type: 'doc', content: [] },
+    is_draft: false,
+    released_at: '2026-04-10T12:00:00Z',
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2026-04-01T12:00:00Z',
+    updated_at: '2026-04-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
 function makeAssignmentDetails(
   assignmentId: string,
   title: string,
@@ -566,6 +598,42 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByRole('dialog')).toHaveTextContent('Editing Assignment One')
     expect(updateSearchParams).not.toHaveBeenCalled()
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders materials and assignments in shared order and gives materials a drag handle in edit mode', async () => {
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-1', 'Assignment One', { position: 2 }),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({
+          materials: [
+            makeMaterialSummary('material-1', 'Opening Reading', { position: 1 }),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
+    })
+
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    const materialButton = await screen.findByRole('button', { name: 'Open Opening Reading' })
+    const assignmentButton = screen.getByRole('button', { name: 'Assignment One' })
+    expect(
+      materialButton.compareDocumentPosition(assignmentButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Drag to reorder material' })).toBeInTheDocument()
+    expect(materialButton.querySelector('.border-l-2')).not.toBeInTheDocument()
+    expect(materialButton.closest('.bg-info-bg')).not.toHaveClass('border-primary/40')
   })
 
   it('exits assignment edit mode when the create assignment modal closes', async () => {

--- a/tests/components/TeacherWorkItemPrimitives.test.tsx
+++ b/tests/components/TeacherWorkItemPrimitives.test.tsx
@@ -34,5 +34,11 @@ describe('TeacherWorkItem primitives', () => {
       <TeacherWorkItemCardFrame tone="selected">Selected card</TeacherWorkItemCardFrame>,
     )
     expect(screen.getByText('Selected card')).toHaveClass('bg-surface-selected')
+
+    rerender(
+      <TeacherWorkItemCardFrame dragging dragTone="neutral">Neutral drag card</TeacherWorkItemCardFrame>,
+    )
+    expect(screen.getByText('Neutral drag card')).toHaveClass('border-border')
+    expect(screen.getByText('Neutral drag card')).not.toHaveClass('border-primary')
   })
 })

--- a/tests/lib/classwork-order.test.ts
+++ b/tests/lib/classwork-order.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildOrderedClassworkItems } from '@/lib/classwork-order'
+
+describe('buildOrderedClassworkItems', () => {
+  it('interleaves assignments and materials by shared position', () => {
+    const items = buildOrderedClassworkItems(
+      [
+        { id: 'a-1', title: 'Essay', position: 2, created_at: '2026-01-02T00:00:00.000Z' },
+        { id: 'a-2', title: 'Reflection', position: 4, created_at: '2026-01-04T00:00:00.000Z' },
+      ],
+      [
+        { id: 'm-1', title: 'Reading', position: 1, created_at: '2026-01-01T00:00:00.000Z' },
+        { id: 'm-2', title: 'Example', position: 3, created_at: '2026-01-03T00:00:00.000Z' },
+      ],
+    )
+
+    expect(items.map((item) => `${item.type}:${item.id}`)).toEqual([
+      'material:m-1',
+      'assignment:a-1',
+      'material:m-2',
+      'assignment:a-2',
+    ])
+  })
+
+  it('falls back to assignment-first order when material positions are unavailable', () => {
+    const items = buildOrderedClassworkItems(
+      [
+        { id: 'a-1', title: 'Essay', position: 0, created_at: '2026-01-01T00:00:00.000Z' },
+      ],
+      [
+        { id: 'm-1', title: 'Reading', created_at: '2026-01-02T00:00:00.000Z' },
+      ],
+    )
+
+    expect(items.map((item) => `${item.type}:${item.id}`)).toEqual([
+      'assignment:a-1',
+      'material:m-1',
+    ])
+  })
+})

--- a/tests/unit/classwork-migration-rpc-grants.test.ts
+++ b/tests/unit/classwork-migration-rpc-grants.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+function readMigration(relativePath: string) {
+  return readFileSync(resolve(testDir, '../..', relativePath), 'utf8')
+}
+
+describe('classwork mixed ordering migration', () => {
+  it('keeps reorder RPCs behind the service-role API boundary', () => {
+    const migration = readMigration('supabase/migrations/067_classwork_mixed_ordering.sql')
+
+    for (const functionName of [
+      'reorder_classwork_items',
+      'reorder_assignments_preserve_materials',
+    ]) {
+      expect(migration).toContain(
+        `revoke all on function public.${functionName}(uuid, jsonb) from public, anon, authenticated;`,
+      )
+      expect(migration).toContain(
+        `grant execute on function public.${functionName}(uuid, jsonb) to service_role;`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add shared assignment/material classwork ordering with material positions
- make teacher materials draggable in assignment edit mode via a mixed classwork reorder endpoint
- keep materials visually distinct with tint/label only, without the Syllabus icon or highlighted outline
- preserve material positions through legacy assignment reorder and bulk assignment save flows

## Validation
- pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx
- pnpm test tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/assignments-reorder.test.ts tests/api/teacher/assignments-bulk.test.ts tests/api/teacher/assignments.test.ts tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/lib/classwork-order.test.ts
- pnpm lint
- pnpm build
- supabase db lint --local --schema public --fail-on error (existing unrelated warning: public.unsubmit_test_attempts_atomic unused p_updated_by)
- Pika UI verify captured the target route, but local DB state returned "Classroom not found" after the local seed/reset issue; supplemental tint/no-outline harness screenshots were reviewed at /tmp/pika-material-no-outline-harness.png and /tmp/pika-material-no-outline-harness-dark.png

## Migration
- adds supabase/migrations/067_classwork_mixed_ordering.sql
- humans still apply/reset local migrations manually per repo workflow
