### PR TITLE
Add Daily quick date buttons

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-07 — Hide classroom view labels outside edit mode
-
-**Completed:**
-- Made the teacher classroom list Active/Archived segmented toggle icon-only until classroom edit mode is enabled.
-- Preserved accessible button names while the toggle is icon-only.
-- Added focused test coverage for the icon-only versus labeled edit-mode states.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification on port 3010:
-  - `/tmp/pika-classrooms-toggle-teacher-desktop.png`
-  - `/tmp/pika-classrooms-toggle-teacher-desktop-edit.png`
-  - `/tmp/pika-classrooms-toggle-teacher-mobile.png`
-  - `/tmp/pika-classrooms-toggle-teacher-mobile-edit.png`
-  - `/tmp/pika-classrooms-student-mobile.png`
-
 ## 2026-05-07 — Add classroom view toggle tooltips
 
 **Completed:**
@@ -371,3 +352,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `supabase db lint --local --schema public --fail-on error` (existing unrelated warning: `public.unsubmit_test_attempts_atomic` unused `p_updated_by`)
 - `pnpm build`
+
+## 2026-05-11 — Add Daily quick date buttons
+
+**Completed:**
+- Added icon-only Daily tab quick-jump buttons for `Last class` and `Today` around the existing date picker arrows.
+- Simplified the quick-jump icons to `UndoDot` for `Last class` and `CircleDot` for `Today`.
+- Reused the existing Toronto date and class-day helpers so `Last class` targets the most recent class day before today.
+- Added focused component coverage for moving from the last class date to today and back.
+- Refreshed the Toronto `today` value on focus/visibility/interval and in quick-jump handlers so open tabs do not keep stale quick-jump dates after midnight.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
+- `pnpm lint`
+- Added rollover coverage for `Today` and `Last class` quick jumps after the mocked Toronto date changes while the tab remains mounted.
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance'`
+- `E2E_BASE_URL=http://localhost:3002 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=attendance'`
+- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=attendance'`
+- Tooltip hover checks:
+  - `/tmp/pika-tooltip-last-class.png`
+  - `/tmp/pika-tooltip-today.png`

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -11,7 +11,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react'
-import { GripHorizontal } from 'lucide-react'
+import { CircleDot, GripHorizontal, UndoDot } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { CalendarDateNavigator } from '@/components/CalendarActionBar'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
@@ -24,7 +24,7 @@ import { addDaysToDateString } from '@/lib/date-string'
 import { getMostRecentClassDayBefore, isClassDayOnDate } from '@/lib/class-days'
 import { entryHasContent, getAttendanceDotClass, getAttendanceLabel } from '@/lib/attendance'
 import { useClassDaysContext } from '@/hooks/useClassDays'
-import { RefreshingIndicator, Tooltip } from '@/ui'
+import { Button, RefreshingIndicator, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import type { AttendanceStatus } from '@/types'
 import {
@@ -104,6 +104,16 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const [summaryPanelCollapsed, setSummaryPanelCollapsed] = useState(false)
   const [summaryPanelHeight, setSummaryPanelHeight] = useState(SUMMARY_PANEL_DEFAULT_HEIGHT)
   const showBlockingSpinner = useDelayedBusy(loading && logs.length === 0)
+  const [today, setToday] = useState(() => getTodayInToronto())
+  const refreshToday = useCallback(() => {
+    const currentToday = getTodayInToronto()
+    setToday(currentToday)
+    return currentToday
+  }, [])
+  const lastClassDate = useMemo(
+    () => getMostRecentClassDayBefore(classDays, today),
+    [classDays, today]
+  )
   const [{ column: sortColumn, direction: sortDirection }, setSortState] = useState<{
     column: SortColumn
     direction: 'asc' | 'desc'
@@ -113,11 +123,27 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   useEffect(() => {
     if (classDaysLoading) return
     if (selectedDate) return // Already initialized
-    const today = getTodayInToronto()
-    const previousClassDay = getMostRecentClassDayBefore(classDays, today)
-    setSelectedDate(previousClassDay || addDaysToDateString(today, -1))
+    setSelectedDate(lastClassDate || addDaysToDateString(today, -1))
     // Do NOT setLoading(false) here — the logs fetch (Effect 3) handles it
-  }, [classDaysLoading, classDays, selectedDate])
+  }, [classDaysLoading, lastClassDate, selectedDate, today])
+
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        refreshToday()
+      }
+    }
+
+    window.addEventListener('focus', refreshToday)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    const intervalId = window.setInterval(refreshToday, 60 * 1000)
+
+    return () => {
+      window.removeEventListener('focus', refreshToday)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.clearInterval(intervalId)
+    }
+  }, [refreshToday])
 
   // Notify parent of date changes
   useEffect(() => {
@@ -175,8 +201,6 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     return isClassDayOnDate(classDays, selectedDate)
   }, [classDays, selectedDate])
 
