### PR TITLE
[codex] Preserve teacher student scroll positions

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,33 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-07 — Add classroom view toggle tooltips
-
-**Completed:**
-- Added styled app tooltips to icon-only segmented controls.
-- Placed icon-only segmented control tooltips above the trigger so the bottom classroom view toggle remains visible on hover.
-- Removed the native title fallback from segmented buttons.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Visual hover verification on port 3011:
-  - `/tmp/pika-classrooms-toggle-active-tooltip.png`
-  - `/tmp/pika-classrooms-toggle-archived-tooltip.png`
-
-## 2026-05-10 — Add student exam-mode e2e coverage
-
-**Completed:**
-- Added a focused Playwright flow for student test exam mode.
-- Seeds a unique active open-response test through existing teacher APIs against the shared seeded teacher/student classroom.
-- Verifies test start, transient window loss without lock, sustained window loss with content obscuring and interaction blocking, restoration, and open-response draft preservation after reload/restart.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm exec playwright test e2e/student-exam-mode.spec.ts`
-- `pnpm lint`
-
 ## 2026-05-08 — Add class log summary controls
 
 **Completed:**
@@ -373,3 +346,32 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Tooltip hover checks:
   - `/tmp/pika-tooltip-last-class.png`
   - `/tmp/pika-tooltip-today.png`
+
+## 2026-05-12 — Preserve teacher assignment student-list scroll
+
+**Completed:**
+- Preserved the teacher assignment workspace class-pane scroll position while selecting students from the left student table.
+- Added regression coverage that remounts the left pane on student selection and verifies the stored scroll offset is restored.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3000 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=assignments&assignmentId=f2e7f53a-8399-42f7-9739-36a91fd837c1&assignmentStudentId=20d7927e-6c8d-4fe0-a31b-b3a4bd097f5e'`
+
+## 2026-05-12 — Continue teacher assignment scroll handoff
+
+**Completed:**
+- Audited the dirty `codex/teacher-assignments-scroll` worktree after the prior Codex session died.
+- Confirmed the assignment scroll fix preserves the class-pane scroll position before student selection and restores it after remount.
+- Seeded local Supabase and refreshed Playwright auth so UI verification used a live local classroom instead of a stale missing-classroom route.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/61164fb0-26d2-4862-abfe-5517ccdc685a?tab=assignments&assignmentId=9ff41b8e-bb7a-485b-a553-fb11dfd98545&assignmentStudentId=852830be-50b4-48fe-9b03-67e4d1d49a37'`
+- Delayed loaded-state teacher desktop screenshot: `/tmp/pika-teacher-loaded.png`

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -26,6 +26,7 @@ import { entryHasContent, getAttendanceDotClass, getAttendanceLabel } from '@/li
 import { useClassDaysContext } from '@/hooks/useClassDays'
 import { Button, RefreshingIndicator, Tooltip } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 import type { AttendanceStatus } from '@/types'
 import {
   DataTable,
@@ -244,6 +245,20 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     return { presentCount: present, absentCount: absent }
   }, [rows, selectedDate, today])
 
+  const {
+    scrollRef: studentTableScrollRef,
+    preserveScrollPosition: preserveStudentTableScrollPosition,
+  } = useScrollPositionMemory<HTMLDivElement>({
+    key: selectedDate ? `${classroom.id}:${selectedDate}` : null,
+    enabled: !showBlockingSpinner,
+    restoreToken: [
+      selectedStudentId ?? 'none',
+      rows.length,
+      loading ? 'loading' : 'ready',
+      refreshing ? 'refreshing' : 'idle',
+    ].join(':'),
+  })
+
   function handleSort(column: SortColumn) {
     setSortState((prev) => toggleSort(prev, column))
   }
