### PR TITLE
[codex] Improve student Today history and plan pane

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -375,3 +375,60 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/61164fb0-26d2-4862-abfe-5517ccdc685a?tab=assignments&assignmentId=9ff41b8e-bb7a-485b-a553-fb11dfd98545&assignmentStudentId=852830be-50b4-48fe-9b03-67e4d1d49a37'`
 - Delayed loaded-state teacher desktop screenshot: `/tmp/pika-teacher-loaded.png`
+## 2026-05-12 — Student Today past log expansion
+
+**Completed:**
+- Removed the parent collapse control from the student Today past-log section.
+- Changed the section to always show past logs, excluding the current Today entry.
+- Added per-log expand/collapse behavior: collapsed entries use a two-line clamp with ellipsis and clicking the log reveals the full text.
+- Split the student Today right pane into `Today` and `Last Class` lesson-plan sections, with the previous class day loaded from shared class-day state.
+- Updated focused Today history component coverage for default visibility, per-entry toggling, empty past-log state, and sessionStorage caching.
+- Added page-client coverage for the student Today sidebar showing both current and last-class lesson-plan content.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- Visual verification via temporary local harness after standard auth/seed path was blocked by local Supabase being down because Docker was not running:
+  - `/tmp/pika-student-today-mobile.png`
+  - `/tmp/pika-student-today-mobile-expanded.png`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/90c4fdd7-28c0-4474-998e-650eee270d57?tab=today'`
+- Additional desktop student pane capture:
+  - `/tmp/pika-student-today-desktop.png`
+
+## 2026-05-12 — Student Today split pane and richer seed logs
+
+**Completed:**
+- Moved the student Today lesson-plan panel out of the global right sidebar and into a teacher-style gapped split workspace.
+- Kept the Today and Last Class lesson-plan sections in a rounded right pane and rendered lesson-plan rich text flush, without the nested viewer border/padding.
+- Disabled the external Today right sidebar route config and expanded the student Today history fetch/cache limit to 12 entries.
+- Updated `seed` and `seed:fresh` to create 20 sample student logs across recent class days, including several long entries, and to seed lesson plans for both today and the last class.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/unit/layout-config.test.ts`
+- `pnpm lint`
+- `pnpm seed:fresh`
+- `pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
+- Additional desktop student split capture: `/tmp/pika-student-today-desktop-split-final.png`
+- `git diff --check`
+- `pnpm build`
+
+## 2026-05-12 — Student Today previous-day heading
+
+**Completed:**
+- Changed the student Today right-pane previous-class heading to show `Yesterday` when the previous class date is yesterday.
+- Moved the formatted date next to the heading instead of pinning it to the far right of the pane.
+- Kept the fallback copy as `Last class` for non-yesterday previous class days.
+
+**Validation:**
+- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/unit/layout-config.test.ts`
+- `pnpm lint`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3010 pnpm e2e:auth`
+- `E2E_BASE_URL=http://localhost:3010 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
+- Additional desktop student split capture: `/tmp/pika-student-today-yesterday-desktop.png`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,54 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-08 — Add class log summary controls
-
-**Completed:**
-- Confirmed the Vercel nightly log summary cron remains `0 6 * * *` (06:00 UTC: 1:00am EST / 2:00am EDT).
-- Added a floating attendance action control to show or hide the bottom Class Log Summary card.
-- Added a drag/keyboard resize handle for the visible Class Log Summary card.
-- Kept the log summary data component unchanged and scoped behavior to teacher attendance presentation state.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/log-summary-panel-controls bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification on port 3000:
-  - `/tmp/pika-log-summary-teacher-visible.png`
-  - `/tmp/pika-log-summary-teacher-hidden.png`
-  - `/tmp/pika-log-summary-teacher-expanded.png`
-  - `/tmp/pika-log-summary-teacher-populated.png`
-  - `/tmp/pika-log-summary-teacher-mobile.png`
-  - `/tmp/pika-log-summary-student-mobile.png`
-
-## 2026-05-08 — Extract assignment lifecycle invariants
-
-**Completed:**
-- Added shared assignment release-state helpers for draft/live/scheduled visibility in `src/lib/assignments.ts`.
-- Moved student assignment visibility behind the shared helper while preserving the server import path.
-- Centralized future scheduled-release due-date validation and migrated assignment update/release routes plus scheduling UI callers.
-- Added release-state and future schedule validation tests, including malformed `released_at` fail-closed behavior.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/.codex/worktrees/53f9/pika bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/unit/assignments.test.ts tests/lib/assignment-schedule-validation.test.ts tests/api/assignment-docs/submit.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-draft.test.ts tests/components/AssignmentModal.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm vitest run tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/student/assignments.test.ts tests/api/integration/assignment-draft-flow.test.ts tests/api/student/notifications.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
-## 2026-05-08 — Open assignment invariant PR
-
-**Completed:**
-- Created branch `codex/assignment-lifecycle-invariants`.
-- Committed assignment lifecycle invariant extraction as `37cd562`.
-- Opened draft PR #570 and added `codex` plus `codex-automation` labels.
-- Posted a self-review comment with no blocking findings.
-
-**Validation:**
-- PR checks showed Vercel skipped by ignored build step, with preview comments passing.
-
 ## 2026-05-08 — Unblock assignment invariant merge
 
 **Completed:**
@@ -375,6 +327,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/61164fb0-26d2-4862-abfe-5517ccdc685a?tab=assignments&assignmentId=9ff41b8e-bb7a-485b-a553-fb11dfd98545&assignmentStudentId=852830be-50b4-48fe-9b03-67e4d1d49a37'`
 - Delayed loaded-state teacher desktop screenshot: `/tmp/pika-teacher-loaded.png`
+
 ## 2026-05-12 — Student Today past log expansion
 
 **Completed:**