-  const today = useMemo(() => getTodayInToronto(), [])
-
   const rows = useMemo(() => {
     return [...logs].sort((a, b) => {
       if (sortColumn === 'status') {
@@ -229,6 +253,17 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       const base = prev || getTodayInToronto()
       return addDaysToDateString(base, deltaDays)
     })
+  }
+
+  function goToLastClass() {
+    const currentToday = refreshToday()
+    const currentLastClassDate = getMostRecentClassDayBefore(classDays, currentToday)
+    if (!currentLastClassDate) return
+    setSelectedDate(currentLastClassDate)
+  }
+
+  function goToToday() {
+    setSelectedDate(refreshToday())
   }
 
   function handleRowClick(row: LogRow) {
@@ -417,6 +452,19 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
             className="sr-only"
             tabIndex={-1}
           />
+          <Tooltip content="Last class">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 px-0"
+              onClick={goToLastClass}
+              disabled={!lastClassDate}
+              aria-label="Go to last class"
+            >
+              <UndoDot className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Tooltip>
           <CalendarDateNavigator
             label={selectedDateLabel}
             onLabelClick={() => dateInputRef.current?.showPicker()}
@@ -426,6 +474,18 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
             prevAriaLabel="Previous day"
             nextAriaLabel="Next day"
           />
+          <Tooltip content="Today">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 px-0"
+              onClick={goToToday}
+              aria-label="Go to today"
+            >
+              <CircleDot className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Tooltip>
         </div>
       }
       centerPlacement="floating"

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -4,11 +4,24 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { TeacherAttendanceTab } from '@/app/classrooms/[classroomId]/TeacherAttendanceTab'
 import type { Classroom, Entry } from '@/types'
 
+const todayMock = vi.hoisted(() => ({
+  today: '2026-05-06',
+}))
+
 vi.mock('@/lib/timezone', () => ({
-  getTodayInToronto: () => '2026-05-06',
+  getTodayInToronto: () => todayMock.today,
 }))
 
 const classDaysMock = vi.hoisted(() => ({
+  defaultClassDays: [
+    {
+      id: 'day-1',
+      classroom_id: 'classroom-1',
+      date: '2026-05-05',
+      prompt_text: null,
+      is_class_day: true,
+    },
+  ],
   classDays: [
     {
       id: 'day-1',
@@ -124,6 +137,9 @@ function mockLogsFetch() {
 describe('TeacherAttendanceTab', () => {
   afterEach(() => {
     cleanup()
+    todayMock.today = '2026-05-06'
+    classDaysMock.classDays = [...classDaysMock.defaultClassDays]
+    classDaysMock.refresh.mockReset()
     vi.unstubAllGlobals()
   })
 
@@ -143,6 +159,72 @@ describe('TeacherAttendanceTab', () => {
     expect(screen.queryByRole('button', { name: 'Show class log summary' })).not.toBeInTheDocument()
     expect(screen.getByRole('separator', { name: 'Resize class log summary' })).toBeInTheDocument()
     expect(screen.queryByRole('separator', { name: 'Resize Daily panes' })).not.toBeInTheDocument()
+  })
+
+  it('moves quickly between today and the last class day from the date picker cluster', async () => {
+    const fetchMock = mockLogsFetch()
+    const onDateChange = vi.fn()
+
+    render(<TeacherAttendanceTab classroom={classroom} onDateChange={onDateChange} />)
+
+    await screen.findByRole('columnheader', { name: 'Log' })
+
+    const lastClassButton = screen.getByRole('button', { name: 'Go to last class' })
+    const todayButton = screen.getByRole('button', { name: 'Go to today' })
+    expect(lastClassButton).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Tue May 5')
+
+    fireEvent.click(todayButton)
+
+    await waitFor(() => {
+      expect(onDateChange).toHaveBeenLastCalledWith('2026-05-06')
+    })
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Wed May 6')
+
+    fireEvent.click(lastClassButton)
+
+    await waitFor(() => {
+      expect(onDateChange).toHaveBeenLastCalledWith('2026-05-05')
+    })
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Tue May 5')
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('uses the current Toronto date for quick jumps after a date rollover', async () => {
+    classDaysMock.classDays = [
+      ...classDaysMock.defaultClassDays,
+      {
+        id: 'day-2',
+        classroom_id: 'classroom-1',
+        date: '2026-05-06',
+        prompt_text: null,
+        is_class_day: true,
+      },
+    ]
+    const onDateChange = vi.fn()
+    mockLogsFetch()
+
+    render(<TeacherAttendanceTab classroom={classroom} onDateChange={onDateChange} />)
+
+    await screen.findByRole('columnheader', { name: 'Log' })
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Tue May 5')
+
+    todayMock.today = '2026-05-07'
+    fireEvent.click(screen.getByRole('button', { name: 'Go to today' }))
+
+    await waitFor(() => {
+      expect(onDateChange).toHaveBeenLastCalledWith('2026-05-07')
+    })
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Thu May 7')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to last class' }))
+
+    await waitFor(() => {
+      expect(onDateChange).toHaveBeenLastCalledWith('2026-05-06')
+    })
+    expect(screen.getByRole('button', { name: 'Select attendance date' })).toHaveTextContent('Wed May 6')
   })
 
   it('collapses and restores the class log summary from a double click', async () => {


### PR DESCRIPTION
## Summary
- Add Daily tab quick-jump icon buttons for Last class and Today around the existing date picker controls.
- Reuse Toronto-aware date and class-day helpers for quick jumps, including refreshing Toronto today for long-lived tabs.
- Add focused component coverage for quick date navigation and post-midnight rollover behavior.

## Validation
- PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/TeacherAttendanceTab.test.tsx
- pnpm lint
- E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=attendance"
- Manual tooltip hover check for Last class and Today