@@ -267,6 +282,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   }
 
   function handleRowClick(row: LogRow) {
+    preserveStudentTableScrollPosition()
     const newSelectedId = selectedStudentId === row.student_id ? null : row.student_id
     setSelectedStudentId(newSelectedId)
 
@@ -279,9 +295,10 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   }
 
   const handleDeselect = useCallback(() => {
+    preserveStudentTableScrollPosition()
     setSelectedStudentId(null)
     onSelectEntry?.(null, '', null)
-  }, [onSelectEntry])
+  }, [onSelectEntry, preserveStudentTableScrollPosition])
 
   useEffect(() => {
     if (!selectedStudentId || !isActive) return
@@ -312,13 +329,14 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
   const selectStudentByRow = useCallback(
     (row: LogRow) => {
+      preserveStudentTableScrollPosition()
       setSelectedStudentId(row.student_id)
       const studentName =
         [row.student_first_name, row.student_last_name].filter(Boolean).join(' ') ||
         row.email_username
       onSelectEntry?.(row.entry, studentName, row.student_id)
     },
-    [onSelectEntry]
+    [onSelectEntry, preserveStudentTableScrollPosition]
   )
 
   const selectStudentByName = useCallback(
@@ -675,7 +693,10 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
           primary={
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
             <div
+              ref={studentTableScrollRef}
               className="h-full min-h-0 overflow-auto"
+              data-testid="daily-student-scroll-pane"
+              onScroll={preserveStudentTableScrollPosition}
               onClick={(e) => {
                 // Deselect when clicking outside the table
                 if (selectedStudentId && (e.target as HTMLElement).closest('table') === null) {
@@ -702,7 +723,12 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
       </div>
     ) : (
       <div className="daily-table-enter flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-        <div className="min-h-[180px] flex-1 overflow-auto rounded-lg bg-surface">
+        <div
+          ref={studentTableScrollRef}
+          className="min-h-[180px] flex-1 overflow-auto rounded-lg bg-surface"
+          data-testid="daily-student-scroll-pane"
+          onScroll={preserveStudentTableScrollPosition}
+        >
           {renderStudentTable(true)}
         </div>
         {selectedDate && (

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -64,6 +64,7 @@ import {
   isAssignmentAlreadyReturnedWithoutResubmission,
 } from '@/lib/assignments'
 import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layout'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   getAssignmentWorkspaceStudentCookieName,
@@ -1519,6 +1520,20 @@ export function TeacherClassroomView({
     return currentStudentRows.find((student) => student.student_id === selectedStudentId) ?? null
   }, [currentStudentRows, selectedStudentId])
   const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
+  const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
+
+  const {
+    scrollRef: classPaneScrollRef,
+    preserveScrollPosition: preserveClassPaneScrollPosition,
+  } = useScrollPositionMemory<HTMLDivElement>({
+    key: selectedAssignmentId,
+    enabled: leftPaneView === 'class',
+    restoreToken: [
+      activeSelectedStudentId ?? 'none',
+      currentStudentRows.length,
+      selectedAssignmentLoading ? 'loading' : 'ready',
+    ].join(':'),
+  })
 
   const handleGoPrevStudent = useCallback(() => {
     if (selectedStudentIndex <= 0) return
@@ -1800,6 +1815,7 @@ export function TeacherClassroomView({
       rows={currentStudentRows}
       selectedStudentId={activeSelectedStudentId}
       onSelectStudent={(studentId) => {
+        preserveClassPaneScrollPosition()
         setIndividualHeaderMeta(null)
         setSelectedStudentAndNavigate(studentId)
       }}
@@ -1821,7 +1837,12 @@ export function TeacherClassroomView({
   )
 
   const classPane = (
-    <div className="h-full min-h-0 overflow-auto">
+    <div
+      ref={classPaneScrollRef}
+      className="h-full min-h-0 overflow-auto"
+      data-testid="assignment-student-scroll-pane"
+      onScroll={preserveClassPaneScrollPosition}
+    >
       {studentTable}
     </div>
   )
@@ -2067,8 +2088,6 @@ export function TeacherClassroomView({
         centerPlacement="floating"
       />
     )
-
-  const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
 
   const feedback = (
     <>

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type Ref } from 'react'
 import { X } from 'lucide-react'
 import type {
   GradebookAssessmentCell,
@@ -35,6 +35,7 @@ import {
 } from '@/lib/request-cache'
 import { applyDirection, compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 
 type GradebookSection = 'grades' | 'settings'
 type ScoreDisplayMode = 'percent' | 'raw'
@@ -430,6 +431,8 @@ function AssessmentMatrixTable({
   sortColumn,
   sortDirection,
   handleSort,
+  scrollContainerRef,
+  onScrollContainerScroll,
 }: {
   students: GradebookStudentSummary[]
   columns: GradebookAssessmentColumn[]
@@ -455,6 +458,8 @@ function AssessmentMatrixTable({
   sortColumn: GradebookSortColumn
   sortDirection: 'asc' | 'desc'
   handleSort: (column: GradebookSortColumn) => void
+  scrollContainerRef?: Ref<HTMLDivElement>
+  onScrollContainerScroll?: () => void
 }) {
   const visibleIdentityCount = IDENTITY_COLUMN_DEFS.filter((column) => visibleColumns[column.key]).length
   const renderedIdentityColumns = editMode
@@ -481,7 +486,12 @@ function AssessmentMatrixTable({
   const renderMedianRow = editMode || visibleSummaryRows.median
 
   return (
-    <div className="h-full min-h-0 overflow-auto">
+    <div
+      ref={scrollContainerRef}
+      className="h-full min-h-0 overflow-auto"
+      data-testid="gradebook-student-scroll-pane"
+      onScroll={onScrollContainerScroll}
+    >
       <TableCard chrome="flush">
         <DataTable density="tight" className="min-w-max">
           <DataTableHead>
@@ -1023,6 +1033,19 @@ export function TeacherGradebookTab({
   )
   const rowKeys = useMemo(() => sortedStudents.map((student) => student.student_id), [sortedStudents])
   const { selectedIds, toggleSelect, toggleSelectAll, allSelected } = useStudentSelection(rowKeys)
+  const {
+    scrollRef: gradebookTableScrollRef,
+    preserveScrollPosition: preserveGradebookTableScrollPosition,
+  } = useScrollPositionMemory<HTMLDivElement>({
+    key: `${classroom.id}:gradebook`,
+    enabled: !columnEditorOpen,
+    restoreToken: [
+      selectedStudentId ?? 'none',
+      sortedStudents.length,
+      loading ? 'loading' : 'ready',
+      columnEditorOpen ? 'settings' : 'grades',
+    ].join(':'),
+  })
 
   function handleSort(column: GradebookSortColumn) {
     setSortState((previous) => toggleSort(previous, column))
@@ -1088,6 +1111,7 @@ export function TeacherGradebookTab({
   }
 
   function handleStudentSelect(student: GradebookStudentSummary) {
+    preserveGradebookTableScrollPosition()
     setSelectedStudentId((previous) => (
       previous === student.student_id ? null : student.student_id
     ))
@@ -1241,6 +1265,8 @@ export function TeacherGradebookTab({
         sortColumn={sortColumn}
         sortDirection={sortDirection}
         handleSort={handleSort}
+        scrollContainerRef={gradebookTableScrollRef}
+        onScrollContainerScroll={preserveGradebookTableScrollPosition}
       />
     </div>
   )

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { Button, ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
@@ -25,6 +25,7 @@ import { Check, Pencil, X } from 'lucide-react'
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 
 type Role = 'student' | 'teacher'
 
@@ -198,6 +199,22 @@ export function TeacherRosterTab({ classroom }: Props) {
   const selectedStudentEmails = selectedRows.map((r) => r.email)
   const selectedCounselorEmails = selectedRows.map((r) => r.counselor_email).filter(Boolean) as string[]
   const selectedRosterRow = sortedRoster.find((row) => row.id === selectedRosterId) ?? null
+  const {
+    scrollRef: rosterTableScrollRef,
+    preserveScrollPosition: preserveRosterTableScrollPosition,
+  } = useScrollPositionMemory<HTMLDivElement>({
+    key: `${classroom.id}:roster`,
+    enabled: !loading,
+    restoreToken: [
+      selectedRosterId ?? 'none',
+      sortedRoster.length,
+      loading ? 'loading' : 'ready',
+    ].join(':'),
+  })
+  const selectRosterId = useCallback((nextRosterId: string | null) => {
+    preserveRosterTableScrollPosition()
+    setSelectedRosterId(nextRosterId)
+  }, [preserveRosterTableScrollPosition])
 
   useEffect(() => {
     if (selectedRosterId && !roster.some((row) => row.id === selectedRosterId)) {
@@ -488,7 +505,12 @@ export function TeacherRosterTab({ classroom }: Props) {
       onInspectorWidthChange={setDetailPaneWidth}
       dividerLabel="Resize Roster panes"
       primary={
-        <div className="h-full min-h-0 overflow-auto">
+        <div
+          ref={rosterTableScrollRef}
+          className="h-full min-h-0 overflow-auto"
+          data-testid="roster-student-scroll-pane"
+          onScroll={preserveRosterTableScrollPosition}
+        >
           <TableCard chrome="flush" overflowX>
             {error && (
               <div className="p-3 border-b border-border">
@@ -501,8 +523,8 @@ export function TeacherRosterTab({ classroom }: Props) {
             <KeyboardNavigableTable
               rowKeys={rosterIds}
               selectedKey={selectedRosterId}
-              onSelectKey={setSelectedRosterId}
-              onDeselect={() => setSelectedRosterId(null)}
+              onSelectKey={selectRosterId}
+              onDeselect={() => selectRosterId(null)}
             >
               <DataTable density="tight">
                 <DataTableHead>
@@ -551,7 +573,7 @@ export function TeacherRosterTab({ classroom }: Props) {
                         ].join(' ')}
                         onClick={(event) => {
                           if ((event.target as HTMLElement).closest('button,input,a')) return
-                          setSelectedRosterId(isSelected ? null : row.id)
+                          selectRosterId(isSelected ? null : row.id)
                         }}
                       >
                         <DataTableCell>

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -39,6 +39,7 @@ import { getQuizExitCount } from '@/lib/quizzes'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 import { Button, ConfirmDialog, DialogPanel, EmptyState, RefreshingIndicator, Select, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
@@ -482,7 +483,24 @@ export function TeacherTestsTab({
     navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
   }, [navigateTestWorkspace])
 
+  const {
+    scrollRef: gradingStudentTableScrollRef,
+    preserveScrollPosition: preserveGradingStudentTableScrollPosition,
+  } = useScrollPositionMemory<HTMLDivElement>({
+    key: selectedTestId && selectedWorkspaceTab === 'grading'
+      ? `${classroom.id}:${selectedTestId}:grading`
+      : null,
+    enabled: selectedWorkspaceTab === 'grading',
+    restoreToken: [
+      selectedStudentId ?? 'none',
+      sortedGradingStudents.length,
+      gradingLoading ? 'loading' : 'ready',
+      gradingRefreshing ? 'refreshing' : 'idle',
+    ].join(':'),
+  })
+
   const selectGradingStudent = useCallback((studentId: string | null) => {
+    preserveGradingStudentTableScrollPosition()
     setInternalSelectedStudentId(studentId)
     if (!selectedTestId || selectedWorkspaceTab !== 'grading') return
     navigateTestWorkspace({
@@ -490,7 +508,12 @@ export function TeacherTestsTab({
       mode: 'grading',
       studentId,
     })
-  }, [navigateTestWorkspace, selectedTestId, selectedWorkspaceTab])
+  }, [
+    navigateTestWorkspace,
+    preserveGradingStudentTableScrollPosition,
+    selectedTestId,
+    selectedWorkspaceTab,
+  ])
 
   const batchAutoGradePreflight = useMemo(() => {
     const selectedCount = batchSelectedStudents.length
@@ -1696,7 +1719,12 @@ export function TeacherTestsTab({
           tone="muted"
         />
       ) : (
-        <div className="min-h-0 w-full overflow-auto rounded-md border border-border bg-surface">
+        <div
+          ref={gradingStudentTableScrollRef}
+          className="min-h-0 w-full overflow-auto rounded-md border border-border bg-surface"
+          data-testid="test-grading-student-scroll-pane"
+          onScroll={preserveGradingStudentTableScrollPosition}
+        >
           <table className="w-full text-sm">
             <thead>
               <tr className="bg-surface-hover text-left text-text-muted">

--- a/src/hooks/useScrollPositionMemory.ts
+++ b/src/hooks/useScrollPositionMemory.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
+
+interface UseScrollPositionMemoryOptions {
+  key: string | null
+  enabled?: boolean
+  restoreToken?: string | number | boolean | null
+}
+
+interface UseScrollPositionMemoryResult<T extends HTMLElement> {
+  scrollRef: RefObject<T>
+  preserveScrollPosition: () => void
+  restoreScrollPosition: () => void
+}
+
+export function useScrollPositionMemory<T extends HTMLElement>({
+  key,
+  enabled = true,
+  restoreToken = null,
+}: UseScrollPositionMemoryOptions): UseScrollPositionMemoryResult<T> {
+  const scrollRef = useRef<T | null>(null)
+  const scrollTopByKeyRef = useRef<Record<string, number>>({})
+
+  const preserveScrollPosition = useCallback(() => {
+    if (!enabled || !key) return
+    const node = scrollRef.current
+    if (!node) return
+    scrollTopByKeyRef.current[key] = node.scrollTop
+  }, [enabled, key])
+
+  const restoreScrollPosition = useCallback(() => {
+    if (!enabled || !key) return
+    const node = scrollRef.current
+    if (!node) return
+    const storedScrollTop = scrollTopByKeyRef.current[key] ?? 0
+    if (node.scrollTop !== storedScrollTop) {
+      node.scrollTop = storedScrollTop
+    }
+  }, [enabled, key])
+
+  useLayoutEffect(() => {
+    restoreScrollPosition()
+    const frameId =
+      typeof window.requestAnimationFrame === 'function'
+        ? window.requestAnimationFrame(restoreScrollPosition)
+        : null
+
+    return () => {
+      if (frameId !== null && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [enabled, key, restoreScrollPosition, restoreToken])
+
+  return {
+    scrollRef,
+    preserveScrollPosition,
+    restoreScrollPosition,
+  }
+}

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TeacherAttendanceTab } from '@/app/classrooms/[classroomId]/TeacherAttendanceTab'
 import type { Classroom, Entry } from '@/types'
 
@@ -126,6 +126,31 @@ function mockLogsFetch() {
             history_preview: [],
           },
         ],
+      })
+    }
+    throw new Error(`Unhandled fetch: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function mockManyLogsFetch(count = 30) {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.startsWith('/api/teacher/logs?')) {
+      return mockJson({
+        logs: Array.from({ length: count }, (_, index) => {
+          const number = String(index + 1).padStart(2, '0')
+          const studentId = `student-${number}`
+          return {
+            student_id: studentId,
+            student_email: `${studentId}@example.com`,
+            student_first_name: `Student${number}`,
+            student_last_name: 'Test',
+            entry: index % 2 === 0 ? entry({ id: `entry-${number}`, student_id: studentId }) : null,
+            history_preview: [],
+          }
+        }),
       })
     }
     throw new Error(`Unhandled fetch: ${url}`)
@@ -316,6 +341,36 @@ describe('TeacherAttendanceTab', () => {
     })
     expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
     expect(screen.getByTestId('class-log-summary')).toBeInTheDocument()
+  })
+
+  it('restores the student table scroll position after opening a selected Daily workspace', async () => {
+    let latestAnimationFrame: FrameRequestCallback | null = null
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      latestAnimationFrame = callback
+      return 1
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    mockManyLogsFetch()
+
+    render(<TeacherAttendanceTab classroom={classroom} />)
+
+    await screen.findByRole('cell', { name: 'Student25', exact: true })
+
+    const scrollPane = screen.getByTestId('daily-student-scroll-pane') as HTMLDivElement
+    scrollPane.scrollTop = 520
+    fireEvent.scroll(scrollPane)
+
+    fireEvent.click(screen.getByRole('cell', { name: 'Student25', exact: true }))
+
+    expect(await screen.findByTestId('student-log-history')).toHaveTextContent('History for student-25')
+
+    const selectedScrollPane = screen.getByTestId('daily-student-scroll-pane') as HTMLDivElement
+    selectedScrollPane.scrollTop = 0
+    act(() => {
+      latestAnimationFrame?.(0)
+    })
+
+    expect(selectedScrollPane.scrollTop).toBe(520)
   })
 
   it('deselects the selected student when Escape is pressed', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -237,7 +237,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
             Mock resize split
           </button>
           <div>{`overview:${assignmentId}:${studentId}`}</div>
-          <div data-testid="assignment-left-pane">
+          <div key={studentId} data-testid="assignment-left-pane">
             {leftHeader}
             {leftPaneView === 'class' ? classPane : <div>{`work:${assignmentId}:${studentId}`}</div>}
           </div>
@@ -404,6 +404,29 @@ function makeMaterialSummary(id: string, title: string, overrides: Partial<Class
   }
 }
 
+function makeStudentSubmissionRow(studentId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    student_id: studentId,
+    student_email: `${studentId}@example.com`,
+    student_first_name: studentId,
+    student_last_name: 'Student',
+    status: 'submitted_on_time',
+    student_updated_at: '2026-04-10T12:00:00Z',
+    artifacts: [],
+    doc: {
+      submitted_at: '2026-04-10T12:00:00Z',
+      updated_at: '2026-04-10T12:00:00Z',
+      score_completion: null,
+      score_thinking: null,
+      score_workflow: null,
+      graded_at: null,
+      returned_at: null,
+      feedback_returned_at: null,
+    },
+    ...overrides,
+  }
+}
+
 function makeAssignmentDetails(
   assignmentId: string,
   title: string,
@@ -427,25 +450,7 @@ function makeAssignmentDetails(
       updated_at: '2026-04-01T12:00:00Z',
     },
     students: [
-      {
-        student_id: studentId,
-        student_email: `${studentId}@example.com`,
-        student_first_name: studentId,
-        student_last_name: 'Student',
-        status: 'submitted_on_time',
-        student_updated_at: '2026-04-10T12:00:00Z',
-        artifacts: [],
-        doc: {
-          submitted_at: '2026-04-10T12:00:00Z',
-          updated_at: '2026-04-10T12:00:00Z',
-          score_completion: null,
-          score_thinking: null,
-          score_workflow: null,
-          graded_at: null,
-          returned_at: null,
-          feedback_returned_at: null,
-        },
-      },
+      makeStudentSubmissionRow(studentId),
     ],
     active_ai_grading_run: activeAiGradingRun,
   }
@@ -1615,6 +1620,57 @@ describe('TeacherClassroomView', () => {
     const leftPaneControls = within(screen.getByRole('group', { name: 'Assignment workspace view' }))
     expect(leftPaneControls.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
     expect(leftPaneControls.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('restores the class-pane scroll position after selecting a lower student row', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            assignment: makeAssignmentDetails('assignment-1', 'Assignment One', 'student-01').assignment,
+            students: Array.from({ length: 30 }, (_, index) =>
+              makeStudentSubmissionRow(`student-${String(index + 1).padStart(2, '0')}`),
+            ),
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-01')
+    })
+
+    const scrollPane = screen.getByTestId('assignment-student-scroll-pane') as HTMLDivElement
+    scrollPane.scrollTop = 520
+    fireEvent.scroll(scrollPane)
+
+    fireEvent.click(screen.getAllByText('student-25')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-25')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-student-scroll-pane')).toHaveProperty('scrollTop', 520)
+    })
   })
 
   it('keeps the active student selected when Escape is pressed in class mode', async () => {


### PR DESCRIPTION
## Summary

- Add a shared `useScrollPositionMemory` hook for scroll containers that remount or refresh after row selection.
- Preserve teacher assignment class-pane scroll while selecting students far down the list.
- Apply the same scroll preservation pattern to Daily, Roster, Gradebook, and Tests grading student tables.
- Add regression coverage for the assignment student table and Daily table scroll restoration.

## Root Cause

Selecting a row updated route/selection state and caused the left student pane to refresh or remount. The replacement scroll container started at `scrollTop = 0`, so teachers selecting lower students lost their place in the list.

## Impact

Teachers can select students lower in the affected tables without the list jumping back to the top. The hook stores scroll offsets per table/work item key and restores them after selection-driven refreshes.

## Validation

- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
- `pnpm lint`
- `pnpm build`
- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/61164fb0-26d2-4862-abfe-5517ccdc685a?tab=assignments&assignmentId=9ff41b8e-bb7a-485b-a553-fb11dfd98545&assignmentStudentId=852830be-50b4-48fe-9b03-67e4d1d49a37'`
- Delayed loaded-state teacher desktop screenshot: `/tmp/pika-teacher-loaded.png`