### PR TITLE
[codex] Add announcement markdown rendering

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-08 — Unblock assignment invariant merge
-
-**Completed:**
-- Rebasing PR #570 onto `origin/main` exposed a CI branch-coverage failure in `src/lib/assignments.ts`.
-- Added focused release-state coverage for malformed comparison dates so the fail-safe `Date.now()` branch is exercised.
-- Kept the assignment lifecycle implementation behavior-preserving.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/.codex/worktrees/53f9/pika bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/unit/assignments.test.ts`
-- `pnpm run test:coverage`
-- `pnpm lint`
-- Targeted mocked-data captures for the shared indicator in the gradebook inspector:
-  - `/tmp/pika-assessment-status-indicator-gradebook-desktop.png`
-  - `/tmp/pika-assessment-status-indicator-gradebook-mobile.png`
-
 ## 2026-05-08 — Gradebook edit weight label
 
 **Completed:**
@@ -385,3 +369,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3010 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
 - Additional desktop student split capture: `/tmp/pika-student-today-yesterday-desktop.png`
 - `pnpm build`
+
+## 2026-05-13 — Announcement markdown rendering
+
+**Completed:**
+- Added shared announcement markdown rendering with safe links, headings, lists, bold, italic, and inline code via the existing limited markdown parser.
+- Updated teacher/student announcement tabs and calendar announcement previews/tooltips to render markdown without changing the database schema or API payload shape.
+- Kept teacher announcement link clicks from entering edit mode.
+- Updated architecture docs to record announcements as markdown text rather than Tiptap JSON.
+
+**Validation:**
+- `pnpm test tests/components/AnnouncementContent.test.tsx tests/components/AnnouncementsMarkdown.test.tsx tests/components/LessonDayCell.test.tsx tests/components/LessonCalendar.test.tsx`
+- `pnpm lint`
+- `bash scripts/verify-env.sh`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcements-markdown E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
+- Additional loaded desktop teacher capture: `/tmp/pika-teacher-ready.png`

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -176,8 +176,8 @@ logic in the app layer:
 - **Scheduling**: `combineScheduleDateTimeToIso()` / `isScheduleIsoInFuture()` from `@/lib/scheduling`
 - **AI grading** (tests only): `src/lib/ai-test-grading.ts` — reference answer SHA-256 cached per question
 
-### Content Fields (Tiptap JSON)
-Assignment docs, quiz/test questions, announcements, and lesson plans store content as Tiptap JSON.
+### Content Fields
+Assignment docs, quiz/test questions, and lesson plans store content as Tiptap JSON.
 Always parse content using the shared utility:
 
 ```ts