--- a/scripts/clear-and-seed.ts
+++ b/scripts/clear-and-seed.ts
@@ -316,61 +316,62 @@ async function clearAndSeed() {
 
   const todayToronto = getTodayInToronto()
   const pastDates = dates.filter(d => d <= todayToronto)
-  const entryDates = (pastDates.length >= 3 ? pastDates.slice(-3) : dates.slice(0, 3)).filter(Boolean)
+  const desiredEntryCount = 12
+  const entryDates = (
+    pastDates.length >= desiredEntryCount
+      ? pastDates.slice(-desiredEntryCount)
+      : dates.slice(0, desiredEntryCount)
+  ).filter(Boolean)
 
-  if (entryDates.length < 3) {
+  if (entryDates.length < 6) {
     throw new Error('Seed calendar did not produce enough dates for sample entries')
   }
 
-  const sampleEntries = [
-    // Student 1 - Good attendance (mostly on time)
-    {
-      student_id: students[0]!.id,
-      classroom_id: createdClassroom.id,
-      date: entryDates[0],
-      text: 'Today I learned about functions in JavaScript. I practiced writing arrow functions and understood the difference between function declarations and expressions.',
-      minutes_reported: 90,
-      mood: '😊',
-      on_time: true,
-    },
-    {
-      student_id: students[0]!.id,
-      classroom_id: createdClassroom.id,
-      date: entryDates[1],
-      text: 'Worked on array methods like map, filter, and reduce. These are really powerful! I created a small project to practice these concepts.',
-      minutes_reported: 120,
-      mood: '😊',
-      on_time: true,
-    },
-    {
-      student_id: students[0]!.id,
-      classroom_id: createdClassroom.id,
-      date: entryDates[2],
-      text: 'Started learning about async/await and promises. This is challenging but I\'m making progress.',
-      minutes_reported: 75,
-      mood: '🙂',
-      on_time: true,
-    },
+  const studentOneLogTexts = [
+    'Set up the course notebook, checked the classroom resources, and made sure my development tools were ready for the term.',
+    'Practiced variables, conditionals, and trace tables. The trace table helped me slow down and catch a mistake before I ran the code.',
+    'Built a small checklist page and connected the buttons to state. I still need to clean up the naming, but the interaction works now.',
+    'Today I wrote a longer reflection on debugging. I started with a layout bug that looked like a CSS problem, but it turned out the data I expected was never reaching the component. I used console output first, then narrowed the issue by checking one function at a time. The important part was writing down what I expected before changing code. I also helped compare two approaches for the same task: one with repeated conditionals and one with a small helper function. The helper version was easier to read because it named the decision directly. My next step is to practice explaining the cause of a bug in one sentence before I fix it, because that makes the fix less random.',
+    'Reviewed array methods with map, filter, and reduce. Reduce is still the trickiest because I have to track the accumulator carefully.',
+    'Worked on an async example that fetches data and shows loading, success, and error states. I had to test the error state twice to make sure it actually appeared.',
+    'I spent most of class revising a project log after peer feedback. The first version only listed what I did, so I rewrote it to explain what changed, why it changed, and what evidence showed the change worked. I included the bug where my empty state showed at the wrong time, then described how I traced it to a stale boolean. This was a useful reminder that a log is more helpful when it captures a decision, not just a task list. I also added a short note about what I would do differently next time: write the empty, loading, and loaded states before styling the page.',
+    'Finished the lesson on functions and parameters. I can explain the difference between passing a value and returning a value more clearly now.',
+    'Started planning the final mini-project. I sketched the main screen, wrote down the data I need, and picked one feature to build first instead of trying everything at once.',
+    'Today was a heavy writing day. I documented the project plan, including the problem, the users, the minimum version, and the stretch ideas. The hardest part was cutting the plan down to something realistic. I originally listed five features, but after checking the time left I moved two of them into a later section. I also wrote acceptance checks for the first feature: the user can add an item, edit it, mark it done, and still see it after refresh. Having those checks made the task feel less vague. I want to keep using that format because it gives me a clear way to know when something is actually finished. I also wrote a risk list for the parts that could take longer than expected. The biggest risks are saving data, handling empty states, and making the layout work on a phone. For each one I wrote a fallback plan so I do not get stuck: save to local state first, show a simple empty message, and keep the mobile layout stacked if the split view feels too tight. This entry is intentionally long because I want to test how the history list handles a student writing several connected thoughts instead of a short sentence.',
+    'Tested the project in a smaller browser width and found two text wrapping problems. I fixed one and wrote a note for the other.',
+    'Submitted today with a short demo of the working feature. I am happy with the progress, but I still want to refactor one repeated block tomorrow.',
+  ]
 
-    // Student 2 - Mixed attendance
-    {
-      student_id: students[1]!.id,
+  const studentTwoLogTexts = [
+    'Joined late but reviewed the starter files and got the local project running.',
+    'Completed the variables practice and wrote down two questions about naming conventions.',
+    'Had trouble with array methods today. I understand map when the example is small, but I get lost when the callback has more than one step. I tried rewriting the callback as a regular function first, which made it easier to read. I also compared my output to the sample output after each change instead of waiting until the end. That helped me find one place where I returned the wrong property. I need more practice, but I can at least explain what each method is supposed to do now.',
+    'Worked with a partner on the layout challenge. We divided the work so one person handled structure and one handled spacing.',
+    'Read through feedback on my last entry and added more detail about the problem I was solving.',
+    'Missed part of the demonstration because of connection problems. I caught up by reading the notes and rebuilding the example slowly.',
+    'This was a long catch-up session. I went back through three older tasks, compared them to the checklist, and marked what was actually complete. One task looked finished visually but did not handle an empty list, so I added an empty message and tested it. Another task saved the right data but used confusing variable names, so I renamed them after checking that the behavior stayed the same. The main thing I learned is that catching up is easier when I separate missing code, unclear code, and untested code instead of treating everything as one big problem.',
+    'Prepared questions for next class about project scope and how to decide when a helper function is worth adding.',
+  ]
+
+  const sampleEntries = [
+    ...entryDates.map((date, index) => ({
+      student_id: students[0]!.id,
       classroom_id: createdClassroom.id,
-      date: entryDates[0],
-      text: 'Introduction to the course. Reviewed the syllabus and set up my development environment.',
-      minutes_reported: 60,
-      mood: '🙂',
+      date,
+      text: studentOneLogTexts[index % studentOneLogTexts.length],
+      minutes_reported: 60 + ((index % 5) * 15),
+      mood: (index % 4 === 3 ? '😐' : index % 2 === 0 ? '😊' : '🙂'),
       on_time: true,
-    },
-    {
+    })),
+    ...entryDates.slice(-studentTwoLogTexts.length).map((date, index) => ({
       student_id: students[1]!.id,
       classroom_id: createdClassroom.id,
-      date: entryDates[1],
-      text: 'Sorry for the late submission. Had some technical issues but completed the reading.',
-      minutes_reported: 45,
-      mood: '😐',
-      on_time: false,
-    },
+      date,
+      text: studentTwoLogTexts[index],
+      minutes_reported: 45 + ((index % 4) * 15),
+      mood: (index % 3 === 2 ? '😐' : '🙂'),
+      on_time: index !== 0 && index !== 5,
+    })),
   ]
 
   const entriesWithTimestamps = sampleEntries.map(entry => {
@@ -395,9 +396,16 @@ async function clearAndSeed() {
   // 6. Create sample lesson plans
   console.log('Creating sample lesson plans...')
 
-  // Get the next few class days for lesson plans
+  // Include last class plus the next few class days for lesson plans.
+  const lastClassLessonPlanDate = pastDates.filter(d => d < todayToronto).slice(-1)[0]
   const futureDates = dates.filter(d => d >= todayToronto).slice(0, 5)
-  const lessonPlanDates = futureDates.length >= 3 ? futureDates : dates.slice(0, 5)
+  const lessonPlanCandidates = [lastClassLessonPlanDate, ...futureDates].filter(
+    (date): date is string => Boolean(date)
+  )
+  const lessonPlanDates =
+    lessonPlanCandidates.length >= 3
+      ? Array.from(new Set(lessonPlanCandidates)).slice(0, 5)
+      : dates.slice(0, 5)
 
   const sampleLessonPlans = lessonPlanDates.map((date, index) => ({
     classroom_id: createdClassroom.id,

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -240,63 +240,64 @@ async function seed() {
 
   const todayToronto = getTodayInToronto()
   const pastDates = dates.filter(d => d <= todayToronto)
-  const entryDates = (pastDates.length >= 3 ? pastDates.slice(-3) : dates.slice(0, 3)).filter(Boolean)
+  const desiredEntryCount = 12
+  const entryDates = (
+    pastDates.length >= desiredEntryCount
+      ? pastDates.slice(-desiredEntryCount)
+      : dates.slice(0, desiredEntryCount)
+  ).filter(Boolean)
 
-  if (entryDates.length < 3) {
+  if (entryDates.length < 6) {
     console.log('⚠ Not enough dates for sample entries, skipping entries')
   } else {
     // Delete existing entries for this classroom
     await supabase.from('entries').delete().eq('classroom_id', createdClassroom.id)
 
-    const sampleEntries = [
-      // Student 1 - Good attendance (mostly on time)
-      {
-        student_id: students[0]!.id,
-        classroom_id: createdClassroom.id,
-        date: entryDates[0],
-        text: 'Today I learned about functions in JavaScript. I practiced writing arrow functions and understood the difference between function declarations and expressions.',
-        minutes_reported: 90,
-        mood: '😊',
-        on_time: true,
-      },
-      {
-        student_id: students[0]!.id,
-        classroom_id: createdClassroom.id,
-        date: entryDates[1],
-        text: 'Worked on array methods like map, filter, and reduce. These are really powerful! I created a small project to practice these concepts.',
-        minutes_reported: 120,
-        mood: '😊',
-        on_time: true,
-      },
-      {
-        student_id: students[0]!.id,
-        classroom_id: createdClassroom.id,
-        date: entryDates[2],
-        text: 'Started learning about async/await and promises. This is challenging but I\'m making progress.',
-        minutes_reported: 75,
-        mood: '🙂',
-        on_time: true,
-      },
+    const studentOneLogTexts = [
+      'Set up the course notebook, checked the classroom resources, and made sure my development tools were ready for the term.',
+      'Practiced variables, conditionals, and trace tables. The trace table helped me slow down and catch a mistake before I ran the code.',
+      'Built a small checklist page and connected the buttons to state. I still need to clean up the naming, but the interaction works now.',
+      'Today I wrote a longer reflection on debugging. I started with a layout bug that looked like a CSS problem, but it turned out the data I expected was never reaching the component. I used console output first, then narrowed the issue by checking one function at a time. The important part was writing down what I expected before changing code. I also helped compare two approaches for the same task: one with repeated conditionals and one with a small helper function. The helper version was easier to read because it named the decision directly. My next step is to practice explaining the cause of a bug in one sentence before I fix it, because that makes the fix less random.',
+      'Reviewed array methods with map, filter, and reduce. Reduce is still the trickiest because I have to track the accumulator carefully.',
+      'Worked on an async example that fetches data and shows loading, success, and error states. I had to test the error state twice to make sure it actually appeared.',
+      'I spent most of class revising a project log after peer feedback. The first version only listed what I did, so I rewrote it to explain what changed, why it changed, and what evidence showed the change worked. I included the bug where my empty state showed at the wrong time, then described how I traced it to a stale boolean. This was a useful reminder that a log is more helpful when it captures a decision, not just a task list. I also added a short note about what I would do differently next time: write the empty, loading, and loaded states before styling the page.',
+      'Finished the lesson on functions and parameters. I can explain the difference between passing a value and returning a value more clearly now.',
+      'Started planning the final mini-project. I sketched the main screen, wrote down the data I need, and picked one feature to build first instead of trying everything at once.',
+      'Today was a heavy writing day. I documented the project plan, including the problem, the users, the minimum version, and the stretch ideas. The hardest part was cutting the plan down to something realistic. I originally listed five features, but after checking the time left I moved two of them into a later section. I also wrote acceptance checks for the first feature: the user can add an item, edit it, mark it done, and still see it after refresh. Having those checks made the task feel less vague. I want to keep using that format because it gives me a clear way to know when something is actually finished. I also wrote a risk list for the parts that could take longer than expected. The biggest risks are saving data, handling empty states, and making the layout work on a phone. For each one I wrote a fallback plan so I do not get stuck: save to local state first, show a simple empty message, and keep the mobile layout stacked if the split view feels too tight. This entry is intentionally long because I want to test how the history list handles a student writing several connected thoughts instead of a short sentence.',
+      'Tested the project in a smaller browser width and found two text wrapping problems. I fixed one and wrote a note for the other.',
+      'Submitted today with a short demo of the working feature. I am happy with the progress, but I still want to refactor one repeated block tomorrow.',
+    ]
 
-      // Student 2 - Mixed attendance
-      {
-        student_id: students[1]!.id,
+    const studentTwoLogTexts = [
+      'Joined late but reviewed the starter files and got the local project running.',
+      'Completed the variables practice and wrote down two questions about naming conventions.',
+      'Had trouble with array methods today. I understand map when the example is small, but I get lost when the callback has more than one step. I tried rewriting the callback as a regular function first, which made it easier to read. I also compared my output to the sample output after each change instead of waiting until the end. That helped me find one place where I returned the wrong property. I need more practice, but I can at least explain what each method is supposed to do now.',
+      'Worked with a partner on the layout challenge. We divided the work so one person handled structure and one handled spacing.',
+      'Read through feedback on my last entry and added more detail about the problem I was solving.',
+      'Missed part of the demonstration because of connection problems. I caught up by reading the notes and rebuilding the example slowly.',
+      'This was a long catch-up session. I went back through three older tasks, compared them to the checklist, and marked what was actually complete. One task looked finished visually but did not handle an empty list, so I added an empty message and tested it. Another task saved the right data but used confusing variable names, so I renamed them after checking that the behavior stayed the same. The main thing I learned is that catching up is easier when I separate missing code, unclear code, and untested code instead of treating everything as one big problem.',
+      'Prepared questions for next class about project scope and how to decide when a helper function is worth adding.',
+    ]
+
+    const sampleEntries = [
+      ...entryDates.map((date, index) => ({
+        student_id: students[0]!.id,
         classroom_id: createdClassroom.id,
-        date: entryDates[0],
-        text: 'Introduction to the course. Reviewed the syllabus and set up my development environment.',
-        minutes_reported: 60,
-        mood: '🙂',
+        date,
+        text: studentOneLogTexts[index % studentOneLogTexts.length],
+        minutes_reported: 60 + ((index % 5) * 15),
+        mood: (index % 4 === 3 ? '😐' : index % 2 === 0 ? '😊' : '🙂'),
         on_time: true,
-      },
-      {
+      })),
+      ...entryDates.slice(-studentTwoLogTexts.length).map((date, index) => ({
         student_id: students[1]!.id,
         classroom_id: createdClassroom.id,
-        date: entryDates[1],
-        text: 'Sorry for the late submission. Had some technical issues but completed the reading.',
-        minutes_reported: 45,
-        mood: '😐',
-        on_time: false,
-      },
+        date,
+        text: studentTwoLogTexts[index],
+        minutes_reported: 45 + ((index % 4) * 15),
+        mood: (index % 3 === 2 ? '😐' : '🙂'),
+        on_time: index !== 0 && index !== 5,
+      })),
     ]
 
     const entriesWithTimestamps = sampleEntries.map(entry => {
@@ -372,9 +373,16 @@ async function seed() {
   // 6. Create sample lesson plans
   console.log('Creating sample lesson plans...')
 
-  // Get the next few class days for lesson plans
+  // Include last class plus the next few class days for lesson plans.
+  const lastClassLessonPlanDate = pastDates.filter(d => d < todayToronto).slice(-1)[0]
   const futureDates = dates.filter(d => d >= todayToronto).slice(0, 5)
-  const lessonPlanDates = futureDates.length >= 3 ? futureDates : dates.slice(0, 5)
+  const lessonPlanCandidates = [lastClassLessonPlanDate, ...futureDates].filter(
+    (date): date is string => Boolean(date)
+  )
+  const lessonPlanDates =
+    lessonPlanCandidates.length >= 3
+      ? Array.from(new Set(lessonPlanCandidates)).slice(0, 5)
+      : dates.slice(0, 5)
 
   // Delete existing lesson plans for this classroom
   await supabase.from('lesson_plans').delete().eq('classroom_id', createdClassroom.id)

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { differenceInCalendarDays, format, parseISO } from 'date-fns'
 import { AppShell } from '@/components/AppShell'
 import { TeacherClassroomView, TeacherAssignmentsMarkdownSidebar, type AssignmentViewMode } from './TeacherClassroomView'
 import { assignmentsToMarkdown, markdownToAssignments } from '@/lib/assignment-markdown'
@@ -20,7 +21,8 @@ import { TeacherQuizzesTab } from './TeacherQuizzesTab'
 import { TeacherTestsTab } from './TeacherTestsTab'
 import { StudentQuizzesTab } from './StudentQuizzesTab'
 import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
-import { ClassDaysProvider } from '@/hooks/useClassDays'
+import { ClassDaysProvider, useClassDaysContext } from '@/hooks/useClassDays'
+import { getMostRecentClassDayBefore } from '@/lib/class-days'
 import {
   ThreePanelProvider,
   ThreePanelShell,
@@ -42,11 +44,13 @@ import {
   TEACHER_QUIZZES_UPDATED_EVENT,
 } from '@/lib/events'
 import { TeacherTestPreviewPage } from '@/components/TeacherTestPreviewPage'
+import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import { ConfirmDialog, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
+import { getTodayInToronto } from '@/lib/timezone'
 import type {
   Classroom,
   LessonPlan,
@@ -202,6 +206,136 @@ export function ClassroomPageClient({
   )
 }
 
+function hasLessonPlanContent(plan: LessonPlan | null) {
+  return Boolean(
+    plan?.content &&
+    plan.content.content &&
+    plan.content.content.length > 0
+  )
+}
+
+function getLastClassHeading(lastClassDate: string | null) {
+  if (!lastClassDate) return 'Last class'
+
+  const daysAgo = differenceInCalendarDays(
+    parseISO(getTodayInToronto()),
+    parseISO(lastClassDate)
+  )
+
+  return daysAgo === 1 ? 'Yesterday' : 'Last class'
+}
+
+function StudentTodayPlanSidebar({
+  todayLessonPlan,
+  lastClassLessonPlan,
+  lastClassDate,
+  lastClassLoading,
+}: {
+  todayLessonPlan: LessonPlan | null
+  lastClassLessonPlan: LessonPlan | null
+  lastClassDate: string | null
+  lastClassLoading: boolean
+}) {
+  const viewerClassName = 'min-h-0 flex-1 overflow-y-auto [&_.simple-viewer-content_.tiptap.ProseMirror.simple-editor]:!p-0'
+  const lastClassHeading = getLastClassHeading(lastClassDate)
+  const missingLessonPlanLabel = lastClassHeading === 'Yesterday' ? 'yesterday' : 'last class'
+
+  return (
+    <div className="flex h-full min-h-0 flex-col divide-y divide-border">
+      <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+        <h3 className="text-sm font-semibold text-text-default">Today</h3>
+        {hasLessonPlanContent(todayLessonPlan) ? (
+          <div className={viewerClassName}>
+            <RichTextViewer content={todayLessonPlan!.content} chrome="flush" />
+          </div>
+        ) : (
+          <p className="text-sm text-text-muted">
+            No lesson plan for today.
+          </p>
+        )}
+      </section>
+
+      <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+        <div className="flex items-baseline gap-2">
+          <h3 className="text-sm font-semibold text-text-default">{lastClassHeading}</h3>
+          {lastClassDate ? (
+            <span className="text-xs text-text-muted">
+              {format(parseISO(lastClassDate), 'EEE MMM d')}
+            </span>
+          ) : null}
+        </div>
+        {!lastClassDate ? (
+          <p className="text-sm text-text-muted">
+            No previous class day yet.
+          </p>
+        ) : lastClassLoading ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : hasLessonPlanContent(lastClassLessonPlan) ? (
+          <div className={viewerClassName}>
+            <RichTextViewer content={lastClassLessonPlan!.content} chrome="flush" />
+          </div>
+        ) : (
+          <p className="text-sm text-text-muted">
+            No lesson plan for {missingLessonPlanLabel}.
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function StudentTodayWorkspace({
+  classroom,
+  todayLessonPlan,
+  lastClassLessonPlan,
+  lastClassDate,
+  lastClassLoading,
+  onLessonPlanLoad,
+}: {
+  classroom: Classroom
+  todayLessonPlan: LessonPlan | null
+  lastClassLessonPlan: LessonPlan | null
+  lastClassDate: string | null
+  lastClassLoading: boolean
+  onLessonPlanLoad: (plan: LessonPlan | null) => void
+}) {
+  const [planPaneWidth, setPlanPaneWidth] = useState(34)
+
+  return (
+    <TeacherWorkspaceSplit
+      className="flex-1 pt-2"
+      splitVariant="gapped"
+      primaryClassName="min-h-0"
+      inspectorClassName="min-h-0 rounded-lg border border-border bg-surface"
+      inspectorCollapsed={false}
+      inspectorWidth={planPaneWidth}
+      minInspectorPx={300}
+      minPrimaryPx={480}
+      minInspectorPercent={28}
+      maxInspectorPercent={46}
+      onInspectorWidthChange={setPlanPaneWidth}
+      dividerLabel="Resize today and plan panes"
+      primary={
+        <StudentTodayTab
+          classroom={classroom}
+          layout="pane"
+          onLessonPlanLoad={onLessonPlanLoad}
+        />
+      }
+      inspector={
+        <StudentTodayPlanSidebar
+          todayLessonPlan={todayLessonPlan}
+          lastClassLessonPlan={lastClassLessonPlan}
+          lastClassDate={lastClassDate}
+          lastClassLoading={lastClassLoading}
+        />
+      }
+    />
+  )
+}
+
 // Separate component to access ThreePanelProvider context
 function ClassroomPageContent({
   classroom,
@@ -222,6 +356,7 @@ function ClassroomPageContent({
 }) {
   const { openLeft, openRight, close: closeMobileDrawer } = useMobileDrawer()
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
+  const { classDays } = useClassDaysContext()
   const { showMarkdown } = useMarkdownPreference()
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
@@ -420,6 +555,9 @@ function ClassroomPageContent({
 
   // State for today's lesson plan (student today tab)
   const [todayLessonPlan, setTodayLessonPlan] = useState<LessonPlan | null>(null)
+  const [lastClassLessonPlan, setLastClassLessonPlan] = useState<LessonPlan | null>(null)
+  const [lastClassLessonPlanDate, setLastClassLessonPlanDate] = useState<string | null>(null)
+  const [lastClassLessonPlanLoading, setLastClassLessonPlanLoading] = useState(false)
 
   // State for calendar sidebar (teacher calendar tab)
   const [calendarSidebarState, setCalendarSidebarState] = useState<CalendarSidebarState | null>(null)
@@ -486,6 +624,50 @@ function ClassroomPageContent({
   const handleSetLessonPlan = useCallback((plan: LessonPlan | null) => {
     setTodayLessonPlan(plan)
   }, [])
+
+  useEffect(() => {
+    if (isTeacher || activeTab !== 'today') return
+
+    const todayDate = getTodayInToronto()
+    const lastClassDate = getMostRecentClassDayBefore(classDays, todayDate)
+    setLastClassLessonPlanDate(lastClassDate)
+
+    if (!lastClassDate) {
+      setLastClassLessonPlan(null)
+      setLastClassLessonPlanLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLastClassLessonPlanLoading(true)
+    fetchJSONWithCache<{ lesson_plans?: LessonPlan[]; lessonPlans?: LessonPlan[] }>(
+      `student-today:last-class-plan:${classroom.id}:${lastClassDate}`,
+      async () => {
+        const response = await fetch(
+          `/api/student/classrooms/${classroom.id}/lesson-plans?start=${lastClassDate}&end=${lastClassDate}`
+        )
+        if (!response.ok) throw new Error('Failed to load last class lesson plan')
+        return response.json()
+      },
+      30_000
+    )
+      .then((data) => {
+        if (cancelled) return
+        const plans = data.lesson_plans || data.lessonPlans || []
+        setLastClassLessonPlan(plans.find(plan => plan.date === lastClassDate) || null)
+        setLastClassLessonPlanLoading(false)
+      })
+      .catch((error) => {
+        if (cancelled) return
+        console.error('Error loading last class lesson plan:', error)
+        setLastClassLessonPlan(null)
+        setLastClassLessonPlanLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, classDays, classroom.id, isTeacher])
 
   const handleViewModeChange = useCallback((mode: AssignmentViewMode) => {
     setAssignmentViewMode(mode)
@@ -938,6 +1120,8 @@ function ClassroomPageContent({
       (activeTab === 'assignments' && !!assignmentIdParam && !!assignmentStudentIdParam) ||
       (activeTab === 'tests' && !!testIdParam && testModeParam === 'grading' && !!testStudentIdParam)
     )
+  const hasConstrainedWorkspace =
+    hasActiveTeacherSplitPanes || (!isTeacher && activeTab === 'today')
 
   async function handleRequestAssessmentDelete() {
     if (!selectedQuiz) return
@@ -1024,7 +1208,7 @@ function ClassroomPageContent({
       onNavigateHome={handleHomeNavigationAttempt}
       onNavigateClassroom={handleClassroomNavigationAttempt}
       mainClassName="max-w-none px-0 py-0"
-      constrainToViewport={hasActiveTeacherSplitPanes}
+      constrainToViewport={hasConstrainedWorkspace}
       examModeHeader={examHeaderData}
       pageTitle={undefined}
     >
@@ -1187,8 +1371,12 @@ function ClassroomPageContent({
                 <>
                   {mountedTabs.today && (
                     <TabContentTransition isActive={activeTab === 'today'}>
-                      <StudentTodayTab
+                      <StudentTodayWorkspace
                         classroom={classroom}
+                        todayLessonPlan={todayLessonPlan}
+                        lastClassLessonPlan={lastClassLessonPlan}
+                        lastClassDate={lastClassLessonPlanDate}
+                        lastClassLoading={lastClassLessonPlanLoading}
                         onLessonPlanLoad={handleSetLessonPlan}
                       />
                     </TabContentTransition>
@@ -1257,6 +1445,7 @@ function ClassroomPageContent({
           </PageDensityProvider>
         </MainContent>
 
+        {!isTeacher && activeTab === 'today' ? null : (
         <RightSidebar
           hideDesktopHeader={false}
           minimalMobileHeader={false}
@@ -1271,8 +1460,6 @@ function ClassroomPageContent({
               ? ''
               : activeTab === 'assignments'
               ? (selectedAssignment?.title || 'Instructions')
-              : activeTab === 'today'
-              ? "Today's Plan"
               : 'Details'
           }
           headerActions={
@@ -1357,24 +1544,13 @@ function ClassroomPageContent({
                 </p>
               )}
             </div>
-          ) : activeTab === 'today' ? (
-            <div className="p-4">
-              {todayLessonPlan?.content &&
-              todayLessonPlan.content.content &&
-              todayLessonPlan.content.content.length > 0 ? (
-                <RichTextViewer content={todayLessonPlan.content} />
-              ) : (
-                <p className="text-sm text-text-muted">
-                  No lesson plan for today.
-                </p>
-              )}
-            </div>
           ) : (
             <div className="p-4 text-sm text-text-muted">
               Inspector panel content will be added in a future update.
             </div>
           )}
         </RightSidebar>
+        )}
       </ThreePanelShell>
 
       <ConfirmDialog

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -1,23 +1,19 @@
 'use client'
 
 import { useEffect, useState, useRef, useCallback } from 'react'
-import { Button, Tooltip } from '@/ui'
+import { Button } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { RichTextEditor } from '@/components/editor'
-import { ACTIONBAR_ICON_BUTTON_CLASSNAME, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
+import { PageContent, PageLayout, PageStack } from '@/components/PageLayout'
 import { getTodayInToronto } from '@/lib/timezone'
 import { isClassDayOnDate } from '@/lib/class-days'
 import { useClassDaysContext } from '@/hooks/useClassDays'
 import { format, parseISO } from 'date-fns'
-import { ChevronDown } from 'lucide-react'
 import {
-  readBooleanCookie,
   safeSessionGetJson,
   safeSessionSetJson,
-  writeCookie,
 } from '@/lib/client-storage'
 import {
-  getEntryPreview,
   getStudentEntryHistoryCacheKey,
   upsertEntryIntoHistory,
 } from '@/lib/student-entry-history'
@@ -50,16 +46,16 @@ function resolveEntryContent(entry: Entry | null): TiptapContent {
 
 interface StudentTodayTabProps {
   classroom: Classroom
+  layout?: 'page' | 'pane'
   onLessonPlanLoad?: (plan: LessonPlan | null) => void
 }
 
-export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTabProps) {
+export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }: StudentTodayTabProps) {
   const notifications = useStudentNotifications()
   const { classDays } = useClassDaysContext()
 
   // Constants
-  const historyLimit = 5
-  const historyCookieName = 'pika_student_today_history'
+  const historyLimit = 12
   const AUTOSAVE_DEBOUNCE_MS = 5000
   const AUTOSAVE_MIN_INTERVAL_MS = 15000
   const MAX_CHARS = 2000
@@ -69,9 +65,7 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
   const [today, setToday] = useState('')
   const [content, setContent] = useState<TiptapContent>(EMPTY_DOC)
   const [historyEntries, setHistoryEntries] = useState<Entry[]>([])
-  const [historyVisible, setHistoryVisible] = useState<boolean>(() =>
-    readBooleanCookie(historyCookieName, true)
-  )
+  const [expandedHistoryIds, setExpandedHistoryIds] = useState<Set<string>>(() => new Set())
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
   const [saveError, setSaveError] = useState('')
   const [conflictEntry, setConflictEntry] = useState<Entry | null>(null)
@@ -383,11 +377,6 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
 
   const isClassDay = today ? isClassDayOnDate(classDays, today) : true
 
-  function setHistoryVisibility(next: boolean) {
-    setHistoryVisible(next)
-    writeCookie(historyCookieName, next ? '1' : '0')
-  }
-
   if (loading) {
     return (
       <div className="flex justify-center py-12">
@@ -396,107 +385,130 @@ export function StudentTodayTab({ classroom, onLessonPlanLoad }: StudentTodayTab
     )
   }
 
-  const historyListId = `student-today-history-${classroom.id}`
+  const pastHistoryEntries = historyEntries.filter(entry => entry.date !== today)
+
+  function toggleHistoryEntry(entryId: string) {
+    setExpandedHistoryIds(prev => {
+      const next = new Set(prev)
+      if (next.has(entryId)) {
+        next.delete(entryId)
+      } else {
+        next.add(entryId)
+      }
+      return next
+    })
+  }
+
+  const todayContent = (
+    <PageStack>
+      <div className="bg-surface rounded-lg border border-border p-6">
+        {!isClassDay ? (
+          <div className="bg-page border border-border rounded-lg p-4 text-center">
+            <p className="text-text-muted">No class today</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-sm font-medium text-text-muted">
+                What did you do today?
+              </label>
+              <span
+                className={
+                  'text-sm ' +
+                  (saveStatus === 'saved'
+                    ? 'text-success'
+                    : saveStatus === 'saving'
+                      ? 'text-text-muted'
+                      : 'text-warning')
+                }
+              >
+                {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
+              </span>
+            </div>
+            <RichTextEditor
+              content={content}
+              onChange={handleContentChange}
+              onBlur={flushAutosave}
+              placeholder="Write something..."
+              editable={true}
+              showToolbar={false}
+              className="min-h-[200px] [&_.tiptap.ProseMirror]:!p-0"
+            />
+
+            {saveError && (
+              <div className="space-y-2">
+                <p className="text-sm text-danger">{saveError}</p>
+                {conflictEntry && (
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" size="sm" variant="secondary" onClick={resolveConflict}>
+                      Reload latest
+                    </Button>
+                    <Button type="button" size="sm" onClick={retryAfterConflict}>
+                      Retry save
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="bg-surface border border-border rounded-lg">
+        <div className="px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold text-text-default">Past logs</h2>
+        </div>
+        <div className="divide-y divide-border">
+          {pastHistoryEntries.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-text-muted">
+              No past logs yet
+            </div>
+          ) : (
+            pastHistoryEntries.map(entry => {
+              const isExpanded = expandedHistoryIds.has(entry.id)
+              const entryDateLabel = format(parseISO(entry.date), 'EEE MMM d')
+
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  className="block w-full px-4 py-3 text-left transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? 'Collapse' : 'Expand'} log from ${entryDateLabel}`}
+                  onClick={() => toggleHistoryEntry(entry.id)}
+                >
+                  <p className="text-sm font-medium text-text-default">
+                    {entryDateLabel}
+                  </p>
+                  <p
+                    className={[
+                      'mt-1 text-sm text-text-muted whitespace-pre-wrap',
+                      isExpanded ? '' : 'line-clamp-2',
+                    ].join(' ')}
+                  >
+                    {entry.text || ''}
+                  </p>
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </PageStack>
+  )
+
+  if (layout === 'pane') {
+    return (
+      <div className="h-full min-h-0 overflow-y-auto">
+        {todayContent}
+      </div>
+    )
+  }
 
   return (
     <PageLayout>
       <PageContent>
-        <PageStack>
-          <div className="bg-surface rounded-lg border border-border p-6">
-            {!isClassDay ? (
-              <div className="bg-page border border-border rounded-lg p-4 text-center">
-                <p className="text-text-muted">No class today</p>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                <div className="flex items-center justify-between mb-2">
-                  <label className="text-sm font-medium text-text-muted">
-                    What did you do today?
-                  </label>
-                  <span
-                    className={
-                      'text-sm ' +
-                      (saveStatus === 'saved'
-                        ? 'text-success'
-                        : saveStatus === 'saving'
-                          ? 'text-text-muted'
-                          : 'text-warning')
-                    }
-                  >
-                    {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
-                  </span>
-                </div>
-                <RichTextEditor
-                  content={content}
-                  onChange={handleContentChange}
-                  onBlur={flushAutosave}
-                  placeholder="Write something..."
-                  editable={true}
-                  showToolbar={false}
-                  className="min-h-[200px] [&_.tiptap.ProseMirror]:!p-0"
-                />
-
-                {saveError && (
-                  <div className="space-y-2">
-                    <p className="text-sm text-danger">{saveError}</p>
-                    {conflictEntry && (
-                      <div className="flex flex-wrap gap-2">
-                        <Button type="button" size="sm" variant="secondary" onClick={resolveConflict}>
-                          Reload latest
-                        </Button>
-                        <Button type="button" size="sm" onClick={retryAfterConflict}>
-                          Retry save
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="bg-surface border border-border rounded-lg">
-            <div className="px-4 py-3 border-b border-border flex items-center justify-end">
-              <Tooltip content="History">
-                <button
-                  type="button"
-                  className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-                  aria-expanded={historyVisible}
-                  aria-controls={historyListId}
-                  aria-label={historyVisible ? 'Hide history' : 'Show history'}
-                  onClick={() => setHistoryVisibility(!historyVisible)}
-                >
-                  <ChevronDown
-                    className={[
-                      'h-5 w-5 transition-transform',
-                      historyVisible ? 'rotate-180' : 'rotate-0',
-                    ].join(' ')}
-                  />
-                </button>
-              </Tooltip>
-            </div>
-            {historyVisible && (
-              <div id={historyListId} className="divide-y divide-border">
-                {historyEntries.length === 0 ? (
-                  <div className="px-4 py-6 text-sm text-text-muted">
-                    No logs yet
-                  </div>
-                ) : (
-                  historyEntries.map(entry => (
-                    <div key={entry.id} className="px-4 py-2">
-                      <p className="text-sm font-medium text-text-default">
-                        {format(parseISO(entry.date), 'EEE MMM d')}
-                      </p>
-                      <p className="text-sm text-text-muted">
-                        {getEntryPreview(entry.text, 150)}
-                      </p>
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
-          </div>
-        </PageStack>
+        {todayContent}
       </PageContent>
     </PageLayout>
   )

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -107,8 +107,8 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   today: {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: 360 },
-    mainContent: { maxWidth: 'reading' },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: 360 },
+    mainContent: { maxWidth: 'full' },
   },
   'assignments-student': {
     rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '40%' },

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -6,6 +6,10 @@ import type { Classroom } from '@/types'
 
 const mockFetchJSONWithCache = vi.hoisted(() => vi.fn())
 const mockAssignmentsToMarkdown = vi.hoisted(() => vi.fn())
+const mockClassDays = vi.hoisted(() => [
+  { id: 'day-today', classroom_id: 'classroom-1', date: '2026-05-12', is_class_day: true, prompt_text: null },
+  { id: 'day-last', classroom_id: 'classroom-1', date: '2026-05-11', is_class_day: true, prompt_text: null },
+])
 
 vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
   TeacherClassroomView: ({ onEditModeChange, onSelectAssignment, onViewModeChange }: any) => (
@@ -54,8 +58,8 @@ vi.mock('@/components/layout', async () => {
   }
 
   return {
-    ThreePanelProvider: ({ children }: any) => {
-      const [isRightOpen, setRightOpen] = React.useState(false)
+    ThreePanelProvider: ({ children, routeKey }: any) => {
+      const [isRightOpen, setRightOpen] = React.useState(routeKey === 'today')
       const [rightWidth, setRightWidth] = React.useState(320)
       const value = React.useMemo(
         () => ({
@@ -115,6 +119,15 @@ vi.mock('@/components/StudentNotificationsProvider', () => ({
 
 vi.mock('@/hooks/useClassDays', () => ({
   ClassDaysProvider: ({ children }: any) => <>{children}</>,
+  useClassDaysContext: () => ({
+    classDays: mockClassDays,
+    isLoading: false,
+    refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/timezone', () => ({
+  getTodayInToronto: () => '2026-05-12',
 }))
 
 vi.mock('@/ui', () => ({
@@ -138,7 +151,11 @@ vi.mock('@/lib/classroom-ux-metrics', () => ({
 }))
 
 vi.mock('@/components/editor', () => ({
-  RichTextViewer: () => <div>Rich text</div>,
+  RichTextViewer: ({ content }: any) => (
+    <div>
+      {content?.content?.[0]?.content?.[0]?.text ?? 'Rich text'}
+    </div>
+  ),
 }))
 
 vi.mock('@/components/Spinner', () => ({
@@ -149,9 +166,35 @@ vi.mock('@/components/TeacherTestPreviewPage', () => ({
   TeacherTestPreviewPage: () => null,
 }))
 
-vi.mock('@/app/classrooms/[classroomId]/StudentTodayTab', () => ({
-  StudentTodayTab: () => <div />,
-}))
+vi.mock('@/app/classrooms/[classroomId]/StudentTodayTab', async () => {
+  const React = await import('react')
+
+  return {
+    StudentTodayTab: ({ onLessonPlanLoad }: any) => {
+      React.useEffect(() => {
+        onLessonPlanLoad?.({
+          id: 'today-plan',
+          classroom_id: 'classroom-1',
+          date: '2026-05-12',
+          content: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Today calendar entry' }],
+              },
+            ],
+          },
+          content_markdown: null,
+          created_at: '2026-05-12T00:00:00Z',
+          updated_at: '2026-05-12T00:00:00Z',
+        })
+      }, [onLessonPlanLoad])
+
+      return <div />
+    },
+  }
+})
 vi.mock('@/app/classrooms/[classroomId]/StudentAssignmentsTab', () => ({
   StudentAssignmentsTab: () => <div />,
 }))
@@ -261,6 +304,23 @@ function renderClient(options?: { initialTab?: string; initialSearchParams?: Rec
   )
 }
 
+function renderStudentClient(options?: { initialTab?: string; initialSearchParams?: Record<string, string | undefined> }) {
+  const initialTab = options?.initialTab ?? 'today'
+  const initialSearchParams = options?.initialSearchParams ?? { tab: initialTab }
+
+  return render(
+    <MarkdownPreferenceProvider>
+      <ClassroomPageClient
+        classroom={classroom}
+        user={{ id: 'student-1', email: 'student1@example.com', role: 'student' }}
+        teacherClassrooms={[]}
+        initialTab={initialTab}
+        initialSearchParams={initialSearchParams}
+      />
+    </MarkdownPreferenceProvider>,
+  )
+}
+
 describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -335,6 +395,45 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     renderClient({ initialTab: 'attendance', initialSearchParams: { tab: 'attendance' } })
 
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
+  })
+
+  it('shows today and last class lesson plans in the student today sidebar', async () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=today')
+    mockFetchJSONWithCache.mockImplementation((key: string) => {
+      if (key.startsWith('student-today:last-class-plan:')) {
+        return Promise.resolve({
+          lesson_plans: [
+            {
+              id: 'last-class-plan',
+              classroom_id: 'classroom-1',
+              date: '2026-05-11',
+              content: {
+                type: 'doc',
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Last class calendar entry' }],
+                  },
+                ],
+              },
+              content_markdown: null,
+              created_at: '2026-05-11T00:00:00Z',
+              updated_at: '2026-05-11T00:00:00Z',
+            },
+          ],
+        })
+      }
+
+      return Promise.resolve({ assignments: [] })
+    })
+
+    renderStudentClient({ initialTab: 'today', initialSearchParams: { tab: 'today' } })
+
+    expect(await screen.findByRole('heading', { name: 'Today' })).toBeInTheDocument()
+    expect(screen.getByText('Today calendar entry')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Yesterday' })).toBeInTheDocument()
+    expect(screen.getByText('Mon May 11')).toBeInTheDocument()
+    expect(await screen.findByText('Last class calendar entry')).toBeInTheDocument()
   })
 
   it('does not pin the quizzes summary label in the app shell title slot', () => {

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -98,7 +98,7 @@ const entries: Entry[] = [
     student_id: 's1',
     classroom_id: 'c1',
     date: '2025-12-15',
-    text: 'Had trouble focusing but completed the reading.',
+    text: 'Had trouble focusing but completed the reading. I wrote a longer reflection about the confusing parts, the examples I reviewed, and the questions I want to ask next class so that the entry needs more than a single short preview line.',
     rich_content: null,
     version: 1,
     minutes_reported: null,
@@ -125,10 +125,10 @@ describe('StudentTodayTab history section', () => {
     cleanup()
   })
 
-  it('toggles history without refetching', async () => {
+  it('shows past logs by default and expands each entry without refetching', async () => {
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
-      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
         return mockJson({ entries })
       }
       if (url.includes('/lesson-plans')) {
@@ -140,16 +140,31 @@ describe('StudentTodayTab history section', () => {
 
     render(<StudentTodayTab classroom={classroom} />)
 
-    await screen.findAllByText('Tue Dec 16')
-    await screen.findByRole('button', { name: /history/i })
+    await screen.findByText('Past logs')
 
-    expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
+    expect(screen.queryByText('Tue Dec 16')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /hide history/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /show history/i })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }))
-    expect(screen.queryByText('Mon Dec 15')).not.toBeInTheDocument()
+    const logButton = screen.getByRole('button', { name: 'Expand log from Mon Dec 15' })
+    const logText = screen.getByText(entries[1].text)
 
-    fireEvent.click(screen.getByRole('button', { name: /show/i }))
-    expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
+    expect(logButton).toHaveAttribute('aria-expanded', 'false')
+    expect(logText).toHaveClass('line-clamp-2')
+
+    fireEvent.click(logButton)
+    expect(screen.getByRole('button', { name: 'Collapse log from Mon Dec 15' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(logText).not.toHaveClass('line-clamp-2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse log from Mon Dec 15' }))
+    expect(screen.getByRole('button', { name: 'Expand log from Mon Dec 15' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    expect(logText).toHaveClass('line-clamp-2')
 
     const entryFetchCalls = fetchMock.mock.calls.filter(([arg]) =>
       String(arg).includes('/api/student/entries?')
@@ -157,11 +172,11 @@ describe('StudentTodayTab history section', () => {
     expect(entryFetchCalls).toHaveLength(1)
   })
 
-  it('persists toggle state via cookie', async () => {
+  it('shows an empty past-log state when only today has an entry', async () => {
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
-      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
-        return mockJson({ entries })
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [entries[0]] })
       }
       if (url.includes('/lesson-plans')) {
         return mockJson({ lessonPlans: [] })
@@ -170,23 +185,14 @@ describe('StudentTodayTab history section', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { unmount } = render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByRole('button', { name: /history/i })
-
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }))
-    expect(document.cookie).toMatch(/pika_student_today_history=0/)
-
-    unmount()
-
     render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByRole('button', { name: /history/i })
 
-    expect(screen.getByRole('button', { name: /show/i })).toBeInTheDocument()
-    expect(screen.queryByText('Mon Dec 15')).not.toBeInTheDocument()
+    expect(await screen.findByText('No past logs yet')).toBeInTheDocument()
+    expect(screen.queryByText('Tue Dec 16')).not.toBeInTheDocument()
   })
 
   it('uses sessionStorage cache for entries', async () => {
-    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 5 })
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
     window.sessionStorage.setItem(cacheKey, JSON.stringify(entries))
 
     const fetchMock = vi.fn((input: RequestInfo) => {
@@ -202,7 +208,7 @@ describe('StudentTodayTab history section', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     render(<StudentTodayTab classroom={classroom} />)
-    await screen.findByRole('button', { name: /history/i })
+    await screen.findByText('Past logs')
     expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
 
     await waitFor(() => {
@@ -218,7 +224,7 @@ describe('StudentTodayTab history section', () => {
 
     const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
       const url = String(input)
-      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=5`)) {
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
         return mockJson({ entries: [] })
       }
       if (url.includes('/lesson-plans')) {

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -51,9 +51,9 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     expect(screen.getByTestId('enabled').textContent).toBe('false')
     expect(screen.getByTestId('open').textContent).toBe('false')
 
-    // Switch to today: enabled=true, defaultOpen=true
+    // Switch to teacher assignment viewing: enabled=true, defaultOpen=true
     act(() => {
-      screen.getByText('go-today').click()
+      screen.getByText('go-teacher-viewing').click()
     })
 
     expect(screen.getByTestId('enabled').textContent).toBe('true')
@@ -61,9 +61,9 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
   })
 
   it('closes sidebar when switching to a tab with enabled: false', () => {
-    render(<TestHarness initialRouteKey="today" />)
+    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
 
-    // today: enabled=true, defaultOpen=true
+    // assignments-teacher-viewing: enabled=true, defaultOpen=true
     expect(screen.getByTestId('open').textContent).toBe('true')
 
     // Switch to assignments-student: enabled=false
@@ -75,8 +75,8 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
-  it('reopens sidebar when returning to today after visiting disabled tab', () => {
-    render(<TestHarness initialRouteKey="today" />)
+  it('reopens sidebar when returning to a default-open tab after visiting disabled tab', () => {
+    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
 
     expect(screen.getByTestId('open').textContent).toBe('true')
 
@@ -86,9 +86,9 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
     expect(screen.getByTestId('open').textContent).toBe('false')
 
-    // Return to today — this is the core bug scenario
+    // Return to a default-open route — this is the core bug scenario
     act(() => {
-      screen.getByText('go-today').click()
+      screen.getByText('go-teacher-viewing').click()
     })
     expect(screen.getByTestId('open').textContent).toBe('true')
   })
@@ -111,7 +111,7 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
   })
 
   it('keeps the external sidebar disabled for teacher quizzes', () => {
-    render(<TestHarness initialRouteKey="today" />)
+    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
 
     expect(screen.getByTestId('open').textContent).toBe('true')
 
@@ -123,10 +123,10 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
-  it('closes sidebar when switching from today to an enabled tab with defaultOpen: false', () => {
-    render(<TestHarness initialRouteKey="today" />)
+  it('closes sidebar when switching from a default-open tab to an enabled tab with defaultOpen: false', () => {
+    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
 
-    // today: enabled=true, defaultOpen=true
+    // assignments-teacher-viewing: enabled=true, defaultOpen=true
     expect(screen.getByTestId('open').textContent).toBe('true')
 
     // Switch to roster: enabled=true, defaultOpen=false
@@ -135,6 +135,19 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
 
     expect(screen.getByTestId('enabled').textContent).toBe('true')
+    expect(screen.getByTestId('open').textContent).toBe('false')
+  })
+
+  it('keeps the Today external sidebar disabled', () => {
+    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
+
+    expect(screen.getByTestId('open').textContent).toBe('true')
+
+    act(() => {
+      screen.getByText('go-today').click()
+    })
+
+    expect(screen.getByTestId('enabled').textContent).toBe('false')
     expect(screen.getByTestId('open').textContent).toBe('false')
   })
 })

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -39,6 +39,13 @@ describe('getLayoutConfig', () => {
     expect(config.rightSidebar.enabled).toBe(false)
   })
 
+  it('should use an integrated split workspace for student today', () => {
+    const config = getLayoutConfig('today')
+    expect(config.rightSidebar.enabled).toBe(false)
+    expect(config.rightSidebar.defaultOpen).toBe(false)
+    expect(config.mainContent.maxWidth).toBe('full')
+  })
+
   it('should return 50% default width for assignments-teacher-viewing (dynamically set to 70% for student work)', () => {
     const config = getLayoutConfig('assignments-teacher-viewing')
     expect(config.rightSidebar.defaultWidth).toBe('50%')


### PR DESCRIPTION
## Summary
- Move the student Today tab into the same split-pane workspace pattern used by teacher views.
- Show today’s plan and the previous class plan in a rounded right pane, with flush lesson content and a compact `Yesterday` label when applicable.
- Keep past Today logs visible by default, clamp long entries to two lines, and let students expand or collapse individual historical logs.
- Expand local seed data with many past logs, including long entries, plus lesson plans for today and recent class days.

## Why
Students could only see a short slice of long historical Today logs, and the previous collapsible history container hid useful context. The plan pane also needed to match the student workspace layout and show recent class context beside today’s log.

## Impact
Students can scan recent logs, expand long entries when needed, and compare today’s class plan with the most recent class plan without leaving the Today tab. Seed data now exercises long-log and prior-plan states during local verification.

## Root Cause
The old student Today history rendered a small fixed preview inside a parent collapsed section, and the plan sidebar was managed outside the main student workspace shell.

## Validation
- `bash scripts/verify-env.sh`
- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/unit/layout-config.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm seed:fresh`
- `E2E_BASE_URL=http://localhost:3010 pnpm e2e:auth`
- `E2E_BASE_URL=http://localhost:3010 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
