### PR TITLE
[codex] Add classwork surveys

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,6 +7,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
+## 2026-05-10 — Submitted-aware test unsubmit action
+
+**Completed:**
+- Confirmed selected-student test-work deletion does not close/open student access; it deletes attempt data only and leaves `test_student_availability` unchanged.
+- Changed the selected-test `Unsubmit Selected` action to enable only when selected rows include submitted work.
+- Filtered batch unsubmit requests so mixed selections submit only the selected students whose work is currently submitted.
+- Added focused component coverage for disabled no-submitted selection and mixed-selection submitted-only unsubmit requests.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
+- Targeted visual captures:
+  - `/tmp/pika-unsubmit-disabled-no-submitted-selected.png`
+  - `/tmp/pika-unsubmit-enabled-submitted-selected.png`
+- `pnpm build`
+
 ## 2026-05-10 — Test action menu counts
 
 **Completed:**
@@ -385,3 +403,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-survey-teacher-workspace.png`
   - `/tmp/pika-survey-student-classwork.png`
   - `/tmp/pika-survey-student-form.png`
+
+## 2026-05-13 — Quiz and survey source editors
+
+**Completed:**
+- Generalized the test editor-only/markdown-only authoring layout so quizzes can use the same modal Code toggle flow without test documents.
+- Added quiz markdown source serialization/parsing and draft source persistence for AI-friendly quiz authoring.
+- Added a survey Code view with markdown serialization/parsing for multiple-choice, short-text, and link questions, including title/results/dynamic settings.
+- Let survey question POST/PATCH accept explicit `position` so markdown apply preserves source order.
+- Added route, parser, and component coverage for the new quiz/survey source authoring paths.
+
+**Validation:**
+- `pnpm test tests/lib/quiz-markdown.test.ts tests/unit/surveys.test.ts tests/components/QuizDetailPanel.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/api/teacher/surveys-questions-route.test.ts tests/api/teacher/surveys-questions-id.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional teacher screenshots:
+  - `/tmp/pika-quiz-edit-modal.png`
+  - `/tmp/pika-quiz-code-modal.png`
+  - `/tmp/pika-survey-code.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,58 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-11 — Classwork migration filename resequence
-
-**Completed:**
-- Renamed the mixed classwork material ordering migration from a timestamped filename to the next numeric-leading Pika migration slot, `067_classwork_mixed_ordering.sql`.
-
-**Validation:**
-- `bash scripts/verify-env.sh` exposed an unrelated session-log length failure before trimming.
-- `node scripts/trim-session-log.mjs`
-
-## 2026-05-11 — Remove material card outline highlight
-
-**Completed:**
-- Removed the primary outline and left accent rail from teacher and student material cards while keeping the soft tint and `Material` label.
-- Added component assertions to keep material cards on neutral borders without the primary rail.
-- Updated assignment UX guidance to describe tint-based material differentiation.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=assignments'` captured the route but local DB state returned "Classroom not found".
-- Supplemental CSS visual harness:
-  - `/tmp/pika-material-no-outline-harness.png`
-  - `/tmp/pika-material-no-outline-harness-dark.png`
-
-## 2026-05-11 — Smooth material drag treatment
-
-**Completed:**
-- Removed the material card's hover transition while it is actively dragging so dnd-kit owns transform movement like assignment cards.
-- Added a neutral drag-border option to the shared teacher work item frame and used it for material cards.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkItemPrimitives.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Pika UI verify captured the target route but local DB state still returned "Classroom not found".
-- Supplemental drag-state harness:
-  - `/tmp/pika-material-drag-state-harness.png`
-
-## 2026-05-11 — Restrict classwork reorder RPC execution
-
-**Completed:**
-- Added explicit `revoke all` from `public`, `anon`, and `authenticated` for the new classwork reorder RPCs.
-- Granted both reorder RPCs only to `service_role`, matching the API route authorization boundary.
-- Added a static migration regression test for the RPC grant contract.
-
-**Validation:**
-- `pnpm test tests/unit/classwork-migration-rpc-grants.test.ts tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/assignments-reorder.test.ts`
-- `pnpm lint`
-- `supabase db lint --local --schema public --fail-on error` (existing unrelated warning: `public.unsubmit_test_attempts_atomic` unused `p_updated_by`)
-- `pnpm build`
-
 ## 2026-05-11 — Add Daily quick date buttons
 
 **Completed:**
@@ -254,6 +202,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/chrome-ui-guidance bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`
+
 ## 2026-05-13 — Classroom list edit control placement
 
 **Completed:**
@@ -266,6 +215,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Extra teacher edit-mode captures: `/tmp/pika-teacher-edit.png`, `/tmp/pika-teacher-mobile-edit.png`
+
 ## 2026-05-13 — Classwork surveys
 
 **Completed:**
@@ -384,3 +334,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `pnpm test tests/api/student/surveys-route.test.ts`
 - `pnpm lint`
+
+## 2026-05-14 — Survey review follow-up fixes
+
+**Completed:**
+- Trimmed the rolling session log and shortened the new survey feature entry to restore startup-budget tests.
+- Reserved survey positions when assignment markdown bulk-save recomputes assignment positions.
+- Replaced the assignment-preserve reorder RPC in the survey migration so it skips both material and survey positions.
+
+**Validation:**
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/api/teacher/assignments-bulk.test.ts tests/api/teacher/assignments-reorder.test.ts tests/unit/classwork-migration-rpc-grants.test.ts`
+- `bash scripts/verify-env.sh`
+- `pnpm lint`
+- `pnpm build`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -352,3 +352,36 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Extra teacher edit-mode captures: `/tmp/pika-teacher-edit.png`, `/tmp/pika-teacher-mobile-edit.png`
+## 2026-05-13 — Classwork surveys
+
+**Completed:**
+- Added surveys as ungraded Classwork items with draft/active/closed status, classwork ordering, and teacher/student API routes.
+- Added survey question types for multiple choice, short text, and link responses, including response validation and link normalization.
+- Added a dynamic responses toggle so students can update answers while an active survey remains open.
+- Fixed the responded-student status priority so dynamic surveys remain updateable even when class results are visible.
+- Added teacher survey creation/settings, question editing, class results, survey cards, and student survey cards/response form/results support.
+- Added the Supabase migration `068_surveys_classwork.sql` for surveys, questions, responses, RLS, and mixed classwork ordering RPC support.
+- Kept Classwork assignment/material loading resilient if the surveys endpoint is unavailable before the migration is applied.
+- Rebased the worktree onto `origin/main` and resequenced the survey migration after `067_classwork_mixed_ordering.sql`.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/unit/surveys.test.ts tests/lib/classwork-order.test.ts tests/unit/classwork-migration-rpc-grants.test.ts`
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/surveys.test.ts`
+- `pnpm test tests/unit/surveys.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm test -- --maxWorkers=4`
+- `pnpm build`
+- `git rev-list --left-right --count origin/main...HEAD` -> `0 0`
+- Migration prefix duplicate check returned no duplicates.
+- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
+- Standard UI verify for live teacher/student Classwork pages:
+  - `/tmp/pika-teacher.png`
+  - `/tmp/pika-student.png`
+  - `/tmp/pika-teacher-mobile.png`
+- Mocked survey UI verification for migration-independent teacher/student survey states:
+  - `/tmp/pika-survey-teacher-classwork.png`
+  - `/tmp/pika-survey-teacher-modal.png`
+  - `/tmp/pika-survey-teacher-workspace.png`
+  - `/tmp/pika-survey-student-classwork.png`
+  - `/tmp/pika-survey-student-form.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,50 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-11 — Mixed classwork material ordering
-
-**Completed:**
-- Added material `position` migration and mixed assignment/material classwork ordering.
-- Added teacher classwork reorder API for `{ type, id }` item lists.
-- Moved classwork reorder persistence into transaction-backed Postgres RPC functions.
-- Hardened classwork reorder requests to reject stale partial lists while preserving assignment-only reorder around material position slots.
-- Made assignment/material create routes fail closed on unexpected mixed-order position lookup errors.
-- Preserved existing material positions when the assignment Markdown bulk-save path rewrites assignment positions.
-- Updated teacher classwork summary so materials are visually distinct and draggable in edit mode.
-- Updated student classwork summary to render the same mixed order with distinct material cards.
-- Refined material cards to use tint plus a left accent rail instead of an icon, keeping the Syllabus icon reserved for Syllabus.
-- Documented the material card/order behavior in assignment UX guidance.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classwork-material-order bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/lib/classwork-order.test.ts tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/api/teacher/assignments.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- Post-iconless refinement:
-  - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-  - `pnpm lint`
-- Final pre-push validation:
-  - `pnpm test tests/api/teacher/classwork-reorder.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-  - `pnpm lint`
-  - `pnpm test`
-  - `pnpm build`
-- Transactional reorder fix:
-  - `pnpm test tests/api/teacher/classwork-reorder.test.ts tests/api/teacher/assignments-reorder.test.ts tests/api/teacher/assignments-bulk.test.ts tests/api/teacher/assignments.test.ts tests/api/teacher/materials.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-  - `pnpm lint`
-  - `pnpm build`
-  - `supabase db lint --local --schema public --fail-on error` (existing unrelated warning: `public.unsubmit_test_attempts_atomic` unused `p_updated_by`)
-  - `pnpm test`
-- Visual verification:
-  - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/491562df-96cd-4d21-8dc5-cff996396d41?tab=assignments'`
-  - `/tmp/pika-teacher-material.png`
-  - `/tmp/pika-student-material.png`
-  - `/tmp/pika-teacher-material-dark.png`
-  - `/tmp/pika-student-material-dark.png`
-  - `/tmp/pika-teacher-material-tinted.png`
-  - `/tmp/pika-student-material-tinted.png`
-  - `/tmp/pika-student-material-tinted-dark.png`
-
 ## 2026-05-11 — Classwork migration filename resequence
 
 **Completed:**
@@ -416,3 +372,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Additional survey creation screenshots:
   - `/tmp/pika-survey-create-shared-desktop.png`
   - `/tmp/pika-survey-create-shared-mobile.png`
+
+## 2026-05-13 — Student survey review fixes
+
+**Completed:**
+- Preserved saved link responses as `question_type: 'link'` in the student survey detail payload.
+- Removed classmate `student_id` values from student-visible survey result responses.
+- Added API regression coverage for link response discriminants and student result payload privacy.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/api/student/surveys-route.test.ts`
+- `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,40 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-10 — Submitted-aware test unsubmit action
-
-**Completed:**
-- Confirmed selected-student test-work deletion does not close/open student access; it deletes attempt data only and leaves `test_student_availability` unchanged.
-- Changed the selected-test `Unsubmit Selected` action to enable only when selected rows include submitted work.
-- Filtered batch unsubmit requests so mixed selections submit only the selected students whose work is currently submitted.
-- Added focused component coverage for disabled no-submitted selection and mixed-selection submitted-only unsubmit requests.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
-- Targeted visual captures:
-  - `/tmp/pika-unsubmit-disabled-no-submitted-selected.png`
-  - `/tmp/pika-unsubmit-enabled-submitted-selected.png`
-- `pnpm build`
-
-## 2026-05-10 — Test action menu counts
-
-**Completed:**
-- Added compact count badges to the selected-test dropdown items for `AI Grade`, `Unsubmit Selected`, `Return`, and `Delete Selected`.
-- Counts now reflect the current selected rows and action eligibility: selected rows for AI grading/deletion, submitted selected rows for unsubmit, and closed/returnable selected rows for return.
-- Added focused component assertions for the action menu count labels.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
-- Targeted visual capture:
-  - `/tmp/pika-test-action-menu-counts.png`
-- `pnpm build`
-
 ## 2026-05-10 — Markdown-only test editor defaults
 
 **Completed:**
@@ -423,3 +389,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-quiz-edit-modal.png`
   - `/tmp/pika-quiz-code-modal.png`
   - `/tmp/pika-survey-code.png`
+
+## 2026-05-13 — Survey setup parity
+
+**Completed:**
+- Extracted a shared assessment setup dialog shell and routed quiz/test setup plus survey setup through it.
+- Updated new survey creation to use the same full-screen assessment setup frame as quiz/test creation.
+- After creating a survey, route the teacher directly into the new survey workspace with Code authoring selected.
+- Added component coverage for survey setup chrome and the created-survey Code-mode handoff.
+
+**Validation:**
+- `pnpm test tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional teacher screenshots:
+  - `/tmp/pika-survey-create-modal.png`
+  - `/tmp/pika-survey-create-modal-mobile.png`
+  - `/tmp/pika-survey-created-code.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,14 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-11 — Trim session log for CI
-
-**Completed:**
-- Trimmed the rolling session log after PR work so it stays within the enforced 20-entry budget.
-
-**Validation:**
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-
 ## 2026-05-11 — Mixed classwork material ordering
 
 **Completed:**
@@ -407,3 +399,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Additional survey modal screenshots:
   - `/tmp/pika-survey-modal-desktop.png`
   - `/tmp/pika-survey-modal-mobile.png`
+
+## 2026-05-13 — Survey setup form parity
+
+**Completed:**
+- Extracted the shared quiz/test setup body into `AssessmentSetupForm` with the common title field, footer actions, and checkbox control.
+- Routed both `QuizModal` and `SurveyModal` through the shared setup form so survey creation matches quiz/test creation structure.
+- Removed the survey-specific settings box from creation; survey options now sit in the same plain form rhythm as the quiz/test controls.
+
+**Validation:**
+- `pnpm test tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork E2E_BASE_URL=http://localhost:3002 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional survey creation screenshots:
+  - `/tmp/pika-survey-create-shared-desktop.png`
+  - `/tmp/pika-survey-create-shared-mobile.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-10 — Markdown-only test editor defaults
-
-**Completed:**
-- Made editable markdown-only test editor surfaces enter writable mode by default, including create-test Code view and existing-test Code view.
-- Removed the markdown `Copy` and `Schema` toolbar actions from `QuizDetailPanel`.
-- Removed the now-redundant `startMarkdownEditing` prop plumbing from the tests tab.
-- Updated focused component coverage for default editable markdown-only layout and absent copy/schema actions.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
-- Targeted visual capture:
-  - `/tmp/pika-test-edit-code.png`
-
 ## 2026-05-11 — Trim session log for CI
 
 **Completed:**
@@ -408,3 +390,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-survey-create-modal.png`
   - `/tmp/pika-survey-create-modal-mobile.png`
   - `/tmp/pika-survey-created-code.png`
