### PR TITLE
[codex] Fix teacher test closed access badge

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-08 — Gradebook edit weight label
-
-**Completed:**
-- Changed the edit-mode gradebook row label from `Weights` to `Weight`.
-- Updated focused gradebook component assertions for the singular label.
-
-**Validation:**
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/gradebook-assessment-matrix E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=gradebook&gradebookSection=settings'`
-- Visual captures:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-teacher-mobile.png`
-  - `/tmp/pika-student.png`
-
 ## 2026-05-11 — Fix stale student log date
 
 **Completed:**
@@ -384,3 +369,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcements-markdown E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
 - Additional loaded desktop teacher capture: `/tmp/pika-teacher-ready.png`
+
+## 2026-05-13 — Teacher test list closed-access badge
+
+**Completed:**
+- Fixed teacher test list cards so an active test with access closed for every enrolled student displays a `Closed` badge instead of `Open`.
+- Kept the underlying test lifecycle status unchanged and updated list access counts locally after open/close-all actions.
+- Added focused utility and component coverage for the all-students-closed display case.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/quizzes.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1301,6 +1301,14 @@ export function TeacherTestsTab({
   async function handleBatchStudentAccess(state: 'open' | 'closed', options?: { studentIds?: string[] }) {
     const targetStudentIds = options?.studentIds || Array.from(batchSelectedIds)
     if (!selectedTestId || targetStudentIds.length === 0) return
+    const previousAccessByStudentId = new Map(
+      gradingStudents
+        .filter((student) => targetStudentIds.includes(student.student_id))
+        .map((student) => [
+          student.student_id,
+          student.effective_access || (selectedTestWorkspace?.status === 'active' ? 'open' : 'closed'),
+        ] as const)
+    )
 
     setIsBatchUpdatingAccess(true)
     setGradingError('')
@@ -1322,6 +1330,34 @@ export function TeacherTestsTab({
       setGradingInfo(
         `${state === 'open' ? 'Opened' : 'Closed'} access for ${updatedCount} student${updatedCount === 1 ? '' : 's'}${skippedCount > 0 ? ` • ${skippedCount} skipped` : ''}`
       )
+      if (updatedCount > 0) {
+        setTests((prev) =>
+          prev.map((test) => {
+            if (test.id !== selectedTestId) return test
+
+            const totalStudents = test.stats.total_students || gradingStudents.length || 0
+            const fallbackOpenAccess = test.status === 'active' ? totalStudents : 0
+            let openAccessCount =
+              typeof test.stats.open_access === 'number' ? test.stats.open_access : fallbackOpenAccess
+
+            for (const studentId of targetStudentIds) {
+              const previousAccess = previousAccessByStudentId.get(studentId)
+              if (!previousAccess || previousAccess === state) continue
+              openAccessCount += state === 'open' ? 1 : -1
+            }
+
+            const clampedOpenAccessCount = Math.min(Math.max(openAccessCount, 0), totalStudents)
+            return {
+              ...test,
+              stats: {
+                ...test.stats,
+                open_access: clampedOpenAccessCount,
+                closed_access: Math.max(totalStudents - clampedOpenAccessCount, 0),
+              },
+            }
+          })
+        )
+      }
 
       clearBatchSelection()
       setShowCloseAccessConfirm(false)

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -4,7 +4,11 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { ExternalLink, GripVertical, Lock, Trash2, Unlock } from 'lucide-react'
 import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
-import { getAssessmentStatusLabel, getQuizStatusBadgeClass } from '@/lib/quizzes'
+import {
+  getAssessmentStatusLabel,
+  getQuizStatusBadgeClass,
+  getTeacherTestListDisplayStatus,
+} from '@/lib/quizzes'
 import { Button, Tooltip } from '@/ui'
 import type { QuizWithStats } from '@/types'
 
@@ -46,8 +50,9 @@ export function TeacherTestCard({
   }
 
   const isDraft = test.status === 'draft'
-  const statusLabel = getAssessmentStatusLabel(test.status, 'test')
-  const statusBadgeClass = getQuizStatusBadgeClass(test.status)
+  const displayStatus = getTeacherTestListDisplayStatus(test)
+  const statusLabel = getAssessmentStatusLabel(displayStatus, 'test')
+  const statusBadgeClass = getQuizStatusBadgeClass(displayStatus)
   const totalStudents = test.stats.total_students || 0
   const submittedCount = test.stats.submitted ?? test.stats.responded ?? 0
   const openAccessCount = test.stats.open_access ?? (test.status === 'active' ? totalStudents : 0)

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -9,6 +9,7 @@ import type {
   QuizFocusSummary,
   QuizQuestion,
   QuizResponse,
+  QuizWithStats,
   QuizStatus,
   StudentQuizStatus,
   QuizResultsAggregate,
@@ -32,6 +33,36 @@ export function getAssessmentStatusLabel(
 ): string {
   if (assessmentType === 'test' && status === 'active') return 'Open'
   return getQuizStatusLabel(status)
+}
+
+export function getTeacherTestListDisplayStatus(
+  test: Pick<Quiz, 'status'> & {
+    stats?: Partial<QuizWithStats['stats']> | null
+  }
+): QuizStatus {
+  if (test.status !== 'active') return test.status
+
+  const totalStudents = toNonNegativeCount(test.stats?.total_students)
+  const openAccess = toNonNegativeCount(test.stats?.open_access)
+  const closedAccess = toNonNegativeCount(test.stats?.closed_access)
+
+  if (
+    openAccess === 0 &&
+    closedAccess !== null &&
+    totalStudents !== null &&
+    totalStudents > 0 &&
+    closedAccess >= totalStudents
+  ) {
+    return 'closed'
+  }
+
+  return 'active'
+}
+
+function toNonNegativeCount(value: unknown): number | null {
+  const count = Number(value)
+  if (!Number.isFinite(count)) return null
+  return Math.max(0, Math.trunc(count))
 }
 
 /**

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -803,6 +803,30 @@ describe('TeacherTestsTab', () => {
     expect(listFetchCalls(fetchMock)).toHaveLength(1)
   })
 
+  it('shows a closed badge when an active test is closed for all students', async () => {
+    mockTestsResponse([
+      makeTest({
+        id: 'test-1',
+        title: 'Unit Test',
+        status: 'active',
+        stats: {
+          total_students: 2,
+          responded: 1,
+          submitted: 1,
+          open_access: 0,
+          closed_access: 2,
+          questions_count: 3,
+        },
+      }),
+    ])
+
+    renderTab()
+
+    expect(await screen.findByText('Unit Test')).toBeInTheDocument()
+    expect(screen.getByText('Closed')).toBeInTheDocument()
+    expect(screen.queryByText('Open')).not.toBeInTheDocument()
+  })
+
   it('shows card reorder controls from the list actions menu and resets reorder mode when tests is revisited', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     const view = renderTab({ testsTabClickToken: 0 })

--- a/tests/unit/quizzes.test.ts
+++ b/tests/unit/quizzes.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest'
 import {
   getQuizStatusLabel,
   getAssessmentStatusLabel,
+  getTeacherTestListDisplayStatus,
   getQuizStatusBadgeClass,
   canStudentRespond,
   canStudentViewResults,
@@ -49,6 +50,53 @@ describe('quiz utilities', () => {
 
     it('should keep "Active" for active quizzes', () => {
       expect(getAssessmentStatusLabel('active', 'quiz')).toBe('Active')
+    })
+  })
+
+  describe('getTeacherTestListDisplayStatus', () => {
+    it('shows active tests as closed when access is closed for every student', () => {
+      expect(
+        getTeacherTestListDisplayStatus({
+          status: 'active',
+          stats: {
+            total_students: 2,
+            responded: 1,
+            questions_count: 3,
+            open_access: 0,
+            closed_access: 2,
+          },
+        })
+      ).toBe('closed')
+    })
+
+    it('keeps active tests open when at least one student still has access', () => {
+      expect(
+        getTeacherTestListDisplayStatus({
+          status: 'active',
+          stats: {
+            total_students: 2,
+            responded: 1,
+            questions_count: 3,
+            open_access: 1,
+            closed_access: 1,
+          },
+        })
+      ).toBe('active')
+    })
+
+    it('keeps active tests open when there are no enrolled students', () => {
+      expect(
+        getTeacherTestListDisplayStatus({
+          status: 'active',
+          stats: {
+            total_students: 0,
+            responded: 0,
+            questions_count: 3,
+            open_access: 0,
+            closed_access: 0,
+          },
+        })
+      ).toBe('active')
     })
   })
 


### PR DESCRIPTION
## Summary
- show teacher test list cards as Closed when an active test has access closed for every enrolled student
- keep the underlying test lifecycle status unchanged while deriving the card badge from access counts
- update cached list access counts immediately after open/close-all actions

## Root Cause
The test list badge used the global test status only. Selected-student access can close an active test for every student, leaving the card badge at Open even though no student can access it.

## Validation
- pnpm test tests/unit/quizzes.test.ts tests/components/TeacherTestsTab.test.tsx
- pnpm lint
- git diff --check
- PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'