### PR TITLE
[codex] Stop closed test grade polling

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,20 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-11 — Fix stale student log date
-
-**Completed:**
-- Fixed Student Today autosave so a stale mounted tab rechecks the current Toronto date before building the save payload.
-- Cleared stale entry identity/version state when the mounted date rolls over, preventing first/new saves from targeting an old day.
-- Added a regression test for a tab mounted on May 6 that saves after today advances to May 11.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx`
-- `pnpm lint`
-- `pnpm vitest run tests/api/student/entries.test.ts tests/components/StudentTodayTabHistory.test.tsx tests/unit/timezone.test.ts`
-- `pnpm test`
-
 ## 2026-05-09 — Test markdown creation defaults
 
 **Completed:**
@@ -382,3 +368,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/quizzes.test.ts tests/components/TeacherTestsTab.test.tsx`
 - `pnpm lint`
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
+
+## 2026-05-13 — Teacher test grading closed-access refresh
+
+**Completed:**
+- Stopped the teacher tests grading workspace from starting the background grade poll when every student has closed effective access.
+- Reused the same effective-access helper for polling decisions, batch action counts, and row access icons.
+- Added regression coverage for an active test whose access is closed for all students so the `Refreshing grades` status does not appear.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/close-test-refresh-notice bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/close-test-refresh-notice E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
+- Closed selected test workspace browser check after 16.5s: no `Refreshing grades` status and no console errors; screenshots `/tmp/pika-teacher-closed-test-workspace.png` and `/tmp/pika-teacher-closed-test-selected-student.png`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -140,6 +140,13 @@ function getSortableNameParts(student: TestGradingStudentRow): { firstName: stri
   return splitDisplayName(student.name)
 }
 
+function getEffectiveTestAccess(
+  student: Pick<TestGradingStudentRow, 'effective_access'>,
+  testStatus: Quiz['status'] | null | undefined,
+): 'open' | 'closed' {
+  return student.effective_access || (testStatus === 'active' ? 'open' : 'closed')
+}
+
 function formatTorontoTime(iso: string | null): { value: string; isPm: boolean } {
   if (!iso) return { value: '—', isPm: false }
 
@@ -444,6 +451,13 @@ export function TeacherTestsTab({
     [batchSelectedSubmittedStudents]
   )
   const batchSelectedSubmittedCount = batchSelectedSubmittedStudents.length
+  const hasOpenGradingAccess = useMemo(
+    () =>
+      sortedGradingStudents.some(
+        (student) => getEffectiveTestAccess(student, selectedTestWorkspace?.status) === 'open'
+      ),
+    [selectedTestWorkspace?.status, sortedGradingStudents]
+  )
 
   const setSelectedStudentId = useCallback((nextStudentId: string | null) => {
     setInternalSelectedStudentId(nextStudentId)
@@ -845,7 +859,8 @@ export function TeacherTestsTab({
       selectedWorkspaceTab !== 'grading' ||
       !selectedTestId ||
       gradingServerTestId !== selectedTestId ||
-      gradingServerTestStatus !== 'active'
+      gradingServerTestStatus !== 'active' ||
+      !hasOpenGradingAccess
     ) {
       return
     }
@@ -901,7 +916,15 @@ export function TeacherTestsTab({
       window.removeEventListener('focus', handlePollingStateChange)
       window.removeEventListener('blur', handlePollingStateChange)
     }
-  }, [gradingServerTestId, gradingServerTestStatus, loadGradingRows, selectedTestId, selectedWorkspaceTab, workspaceState])
+  }, [
+    gradingServerTestId,
+    gradingServerTestStatus,
+    hasOpenGradingAccess,
+    loadGradingRows,
+    selectedTestId,
+    selectedWorkspaceTab,
+    workspaceState,
+  ])
 
   useEffect(() => {
     function handleGradingRowUpdate(event: Event) {
@@ -1555,7 +1578,7 @@ export function TeacherTestsTab({
     : { valid: false }
   const isSelectedWorkspace = workspaceState === 'selected'
   const getEffectiveStudentAccess = useCallback((student: TestGradingStudentRow): 'open' | 'closed' => {
-    return student.effective_access || (selectedTestWorkspace?.status === 'active' ? 'open' : 'closed')
+    return getEffectiveTestAccess(student, selectedTestWorkspace?.status)
   }, [selectedTestWorkspace?.status])
   const selectedOpenAccessCount = batchSelectedStudents.filter((student) => {
     return getEffectiveStudentAccess(student) === 'open'
@@ -1842,8 +1865,7 @@ export function TeacherTestsTab({
                 const windowUnmaximizeAttempts = student.focus_summary?.window_unmaximize_attempts ?? 0
                 const exitsCount = getQuizExitCount(student.focus_summary)
                 const formattedLastActivity = formatTorontoTime(student.last_activity_at)
-                const effectiveAccess =
-                  student.effective_access || (selectedTestWorkspace?.status === 'active' ? 'open' : 'closed')
+                const effectiveAccess = getEffectiveTestAccess(student, selectedTestWorkspace?.status)
                 const accessSource = student.access_source || 'test'
                 const accessLabel = effectiveAccess === 'open' ? 'Open' : 'Closed'
                 const AccessIcon = effectiveAccess === 'open' ? Unlock : Lock

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1320,6 +1320,68 @@ describe('TeacherTestsTab', () => {
     expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
   })
 
+  it('does not poll grades when every student has closed access', async () => {
+    let visibilityState: DocumentVisibilityState = 'visible'
+    let hasFocus = true
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => hasFocus)
+    const setIntervalSpy = vi
+      .spyOn(window, 'setInterval')
+      .mockImplementation((() => 1) as typeof window.setInterval)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValue(
+        makeResultsResponse({
+          students: [
+            {
+              student_id: 'student-1',
+              name: 'Alice Zephyr',
+              first_name: 'Alice',
+              last_name: 'Zephyr',
+              email: 'alice@example.com',
+              status: 'closed',
+              submitted_at: null,
+              last_activity_at: '2026-04-17T18:15:00.000Z',
+              points_earned: 3,
+              points_possible: 5,
+              percent: 60,
+              graded_open_responses: 0,
+              ungraded_open_responses: 1,
+              access_state: 'closed',
+              effective_access: 'closed',
+              access_source: 'student',
+              focus_summary: null,
+            },
+          ],
+        })
+      )
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 15_000)
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
   it('starts polling when the server reports the test is active even if the list was stale', async () => {
     let visibilityState: DocumentVisibilityState = 'visible'
     let hasFocus = true


### PR DESCRIPTION
## Summary
- Stop the teacher tests grading workspace from starting the 15s grade poll when every student has closed effective access.
- Reuse a single effective-access helper for polling, batch action counts, and row access icons.
- Add regression coverage for active tests that are closed for all students so the Refreshing grades status does not appear.

## Root Cause
The grading poll was keyed only off the server test lifecycle status being active. Closing access for every student leaves the test lifecycle active, so the workspace still ran background refreshes while teachers were manually marking closed work.

## Validation
- pnpm test tests/components/TeacherTestsTab.test.tsx
- pnpm lint
- pnpm test
- PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/close-test-refresh-notice E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests"
- Browser check on the selected closed-test workspace after 16.5s: no Refreshing grades status and no console errors