+
+## 2026-05-13 — Survey workspace modal routing
+
+**Completed:**
+- Changed teacher survey cards and `surveyId` routes to open `TeacherSurveyWorkspace` in a dialog over the Classwork summary instead of replacing the main content pane.
+- Kept survey creation handoff to Code mode while returning the pane selection/cookie to the Classwork summary.
+- Added regression coverage for card-opened and routed survey modals preserving the classwork list behind the dialog.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/SurveyModal.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional survey modal screenshots:
+  - `/tmp/pika-survey-modal-desktop.png`
+  - `/tmp/pika-survey-modal-mobile.png`

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -1,19 +1,19 @@
 {
   "meta": {
     "project": "pika",
-    "lastUpdated": "2026-04-26",
+    "lastUpdated": "2026-05-13",
     "phase": "Infrastructure — AI Effectiveness Layer",
-    "DO_NOT_DELETE_FEATURES": "This inventory is APPEND-ONLY. Mark features as passing/failing, add new features, but NEVER DELETE FEATURES FROM THIS FILE. Deletion corrupts project history.",
+    "DO_NOT_DELETE_FEATURES": "APPEND-ONLY. Never delete entries.",
     "deletionPolicy": "PROHIBITED",
-    "totalFeatures": 10,
-    "passing": 10,
+    "totalFeatures": 11,
+    "passing": 11,
     "failing": 0
   },
   "features": [
     {
       "id": "epic-setup",
       "phase": "Phase 0 — Setup",
-      "description": "Project bootstrapped (Next.js + TypeScript + Tailwind + Supabase wiring)",
+      "description": "Next.js, TypeScript, Tailwind, and Supabase bootstrap",
       "passes": true,
       "verification": "Run: pnpm test",
       "issueRefs": [],
@@ -23,7 +23,7 @@
     {
       "id": "epic-auth",
       "phase": "Phase 1 — Auth",
-      "description": "Email verification + password auth with secure sessions (iron-session), lockout, and role routing",
+      "description": "Email-code auth, password login, secure sessions, lockout, and role routing",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: signup → verify → create password → login → logout → reset password",
       "issueRefs": [],
@@ -33,7 +33,7 @@
     {
       "id": "epic-student-experience",
       "phase": "Phase 2 — Student Experience",
-      "description": "Student journal/attendance flows per classroom (Toronto timezone rules), plus student dashboards",
+      "description": "Student journal, attendance, and dashboard flows per classroom",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: student submits entry for today and sees history update",
       "issueRefs": [],
@@ -53,7 +53,7 @@
     {
       "id": "epic-classrooms-rosters",
       "phase": "Phase 4 — Classrooms & Rosters",
-      "description": "Classroom CRUD, join codes/links, enrollments, roster CSV upload, and per-classroom class days",
+      "description": "Classrooms, join codes/links, enrollments, roster CSV, and class days",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: teacher creates classroom and uploads roster; student joins by code",
       "issueRefs": [],
@@ -63,7 +63,7 @@
     {
       "id": "epic-assignments",
       "phase": "Phase 5 — Assignments",
-      "description": "Assignments per classroom with student editor (autosave + submit/unsubmit + late detection) and teacher read-only views",
+      "description": "Classroom assignments with autosave, submit/unsubmit, late detection, and teacher views",
       "passes": true,
       "verification": "Run: pnpm test. Manual smoke: student edits + submits; teacher views submission status",
       "issueRefs": [],
@@ -116,6 +116,17 @@
       "blockedBy": [],
       "addedDate": "2026-04-17",
       "completedDate": "2026-04-17"
+    },
+    {
+      "id": "epic-classwork-surveys",
+      "phase": "Phase 9 — Classwork Engagement",
+      "description": "Ungraded Classwork surveys with MC/text/link, dynamic updates, and results",
+      "passes": true,
+      "verification": "Run: pnpm lint && pnpm test -- --maxWorkers=4 && pnpm build; smoke survey flow.",
+      "issueRefs": [],
+      "blockedBy": [],
+      "addedDate": "2026-05-13",
+      "completedDate": "2026-05-13"
     }
   ]
 }

--- a/.ai/features.json
+++ b/.ai/features.json
@@ -119,10 +119,10 @@
     },
     {
       "id": "epic-classwork-surveys",
-      "phase": "Phase 9 — Classwork Engagement",
-      "description": "Ungraded Classwork surveys with MC/text/link, dynamic updates, and results",
+      "phase": "Phase 9 — Surveys",
+      "description": "Classwork surveys: MC/text/link, updates, results",
       "passes": true,
-      "verification": "Run: pnpm lint && pnpm test -- --maxWorkers=4 && pnpm build; smoke survey flow.",
+      "verification": "pnpm lint && pnpm test && pnpm build",
       "issueRefs": [],
       "blockedBy": [],
       "addedDate": "2026-05-13",

--- a/src/app/api/student/surveys/[id]/respond/route.ts
+++ b/src/app/api/student/surveys/[id]/respond/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertStudentCanAccessSurvey } from '@/lib/server/surveys'
+import {
+  canStudentRespondToSurvey,
+  isSurveyVisibleToStudents,
+  validateSurveyResponses,
+} from '@/lib/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+import type { SurveyQuestion } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const POST = withErrorHandler('PostStudentSurveyRespond', async (request, context) => {
+  const user = await requireRole('student')
+  const { id: surveyId } = await context.params
+  const body = await request.json()
+  const { responses } = body as { responses?: Record<string, unknown> }
+
+  if (!responses || typeof responses !== 'object') {
+    return NextResponse.json({ error: 'Responses are required' }, { status: 400 })
+  }
+
+  const access = await assertStudentCanAccessSurvey(user.id, surveyId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+  const survey = access.survey
+
+  if (survey.status !== 'active' || !isSurveyVisibleToStudents(survey)) {
+    return NextResponse.json({ error: 'Survey is not open' }, { status: 400 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: existingResponses } = await supabase
+    .from('survey_responses')
+    .select('id')
+    .eq('survey_id', surveyId)
+    .eq('student_id', user.id)
+    .limit(1)
+
+  const hasResponded = (existingResponses?.length || 0) > 0
+  if (!canStudentRespondToSurvey(survey, hasResponded)) {
+    return NextResponse.json({ error: 'You have already responded to this survey' }, { status: 400 })
+  }
+
+  const { data: questions, error: questionsError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('survey_id', surveyId)
+    .order('position', { ascending: true })
+
+  if (questionsError || !questions) {
+    console.error('Error fetching survey questions:', questionsError)
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+  }
+
+  const validation = validateSurveyResponses(questions as SurveyQuestion[], responses)
+  if (!validation.valid) {
+    return NextResponse.json({ error: validation.error }, { status: 400 })
+  }
+
+  const now = new Date().toISOString()
+  const rows = Object.entries(validation.responses).map(([questionId, response]) => ({
+    survey_id: surveyId,
+    question_id: questionId,
+    student_id: user.id,
+    selected_option:
+      response.question_type === 'multiple_choice' ? response.selected_option : null,
+    response_text:
+      response.question_type === 'multiple_choice' ? null : response.response_text,
+    submitted_at: hasResponded ? undefined : now,
+    updated_at: now,
+  }))
+
+  const query = survey.dynamic_responses
+    ? supabase
+        .from('survey_responses')
+        .upsert(rows, { onConflict: 'question_id,student_id' })
+    : supabase
+        .from('survey_responses')
+        .insert(rows)
+
+  const { error } = await query
+
+  if (error) {
+    if (error.code === '23505') {
+      return NextResponse.json({ error: 'You have already responded to this survey' }, { status: 400 })
+    }
+    console.error('Error saving survey responses:', error)
+    return NextResponse.json({ error: 'Failed to submit responses' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, updated: hasResponded }, { status: hasResponded ? 200 : 201 })
+})

--- a/src/app/api/student/surveys/[id]/results/route.ts
+++ b/src/app/api/student/surveys/[id]/results/route.ts
@@ -63,7 +63,6 @@ export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, 
     ...result,
     responses: result.responses.map((response) => ({
       response_id: response.response_id,
-      student_id: response.student_id,
       response_text: response.response_text,
       submitted_at: response.submitted_at,
       updated_at: response.updated_at,

--- a/src/app/api/student/surveys/[id]/results/route.ts
+++ b/src/app/api/student/surveys/[id]/results/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertStudentCanAccessSurvey } from '@/lib/server/surveys'
+import { aggregateSurveyResults } from '@/lib/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+import type { SurveyQuestion, SurveyResponse } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, context) => {
+  const user = await requireRole('student')
+  const { id: surveyId } = await context.params
+
+  const access = await assertStudentCanAccessSurvey(user.id, surveyId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+  const survey = access.survey
+
+  if (!survey.show_results) {
+    return NextResponse.json({ error: 'Results are not available' }, { status: 403 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: ownResponses } = await supabase
+    .from('survey_responses')
+    .select('id')
+    .eq('survey_id', surveyId)
+    .eq('student_id', user.id)
+    .limit(1)
+
+  if ((ownResponses?.length || 0) === 0) {
+    return NextResponse.json({ error: 'Submit a response to view results' }, { status: 403 })
+  }
+
+  const { data: questions, error: questionsError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('survey_id', surveyId)
+    .order('position', { ascending: true })
+
+  if (questionsError) {
+    console.error('Error fetching survey questions:', questionsError)
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } = await supabase
+    .from('survey_responses')
+    .select('*')
+    .eq('survey_id', surveyId)
+
+  if (responsesError) {
+    console.error('Error fetching survey responses:', responsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
+  const results = aggregateSurveyResults(
+    (questions || []) as SurveyQuestion[],
+    (responses || []) as SurveyResponse[]
+  ).map((result) => ({
+    ...result,
+    responses: result.responses.map((response) => ({
+      response_id: response.response_id,
+      student_id: response.student_id,
+      response_text: response.response_text,
+      submitted_at: response.submitted_at,
+      updated_at: response.updated_at,
+    })),
+  }))
+
+  return NextResponse.json({
+    survey: {
+      id: survey.id,
+      title: survey.title,
+      status: survey.status,
+      show_results: survey.show_results,
+      dynamic_responses: survey.dynamic_responses,
+    },
+    results,
+  })
+})

--- a/src/app/api/student/surveys/[id]/route.ts
+++ b/src/app/api/student/surveys/[id]/route.ts
@@ -51,19 +51,25 @@ export const GET = withErrorHandler('GetStudentSurvey', async (_request, context
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
+  const questionTypeById = new Map(
+    (questions || []).map((question) => [question.id, question.question_type])
+  )
   const studentResponses = Object.fromEntries(
-    (responseRows || []).map((response) => [
-      response.question_id,
-      response.selected_option !== null
-        ? {
-            question_type: 'multiple_choice' as const,
-            selected_option: response.selected_option,
-          }
-        : {
-            question_type: 'short_text' as const,
-            response_text: response.response_text || '',
-          },
-    ])
+    (responseRows || []).map((response) => {
+      const questionType = questionTypeById.get(response.question_id)
+      return [
+        response.question_id,
+        response.selected_option !== null
+          ? {
+              question_type: 'multiple_choice' as const,
+              selected_option: response.selected_option,
+            }
+          : {
+              question_type: questionType === 'link' ? 'link' as const : 'short_text' as const,
+              response_text: response.response_text || '',
+            },
+      ]
+    })
   )
 
   const studentStatus = getStudentSurveyStatus(survey, hasResponded)

--- a/src/app/api/student/surveys/[id]/route.ts
+++ b/src/app/api/student/surveys/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertStudentCanAccessSurvey } from '@/lib/server/surveys'
+import {
+  getStudentSurveyStatus,
+  isSurveyVisibleToStudents,
+} from '@/lib/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetStudentSurvey', async (_request, context) => {
+  const user = await requireRole('student')
+  const { id: surveyId } = await context.params
+
+  const access = await assertStudentCanAccessSurvey(user.id, surveyId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+  const survey = access.survey
+  const supabase = getServiceRoleClient()
+
+  const { data: responseRows } = await supabase
+    .from('survey_responses')
+    .select('question_id, selected_option, response_text')
+    .eq('survey_id', surveyId)
+    .eq('student_id', user.id)
+
+  const hasResponded = (responseRows?.length || 0) > 0
+
+  if (survey.status === 'draft') {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+  if (survey.status === 'active' && !isSurveyVisibleToStudents(survey)) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+  if (survey.status === 'closed' && !hasResponded) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+
+  const { data: questions, error: questionsError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('survey_id', surveyId)
+    .order('position', { ascending: true })
+
+  if (questionsError) {
+    console.error('Error fetching survey questions:', questionsError)
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+  }
+
+  const studentResponses = Object.fromEntries(
+    (responseRows || []).map((response) => [
+      response.question_id,
+      response.selected_option !== null
+        ? {
+            question_type: 'multiple_choice' as const,
+            selected_option: response.selected_option,
+          }
+        : {
+            question_type: 'short_text' as const,
+            response_text: response.response_text || '',
+          },
+    ])
+  )
+
+  const studentStatus = getStudentSurveyStatus(survey, hasResponded)
+
+  return NextResponse.json({
+    survey: {
+      id: survey.id,
+      classroom_id: survey.classroom_id,
+      title: survey.title,
+      status: survey.status,
+      opens_at: survey.opens_at,
+      show_results: survey.show_results,
+      dynamic_responses: survey.dynamic_responses,
+      position: survey.position,
+      student_status: studentStatus,
+      created_at: survey.created_at,
+      updated_at: survey.updated_at,
+    },
+    questions: questions || [],
+    student_status: studentStatus,
+    student_responses: studentResponses,
+  })
+})

--- a/src/app/api/student/surveys/route.ts
+++ b/src/app/api/student/surveys/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
+import { isMissingSurveysTableError } from '@/lib/server/surveys'
+import { getStudentSurveyStatus, isSurveyVisibleToStudents } from '@/lib/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetStudentSurveys', async (request) => {
+  const user = await requireRole('student')
+  const { searchParams } = new URL(request.url)
+  const classroomId = searchParams.get('classroom_id')
+
+  if (!classroomId) {
+    return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+  }
+
+  const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: surveys, error: surveysError } = await supabase
+    .from('surveys')
+    .select('*')
+    .eq('classroom_id', classroomId)
+    .order('position', { ascending: true })
+    .order('created_at', { ascending: true })
+
+  if (surveysError) {
+    if (isMissingSurveysTableError(surveysError)) {
+      return NextResponse.json({ surveys: [] })
+    }
+    console.error('Error fetching student surveys:', surveysError)
+    return NextResponse.json({ error: 'Failed to fetch surveys' }, { status: 500 })
+  }
+
+  const surveyIds = (surveys || []).map((survey) => survey.id)
+  const responseMap = new Map<string, boolean>()
+
+  if (surveyIds.length > 0) {
+    const { data: responseRows } = await supabase
+      .from('survey_responses')
+      .select('survey_id')
+      .eq('student_id', user.id)
+      .in('survey_id', surveyIds)
+
+    for (const row of responseRows || []) {
+      responseMap.set(row.survey_id, true)
+    }
+  }
+
+  const visibleSurveys = (surveys || [])
+    .filter((survey) => isSurveyVisibleToStudents(survey) || responseMap.has(survey.id))
+    .map((survey) => {
+      const hasResponded = responseMap.has(survey.id)
+      return {
+        ...survey,
+        student_status: getStudentSurveyStatus(survey, hasResponded),
+      }
+    })
+
+  return NextResponse.json({ surveys: visibleSurveys })
+})

--- a/src/app/api/teacher/assignments/bulk/route.ts
+++ b/src/app/api/teacher/assignments/bulk/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
 import { buildAssignmentInstructionFields } from '@/lib/assignment-instructions'
 import { withErrorHandler } from '@/lib/api-handler'
+import { isMissingSurveysTableError } from '@/lib/server/surveys'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -51,9 +52,9 @@ function isLiveAssignment(
 
 function buildAssignmentPositions(
   inputAssignments: BulkAssignmentInput[],
-  reservedMaterialPositions: number[],
+  reservedClassworkPositions: number[],
 ) {
-  const reserved = new Set(reservedMaterialPositions)
+  const reserved = new Set(reservedClassworkPositions)
   const positions = new Map<BulkAssignmentInput, number>()
   let nextPosition = 0
 
@@ -188,10 +189,16 @@ export const POST = withErrorHandler('PostTeacherAssignmentsBulk', async (reques
     return NextResponse.json({ errors }, { status: 400 })
   }
 
-  const materialPositionsResult = await supabase
-    .from('classwork_materials')
-    .select('position')
-    .eq('classroom_id', classroom_id)
+  const [materialPositionsResult, surveyPositionsResult] = await Promise.all([
+    supabase
+      .from('classwork_materials')
+      .select('position')
+      .eq('classroom_id', classroom_id),
+    supabase
+      .from('surveys')
+      .select('position')
+      .eq('classroom_id', classroom_id),
+  ])
 
   if (
     materialPositionsResult.error &&
@@ -204,10 +211,27 @@ export const POST = withErrorHandler('PostTeacherAssignmentsBulk', async (reques
     )
   }
 
+  if (
+    surveyPositionsResult.error &&
+    !isMissingSurveysTableError(surveyPositionsResult.error)
+  ) {
+    console.error('Error fetching survey positions:', surveyPositionsResult.error)
+    return NextResponse.json(
+      { error: 'Failed to save assignments' },
+      { status: 500 }
+    )
+  }
+
   const materialPositions = (materialPositionsResult.data || [])
     .map((material: { position?: number | null }) => material.position)
     .filter((position: unknown): position is number => typeof position === 'number' && Number.isFinite(position))
-  const assignmentPositions = buildAssignmentPositions(inputAssignments, materialPositions)
+  const surveyPositions = (surveyPositionsResult.data || [])
+    .map((survey: { position?: number | null }) => survey.position)
+    .filter((position: unknown): position is number => typeof position === 'number' && Number.isFinite(position))
+  const assignmentPositions = buildAssignmentPositions(inputAssignments, [
+    ...materialPositions,
+    ...surveyPositions,
+  ])
 
   // Process assignments: separate creates and updates
   const toCreate: BulkAssignmentInput[] = []

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -6,6 +6,7 @@ import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } f
 import { calculateAssignmentStats } from '@/lib/assignments'
 import { withErrorHandler } from '@/lib/api-handler'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
+import { isMissingSurveysTableError } from '@/lib/server/surveys'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -142,7 +143,7 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
 
   const supabase = getServiceRoleClient()
 
-  const [lastAssignmentResult, lastMaterialResult] = await Promise.all([
+  const [lastAssignmentResult, lastMaterialResult, lastSurveyResult] = await Promise.all([
     supabase
       .from('assignments')
       .select('position')
@@ -157,6 +158,13 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
       .order('position', { ascending: false })
       .limit(1)
       .maybeSingle(),
+    supabase
+      .from('surveys')
+      .select('position')
+      .eq('classroom_id', classroom_id)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ])
 
   const lastAssignmentPosition =
@@ -164,6 +172,10 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
   const lastMaterialPosition =
     !lastMaterialResult.error && typeof lastMaterialResult.data?.position === 'number'
       ? lastMaterialResult.data.position
+      : -1
+  const lastSurveyPosition =
+    !lastSurveyResult.error && typeof lastSurveyResult.data?.position === 'number'
+      ? lastSurveyResult.data.position
       : -1
 
   if (lastAssignmentResult.error) {
@@ -176,7 +188,12 @@ export const POST = withErrorHandler('PostTeacherAssignments', async (request, c
     return NextResponse.json({ error: 'Failed to create assignment' }, { status: 500 })
   }
 
-  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition) + 1
+  if (lastSurveyResult.error && !isMissingSurveysTableError(lastSurveyResult.error)) {
+    console.error('Error fetching last survey position:', lastSurveyResult.error)
+    return NextResponse.json({ error: 'Failed to create assignment' }, { status: 500 })
+  }
+
+  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition, lastSurveyPosition) + 1
 
   const instructionFields = buildAssignmentInstructionFields(
     typeof instructions_markdown === 'string'

--- a/src/app/api/teacher/classrooms/[id]/classwork/reorder/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/classwork/reorder/route.ts
@@ -8,7 +8,7 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 type ReorderItem = {
-  type?: 'assignment' | 'material'
+  type?: 'assignment' | 'material' | 'survey'
   id?: string
 }
 
@@ -47,7 +47,7 @@ export const POST = withErrorHandler('PostTeacherClassworkReorder', async (reque
 
   const invalidItem = items.find((item) => (
     !item ||
-    (item.type !== 'assignment' && item.type !== 'material') ||
+    (item.type !== 'assignment' && item.type !== 'material' && item.type !== 'survey') ||
     typeof item.id !== 'string' ||
     item.id.length === 0
   ))

--- a/src/app/api/teacher/classrooms/[id]/materials/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/materials/route.ts
@@ -3,6 +3,7 @@ import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { isMissingSurveysTableError } from '@/lib/server/surveys'
 import type { TiptapContent } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -87,7 +88,7 @@ export const POST = withErrorHandler('PostTeacherClassworkMaterial', async (requ
   }
 
   const supabase = getServiceRoleClient()
-  const [lastAssignmentResult, lastMaterialResult] = await Promise.all([
+  const [lastAssignmentResult, lastMaterialResult, lastSurveyResult] = await Promise.all([
     supabase
       .from('assignments')
       .select('position')
@@ -102,12 +103,22 @@ export const POST = withErrorHandler('PostTeacherClassworkMaterial', async (requ
       .order('position', { ascending: false })
       .limit(1)
       .maybeSingle(),
+    supabase
+      .from('surveys')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ])
   const lastAssignmentPosition = typeof lastAssignmentResult.data?.position === 'number'
     ? lastAssignmentResult.data.position
     : -1
   const lastMaterialPosition = !lastMaterialResult.error && typeof lastMaterialResult.data?.position === 'number'
     ? lastMaterialResult.data.position
+    : -1
+  const lastSurveyPosition = !lastSurveyResult.error && typeof lastSurveyResult.data?.position === 'number'
+    ? lastSurveyResult.data.position
     : -1
 
   if (lastAssignmentResult.error) {
@@ -120,7 +131,12 @@ export const POST = withErrorHandler('PostTeacherClassworkMaterial', async (requ
     return NextResponse.json({ error: 'Failed to create material' }, { status: 500 })
   }
 
-  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition) + 1
+  if (lastSurveyResult.error && !isMissingSurveysTableError(lastSurveyResult.error)) {
+    console.error('Error fetching last survey position:', lastSurveyResult.error)
+    return NextResponse.json({ error: 'Failed to create material' }, { status: 500 })
+  }
+
+  const nextPosition = Math.max(lastAssignmentPosition, lastMaterialPosition, lastSurveyPosition) + 1
   const insertBody: Record<string, unknown> = {
     classroom_id: classroomId,
     title: cleanTitle,

--- a/src/app/api/teacher/surveys/[id]/questions/[qid]/route.ts
+++ b/src/app/api/teacher/surveys/[id]/questions/[qid]/route.ts
@@ -40,9 +40,14 @@ export const PATCH = withErrorHandler('PatchTeacherSurveyQuestion', async (reque
     return NextResponse.json({ error: normalized.error }, { status: 400 })
   }
 
+  const updates: Record<string, unknown> = { ...normalized.question }
+  if (typeof body.position === 'number' && Number.isFinite(body.position)) {
+    updates.position = Math.max(0, Math.floor(body.position))
+  }
+
   const { data: question, error } = await supabase
     .from('survey_questions')
-    .update(normalized.question)
+    .update(updates)
     .eq('id', questionId)
     .select()
     .single()

--- a/src/app/api/teacher/surveys/[id]/questions/[qid]/route.ts
+++ b/src/app/api/teacher/surveys/[id]/questions/[qid]/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { normalizeSurveyQuestionInput } from '@/lib/surveys'
+import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const PATCH = withErrorHandler('PatchTeacherSurveyQuestion', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id: surveyId, qid: questionId } = await context.params
+  const body = await request.json()
+
+  const access = await assertTeacherOwnsSurvey(user.id, surveyId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: existingQuestion, error: questionError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('id', questionId)
+    .eq('survey_id', surveyId)
+    .single()
+
+  if (questionError || !existingQuestion) {
+    return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+  }
+
+  const normalized = normalizeSurveyQuestionInput({
+    question_type: body.question_type ?? existingQuestion.question_type,
+    question_text: body.question_text ?? existingQuestion.question_text,
+    options: body.options ?? existingQuestion.options,
+    response_max_chars: body.response_max_chars ?? existingQuestion.response_max_chars,
+  })
+  if (!normalized.valid) {
+    return NextResponse.json({ error: normalized.error }, { status: 400 })
+  }
+
+  const { data: question, error } = await supabase
+    .from('survey_questions')
+    .update(normalized.question)
+    .eq('id', questionId)
+    .select()
+    .single()
+
+  if (error || !question) {
+    console.error('Error updating survey question:', error)
+    return NextResponse.json({ error: 'Failed to update question' }, { status: 500 })
+  }
+
+  return NextResponse.json({ question })
+})
+
+export const DELETE = withErrorHandler('DeleteTeacherSurveyQuestion', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id: surveyId, qid: questionId } = await context.params
+
+  const access = await assertTeacherOwnsSurvey(user.id, surveyId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: existingQuestion, error: questionError } = await supabase
+    .from('survey_questions')
+    .select('id')
+    .eq('id', questionId)
+    .eq('survey_id', surveyId)
+    .single()
+
+  if (questionError || !existingQuestion) {
+    return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+  }
+
+  const { error } = await supabase
+    .from('survey_questions')
+    .delete()
+    .eq('id', questionId)
+
+  if (error) {
+    console.error('Error deleting survey question:', error)
+    return NextResponse.json({ error: 'Failed to delete question' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+})

--- a/src/app/api/teacher/surveys/[id]/questions/route.ts
+++ b/src/app/api/teacher/surveys/[id]/questions/route.ts
@@ -33,13 +33,17 @@ export const POST = withErrorHandler('PostTeacherSurveyQuestion', async (request
     .maybeSingle()
 
   const nextPosition = typeof lastQuestion?.position === 'number' ? lastQuestion.position + 1 : 0
+  const requestedPosition =
+    typeof body.position === 'number' && Number.isFinite(body.position)
+      ? Math.max(0, Math.floor(body.position))
+      : nextPosition
 
   const { data: question, error } = await supabase
     .from('survey_questions')
     .insert({
       survey_id: surveyId,
       ...normalized.question,
-      position: nextPosition,
+      position: requestedPosition,
     })
     .select()
     .single()

--- a/src/app/api/teacher/surveys/[id]/questions/route.ts
+++ b/src/app/api/teacher/surveys/[id]/questions/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { normalizeSurveyQuestionInput } from '@/lib/surveys'
+import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const POST = withErrorHandler('PostTeacherSurveyQuestion', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id: surveyId } = await context.params
+  const body = await request.json()
+
+  const access = await assertTeacherOwnsSurvey(user.id, surveyId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const normalized = normalizeSurveyQuestionInput(body)
+  if (!normalized.valid) {
+    return NextResponse.json({ error: normalized.error }, { status: 400 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: lastQuestion } = await supabase
+    .from('survey_questions')
+    .select('position')
+    .eq('survey_id', surveyId)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  const nextPosition = typeof lastQuestion?.position === 'number' ? lastQuestion.position + 1 : 0
+
+  const { data: question, error } = await supabase
+    .from('survey_questions')
+    .insert({
+      survey_id: surveyId,
+      ...normalized.question,
+      position: nextPosition,
+    })
+    .select()
+    .single()
+
+  if (error || !question) {
+    console.error('Error creating survey question:', error)
+    return NextResponse.json({ error: 'Failed to create question' }, { status: 500 })
+  }
+
+  return NextResponse.json({ question }, { status: 201 })
+})

--- a/src/app/api/teacher/surveys/[id]/results/route.ts
+++ b/src/app/api/teacher/surveys/[id]/results/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { aggregateSurveyResults } from '@/lib/surveys'
+import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+import type { SurveyQuestion, SurveyResponse } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id: surveyId } = await context.params
+
+  const access = await assertTeacherOwnsSurvey(user.id, surveyId)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+  const survey = access.survey
+
+  const supabase = getServiceRoleClient()
+  const { data: questions, error: questionsError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('survey_id', surveyId)
+    .order('position', { ascending: true })
+
+  if (questionsError) {
+    console.error('Error fetching survey questions:', questionsError)
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } = await supabase
+    .from('survey_responses')
+    .select('*')
+    .eq('survey_id', surveyId)
+
+  if (responsesError) {
+    console.error('Error fetching survey responses:', responsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
+  const responderIds = [...new Set((responses || []).map((response) => response.student_id))]
+  const usersById = new Map<string, { email: string; name: string | null }>()
+
+  if (responderIds.length > 0) {
+    const { data: users } = await supabase
+      .from('users')
+      .select('id, email')
+      .in('id', responderIds)
+
+    const { data: profiles } = await supabase
+      .from('student_profiles')
+      .select('user_id, first_name, last_name')
+      .in('user_id', responderIds)
+
+    const profileMap = new Map(
+      (profiles || []).map((profile) => [
+        profile.user_id,
+        `${profile.first_name || ''} ${profile.last_name || ''}`.trim(),
+      ])
+    )
+
+    for (const userRecord of users || []) {
+      usersById.set(userRecord.id, {
+        email: userRecord.email,
+        name: profileMap.get(userRecord.id) || null,
+      })
+    }
+  }
+
+  const results = aggregateSurveyResults(
+    (questions || []) as SurveyQuestion[],
+    (responses || []) as SurveyResponse[]
+  ).map((result) => ({
+    ...result,
+    responses: result.responses.map((response) => {
+      const userRecord = usersById.get(response.student_id)
+      return {
+        ...response,
+        name: userRecord?.name ?? null,
+        email: userRecord?.email ?? null,
+      }
+    }),
+  }))
+
+  const responders = responderIds
+    .map((studentId) => {
+      const userRecord = usersById.get(studentId)
+      return {
+        student_id: studentId,
+        name: userRecord?.name ?? null,
+        email: userRecord?.email ?? '',
+      }
+    })
+    .sort((a, b) => (a.name || a.email).localeCompare(b.name || b.email))
+
+  const { count: totalStudents } = await supabase
+    .from('classroom_enrollments')
+    .select('*', { count: 'exact', head: true })
+    .eq('classroom_id', survey.classroom_id)
+
+  return NextResponse.json({
+    survey: {
+      id: survey.id,
+      title: survey.title,
+      status: survey.status,
+      show_results: survey.show_results,
+      dynamic_responses: survey.dynamic_responses,
+    },
+    questions: (questions || []).map((question) => ({
+      id: question.id,
+      question_type: question.question_type,
+      question_text: question.question_text,
+      options: question.options,
+      response_max_chars: question.response_max_chars,
+      position: question.position,
+    })),
+    results,
+    responders,
+    stats: {
+      total_students: totalStudents || 0,
+      responded: responderIds.length,
+    },
+  })
+})

--- a/src/app/api/teacher/surveys/[id]/route.ts
+++ b/src/app/api/teacher/surveys/[id]/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { canActivateSurvey, hasSurveyOpened } from '@/lib/surveys'
+import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+import type { SurveyStatus } from '@/types'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const GET = withErrorHandler('GetTeacherSurvey', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+
+  const access = await assertTeacherOwnsSurvey(user.id, id)
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: questions, error: questionsError } = await supabase
+    .from('survey_questions')
+    .select('*')
+    .eq('survey_id', id)
+    .order('position', { ascending: true })
+
+  if (questionsError) {
+    console.error('Error fetching survey questions:', questionsError)
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    survey: access.survey,
+    questions: questions || [],
+    classroom: access.survey.classrooms,
+  })
+})
+
+export const PATCH = withErrorHandler('PatchTeacherSurvey', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+  const body = await request.json()
+  const { title, status, show_results, dynamic_responses, opens_at } = body as {
+    title?: string
+    status?: SurveyStatus
+    show_results?: boolean
+    dynamic_responses?: boolean
+    opens_at?: string | null
+  }
+
+  const access = await assertTeacherOwnsSurvey(user.id, id, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+  const existing = access.survey
+  const supabase = getServiceRoleClient()
+
+  let parsedOpensAt: string | null | undefined
+  if (opens_at !== undefined) {
+    if (opens_at === null) {
+      parsedOpensAt = null
+    } else {
+      const parsed = new Date(opens_at)
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json({ error: 'Invalid open date' }, { status: 400 })
+      }
+      parsedOpensAt = parsed.toISOString()
+    }
+  }
+
+  if (status !== undefined) {
+    const validStatuses: SurveyStatus[] = ['draft', 'active', 'closed']
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+    }
+
+    if (existing.status === 'active' && status === 'draft' && hasSurveyOpened(existing)) {
+      return NextResponse.json(
+        { error: 'Cannot revert a survey that has already opened to draft' },
+        { status: 400 }
+      )
+    }
+
+    const validTransitions: Record<SurveyStatus, SurveyStatus[]> = {
+      draft: ['active'],
+      active: ['closed', 'draft'],
+      closed: ['active'],
+    }
+    if (!validTransitions[existing.status].includes(status)) {
+      return NextResponse.json(
+        { error: `Cannot transition from ${existing.status} to ${status}` },
+        { status: 400 }
+      )
+    }
+  }
+
+  if (status === 'active' && existing.status === 'draft') {
+    const { count: questionsCount } = await supabase
+      .from('survey_questions')
+      .select('*', { count: 'exact', head: true })
+      .eq('survey_id', id)
+
+    const activation = canActivateSurvey(existing, questionsCount || 0)
+    if (!activation.valid) {
+      return NextResponse.json({ error: activation.error }, { status: 400 })
+    }
+  }
+
+  if (title !== undefined && !title.trim()) {
+    return NextResponse.json({ error: 'Title cannot be empty' }, { status: 400 })
+  }
+  if (show_results !== undefined && typeof show_results !== 'boolean') {
+    return NextResponse.json({ error: 'show_results must be a boolean' }, { status: 400 })
+  }
+  if (dynamic_responses !== undefined && typeof dynamic_responses !== 'boolean') {
+    return NextResponse.json({ error: 'dynamic_responses must be a boolean' }, { status: 400 })
+  }
+
+  const updates: Record<string, unknown> = {}
+  if (title !== undefined) updates.title = title.trim()
+  if (status !== undefined) updates.status = status
+  if (show_results !== undefined) updates.show_results = show_results
+  if (dynamic_responses !== undefined) updates.dynamic_responses = dynamic_responses
+  if (opens_at !== undefined) updates.opens_at = parsedOpensAt
+
+  if (status === 'active') {
+    updates.opens_at = parsedOpensAt ?? new Date().toISOString()
+  }
+  if (status === 'draft') {
+    updates.opens_at = null
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No updates provided' }, { status: 400 })
+  }
+
+  const { data: survey, error } = await supabase
+    .from('surveys')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error || !survey) {
+    console.error('Error updating survey:', error)
+    return NextResponse.json({ error: 'Failed to update survey' }, { status: 500 })
+  }
+
+  return NextResponse.json({ survey })
+})
+
+export const DELETE = withErrorHandler('DeleteTeacherSurvey', async (_request, context) => {
+  const user = await requireRole('teacher')
+  const { id } = await context.params
+
+  const access = await assertTeacherOwnsSurvey(user.id, id, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { error } = await supabase
+    .from('surveys')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error deleting survey:', error)
+    return NextResponse.json({ error: 'Failed to delete survey' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+})

--- a/src/app/api/teacher/surveys/route.ts
+++ b/src/app/api/teacher/surveys/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { isMissingSurveysTableError } from '@/lib/server/surveys'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+async function getNextClassworkPosition(classroomId: string) {
+  const supabase = getServiceRoleClient()
+  const [lastAssignmentResult, lastMaterialResult, lastSurveyResult] = await Promise.all([
+    supabase
+      .from('assignments')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('classwork_materials')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('surveys')
+      .select('position')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ])
+
+  if (lastAssignmentResult.error) throw lastAssignmentResult.error
+  if (lastMaterialResult.error && !String(lastMaterialResult.error.message || '').includes('classwork_materials')) {
+    throw lastMaterialResult.error
+  }
+  if (lastSurveyResult.error && !isMissingSurveysTableError(lastSurveyResult.error)) {
+    throw lastSurveyResult.error
+  }
+
+  const positions = [
+    lastAssignmentResult.data?.position,
+    lastMaterialResult.data?.position,
+    lastSurveyResult.data?.position,
+  ].filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+
+  return (positions.length > 0 ? Math.max(...positions) : -1) + 1
+}
+
+export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
+  const user = await requireRole('teacher')
+  const { searchParams } = new URL(request.url)
+  const classroomId = searchParams.get('classroom_id')
+
+  if (!classroomId) {
+    return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+  }
+
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+  if (!ownership.ok) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: surveys, error: surveysError } = await supabase
+    .from('surveys')
+    .select('*')
+    .eq('classroom_id', classroomId)
+    .order('position', { ascending: true })
+    .order('created_at', { ascending: true })
+
+  if (surveysError) {
+    if (isMissingSurveysTableError(surveysError)) {
+      return NextResponse.json({ surveys: [], migration_required: true })
+    }
+    console.error('Error fetching surveys:', surveysError)
+    return NextResponse.json({ error: 'Failed to fetch surveys' }, { status: 500 })
+  }
+
+  const { count: totalStudents } = await supabase
+    .from('classroom_enrollments')
+    .select('*', { count: 'exact', head: true })
+    .eq('classroom_id', classroomId)
+
+  const surveyIds = (surveys || []).map((survey) => survey.id)
+
+  const questionCountMap: Record<string, number> = {}
+  if (surveyIds.length > 0) {
+    const { data: questionRows } = await supabase
+      .from('survey_questions')
+      .select('survey_id')
+      .in('survey_id', surveyIds)
+
+    for (const row of questionRows || []) {
+      questionCountMap[row.survey_id] = (questionCountMap[row.survey_id] || 0) + 1
+    }
+  }
+
+  const respondentCountMap: Record<string, number> = {}
+  if (surveyIds.length > 0) {
+    const { data: responseRows } = await supabase
+      .from('survey_responses')
+      .select('survey_id, student_id')
+      .in('survey_id', surveyIds)
+
+    const seen: Record<string, Set<string>> = {}
+    for (const row of responseRows || []) {
+      if (!seen[row.survey_id]) seen[row.survey_id] = new Set()
+      seen[row.survey_id].add(row.student_id)
+    }
+    for (const [surveyId, students] of Object.entries(seen)) {
+      respondentCountMap[surveyId] = students.size
+    }
+  }
+
+  return NextResponse.json({
+    surveys: (surveys || []).map((survey) => ({
+      ...survey,
+      stats: {
+        total_students: totalStudents || 0,
+        responded: respondentCountMap[survey.id] || 0,
+        questions_count: questionCountMap[survey.id] || 0,
+      },
+    })),
+  })
+})
+
+export const POST = withErrorHandler('PostTeacherSurvey', async (request) => {
+  const user = await requireRole('teacher')
+  const body = await request.json()
+  const { classroom_id, title, show_results = true, dynamic_responses = false } = body as {
+    classroom_id?: string
+    title?: string
+    show_results?: boolean
+    dynamic_responses?: boolean
+  }
+
+  if (!classroom_id) {
+    return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
+  }
+
+  const cleanTitle = title?.trim()
+  if (!cleanTitle) {
+    return NextResponse.json({ error: 'Title is required' }, { status: 400 })
+  }
+
+  const ownership = await assertTeacherCanMutateClassroom(user.id, classroom_id)
+  if (!ownership.ok) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  let position = 0
+  try {
+    position = await getNextClassworkPosition(classroom_id)
+  } catch (error) {
+    console.error('Error fetching classwork position for survey:', error)
+    return NextResponse.json({ error: 'Failed to create survey' }, { status: 500 })
+  }
+
+  const { data: survey, error } = await supabase
+    .from('surveys')
+    .insert({
+      classroom_id,
+      title: cleanTitle,
+      show_results: show_results === true,
+      dynamic_responses: dynamic_responses === true,
+      created_by: user.id,
+      position,
+    })
+    .select()
+    .single()
+
+  if (error || !survey) {
+    console.error('Error creating survey:', error)
+    return NextResponse.json({ error: 'Failed to create survey' }, { status: 500 })
+  }
+
+  return NextResponse.json({ survey }, { status: 201 })
+})

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -361,6 +361,7 @@ function ClassroomPageContent({
   const isTeacher = user.role === 'teacher'
   const assignmentIdParam = searchParams.get('assignmentId')
   const materialIdParam = activeTab === 'assignments' ? searchParams.get('materialId') : null
+  const surveyIdParam = activeTab === 'assignments' ? searchParams.get('surveyId') : null
   const assignmentStudentIdParam = searchParams.get('assignmentStudentId')
   const quizIdParam = activeTab === 'quizzes' ? searchParams.get('quizId') : null
   const testIdParam = activeTab === 'tests' ? searchParams.get('testId') : null
@@ -1049,6 +1050,7 @@ function ClassroomPageContent({
         if (tab !== 'assignments') {
           params.delete('assignmentId')
           params.delete('materialId')
+          params.delete('surveyId')
           params.delete('assignmentStudentId')
         }
         if (tab !== 'settings') {
@@ -1272,6 +1274,7 @@ function ClassroomPageContent({
                         isActive={activeTab === 'assignments'}
                         selectedAssignmentId={assignmentIdParam}
                         selectedMaterialId={materialIdParam}
+                        selectedSurveyId={surveyIdParam}
                         selectedAssignmentStudentId={assignmentStudentIdParam}
                         updateSearchParams={navigateInClassroom}
                       />
@@ -1323,6 +1326,7 @@ function ClassroomPageContent({
                             }
                             params.delete('assignmentStudentId')
                             params.delete('materialId')
+                            params.delete('surveyId')
                           })
                         }
                         onNavigateToAnnouncements={() =>
@@ -1331,6 +1335,7 @@ function ClassroomPageContent({
                             params.delete('section')
                             params.delete('assignmentId')
                             params.delete('materialId')
+                            params.delete('surveyId')
                             params.delete('assignmentStudentId')
                           })
                         }
@@ -1387,6 +1392,7 @@ function ClassroomPageContent({
                         classroom={classroom}
                         selectedAssignmentId={assignmentIdParam}
                         selectedMaterialId={materialIdParam}
+                        selectedSurveyId={surveyIdParam}
                         isActive={activeTab === 'assignments'}
                         updateSearchParams={navigateInClassroom}
                       />
@@ -1416,6 +1422,7 @@ function ClassroomPageContent({
                             }
                             params.delete('assignmentStudentId')
                             params.delete('materialId')
+                            params.delete('surveyId')
                           })
                         }
                         onNavigateToAnnouncements={() =>
@@ -1424,6 +1431,7 @@ function ClassroomPageContent({
                             params.delete('section')
                             params.delete('assignmentId')
                             params.delete('materialId')
+                            params.delete('surveyId')
                           })
                         }
                       />

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -11,33 +11,44 @@ import {
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
 } from '@/lib/assignments'
-import type { AssignmentWithStatus, Classroom, ClassworkMaterial, TiptapContent } from '@/types'
+import type {
+  AssignmentWithStatus,
+  Classroom,
+  ClassworkMaterial,
+  StudentSurveyView,
+  TiptapContent,
+} from '@/types'
 import { StudentAssignmentEditor, type StudentAssignmentEditorHandle } from '@/components/StudentAssignmentEditor'
 import { RichTextViewer } from '@/components/editor'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { StudentSurveyPanel } from '@/components/surveys/StudentSurveyPanel'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { buildOrderedClassworkItems } from '@/lib/classwork-order'
+import { getStudentSurveyStatus, getSurveyStatusBadgeClass, getSurveyStatusLabel } from '@/lib/surveys'
 
 interface Props {
   classroom: Classroom
   selectedAssignmentId?: string | null
   selectedMaterialId?: string | null
+  selectedSurveyId?: string | null
   isActive?: boolean
   updateSearchParams?: (updater: (params: URLSearchParams) => void, options?: { replace?: boolean }) => void
 }
 
-type StudentAssignmentsView = 'summary' | 'edit' | 'material'
+type StudentAssignmentsView = 'summary' | 'edit' | 'material' | 'survey'
 
 export function StudentAssignmentsTab({
   classroom,
   selectedAssignmentId = null,
   selectedMaterialId = null,
+  selectedSurveyId = null,
   isActive = true,
   updateSearchParams = () => {},
 }: Props) {
   const [assignments, setAssignments] = useState<AssignmentWithStatus[]>([])
   const [materials, setMaterials] = useState<ClassworkMaterial[]>([])
+  const [surveys, setSurveys] = useState<StudentSurveyView[]>([])
   const [loading, setLoading] = useState(false)
   const [hasLoaded, setHasLoaded] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -45,7 +56,9 @@ export function StudentAssignmentsTab({
   const [editorState, setEditorState] = useState({ isSubmitted: false, canSubmit: false, submitting: false, hasRepoMetadata: false })
   const editorRef = useRef<StudentAssignmentEditorHandle>(null)
   const wasActiveRef = useRef(isActive)
-  const showBlockingSpinner = useDelayedBusy(loading && assignments.length === 0 && materials.length === 0)
+  const showBlockingSpinner = useDelayedBusy(
+    loading && assignments.length === 0 && materials.length === 0 && surveys.length === 0
+  )
 
   const loadAssignments = useCallback(
     async (options?: { preserveContent?: boolean }) => {
@@ -56,7 +69,7 @@ export function StudentAssignmentsTab({
         setLoading(true)
       }
       try {
-        const [assignmentsData, materialsData] = await Promise.all([
+        const [assignmentsData, materialsData, surveysData] = await Promise.all([
           fetchJSONWithCache(
             `student-assignments:${classroom.id}`,
             async () => {
@@ -75,9 +88,19 @@ export function StudentAssignmentsTab({
             },
             20_000,
           ),
+          fetchJSONWithCache(
+            `student-surveys:${classroom.id}`,
+            async () => {
+              const res = await fetch(`/api/student/surveys?classroom_id=${classroom.id}`)
+              if (!res.ok) throw new Error('Failed to load surveys')
+              return res.json()
+            },
+            20_000,
+          ).catch(() => ({ surveys: [] })),
         ])
         setAssignments(assignmentsData.assignments || [])
         setMaterials(materialsData.materials || [])
+        setSurveys(surveysData.surveys || [])
         setHasLoaded(true)
       } catch (err) {
         console.error('Error loading assignments:', err)
@@ -111,20 +134,26 @@ export function StudentAssignmentsTab({
     return materials.find((material) => material.id === selectedMaterialId) ?? null
   }, [materials, selectedMaterialId])
 
+  const selectedSurvey = useMemo(() => {
+    if (!selectedSurveyId) return null
+    return surveys.find((survey) => survey.id === selectedSurveyId) ?? null
+  }, [selectedSurveyId, surveys])
+
   const classworkItems = useMemo(
-    () => buildOrderedClassworkItems(assignments, materials),
-    [assignments, materials],
+    () => buildOrderedClassworkItems(assignments, materials, surveys),
+    [assignments, materials, surveys],
   )
 
   const view: StudentAssignmentsView = useMemo(() => {
     if (selectedMaterialId && selectedMaterial) return 'material'
+    if (selectedSurveyId && selectedSurvey) return 'survey'
     if (!selectedAssignmentId) return 'summary'
     if (!selectedAssignment) return 'summary'
     return 'edit'
-  }, [selectedAssignment, selectedAssignmentId, selectedMaterial, selectedMaterialId])
+  }, [selectedAssignment, selectedAssignmentId, selectedMaterial, selectedMaterialId, selectedSurvey, selectedSurveyId])
 
   const navigate = useCallback(
-    (next: { assignmentId?: string | null; materialId?: string | null }) => {
+    (next: { assignmentId?: string | null; materialId?: string | null; surveyId?: string | null }) => {
       updateSearchParams((params) => {
         params.set('tab', 'assignments')
         params.delete('view')
@@ -137,6 +166,11 @@ export function StudentAssignmentsTab({
           params.set('materialId', next.materialId)
         } else {
           params.delete('materialId')
+        }
+        if (next.surveyId) {
+          params.set('surveyId', next.surveyId)
+        } else {
+          params.delete('surveyId')
         }
       })
     },
@@ -267,10 +301,10 @@ export function StudentAssignmentsTab({
                 </div>
               </Card>
             ) : view === 'summary' ? (
-              assignments.length === 0 && materials.length === 0 ? (
+              assignments.length === 0 && materials.length === 0 && surveys.length === 0 ? (
                 <EmptyState
                   title="No classwork yet"
-                  description="When your teacher posts assignments or materials, they will show up here."
+                  description="When your teacher posts assignments, materials, or surveys, they will show up here."
                 />
               ) : (
                 <PageStack>
@@ -296,6 +330,37 @@ export function StudentAssignmentsTab({
                             </div>
                             <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-primary">
                               Posted
+                            </span>
+                          </div>
+                        </button>
+                      )
+                    }
+
+                    if (item.type === 'survey') {
+                      const survey = item.survey
+                      return (
+                        <button
+                          key={survey.id}
+                          type="button"
+                          data-testid="survey-card"
+                          onClick={() => navigate({ surveyId: survey.id })}
+                          className="block w-full rounded-card border border-border bg-surface-panel px-5 py-4 text-left transition-[background-color,border-color,box-shadow,transform] hover:-translate-y-px hover:border-border-strong hover:bg-surface-accent hover:shadow-panel"
+                        >
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0">
+                              <h3 className="truncate text-base font-semibold text-text-default">
+                                {survey.title}
+                              </h3>
+                              <p className="mt-1 text-sm text-primary">
+                                Survey{survey.dynamic_responses ? ' · Dynamic' : ''}
+                              </p>
+                            </div>
+                            <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getSurveyStatusBadgeClass(survey.status)}`}>
+                              {survey.student_status === 'not_started'
+                                ? getSurveyStatusLabel(survey.status)
+                                : survey.student_status === 'can_update'
+                                  ? 'Update'
+                                  : 'Done'}
                             </span>
                           </div>
                         </button>
@@ -342,6 +407,23 @@ export function StudentAssignmentsTab({
                 </div>
                 <RichTextViewer content={selectedMaterial.content} />
               </Card>
+            ) : view === 'survey' && selectedSurvey ? (
+              <StudentSurveyPanel
+                surveyId={selectedSurvey.id}
+                onBack={() => navigate({ surveyId: null })}
+                onCompleted={() => {
+                  setSurveys((current) =>
+                    current.map((survey) =>
+                      survey.id === selectedSurvey.id
+                        ? {
+                            ...survey,
+                            student_status: getStudentSurveyStatus(survey, true),
+                          }
+                        : survey
+                    )
+                  )
+                }}
+              />
             ) : !selectedAssignment ? (
               <EmptyState
                 title="Assignment unavailable"

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -40,6 +40,9 @@ import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
+import { SortableSurveyCard } from '@/components/surveys/SortableSurveyCard'
+import { SurveyModal } from '@/components/surveys/SurveyModal'
+import { TeacherSurveyWorkspace } from '@/components/surveys/TeacherSurveyWorkspace'
 import {
   TeacherAssignmentStudentTable,
   type TeacherAssignmentStudentRow,
@@ -80,6 +83,8 @@ import type {
   AssignmentStatus,
   ClassDay,
   ClassworkMaterial,
+  Survey,
+  SurveyWithStats,
   TiptapContent,
 } from '@/types'
 import {
@@ -98,6 +103,9 @@ interface AssignmentWithStats extends Assignment {
 }
 
 type TeacherAssignmentSelection = { mode: 'summary' } | { mode: 'assignment'; assignmentId: string }
+type TeacherClassworkSelection =
+  | TeacherAssignmentSelection
+  | { mode: 'survey'; surveyId: string }
 
 type StudentSubmissionRow = TeacherAssignmentStudentRow
 type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
@@ -123,6 +131,7 @@ interface Props {
   isActive?: boolean
   selectedAssignmentId?: string | null
   selectedMaterialId?: string | null
+  selectedSurveyId?: string | null
   selectedAssignmentStudentId?: string | null
   updateSearchParams?: UpdateSearchParamsFn
 }
@@ -522,23 +531,29 @@ export function TeacherClassroomView({
   onEditModeChange,
   isActive = true,
   selectedAssignmentId: selectedAssignmentIdProp,
+  selectedSurveyId: selectedSurveyIdProp,
   selectedAssignmentStudentId,
   updateSearchParams,
 }: Props) {
   const isReadOnly = !!classroom.archived_at
-  const isUrlSelectionControlled = selectedAssignmentIdProp !== undefined
+  const isUrlSelectionControlled =
+    selectedAssignmentIdProp !== undefined || selectedSurveyIdProp !== undefined
 
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([])
   const [materials, setMaterials] = useState<ClassworkMaterial[]>([])
+  const [surveys, setSurveys] = useState<SurveyWithStats[]>([])
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(false)
+  const [isSurveyModalOpen, setIsSurveyModalOpen] = useState(false)
   const [editMaterial, setEditMaterial] = useState<ClassworkMaterial | null>(null)
   const [pendingMaterialDelete, setPendingMaterialDelete] = useState<ClassworkMaterial | null>(null)
   const [isDeletingMaterial, setIsDeletingMaterial] = useState(false)
-  const [selection, setSelection] = useState<TeacherAssignmentSelection>({ mode: 'summary' })
+  const [pendingSurveyDelete, setPendingSurveyDelete] = useState<SurveyWithStats | null>(null)
+  const [isDeletingSurvey, setIsDeletingSurvey] = useState(false)
+  const [selection, setSelection] = useState<TeacherClassworkSelection>({ mode: 'summary' })
   const [isReordering, setIsReordering] = useState(false)
   const [assignmentEditMode, setAssignmentEditMode] = useState(false)
 
@@ -600,7 +615,9 @@ export function TeacherClassroomView({
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const wasActiveRef = useRef(isActive)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
-  const showSummarySpinner = useDelayedBusy(loading && assignments.length === 0 && materials.length === 0)
+  const showSummarySpinner = useDelayedBusy(
+    loading && assignments.length === 0 && materials.length === 0 && surveys.length === 0
+  )
   const { showMessage } = useAppMessage()
   const {
     layout: assignmentGradingLayout,
@@ -613,7 +630,7 @@ export function TeacherClassroomView({
       setLoading(true)
     }
     try {
-      const [assignmentsData, materialsData, classDaysRes] = await Promise.all([
+      const [assignmentsData, materialsData, surveysData, classDaysRes] = await Promise.all([
         fetchJSONWithCache(
           `teacher-assignments:${classroom.id}`,
           async () => {
@@ -633,6 +650,15 @@ export function TeacherClassroomView({
           20_000,
         ),
         fetchJSONWithCache(
+          `teacher-surveys:${classroom.id}`,
+          async () => {
+            const response = await fetch(`/api/teacher/surveys?classroom_id=${classroom.id}`)
+            if (!response.ok) throw new Error('Failed to load surveys')
+            return response.json()
+          },
+          20_000,
+        ).catch(() => ({ surveys: [] })),
+        fetchJSONWithCache(
           `class-days:${classroom.id}`,
           async () => {
             const response = await fetch(`/api/classrooms/${classroom.id}/class-days`)
@@ -644,6 +670,7 @@ export function TeacherClassroomView({
       ])
       setAssignments(assignmentsData.assignments || [])
       setMaterials(materialsData.materials || [])
+      setSurveys(surveysData.surveys || [])
       setClassDays(classDaysRes.class_days || [])
       setHasLoadedOnce(true)
       window.dispatchEvent(
@@ -675,6 +702,26 @@ export function TeacherClassroomView({
     setIsMaterialModalOpen(false)
   }, [classroom.id])
 
+  const handleSurveySaved = useCallback((survey: Survey) => {
+    invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+    invalidateCachedJSON(`student-surveys:${classroom.id}`)
+    setSurveys((current) => {
+      const withStats = survey as SurveyWithStats
+      const exists = current.some((item) => item.id === survey.id)
+      return exists
+        ? current.map((item) => (item.id === survey.id ? { ...item, ...withStats } : item))
+        : [
+            ...current,
+            {
+              ...withStats,
+              stats: withStats.stats ?? { total_students: 0, responded: 0, questions_count: 0 },
+            },
+          ]
+    })
+    setIsSurveyModalOpen(false)
+    void loadAssignments({ preserveContent: true })
+  }, [classroom.id, loadAssignments])
+
   const deleteMaterial = useCallback(async () => {
     if (!pendingMaterialDelete) return
     setIsDeletingMaterial(true)
@@ -698,6 +745,35 @@ export function TeacherClassroomView({
     }
   }, [classroom.id, pendingMaterialDelete, showMessage])
 
+  const deleteSurvey = useCallback(async () => {
+    if (!pendingSurveyDelete) return
+    setIsDeletingSurvey(true)
+    try {
+      const response = await fetch(`/api/teacher/surveys/${pendingSurveyDelete.id}`, {
+        method: 'DELETE',
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Failed to delete survey')
+      invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+      invalidateCachedJSON(`student-surveys:${classroom.id}`)
+      setSurveys((current) => current.filter((survey) => survey.id !== pendingSurveyDelete.id))
+      if (selection.mode === 'survey' && selection.surveyId === pendingSurveyDelete.id) {
+        writeCookie(`teacherAssignmentsSelection:${classroom.id}`, 'summary')
+        setSelection({ mode: 'summary' })
+        updateSearchParams?.((params) => {
+          params.set('tab', 'assignments')
+          params.delete('surveyId')
+        }, { replace: true })
+      }
+      setPendingSurveyDelete(null)
+      showMessage({ text: 'Survey deleted.', tone: 'success' })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete survey')
+    } finally {
+      setIsDeletingSurvey(false)
+    }
+  }, [classroom.id, pendingSurveyDelete, selection, showMessage, updateSearchParams])
+
   useEffect(() => {
     if (isActive && !wasActiveRef.current && hasLoadedOnce) {
       loadAssignments({ preserveContent: true })
@@ -719,8 +795,8 @@ export function TeacherClassroomView({
   }, [selection.mode, leftPaneView, selectedStudentId])
 
   const classworkItems = useMemo(
-    () => buildOrderedClassworkItems(assignments, materials),
-    [assignments, materials],
+    () => buildOrderedClassworkItems(assignments, materials, surveys),
+    [assignments, materials, surveys],
   )
 
   const handleDragEnd = useCallback(
@@ -749,6 +825,13 @@ export function TeacherClassroomView({
             : []
         )),
       )
+      setSurveys(
+        reordered.flatMap((item, position) => (
+          item.type === 'survey'
+            ? [{ ...item.survey, position }]
+            : []
+        )),
+      )
 
       // Persist to server
       setIsReordering(true)
@@ -766,8 +849,10 @@ export function TeacherClassroomView({
         }
         invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
         invalidateCachedJSON(`teacher-materials:${classroom.id}`)
+        invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
         invalidateCachedJSON(`student-assignments:${classroom.id}`)
         invalidateCachedJSON(`student-materials:${classroom.id}`)
+        invalidateCachedJSON(`student-surveys:${classroom.id}`)
         // Notify sidebar to refresh
         window.dispatchEvent(
           new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
@@ -795,6 +880,12 @@ export function TeacherClassroomView({
       setSelection({ mode: 'summary' })
       return
     }
+    if (value.startsWith('survey:')) {
+      const surveyId = value.slice('survey:'.length)
+      const survey = surveys.find((item) => item.id === surveyId)
+      setSelection(survey ? { mode: 'survey', surveyId } : { mode: 'summary' })
+      return
+    }
     const assignment = assignments.find((a) => a.id === value)
     if (!assignment) {
       setSelection({ mode: 'summary' })
@@ -807,13 +898,25 @@ export function TeacherClassroomView({
     } else {
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, isUrlSelectionControlled, loading])
+  }, [assignments, classroom.id, isUrlSelectionControlled, loading, surveys])
 
   useEffect(() => {
     if (!isUrlSelectionControlled) return
     if (loading) return
 
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
+    if (selectedSurveyIdProp) {
+      const survey = surveys.find((item) => item.id === selectedSurveyIdProp)
+      if (survey) {
+        writeCookie(cookieName, `survey:${selectedSurveyIdProp}`)
+        setSelection({ mode: 'survey', surveyId: selectedSurveyIdProp })
+      } else {
+        writeCookie(cookieName, 'summary')
+        setSelection({ mode: 'summary' })
+      }
+      return
+    }
+
     const value = selectedAssignmentIdProp
     if (!value || value === 'summary') {
       writeCookie(cookieName, 'summary')
@@ -836,13 +939,14 @@ export function TeacherClassroomView({
       updateSearchParams?.((params) => {
         params.set('tab', 'assignments')
         params.delete('assignmentId')
+        params.delete('surveyId')
         params.delete('assignmentStudentId')
       }, { replace: true })
     } else {
       writeCookie(cookieName, value)
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp, updateSearchParams])
+  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp, selectedSurveyIdProp, surveys, updateSearchParams])
 
   useEffect(() => {
     function onSelectionEvent(e: Event) {
@@ -972,7 +1076,7 @@ export function TeacherClassroomView({
 
   // Notify parent of view mode changes
   useEffect(() => {
-    onViewModeChange?.(selection.mode)
+    onViewModeChange?.(selection.mode === 'assignment' ? 'assignment' : 'summary')
   }, [selection.mode, onViewModeChange])
 
   useEffect(() => {
@@ -986,7 +1090,11 @@ export function TeacherClassroomView({
   }, [onEditModeChange])
 
   const assignmentEditModeResetKey =
-    selection.mode === 'assignment' ? selection.assignmentId : 'summary'
+    selection.mode === 'assignment'
+      ? selection.assignmentId
+      : selection.mode === 'survey'
+        ? `survey:${selection.surveyId}`
+        : 'summary'
 
   useEffect(() => {
     setAssignmentEditMode(false)
@@ -1053,11 +1161,16 @@ export function TeacherClassroomView({
   }, [])
 
   const setSelectionAndPersist = useCallback((
-    next: TeacherAssignmentSelection,
+    next: TeacherClassworkSelection,
     options: { updateUrl?: boolean; replace?: boolean } = {},
   ) => {
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
-    const cookieValue = next.mode === 'summary' ? 'summary' : next.assignmentId
+    const cookieValue =
+      next.mode === 'summary'
+        ? 'summary'
+        : next.mode === 'survey'
+          ? `survey:${next.surveyId}`
+          : next.assignmentId
     writeCookie(cookieName, cookieValue)
     setSelection(next)
     if (options.updateUrl === false || !updateSearchParams) return
@@ -1068,6 +1181,11 @@ export function TeacherClassroomView({
         params.set('assignmentId', next.assignmentId)
       } else {
         params.delete('assignmentId')
+      }
+      if (next.mode === 'survey') {
+        params.set('surveyId', next.surveyId)
+      } else {
+        params.delete('surveyId')
       }
       params.delete('assignmentStudentId')
     }, { replace: options.replace })
@@ -1521,6 +1639,7 @@ export function TeacherClassroomView({
   }, [currentStudentRows, selectedStudentId])
   const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
   const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
+  const selectedSurveyId = selection.mode === 'survey' ? selection.surveyId : null
 
   const {
     scrollRef: classPaneScrollRef,
@@ -2048,34 +2167,41 @@ export function TeacherClassroomView({
         center={
           <div className="flex items-center justify-center gap-1.5">
             <Tooltip content="Create a new assignment">
-              <SplitButton
-                label={
-                  <span className="inline-flex items-center gap-1.5">
-                    <Plus className="h-4 w-4" aria-hidden="true" />
-                    <span>New</span>
-                  </span>
-                }
-                onPrimaryClick={() => setIsCreateModalOpen(true)}
-                options={[
-                  {
-                    id: 'assignment',
-                    label: 'Assignment',
-                    onSelect: () => setIsCreateModalOpen(true),
-                  },
-                  {
-                    id: 'material',
-                    label: 'Material',
-                    onSelect: () => {
-                      setEditMaterial(null)
-                      setIsMaterialModalOpen(true)
+              <span className="inline-flex">
+                <SplitButton
+                  label={
+                    <span className="inline-flex items-center gap-1.5">
+                      <Plus className="h-4 w-4" aria-hidden="true" />
+                      <span>New</span>
+                    </span>
+                  }
+                  onPrimaryClick={() => setIsCreateModalOpen(true)}
+                  options={[
+                    {
+                      id: 'assignment',
+                      label: 'Assignment',
+                      onSelect: () => setIsCreateModalOpen(true),
                     },
-                  },
-                ]}
-                disabled={isReadOnly}
-                toggleAriaLabel="Choose classwork type"
-                menuPlacement="down"
-                primaryButtonProps={{ 'aria-label': 'New assignment' }}
-              />
+                    {
+                      id: 'material',
+                      label: 'Material',
+                      onSelect: () => {
+                        setEditMaterial(null)
+                        setIsMaterialModalOpen(true)
+                      },
+                    },
+                    {
+                      id: 'survey',
+                      label: 'Survey',
+                      onSelect: () => setIsSurveyModalOpen(true),
+                    },
+                  ]}
+                  disabled={isReadOnly}
+                  toggleAriaLabel="Choose classwork type"
+                  menuPlacement="down"
+                  primaryButtonProps={{ 'aria-label': 'New assignment' }}
+                />
+              </span>
             </Tooltip>
             {assignmentSummaryEditControls}
           </div>
@@ -2103,7 +2229,7 @@ export function TeacherClassroomView({
     <div className="flex justify-center py-8">
       <Spinner />
     </div>
-  ) : assignments.length === 0 && materials.length === 0 ? (
+  ) : assignments.length === 0 && materials.length === 0 && surveys.length === 0 ? (
     <div className="py-6 text-center text-sm text-text-muted">
       No classwork yet
     </div>
@@ -2137,6 +2263,21 @@ export function TeacherClassroomView({
               )
             }
 
+            if (item.type === 'survey') {
+              const survey = item.survey
+              return (
+                <SortableSurveyCard
+                  key={survey.id}
+                  survey={survey}
+                  isReadOnly={isReadOnly}
+                  isDragDisabled={isReordering}
+                  editMode={assignmentEditMode}
+                  onOpen={() => setSelectionAndPersist({ mode: 'survey', surveyId: survey.id })}
+                  onDelete={() => setPendingSurveyDelete(survey)}
+                />
+              )
+            }
+
             const assignment = item.assignment
             return (
               <SortableAssignmentCard
@@ -2164,7 +2305,28 @@ export function TeacherClassroomView({
 
   const leftPaneHeader = leftPaneView === 'individual' ? selectedStudentControls : null
 
-  const workspaceContent = selectedAssignmentId == null ? null : activeSelectedStudentId ? (
+  const workspaceContent = selectedSurveyId ? (
+    <TeacherSurveyWorkspace
+      classroomId={classroom.id}
+      surveyId={selectedSurveyId}
+      isReadOnly={isReadOnly}
+      onBack={() => setSelectionAndPersist({ mode: 'summary' })}
+      onSurveyUpdated={(updatedSurvey) => {
+        setSurveys((current) =>
+          current.map((survey) =>
+            survey.id === updatedSurvey.id ? { ...survey, ...updatedSurvey } : survey
+          )
+        )
+        invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+        invalidateCachedJSON(`student-surveys:${classroom.id}`)
+      }}
+      onSurveyDeleted={(surveyId) => {
+        setSurveys((current) => current.filter((survey) => survey.id !== surveyId))
+        invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+        invalidateCachedJSON(`student-surveys:${classroom.id}`)
+      }}
+    />
+  ) : selectedAssignmentId == null ? null : activeSelectedStudentId ? (
     <TeacherStudentWorkPanel
       classroomId={classroom.id}
       assignmentId={selectedAssignmentId}
@@ -2239,6 +2401,21 @@ export function TeacherClassroomView({
         }}
       />
 
+      <ConfirmDialog
+        isOpen={!!pendingSurveyDelete}
+        title="Delete survey?"
+        description={pendingSurveyDelete ? `${pendingSurveyDelete.title}\n\nThis cannot be undone.` : undefined}
+        confirmLabel={isDeletingSurvey ? 'Deleting...' : 'Delete'}
+        cancelLabel="Cancel"
+        confirmVariant="danger"
+        isConfirmDisabled={isDeletingSurvey}
+        isCancelDisabled={isDeletingSurvey}
+        onCancel={() => (isDeletingSurvey ? null : setPendingSurveyDelete(null))}
+        onConfirm={() => {
+          void deleteSurvey()
+        }}
+      />
+
 
       <ConfirmDialog
         isOpen={!!gradeSelectedConfirmTarget}
@@ -2308,6 +2485,13 @@ export function TeacherClassroomView({
         }}
         onSaved={handleMaterialSaved}
         onRequestDelete={setPendingMaterialDelete}
+      />
+
+      <SurveyModal
+        isOpen={isSurveyModalOpen}
+        classroomId={classroom.id}
+        onClose={() => setIsSurveyModalOpen(false)}
+        onSuccess={handleSurveySaved}
       />
     </>
   )

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -34,7 +34,7 @@ import {
   User,
   Users,
 } from 'lucide-react'
-import { Button, ConfirmDialog, ContentDialog, FormField, Input, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -103,9 +103,6 @@ interface AssignmentWithStats extends Assignment {
 }
 
 type TeacherAssignmentSelection = { mode: 'summary' } | { mode: 'assignment'; assignmentId: string }
-type TeacherClassworkSelection =
-  | TeacherAssignmentSelection
-  | { mode: 'survey'; surveyId: string }
 
 type StudentSubmissionRow = TeacherAssignmentStudentRow
 type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
@@ -553,7 +550,8 @@ export function TeacherClassroomView({
   const [isDeletingMaterial, setIsDeletingMaterial] = useState(false)
   const [pendingSurveyDelete, setPendingSurveyDelete] = useState<SurveyWithStats | null>(null)
   const [isDeletingSurvey, setIsDeletingSurvey] = useState(false)
-  const [selection, setSelection] = useState<TeacherClassworkSelection>({ mode: 'summary' })
+  const [selection, setSelection] = useState<TeacherAssignmentSelection>({ mode: 'summary' })
+  const [surveyModalId, setSurveyModalId] = useState<string | null>(null)
   const [createdSurveyEditorIntent, setCreatedSurveyEditorIntent] = useState<{
     surveyId: string
     editMode: 'edit' | 'markdown'
@@ -724,8 +722,9 @@ export function TeacherClassroomView({
     })
     setIsSurveyModalOpen(false)
     setCreatedSurveyEditorIntent({ surveyId: survey.id, editMode: 'markdown' })
-    writeCookie(`teacherAssignmentsSelection:${classroom.id}`, `survey:${survey.id}`)
-    setSelection({ mode: 'survey', surveyId: survey.id })
+    setSurveyModalId(survey.id)
+    writeCookie(`teacherAssignmentsSelection:${classroom.id}`, 'summary')
+    setSelection({ mode: 'summary' })
     updateSearchParams?.((params) => {
       params.set('tab', 'assignments')
       params.delete('assignmentId')
@@ -734,6 +733,27 @@ export function TeacherClassroomView({
     }, { replace: true })
     void loadAssignments({ preserveContent: true })
   }, [classroom.id, loadAssignments, updateSearchParams])
+
+  const openSurveyModal = useCallback((surveyId: string, options?: { replace?: boolean }) => {
+    setSurveyModalId(surveyId)
+    writeCookie(`teacherAssignmentsSelection:${classroom.id}`, 'summary')
+    setSelection({ mode: 'summary' })
+    updateSearchParams?.((params) => {
+      params.set('tab', 'assignments')
+      params.delete('assignmentId')
+      params.set('surveyId', surveyId)
+      params.delete('assignmentStudentId')
+    }, { replace: options?.replace })
+  }, [classroom.id, updateSearchParams])
+
+  const closeSurveyModal = useCallback((options?: { replace?: boolean }) => {
+    setSurveyModalId(null)
+    setCreatedSurveyEditorIntent(null)
+    updateSearchParams?.((params) => {
+      params.set('tab', 'assignments')
+      params.delete('surveyId')
+    }, { replace: options?.replace })
+  }, [updateSearchParams])
 
   const deleteMaterial = useCallback(async () => {
     if (!pendingMaterialDelete) return
@@ -770,13 +790,8 @@ export function TeacherClassroomView({
       invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
       invalidateCachedJSON(`student-surveys:${classroom.id}`)
       setSurveys((current) => current.filter((survey) => survey.id !== pendingSurveyDelete.id))
-      if (selection.mode === 'survey' && selection.surveyId === pendingSurveyDelete.id) {
-        writeCookie(`teacherAssignmentsSelection:${classroom.id}`, 'summary')
-        setSelection({ mode: 'summary' })
-        updateSearchParams?.((params) => {
-          params.set('tab', 'assignments')
-          params.delete('surveyId')
-        }, { replace: true })
+      if (surveyModalId === pendingSurveyDelete.id) {
+        closeSurveyModal({ replace: true })
       }
       setPendingSurveyDelete(null)
       showMessage({ text: 'Survey deleted.', tone: 'success' })
@@ -785,7 +800,7 @@ export function TeacherClassroomView({
     } finally {
       setIsDeletingSurvey(false)
     }
-  }, [classroom.id, pendingSurveyDelete, selection, showMessage, updateSearchParams])
+  }, [classroom.id, closeSurveyModal, pendingSurveyDelete, showMessage, surveyModalId])
 
   useEffect(() => {
     if (isActive && !wasActiveRef.current && hasLoadedOnce) {
@@ -894,9 +909,8 @@ export function TeacherClassroomView({
       return
     }
     if (value.startsWith('survey:')) {
-      const surveyId = value.slice('survey:'.length)
-      const survey = surveys.find((item) => item.id === surveyId)
-      setSelection(survey ? { mode: 'survey', surveyId } : { mode: 'summary' })
+      writeCookie(cookieName, 'summary')
+      setSelection({ mode: 'summary' })
       return
     }
     const assignment = assignments.find((a) => a.id === value)
@@ -921,14 +935,18 @@ export function TeacherClassroomView({
     if (selectedSurveyIdProp) {
       const survey = surveys.find((item) => item.id === selectedSurveyIdProp)
       if (survey) {
-        writeCookie(cookieName, `survey:${selectedSurveyIdProp}`)
-        setSelection({ mode: 'survey', surveyId: selectedSurveyIdProp })
+        writeCookie(cookieName, 'summary')
+        setSelection({ mode: 'summary' })
+        setSurveyModalId(selectedSurveyIdProp)
       } else {
         writeCookie(cookieName, 'summary')
         setSelection({ mode: 'summary' })
+        setSurveyModalId(null)
       }
       return
     }
+
+    setSurveyModalId(null)
 
     const value = selectedAssignmentIdProp
     if (!value || value === 'summary') {
@@ -1105,9 +1123,7 @@ export function TeacherClassroomView({
   const assignmentEditModeResetKey =
     selection.mode === 'assignment'
       ? selection.assignmentId
-      : selection.mode === 'survey'
-        ? `survey:${selection.surveyId}`
-        : 'summary'
+      : 'summary'
 
   useEffect(() => {
     setAssignmentEditMode(false)
@@ -1174,16 +1190,14 @@ export function TeacherClassroomView({
   }, [])
 
   const setSelectionAndPersist = useCallback((
-    next: TeacherClassworkSelection,
+    next: TeacherAssignmentSelection,
     options: { updateUrl?: boolean; replace?: boolean } = {},
   ) => {
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     const cookieValue =
       next.mode === 'summary'
         ? 'summary'
-        : next.mode === 'survey'
-          ? `survey:${next.surveyId}`
-          : next.assignmentId
+        : next.assignmentId
     writeCookie(cookieName, cookieValue)
     setSelection(next)
     if (options.updateUrl === false || !updateSearchParams) return
@@ -1195,11 +1209,7 @@ export function TeacherClassroomView({
       } else {
         params.delete('assignmentId')
       }
-      if (next.mode === 'survey') {
-        params.set('surveyId', next.surveyId)
-      } else {
-        params.delete('surveyId')
-      }
+      params.delete('surveyId')
       params.delete('assignmentStudentId')
     }, { replace: options.replace })
   }, [classroom.id, updateSearchParams])
@@ -1652,7 +1662,6 @@ export function TeacherClassroomView({
   }, [currentStudentRows, selectedStudentId])
   const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
   const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
-  const selectedSurveyId = selection.mode === 'survey' ? selection.surveyId : null
 
   const {
     scrollRef: classPaneScrollRef,
@@ -2285,7 +2294,7 @@ export function TeacherClassroomView({
                   isReadOnly={isReadOnly}
                   isDragDisabled={isReordering}
                   editMode={assignmentEditMode}
-                  onOpen={() => setSelectionAndPersist({ mode: 'survey', surveyId: survey.id })}
+                  onOpen={() => openSurveyModal(survey.id)}
                   onDelete={() => setPendingSurveyDelete(survey)}
                 />
               )
@@ -2318,34 +2327,7 @@ export function TeacherClassroomView({
 
   const leftPaneHeader = leftPaneView === 'individual' ? selectedStudentControls : null
 
-  const workspaceContent = selectedSurveyId ? (
-    <TeacherSurveyWorkspace
-      classroomId={classroom.id}
-      surveyId={selectedSurveyId}
-      isReadOnly={isReadOnly}
-      initialEditMode={
-        createdSurveyEditorIntent?.surveyId === selectedSurveyId
-          ? createdSurveyEditorIntent.editMode
-          : undefined
-      }
-      onInitialEditModeConsumed={() => setCreatedSurveyEditorIntent(null)}
-      onBack={() => setSelectionAndPersist({ mode: 'summary' })}
-      onSurveyUpdated={(updatedSurvey) => {
-        setSurveys((current) =>
-          current.map((survey) =>
-            survey.id === updatedSurvey.id ? { ...survey, ...updatedSurvey } : survey
-          )
-        )
-        invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
-        invalidateCachedJSON(`student-surveys:${classroom.id}`)
-      }}
-      onSurveyDeleted={(surveyId) => {
-        setSurveys((current) => current.filter((survey) => survey.id !== surveyId))
-        invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
-        invalidateCachedJSON(`student-surveys:${classroom.id}`)
-      }}
-    />
-  ) : selectedAssignmentId == null ? null : activeSelectedStudentId ? (
+  const workspaceContent = selectedAssignmentId == null ? null : activeSelectedStudentId ? (
     <TeacherStudentWorkPanel
       classroomId={classroom.id}
       assignmentId={selectedAssignmentId}
@@ -2505,6 +2487,47 @@ export function TeacherClassroomView({
         onSaved={handleMaterialSaved}
         onRequestDelete={setPendingMaterialDelete}
       />
+
+      <DialogPanel
+        isOpen={!!surveyModalId}
+        onClose={() => closeSurveyModal()}
+        ariaLabelledBy="survey-workspace-dialog-title"
+        maxWidth="max-w-6xl"
+        className="h-[85vh] overflow-hidden p-0"
+      >
+        <h2 id="survey-workspace-dialog-title" className="sr-only">
+          Survey
+        </h2>
+        {surveyModalId ? (
+          <TeacherSurveyWorkspace
+            classroomId={classroom.id}
+            surveyId={surveyModalId}
+            isReadOnly={isReadOnly}
+            initialEditMode={
+              createdSurveyEditorIntent?.surveyId === surveyModalId
+                ? createdSurveyEditorIntent.editMode
+                : undefined
+            }
+            onInitialEditModeConsumed={() => setCreatedSurveyEditorIntent(null)}
+            onBack={() => closeSurveyModal()}
+            onSurveyUpdated={(updatedSurvey) => {
+              setSurveys((current) =>
+                current.map((survey) =>
+                  survey.id === updatedSurvey.id ? { ...survey, ...updatedSurvey } : survey
+                )
+              )
+              invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+              invalidateCachedJSON(`student-surveys:${classroom.id}`)
+            }}
+            onSurveyDeleted={(surveyId) => {
+              setSurveys((current) => current.filter((survey) => survey.id !== surveyId))
+              invalidateCachedJSON(`teacher-surveys:${classroom.id}`)
+              invalidateCachedJSON(`student-surveys:${classroom.id}`)
+              closeSurveyModal({ replace: true })
+            }}
+          />
+        ) : null}
+      </DialogPanel>
 
       <SurveyModal
         isOpen={isSurveyModalOpen}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -554,6 +554,10 @@ export function TeacherClassroomView({
   const [pendingSurveyDelete, setPendingSurveyDelete] = useState<SurveyWithStats | null>(null)
   const [isDeletingSurvey, setIsDeletingSurvey] = useState(false)
   const [selection, setSelection] = useState<TeacherClassworkSelection>({ mode: 'summary' })
+  const [createdSurveyEditorIntent, setCreatedSurveyEditorIntent] = useState<{
+    surveyId: string
+    editMode: 'edit' | 'markdown'
+  } | null>(null)
   const [isReordering, setIsReordering] = useState(false)
   const [assignmentEditMode, setAssignmentEditMode] = useState(false)
 
@@ -719,8 +723,17 @@ export function TeacherClassroomView({
           ]
     })
     setIsSurveyModalOpen(false)
+    setCreatedSurveyEditorIntent({ surveyId: survey.id, editMode: 'markdown' })
+    writeCookie(`teacherAssignmentsSelection:${classroom.id}`, `survey:${survey.id}`)
+    setSelection({ mode: 'survey', surveyId: survey.id })
+    updateSearchParams?.((params) => {
+      params.set('tab', 'assignments')
+      params.delete('assignmentId')
+      params.set('surveyId', survey.id)
+      params.delete('assignmentStudentId')
+    }, { replace: true })
     void loadAssignments({ preserveContent: true })
-  }, [classroom.id, loadAssignments])
+  }, [classroom.id, loadAssignments, updateSearchParams])
 
   const deleteMaterial = useCallback(async () => {
     if (!pendingMaterialDelete) return
@@ -2310,6 +2323,12 @@ export function TeacherClassroomView({
       classroomId={classroom.id}
       surveyId={selectedSurveyId}
       isReadOnly={isReadOnly}
+      initialEditMode={
+        createdSurveyEditorIntent?.surveyId === selectedSurveyId
+          ? createdSurveyEditorIntent.editMode
+          : undefined
+      }
+      onInitialEditModeConsumed={() => setCreatedSurveyEditorIntent(null)}
       onBack={() => setSelectionAndPersist({ mode: 'summary' })}
       onSurveyUpdated={(updatedSurvey) => {
         setSurveys((current) =>

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Plus, Trash2 } from 'lucide-react'
+import { Code, Plus, Trash2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizCard } from '@/components/QuizCard'
@@ -10,7 +10,7 @@ import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWo
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
-import { Button, EmptyState, Tooltip } from '@/ui'
+import { Button, DialogPanel, EmptyState, Tooltip } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
   Classroom,
@@ -51,6 +51,9 @@ export function TeacherQuizzesTab({
   const [loading, setLoading] = useState(true)
   const [internalSelectedQuizId, setInternalSelectedQuizId] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
+  const [showEditModal, setShowEditModal] = useState(false)
+  const [quizEditModalView, setQuizEditModalView] = useState<'edit' | 'markdown'>('edit')
+  const [hasPendingMarkdownImport, setHasPendingMarkdownImport] = useState(false)
   const [pendingCreatedQuizId, setPendingCreatedQuizId] = useState<string | null>(null)
   const [selectedQuizDraftSummary, setSelectedQuizDraftSummary] =
     useState<AssessmentEditorSummaryUpdate | null>(null)
@@ -169,11 +172,20 @@ export function TeacherQuizzesTab({
     if (!quizzes.some((quiz) => quiz.id === pendingCreatedQuizId)) return
 
     navigateQuizWorkspace(pendingCreatedQuizId)
+    setQuizEditModalView('edit')
+    setHasPendingMarkdownImport(false)
+    setShowEditModal(true)
     setPendingCreatedQuizId(null)
   }, [navigateQuizWorkspace, pendingCreatedQuizId, quizzes])
 
   function handleCardSelect(quiz: QuizWithStats) {
     navigateQuizWorkspace(quiz.id)
+  }
+
+  function closeEditModal() {
+    setShowEditModal(false)
+    setQuizEditModalView('edit')
+    setHasPendingMarkdownImport(false)
   }
 
   function handleNewQuiz() {
@@ -191,18 +203,33 @@ export function TeacherQuizzesTab({
   const primaryContent = selectedQuizWorkspace ? (
     <TeacherWorkSurfaceActionBar
       center={
-        onRequestDelete ? (
+        <div className="flex flex-wrap items-center justify-center gap-2">
           <Button
             type="button"
-            variant="danger"
+            variant="secondary"
             size="sm"
-            onClick={onRequestDelete}
+            onClick={() => {
+              setQuizEditModalView('edit')
+              setHasPendingMarkdownImport(false)
+              setShowEditModal(true)
+            }}
             disabled={isReadOnly}
           >
-            <Trash2 className="h-4 w-4" />
-            Delete Quiz
+            Edit Quiz
           </Button>
-        ) : null
+          {onRequestDelete ? (
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              onClick={onRequestDelete}
+              disabled={isReadOnly}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete Quiz
+            </Button>
+          ) : null}
+        </div>
       }
       centerPlacement="floating"
     />
@@ -298,6 +325,69 @@ export function TeacherQuizzesTab({
         onClose={() => setShowModal(false)}
         onSuccess={handleQuizCreated}
       />
+
+      <DialogPanel
+        isOpen={showEditModal && !!selectedQuizWorkspace}
+        onClose={closeEditModal}
+        ariaLabelledBy="quiz-edit-title"
+        maxWidth="max-w-6xl"
+        className="h-[85vh] overflow-hidden p-0"
+      >
+        <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3">
+          <h2 id="quiz-edit-title" className="min-w-0 basis-full truncate text-base font-semibold text-text-default sm:basis-auto sm:flex-1">
+            {selectedQuizWorkspace ? `Edit ${selectedQuizWorkspace.title}` : 'Edit quiz'}
+          </h2>
+          <Tooltip content="Markdown view">
+            <Button
+              type="button"
+              variant={quizEditModalView === 'markdown' ? 'subtle' : 'secondary'}
+              size="sm"
+              aria-pressed={quizEditModalView === 'markdown'}
+              className="gap-1.5"
+              onClick={() => {
+                setQuizEditModalView((current) => (current === 'markdown' ? 'edit' : 'markdown'))
+              }}
+            >
+              <Code className="h-4 w-4" aria-hidden="true" />
+              <span>Code</span>
+            </Button>
+          </Tooltip>
+          {hasPendingMarkdownImport ? (
+            <span className="text-xs font-medium text-warning">Markdown edits not applied</span>
+          ) : null}
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={closeEditModal}
+          >
+            Close
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          {selectedQuizWorkspace ? (
+            <QuizDetailPanel
+              quiz={selectedQuizWorkspace}
+              classroomId={classroom.id}
+              apiBasePath={apiBasePath}
+              onDraftSummaryChange={setSelectedQuizDraftSummary}
+              onQuizUpdate={(update) => {
+                if (update) {
+                  setSelectedQuizDraftSummary(update)
+                  applyQuizSummaryPatch(selectedQuizWorkspace.id, update)
+                  return
+                }
+                void loadQuizzes()
+              }}
+              onPendingMarkdownImportChange={setHasPendingMarkdownImport}
+              showInlineDeleteAction={false}
+              assessmentQuestionLayout={quizEditModalView === 'markdown' ? 'markdown-only' : 'editor-only'}
+              showPreviewButton={false}
+              showResultsTab={false}
+            />
+          ) : null}
+        </div>
+      </DialogPanel>
     </>
   )
 }

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -34,6 +34,7 @@ import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
+import { markdownToQuiz, quizToMarkdown } from '@/lib/quiz-markdown'
 import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
 import type {
   AssessmentEditorSummaryUpdate,
@@ -55,6 +56,7 @@ interface Props {
   onPendingMarkdownImportChange?: (pending: boolean) => void
   onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
   showInlineDeleteAction?: boolean
+  assessmentQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
   testQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
   showPreviewButton?: boolean
   showResultsTab?: boolean
@@ -124,6 +126,7 @@ export function QuizDetailPanel({
   onPendingMarkdownImportChange,
   onSaveStatusChange,
   showInlineDeleteAction = true,
+  assessmentQuestionLayout,
   testQuestionLayout = 'stacked',
   showPreviewButton = true,
   showResultsTab,
@@ -133,6 +136,7 @@ export function QuizDetailPanel({
   const AUTOSAVE_MIN_INTERVAL_MS = 10_000
   const isTestsView = quiz.assessment_type === 'test' || apiBasePath.includes('/tests')
   const { showMarkdown } = useMarkdownPreference()
+  const questionLayout = assessmentQuestionLayout ?? testQuestionLayout
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
   const [documents, setDocuments] = useState<TestDocument[]>(
     () => normalizeTestDocuments((quiz as { documents?: unknown }).documents)
@@ -336,18 +340,28 @@ export function QuizDetailPanel({
       const nextSourceMarkdown =
         typeof draft.content.source_markdown === 'string'
           ? draft.content.source_markdown
-          : testToMarkdown({
-              title: nextTitle,
-              show_results: nextShowResults,
-              questions: nextQuestions,
-              documents: documentsRef.current,
-            })
+          : isTestsView
+            ? testToMarkdown({
+                title: nextTitle,
+                show_results: nextShowResults,
+                questions: nextQuestions,
+                documents: documentsRef.current,
+              })
+            : quizToMarkdown({
+                title: nextTitle,
+                show_results: nextShowResults,
+                questions: nextQuestions,
+              })
+      const shouldTrackSourceMarkdown =
+        isTestsView ||
+        draft.content.source_format === 'markdown' ||
+        typeof draft.content.source_markdown === 'string'
       const nextSnapshot = {
         title: nextTitle,
         show_results: nextShowResults,
         questions: nextQuestions,
-        ...(draft.content.source_format === 'markdown' ? { source_format: 'markdown' as const } : {}),
-        source_markdown: nextSourceMarkdown,
+        ...(shouldTrackSourceMarkdown ? { source_format: 'markdown' as const } : {}),
+        ...(shouldTrackSourceMarkdown ? { source_markdown: nextSourceMarkdown } : {}),
       }
 
       setEditTitle(nextTitle)
@@ -366,7 +380,7 @@ export function QuizDetailPanel({
       setError('')
       setConflictDraft(null)
     },
-    [normalizeDraftQuestions, quiz.id, quiz.show_results, quiz.title, updateSaveStatus]
+    [isTestsView, normalizeDraftQuestions, quiz.id, quiz.show_results, quiz.title, updateSaveStatus]
   )
 
   // Sync editTitle when quiz changes
@@ -414,20 +428,27 @@ export function QuizDetailPanel({
     documentsRef.current = documents
   }, [documents])
 
-  const currentTestMarkdown = useMemo(() => {
-    if (!isTestsView) return ''
-    return testToMarkdown({
+  const currentAssessmentMarkdown = useMemo(() => {
+    if (isTestsView) {
+      return testToMarkdown({
+        title: editTitle,
+        show_results: draftShowResults,
+        questions,
+        documents,
+      })
+    }
+
+    return quizToMarkdown({
       title: editTitle,
       show_results: draftShowResults,
       questions,
-      documents,
     })
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
   const hasResponses = quiz.stats.responded > 0
   const isEditable = canEditQuizQuestions(quiz, hasResponses)
-  const usesMarkdownOnlyQuestions = isTestsView && testQuestionLayout === 'markdown-only'
+  const usesMarkdownOnlyQuestions = questionLayout === 'markdown-only'
   const isMarkdownSurfaceEnabled = showMarkdown || usesMarkdownOnlyQuestions
-  const hasPendingMarkdownImport = isTestsView && isMarkdownSurfaceEnabled && markdownDirty
+  const hasPendingMarkdownImport = isMarkdownSurfaceEnabled && markdownDirty
   const isMarkdownEditable = isEditable && isMarkdownEditing
   const markdownHelperStatus = markdownSaving
     ? 'Applying markdown...'
@@ -436,13 +457,13 @@ export function QuizDetailPanel({
       : isMarkdownEditing
         ? 'Editing markdown'
         : 'Markdown mirror'
-  const usesSummaryDetailQuestions = isTestsView && showMarkdown && testQuestionLayout === 'summary-detail'
-  const usesEditorOnlyQuestions = isTestsView && testQuestionLayout === 'editor-only'
+  const usesSummaryDetailQuestions = isTestsView && showMarkdown && questionLayout === 'summary-detail'
+  const usesEditorOnlyQuestions = questionLayout === 'editor-only'
   const { width: summaryDetailWorkspaceWidth } = useRefRect(summaryDetailWorkspaceRef, {
     enabled: usesSummaryDetailQuestions,
   })
   const { width: viewportWidth } = useWindowSize()
-  const hasInlineDocumentsCard = usesSummaryDetailQuestions || usesEditorOnlyQuestions
+  const hasInlineDocumentsCard = isTestsView && (usesSummaryDetailQuestions || usesEditorOnlyQuestions)
   const resolvedShowResultsTab = showResultsTab ?? !isTestsView
   const totalQuestionPoints = useMemo(
     () =>
@@ -475,19 +496,18 @@ export function QuizDetailPanel({
         TEST_SUMMARY_DETAIL_LAYOUT.minEditorWidthPx +
           TEST_SUMMARY_DETAIL_LAYOUT.minMarkdownWidthPx +
           48)
-  const hasCollapsibleEditorSections = questions.length > 0 || hasInlineDocumentsCard
+  const hasCollapsibleEditorSections = isTestsView && (questions.length > 0 || hasInlineDocumentsCard)
   const areAllEditorSectionsExpanded =
     (questions.length === 0 || areAllQuestionsExpanded) &&
     (!hasInlineDocumentsCard || isDocumentsCardExpanded)
 
   useEffect(() => {
-    if (!isTestsView) return
     if (markdownDirty) return
-    if (markdownContent !== currentTestMarkdown) {
-      setMarkdownContent(currentTestMarkdown)
+    if (markdownContent !== currentAssessmentMarkdown) {
+      setMarkdownContent(currentAssessmentMarkdown)
     }
-    savedMarkdownRef.current = currentTestMarkdown
-  }, [currentTestMarkdown, isTestsView, markdownContent, markdownDirty])
+    savedMarkdownRef.current = currentAssessmentMarkdown
+  }, [currentAssessmentMarkdown, markdownContent, markdownDirty])
 
   useEffect(() => {
     if (!usesMarkdownOnlyQuestions || !isEditable) return
@@ -503,7 +523,7 @@ export function QuizDetailPanel({
       setViewMode('questions')
     }
     if (markdownDirty) {
-      const fallbackMarkdown = savedMarkdownRef.current || currentTestMarkdown
+      const fallbackMarkdown = savedMarkdownRef.current || currentAssessmentMarkdown
       setMarkdownContent(fallbackMarkdown)
       setMarkdownDirty(false)
       markdownDirtyRef.current = false
@@ -511,15 +531,15 @@ export function QuizDetailPanel({
     setIsMarkdownEditing(false)
     setMarkdownError('')
     setMarkdownInfo('')
-  }, [currentTestMarkdown, isMarkdownSurfaceEnabled, markdownDirty, viewMode])
+  }, [currentAssessmentMarkdown, isMarkdownSurfaceEnabled, markdownDirty, viewMode])
 
   useEffect(() => {
-    onPendingMarkdownImportChange?.(isTestsView ? hasPendingMarkdownImport : false)
+    onPendingMarkdownImportChange?.(hasPendingMarkdownImport)
 
     return () => {
       onPendingMarkdownImportChange?.(false)
     }
-  }, [hasPendingMarkdownImport, isTestsView, onPendingMarkdownImportChange])
+  }, [hasPendingMarkdownImport, onPendingMarkdownImportChange])
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -539,19 +559,30 @@ export function QuizDetailPanel({
       nextDraft: AssessmentEditorDraft,
       options?: { forceFull?: boolean; documents?: TestDocument[]; sourceMarkdown?: string }
     ) => {
+      const shouldPersistMarkdownSource =
+        isTestsView ||
+        isMarkdownSurfaceEnabled ||
+        typeof options?.sourceMarkdown === 'string' ||
+        nextDraft.source_format === 'markdown'
       const contentDraft =
-        isTestsView
+        shouldPersistMarkdownSource
           ? {
               ...nextDraft,
               source_format: 'markdown' as const,
               source_markdown:
                 options?.sourceMarkdown ??
-                testToMarkdown({
-                  title: nextDraft.title,
-                  show_results: nextDraft.show_results,
-                  questions: nextDraft.questions,
-                  documents: options?.documents ?? documents,
-                }),
+                (isTestsView
+                  ? testToMarkdown({
+                      title: nextDraft.title,
+                      show_results: nextDraft.show_results,
+                      questions: nextDraft.questions,
+                      documents: options?.documents ?? documents,
+                    })
+                  : quizToMarkdown({
+                      title: nextDraft.title,
+                      show_results: nextDraft.show_results,
+                      questions: nextDraft.questions,
+                    })),
             }
           : nextDraft
       const nextSerialized = JSON.stringify(contentDraft)
@@ -684,7 +715,17 @@ export function QuizDetailPanel({
         return false
       }
     },
-    [apiBasePath, applyServerDraft, documents, isTestsView, normalizeDraftQuestions, onQuizUpdate, quiz.id, updateSaveStatus]
+    [
+      apiBasePath,
+      applyServerDraft,
+      documents,
+      isMarkdownSurfaceEnabled,
+      isTestsView,
+      normalizeDraftQuestions,
+      onQuizUpdate,
+      quiz.id,
+      updateSaveStatus,
+    ]
   )
 
   const scheduleSave = useCallback(
@@ -1214,7 +1255,7 @@ export function QuizDetailPanel({
   }
 
   function handleUndoMarkdownChanges() {
-    setMarkdownContent(currentTestMarkdown)
+    setMarkdownContent(currentAssessmentMarkdown)
     setIsMarkdownEditing(usesMarkdownOnlyQuestions && isEditable)
     setMarkdownDirty(false)
     markdownDirtyRef.current = false
@@ -1223,9 +1264,8 @@ export function QuizDetailPanel({
   }
 
   async function handleApplyMarkdown() {
-    if (!isTestsView) return
     if (!isEditable) {
-      setMarkdownError('This test cannot be edited after students have responded.')
+      setMarkdownError(`This ${isTestsView ? 'test' : 'quiz'} cannot be edited after students have responded.`)
       return
     }
 
@@ -1233,10 +1273,89 @@ export function QuizDetailPanel({
     setMarkdownError('')
     setMarkdownInfo('')
 
-    const parsed = markdownToTest(markdownContent, {
+    const existingById = new Map(questions.map((question) => [question.id, question]))
+    const now = new Date().toISOString()
+
+    if (isTestsView) {
+      const parsed = markdownToTest(markdownContent, {
+        defaultShowResults: draftShowResults,
+        existingQuestions: questions.map((question) => ({ id: question.id })),
+        existingDocuments: documents,
+      })
+
+      if (parsed.errors.length > 0 || !parsed.draftContent) {
+        setMarkdownError(parsed.errors.join('\n') || 'Invalid markdown')
+        setMarkdownSaving(false)
+        return
+      }
+
+      const nextQuestions = normalizeQuestionPositions(
+        parsed.draftContent.questions.map((question, index) => {
+          const existing = existingById.get(question.id)
+          return {
+            id: question.id,
+            quiz_id: quiz.id,
+            question_type: question.question_type,
+            question_text: question.question_text,
+            options: question.options,
+            correct_option: question.correct_option,
+            answer_key: question.answer_key,
+            sample_solution: question.sample_solution,
+            points: question.points,
+            response_max_chars: question.response_max_chars,
+            response_monospace: question.response_monospace,
+            position: index,
+            created_at: existing?.created_at || now,
+            updated_at: now,
+          }
+        })
+      )
+
+      const nextDraft = {
+        title: parsed.draftContent.title,
+        show_results: parsed.draftContent.show_results,
+        questions: nextQuestions,
+      }
+
+      const nextDerivedMarkdown = testToMarkdown({
+        title: parsed.draftContent.title,
+        show_results: parsed.draftContent.show_results,
+        questions: nextQuestions,
+        documents: parsed.documents,
+      })
+
+      setEditTitle(parsed.draftContent.title)
+      setDraftShowResults(parsed.draftContent.show_results)
+      setQuestions(nextQuestions)
+      setDocuments(parsed.documents)
+      emitDraftSummaryChange(nextDraft)
+      setMarkdownContent(nextDerivedMarkdown)
+      savedMarkdownRef.current = nextDerivedMarkdown
+      setIsMarkdownEditing(usesMarkdownOnlyQuestions && isEditable)
+      setMarkdownDirty(false)
+      markdownDirtyRef.current = false
+      setMarkdownError('')
+      setMarkdownInfo('')
+      pendingDraftRef.current = nextDraft
+      markDraftUnsaved()
+
+      const saved = await saveDraft(nextDraft, {
+        forceFull: true,
+        documents: parsed.documents,
+        sourceMarkdown: nextDerivedMarkdown,
+      })
+
+      if (saved) {
+        setMarkdownInfo('Markdown applied')
+      }
+
+      setMarkdownSaving(false)
+      return
+    }
+
+    const parsed = markdownToQuiz(markdownContent, {
       defaultShowResults: draftShowResults,
       existingQuestions: questions.map((question) => ({ id: question.id })),
-      existingDocuments: documents,
     })
 
     if (parsed.errors.length > 0 || !parsed.draftContent) {
@@ -1245,23 +1364,14 @@ export function QuizDetailPanel({
       return
     }
 
-    const existingById = new Map(questions.map((question) => [question.id, question]))
-    const now = new Date().toISOString()
     const nextQuestions = normalizeQuestionPositions(
       parsed.draftContent.questions.map((question, index) => {
         const existing = existingById.get(question.id)
         return {
           id: question.id,
           quiz_id: quiz.id,
-          question_type: question.question_type,
           question_text: question.question_text,
           options: question.options,
-          correct_option: question.correct_option,
-          answer_key: question.answer_key,
-          sample_solution: question.sample_solution,
-          points: question.points,
-          response_max_chars: question.response_max_chars,
-          response_monospace: question.response_monospace,
           position: index,
           created_at: existing?.created_at || now,
           updated_at: now,
@@ -1275,17 +1385,15 @@ export function QuizDetailPanel({
       questions: nextQuestions,
     }
 
-    const nextDerivedMarkdown = testToMarkdown({
+    const nextDerivedMarkdown = quizToMarkdown({
       title: parsed.draftContent.title,
       show_results: parsed.draftContent.show_results,
       questions: nextQuestions,
-      documents: parsed.documents,
     })
 
     setEditTitle(parsed.draftContent.title)
     setDraftShowResults(parsed.draftContent.show_results)
     setQuestions(nextQuestions)
-    setDocuments(parsed.documents)
     emitDraftSummaryChange(nextDraft)
     setMarkdownContent(nextDerivedMarkdown)
     savedMarkdownRef.current = nextDerivedMarkdown
@@ -1299,7 +1407,6 @@ export function QuizDetailPanel({
 
     const saved = await saveDraft(nextDraft, {
       forceFull: true,
-      documents: parsed.documents,
       sourceMarkdown: nextDerivedMarkdown,
     })
 
@@ -1426,7 +1533,7 @@ export function QuizDetailPanel({
       </div>
       {!isEditable && (
         <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
-          This test is locked because students have responded.
+          This {isTestsView ? 'test' : 'quiz'} is locked because students have responded.
         </div>
       )}
       {markdownInfo && (
@@ -1440,7 +1547,7 @@ export function QuizDetailPanel({
         </div>
       )}
       <textarea
-        data-testid="test-markdown-editor"
+        data-testid={isTestsView ? 'test-markdown-editor' : 'quiz-markdown-editor'}
         value={markdownContent}
         readOnly={!isMarkdownEditable}
         onChange={(event) => handleMarkdownChange(event.target.value)}
@@ -1566,7 +1673,10 @@ export function QuizDetailPanel({
   )
 
   const testQuestionEditorPane = (
-    <div data-testid="test-question-editor-pane" className="flex h-full min-h-0 flex-col">
+    <div
+      data-testid={isTestsView ? 'test-question-editor-pane' : 'quiz-question-editor-pane'}
+      className="flex h-full min-h-0 flex-col"
+    >
       <div className="border-b border-border px-3 py-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-text-muted">
@@ -1575,27 +1685,30 @@ export function QuizDetailPanel({
             </span>
             <span aria-hidden="true">•</span>
             <span data-testid="test-question-editor-header-summary">
-              {questions.length} question{questions.length === 1 ? '' : 's'} • {totalQuestionPoints} pts
+              {questions.length} question{questions.length === 1 ? '' : 's'}
+              {isTestsView ? ` • ${totalQuestionPoints} pts` : ''}
             </span>
           </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            aria-label={areAllEditorSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
-            onClick={handleToggleAllQuestions}
-            disabled={!hasCollapsibleEditorSections}
-            className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
-          >
-            {areAllEditorSectionsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-          </Button>
+          {isTestsView ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-label={areAllEditorSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+              onClick={handleToggleAllQuestions}
+              disabled={!hasCollapsibleEditorSections}
+              className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-text-default"
+            >
+              {areAllEditorSectionsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </Button>
+          ) : null}
         </div>
       </div>
       <div className="relative min-h-0 flex-1">
         <div className={cn('flex h-full min-h-0 flex-col', hasPendingMarkdownImport && 'opacity-60')}>
           <div className="min-h-0 flex-1 overflow-y-auto p-3" data-testid="test-question-accordion-list">
             <div className="space-y-3">
-              {testsInlineDocumentsCard}
+              {isTestsView ? testsInlineDocumentsCard : null}
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -1606,20 +1719,31 @@ export function QuizDetailPanel({
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="space-y-3">
-                    {questions.map((question, index) => (
-                      <TestQuestionEditor
-                        key={question.id}
-                        question={question}
-                        questionNumber={index + 1}
-                        isEditable={isEditable}
-                        onChange={handleQuestionChange}
-                        onDuplicate={handleDuplicateQuestion}
-                        onDelete={handleQuestionDelete}
-                        variant="accordion"
-                        isExpanded={expandedQuestionIds.includes(question.id)}
-                        onToggleExpanded={() => handleToggleQuestionExpanded(question.id)}
-                      />
-                    ))}
+                    {questions.map((question, index) =>
+                      isTestsView ? (
+                        <TestQuestionEditor
+                          key={question.id}
+                          question={question}
+                          questionNumber={index + 1}
+                          isEditable={isEditable}
+                          onChange={handleQuestionChange}
+                          onDuplicate={handleDuplicateQuestion}
+                          onDelete={handleQuestionDelete}
+                          variant="accordion"
+                          isExpanded={expandedQuestionIds.includes(question.id)}
+                          onToggleExpanded={() => handleToggleQuestionExpanded(question.id)}
+                        />
+                      ) : (
+                        <QuizQuestionEditor
+                          key={question.id}
+                          question={question}
+                          questionNumber={index + 1}
+                          isEditable={isEditable}
+                          onChange={handleQuestionChange}
+                          onDelete={handleQuestionDelete}
+                        />
+                      )
+                    )}
                   </div>
                 </SortableContext>
               </DndContext>
@@ -1628,7 +1752,20 @@ export function QuizDetailPanel({
 
           {isEditable ? (
             <div className="border-t border-border p-3">
-              {renderTestAddQuestionSplitButton()}
+              {isTestsView ? (
+                renderTestAddQuestionSplitButton()
+              ) : (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => handleAddQuestion('multiple_choice')}
+                  className="w-full gap-1.5"
+                  disabled={hasPendingMarkdownImport}
+                >
+                  <Plus className="h-4 w-4" />
+                  Add Question
+                </Button>
+              )}
             </div>
           ) : null}
         </div>
@@ -1712,7 +1849,7 @@ export function QuizDetailPanel({
             {documents.length > 0 ? `Documents (${documents.length})` : 'Documents'}
           </button>
         )}
-        {isTestsView && showMarkdown && (
+        {showMarkdown && (
           <button
             type="button"
             onClick={() => setViewMode('markdown')}
@@ -1804,11 +1941,17 @@ export function QuizDetailPanel({
         )}
 
         {usesEditorOnlyQuestions ? (
-          <div data-testid="test-editor-only-layout" className="h-full min-h-0 bg-surface-2">
+          <div
+            data-testid={isTestsView ? 'test-editor-only-layout' : 'quiz-editor-only-layout'}
+            className="h-full min-h-0 bg-surface-2"
+          >
             {testQuestionEditorPane}
           </div>
         ) : usesMarkdownOnlyQuestions ? (
-          <div data-testid="test-markdown-only-layout" className="flex h-full min-h-0 flex-col p-4">
+          <div
+            data-testid={isTestsView ? 'test-markdown-only-layout' : 'quiz-markdown-only-layout'}
+            className="flex h-full min-h-0 flex-col p-4"
+          >
             {testsMarkdownPanel}
           </div>
         ) : usesSummaryDetailQuestions ? (
@@ -1875,7 +2018,7 @@ export function QuizDetailPanel({
             </div>
 
             <div className="relative">
-              <div className={cn('space-y-3', isTestsView && hasPendingMarkdownImport && 'opacity-60')}>
+              <div className={cn('space-y-3', hasPendingMarkdownImport && 'opacity-60')}>
                 <DndContext
                   sensors={sensors}
                   collisionDetection={closestCenter}
@@ -1926,7 +2069,7 @@ export function QuizDetailPanel({
                   )
                 )}
               </div>
-              {isTestsView && hasPendingMarkdownImport ? (
+              {hasPendingMarkdownImport ? (
                 <div
                   data-testid="markdown-pending-lock"
                   className="absolute inset-0 z-10 flex items-center justify-center bg-surface/75 px-6 text-center"
@@ -1951,7 +2094,7 @@ export function QuizDetailPanel({
               headerTitle="Reference Documents"
             />
           </div>
-        ) : viewMode === 'markdown' && isTestsView && showMarkdown ? (
+        ) : viewMode === 'markdown' && isMarkdownSurfaceEnabled ? (
           testsMarkdownPanel
         ) : viewMode === 'preview' ? (
           <QuizPreview questions={questions} isTestsView={isTestsView} />

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { AssessmentSetupDialog } from '@/components/assessment/AssessmentSetupDialog'
-import { Button, FormField, Input } from '@/ui'
+import { AssessmentSetupCheckbox, AssessmentSetupForm } from '@/components/assessment/AssessmentSetupForm'
 import type { Quiz, QuizAssessmentType } from '@/types'
 
 interface QuizModalProps {
@@ -111,53 +111,28 @@ export function QuizModal({
       closeLabel={`Close ${assessmentLabel.toLowerCase()} modal`}
       closeDisabled={saving}
     >
-      <form
+      <AssessmentSetupForm
+        isCompact={isEditMode}
+        title={title}
+        titlePlaceholder={`Enter ${assessmentLabel.toLowerCase()} title`}
+        titleError={error}
+        titleInputRef={titleInputRef}
+        saving={saving}
+        submitLabel={isEditMode ? 'Save' : 'Create'}
+        onTitleChange={setTitle}
+        onCancel={onClose}
         onSubmit={handleSubmit}
-        className={
-          isEditMode
-            ? 'space-y-4 flex-1 min-h-0 overflow-y-auto'
-            : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'
-        }
       >
-        <FormField label="Title" error={error}>
-          <Input
-            ref={titleInputRef}
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder={`Enter ${assessmentLabel.toLowerCase()} title`}
-            disabled={saving}
-          />
-        </FormField>
-
         {isEditMode && (
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={showResults}
-              onChange={(e) => setShowResults(e.target.checked)}
-              disabled={saving}
-              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-            />
-            <span className="text-sm text-text-default">Show results to students after responding</span>
-          </label>
-        )}
-
-        <div className={isEditMode ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
-          <Button
-            type="button"
-            variant="secondary"
-            className={isEditMode ? 'flex-1' : 'min-w-28'}
-            onClick={onClose}
+          <AssessmentSetupCheckbox
+            checked={showResults}
             disabled={saving}
+            onChange={setShowResults}
           >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" className={isEditMode ? 'flex-1' : 'min-w-28'} disabled={saving}>
-            {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
-          </Button>
-        </div>
-      </form>
+            Show results to students after responding
+          </AssessmentSetupCheckbox>
+        )}
+      </AssessmentSetupForm>
     </AssessmentSetupDialog>
   )
 }

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
-import { X } from 'lucide-react'
-import { Button, DialogPanel, FormField, Input } from '@/ui'
+import { AssessmentSetupDialog } from '@/components/assessment/AssessmentSetupDialog'
+import { Button, FormField, Input } from '@/ui'
 import type { Quiz, QuizAssessmentType } from '@/types'
 
 interface QuizModalProps {
@@ -33,8 +33,6 @@ export function QuizModal({
   const isEditMode = !!quiz
   const isTest = (quiz?.assessment_type ?? assessmentType) === 'test'
   const assessmentLabel = isTest ? 'Test' : 'Quiz'
-  const fullViewportPanelClass =
-    '!h-[calc(100dvh-0.5rem)] !max-h-[calc(100dvh-0.5rem)] !w-[calc(100vw-0.5rem)] !max-w-[calc(100vw-0.5rem)] overflow-hidden p-0 sm:!h-[calc(100dvh-1rem)] sm:!max-h-[calc(100dvh-1rem)] sm:!w-[calc(100vw-1rem)] sm:!max-w-[calc(100vw-1rem)]'
 
   useEffect(() => {
     if (!isOpen) return
@@ -104,74 +102,62 @@ export function QuizModal({
   }
 
   return (
-    <DialogPanel
+    <AssessmentSetupDialog
       isOpen={isOpen}
       onClose={onClose}
-      maxWidth={isEditMode ? 'max-w-xs' : 'max-w-none'}
-      className={isEditMode ? 'p-6' : fullViewportPanelClass}
-      viewportPaddingClassName={isEditMode ? undefined : 'p-1 sm:p-2'}
-      ariaLabelledBy="quiz-modal-title"
+      isCompact={isEditMode}
+      title={isEditMode ? `Edit ${assessmentLabel}` : `New ${assessmentLabel}`}
+      titleId="quiz-modal-title"
+      closeLabel={`Close ${assessmentLabel.toLowerCase()} modal`}
+      closeDisabled={saving}
     >
-      <div className={isEditMode ? '' : 'flex min-h-0 flex-1 flex-col'}>
-        <div className={isEditMode ? 'mb-4 flex flex-shrink-0 items-start gap-3' : 'flex flex-shrink-0 items-center gap-3 border-b border-border px-4 py-3'}>
-          <h2 id="quiz-modal-title" className="min-w-0 flex-1 truncate text-xl font-bold text-text-default">
-            {isEditMode ? `Edit ${assessmentLabel}` : `New ${assessmentLabel}`}
-          </h2>
+      <form
+        onSubmit={handleSubmit}
+        className={
+          isEditMode
+            ? 'space-y-4 flex-1 min-h-0 overflow-y-auto'
+            : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'
+        }
+      >
+        <FormField label="Title" error={error}>
+          <Input
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={`Enter ${assessmentLabel.toLowerCase()} title`}
+            disabled={saving}
+          />
+        </FormField>
+
+        {isEditMode && (
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showResults}
+              onChange={(e) => setShowResults(e.target.checked)}
+              disabled={saving}
+              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+            />
+            <span className="text-sm text-text-default">Show results to students after responding</span>
+          </label>
+        )}
+
+        <div className={isEditMode ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
           <Button
             type="button"
-            variant="surface"
-            size="sm"
-            className="h-10 w-10 flex-shrink-0 px-0"
+            variant="secondary"
+            className={isEditMode ? 'flex-1' : 'min-w-28'}
             onClick={onClose}
             disabled={saving}
-            aria-label={`Close ${assessmentLabel.toLowerCase()} modal`}
-            title="Close"
           >
-            <X className="h-5 w-5" aria-hidden="true" />
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" className={isEditMode ? 'flex-1' : 'min-w-28'} disabled={saving}>
+            {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
           </Button>
         </div>
-
-        <form onSubmit={handleSubmit} className={isEditMode ? 'space-y-4 flex-1 min-h-0 overflow-y-auto' : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'}>
-          <FormField label="Title" error={error}>
-            <Input
-              ref={titleInputRef}
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder={`Enter ${assessmentLabel.toLowerCase()} title`}
-              disabled={saving}
-            />
-          </FormField>
-
-          {isEditMode && (
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showResults}
-                onChange={(e) => setShowResults(e.target.checked)}
-                disabled={saving}
-                className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              <span className="text-sm text-text-default">Show results to students after responding</span>
-            </label>
-          )}
-
-          <div className={isEditMode ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
-            <Button
-              type="button"
-              variant="secondary"
-              className={isEditMode ? 'flex-1' : 'min-w-28'}
-              onClick={onClose}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary" className={isEditMode ? 'flex-1' : 'min-w-28'} disabled={saving}>
-              {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </DialogPanel>
+      </form>
+    </AssessmentSetupDialog>
   )
 }

--- a/src/components/assessment/AssessmentSetupDialog.tsx
+++ b/src/components/assessment/AssessmentSetupDialog.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { X } from 'lucide-react'
+import { Button, DialogPanel } from '@/ui'
+
+interface AssessmentSetupDialogProps {
+  isOpen: boolean
+  title: string
+  titleId: string
+  closeLabel: string
+  isCompact?: boolean
+  compactMaxWidth?: string
+  closeDisabled?: boolean
+  onClose: () => void
+  children: ReactNode
+}
+
+const FULL_VIEWPORT_PANEL_CLASS =
+  '!h-[calc(100dvh-0.5rem)] !max-h-[calc(100dvh-0.5rem)] !w-[calc(100vw-0.5rem)] !max-w-[calc(100vw-0.5rem)] overflow-hidden p-0 sm:!h-[calc(100dvh-1rem)] sm:!max-h-[calc(100dvh-1rem)] sm:!w-[calc(100vw-1rem)] sm:!max-w-[calc(100vw-1rem)]'
+
+export function AssessmentSetupDialog({
+  isOpen,
+  title,
+  titleId,
+  closeLabel,
+  isCompact = false,
+  compactMaxWidth = 'max-w-xs',
+  closeDisabled = false,
+  onClose,
+  children,
+}: AssessmentSetupDialogProps) {
+  return (
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth={isCompact ? compactMaxWidth : 'max-w-none'}
+      className={isCompact ? 'p-6' : FULL_VIEWPORT_PANEL_CLASS}
+      viewportPaddingClassName={isCompact ? undefined : 'p-1 sm:p-2'}
+      ariaLabelledBy={titleId}
+    >
+      <div className={isCompact ? '' : 'flex min-h-0 flex-1 flex-col'}>
+        <div
+          className={
+            isCompact
+              ? 'mb-4 flex flex-shrink-0 items-start gap-3'
+              : 'flex flex-shrink-0 items-center gap-3 border-b border-border px-4 py-3'
+          }
+        >
+          <h2 id={titleId} className="min-w-0 flex-1 truncate text-xl font-bold text-text-default">
+            {title}
+          </h2>
+          <Button
+            type="button"
+            variant="surface"
+            size="sm"
+            className="h-10 w-10 flex-shrink-0 px-0"
+            onClick={onClose}
+            disabled={closeDisabled}
+            aria-label={closeLabel}
+            title="Close"
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+          </Button>
+        </div>
+        {children}
+      </div>
+    </DialogPanel>
+  )
+}

--- a/src/components/assessment/AssessmentSetupForm.tsx
+++ b/src/components/assessment/AssessmentSetupForm.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import type { FormEvent, ReactNode, Ref } from 'react'
+import { Button, FormField, Input } from '@/ui'
+
+interface AssessmentSetupFormProps {
+  isCompact?: boolean
+  title: string
+  titlePlaceholder: string
+  titleError?: string
+  titleInputRef?: Ref<HTMLInputElement>
+  saving?: boolean
+  submitLabel: string
+  onTitleChange: (value: string) => void
+  onCancel: () => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  children?: ReactNode
+}
+
+interface AssessmentSetupCheckboxProps {
+  checked: boolean
+  disabled?: boolean
+  onChange: (checked: boolean) => void
+  children: ReactNode
+}
+
+export function AssessmentSetupForm({
+  isCompact = false,
+  title,
+  titlePlaceholder,
+  titleError,
+  titleInputRef,
+  saving = false,
+  submitLabel,
+  onTitleChange,
+  onCancel,
+  onSubmit,
+  children,
+}: AssessmentSetupFormProps) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={
+        isCompact
+          ? 'min-h-0 flex-1 space-y-4 overflow-y-auto'
+          : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'
+      }
+    >
+      <FormField label="Title" error={titleError}>
+        <Input
+          ref={titleInputRef}
+          type="text"
+          value={title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          placeholder={titlePlaceholder}
+          disabled={saving}
+        />
+      </FormField>
+
+      {children}
+
+      <div className={isCompact ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
+        <Button
+          type="button"
+          variant="secondary"
+          className={isCompact ? 'flex-1' : 'min-w-28'}
+          onClick={onCancel}
+          disabled={saving}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary" className={isCompact ? 'flex-1' : 'min-w-28'} disabled={saving}>
+          {saving ? 'Saving...' : submitLabel}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export function AssessmentSetupCheckbox({
+  checked,
+  disabled = false,
+  onChange,
+  children,
+}: AssessmentSetupCheckboxProps) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2 text-sm text-text-default">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        disabled={disabled}
+        className="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+      />
+      <span className="leading-5">{children}</span>
+    </label>
+  )
+}

--- a/src/components/surveys/SortableSurveyCard.tsx
+++ b/src/components/surveys/SortableSurveyCard.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, Trash2 } from 'lucide-react'
+import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
+import { getSurveyStatusBadgeClass, getSurveyStatusLabel } from '@/lib/surveys'
+import { Button, Tooltip } from '@/ui'
+import type { SurveyWithStats } from '@/types'
+
+interface SortableSurveyCardProps {
+  survey: SurveyWithStats
+  isReadOnly: boolean
+  isDragDisabled?: boolean
+  editMode: boolean
+  onOpen: () => void
+  onDelete: () => void
+}
+
+export function SortableSurveyCard({
+  survey,
+  isReadOnly,
+  isDragDisabled = false,
+  editMode,
+  onOpen,
+  onDelete,
+}: SortableSurveyCardProps) {
+  const showEditActions = editMode && !isReadOnly
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: survey.id, disabled: isReadOnly || isDragDisabled || !editMode })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: isDragging ? undefined : transition,
+  }
+
+  const statusLabel = getSurveyStatusLabel(survey.status)
+  const statusClassName = getSurveyStatusBadgeClass(survey.status)
+
+  return (
+    <TeacherWorkItemCardFrame
+      ref={setNodeRef}
+      style={style}
+      onClick={onOpen}
+      tone={survey.status === 'draft' ? 'muted' : 'default'}
+      dragging={isDragging}
+      dragTone="neutral"
+      className="cursor-pointer"
+    >
+      <div
+        className={[
+          'grid items-center gap-3',
+          showEditActions
+            ? 'grid-cols-[auto_minmax(0,1fr)_auto]'
+            : 'grid-cols-[minmax(0,1fr)]',
+        ].join(' ')}
+      >
+        {showEditActions && (
+          <button
+            type="button"
+            className={[
+              'p-1 -ml-1 touch-none transition-colors',
+              isDragDisabled
+                ? 'text-text-muted cursor-default'
+                : 'text-text-muted hover:text-text-default cursor-grab active:cursor-grabbing',
+            ].join(' ')}
+            {...attributes}
+            {...listeners}
+            aria-label="Drag to reorder survey"
+            disabled={isDragDisabled}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <GripVertical className="h-5 w-5" aria-hidden="true" />
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            onOpen()
+          }}
+          className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-left"
+          aria-label={survey.title}
+        >
+          <span className="min-w-0">
+            <span
+              className={[
+                'block truncate font-medium',
+                survey.status === 'draft' ? 'text-text-muted' : 'text-text-default',
+              ].join(' ')}
+            >
+              {survey.title}
+            </span>
+            <span className="block text-xs text-primary">
+              Survey{survey.dynamic_responses ? ' · Dynamic' : ''}
+            </span>
+          </span>
+
+          <span className="flex items-center gap-2 whitespace-nowrap px-2 text-center">
+            <span className={`inline-flex items-center rounded-badge px-2.5 py-1 text-xs font-semibold ${statusClassName}`}>
+              {statusLabel}
+            </span>
+            {survey.status !== 'draft' && (
+              <span className="text-sm text-text-muted">
+                {survey.stats.responded}/{survey.stats.total_students}
+              </span>
+            )}
+          </span>
+        </button>
+
+        {showEditActions && (
+          <Tooltip content="Delete survey">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="p-1.5 text-danger hover:bg-danger-bg"
+              aria-label={`Delete ${survey.title}`}
+              disabled={isReadOnly}
+              onClick={(event) => {
+                event.stopPropagation()
+                onDelete()
+              }}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Tooltip>
+        )}
+      </div>
+    </TeacherWorkItemCardFrame>
+  )
+}

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -1,0 +1,373 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { Button, Card, Input } from '@/ui'
+import { QuestionMarkdown } from '@/components/QuestionMarkdown'
+import { Spinner } from '@/components/Spinner'
+import type {
+  StudentSurveyStatus,
+  Survey,
+  SurveyQuestion,
+  SurveyQuestionResult,
+  SurveyResponseValue,
+} from '@/types'
+
+interface StudentSurveyPanelProps {
+  surveyId: string
+  onBack: () => void
+  onCompleted?: () => void
+}
+
+type SurveyDetailPayload = {
+  survey: Survey & { student_status: StudentSurveyStatus }
+  questions: SurveyQuestion[]
+  student_responses: Record<string, SurveyResponseValue>
+  student_status: StudentSurveyStatus
+}
+
+type SurveyResultsPayload = {
+  results: SurveyQuestionResult[]
+}
+
+function selectedOptionFromResponse(response: SurveyResponseValue | undefined): number | null {
+  return response?.question_type === 'multiple_choice' ? response.selected_option : null
+}
+
+function textFromResponse(response: SurveyResponseValue | undefined): string {
+  return response && response.question_type !== 'multiple_choice' ? response.response_text : ''
+}
+
+function StudentSurveyResults({ payload }: { payload: SurveyResultsPayload | null }) {
+  if (!payload) {
+    return (
+      <div className="flex justify-center py-6">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (payload.results.length === 0) {
+    return <p className="text-sm text-text-muted">No class results yet.</p>
+  }
+
+  return (
+    <div className="space-y-5">
+      {payload.results.map((result, index) => (
+        <div key={result.question_id} className="space-y-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
+            <QuestionMarkdown content={result.question_text} />
+          </div>
+          {result.question_type === 'multiple_choice' ? (
+            <div className="space-y-1.5">
+              {result.options.map((option, optionIndex) => {
+                const count = result.counts[optionIndex] || 0
+                const percent = result.total_responses > 0 ? (count / result.total_responses) * 100 : 0
+                return (
+                  <div key={optionIndex} className="space-y-0.5">
+                    <div className="flex justify-between gap-3 text-sm">
+                      <span className="min-w-0 text-text-default">{option}</span>
+                      <span className="shrink-0 text-text-muted">{count} ({percent.toFixed(0)}%)</span>
+                    </div>
+                    <div className="h-3 overflow-hidden rounded-full bg-surface-2">
+                      <div className="h-full rounded-full bg-primary" style={{ width: `${percent}%` }} />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : result.responses.length === 0 ? (
+            <p className="text-sm text-text-muted">No responses yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {result.responses.map((response) => (
+                <div key={response.response_id} className="rounded-lg border border-border bg-surface px-3 py-2 text-sm">
+                  {result.question_type === 'link' ? (
+                    <a
+                      href={response.response_text}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex max-w-full items-center gap-1 text-primary hover:underline"
+                    >
+                      <span className="truncate">{response.response_text}</span>
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    </a>
+                  ) : (
+                    <p className="whitespace-pre-wrap text-text-default">{response.response_text}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function StudentSurveyPanel({
+  surveyId,
+  onBack,
+  onCompleted,
+}: StudentSurveyPanelProps) {
+  const [detail, setDetail] = useState<SurveyDetailPayload | null>(null)
+  const [responses, setResponses] = useState<Record<string, SurveyResponseValue>>({})
+  const [results, setResults] = useState<SurveyResultsPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const loadSurvey = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/student/surveys/${surveyId}`)
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load survey')
+      setDetail(data)
+      setResponses(data.student_responses || {})
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load survey')
+      setDetail(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [surveyId])
+
+  const loadResults = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/student/surveys/${surveyId}/results`)
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load results')
+      setResults(data)
+    } catch {
+      setResults(null)
+    }
+  }, [surveyId])
+
+  useEffect(() => {
+    void loadSurvey()
+  }, [loadSurvey])
+
+  useEffect(() => {
+    if (detail?.survey.show_results && detail.student_status !== 'not_started') {
+      void loadResults()
+    } else {
+      setResults(null)
+    }
+  }, [detail?.student_status, detail?.survey.show_results, loadResults])
+
+  const canRespond = useMemo(() => {
+    if (!detail) return false
+    if (detail.survey.status !== 'active') return false
+    return detail.student_status === 'not_started' || detail.student_status === 'can_update'
+  }, [detail])
+
+  const allAnswered = useMemo(() => {
+    if (!detail) return false
+    return detail.questions.every((question) => {
+      const response = responses[question.id]
+      if (!response) return false
+      if (question.question_type === 'multiple_choice') {
+        return response.question_type === 'multiple_choice'
+      }
+      return response.question_type !== 'multiple_choice' && response.response_text.trim().length > 0
+    })
+  }, [detail, responses])
+
+  async function submitResponses() {
+    if (!detail) return
+    setSubmitting(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/student/surveys/${surveyId}/respond`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ responses }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to submit responses')
+      onCompleted?.()
+      await loadSurvey()
+      if (detail.survey.show_results) await loadResults()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit responses')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card tone="panel" padding="lg">
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      </Card>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <Card tone="panel" padding="lg">
+        <Button size="sm" variant="secondary" onClick={onBack}>
+          <ArrowLeft className="mr-1 h-4 w-4" aria-hidden="true" />
+          Back
+        </Button>
+        <p className="mt-4 text-sm text-danger">{error || 'Survey unavailable'}</p>
+      </Card>
+    )
+  }
+
+  const { survey, questions, student_status: studentStatus } = detail
+  const hasSubmitted = studentStatus !== 'not_started'
+
+  return (
+    <div className="space-y-4">
+      <Card tone="panel" padding="lg" className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <button
+              type="button"
+              onClick={onBack}
+              className="mb-2 inline-flex items-center gap-1 text-sm font-medium text-text-muted hover:text-text-default"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              Classwork
+            </button>
+            <h2 className="text-xl font-semibold text-text-default">{survey.title}</h2>
+            <p className="mt-1 text-sm text-text-muted">
+              {survey.dynamic_responses
+                ? 'Dynamic survey'
+                : 'Survey'}
+            </p>
+          </div>
+          {hasSubmitted && (
+            <span className="rounded-badge bg-success-bg px-2.5 py-1 text-xs font-semibold text-success">
+              Submitted
+            </span>
+          )}
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-5">
+          {questions.map((question, index) => {
+            const selectedOption = selectedOptionFromResponse(responses[question.id])
+            const textValue = textFromResponse(responses[question.id])
+            return (
+              <div key={question.id} className="space-y-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
+                  <QuestionMarkdown content={question.question_text} />
+                </div>
+
+                {question.question_type === 'multiple_choice' ? (
+                  <div className="space-y-2">
+                    {question.options.map((option, optionIndex) => {
+                      const isSelected = selectedOption === optionIndex
+                      return (
+                        <button
+                          key={optionIndex}
+                          type="button"
+                          disabled={!canRespond || submitting}
+                          onClick={() => {
+                            setResponses((current) => ({
+                              ...current,
+                              [question.id]: {
+                                question_type: 'multiple_choice',
+                                selected_option: optionIndex,
+                              },
+                            }))
+                          }}
+                          className={[
+                            'flex w-full items-center gap-3 rounded-lg border p-3 text-left text-sm transition-colors',
+                            isSelected
+                              ? 'border-primary bg-primary/5 text-text-default'
+                              : 'border-border bg-surface hover:bg-surface-hover text-text-default',
+                            !canRespond ? 'cursor-not-allowed opacity-70' : '',
+                          ].join(' ')}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={[
+                              'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2',
+                              isSelected ? 'border-primary' : 'border-border',
+                            ].join(' ')}
+                          >
+                            {isSelected && <span className="h-2.5 w-2.5 rounded-full bg-primary" />}
+                          </span>
+                          <span>{option}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                ) : question.question_type === 'link' ? (
+                  <Input
+                    type="url"
+                    value={textValue}
+                    onChange={(event) =>
+                      setResponses((current) => ({
+                        ...current,
+                        [question.id]: {
+                          question_type: 'link',
+                          response_text: event.target.value,
+                        },
+                      }))
+                    }
+                    disabled={!canRespond || submitting}
+                    placeholder="https://example.com"
+                  />
+                ) : (
+                  <textarea
+                    value={textValue}
+                    onChange={(event) =>
+                      setResponses((current) => ({
+                        ...current,
+                        [question.id]: {
+                          question_type: 'short_text',
+                          response_text: event.target.value,
+                        },
+                      }))
+                    }
+                    rows={4}
+                    maxLength={question.response_max_chars}
+                    disabled={!canRespond || submitting}
+                    className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
+                    placeholder="Write your response..."
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {canRespond ? (
+          <div className="flex justify-end border-t border-border pt-4">
+            <Button onClick={submitResponses} disabled={!allAnswered || submitting}>
+              {submitting ? 'Saving...' : hasSubmitted ? 'Update responses' : 'Submit'}
+            </Button>
+          </div>
+        ) : hasSubmitted ? (
+          <p className="border-t border-border pt-4 text-sm text-text-muted">
+            {survey.dynamic_responses && survey.status === 'closed'
+              ? 'This survey is closed.'
+              : 'Your response is locked.'}
+          </p>
+        ) : null}
+      </Card>
+
+      {survey.show_results && hasSubmitted && (
+        <Card tone="panel" padding="lg" className="space-y-4">
+          <h3 className="text-base font-semibold text-text-default">Class results</h3>
+          <StudentSurveyResults payload={results} />
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -10,6 +10,7 @@ import type {
   Survey,
   SurveyQuestion,
   SurveyQuestionResult,
+  SurveyTextResponseResult,
   SurveyResponseValue,
 } from '@/types'
 
@@ -26,8 +27,12 @@ type SurveyDetailPayload = {
   student_status: StudentSurveyStatus
 }
 
+type StudentSurveyQuestionResult = Omit<SurveyQuestionResult, 'responses'> & {
+  responses: Array<Omit<SurveyTextResponseResult, 'student_id' | 'name' | 'email'>>
+}
+
 type SurveyResultsPayload = {
-  results: SurveyQuestionResult[]
+  results: StudentSurveyQuestionResult[]
 }
 
 function selectedOptionFromResponse(response: SurveyResponseValue | undefined): number | null {

--- a/src/components/surveys/SurveyModal.tsx
+++ b/src/components/surveys/SurveyModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { AssessmentSetupDialog } from '@/components/assessment/AssessmentSetupDialog'
-import { Button, FormField, Input } from '@/ui'
+import { AssessmentSetupCheckbox, AssessmentSetupForm } from '@/components/assessment/AssessmentSetupForm'
 import type { Survey } from '@/types'
 
 interface SurveyModalProps {
@@ -88,66 +88,36 @@ export function SurveyModal({
       closeLabel="Close survey modal"
       closeDisabled={saving}
     >
-      <form
+      <AssessmentSetupForm
+        isCompact={isEditMode}
+        title={title}
+        titlePlaceholder="Enter survey title"
+        titleError={error}
+        titleInputRef={titleInputRef}
+        saving={saving}
+        submitLabel={isEditMode ? 'Save' : 'Create'}
+        onTitleChange={setTitle}
+        onCancel={onClose}
         onSubmit={handleSubmit}
-        className={
-          isEditMode
-            ? 'space-y-4 flex-1 min-h-0 overflow-y-auto'
-            : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'
-        }
       >
-        <FormField label="Title" error={error}>
-          <Input
-            ref={titleInputRef}
-            type="text"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-            placeholder="Enter survey title"
+        <div className="space-y-3">
+          <AssessmentSetupCheckbox
+            checked={showResults}
             disabled={saving}
-          />
-        </FormField>
-
-        <div className={isEditMode ? 'space-y-3' : 'rounded-lg border border-border bg-surface-2 p-4'}>
-          <div className="space-y-3">
-            <label className="flex items-start gap-2">
-              <input
-                type="checkbox"
-                checked={showResults}
-                onChange={(event) => setShowResults(event.target.checked)}
-                disabled={saving}
-                className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              <span className="text-sm text-text-default">Show class results to students after they respond</span>
-            </label>
-
-            <label className="flex items-start gap-2">
-              <input
-                type="checkbox"
-                checked={dynamicResponses}
-                onChange={(event) => setDynamicResponses(event.target.checked)}
-                disabled={saving}
-                className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
-              />
-              <span className="text-sm text-text-default">Dynamic responses: students can update answers while open</span>
-            </label>
-          </div>
-        </div>
-
-        <div className={isEditMode ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
-          <Button
-            type="button"
-            variant="secondary"
-            className={isEditMode ? 'flex-1' : 'min-w-28'}
-            onClick={onClose}
-            disabled={saving}
+            onChange={setShowResults}
           >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" className={isEditMode ? 'flex-1' : 'min-w-28'} disabled={saving}>
-            {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
-          </Button>
+            Show class results to students after they respond
+          </AssessmentSetupCheckbox>
+
+          <AssessmentSetupCheckbox
+            checked={dynamicResponses}
+            disabled={saving}
+            onChange={setDynamicResponses}
+          >
+            Dynamic responses: students can update answers while open
+          </AssessmentSetupCheckbox>
         </div>
-      </form>
+      </AssessmentSetupForm>
     </AssessmentSetupDialog>
   )
 }

--- a/src/components/surveys/SurveyModal.tsx
+++ b/src/components/surveys/SurveyModal.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useState, type FormEvent } from 'react'
-import { X } from 'lucide-react'
-import { Button, DialogPanel, FormField, Input } from '@/ui'
+import { AssessmentSetupDialog } from '@/components/assessment/AssessmentSetupDialog'
+import { Button, FormField, Input } from '@/ui'
 import type { Survey } from '@/types'
 
 interface SurveyModalProps {
@@ -78,32 +78,24 @@ export function SurveyModal({
   }
 
   return (
-    <DialogPanel
+    <AssessmentSetupDialog
       isOpen={isOpen}
       onClose={onClose}
-      maxWidth="max-w-md"
-      className="p-6"
-      ariaLabelledBy="survey-modal-title"
+      isCompact={isEditMode}
+      compactMaxWidth="max-w-md"
+      title={isEditMode ? 'Edit Survey' : 'New Survey'}
+      titleId="survey-modal-title"
+      closeLabel="Close survey modal"
+      closeDisabled={saving}
     >
-      <div className="mb-4 flex items-start gap-3">
-        <h2 id="survey-modal-title" className="min-w-0 flex-1 truncate text-xl font-bold text-text-default">
-          {isEditMode ? 'Edit Survey' : 'New Survey'}
-        </h2>
-        <Button
-          type="button"
-          variant="surface"
-          size="sm"
-          className="h-10 w-10 flex-shrink-0 px-0"
-          onClick={onClose}
-          disabled={saving}
-          aria-label="Close survey modal"
-          title="Close"
-        >
-          <X className="h-5 w-5" aria-hidden="true" />
-        </Button>
-      </div>
-
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form
+        onSubmit={handleSubmit}
+        className={
+          isEditMode
+            ? 'space-y-4 flex-1 min-h-0 overflow-y-auto'
+            : 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4'
+        }
+      >
         <FormField label="Title" error={error}>
           <Input
             ref={titleInputRef}
@@ -115,43 +107,47 @@ export function SurveyModal({
           />
         </FormField>
 
-        <label className="flex items-start gap-2">
-          <input
-            type="checkbox"
-            checked={showResults}
-            onChange={(event) => setShowResults(event.target.checked)}
-            disabled={saving}
-            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
-          />
-          <span className="text-sm text-text-default">Show class results to students after they respond</span>
-        </label>
+        <div className={isEditMode ? 'space-y-3' : 'rounded-lg border border-border bg-surface-2 p-4'}>
+          <div className="space-y-3">
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={showResults}
+                onChange={(event) => setShowResults(event.target.checked)}
+                disabled={saving}
+                className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-text-default">Show class results to students after they respond</span>
+            </label>
 
-        <label className="flex items-start gap-2">
-          <input
-            type="checkbox"
-            checked={dynamicResponses}
-            onChange={(event) => setDynamicResponses(event.target.checked)}
-            disabled={saving}
-            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
-          />
-          <span className="text-sm text-text-default">Dynamic responses: students can update answers while open</span>
-        </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={dynamicResponses}
+                onChange={(event) => setDynamicResponses(event.target.checked)}
+                disabled={saving}
+                className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm text-text-default">Dynamic responses: students can update answers while open</span>
+            </label>
+          </div>
+        </div>
 
-        <div className="flex gap-3 pt-2">
+        <div className={isEditMode ? 'flex gap-3 pt-2' : 'mt-auto flex justify-end gap-3 border-t border-border pt-4'}>
           <Button
             type="button"
             variant="secondary"
-            className="flex-1"
+            className={isEditMode ? 'flex-1' : 'min-w-28'}
             onClick={onClose}
             disabled={saving}
           >
             Cancel
           </Button>
-          <Button type="submit" variant="primary" className="flex-1" disabled={saving}>
+          <Button type="submit" variant="primary" className={isEditMode ? 'flex-1' : 'min-w-28'} disabled={saving}>
             {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
           </Button>
         </div>
       </form>
-    </DialogPanel>
+    </AssessmentSetupDialog>
   )
 }

--- a/src/components/surveys/SurveyModal.tsx
+++ b/src/components/surveys/SurveyModal.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { X } from 'lucide-react'
+import { Button, DialogPanel, FormField, Input } from '@/ui'
+import type { Survey } from '@/types'
+
+interface SurveyModalProps {
+  isOpen: boolean
+  classroomId: string
+  survey?: Survey | null
+  onClose: () => void
+  onSuccess: (survey: Survey) => void
+}
+
+export function SurveyModal({
+  isOpen,
+  classroomId,
+  survey,
+  onClose,
+  onSuccess,
+}: SurveyModalProps) {
+  const titleInputRef = useRef<HTMLInputElement>(null)
+  const [title, setTitle] = useState('')
+  const [showResults, setShowResults] = useState(true)
+  const [dynamicResponses, setDynamicResponses] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const isEditMode = !!survey
+
+  useEffect(() => {
+    if (!isOpen) return
+    setTitle(survey?.title ?? '')
+    setShowResults(survey?.show_results ?? true)
+    setDynamicResponses(survey?.dynamic_responses ?? false)
+    setError('')
+
+    setTimeout(() => {
+      titleInputRef.current?.focus()
+      if (survey) titleInputRef.current?.select()
+    }, 100)
+  }, [isOpen, survey])
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!title.trim()) {
+      setError('Title is required')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+
+    try {
+      const response = await fetch(
+        isEditMode ? `/api/teacher/surveys/${survey.id}` : '/api/teacher/surveys',
+        {
+          method: isEditMode ? 'PATCH' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            classroom_id: classroomId,
+            title: title.trim(),
+            show_results: showResults,
+            dynamic_responses: dynamicResponses,
+          }),
+        }
+      )
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to save survey')
+      onSuccess(data.survey)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save survey')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-md"
+      className="p-6"
+      ariaLabelledBy="survey-modal-title"
+    >
+      <div className="mb-4 flex items-start gap-3">
+        <h2 id="survey-modal-title" className="min-w-0 flex-1 truncate text-xl font-bold text-text-default">
+          {isEditMode ? 'Edit Survey' : 'New Survey'}
+        </h2>
+        <Button
+          type="button"
+          variant="surface"
+          size="sm"
+          className="h-10 w-10 flex-shrink-0 px-0"
+          onClick={onClose}
+          disabled={saving}
+          aria-label="Close survey modal"
+          title="Close"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </Button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField label="Title" error={error}>
+          <Input
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Enter survey title"
+            disabled={saving}
+          />
+        </FormField>
+
+        <label className="flex items-start gap-2">
+          <input
+            type="checkbox"
+            checked={showResults}
+            onChange={(event) => setShowResults(event.target.checked)}
+            disabled={saving}
+            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+          />
+          <span className="text-sm text-text-default">Show class results to students after they respond</span>
+        </label>
+
+        <label className="flex items-start gap-2">
+          <input
+            type="checkbox"
+            checked={dynamicResponses}
+            onChange={(event) => setDynamicResponses(event.target.checked)}
+            disabled={saving}
+            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+          />
+          <span className="text-sm text-text-default">Dynamic responses: students can update answers while open</span>
+        </label>
+
+        <div className="flex gap-3 pt-2">
+          <Button
+            type="button"
+            variant="secondary"
+            className="flex-1"
+            onClick={onClose}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" className="flex-1" disabled={saving}>
+            {saving ? 'Saving...' : isEditMode ? 'Save' : 'Create'}
+          </Button>
+        </div>
+      </form>
+    </DialogPanel>
+  )
+}

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -27,6 +27,8 @@ interface TeacherSurveyWorkspaceProps {
   classroomId: string
   surveyId: string
   isReadOnly?: boolean
+  initialEditMode?: 'edit' | 'markdown'
+  onInitialEditModeConsumed?: () => void
   onBack: () => void
   onSurveyUpdated: (survey: Survey) => void
   onSurveyDeleted: (surveyId: string) => void
@@ -278,6 +280,8 @@ export function TeacherSurveyWorkspace({
   classroomId,
   surveyId,
   isReadOnly = false,
+  initialEditMode,
+  onInitialEditModeConsumed,
   onBack,
   onSurveyUpdated,
   onSurveyDeleted,
@@ -300,6 +304,7 @@ export function TeacherSurveyWorkspace({
   const [surveyMarkdownError, setSurveyMarkdownError] = useState('')
   const [surveyMarkdownInfo, setSurveyMarkdownInfo] = useState('')
   const onSurveyUpdatedRef = useRef(onSurveyUpdated)
+  const consumedInitialEditModeRef = useRef<string | null>(null)
 
   useEffect(() => {
     onSurveyUpdatedRef.current = onSurveyUpdated
@@ -354,6 +359,18 @@ export function TeacherSurveyWorkspace({
       setSurveyMarkdown(currentSurveyMarkdown)
     }
   }, [currentSurveyMarkdown, survey, surveyMarkdown, surveyMarkdownDirty])
+
+  useEffect(() => {
+    if (!survey || !initialEditMode) return
+    const initialEditModeKey = `${survey.id}:${initialEditMode}`
+    if (consumedInitialEditModeRef.current === initialEditModeKey) return
+
+    consumedInitialEditModeRef.current = initialEditModeKey
+    setSurveyEditMode(initialEditMode)
+    setSurveyMarkdownError('')
+    setSurveyMarkdownInfo('')
+    onInitialEditModeConsumed?.()
+  }, [initialEditMode, onInitialEditModeConsumed, survey])
 
   const canOpen = useMemo(() => survey?.status === 'draft' && questions.length > 0, [questions.length, survey?.status])
 

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type TextareaHTMLAttributes,
 } from 'react'
-import { ArrowLeft, BarChart3, ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react'
+import { ArrowLeft, BarChart3, Code, ExternalLink, Pencil, Plus, RotateCcw, Trash2 } from 'lucide-react'
 import { Button, Card, ConfirmDialog, FormField, Input, Select } from '@/ui'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { Spinner } from '@/components/Spinner'
@@ -20,6 +20,7 @@ import {
   getSurveyStatusBadgeClass,
   getSurveyStatusLabel,
 } from '@/lib/surveys'
+import { markdownToSurvey, surveyToMarkdown } from '@/lib/survey-markdown'
 import type { Survey, SurveyQuestion, SurveyQuestionResult, SurveyQuestionType } from '@/types'
 
 interface TeacherSurveyWorkspaceProps {
@@ -292,6 +293,12 @@ export function TeacherSurveyWorkspace({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [statusChanging, setStatusChanging] = useState(false)
+  const [surveyEditMode, setSurveyEditMode] = useState<'edit' | 'markdown'>('edit')
+  const [surveyMarkdown, setSurveyMarkdown] = useState('')
+  const [surveyMarkdownDirty, setSurveyMarkdownDirty] = useState(false)
+  const [surveyMarkdownSaving, setSurveyMarkdownSaving] = useState(false)
+  const [surveyMarkdownError, setSurveyMarkdownError] = useState('')
+  const [surveyMarkdownInfo, setSurveyMarkdownInfo] = useState('')
   const onSurveyUpdatedRef = useRef(onSurveyUpdated)
 
   useEffect(() => {
@@ -299,8 +306,12 @@ export function TeacherSurveyWorkspace({
   }, [onSurveyUpdated])
 
   const survey = detail?.survey ?? null
-  const questions = detail?.questions ?? []
+  const questions = useMemo(() => detail?.questions ?? [], [detail?.questions])
   const statusClassName = survey ? getSurveyStatusBadgeClass(survey.status) : ''
+  const currentSurveyMarkdown = useMemo(
+    () => (survey ? surveyToMarkdown({ survey, questions }) : ''),
+    [questions, survey],
+  )
 
   const loadSurvey = useCallback(async () => {
     setLoading(true)
@@ -335,6 +346,14 @@ export function TeacherSurveyWorkspace({
     void loadSurvey()
     void loadResults()
   }, [loadResults, loadSurvey])
+
+  useEffect(() => {
+    if (!survey) return
+    if (surveyMarkdownDirty) return
+    if (surveyMarkdown !== currentSurveyMarkdown) {
+      setSurveyMarkdown(currentSurveyMarkdown)
+    }
+  }, [currentSurveyMarkdown, survey, surveyMarkdown, surveyMarkdownDirty])
 
   const canOpen = useMemo(() => survey?.status === 'draft' && questions.length > 0, [questions.length, survey?.status])
 
@@ -386,6 +405,123 @@ export function TeacherSurveyWorkspace({
       setError(err instanceof Error ? err.message : 'Failed to add question')
     } finally {
       setAddingQuestion(false)
+    }
+  }
+
+  function handleSurveyMarkdownChange(content: string) {
+    setSurveyMarkdown(content)
+    setSurveyMarkdownDirty(true)
+    setSurveyMarkdownError('')
+    setSurveyMarkdownInfo('')
+  }
+
+  function handleUndoSurveyMarkdownChanges() {
+    setSurveyMarkdown(currentSurveyMarkdown)
+    setSurveyMarkdownDirty(false)
+    setSurveyMarkdownError('')
+    setSurveyMarkdownInfo('')
+  }
+
+  async function applySurveyMarkdown() {
+    if (!survey) return
+    if (isReadOnly) {
+      setSurveyMarkdownError('This survey is read-only.')
+      return
+    }
+
+    setSurveyMarkdownSaving(true)
+    setSurveyMarkdownError('')
+    setSurveyMarkdownInfo('')
+
+    const parsed = markdownToSurvey(surveyMarkdown, {
+      defaultShowResults: survey.show_results,
+      defaultDynamicResponses: survey.dynamic_responses,
+      existingQuestions: questions.map((question) => ({ id: question.id })),
+    })
+
+    if (parsed.errors.length > 0 || !parsed.content) {
+      setSurveyMarkdownError(parsed.errors.join('\n') || 'Invalid markdown')
+      setSurveyMarkdownSaving(false)
+      return
+    }
+
+    try {
+      let nextSurvey = survey
+      const surveyUpdate: Record<string, unknown> = {}
+      if (parsed.content.title !== survey.title) surveyUpdate.title = parsed.content.title
+      if (parsed.content.show_results !== survey.show_results) {
+        surveyUpdate.show_results = parsed.content.show_results
+      }
+      if (parsed.content.dynamic_responses !== survey.dynamic_responses) {
+        surveyUpdate.dynamic_responses = parsed.content.dynamic_responses
+      }
+
+      if (Object.keys(surveyUpdate).length > 0) {
+        const response = await fetch(`/api/teacher/surveys/${surveyId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(surveyUpdate),
+        })
+        const data = await response.json()
+        if (!response.ok) throw new Error(data.error || 'Failed to update survey')
+        nextSurvey = data.survey
+      }
+
+      const existingById = new Map(questions.map((question) => [question.id, question]))
+      const retainedQuestionIds = new Set<string>()
+      const savedQuestions: SurveyQuestion[] = []
+
+      for (let index = 0; index < parsed.content.questions.length; index += 1) {
+        const question = parsed.content.questions[index]
+        const body = {
+          question_type: question.question_type,
+          question_text: question.question_text,
+          options: question.options,
+          response_max_chars: question.response_max_chars,
+          position: index,
+        }
+        const existingQuestion = question.id ? existingById.get(question.id) : undefined
+        const response = await fetch(
+          existingQuestion
+            ? `/api/teacher/surveys/${surveyId}/questions/${encodeURIComponent(existingQuestion.id)}`
+            : `/api/teacher/surveys/${surveyId}/questions`,
+          {
+            method: existingQuestion ? 'PATCH' : 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          },
+        )
+        const data = await response.json()
+        if (!response.ok) throw new Error(data.error || 'Failed to save question')
+        retainedQuestionIds.add(data.question.id)
+        savedQuestions.push(data.question)
+      }
+
+      for (const existingQuestion of questions) {
+        if (retainedQuestionIds.has(existingQuestion.id)) continue
+        const response = await fetch(
+          `/api/teacher/surveys/${surveyId}/questions/${encodeURIComponent(existingQuestion.id)}`,
+          { method: 'DELETE' },
+        )
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || 'Failed to delete removed question')
+      }
+
+      const nextQuestions = savedQuestions
+        .slice()
+        .sort((left, right) => left.position - right.position)
+      setDetail({ survey: nextSurvey, questions: nextQuestions })
+      onSurveyUpdated(nextSurvey)
+      await loadResults()
+
+      const nextMarkdown = surveyToMarkdown({ survey: nextSurvey, questions: nextQuestions })
+      setSurveyMarkdown(nextMarkdown)
+      setSurveyMarkdownDirty(false)
+      setSurveyMarkdownInfo('Markdown applied')
+    } catch (err) {
+      setSurveyMarkdownError(err instanceof Error ? err.message : 'Failed to apply markdown')
+    } finally {
+      setSurveyMarkdownSaving(false)
     }
   }
 
@@ -450,6 +586,19 @@ export function TeacherSurveyWorkspace({
             </div>
 
             <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant={surveyEditMode === 'markdown' ? 'subtle' : 'secondary'}
+                aria-pressed={surveyEditMode === 'markdown'}
+                onClick={() => {
+                  setSurveyEditMode((current) => (current === 'markdown' ? 'edit' : 'markdown'))
+                  setSurveyMarkdownError('')
+                  setSurveyMarkdownInfo('')
+                }}
+              >
+                <Code className="mr-1 h-4 w-4" aria-hidden="true" />
+                Code
+              </Button>
               <Button size="sm" variant="secondary" onClick={() => setSettingsOpen(true)}>
                 <Pencil className="mr-1 h-4 w-4" aria-hidden="true" />
                 Settings
@@ -499,104 +648,174 @@ export function TeacherSurveyWorkspace({
               {error}
             </div>
           )}
+          {surveyMarkdownDirty && surveyEditMode === 'markdown' ? (
+            <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+              Markdown edits not applied
+            </div>
+          ) : null}
         </Card>
 
-        <Card tone="panel" padding="md" className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-base font-semibold text-text-default">Questions</h3>
-            <span className="text-sm text-text-muted">{questions.length} total</span>
-          </div>
+        {surveyEditMode === 'markdown' ? (
+          <Card tone="panel" padding="md" className="flex min-h-[560px] flex-col gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-text-default">Code</h3>
+                <p className="text-sm text-text-muted">{questions.length} question{questions.length === 1 ? '' : 's'}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {surveyMarkdownDirty ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Undo markdown edits"
+                    title="Undo markdown edits"
+                    onClick={handleUndoSurveyMarkdownChanges}
+                    disabled={surveyMarkdownSaving}
+                    className="h-8 w-8 p-0"
+                  >
+                    <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => {
+                    void applySurveyMarkdown()
+                  }}
+                  disabled={isReadOnly || surveyMarkdownSaving || !surveyMarkdownDirty}
+                >
+                  {surveyMarkdownSaving ? 'Applying...' : 'Apply Markdown'}
+                </Button>
+              </div>
+            </div>
 
-          <div className="grid gap-3 rounded-lg border border-border bg-surface-2 p-3 lg:grid-cols-[12rem_minmax(0,1fr)]">
-            <FormField label="Type">
-              <Select
-                value={newQuestionType}
-                onChange={(event) => setNewQuestionType(event.target.value as SurveyQuestionType)}
-                options={QUESTION_TYPE_OPTIONS}
-                disabled={isReadOnly || addingQuestion}
-              />
-            </FormField>
-            <FormField label="New question">
-              <Input
-                value={newQuestionText}
-                onChange={(event) => setNewQuestionText(event.target.value)}
-                placeholder="Ask students a question"
-                disabled={isReadOnly || addingQuestion}
-              />
-            </FormField>
-            {newQuestionType === 'multiple_choice' && (
-              <div className="lg:col-span-2">
-                <FormField label="Options">
-                  <SurveyTextarea
-                    value={newOptionsText}
-                    onChange={(event) => setNewOptionsText(event.target.value)}
-                    rows={3}
+            {surveyMarkdownInfo ? (
+              <div className="rounded-md border border-success bg-success-bg px-3 py-2 text-sm text-success">
+                {surveyMarkdownInfo}
+              </div>
+            ) : null}
+            {surveyMarkdownError ? (
+              <div className="whitespace-pre-wrap rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+                {surveyMarkdownError}
+              </div>
+            ) : null}
+
+            <textarea
+              data-testid="survey-markdown-editor"
+              value={surveyMarkdown}
+              onChange={(event) => handleSurveyMarkdownChange(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's' && surveyMarkdownDirty) {
+                  event.preventDefault()
+                  void applySurveyMarkdown()
+                }
+              }}
+              readOnly={isReadOnly || surveyMarkdownSaving}
+              className="min-h-[460px] flex-1 rounded-md border border-border bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
+              spellCheck={false}
+            />
+          </Card>
+        ) : (
+          <>
+            <Card tone="panel" padding="md" className="space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="text-base font-semibold text-text-default">Questions</h3>
+                <span className="text-sm text-text-muted">{questions.length} total</span>
+              </div>
+
+              <div className="grid gap-3 rounded-lg border border-border bg-surface-2 p-3 lg:grid-cols-[12rem_minmax(0,1fr)]">
+                <FormField label="Type">
+                  <Select
+                    value={newQuestionType}
+                    onChange={(event) => setNewQuestionType(event.target.value as SurveyQuestionType)}
+                    options={QUESTION_TYPE_OPTIONS}
                     disabled={isReadOnly || addingQuestion}
-                    className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
                   />
                 </FormField>
+                <FormField label="New question">
+                  <Input
+                    value={newQuestionText}
+                    onChange={(event) => setNewQuestionText(event.target.value)}
+                    placeholder="Ask students a question"
+                    disabled={isReadOnly || addingQuestion}
+                  />
+                </FormField>
+                {newQuestionType === 'multiple_choice' && (
+                  <div className="lg:col-span-2">
+                    <FormField label="Options">
+                      <SurveyTextarea
+                        value={newOptionsText}
+                        onChange={(event) => setNewOptionsText(event.target.value)}
+                        rows={3}
+                        disabled={isReadOnly || addingQuestion}
+                        className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
+                      />
+                    </FormField>
+                  </div>
+                )}
+                <div className="lg:col-span-2 flex justify-end">
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={addQuestion}
+                    disabled={isReadOnly || addingQuestion || !newQuestionText.trim()}
+                  >
+                    <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
+                    {addingQuestion ? 'Adding...' : 'Add question'}
+                  </Button>
+                </div>
               </div>
-            )}
-            <div className="lg:col-span-2 flex justify-end">
-              <Button
-                type="button"
-                size="sm"
-                onClick={addQuestion}
-                disabled={isReadOnly || addingQuestion || !newQuestionText.trim()}
-              >
-                <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
-                {addingQuestion ? 'Adding...' : 'Add question'}
-              </Button>
-            </div>
-          </div>
 
-          <div className="space-y-3">
-            {questions.length === 0 ? (
-              <p className="rounded-lg border border-border bg-surface px-3 py-4 text-center text-sm text-text-muted">
-                Add at least one question before opening the survey.
-              </p>
-            ) : (
-              questions.map((question) => (
-                <QuestionEditor
-                  key={question.id}
-                  question={question}
-                  disabled={isReadOnly}
-                  onSaved={(updatedQuestion) => {
-                    setDetail((current) =>
-                      current
-                        ? {
-                            ...current,
-                            questions: current.questions.map((item) =>
-                              item.id === updatedQuestion.id ? updatedQuestion : item
-                            ),
-                          }
-                        : current
-                    )
-                  }}
-                  onDeleted={(questionId) => {
-                    setDetail((current) =>
-                      current
-                        ? {
-                            ...current,
-                            questions: current.questions.filter((item) => item.id !== questionId),
-                          }
-                        : current
-                    )
-                    void loadResults()
-                  }}
-                />
-              ))
-            )}
-          </div>
-        </Card>
+              <div className="space-y-3">
+                {questions.length === 0 ? (
+                  <p className="rounded-lg border border-border bg-surface px-3 py-4 text-center text-sm text-text-muted">
+                    Add at least one question before opening the survey.
+                  </p>
+                ) : (
+                  questions.map((question) => (
+                    <QuestionEditor
+                      key={question.id}
+                      question={question}
+                      disabled={isReadOnly}
+                      onSaved={(updatedQuestion) => {
+                        setDetail((current) =>
+                          current
+                            ? {
+                                ...current,
+                                questions: current.questions.map((item) =>
+                                  item.id === updatedQuestion.id ? updatedQuestion : item
+                                ),
+                              }
+                            : current
+                        )
+                      }}
+                      onDeleted={(questionId) => {
+                        setDetail((current) =>
+                          current
+                            ? {
+                                ...current,
+                                questions: current.questions.filter((item) => item.id !== questionId),
+                              }
+                            : current
+                        )
+                        void loadResults()
+                      }}
+                    />
+                  ))
+                )}
+              </div>
+            </Card>
 
-        <Card tone="panel" padding="md" className="space-y-4">
-          <div className="flex items-center gap-2">
-            <BarChart3 className="h-4 w-4 text-text-muted" aria-hidden="true" />
-            <h3 className="text-base font-semibold text-text-default">Results</h3>
-          </div>
-          <ResultsView payload={results} />
-        </Card>
+            <Card tone="panel" padding="md" className="space-y-4">
+              <div className="flex items-center gap-2">
+                <BarChart3 className="h-4 w-4 text-text-muted" aria-hidden="true" />
+                <h3 className="text-base font-semibold text-text-default">Results</h3>
+              </div>
+              <ResultsView payload={results} />
+            </Card>
+          </>
+        )}
       </div>
 
       <SurveyModal

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -1,0 +1,629 @@
+'use client'
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type TextareaHTMLAttributes,
+} from 'react'
+import { ArrowLeft, BarChart3, ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Button, Card, ConfirmDialog, FormField, Input, Select } from '@/ui'
+import { QuestionMarkdown } from '@/components/QuestionMarkdown'
+import { Spinner } from '@/components/Spinner'
+import { SurveyModal } from '@/components/surveys/SurveyModal'
+import {
+  DEFAULT_SURVEY_LINK_MAX_CHARS,
+  DEFAULT_SURVEY_TEXT_MAX_CHARS,
+  getSurveyStatusBadgeClass,
+  getSurveyStatusLabel,
+} from '@/lib/surveys'
+import type { Survey, SurveyQuestion, SurveyQuestionResult, SurveyQuestionType } from '@/types'
+
+interface TeacherSurveyWorkspaceProps {
+  classroomId: string
+  surveyId: string
+  isReadOnly?: boolean
+  onBack: () => void
+  onSurveyUpdated: (survey: Survey) => void
+  onSurveyDeleted: (surveyId: string) => void
+}
+
+type SurveyDetailPayload = {
+  survey: Survey
+  questions: SurveyQuestion[]
+}
+
+type SurveyResultsPayload = {
+  results: SurveyQuestionResult[]
+  stats: {
+    total_students: number
+    responded: number
+  }
+}
+
+const QUESTION_TYPE_OPTIONS = [
+  { value: 'multiple_choice', label: 'Multiple choice' },
+  { value: 'short_text', label: 'Short text' },
+  { value: 'link', label: 'Link' },
+]
+
+type SurveyTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  hasError?: boolean
+}
+
+const SurveyTextarea = forwardRef<HTMLTextAreaElement, SurveyTextareaProps>(
+  function SurveyTextarea({ hasError: _hasError, ...props }, ref) {
+    return <textarea ref={ref} {...props} />
+  }
+)
+
+function defaultMaxChars(questionType: SurveyQuestionType) {
+  return questionType === 'link' ? DEFAULT_SURVEY_LINK_MAX_CHARS : DEFAULT_SURVEY_TEXT_MAX_CHARS
+}
+
+function QuestionEditor({
+  question,
+  disabled,
+  onSaved,
+  onDeleted,
+}: {
+  question: SurveyQuestion
+  disabled: boolean
+  onSaved: (question: SurveyQuestion) => void
+  onDeleted: (questionId: string) => void
+}) {
+  const [questionType, setQuestionType] = useState<SurveyQuestionType>(question.question_type)
+  const [questionText, setQuestionText] = useState(question.question_text)
+  const [optionsText, setOptionsText] = useState(question.options.join('\n'))
+  const [responseMaxChars, setResponseMaxChars] = useState(String(question.response_max_chars))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setQuestionType(question.question_type)
+    setQuestionText(question.question_text)
+    setOptionsText(question.options.join('\n'))
+    setResponseMaxChars(String(question.response_max_chars))
+    setError('')
+  }, [question])
+
+  async function saveQuestion() {
+    setSaving(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/surveys/${question.survey_id}/questions/${question.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question_type: questionType,
+          question_text: questionText,
+          options: questionType === 'multiple_choice' ? optionsText.split('\n') : [],
+          response_max_chars: Number(responseMaxChars) || defaultMaxChars(questionType),
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to save question')
+      onSaved(data.question)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save question')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function deleteQuestion() {
+    setSaving(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/surveys/${question.survey_id}/questions/${question.id}`, {
+        method: 'DELETE',
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Failed to delete question')
+      onDeleted(question.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete question')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card tone="panel" padding="md" className="space-y-3">
+      <div className="grid gap-3 lg:grid-cols-[12rem_minmax(0,1fr)]">
+        <FormField label="Type">
+          <Select
+            value={questionType}
+            onChange={(event) => {
+              const nextType = event.target.value as SurveyQuestionType
+              setQuestionType(nextType)
+              setResponseMaxChars(String(defaultMaxChars(nextType)))
+            }}
+            options={QUESTION_TYPE_OPTIONS}
+            disabled={disabled || saving}
+          />
+        </FormField>
+        <FormField label="Prompt" error={error}>
+          <Input
+            value={questionText}
+            onChange={(event) => setQuestionText(event.target.value)}
+            disabled={disabled || saving}
+          />
+        </FormField>
+      </div>
+
+      {questionType === 'multiple_choice' ? (
+        <FormField label="Options">
+          <SurveyTextarea
+            value={optionsText}
+            onChange={(event) => setOptionsText(event.target.value)}
+            disabled={disabled || saving}
+            rows={4}
+            className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
+          />
+        </FormField>
+      ) : (
+        <FormField label="Max characters">
+          <Input
+            type="number"
+            min={1}
+            max={5000}
+            value={responseMaxChars}
+            onChange={(event) => setResponseMaxChars(event.target.value)}
+            disabled={disabled || saving}
+          />
+        </FormField>
+      )}
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="text-danger hover:bg-danger-bg"
+          onClick={deleteQuestion}
+          disabled={disabled || saving}
+        >
+          <Trash2 className="mr-1 h-4 w-4" aria-hidden="true" />
+          Delete
+        </Button>
+        <Button type="button" size="sm" onClick={saveQuestion} disabled={disabled || saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </Card>
+  )
+}
+
+function ResultsView({ payload }: { payload: SurveyResultsPayload | null }) {
+  if (!payload) {
+    return (
+      <div className="flex justify-center py-6">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (payload.results.length === 0) {
+    return <p className="py-4 text-sm text-text-muted">No responses yet.</p>
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-sm text-text-muted">
+        {payload.stats.responded} of {payload.stats.total_students} students responded
+      </div>
+      {payload.results.map((result, index) => (
+        <div key={result.question_id} className="space-y-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
+            <QuestionMarkdown content={result.question_text} />
+          </div>
+
+          {result.question_type === 'multiple_choice' ? (
+            <div className="space-y-1.5">
+              {result.options.map((option, optionIndex) => {
+                const count = result.counts[optionIndex] || 0
+                const percent = result.total_responses > 0 ? (count / result.total_responses) * 100 : 0
+                return (
+                  <div key={optionIndex} className="space-y-0.5">
+                    <div className="flex justify-between gap-3 text-sm">
+                      <span className="min-w-0 text-text-default">{option}</span>
+                      <span className="shrink-0 text-text-muted">{count} ({percent.toFixed(0)}%)</span>
+                    </div>
+                    <div className="h-3 overflow-hidden rounded-full bg-surface-2">
+                      <div className="h-full rounded-full bg-primary" style={{ width: `${percent}%` }} />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : result.responses.length === 0 ? (
+            <p className="text-sm text-text-muted">No text responses yet.</p>
+          ) : (
+            <div className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+              {result.responses.map((response) => (
+                <div key={response.response_id} className="grid gap-1 bg-surface px-3 py-2 text-sm sm:grid-cols-[12rem_minmax(0,1fr)]">
+                  <span className="min-w-0 truncate font-medium text-text-default">
+                    {response.name || response.email || 'Student'}
+                  </span>
+                  {result.question_type === 'link' ? (
+                    <a
+                      href={response.response_text}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex min-w-0 items-center gap-1 text-primary hover:underline"
+                    >
+                      <span className="truncate">{response.response_text}</span>
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    </a>
+                  ) : (
+                    <span className="whitespace-pre-wrap text-text-default">{response.response_text}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function TeacherSurveyWorkspace({
+  classroomId,
+  surveyId,
+  isReadOnly = false,
+  onBack,
+  onSurveyUpdated,
+  onSurveyDeleted,
+}: TeacherSurveyWorkspaceProps) {
+  const [detail, setDetail] = useState<SurveyDetailPayload | null>(null)
+  const [results, setResults] = useState<SurveyResultsPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [newQuestionType, setNewQuestionType] = useState<SurveyQuestionType>('multiple_choice')
+  const [newQuestionText, setNewQuestionText] = useState('')
+  const [newOptionsText, setNewOptionsText] = useState('Option 1\nOption 2')
+  const [addingQuestion, setAddingQuestion] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [statusChanging, setStatusChanging] = useState(false)
+  const onSurveyUpdatedRef = useRef(onSurveyUpdated)
+
+  useEffect(() => {
+    onSurveyUpdatedRef.current = onSurveyUpdated
+  }, [onSurveyUpdated])
+
+  const survey = detail?.survey ?? null
+  const questions = detail?.questions ?? []
+  const statusClassName = survey ? getSurveyStatusBadgeClass(survey.status) : ''
+
+  const loadSurvey = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/surveys/${surveyId}`)
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load survey')
+      setDetail({ survey: data.survey, questions: data.questions || [] })
+      onSurveyUpdatedRef.current(data.survey)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load survey')
+      setDetail(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [surveyId])
+
+  const loadResults = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/teacher/surveys/${surveyId}/results`)
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load survey results')
+      setResults(data)
+    } catch (err) {
+      console.error('Error loading survey results:', err)
+      setResults({ results: [], stats: { responded: 0, total_students: 0 } })
+    }
+  }, [surveyId])
+
+  useEffect(() => {
+    void loadSurvey()
+    void loadResults()
+  }, [loadResults, loadSurvey])
+
+  const canOpen = useMemo(() => survey?.status === 'draft' && questions.length > 0, [questions.length, survey?.status])
+
+  async function patchSurvey(update: Record<string, unknown>) {
+    setStatusChanging(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/surveys/${surveyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(update),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to update survey')
+      setDetail((current) => current ? { ...current, survey: data.survey } : current)
+      onSurveyUpdated(data.survey)
+      void loadResults()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update survey')
+    } finally {
+      setStatusChanging(false)
+    }
+  }
+
+  async function addQuestion() {
+    setAddingQuestion(true)
+    setError('')
+    try {
+      const response = await fetch(`/api/teacher/surveys/${surveyId}/questions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question_type: newQuestionType,
+          question_text: newQuestionText,
+          options: newQuestionType === 'multiple_choice' ? newOptionsText.split('\n') : [],
+          response_max_chars: defaultMaxChars(newQuestionType),
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to add question')
+      setDetail((current) =>
+        current
+          ? { ...current, questions: [...current.questions, data.question] }
+          : current
+      )
+      setNewQuestionText('')
+      setNewOptionsText('Option 1\nOption 2')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add question')
+    } finally {
+      setAddingQuestion(false)
+    }
+  }
+
+  async function deleteSurvey() {
+    if (!survey) return
+    setStatusChanging(true)
+    try {
+      const response = await fetch(`/api/teacher/surveys/${survey.id}`, { method: 'DELETE' })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Failed to delete survey')
+      onSurveyDeleted(survey.id)
+      onBack()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete survey')
+    } finally {
+      setStatusChanging(false)
+      setDeleteConfirmOpen(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center py-12">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (!survey) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-sm text-danger">
+        {error || 'Survey unavailable'}
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-auto p-4">
+      <div className="mx-auto flex max-w-5xl flex-col gap-4">
+        <Card tone="panel" padding="md" className="space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <button
+                type="button"
+                onClick={onBack}
+                className="mb-2 inline-flex items-center gap-1 text-sm font-medium text-text-muted hover:text-text-default"
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Classwork
+              </button>
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <h2 className="min-w-0 text-xl font-semibold text-text-default">{survey.title}</h2>
+                <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${statusClassName}`}>
+                  {getSurveyStatusLabel(survey.status)}
+                </span>
+                {survey.dynamic_responses && (
+                  <span className="rounded-badge bg-info-bg px-2.5 py-1 text-xs font-semibold text-primary">
+                    Dynamic
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" variant="secondary" onClick={() => setSettingsOpen(true)}>
+                <Pencil className="mr-1 h-4 w-4" aria-hidden="true" />
+                Settings
+              </Button>
+              {survey.status === 'draft' ? (
+                <Button
+                  size="sm"
+                  onClick={() => patchSurvey({ status: 'active' })}
+                  disabled={isReadOnly || statusChanging || !canOpen}
+                >
+                  Open
+                </Button>
+              ) : survey.status === 'active' ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => patchSurvey({ status: 'closed' })}
+                  disabled={isReadOnly || statusChanging}
+                >
+                  Close
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => patchSurvey({ status: 'active' })}
+                  disabled={isReadOnly || statusChanging}
+                >
+                  Reopen
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-danger hover:bg-danger-bg"
+                onClick={() => setDeleteConfirmOpen(true)}
+                disabled={isReadOnly || statusChanging}
+              >
+                <Trash2 className="mr-1 h-4 w-4" aria-hidden="true" />
+                Delete
+              </Button>
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+              {error}
+            </div>
+          )}
+        </Card>
+
+        <Card tone="panel" padding="md" className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-base font-semibold text-text-default">Questions</h3>
+            <span className="text-sm text-text-muted">{questions.length} total</span>
+          </div>
+
+          <div className="grid gap-3 rounded-lg border border-border bg-surface-2 p-3 lg:grid-cols-[12rem_minmax(0,1fr)]">
+            <FormField label="Type">
+              <Select
+                value={newQuestionType}
+                onChange={(event) => setNewQuestionType(event.target.value as SurveyQuestionType)}
+                options={QUESTION_TYPE_OPTIONS}
+                disabled={isReadOnly || addingQuestion}
+              />
+            </FormField>
+            <FormField label="New question">
+              <Input
+                value={newQuestionText}
+                onChange={(event) => setNewQuestionText(event.target.value)}
+                placeholder="Ask students a question"
+                disabled={isReadOnly || addingQuestion}
+              />
+            </FormField>
+            {newQuestionType === 'multiple_choice' && (
+              <div className="lg:col-span-2">
+                <FormField label="Options">
+                  <SurveyTextarea
+                    value={newOptionsText}
+                    onChange={(event) => setNewOptionsText(event.target.value)}
+                    rows={3}
+                    disabled={isReadOnly || addingQuestion}
+                    className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-surface-2"
+                  />
+                </FormField>
+              </div>
+            )}
+            <div className="lg:col-span-2 flex justify-end">
+              <Button
+                type="button"
+                size="sm"
+                onClick={addQuestion}
+                disabled={isReadOnly || addingQuestion || !newQuestionText.trim()}
+              >
+                <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
+                {addingQuestion ? 'Adding...' : 'Add question'}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {questions.length === 0 ? (
+              <p className="rounded-lg border border-border bg-surface px-3 py-4 text-center text-sm text-text-muted">
+                Add at least one question before opening the survey.
+              </p>
+            ) : (
+              questions.map((question) => (
+                <QuestionEditor
+                  key={question.id}
+                  question={question}
+                  disabled={isReadOnly}
+                  onSaved={(updatedQuestion) => {
+                    setDetail((current) =>
+                      current
+                        ? {
+                            ...current,
+                            questions: current.questions.map((item) =>
+                              item.id === updatedQuestion.id ? updatedQuestion : item
+                            ),
+                          }
+                        : current
+                    )
+                  }}
+                  onDeleted={(questionId) => {
+                    setDetail((current) =>
+                      current
+                        ? {
+                            ...current,
+                            questions: current.questions.filter((item) => item.id !== questionId),
+                          }
+                        : current
+                    )
+                    void loadResults()
+                  }}
+                />
+              ))
+            )}
+          </div>
+        </Card>
+
+        <Card tone="panel" padding="md" className="space-y-4">
+          <div className="flex items-center gap-2">
+            <BarChart3 className="h-4 w-4 text-text-muted" aria-hidden="true" />
+            <h3 className="text-base font-semibold text-text-default">Results</h3>
+          </div>
+          <ResultsView payload={results} />
+        </Card>
+      </div>
+
+      <SurveyModal
+        isOpen={settingsOpen}
+        classroomId={classroomId}
+        survey={survey}
+        onClose={() => setSettingsOpen(false)}
+        onSuccess={(updatedSurvey) => {
+          setDetail((current) => current ? { ...current, survey: updatedSurvey } : current)
+          onSurveyUpdated(updatedSurvey)
+        }}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteConfirmOpen}
+        title="Delete survey?"
+        description={`${survey.title}\n\nThis cannot be undone.`}
+        confirmLabel={statusChanging ? 'Deleting...' : 'Delete'}
+        cancelLabel="Cancel"
+        confirmVariant="danger"
+        isConfirmDisabled={statusChanging}
+        isCancelDisabled={statusChanging}
+        onCancel={() => (statusChanging ? null : setDeleteConfirmOpen(false))}
+        onConfirm={() => {
+          void deleteSurvey()
+        }}
+      />
+    </div>
+  )
+}

--- a/src/lib/classwork-order.ts
+++ b/src/lib/classwork-order.ts
@@ -1,4 +1,4 @@
-export type OrderedClassworkItem<TAssignment, TMaterial> =
+export type OrderedClassworkItem<TAssignment, TMaterial, TSurvey = never> =
   | {
       id: string
       type: 'assignment'
@@ -15,6 +15,14 @@ export type OrderedClassworkItem<TAssignment, TMaterial> =
       title: string
       material: TMaterial
     }
+  | {
+      id: string
+      type: 'survey'
+      position: number
+      createdAt: string
+      title: string
+      survey: TSurvey
+    }
 
 type AssignmentLike = {
   id: string
@@ -30,6 +38,13 @@ type MaterialLike = {
   created_at?: string | null
 }
 
+type SurveyLike = {
+  id: string
+  title: string
+  position?: number | null
+  created_at?: string | null
+}
+
 function normalizedPosition(position: number | null | undefined, fallback: number) {
   return typeof position === 'number' && Number.isFinite(position) ? position : fallback
 }
@@ -37,10 +52,12 @@ function normalizedPosition(position: number | null | undefined, fallback: numbe
 export function buildOrderedClassworkItems<
   TAssignment extends AssignmentLike,
   TMaterial extends MaterialLike,
+  TSurvey extends SurveyLike = never,
 >(
   assignments: TAssignment[],
   materials: TMaterial[],
-): OrderedClassworkItem<TAssignment, TMaterial>[] {
+  surveys: TSurvey[] = [],
+): OrderedClassworkItem<TAssignment, TMaterial, TSurvey>[] {
   const assignmentItems = assignments.map((assignment, index) => ({
     id: assignment.id,
     type: 'assignment' as const,
@@ -60,7 +77,17 @@ export function buildOrderedClassworkItems<
     material,
   }))
 
-  return [...assignmentItems, ...materialItems].sort((left, right) => {
+  const surveyOffset = assignments.length + materials.length
+  const surveyItems = surveys.map((survey, index) => ({
+    id: survey.id,
+    type: 'survey' as const,
+    position: normalizedPosition(survey.position, surveyOffset + index),
+    createdAt: survey.created_at || '',
+    title: survey.title,
+    survey,
+  }))
+
+  return [...assignmentItems, ...materialItems, ...surveyItems].sort((left, right) => {
     const positionDelta = left.position - right.position
     if (positionDelta !== 0) return positionDelta
 

--- a/src/lib/quiz-markdown.ts
+++ b/src/lib/quiz-markdown.ts
@@ -1,13 +1,10 @@
-import type { QuizDraftContent } from '@/lib/server/assessment-drafts'
+import { validateQuizOptions } from '@/lib/quizzes'
+import type { QuizDraftContent, QuizDraftQuestion } from '@/lib/server/assessment-drafts'
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-type ParsedQuestion = {
-  id?: string
-  question_text?: string
-  options?: string[]
-}
+const FIELD_KEYS = new Set(['id', 'prompt', 'options', 'show results', 'title'])
 
 export interface QuizMarkdownSerializeInput {
   title: string
@@ -19,24 +16,87 @@ export interface QuizMarkdownSerializeInput {
   }>
 }
 
+export interface QuizMarkdownParseOptions {
+  defaultShowResults?: boolean
+  existingQuestions?: Array<{ id: string }>
+}
+
 export interface QuizMarkdownParseResult {
   draftContent: QuizDraftContent | null
   errors: string[]
-}
-
-export interface ParseQuizMarkdownOptions {
-  defaultShowResults?: boolean
-  existingQuestions?: Array<{ id: string }>
 }
 
 function normalizeLineEndings(markdown: string): string[] {
   return markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n')
 }
 
+function parseBoolean(value: string): boolean | null {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'true' || normalized === 'yes' || normalized === '1') return true
+  if (normalized === 'false' || normalized === 'no' || normalized === '0') return false
+  return null
+}
+
 function parseFieldLine(line: string): { key: string; value: string } | null {
   const match = line.match(/^([A-Za-z ]+):\s*(.*)$/)
   if (!match) return null
   return { key: match[1].trim().toLowerCase(), value: match[2] ?? '' }
+}
+
+function isKnownFieldLine(line: string): boolean {
+  const parsed = parseFieldLine(line.trim())
+  return parsed ? FIELD_KEYS.has(parsed.key) : false
+}
+
+function isHeading(line: string, level: 2 | 3): boolean {
+  return line.trim().startsWith(level === 2 ? '## ' : '### ')
+}
+
+function parseMultilineField(
+  lines: string[],
+  startIndex: number,
+  initialValue: string
+): { value: string; nextIndex: number } {
+  const collected: string[] = []
+  if (initialValue.trim().length > 0) collected.push(initialValue)
+
+  let index = startIndex + 1
+  while (index < lines.length) {
+    const nextLine = lines[index]
+    if (isHeading(nextLine, 2) || isHeading(nextLine, 3) || isKnownFieldLine(nextLine)) break
+    collected.push(nextLine)
+    index += 1
+  }
+
+  return { value: collected.join('\n').trim(), nextIndex: index }
+}
+
+function parseOptionsField(
+  lines: string[],
+  startIndex: number,
+  inlineValue: string
+): { options: string[]; nextIndex: number } {
+  const options: string[] = []
+  if (inlineValue.trim().length > 0) options.push(inlineValue.trim())
+
+  let index = startIndex + 1
+  while (index < lines.length) {
+    const line = lines[index].trim()
+    if (!line) {
+      index += 1
+      continue
+    }
+    if (line.startsWith('- ')) {
+      const option = line.replace(/^- /, '').trim()
+      if (option) options.push(option)
+      index += 1
+      continue
+    }
+    if (isHeading(lines[index], 2) || isHeading(lines[index], 3) || isKnownFieldLine(lines[index])) break
+    break
+  }
+
+  return { options, nextIndex: index }
 }
 
 function generateUuid(): string {
@@ -57,204 +117,145 @@ function chooseId(candidate: string | undefined, fallback: string | undefined): 
   return generateUuid()
 }
 
-function parseOptionsField(
-  lines: string[],
-  startIndex: number,
-  inlineValue: string
-): { options: string[]; nextIndex: number } {
-  const options: string[] = []
-  if (inlineValue.trim().length > 0) options.push(inlineValue.trim())
+function splitQuestionBlocks(lines: string[]): Array<{ heading: string; lines: string[] }> {
+  const blocks: Array<{ heading: string; lines: string[] }> = []
+  let current: { heading: string; lines: string[] } | null = null
 
-  let index = startIndex + 1
-  while (index < lines.length) {
-    const line = lines[index].trim()
-    if (line.length === 0) {
-      index += 1
-      continue
-    }
-    if (!line.startsWith('- ')) break
-    const option = line.replace(/^- /, '').trim()
-    if (option.length > 0) options.push(option)
-    index += 1
-  }
-
-  return { options, nextIndex: index }
-}
-
-export function quizToMarkdown(input: QuizMarkdownSerializeInput): string {
-  const lines: string[] = []
-  lines.push('# Quiz')
-  lines.push(`Title: ${input.title}`)
-  lines.push(`Show Results: ${input.show_results ? 'true' : 'false'}`)
-  lines.push('')
-  lines.push('## Questions')
-
-  input.questions.forEach((question, index) => {
-    lines.push(`### Question ${index + 1}`)
-    lines.push('Prompt:')
-    for (const promptLine of question.question_text.split('\n')) {
-      lines.push(promptLine)
-    }
-    lines.push('Options:')
-    question.options.forEach((option) => {
-      lines.push(`- ${option}`)
-    })
-    lines.push('')
-  })
-
-  return lines.join('\n').trim()
-}
-
-export function markdownToQuiz(
-  markdown: string,
-  options: ParseQuizMarkdownOptions = {}
-): QuizMarkdownParseResult {
-  const lines = normalizeLineEndings(markdown)
-  const errors: string[] = []
-
-  let title = ''
-  let showResults = options.defaultShowResults ?? false
-  const questions: QuizDraftContent['questions'] = []
-  const fallbackIds = options.existingQuestions?.map((question) => question.id) ?? []
-
-  let inQuestionsSection = false
-  let currentQuestion: ParsedQuestion | null = null
-  let promptLines: string[] = []
-  let lineIndex = 0
-
-  function flushQuestion() {
-    if (!currentQuestion) return
-
-    const questionIndex = questions.length
-    const questionText = promptLines.join('\n').trim()
-    const questionLabel = `Question ${questionIndex + 1}`
-
-    if (!questionText) {
-      errors.push(`${questionLabel}: Prompt is required`)
-    }
-
-    if (!currentQuestion.options || currentQuestion.options.length < 2) {
-      errors.push(`${questionLabel}: At least 2 options are required`)
-    }
-
-    if (questionText && currentQuestion.options && currentQuestion.options.length >= 2) {
-      questions.push({
-        id: chooseId(currentQuestion.id, fallbackIds[questionIndex]),
-        question_text: questionText,
-        options: currentQuestion.options,
-      })
-    }
-
-    currentQuestion = null
-    promptLines = []
-  }
-
-  while (lineIndex < lines.length) {
-    const rawLine = lines[lineIndex]
+  for (const rawLine of lines) {
     const line = rawLine.trimEnd()
+    if (isHeading(line, 3)) {
+      if (current) blocks.push(current)
+      current = { heading: line.replace(/^###\s+/, '').trim(), lines: [] }
+      continue
+    }
+    if (!current) continue
+    current.lines.push(line)
+  }
+
+  if (current) blocks.push(current)
+  return blocks
+}
+
+function parseQuestionBlock(
+  blockLines: string[],
+  index: number,
+  options: QuizMarkdownParseOptions,
+  errors: string[]
+): QuizDraftQuestion | null {
+  let id: string | undefined
+  let prompt = ''
+  let choices: string[] = []
+  let lineIndex = 0
+  const label = `Question ${index + 1}`
+
+  while (lineIndex < blockLines.length) {
+    const line = blockLines[lineIndex]
     const trimmed = line.trim()
-
     if (!trimmed) {
-      if (currentQuestion) promptLines.push('')
-      lineIndex += 1
-      continue
-    }
-
-    if (trimmed.startsWith('# ')) {
-      lineIndex += 1
-      continue
-    }
-
-    if (trimmed === '## Questions') {
-      flushQuestion()
-      inQuestionsSection = true
-      lineIndex += 1
-      continue
-    }
-
-    if (!inQuestionsSection) {
-      const field = parseFieldLine(trimmed)
-      if (!field) {
-        errors.push(`Invalid line before questions: "${trimmed}"`)
-        lineIndex += 1
-        continue
-      }
-
-      if (field.key === 'title') {
-        title = field.value.trim()
-      } else if (field.key === 'show results') {
-        showResults = ['true', 'yes', '1'].includes(field.value.trim().toLowerCase())
-      } else {
-        errors.push(`Unknown field: ${field.key}`)
-      }
-      lineIndex += 1
-      continue
-    }
-
-    if (trimmed.startsWith('### ')) {
-      flushQuestion()
-      currentQuestion = {}
-      lineIndex += 1
-      continue
-    }
-
-    if (!currentQuestion) {
-      errors.push(`Content outside question block: "${trimmed}"`)
       lineIndex += 1
       continue
     }
 
     const field = parseFieldLine(trimmed)
     if (!field) {
-      promptLines.push(line)
+      errors.push(`${label}: Invalid line "${trimmed}"`)
       lineIndex += 1
       continue
     }
 
     if (field.key === 'id') {
-      currentQuestion.id = field.value.trim()
+      id = field.value.trim()
       lineIndex += 1
       continue
     }
-
     if (field.key === 'prompt') {
-      lineIndex += 1
-      while (lineIndex < lines.length) {
-        const nextLine = lines[lineIndex]
-        const nextTrimmed = nextLine.trim()
-        if (
-          nextTrimmed.startsWith('### ') ||
-          nextTrimmed === '## Questions' ||
-          nextTrimmed.startsWith('Options:')
-        ) {
-          break
-        }
-        promptLines.push(nextLine)
-        lineIndex += 1
-      }
+      const parsed = parseMultilineField(blockLines, lineIndex, field.value)
+      prompt = parsed.value
+      lineIndex = parsed.nextIndex
       continue
     }
-
     if (field.key === 'options') {
-      const parsed = parseOptionsField(lines, lineIndex, field.value)
-      currentQuestion.options = parsed.options
+      const parsed = parseOptionsField(blockLines, lineIndex, field.value)
+      choices = parsed.options
       lineIndex = parsed.nextIndex
       continue
     }
 
-    errors.push(`Unknown question field: ${field.key}`)
+    errors.push(`${label}: Unknown field "${field.key}"`)
     lineIndex += 1
   }
 
-  flushQuestion()
+  if (!prompt.trim()) errors.push(`${label}: Prompt is required`)
+  const optionsValidation = validateQuizOptions(choices)
+  if (!optionsValidation.valid) {
+    errors.push(`${label}: ${optionsValidation.error || 'Invalid options'}`)
+  }
+  if (!prompt.trim() || !optionsValidation.valid) return null
 
-  if (!title.trim()) {
-    errors.push('Title is required')
+  return {
+    id: chooseId(id, options.existingQuestions?.[index]?.id),
+    question_text: prompt.trim(),
+    options: choices.map((choice) => choice.trim()),
+  }
+}
+
+export function quizToMarkdown(input: QuizMarkdownSerializeInput): string {
+  const lines: string[] = [
+    '# Quiz',
+    `Title: ${input.title}`,
+    `Show Results: ${input.show_results ? 'true' : 'false'}`,
+    '',
+    '## Questions',
+  ]
+
+  input.questions.forEach((question, index) => {
+    lines.push('', `### Question ${index + 1}`, `ID: ${question.id}`, 'Prompt:')
+    lines.push(question.question_text || '')
+    lines.push('', 'Options:')
+    question.options.forEach((option) => lines.push(`- ${option}`))
+  })
+
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+export function markdownToQuiz(
+  markdown: string,
+  options: QuizMarkdownParseOptions = {}
+): QuizMarkdownParseResult {
+  const lines = normalizeLineEndings(markdown)
+  const errors: string[] = []
+  let title = ''
+  let showResults = options.defaultShowResults ?? false
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+    if (isHeading(line, 2)) break
+
+    const field = parseFieldLine(line.trim())
+    if (field?.key === 'title') {
+      title = field.value.trim()
+    } else if (field?.key === 'show results') {
+      const parsed = parseBoolean(field.value)
+      if (parsed === null) errors.push('Show Results must be true or false')
+      else showResults = parsed
+    }
+
+    index += 1
   }
 
-  if (questions.length === 0) {
-    errors.push('At least 1 question is required')
+  if (!title) {
+    const heading = lines.find((line) => line.trim().startsWith('# '))
+    title = heading?.replace(/^#\s+/, '').trim() || ''
   }
+  if (!title || title.toLowerCase() === 'quiz') errors.push('Title is required')
+
+  const questionBlocks = splitQuestionBlocks(lines)
+  const questions = questionBlocks
+    .map((block, questionIndex) => parseQuestionBlock(block.lines, questionIndex, options, errors))
+    .filter((question): question is QuizDraftQuestion => Boolean(question))
+
+  if (questions.length === 0) errors.push('At least one question is required')
 
   if (errors.length > 0) {
     return { draftContent: null, errors }
@@ -262,9 +263,11 @@ export function markdownToQuiz(
 
   return {
     draftContent: {
-      title: title.trim(),
+      title,
       show_results: showResults,
       questions,
+      source_format: 'markdown',
+      source_markdown: markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n'),
     },
     errors: [],
   }

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -33,6 +33,8 @@ export type QuizDraftContent = {
   title: string
   show_results: boolean
   questions: QuizDraftQuestion[]
+  source_format?: 'markdown'
+  source_markdown?: string
 }
 
 export type TestDraftContent = {

--- a/src/lib/server/surveys.ts
+++ b/src/lib/server/surveys.ts
@@ -1,0 +1,104 @@
+import { getServiceRoleClient } from '@/lib/supabase'
+import type { SurveyStatus } from '@/types'
+
+export type SurveyAccessRecord = {
+  id: string
+  classroom_id: string
+  title: string
+  status: SurveyStatus
+  opens_at: string | null
+  show_results: boolean
+  dynamic_responses: boolean
+  position: number
+  created_by: string
+  created_at: string
+  updated_at: string
+  classrooms: {
+    id: string
+    teacher_id: string
+    archived_at: string | null
+  }
+}
+
+type AccessResult<T> =
+  | { ok: true; survey: T }
+  | { ok: false; status: number; error: string }
+
+export function isMissingSurveysTableError(error: any): boolean {
+  const message = String(error?.message || '')
+  return error?.code === 'PGRST205' || message.includes('surveys')
+}
+
+export async function assertTeacherOwnsSurvey(
+  teacherId: string,
+  surveyId: string,
+  opts?: { checkArchived?: boolean }
+): Promise<AccessResult<SurveyAccessRecord>> {
+  const supabase = getServiceRoleClient()
+  const { data: survey, error } = await supabase
+    .from('surveys')
+    .select(`
+      *,
+      classrooms!inner (
+        id,
+        teacher_id,
+        archived_at
+      )
+    `)
+    .eq('id', surveyId)
+    .single()
+
+  if (error || !survey) {
+    return { ok: false, status: 404, error: 'Survey not found' }
+  }
+
+  if (survey.classrooms.teacher_id !== teacherId) {
+    return { ok: false, status: 403, error: 'Forbidden' }
+  }
+
+  if (opts?.checkArchived && survey.classrooms.archived_at) {
+    return { ok: false, status: 403, error: 'Classroom is archived' }
+  }
+
+  return { ok: true, survey: survey as SurveyAccessRecord }
+}
+
+export async function assertStudentCanAccessSurvey(
+  studentId: string,
+  surveyId: string
+): Promise<AccessResult<SurveyAccessRecord>> {
+  const supabase = getServiceRoleClient()
+  const { data: survey, error } = await supabase
+    .from('surveys')
+    .select(`
+      *,
+      classrooms!inner (
+        id,
+        teacher_id,
+        archived_at
+      )
+    `)
+    .eq('id', surveyId)
+    .single()
+
+  if (error || !survey) {
+    return { ok: false, status: 404, error: 'Survey not found' }
+  }
+
+  if (survey.classrooms.archived_at) {
+    return { ok: false, status: 403, error: 'Classroom is archived' }
+  }
+
+  const { data: enrollment, error: enrollError } = await supabase
+    .from('classroom_enrollments')
+    .select('id')
+    .eq('classroom_id', survey.classroom_id)
+    .eq('student_id', studentId)
+    .single()
+
+  if (enrollError || !enrollment) {
+    return { ok: false, status: 403, error: 'Not enrolled in this classroom' }
+  }
+
+  return { ok: true, survey: survey as SurveyAccessRecord }
+}

--- a/src/lib/survey-markdown.ts
+++ b/src/lib/survey-markdown.ts
@@ -1,0 +1,329 @@
+import {
+  DEFAULT_SURVEY_LINK_MAX_CHARS,
+  DEFAULT_SURVEY_TEXT_MAX_CHARS,
+  normalizeSurveyQuestionInput,
+} from '@/lib/surveys'
+import type { Survey, SurveyQuestion, SurveyQuestionType } from '@/types'
+
+const FIELD_KEYS = new Set([
+  'dynamic responses',
+  'id',
+  'max chars',
+  'options',
+  'prompt',
+  'show results',
+  'title',
+  'type',
+])
+
+export interface SurveyMarkdownQuestion {
+  id?: string
+  question_type: SurveyQuestionType
+  question_text: string
+  options: string[]
+  response_max_chars: number
+}
+
+export interface SurveyMarkdownContent {
+  title: string
+  show_results: boolean
+  dynamic_responses: boolean
+  questions: SurveyMarkdownQuestion[]
+}
+
+export interface SurveyMarkdownParseOptions {
+  defaultShowResults?: boolean
+  defaultDynamicResponses?: boolean
+  existingQuestions?: Array<{ id: string }>
+}
+
+export interface SurveyMarkdownParseResult {
+  content: SurveyMarkdownContent | null
+  errors: string[]
+}
+
+export function surveyToMarkdown(input: {
+  survey: Pick<Survey, 'title' | 'show_results' | 'dynamic_responses'>
+  questions: Array<
+    Pick<SurveyQuestion, 'id' | 'question_type' | 'question_text' | 'options' | 'response_max_chars'>
+  >
+}): string {
+  const lines = [
+    '# Survey',
+    `Title: ${input.survey.title}`,
+    `Show Results: ${input.survey.show_results ? 'true' : 'false'}`,
+    `Dynamic Responses: ${input.survey.dynamic_responses ? 'true' : 'false'}`,
+    '',
+    '## Questions',
+  ]
+
+  input.questions.forEach((question, index) => {
+    lines.push('', `### Question ${index + 1}`, `ID: ${question.id}`, `Type: ${question.question_type}`, 'Prompt:')
+    lines.push(question.question_text || '')
+
+    if (question.question_type === 'multiple_choice') {
+      lines.push('', 'Options:')
+      question.options.forEach((option) => lines.push(`- ${option}`))
+    } else {
+      lines.push('', `Max Chars: ${question.response_max_chars}`)
+    }
+  })
+
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+function normalizeLineEndings(markdown: string): string[] {
+  return markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n')
+}
+
+function parseBoolean(value: string): boolean | null {
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'true' || normalized === 'yes' || normalized === '1') return true
+  if (normalized === 'false' || normalized === 'no' || normalized === '0') return false
+  return null
+}
+
+function parseQuestionType(value: string): SurveyQuestionType | null {
+  const normalized = value.trim().toLowerCase().replace(/[-\s]+/g, '_')
+  if (normalized === 'mc' || normalized === 'multiple_choice') return 'multiple_choice'
+  if (normalized === 'text' || normalized === 'short_text') return 'short_text'
+  if (normalized === 'url' || normalized === 'link') return 'link'
+  return null
+}
+
+function parseFieldLine(line: string): { key: string; value: string } | null {
+  const match = line.match(/^([A-Za-z ]+):\s*(.*)$/)
+  if (!match) return null
+  return { key: match[1].trim().toLowerCase(), value: match[2] ?? '' }
+}
+
+function isKnownFieldLine(line: string): boolean {
+  const parsed = parseFieldLine(line.trim())
+  return parsed ? FIELD_KEYS.has(parsed.key) : false
+}
+
+function isHeading(line: string, level: 2 | 3): boolean {
+  return line.trim().startsWith(level === 2 ? '## ' : '### ')
+}
+
+function parseMultilineField(
+  lines: string[],
+  startIndex: number,
+  initialValue: string
+): { value: string; nextIndex: number } {
+  const collected: string[] = []
+  if (initialValue.trim().length > 0) collected.push(initialValue)
+
+  let index = startIndex + 1
+  while (index < lines.length) {
+    const nextLine = lines[index]
+    if (isHeading(nextLine, 2) || isHeading(nextLine, 3) || isKnownFieldLine(nextLine)) break
+    collected.push(nextLine)
+    index += 1
+  }
+
+  return { value: collected.join('\n').trim(), nextIndex: index }
+}
+
+function parseOptionsField(
+  lines: string[],
+  startIndex: number,
+  inlineValue: string
+): { options: string[]; nextIndex: number } {
+  const options: string[] = []
+  if (inlineValue.trim().length > 0) options.push(inlineValue.trim())
+
+  let index = startIndex + 1
+  while (index < lines.length) {
+    const line = lines[index].trim()
+    if (!line) {
+      index += 1
+      continue
+    }
+    if (line.startsWith('- ')) {
+      const option = line.replace(/^- /, '').trim()
+      if (option) options.push(option)
+      index += 1
+      continue
+    }
+    if (isHeading(lines[index], 2) || isHeading(lines[index], 3) || isKnownFieldLine(lines[index])) break
+    break
+  }
+
+  return { options, nextIndex: index }
+}
+
+function splitQuestionBlocks(lines: string[]): Array<{ lines: string[] }> {
+  const blocks: Array<{ lines: string[] }> = []
+  let current: { lines: string[] } | null = null
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+    if (isHeading(line, 3)) {
+      if (current) blocks.push(current)
+      current = { lines: [] }
+      continue
+    }
+    if (!current) continue
+    current.lines.push(line)
+  }
+
+  if (current) blocks.push(current)
+  return blocks
+}
+
+function chooseId(candidate: string | undefined, fallback: string | undefined): string | undefined {
+  const trimmedCandidate = candidate?.trim()
+  if (trimmedCandidate) return trimmedCandidate
+  const trimmedFallback = fallback?.trim()
+  return trimmedFallback || undefined
+}
+
+function parseQuestionBlock(
+  blockLines: string[],
+  index: number,
+  options: SurveyMarkdownParseOptions,
+  errors: string[]
+): SurveyMarkdownQuestion | null {
+  let id: string | undefined
+  let questionType: SurveyQuestionType = 'multiple_choice'
+  let prompt = ''
+  let choices: string[] = []
+  let responseMaxChars: number | undefined
+  let lineIndex = 0
+  const label = `Question ${index + 1}`
+
+  while (lineIndex < blockLines.length) {
+    const line = blockLines[lineIndex]
+    const trimmed = line.trim()
+    if (!trimmed) {
+      lineIndex += 1
+      continue
+    }
+
+    const field = parseFieldLine(trimmed)
+    if (!field) {
+      errors.push(`${label}: Invalid line "${trimmed}"`)
+      lineIndex += 1
+      continue
+    }
+
+    if (field.key === 'id') {
+      id = field.value.trim()
+      lineIndex += 1
+      continue
+    }
+    if (field.key === 'type') {
+      const parsedType = parseQuestionType(field.value)
+      if (!parsedType) errors.push(`${label}: Type must be multiple_choice, short_text, or link`)
+      else questionType = parsedType
+      lineIndex += 1
+      continue
+    }
+    if (field.key === 'prompt') {
+      const parsed = parseMultilineField(blockLines, lineIndex, field.value)
+      prompt = parsed.value
+      lineIndex = parsed.nextIndex
+      continue
+    }
+    if (field.key === 'options') {
+      const parsed = parseOptionsField(blockLines, lineIndex, field.value)
+      choices = parsed.options
+      lineIndex = parsed.nextIndex
+      continue
+    }
+    if (field.key === 'max chars') {
+      const parsedMaxChars = Number(field.value)
+      if (!Number.isFinite(parsedMaxChars) || parsedMaxChars < 1) {
+        errors.push(`${label}: Max Chars must be a positive number`)
+      } else {
+        responseMaxChars = parsedMaxChars
+      }
+      lineIndex += 1
+      continue
+    }
+
+    errors.push(`${label}: Unknown field "${field.key}"`)
+    lineIndex += 1
+  }
+
+  const normalized = normalizeSurveyQuestionInput({
+    question_type: questionType,
+    question_text: prompt,
+    options: questionType === 'multiple_choice' ? choices : [],
+    response_max_chars:
+      responseMaxChars ??
+      (questionType === 'link' ? DEFAULT_SURVEY_LINK_MAX_CHARS : DEFAULT_SURVEY_TEXT_MAX_CHARS),
+  })
+
+  if (!normalized.valid) {
+    errors.push(`${label}: ${normalized.error}`)
+    return null
+  }
+
+  const chosenId = chooseId(id, options.existingQuestions?.[index]?.id)
+  return {
+    ...(chosenId ? { id: chosenId } : {}),
+    ...normalized.question,
+  }
+}
+
+export function markdownToSurvey(
+  markdown: string,
+  options: SurveyMarkdownParseOptions = {}
+): SurveyMarkdownParseResult {
+  const lines = normalizeLineEndings(markdown)
+  const errors: string[] = []
+  let title = ''
+  let showResults = options.defaultShowResults ?? false
+  let dynamicResponses = options.defaultDynamicResponses ?? false
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+    if (isHeading(line, 2)) break
+
+    const field = parseFieldLine(line.trim())
+    if (field?.key === 'title') {
+      title = field.value.trim()
+    } else if (field?.key === 'show results') {
+      const parsed = parseBoolean(field.value)
+      if (parsed === null) errors.push('Show Results must be true or false')
+      else showResults = parsed
+    } else if (field?.key === 'dynamic responses') {
+      const parsed = parseBoolean(field.value)
+      if (parsed === null) errors.push('Dynamic Responses must be true or false')
+      else dynamicResponses = parsed
+    }
+
+    index += 1
+  }
+
+  if (!title) {
+    const heading = lines.find((line) => line.trim().startsWith('# '))
+    title = heading?.replace(/^#\s+/, '').trim() || ''
+  }
+  if (!title || title.toLowerCase() === 'survey') errors.push('Title is required')
+
+  const questions = splitQuestionBlocks(lines)
+    .map((block, questionIndex) => parseQuestionBlock(block.lines, questionIndex, options, errors))
+    .filter((question): question is SurveyMarkdownQuestion => Boolean(question))
+
+  const questionIds = questions.map((question) => question.id).filter((id): id is string => Boolean(id))
+  if (new Set(questionIds).size !== questionIds.length) {
+    errors.push('Question IDs must be unique')
+  }
+  if (questions.length === 0) errors.push('At least one question is required')
+
+  if (errors.length > 0) return { content: null, errors }
+
+  return {
+    content: {
+      title,
+      show_results: showResults,
+      dynamic_responses: dynamicResponses,
+      questions,
+    },
+    errors: [],
+  }
+}

--- a/src/lib/surveys.ts
+++ b/src/lib/surveys.ts
@@ -1,0 +1,292 @@
+import { isVisibleAtNow } from '@/lib/scheduling'
+import type {
+  StudentSurveyStatus,
+  Survey,
+  SurveyQuestion,
+  SurveyQuestionResult,
+  SurveyQuestionType,
+  SurveyResponse,
+  SurveyResponseValue,
+  SurveyStatus,
+} from '@/types'
+
+export const MAX_SURVEY_OPTIONS = 6
+export const DEFAULT_SURVEY_TEXT_MAX_CHARS = 500
+export const DEFAULT_SURVEY_LINK_MAX_CHARS = 2048
+
+export function getSurveyStatusLabel(status: SurveyStatus): string {
+  const labels: Record<SurveyStatus, string> = {
+    draft: 'Draft',
+    active: 'Open',
+    closed: 'Closed',
+  }
+  return labels[status]
+}
+
+export function getSurveyStatusBadgeClass(status: SurveyStatus): string {
+  const classes: Record<SurveyStatus, string> = {
+    draft: 'bg-surface-2 text-text-muted',
+    active: 'bg-success-bg text-success',
+    closed: 'bg-danger-bg text-danger',
+  }
+  return classes[status]
+}
+
+export function isSurveyVisibleToStudents(
+  survey: Pick<Survey, 'status' | 'opens_at'>,
+  now: Date = new Date()
+): boolean {
+  if (survey.status !== 'active') return false
+  return isVisibleAtNow(survey.opens_at, now)
+}
+
+export function hasSurveyOpened(
+  survey: Pick<Survey, 'status' | 'opens_at'>,
+  now: Date = new Date()
+): boolean {
+  return survey.status === 'active' && isVisibleAtNow(survey.opens_at, now)
+}
+
+export function canStudentRespondToSurvey(
+  survey: Pick<Survey, 'status' | 'opens_at' | 'dynamic_responses'>,
+  hasResponded: boolean,
+  now: Date = new Date()
+): boolean {
+  if (!isSurveyVisibleToStudents(survey, now)) return false
+  if (!hasResponded) return true
+  return survey.dynamic_responses
+}
+
+export function getStudentSurveyStatus(
+  survey: Pick<Survey, 'status' | 'opens_at' | 'show_results' | 'dynamic_responses'>,
+  hasResponded: boolean,
+  now: Date = new Date()
+): StudentSurveyStatus {
+  if (!hasResponded) return 'not_started'
+  if (canStudentRespondToSurvey(survey, hasResponded, now)) return 'can_update'
+  if (survey.show_results) return 'can_view_results'
+  return 'responded'
+}
+
+export function canActivateSurvey(
+  survey: Pick<Survey, 'status'>,
+  questionsCount: number
+): { valid: boolean; error?: string } {
+  if (survey.status !== 'draft') {
+    return { valid: false, error: 'Only draft surveys can be opened' }
+  }
+  if (questionsCount < 1) {
+    return { valid: false, error: 'Survey must have at least 1 question' }
+  }
+  return { valid: true }
+}
+
+export function normalizeSurveyQuestionType(value: unknown): SurveyQuestionType | null {
+  if (value === 'multiple_choice' || value === 'short_text' || value === 'link') return value
+  return null
+}
+
+export function validateSurveyOptions(options: string[]): { valid: boolean; error?: string } {
+  if (options.length < 2) return { valid: false, error: 'At least 2 options required' }
+  if (options.length > MAX_SURVEY_OPTIONS) {
+    return { valid: false, error: `Maximum ${MAX_SURVEY_OPTIONS} options allowed` }
+  }
+  if (options.some((option) => !option.trim())) {
+    return { valid: false, error: 'Options cannot be empty' }
+  }
+  return { valid: true }
+}
+
+export function normalizeSurveyQuestionInput(input: {
+  question_type?: unknown
+  question_text?: unknown
+  options?: unknown
+  response_max_chars?: unknown
+}): { valid: true; question: Pick<SurveyQuestion, 'question_type' | 'question_text' | 'options' | 'response_max_chars'> } | { valid: false; error: string } {
+  const questionType = normalizeSurveyQuestionType(input.question_type ?? 'multiple_choice')
+  if (!questionType) return { valid: false, error: 'Invalid question type' }
+
+  const questionText = typeof input.question_text === 'string' ? input.question_text.trim() : ''
+  if (!questionText) return { valid: false, error: 'Question text is required' }
+
+  const responseMaxChars =
+    typeof input.response_max_chars === 'number' && Number.isFinite(input.response_max_chars)
+      ? Math.max(1, Math.min(5000, Math.floor(input.response_max_chars)))
+      : questionType === 'link'
+        ? DEFAULT_SURVEY_LINK_MAX_CHARS
+        : DEFAULT_SURVEY_TEXT_MAX_CHARS
+
+  if (questionType === 'multiple_choice') {
+    if (!Array.isArray(input.options)) return { valid: false, error: 'Options must be an array' }
+    const options = input.options
+      .map((option) => (typeof option === 'string' ? option.trim() : ''))
+      .filter(Boolean)
+    const optionsValidation = validateSurveyOptions(options)
+    if (!optionsValidation.valid) {
+      return { valid: false, error: optionsValidation.error || 'Invalid options' }
+    }
+    return {
+      valid: true,
+      question: {
+        question_type: 'multiple_choice',
+        question_text: questionText,
+        options,
+        response_max_chars: responseMaxChars,
+      },
+    }
+  }
+
+  return {
+    valid: true,
+    question: {
+      question_type: questionType,
+      question_text: questionText,
+      options: [],
+      response_max_chars: responseMaxChars,
+    },
+  }
+}
+
+export function normalizeSurveyUrl(rawValue: string): string | null {
+  const value = rawValue.trim()
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+export function validateSurveyResponses(
+  questions: SurveyQuestion[],
+  responses: Record<string, unknown>
+): { valid: true; responses: Record<string, SurveyResponseValue> } | { valid: false; error: string } {
+  const questionById = new Map(questions.map((question) => [question.id, question]))
+  const responseQuestionIds = Object.keys(responses)
+
+  for (const questionId of responseQuestionIds) {
+    if (!questionById.has(questionId)) {
+      return { valid: false, error: `Invalid question ID: ${questionId}` }
+    }
+  }
+
+  for (const question of questions) {
+    if (!responseQuestionIds.includes(question.id)) {
+      return { valid: false, error: 'All questions must be answered' }
+    }
+  }
+
+  const normalized: Record<string, SurveyResponseValue> = {}
+
+  for (const question of questions) {
+    const rawValue = responses[question.id]
+    const maxChars = Math.max(1, Math.floor(question.response_max_chars || DEFAULT_SURVEY_TEXT_MAX_CHARS))
+
+    if (question.question_type === 'multiple_choice') {
+      const selectedOption =
+        typeof rawValue === 'number'
+          ? rawValue
+          : rawValue &&
+              typeof rawValue === 'object' &&
+              (rawValue as { question_type?: unknown }).question_type === 'multiple_choice'
+            ? (rawValue as { selected_option?: unknown }).selected_option
+            : null
+
+      if (
+        typeof selectedOption !== 'number' ||
+        !Number.isInteger(selectedOption) ||
+        selectedOption < 0 ||
+        selectedOption >= question.options.length
+      ) {
+        return { valid: false, error: `Invalid option for question ${question.id}` }
+      }
+
+      normalized[question.id] = {
+        question_type: 'multiple_choice',
+        selected_option: selectedOption,
+      }
+      continue
+    }
+
+    const responseText =
+      typeof rawValue === 'string'
+        ? rawValue
+        : rawValue &&
+            typeof rawValue === 'object' &&
+            ((rawValue as { question_type?: unknown }).question_type === 'short_text' ||
+              (rawValue as { question_type?: unknown }).question_type === 'link')
+          ? (rawValue as { response_text?: unknown }).response_text
+          : null
+
+    if (typeof responseText !== 'string') {
+      return { valid: false, error: 'All questions must be answered' }
+    }
+
+    const trimmed = responseText.trim()
+    if (!trimmed) return { valid: false, error: 'All questions must be answered' }
+    if (trimmed.length > maxChars) {
+      return { valid: false, error: `Response is too long for question ${question.id}` }
+    }
+
+    if (question.question_type === 'link') {
+      const normalizedUrl = normalizeSurveyUrl(trimmed)
+      if (!normalizedUrl) return { valid: false, error: `Enter a valid link for question ${question.id}` }
+      normalized[question.id] = {
+        question_type: 'link',
+        response_text: normalizedUrl,
+      }
+    } else {
+      normalized[question.id] = {
+        question_type: 'short_text',
+        response_text: trimmed,
+      }
+    }
+  }
+
+  return { valid: true, responses: normalized }
+}
+
+export function aggregateSurveyResults(
+  questions: SurveyQuestion[],
+  responses: SurveyResponse[]
+): SurveyQuestionResult[] {
+  return questions.map((question) => {
+    const questionResponses = responses.filter((response) => response.question_id === question.id)
+
+    if (question.question_type === 'multiple_choice') {
+      const counts = question.options.map((_, optionIndex) =>
+        questionResponses.filter((response) => response.selected_option === optionIndex).length
+      )
+      return {
+        question_id: question.id,
+        question_type: question.question_type,
+        question_text: question.question_text,
+        options: question.options,
+        counts,
+        responses: [],
+        total_responses: questionResponses.length,
+      }
+    }
+
+    return {
+      question_id: question.id,
+      question_type: question.question_type,
+      question_text: question.question_text,
+      options: [],
+      counts: [],
+      responses: questionResponses
+        .filter((response) => typeof response.response_text === 'string' && response.response_text.trim().length > 0)
+        .map((response) => ({
+          response_id: response.id,
+          student_id: response.student_id,
+          response_text: response.response_text || '',
+          submitted_at: response.submitted_at,
+          updated_at: response.updated_at,
+        })),
+      total_responses: questionResponses.length,
+    }
+  })
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -702,6 +702,8 @@ export interface CreateClassroomFromBlueprintInput {
 // Quiz types
 export type QuizStatus = 'draft' | 'active' | 'closed'
 export type QuizAssessmentType = 'quiz' | 'test'
+export type SurveyStatus = 'draft' | 'active' | 'closed'
+export type SurveyQuestionType = 'multiple_choice' | 'short_text' | 'link'
 export type TestStudentAvailabilityState = 'open' | 'closed'
 export type QuizFocusEventType =
   | 'away_start'
@@ -731,6 +733,88 @@ export interface QuizFocusSummary {
   window_unmaximize_attempts: number
   last_away_started_at: string | null
   last_away_ended_at: string | null
+}
+
+export interface Survey {
+  id: string
+  classroom_id: string
+  title: string
+  status: SurveyStatus
+  opens_at: string | null
+  show_results: boolean
+  dynamic_responses: boolean
+  position: number
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+export interface SurveyQuestion {
+  id: string
+  survey_id: string
+  question_type: SurveyQuestionType
+  question_text: string
+  options: string[]
+  response_max_chars: number
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface SurveyResponse {
+  id: string
+  survey_id: string
+  question_id: string
+  student_id: string
+  selected_option: number | null
+  response_text: string | null
+  submitted_at: string
+  updated_at: string
+}
+
+export type SurveyResponseValue =
+  | {
+      question_type: 'multiple_choice'
+      selected_option: number
+    }
+  | {
+      question_type: 'short_text' | 'link'
+      response_text: string
+    }
+
+export type StudentSurveyStatus = 'not_started' | 'responded' | 'can_update' | 'can_view_results'
+
+export interface SurveyWithStats extends Survey {
+  stats: {
+    total_students: number
+    responded: number
+    questions_count: number
+  }
+}
+
+export interface StudentSurveyView extends Survey {
+  student_status: StudentSurveyStatus
+  questions?: SurveyQuestion[]
+}
+
+export interface SurveyTextResponseResult {
+  response_id: string
+  student_id: string
+  name?: string | null
+  email?: string | null
+  response_text: string
+  submitted_at: string
+  updated_at: string
+}
+
+export interface SurveyQuestionResult {
+  question_id: string
+  question_type: SurveyQuestionType
+  question_text: string
+  options: string[]
+  counts: number[]
+  responses: SurveyTextResponseResult[]
+  total_responses: number
 }
 
 export interface Quiz {

--- a/supabase/migrations/068_surveys_classwork.sql
+++ b/supabase/migrations/068_surveys_classwork.sql
@@ -368,6 +368,135 @@ $$ language plpgsql;
 revoke all on function public.reorder_classwork_items(uuid, jsonb) from public, anon, authenticated;
 grant execute on function public.reorder_classwork_items(uuid, jsonb) to service_role;
 
+create or replace function public.reorder_assignments_preserve_materials(
+  p_classroom_id uuid,
+  p_assignment_ids jsonb
+)
+returns void as $$
+declare
+  submitted_count integer;
+  current_count integer;
+  next_position integer := 0;
+  submitted_assignment record;
+begin
+  if p_assignment_ids is null or jsonb_typeof(p_assignment_ids) <> 'array' then
+    raise exception 'assignment_ids must be an array' using errcode = '22023';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as submitted_position,
+      entry.value #>> '{}' as assignment_id,
+      jsonb_typeof(entry.value) as value_type
+    from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+  )
+  select count(*) into submitted_count
+  from submitted;
+
+  if exists (
+    with submitted as (
+      select
+        entry.value #>> '{}' as assignment_id,
+        jsonb_typeof(entry.value) as value_type
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    where value_type <> 'string'
+      or assignment_id is null
+      or assignment_id = ''
+  ) then
+    raise exception 'assignment_ids must include strings' using errcode = '22023';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    group by assignment_id
+    having count(*) > 1
+  ) then
+    raise exception 'assignment_ids must be unique' using errcode = '22023';
+  end if;
+
+  select count(*) into current_count
+  from public.assignments assignment
+  where assignment.classroom_id = p_classroom_id;
+
+  if submitted_count <> current_count then
+    raise exception 'Assignment list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from submitted
+    where not exists (
+      select 1
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+        and assignment.id::text = submitted.assignment_id
+    )
+  ) then
+    raise exception 'One or more assignments not found in classroom' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select entry.value #>> '{}' as assignment_id
+      from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    )
+    select 1
+    from public.assignments assignment
+    where assignment.classroom_id = p_classroom_id
+      and not exists (
+        select 1
+        from submitted
+        where submitted.assignment_id = assignment.id::text
+      )
+  ) then
+    raise exception 'Assignment list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  for submitted_assignment in
+    select
+      entry.value #>> '{}' as assignment_id
+    from jsonb_array_elements(p_assignment_ids) with ordinality as entry(value, ordinality)
+    order by entry.ordinality
+  loop
+    while exists (
+      select 1
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+        and material.position = next_position
+    ) or exists (
+      select 1
+      from public.surveys survey
+      where survey.classroom_id = p_classroom_id
+        and survey.position = next_position
+    ) loop
+      next_position := next_position + 1;
+    end loop;
+
+    update public.assignments assignment
+    set position = next_position
+    where assignment.classroom_id = p_classroom_id
+      and assignment.id::text = submitted_assignment.assignment_id;
+
+    next_position := next_position + 1;
+  end loop;
+end;
+$$ language plpgsql;
+
+revoke all on function public.reorder_assignments_preserve_materials(uuid, jsonb) from public, anon, authenticated;
+grant execute on function public.reorder_assignments_preserve_materials(uuid, jsonb) to service_role;
+
 alter table public.surveys enable row level security;
 alter table public.survey_questions enable row level security;
 alter table public.survey_responses enable row level security;

--- a/supabase/migrations/068_surveys_classwork.sql
+++ b/supabase/migrations/068_surveys_classwork.sql
@@ -1,0 +1,515 @@
+-- Add ungraded classwork surveys.
+-- Surveys live in the classwork stream beside assignments and materials, but
+-- they do not create gradebook records or correctness data.
+
+create table if not exists public.surveys (
+  id uuid primary key default gen_random_uuid(),
+  classroom_id uuid not null references public.classrooms (id) on delete cascade,
+  title text not null,
+  status text not null default 'draft' check (status in ('draft', 'active', 'closed')),
+  opens_at timestamptz,
+  show_results boolean not null default true,
+  dynamic_responses boolean not null default false,
+  position integer not null,
+  created_by uuid not null references public.users (id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_surveys_classroom_position
+  on public.surveys (classroom_id, position, created_at);
+
+create index if not exists idx_surveys_student_visible
+  on public.surveys (classroom_id, status, opens_at);
+
+create or replace function public.update_surveys_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_surveys_updated_at on public.surveys;
+create trigger update_surveys_updated_at
+  before update on public.surveys
+  for each row
+  execute function public.update_surveys_updated_at();
+
+create table if not exists public.survey_questions (
+  id uuid primary key default gen_random_uuid(),
+  survey_id uuid not null references public.surveys (id) on delete cascade,
+  question_type text not null default 'multiple_choice'
+    check (question_type in ('multiple_choice', 'short_text', 'link')),
+  question_text text not null,
+  options jsonb not null default '[]'::jsonb,
+  response_max_chars integer not null default 500
+    check (response_max_chars >= 1 and response_max_chars <= 5000),
+  position integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (
+    (
+      question_type = 'multiple_choice'
+      and jsonb_typeof(options) = 'array'
+      and jsonb_array_length(options) >= 2
+    )
+    or (
+      question_type in ('short_text', 'link')
+      and jsonb_typeof(options) = 'array'
+      and jsonb_array_length(options) = 0
+    )
+  )
+);
+
+create index if not exists idx_survey_questions_survey_position
+  on public.survey_questions (survey_id, position);
+
+create or replace function public.update_survey_questions_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_survey_questions_updated_at on public.survey_questions;
+create trigger update_survey_questions_updated_at
+  before update on public.survey_questions
+  for each row
+  execute function public.update_survey_questions_updated_at();
+
+create table if not exists public.survey_responses (
+  id uuid primary key default gen_random_uuid(),
+  survey_id uuid not null references public.surveys (id) on delete cascade,
+  question_id uuid not null references public.survey_questions (id) on delete cascade,
+  student_id uuid not null references public.users (id) on delete cascade,
+  selected_option integer check (selected_option is null or selected_option >= 0),
+  response_text text,
+  submitted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (question_id, student_id),
+  check (
+    selected_option is not null
+    or (response_text is not null and length(btrim(response_text)) > 0)
+  )
+);
+
+create index if not exists idx_survey_responses_survey_student
+  on public.survey_responses (survey_id, student_id);
+
+create index if not exists idx_survey_responses_question
+  on public.survey_responses (question_id);
+
+create or replace function public.update_survey_responses_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists update_survey_responses_updated_at on public.survey_responses;
+create trigger update_survey_responses_updated_at
+  before update on public.survey_responses
+  for each row
+  execute function public.update_survey_responses_updated_at();
+
+create or replace function public.set_survey_position()
+returns trigger as $$
+begin
+  if new.position is null then
+    select coalesce(max(existing.position), -1) + 1
+    into new.position
+    from (
+      select position
+      from public.assignments
+      where classroom_id = new.classroom_id
+
+      union all
+
+      select position
+      from public.classwork_materials
+      where classroom_id = new.classroom_id
+
+      union all
+
+      select position
+      from public.surveys
+      where classroom_id = new.classroom_id
+    ) existing;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_survey_position on public.surveys;
+create trigger set_survey_position
+  before insert on public.surveys
+  for each row
+  execute function public.set_survey_position();
+
+create or replace function public.set_classwork_material_position()
+returns trigger as $$
+begin
+  if new.position is null then
+    select coalesce(max(existing.position), -1) + 1
+    into new.position
+    from (
+      select position
+      from public.assignments
+      where classroom_id = new.classroom_id
+
+      union all
+
+      select position
+      from public.classwork_materials
+      where classroom_id = new.classroom_id
+
+      union all
+
+      select position
+      from public.surveys
+      where classroom_id = new.classroom_id
+    ) existing;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+create or replace function public.reorder_classwork_items(
+  p_classroom_id uuid,
+  p_items jsonb
+)
+returns void as $$
+declare
+  submitted_count integer;
+  current_count integer;
+begin
+  if p_items is null or jsonb_typeof(p_items) <> 'array' then
+    raise exception 'items must be an array' using errcode = '22023';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  select count(*) into submitted_count
+  from submitted;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    )
+    select 1
+    from submitted
+    where item_type not in ('assignment', 'material', 'survey')
+      or item_id is null
+      or item_id = ''
+  ) then
+    raise exception 'items must include type and id' using errcode = '22023';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    )
+    select 1
+    from submitted
+    group by item_type, item_id
+    having count(*) > 1
+  ) then
+    raise exception 'items must be unique' using errcode = '22023';
+  end if;
+
+  with current_items as (
+    select 'assignment'::text as item_type, assignment.id::text as item_id
+    from public.assignments assignment
+    where assignment.classroom_id = p_classroom_id
+
+    union all
+
+    select 'material'::text as item_type, material.id::text as item_id
+    from public.classwork_materials material
+    where material.classroom_id = p_classroom_id
+
+    union all
+
+    select 'survey'::text as item_type, survey.id::text as item_id
+    from public.surveys survey
+    where survey.classroom_id = p_classroom_id
+  )
+  select count(*) into current_count
+  from current_items;
+
+  if submitted_count <> current_count then
+    raise exception 'Classwork list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    ),
+    current_items as (
+      select 'assignment'::text as item_type, assignment.id::text as item_id
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+
+      union all
+
+      select 'material'::text as item_type, material.id::text as item_id
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+
+      union all
+
+      select 'survey'::text as item_type, survey.id::text as item_id
+      from public.surveys survey
+      where survey.classroom_id = p_classroom_id
+    )
+    select 1
+    from submitted
+    left join current_items using (item_type, item_id)
+    where current_items.item_id is null
+  ) then
+    raise exception 'One or more classwork items not found in classroom' using errcode = 'P0001';
+  end if;
+
+  if exists (
+    with submitted as (
+      select
+        entry.item->>'type' as item_type,
+        entry.item->>'id' as item_id
+      from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+    ),
+    current_items as (
+      select 'assignment'::text as item_type, assignment.id::text as item_id
+      from public.assignments assignment
+      where assignment.classroom_id = p_classroom_id
+
+      union all
+
+      select 'material'::text as item_type, material.id::text as item_id
+      from public.classwork_materials material
+      where material.classroom_id = p_classroom_id
+
+      union all
+
+      select 'survey'::text as item_type, survey.id::text as item_id
+      from public.surveys survey
+      where survey.classroom_id = p_classroom_id
+    )
+    select 1
+    from current_items
+    left join submitted using (item_type, item_id)
+    where submitted.item_id is null
+  ) then
+    raise exception 'Classwork list changed. Refresh and try again.' using errcode = 'P0001';
+  end if;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  update public.assignments assignment
+  set position = submitted.position
+  from submitted
+  where submitted.item_type = 'assignment'
+    and assignment.classroom_id = p_classroom_id
+    and assignment.id::text = submitted.item_id;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  update public.classwork_materials material
+  set position = submitted.position
+  from submitted
+  where submitted.item_type = 'material'
+    and material.classroom_id = p_classroom_id
+    and material.id::text = submitted.item_id;
+
+  with submitted as (
+    select
+      (entry.ordinality - 1)::integer as position,
+      entry.item->>'type' as item_type,
+      entry.item->>'id' as item_id
+    from jsonb_array_elements(p_items) with ordinality as entry(item, ordinality)
+  )
+  update public.surveys survey
+  set position = submitted.position
+  from submitted
+  where submitted.item_type = 'survey'
+    and survey.classroom_id = p_classroom_id
+    and survey.id::text = submitted.item_id;
+end;
+$$ language plpgsql;
+
+revoke all on function public.reorder_classwork_items(uuid, jsonb) from public, anon, authenticated;
+grant execute on function public.reorder_classwork_items(uuid, jsonb) to service_role;
+
+alter table public.surveys enable row level security;
+alter table public.survey_questions enable row level security;
+alter table public.survey_responses enable row level security;
+
+drop policy if exists "Teachers can manage surveys" on public.surveys;
+create policy "Teachers can manage surveys"
+  on public.surveys for all
+  using (
+    exists (
+      select 1
+      from public.classrooms
+      where classrooms.id = surveys.classroom_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.classrooms
+      where classrooms.id = surveys.classroom_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Students can view open or answered surveys" on public.surveys;
+create policy "Students can view open or answered surveys"
+  on public.surveys for select
+  using (
+    exists (
+      select 1
+      from public.classroom_enrollments
+      where classroom_enrollments.classroom_id = surveys.classroom_id
+        and classroom_enrollments.student_id = auth.uid()
+    )
+    and (
+      status = 'active'
+      or exists (
+        select 1
+        from public.survey_responses
+        where survey_responses.survey_id = surveys.id
+          and survey_responses.student_id = auth.uid()
+      )
+    )
+  );
+
+drop policy if exists "Teachers can manage survey questions" on public.survey_questions;
+create policy "Teachers can manage survey questions"
+  on public.survey_questions for all
+  using (
+    exists (
+      select 1
+      from public.surveys
+      join public.classrooms on classrooms.id = surveys.classroom_id
+      where surveys.id = survey_questions.survey_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.surveys
+      join public.classrooms on classrooms.id = surveys.classroom_id
+      where surveys.id = survey_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Students can view survey questions" on public.survey_questions;
+create policy "Students can view survey questions"
+  on public.survey_questions for select
+  using (
+    exists (
+      select 1
+      from public.surveys
+      join public.classroom_enrollments on classroom_enrollments.classroom_id = surveys.classroom_id
+      where surveys.id = survey_questions.survey_id
+        and classroom_enrollments.student_id = auth.uid()
+        and (
+          surveys.status = 'active'
+          or exists (
+            select 1
+            from public.survey_responses
+            where survey_responses.survey_id = surveys.id
+              and survey_responses.student_id = auth.uid()
+          )
+        )
+    )
+  );
+
+drop policy if exists "Teachers can view survey responses" on public.survey_responses;
+create policy "Teachers can view survey responses"
+  on public.survey_responses for select
+  using (
+    exists (
+      select 1
+      from public.surveys
+      join public.classrooms on classrooms.id = surveys.classroom_id
+      where surveys.id = survey_responses.survey_id
+        and classrooms.teacher_id = auth.uid()
+    )
+  );
+
+drop policy if exists "Students can view their own survey responses" on public.survey_responses;
+create policy "Students can view their own survey responses"
+  on public.survey_responses for select
+  using (student_id = auth.uid());
+
+drop policy if exists "Students can create survey responses" on public.survey_responses;
+create policy "Students can create survey responses"
+  on public.survey_responses for insert
+  with check (
+    student_id = auth.uid()
+    and exists (
+      select 1
+      from public.surveys
+      join public.classroom_enrollments on classroom_enrollments.classroom_id = surveys.classroom_id
+      where surveys.id = survey_id
+        and classroom_enrollments.student_id = auth.uid()
+        and surveys.status = 'active'
+    )
+  );
+
+drop policy if exists "Students can update dynamic survey responses" on public.survey_responses;
+create policy "Students can update dynamic survey responses"
+  on public.survey_responses for update
+  using (
+    student_id = auth.uid()
+    and exists (
+      select 1
+      from public.surveys
+      where surveys.id = survey_responses.survey_id
+        and surveys.status = 'active'
+        and surveys.dynamic_responses
+    )
+  )
+  with check (
+    student_id = auth.uid()
+    and exists (
+      select 1
+      from public.surveys
+      where surveys.id = survey_id
+        and surveys.status = 'active'
+        and surveys.dynamic_responses
+    )
+  );

--- a/tests/api/student/surveys-route.test.ts
+++ b/tests/api/student/surveys-route.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET as GET_SURVEY } from '@/app/api/student/surveys/[id]/route'
+import { GET as GET_SURVEY_RESULTS } from '@/app/api/student/surveys/[id]/results/route'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'student-1',
+    email: 'student1@example.com',
+    role: 'student',
+  })),
+}))
+
+vi.mock('@/lib/server/surveys', () => ({
+  assertStudentCanAccessSurvey: vi.fn(async () => ({
+    ok: true,
+    survey: {
+      id: 'survey-1',
+      classroom_id: 'classroom-1',
+      title: 'Game Jam Links',
+      status: 'active',
+      opens_at: null,
+      show_results: true,
+      dynamic_responses: true,
+      position: 0,
+      created_by: 'teacher-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      classrooms: {
+        id: 'classroom-1',
+        teacher_id: 'teacher-1',
+        archived_at: null,
+      },
+    },
+  })),
+}))
+
+describe('GET /api/student/surveys/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves link response discriminants in the student response map', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_responses') {
+        const responseFilter: any = {
+          eq: vi.fn(() => responseFilter),
+        }
+        responseFilter.eq
+          .mockReturnValueOnce(responseFilter)
+          .mockResolvedValueOnce({
+            data: [
+              { question_id: 'link-question', selected_option: null, response_text: 'https://example.com/game' },
+              { question_id: 'text-question', selected_option: null, response_text: 'Built in Godot' },
+            ],
+            error: null,
+          })
+        return {
+          select: vi.fn(() => responseFilter),
+        }
+      }
+
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'link-question',
+                  survey_id: 'survey-1',
+                  question_type: 'link',
+                  question_text: 'Share your game',
+                  options: [],
+                  response_max_chars: 2048,
+                  position: 0,
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  id: 'text-question',
+                  survey_id: 'survey-1',
+                  question_type: 'short_text',
+                  question_text: 'What did you build?',
+                  options: [],
+                  response_max_chars: 500,
+                  position: 1,
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET_SURVEY(
+      new NextRequest('http://localhost:3000/api/student/surveys/survey-1'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.student_responses['link-question']).toEqual({
+      question_type: 'link',
+      response_text: 'https://example.com/game',
+    })
+    expect(data.student_responses['text-question']).toEqual({
+      question_type: 'short_text',
+      response_text: 'Built in Godot',
+    })
+  })
+})
+
+describe('GET /api/student/surveys/[id]/results', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('omits classmate student ids from text and link result payloads', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockResolvedValue({ data: [{ id: 'own-response' }], error: null }),
+              }
+            }
+
+            if (columns === '*') {
+              return {
+                eq: vi.fn().mockResolvedValue({
+                  data: [
+                    {
+                      id: 'response-1',
+                      survey_id: 'survey-1',
+                      question_id: 'link-question',
+                      student_id: 'student-1',
+                      selected_option: null,
+                      response_text: 'https://example.com/game',
+                      submitted_at: '2026-01-01T00:00:00.000Z',
+                      updated_at: '2026-01-01T00:00:00.000Z',
+                    },
+                    {
+                      id: 'response-2',
+                      survey_id: 'survey-1',
+                      question_id: 'link-question',
+                      student_id: 'student-2',
+                      selected_option: null,
+                      response_text: 'https://example.com/other-game',
+                      submitted_at: '2026-01-02T00:00:00.000Z',
+                      updated_at: '2026-01-02T00:00:00.000Z',
+                    },
+                    {
+                      id: 'response-3',
+                      survey_id: 'survey-1',
+                      question_id: 'text-question',
+                      student_id: 'student-1',
+                      selected_option: null,
+                      response_text: 'Built in Godot',
+                      submitted_at: '2026-01-03T00:00:00.000Z',
+                      updated_at: '2026-01-03T00:00:00.000Z',
+                    },
+                    {
+                      id: 'response-4',
+                      survey_id: 'survey-1',
+                      question_id: 'text-question',
+                      student_id: 'student-2',
+                      selected_option: null,
+                      response_text: 'Built in Phaser',
+                      submitted_at: '2026-01-04T00:00:00.000Z',
+                      updated_at: '2026-01-04T00:00:00.000Z',
+                    },
+                  ],
+                  error: null,
+                }),
+              }
+            }
+
+            throw new Error(`Unexpected survey_responses columns: ${columns}`)
+          }),
+        }
+      }
+
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'link-question',
+                  survey_id: 'survey-1',
+                  question_type: 'link',
+                  question_text: 'Share your game',
+                  options: [],
+                  response_max_chars: 2048,
+                  position: 0,
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  id: 'text-question',
+                  survey_id: 'survey-1',
+                  question_type: 'short_text',
+                  question_text: 'What did you build?',
+                  options: [],
+                  response_max_chars: 500,
+                  position: 1,
+                  created_at: '2026-01-01T00:00:00.000Z',
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET_SURVEY_RESULTS(
+      new NextRequest('http://localhost:3000/api/student/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0].responses).toEqual([
+      {
+        response_id: 'response-1',
+        response_text: 'https://example.com/game',
+        submitted_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        response_id: 'response-2',
+        response_text: 'https://example.com/other-game',
+        submitted_at: '2026-01-02T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+      },
+    ])
+    expect(data.results[1].responses).toEqual([
+      {
+        response_id: 'response-3',
+        response_text: 'Built in Godot',
+        submitted_at: '2026-01-03T00:00:00.000Z',
+        updated_at: '2026-01-03T00:00:00.000Z',
+      },
+      {
+        response_id: 'response-4',
+        response_text: 'Built in Phaser',
+        submitted_at: '2026-01-04T00:00:00.000Z',
+        updated_at: '2026-01-04T00:00:00.000Z',
+      },
+    ])
+  })
+})

--- a/tests/api/teacher/assignments-bulk.test.ts
+++ b/tests/api/teacher/assignments-bulk.test.ts
@@ -291,7 +291,7 @@ describe('POST /api/teacher/assignments/bulk', () => {
     expect(data.created).toBe(0)
   })
 
-  it('should preserve material positions when saving assignment markdown', async () => {
+  it('should preserve material and survey positions when saving assignment markdown', async () => {
     const updates: Array<{ id: string; payload: Record<string, any> }> = []
 
     const mockFrom = vi.fn((table: string) => {
@@ -331,6 +331,17 @@ describe('POST /api/teacher/assignments/bulk', () => {
         }
       }
 
+      if (table === 'surveys') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ position: 2 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table: ${table}`)
     })
     ;(mockSupabaseClient.from as any) = mockFrom
@@ -352,7 +363,7 @@ describe('POST /api/teacher/assignments/bulk', () => {
     expect(response.status).toBe(200)
     expect(updates.map((update) => ({ id: update.id, position: update.payload.position }))).toEqual([
       { id: 'a-2', position: 0 },
-      { id: 'a-1', position: 2 },
+      { id: 'a-1', position: 3 },
     ])
   })
 

--- a/tests/api/teacher/assignments.test.ts
+++ b/tests/api/teacher/assignments.test.ts
@@ -289,6 +289,20 @@ describe('POST /api/teacher/assignments', () => {
         }
       }
 
+      if (table === 'surveys') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -330,6 +344,20 @@ describe('POST /api/teacher/assignments', () => {
               order: vi.fn(() => ({
                 limit: vi.fn(() => ({
                   maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: 'database unavailable' } }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'surveys') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
                 })),
               })),
             })),

--- a/tests/api/teacher/materials.test.ts
+++ b/tests/api/teacher/materials.test.ts
@@ -107,6 +107,19 @@ describe('POST /api/teacher/classrooms/[id]/materials', () => {
           insert,
         }
       }
+      if (table === 'surveys') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                })),
+              })),
+            })),
+          })),
+        }
+      }
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -157,6 +170,19 @@ describe('POST /api/teacher/classrooms/[id]/materials', () => {
             })),
           })),
           insert,
+        }
+      }
+      if (table === 'surveys') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                })),
+              })),
+            })),
+          })),
         }
       }
       throw new Error(`Unexpected table: ${table}`)

--- a/tests/api/teacher/surveys-questions-id.test.ts
+++ b/tests/api/teacher/surveys-questions-id.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PATCH } from '@/app/api/teacher/surveys/[id]/questions/[qid]/route'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/surveys', () => ({
+  assertTeacherOwnsSurvey: vi.fn(async () => ({
+    ok: true,
+    survey: { id: 'survey-1', title: 'Survey', classroom_id: 'classroom-1', classrooms: { archived_at: null } },
+  })),
+}))
+
+describe('PATCH /api/teacher/surveys/[id]/questions/[qid]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates survey question content and markdown position', async () => {
+    const updateSpy = vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'question-1',
+              question_type: 'multiple_choice',
+              question_text: 'Updated prompt',
+              options: ['A', 'B'],
+              response_max_chars: 500,
+              position: 3,
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = vi.fn(() => {
+      const selectQuery: any = {
+        eq: vi.fn(() => selectQuery),
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: 'question-1',
+            survey_id: 'survey-1',
+            question_type: 'multiple_choice',
+            question_text: 'Prompt',
+            options: ['A', 'B'],
+            response_max_chars: 500,
+            position: 0,
+          },
+          error: null,
+        }),
+      }
+
+      return {
+        select: vi.fn(() => selectQuery),
+        update: updateSpy,
+      }
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/questions/question-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          question_text: ' Updated prompt ',
+          options: [' A ', 'B'],
+          position: 3,
+        }),
+      }),
+      { params: Promise.resolve({ id: 'survey-1', qid: 'question-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateSpy).toHaveBeenCalledWith({
+      question_type: 'multiple_choice',
+      question_text: 'Updated prompt',
+      options: ['A', 'B'],
+      response_max_chars: 500,
+      position: 3,
+    })
+  })
+})

--- a/tests/api/teacher/surveys-questions-route.test.ts
+++ b/tests/api/teacher/surveys-questions-route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/surveys/[id]/questions/route'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/surveys', () => ({
+  assertTeacherOwnsSurvey: vi.fn(async () => ({
+    ok: true,
+    survey: { id: 'survey-1', title: 'Survey', classroom_id: 'classroom-1', classrooms: { archived_at: null } },
+  })),
+}))
+
+describe('POST /api/teacher/surveys/[id]/questions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a question at an explicit markdown position', async () => {
+    const insertSpy = vi.fn((payload: Record<string, unknown>) => ({
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({ data: { id: 'question-1', ...payload }, error: null }),
+      })),
+    }))
+    ;(mockSupabaseClient.from as any) = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn(() => ({
+          limit: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { position: 7 }, error: null }),
+          })),
+        })),
+      })),
+      insert: insertSpy,
+    }))
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/questions', {
+        method: 'POST',
+        body: JSON.stringify({
+          question_type: 'link',
+          question_text: 'Share your game',
+          options: [],
+          response_max_chars: 2048,
+          position: 2,
+        }),
+      }),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+
+    expect(response.status).toBe(201)
+    expect(insertSpy).toHaveBeenCalledWith({
+      survey_id: 'survey-1',
+      question_type: 'link',
+      question_text: 'Share your game',
+      options: [],
+      response_max_chars: 2048,
+      position: 2,
+    })
+  })
+})

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -490,6 +490,131 @@ describe('QuizDetailPanel', () => {
       expect(screen.queryByText('Markdown')).not.toBeInTheDocument()
     })
 
+    it('renders quizzes in editor-only mode without test documents', async () => {
+      mockFetchForQuiz(sampleQuestions)
+      const quiz = makeQuizWithStats({
+        title: 'Quiz Editor Modal',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={quiz}
+          classroomId="classroom-1"
+          onQuizUpdate={vi.fn()}
+          assessmentQuestionLayout="editor-only"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByTestId('quiz-editor-only-layout')).toBeInTheDocument()
+      const editorPane = screen.getByTestId('quiz-question-editor-pane')
+      expect(editorPane).toBeInTheDocument()
+      expect(screen.queryByTestId('test-documents-card')).not.toBeInTheDocument()
+      expect(within(editorPane).getByText('2 questions')).toBeInTheDocument()
+      expect(within(editorPane).getByRole('button', { name: 'Add Question' })).toBeInTheDocument()
+    })
+
+    it('renders quizzes in markdown-only mode and saves through the quiz draft endpoint', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Quiz Markdown Modal',
+                show_results: false,
+                questions: sampleQuestions,
+              },
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            draft: {
+              version: 2,
+              content: {
+                title: 'Quiz Markdown Modal Updated',
+                show_results: true,
+                questions: [
+                  {
+                    id: '33333333-3333-4333-8333-333333333333',
+                    question_text: 'Updated quiz prompt?',
+                    options: ['A', 'B'],
+                  },
+                ],
+                source_format: 'markdown',
+              },
+            },
+          }),
+        })
+
+      const quiz = makeQuizWithStats({
+        id: 'quiz-markdown-modal-id',
+        title: 'Quiz Markdown Modal',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={quiz}
+          classroomId="classroom-1"
+          onQuizUpdate={vi.fn()}
+          assessmentQuestionLayout="markdown-only"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByTestId('quiz-markdown-only-layout')).toBeInTheDocument()
+      const markdownEditor = screen.getByTestId('quiz-markdown-editor') as HTMLTextAreaElement
+      expect(markdownEditor.value).toContain('Quiz Markdown Modal')
+      expect(markdownEditor).toHaveProperty('readOnly', false)
+
+      fireEvent.change(markdownEditor, {
+        target: {
+          value: `# Quiz
+Title: Quiz Markdown Modal Updated
+Show Results: true
+
+## Questions
+### Question 1
+Prompt:
+Updated quiz prompt?
+Options:
+- A
+- B
+`,
+        },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Apply Markdown' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Markdown applied')).toBeInTheDocument()
+      })
+
+      const patchCall = fetchMock.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' &&
+          call[0].includes('/api/teacher/quizzes/quiz-markdown-modal-id/draft') &&
+          call[1]?.method === 'PATCH'
+      )
+      expect(patchCall).toBeTruthy()
+      const body = JSON.parse(patchCall?.[1]?.body ?? '{}')
+      expect(body.content.title).toBe('Quiz Markdown Modal Updated')
+      expect(body.content.show_results).toBe(true)
+      expect(body.content.questions).toHaveLength(1)
+      expect(body.content.source_format).toBe('markdown')
+      expect(body.content.source_markdown).toContain('Updated quiz prompt?')
+      expect(body.documents).toBeUndefined()
+    })
+
     it('cleans up interrupted summary-detail drags and resets on double click', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({

--- a/tests/components/SurveyModal.test.tsx
+++ b/tests/components/SurveyModal.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SurveyModal } from '@/components/surveys/SurveyModal'
+import type { Survey } from '@/types'
+
+function makeSurvey(overrides: Partial<Survey> = {}): Survey {
+  return {
+    id: 'survey-1',
+    classroom_id: 'classroom-1',
+    title: 'Resource Links',
+    status: 'draft',
+    opens_at: null,
+    show_results: true,
+    dynamic_responses: false,
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SurveyModal', () => {
+  it('uses the shared full-screen assessment setup chrome when creating a survey', () => {
+    render(
+      <SurveyModal
+        isOpen={true}
+        classroomId="classroom-1"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'New Survey' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter survey title')).toBeInTheDocument()
+    expect(screen.getByLabelText('Show class results to students after they respond')).toBeInTheDocument()
+    expect(screen.getByLabelText('Dynamic responses: students can update answers while open')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveClass('max-w-none')
+  })
+
+  it('keeps settings edits compact while using the same setup shell', () => {
+    render(
+      <SurveyModal
+        isOpen={true}
+        classroomId="classroom-1"
+        survey={makeSurvey({ title: 'Game Jam Links', dynamic_responses: true })}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Edit Survey' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Game Jam Links')).toHaveAttribute('placeholder', 'Enter survey title')
+    expect(screen.getByRole('dialog')).toHaveClass('max-w-md')
+  })
+})

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -74,6 +74,13 @@ vi.mock('@/ui', () => ({
       </div>
     ) : null
   ),
+  DialogPanel: ({ isOpen, children }: any) => (
+    isOpen ? (
+      <div role="dialog">
+        {children}
+      </div>
+    ) : null
+  ),
   FormField: ({ label, children }: any) => (
     <label>
       <span>{label}</span>

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
-import type { Classroom, ClassworkMaterial } from '@/types'
+import type { Classroom, ClassworkMaterial, SurveyWithStats } from '@/types'
 
 const mockFetchJSONWithCache = vi.fn()
 const mockInvalidateCachedJSON = vi.fn()
@@ -185,6 +185,17 @@ vi.mock('@/components/SortableAssignmentCard', () => ({
           Delete
         </button>
       ) : null}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/surveys/TeacherSurveyWorkspace', () => ({
+  TeacherSurveyWorkspace: ({ surveyId, onBack }: any) => (
+    <div data-testid="mock-survey-workspace">
+      Survey workspace {surveyId}
+      <button type="button" onClick={onBack}>
+        Close survey workspace
+      </button>
     </div>
   ),
 }))
@@ -407,6 +418,24 @@ function makeMaterialSummary(id: string, title: string, overrides: Partial<Class
     created_by: 'teacher-1',
     created_at: '2026-04-01T12:00:00Z',
     updated_at: '2026-04-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeSurveySummary(id: string, title: string, overrides: Partial<SurveyWithStats> = {}): SurveyWithStats {
+  return {
+    id,
+    classroom_id: classroom.id,
+    title,
+    status: 'draft',
+    opens_at: null,
+    show_results: true,
+    dynamic_responses: false,
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2026-04-01T12:00:00Z',
+    updated_at: '2026-04-01T12:00:00Z',
+    stats: { total_students: 2, responded: 0, questions_count: 0 },
     ...overrides,
   }
 }
@@ -646,6 +675,89 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByRole('button', { name: 'Drag to reorder material' })).toBeInTheDocument()
     expect(materialButton.querySelector('.border-l-2')).not.toBeInTheDocument()
     expect(materialButton.closest('.bg-info-bg')).not.toHaveClass('border-primary/40')
+  })
+
+  it('opens a survey in a modal instead of replacing the classwork pane', async () => {
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-1', 'Assignment One', { position: 1 }),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({
+          surveys: [
+            makeSurveySummary('survey-1', 'Game Jam Links', { position: 2 }),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
+    })
+    const updateSearchParams = vi.fn()
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId={null}
+        updateSearchParams={updateSearchParams}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Game Jam Links' }))
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Survey workspace survey-1')
+    expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+
+    const { params } = applySearchParamsUpdate(updateSearchParams.mock.calls[0])
+    expect(params.get('tab')).toBe('assignments')
+    expect(params.get('surveyId')).toBe('survey-1')
+    expect(params.get('assignmentId')).toBeNull()
+  })
+
+  it('opens a routed survey selection as a modal over the classwork summary', async () => {
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-1', 'Assignment One'),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({
+          surveys: [
+            makeSurveySummary('survey-1', 'Game Jam Links'),
+          ],
+        })
+      }
+      if (key === `class-days:${classroom.id}`) {
+        return Promise.resolve({ class_days: [] })
+      }
+      return fetcher()
+    })
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedSurveyId="survey-1"
+      />,
+    )
+
+    expect(await screen.findByRole('dialog')).toHaveTextContent('Survey workspace survey-1')
+    expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
   })
 
   it('exits assignment edit mode when the create assignment modal closes', async () => {

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -47,12 +47,15 @@ vi.mock('@/components/QuizDetailPanel', () => ({
   QuizDetailPanel: ({
     quiz,
     onQuizUpdate,
+    assessmentQuestionLayout,
   }: {
     quiz: QuizWithStats
     onQuizUpdate?: () => void
+    assessmentQuestionLayout?: 'stacked' | 'summary-detail' | 'editor-only' | 'markdown-only'
   }) => (
     <div data-testid="mock-quiz-detail">
       Detail for {quiz.title}
+      <span data-testid="mock-quiz-detail-layout">{assessmentQuestionLayout || 'workspace'}</span>
       <button type="button" onClick={() => onQuizUpdate?.()}>
         Simulate quiz update
       </button>
@@ -192,6 +195,25 @@ describe('TeacherQuizzesTab', () => {
     expect(await screen.findByTestId('mock-quiz-detail')).toHaveTextContent('Detail for Loops Quiz')
     expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
     expect(setOpenMock).not.toHaveBeenCalledWith(true)
+  })
+
+  it('opens the quiz editor modal with an editor/code toggle', async () => {
+    mockQuizzesResponse([makeQuiz({ id: 'quiz-1', title: 'Loops Quiz' })])
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Loops Quiz'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit Quiz' }))
+
+    expect(await screen.findByRole('dialog', { name: 'Edit Loops Quiz' })).toBeInTheDocument()
+    expect(screen.getAllByTestId('mock-quiz-detail-layout').map((item) => item.textContent)).toContain('editor-only')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Code' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('mock-quiz-detail-layout').map((item) => item.textContent)).toContain(
+        'markdown-only'
+      )
+    })
   })
 
   it('reports quiz selection through search params', async () => {

--- a/tests/components/TeacherSurveyWorkspace.test.tsx
+++ b/tests/components/TeacherSurveyWorkspace.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { TeacherSurveyWorkspace } from '@/components/surveys/TeacherSurveyWorkspace'
+import type { Survey } from '@/types'
+
+function makeSurvey(overrides: Partial<Survey> = {}): Survey {
+  return {
+    id: 'survey-1',
+    classroom_id: 'classroom-1',
+    title: 'Game Jam Links',
+    status: 'draft',
+    opens_at: null,
+    show_results: true,
+    dynamic_responses: true,
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('TeacherSurveyWorkspace', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/results')) {
+        return {
+          ok: true,
+          json: async () => ({
+            results: [],
+            stats: { total_students: 0, responded: 0 },
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          survey: makeSurvey(),
+          questions: [],
+        }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('can open a newly created survey directly into code authoring mode', async () => {
+    const onInitialEditModeConsumed = vi.fn()
+
+    render(
+      <TeacherSurveyWorkspace
+        classroomId="classroom-1"
+        surveyId="survey-1"
+        initialEditMode="markdown"
+        onInitialEditModeConsumed={onInitialEditModeConsumed}
+        onBack={vi.fn()}
+        onSurveyUpdated={vi.fn()}
+        onSurveyDeleted={vi.fn()}
+      />
+    )
+
+    const editor = await screen.findByTestId('survey-markdown-editor')
+    const editorValue = (editor as HTMLTextAreaElement).value
+
+    expect(editorValue).toContain('# Survey')
+    expect(editorValue).toContain('Dynamic Responses: true')
+    await waitFor(() => {
+      expect(onInitialEditModeConsumed).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/tests/lib/classwork-order.test.ts
+++ b/tests/lib/classwork-order.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { buildOrderedClassworkItems } from '@/lib/classwork-order'
 
 describe('buildOrderedClassworkItems', () => {
-  it('interleaves assignments and materials by shared position', () => {
+  it('interleaves assignments, materials, and surveys by shared position', () => {
     const items = buildOrderedClassworkItems(
       [
         { id: 'a-1', title: 'Essay', position: 2, created_at: '2026-01-02T00:00:00.000Z' },
-        { id: 'a-2', title: 'Reflection', position: 4, created_at: '2026-01-04T00:00:00.000Z' },
+        { id: 'a-2', title: 'Reflection', position: 5, created_at: '2026-01-04T00:00:00.000Z' },
       ],
       [
         { id: 'm-1', title: 'Reading', position: 1, created_at: '2026-01-01T00:00:00.000Z' },
         { id: 'm-2', title: 'Example', position: 3, created_at: '2026-01-03T00:00:00.000Z' },
+      ],
+      [
+        { id: 's-1', title: 'Project links', position: 4, created_at: '2026-01-03T12:00:00.000Z' },
       ],
     )
 
@@ -18,6 +21,7 @@ describe('buildOrderedClassworkItems', () => {
       'material:m-1',
       'assignment:a-1',
       'material:m-2',
+      'survey:s-1',
       'assignment:a-2',
     ])
   })

--- a/tests/lib/quiz-markdown.test.ts
+++ b/tests/lib/quiz-markdown.test.ts
@@ -40,7 +40,7 @@ Options:
     const result = markdownToQuiz(markdown)
 
     expect(result.errors).toEqual([])
-    expect(result.draftContent).toEqual({
+    expect(result.draftContent).toMatchObject({
       title: 'Intro Quiz',
       show_results: true,
       questions: [
@@ -51,6 +51,8 @@ Options:
         },
       ],
     })
+    expect(result.draftContent?.source_format).toBe('markdown')
+    expect(result.draftContent?.source_markdown).toContain('Title: Intro Quiz')
   })
 
   it('returns actionable errors for invalid markdown', () => {
@@ -67,7 +69,7 @@ Options:
 
     expect(result.draftContent).toBeNull()
     expect(result.errors).toContain('Question 1: Prompt is required')
-    expect(result.errors).toContain('Question 1: At least 2 options are required')
+    expect(result.errors).toContain('Question 1: At least 2 options required')
     expect(result.errors).toContain('Title is required')
   })
 })

--- a/tests/unit/classwork-migration-rpc-grants.test.ts
+++ b/tests/unit/classwork-migration-rpc-grants.test.ts
@@ -12,17 +12,29 @@ function readMigration(relativePath: string) {
 describe('classwork mixed ordering migration', () => {
   it('keeps reorder RPCs behind the service-role API boundary', () => {
     const migration = readMigration('supabase/migrations/067_classwork_mixed_ordering.sql')
+    const surveyMigration = readMigration('supabase/migrations/068_surveys_classwork.sql')
 
     for (const functionName of [
       'reorder_classwork_items',
       'reorder_assignments_preserve_materials',
     ]) {
-      expect(migration).toContain(
+      const migrationText =
+        functionName === 'reorder_classwork_items' ? `${migration}\n${surveyMigration}` : migration
+
+      expect(migrationText).toContain(
         `revoke all on function public.${functionName}(uuid, jsonb) from public, anon, authenticated;`,
       )
-      expect(migration).toContain(
+      expect(migrationText).toContain(
         `grant execute on function public.${functionName}(uuid, jsonb) to service_role;`,
       )
     }
+  })
+
+  it('includes surveys in mixed classwork ordering', () => {
+    const migration = readMigration('supabase/migrations/068_surveys_classwork.sql')
+
+    expect(migration).toContain("item_type not in ('assignment', 'material', 'survey')")
+    expect(migration).toContain("select 'survey'::text as item_type")
+    expect(migration).toContain('update public.surveys survey')
   })
 })

--- a/tests/unit/classwork-migration-rpc-grants.test.ts
+++ b/tests/unit/classwork-migration-rpc-grants.test.ts
@@ -18,8 +18,7 @@ describe('classwork mixed ordering migration', () => {
       'reorder_classwork_items',
       'reorder_assignments_preserve_materials',
     ]) {
-      const migrationText =
-        functionName === 'reorder_classwork_items' ? `${migration}\n${surveyMigration}` : migration
+      const migrationText = `${migration}\n${surveyMigration}`
 
       expect(migrationText).toContain(
         `revoke all on function public.${functionName}(uuid, jsonb) from public, anon, authenticated;`,
@@ -36,5 +35,7 @@ describe('classwork mixed ordering migration', () => {
     expect(migration).toContain("item_type not in ('assignment', 'material', 'survey')")
     expect(migration).toContain("select 'survey'::text as item_type")
     expect(migration).toContain('update public.surveys survey')
+    expect(migration).toContain('create or replace function public.reorder_assignments_preserve_materials')
+    expect(migration).toContain('survey.position = next_position')
   })
 })

--- a/tests/unit/surveys.test.ts
+++ b/tests/unit/surveys.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeSurveyQuestionInput,
   validateSurveyResponses,
 } from '@/lib/surveys'
+import { markdownToSurvey, surveyToMarkdown } from '@/lib/survey-markdown'
 import type { Survey, SurveyQuestion, SurveyResponse } from '@/types'
 
 function makeSurvey(overrides: Partial<Survey> = {}): Survey {
@@ -143,5 +144,90 @@ describe('survey utilities', () => {
     expect(results[0].counts).toEqual([1, 1])
     expect(results[1].responses).toHaveLength(1)
     expect(results[1].responses[0].response_text).toBe('I found a resource')
+  })
+
+  it('serializes survey markdown with multiple-choice, text, and link questions', () => {
+    const markdown = surveyToMarkdown({
+      survey: makeSurvey({ title: 'Project links', show_results: true, dynamic_responses: true }),
+      questions: [
+        makeQuestion({ id: 'mc', question_type: 'multiple_choice', question_text: 'Pick one', options: ['A', 'B'] }),
+        makeQuestion({
+          id: 'link',
+          question_type: 'link',
+          question_text: 'Share your game',
+          options: [],
+          response_max_chars: 2048,
+        }),
+      ],
+    })
+
+    expect(markdown).toContain('Title: Project links')
+    expect(markdown).toContain('Dynamic Responses: true')
+    expect(markdown).toContain('Type: multiple_choice')
+    expect(markdown).toContain('Type: link')
+    expect(markdown).toContain('Max Chars: 2048')
+  })
+
+  it('parses survey markdown into editable survey content', () => {
+    const result = markdownToSurvey(`# Survey
+Title: Project links
+Show Results: true
+Dynamic Responses: true
+
+## Questions
+### Question 1
+ID: existing-mc
+Type: multiple choice
+Prompt:
+Which engine did you use?
+Options:
+- Godot
+- Unity
+
+### Question 2
+Type: link
+Prompt:
+Share your game.
+Max Chars: 2048
+`)
+
+    expect(result.errors).toEqual([])
+    expect(result.content).toEqual({
+      title: 'Project links',
+      show_results: true,
+      dynamic_responses: true,
+      questions: [
+        {
+          id: 'existing-mc',
+          question_type: 'multiple_choice',
+          question_text: 'Which engine did you use?',
+          options: ['Godot', 'Unity'],
+          response_max_chars: 500,
+        },
+        {
+          question_type: 'link',
+          question_text: 'Share your game.',
+          options: [],
+          response_max_chars: 2048,
+        },
+      ],
+    })
+  })
+
+  it('returns survey markdown validation errors', () => {
+    const result = markdownToSurvey(`# Survey
+Title:
+
+## Questions
+### Question 1
+Type: multiple_choice
+Prompt:
+Options:
+- Only one
+`)
+
+    expect(result.content).toBeNull()
+    expect(result.errors).toContain('Title is required')
+    expect(result.errors).toContain('Question 1: Question text is required')
   })
 })

--- a/tests/unit/surveys.test.ts
+++ b/tests/unit/surveys.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aggregateSurveyResults,
+  canStudentRespondToSurvey,
+  getStudentSurveyStatus,
+  normalizeSurveyQuestionInput,
+  validateSurveyResponses,
+} from '@/lib/surveys'
+import type { Survey, SurveyQuestion, SurveyResponse } from '@/types'
+
+function makeSurvey(overrides: Partial<Survey> = {}): Survey {
+  return {
+    id: 'survey-1',
+    classroom_id: 'classroom-1',
+    title: 'Project links',
+    status: 'active',
+    opens_at: '2026-01-01T00:00:00.000Z',
+    show_results: true,
+    dynamic_responses: false,
+    position: 0,
+    created_by: 'teacher-1',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeQuestion(overrides: Partial<SurveyQuestion> = {}): SurveyQuestion {
+  return {
+    id: 'question-1',
+    survey_id: 'survey-1',
+    question_type: 'multiple_choice',
+    question_text: 'Pick one',
+    options: ['A', 'B'],
+    response_max_chars: 500,
+    position: 0,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeResponse(overrides: Partial<SurveyResponse> = {}): SurveyResponse {
+  return {
+    id: 'response-1',
+    survey_id: 'survey-1',
+    question_id: 'question-1',
+    student_id: 'student-1',
+    selected_option: 0,
+    response_text: null,
+    submitted_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('survey utilities', () => {
+  it('allows dynamic surveys to be updated while open', () => {
+    const survey = makeSurvey({ dynamic_responses: true })
+
+    expect(canStudentRespondToSurvey(survey, true, new Date('2026-01-02T00:00:00.000Z'))).toBe(true)
+    expect(getStudentSurveyStatus(survey, true, new Date('2026-01-02T00:00:00.000Z'))).toBe('can_update')
+    expect(getStudentSurveyStatus({ ...survey, show_results: false }, true, new Date('2026-01-02T00:00:00.000Z'))).toBe('can_update')
+  })
+
+  it('shows results after a dynamic survey is closed', () => {
+    const survey = makeSurvey({ status: 'closed', dynamic_responses: true, show_results: true })
+
+    expect(getStudentSurveyStatus(survey, true, new Date('2026-01-02T00:00:00.000Z'))).toBe('can_view_results')
+  })
+
+  it('locks non-dynamic surveys after a response', () => {
+    const survey = makeSurvey({ dynamic_responses: false, show_results: false })
+
+    expect(canStudentRespondToSurvey(survey, true, new Date('2026-01-02T00:00:00.000Z'))).toBe(false)
+    expect(getStudentSurveyStatus(survey, true, new Date('2026-01-02T00:00:00.000Z'))).toBe('responded')
+  })
+
+  it('normalizes link questions without options', () => {
+    const result = normalizeSurveyQuestionInput({
+      question_type: 'link',
+      question_text: 'Share your game',
+      options: ['ignored'],
+    })
+
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.question.question_type).toBe('link')
+      expect(result.question.options).toEqual([])
+    }
+  })
+
+  it('validates multiple-choice, short-text, and link responses', () => {
+    const questions = [
+      makeQuestion({ id: 'mc', question_type: 'multiple_choice', options: ['Yes', 'No'] }),
+      makeQuestion({ id: 'text', question_type: 'short_text', options: [], response_max_chars: 20 }),
+      makeQuestion({ id: 'link', question_type: 'link', options: [], response_max_chars: 200 }),
+    ]
+
+    const result = validateSurveyResponses(questions, {
+      mc: { question_type: 'multiple_choice', selected_option: 1 },
+      text: { question_type: 'short_text', response_text: 'Looks good' },
+      link: { question_type: 'link', response_text: 'https://example.com/game' },
+    })
+
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.responses.link).toEqual({
+        question_type: 'link',
+        response_text: 'https://example.com/game',
+      })
+    }
+  })
+
+  it('rejects invalid link responses', () => {
+    const result = validateSurveyResponses(
+      [makeQuestion({ id: 'link', question_type: 'link', options: [] })],
+      { link: { question_type: 'link', response_text: 'not a url' } },
+    )
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('aggregates multiple-choice counts and text response lists', () => {
+    const questions = [
+      makeQuestion({ id: 'mc', options: ['A', 'B'] }),
+      makeQuestion({ id: 'text', question_type: 'short_text', options: [] }),
+    ]
+    const responses = [
+      makeResponse({ id: 'r1', question_id: 'mc', selected_option: 0 }),
+      makeResponse({ id: 'r2', question_id: 'mc', student_id: 'student-2', selected_option: 1 }),
+      makeResponse({
+        id: 'r3',
+        question_id: 'text',
+        student_id: 'student-1',
+        selected_option: null,
+        response_text: 'I found a resource',
+      }),
+    ]
+
+    const results = aggregateSurveyResults(questions, responses)
+
+    expect(results[0].counts).toEqual([1, 1])
+    expect(results[1].responses).toHaveLength(1)
+    expect(results[1].responses[0].response_text).toBe('I found a resource')
+  })
+})


### PR DESCRIPTION
## Summary

Adds Surveys as an ungraded Classwork item type for quick student responses and class-visible results.

- Adds teacher survey creation, settings, question editing, open/close/reopen, delete, and results views.
- Adds student survey cards, response forms, updateable dynamic responses, and class results after submission when enabled.
- Supports multiple choice, short text, and link questions with shared validation and URL normalization.
- Extends mixed Classwork ordering so assignments, materials, and surveys share positions.
- Adds Supabase migration `068_surveys_classwork.sql` for surveys, questions, responses, RLS, and classwork reorder support.

## Review Notes

- Self-review caught and fixed dynamic survey status priority: dynamic surveys now remain updateable even when class results are visible.
- Migration naming was resequenced after rebasing onto `origin/main`; `068_surveys_classwork.sql` follows `067_classwork_mixed_ordering.sql` and duplicate prefix check is clean.
- Existing assignment/material creation tolerates the surveys endpoint/table being unavailable before the migration is applied.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test tests/unit/surveys.test.ts tests/lib/classwork-order.test.ts tests/unit/classwork-migration-rpc-grants.test.ts`
- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/surveys.test.ts`
- `pnpm test tests/unit/surveys.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm lint`
- `pnpm test -- --maxWorkers=4` (261 files, 2208 tests)
- `pnpm build`
- `git diff --cached --check`
- `git rev-list --left-right --count origin/main...HEAD` -> `0 0` before commit
- Migration prefix duplicate check returned no duplicates
- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
- UI verification screenshots for teacher/student Classwork and mocked survey states

## Deployment Notes

Apply `supabase/migrations/068_surveys_classwork.sql` before relying on survey storage in shared environments.