@@ -187,6 +187,9 @@ const content = parseContentField(doc.content)  // handles string or object
 ```
 
 **Never define a local `parseContentField` function in a route file.**
+
+Announcement content is stored as markdown text in `announcements.content` and rendered through
+`LimitedMarkdown` via `AnnouncementContent`.
 
 ### Migration Shims
 When a DB migration is applied in stages (some environments may not have it yet), code uses
@@ -365,7 +368,7 @@ Existing indexes (migration 038):
 - `assessment_drafts` — `assessment_id`, `assessment_type`, `content` (JSONB), `version`, `created_by`; used for collaborative editing with JSON Patch
 
 ### Content
-- `announcements` — `classroom_id`, `title`, `content` (Tiptap JSON), `created_by`, timestamps
+- `announcements` — `classroom_id`, `content` (markdown text), `created_by`, timestamps
 - `resources` — `classroom_id`, `title`, `url`, `description`, timestamps
 - `lesson_plans` — `classroom_id`, `class_day_id`, `content` (Tiptap JSON)
 

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/ui'
+import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { Spinner } from '@/components/Spinner'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import type { Announcement, Classroom } from '@/types'
@@ -103,9 +104,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
             {formatDate(announcement.created_at)}
             {announcement.updated_at !== announcement.created_at && ' (edited)'}
           </p>
-          <p className="text-sm text-text-default whitespace-pre-wrap">
-            {announcement.content}
-          </p>
+          <AnnouncementContent content={announcement.content} />
         </div>
       ))}
 

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState, useRef } from 'react'
 import { Trash2, Plus, Clock, ChevronDown, Calendar } from 'lucide-react'
 import { Button, ConfirmDialog } from '@/ui'
 import { Spinner } from '@/components/Spinner'
+import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import type { Announcement, Classroom } from '@/types'
@@ -498,7 +499,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                   <div className="flex items-start justify-between gap-3">
                     <div
                       className={`min-w-0 flex-1 ${!isReadOnly ? 'cursor-pointer' : ''}`}
-                      onClick={() => startEditing(announcement)}
+                      onClick={(event) => {
+                        if ((event.target as HTMLElement).closest('a')) return
+                        startEditing(announcement)
+                      }}
                     >
                       {scheduled ? (
                         <div className="flex items-center gap-2 mb-2">
@@ -513,9 +517,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                           {announcement.updated_at !== announcement.created_at && ' (edited)'}
                         </p>
                       )}
-                      <p className={`text-sm whitespace-pre-wrap ${scheduled ? 'text-text-muted' : 'text-text-default'}`}>
-                        {announcement.content}
-                      </p>
+                      <AnnouncementContent
+                        content={announcement.content}
+                        tone={scheduled ? 'muted' : 'default'}
+                      />
                     </div>
                     {!isReadOnly && (
                       <Button

--- a/src/components/AnnouncementContent.tsx
+++ b/src/components/AnnouncementContent.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { cn } from '@/ui/utils'
+
+type AnnouncementContentTone = 'default' | 'muted'
+type AnnouncementContentSize = 'sm' | 'lg'
+
+interface AnnouncementContentProps {
+  content: string
+  tone?: AnnouncementContentTone
+  size?: AnnouncementContentSize
+  className?: string
+}
+
+const toneClasses: Record<AnnouncementContentTone, string> = {
+  default:
+    '[&_p]:!text-text-default [&_li]:!text-text-default [&_blockquote]:!text-text-muted [&_h1]:!text-text-default [&_h2]:!text-text-default [&_h3]:!text-text-default',
+  muted:
+    '[&_p]:!text-text-muted [&_li]:!text-text-muted [&_blockquote]:!text-text-muted [&_h1]:!text-text-muted [&_h2]:!text-text-muted [&_h3]:!text-text-muted',
+}
+
+const sizeClasses: Record<AnnouncementContentSize, string> = {
+  sm:
+    '[&_p]:!text-sm [&_li]:!text-sm [&_blockquote]:!text-sm [&_h1]:!text-base [&_h2]:!text-base [&_h3]:!text-sm',
+  lg:
+    '[&_p]:!text-xl [&_p]:!leading-relaxed [&_li]:!text-xl [&_li]:!leading-relaxed [&_blockquote]:!text-xl [&_blockquote]:!leading-relaxed [&_h1]:!text-2xl [&_h2]:!text-2xl [&_h3]:!text-xl sm:[&_p]:!text-2xl sm:[&_li]:!text-2xl sm:[&_blockquote]:!text-2xl sm:[&_h1]:!text-3xl sm:[&_h2]:!text-3xl sm:[&_h3]:!text-2xl',
+}
+
+export function AnnouncementContent({
+  content,
+  tone = 'default',
+  size = 'sm',
+  className,
+}: AnnouncementContentProps) {
+  return (
+    <LimitedMarkdown
+      content={content}
+      className={cn('break-words', toneClasses[tone], sizeClasses[size], className)}
+      emptyPlaceholder={null}
+    />
+  )
+}

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -5,6 +5,7 @@ import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, 
 import { toZonedTime } from 'date-fns-tz'
 import { ChevronLeft, ChevronRight, PanelRight, PanelRightClose } from 'lucide-react'
 import { LessonDayCell } from './LessonDayCell'
+import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { useKeyboardShortcutHint } from '@/hooks/use-keyboard-shortcut-hint'
@@ -653,12 +654,11 @@ export function LessonCalendar({
                   </h3>
                   <div className="mt-4 space-y-4">
                     {presentedDayDetails.announcements.map((announcement) => (
-                      <p
+                      <AnnouncementContent
                         key={announcement.id}
-                        className="text-xl leading-relaxed text-text-default sm:text-2xl"
-                      >
-                        {announcement.content}
-                      </p>
+                        content={announcement.content}
+                        size="lg"
+                      />
                     ))}
                   </div>
                 </div>

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { format } from 'date-fns'
+import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
@@ -16,11 +17,13 @@ function isScheduled(announcement: Announcement): boolean {
 
 function AnnouncementTooltipContent({ announcements }: { announcements: Announcement[] }) {
   return (
-    <div className="w-[min(14rem,calc(100vw-2rem))] text-left text-sm leading-5 whitespace-pre-wrap break-words">
+    <div className="w-[min(14rem,calc(100vw-2rem))] text-left text-sm leading-5 break-words">
       {announcements.map((announcement, index) => (
-        <p key={announcement.id} className={index > 0 ? 'mt-3' : undefined}>
-          {announcement.content}
-        </p>
+        <AnnouncementContent
+          key={announcement.id}
+          content={announcement.content}
+          className={index > 0 ? 'mt-3' : undefined}
+        />
       ))}
     </div>
   )

--- a/tests/components/AnnouncementContent.test.tsx
+++ b/tests/components/AnnouncementContent.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AnnouncementContent } from '@/components/AnnouncementContent'
+
+describe('AnnouncementContent', () => {
+  it('renders supported markdown in announcement content', () => {
+    render(
+      <AnnouncementContent content={'## Update\nRead the [course outline](https://example.com/outline) and **bring notes**.'} />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Update' })).toBeInTheDocument()
+    expect(screen.getByText('bring notes')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'course outline' })).toHaveAttribute(
+      'href',
+      'https://example.com/outline',
+    )
+  })
+
+  it('does not render unsafe markdown links as anchors', () => {
+    render(<AnnouncementContent content={'Open [unsafe](javascript:alert(1))'} />)
+
+    expect(screen.queryByRole('link', { name: 'unsafe' })).not.toBeInTheDocument()
+    expect(
+      screen.getByText((_, node) => node?.tagName === 'P' && node.textContent === 'Open unsafe)')
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
+import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
+import type { Announcement, Classroom } from '@/types'
+
+const classroom: Classroom = {
+  id: 'classroom-announcements-markdown',
+  teacher_id: 'teacher-1',
+  title: 'Announcements Markdown',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: '2026-02-01',
+  end_date: '2026-06-30',
+  lesson_plan_visibility: 'current_week',
+  source_blueprint_id: null,
+  source_blueprint_origin: null,
+  actual_site_slug: null,
+  actual_site_published: false,
+  actual_site_config: {
+    overview: true,
+    outline: true,
+    resources: true,
+    assignments: true,
+    quizzes: true,
+    tests: true,
+    lesson_plans: true,
+    announcements: true,
+    lesson_plan_scope: 'current_week',
+  },
+  course_overview_markdown: '',
+  course_outline_markdown: '',
+  archived_at: null,
+  created_at: '2026-05-13T00:00:00.000Z',
+  updated_at: '2026-05-13T00:00:00.000Z',
+}
+
+const markdownAnnouncement: Announcement = {
+  id: 'announcement-1',
+  classroom_id: classroom.id,
+  content: 'Read the [course outline](https://example.com/outline) and **bring notes**.',
+  created_by: classroom.teacher_id,
+  scheduled_for: null,
+  created_at: '2026-05-13T12:00:00.000Z',
+  updated_at: '2026-05-13T12:00:00.000Z',
+}
+
+function mockAnnouncementFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 })
+      }
+
+      return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }),
+  )
+}
+
+describe('announcement markdown rendering', () => {
+  beforeEach(() => {
+    invalidateCachedJSONMatching('teacher-announcements:')
+    invalidateCachedJSONMatching('student-announcements:')
+    mockAnnouncementFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders teacher announcements as markdown without turning link clicks into edit mode', async () => {
+    render(<TeacherAnnouncementsSection classroom={classroom} />)
+
+    const link = await screen.findByRole('link', { name: 'course outline' })
+
+    expect(link).toHaveAttribute('href', 'https://example.com/outline')
+    expect(screen.getByText('bring notes')).toBeInTheDocument()
+
+    fireEvent.click(link)
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue(markdownAnnouncement.content)).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders student announcements as markdown links', async () => {
+    render(<StudentAnnouncementsSection classroom={classroom} />)
+
+    const link = await screen.findByRole('link', { name: 'course outline' })
+
+    expect(link).toHaveAttribute('href', 'https://example.com/outline')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(screen.getByText('bring notes')).toBeInTheDocument()
+  })
+})

--- a/tests/components/LessonCalendar.test.tsx
+++ b/tests/components/LessonCalendar.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { LessonCalendar } from '@/components/LessonCalendar'
 import { MarkdownPreferenceProvider } from '@/contexts/MarkdownPreferenceContext'
 import { TooltipProvider } from '@/ui'
-import type { Assignment, Classroom, LessonPlan, TiptapContent } from '@/types'
+import type { Announcement, Assignment, Classroom, LessonPlan, TiptapContent } from '@/types'
 import type { ReactNode } from 'react'
 
 // Mock the keyboard shortcut hook
@@ -54,6 +54,16 @@ const allModeLessonPlan: LessonPlan = {
   content_markdown: 'All mode lesson',
   created_at: '2026-03-01T00:00:00.000Z',
   updated_at: '2026-03-01T00:00:00.000Z',
+}
+
+const markdownAnnouncement: Announcement = {
+  id: 'announcement-1',
+  classroom_id: 'cls-123',
+  content: 'Read the [course outline](https://example.com/outline) before class.',
+  created_by: 't1',
+  scheduled_for: null,
+  created_at: '2026-03-16T14:00:00.000Z',
+  updated_at: '2026-03-16T14:00:00.000Z',
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -186,6 +196,30 @@ describe('LessonCalendar', () => {
 
     expect(dialog).toBeInTheDocument()
     expect(within(dialog).getByText('Week 11 quiz')).toBeInTheDocument()
+  })
+
+  it('renders announcement markdown in the focused day dialog', () => {
+    render(
+      <LessonCalendar
+        classroom={mockClassroom}
+        lessonPlans={[]}
+        announcements={[markdownAnnouncement]}
+        viewMode="week"
+        currentDate={new Date('2026-03-16T12:00:00')}
+        editable={false}
+        onDateChange={vi.fn()}
+        onViewModeChange={vi.fn()}
+      />,
+      { wrapper: Wrapper }
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /open monday, march 16, 2026/i }))
+
+    const dialog = screen.getByRole('dialog', { name: /monday, march 16, 2026/i })
+    expect(within(dialog).getByRole('link', { name: 'course outline' })).toHaveAttribute(
+      'href',
+      'https://example.com/outline',
+    )
   })
 
   it('allows inline editing in all view', () => {

--- a/tests/components/LessonDayCell.test.tsx
+++ b/tests/components/LessonDayCell.test.tsx
@@ -37,6 +37,12 @@ const multiLineAnnouncement: Announcement = {
   content: `${'This announcement keeps going so the tooltip has enough text to wrap onto multiple lines in a narrower tooltip. '.repeat(3)}Final sentence should still be visible.`,
 }
 
+const markdownAnnouncement: Announcement = {
+  ...longAnnouncement,
+  id: 'announcement-3',
+  content: 'Read the [course outline](https://example.com/outline) before class.',
+}
+
 function renderWithTooltip(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>)
 }
@@ -221,5 +227,28 @@ describe('LessonDayCell', () => {
 
     expect(tooltipText).toContain('Final sentence should still be visible.')
     expect(tooltipText).not.toContain('...')
+  })
+
+  it('renders markdown links in announcement tooltips', async () => {
+    renderWithTooltip(
+      <LessonDayCell
+        date="2026-03-13"
+        day={new Date('2026-03-13T12:00:00.000Z')}
+        lessonPlan={null}
+        announcements={[markdownAnnouncement]}
+        isWeekend={false}
+        isToday={false}
+        editable={false}
+        compact={false}
+      />
+    )
+
+    fireEvent.focus(screen.getByRole('button', { name: 'Announcement' }))
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(within(tooltip).getByRole('link', { name: 'course outline' })).toHaveAttribute(
+      'href',
+      'https://example.com/outline',
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Render classroom announcements with the existing sanitized limited Markdown renderer.
- Reuse the rendering in teacher/student announcement tabs and calendar announcement previews/tooltips.
- Preserve the existing `announcements.content` text storage and API shape; no migration required.
- Document announcements as Markdown text and add focused component coverage.

## Validation

- `pnpm test tests/components/AnnouncementContent.test.tsx tests/components/AnnouncementsMarkdown.test.tsx tests/components/LessonDayCell.test.tsx tests/components/LessonCalendar.test.tsx`
- `pnpm lint`
- `bash scripts/verify-env.sh`
- `pnpm build`
- Visual verification against local seeded classroom:
  - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcements-markdown E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
  - Additional loaded desktop teacher capture: `/tmp/pika-teacher-ready.png`