### PR TITLE
[codex] Fix test grading student keyboard navigation

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-09 — Daily log summary collapse
-
-**Completed:**
-- Removed the Daily tab floating action cluster show/hide button for the class log summary.
-- Changed the class log summary from hidden/shown to expanded/collapsed states.
-- Double-clicking the bottom summary panel collapses it to a 40px bar labeled `Log Summary`.
-- Double-clicking the collapsed bar restores the summary to the standard 180px height.
-- Preserved handle resizing, including dragging upward from the collapsed bar to reopen and resize the panel.
-- Added focused component coverage for double-click collapse/restore and drag-reopen behavior.
-
-**Validation:**
-- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance'`
-- Targeted visual captures:
-  - `/tmp/pika-daily-log-summary-collapsed.png`
-  - `/tmp/pika-daily-log-summary-drag-reopened.png`
-- `pnpm build`
-
 ## 2026-05-10 — Submitted-aware test unsubmit action
 
 **Completed:**
@@ -348,4 +329,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-pane-scroll bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests&testId=92120fed-7145-4118-a8ad-117e7962d679&testMode=grading&testStudentId=23977f0b-efb8-4408-98cb-2e6887c4fd7e'`
 - DOM scroll check: window stayed at `scrollY=0`, left table pane filled the workspace, right inspector reported `overflow-y: auto` with independent scroll.
 - Temporary sample tests were seeded for the visual capture and removed afterward; the shared classroom test list returned to empty.
+- `pnpm test`
+
+## 2026-05-13 — Teacher test student arrow navigation
+
+**Completed:**
+- Put the selected teacher test grading student list on the shared `KeyboardNavigableTable` and `DataTable` primitives used by assignment student tables.
+- Extended `KeyboardNavigableTable` so it can own scroll-pane props like `className`, `data-testid`, and `onScroll` while preserving its arrow-key selection behavior.
+- Added regression coverage for moving the selected test student with ArrowDown and ArrowUp.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/DataTable.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
+- `pnpm lint`
+- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests&testId=88a8b3b5-7559-417e-8d16-c53175a3d692&testMode=grading&testStudentId=23977f0b-efb8-4408-98cb-2e6887c4fd7e'`
+- Browser smoke check: clicked the selected student row, pressed ArrowDown, and confirmed the URL, selected row, and grading inspector moved from Student1 to Student2.
+- Temporary verification test `88a8b3b5-7559-417e-8d16-c53175a3d692` was deleted after screenshots and browser checks.
+- `pnpm build`
 - `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -25,6 +25,15 @@ import {
   AssessmentStatusIndicator,
   getTestGradingWorkStatusDisplay,
 } from '@/components/AssessmentStatusIndicator'
+import {
+  DataTable,
+  DataTableBody,
+  DataTableCell,
+  DataTableHead,
+  DataTableHeaderCell,
+  DataTableRow,
+  KeyboardNavigableTable,
+} from '@/components/DataTable'
 import { TestStudentGradingPanel } from '@/components/TestStudentGradingPanel'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
@@ -1788,16 +1797,20 @@ export function TeacherTestsTab({
           tone="muted"
         />
       ) : (
-        <div
+        <KeyboardNavigableTable
           ref={gradingStudentTableScrollRef}
+          rowKeys={gradingRowIds}
+          selectedKey={selectedStudentId}
+          onSelectKey={selectGradingStudent}
+          onDeselect={() => selectGradingStudent(null)}
           className="min-h-0 w-full flex-1 overflow-auto rounded-md border border-border bg-surface"
           data-testid="test-grading-student-scroll-pane"
           onScroll={preserveGradingStudentTableScrollPosition}
         >
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-surface-hover text-left text-text-muted">
-                <th className="w-10 px-3 py-2 font-medium">
+          <DataTable density="tight" className="text-sm">
+            <DataTableHead>
+              <DataTableRow>
+                <DataTableHeaderCell className="w-10 px-3 py-2">
                   <input
                     type="checkbox"
                     checked={batchAllSelected}
@@ -1805,8 +1818,8 @@ export function TeacherTestsTab({
                     className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                     aria-label="Select all students"
                   />
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">
                   <button
                     type="button"
                     onClick={() => {
@@ -1824,16 +1837,16 @@ export function TeacherTestsTab({
                       {gradingSortColumn === 'last_name' ? 'Last' : 'First'}
                     </span>
                   </button>
-                </th>
-                <th className="px-3 py-2 font-medium">Status</th>
-                <th className="px-3 py-2 font-medium">Access</th>
-                <th className="px-3 py-2 font-medium">Score</th>
-                <th className="px-3 py-2 font-medium">
+                </DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">Status</DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">Access</DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">Score</DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">
                   <Tooltip content="Most recent recorded in-test activity time (Toronto).">
                     <span className="cursor-help">Last</span>
                   </Tooltip>
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">
                   <Tooltip
                     content={
                       <div className="space-y-0.5">
@@ -1848,17 +1861,17 @@ export function TeacherTestsTab({
                       <LogOut className="h-4 w-4" />
                     </span>
                   </Tooltip>
-                </th>
-                <th className="px-3 py-2 font-medium">
+                </DataTableHeaderCell>
+                <DataTableHeaderCell className="px-3 py-2">
                   <Tooltip content="Total time this student was away from the test route.">
                     <span className="inline-flex cursor-help items-center" aria-label="Away column">
                       <ClockAlert className="h-4 w-4" />
                     </span>
                   </Tooltip>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
+                </DataTableHeaderCell>
+              </DataTableRow>
+            </DataTableHead>
+            <DataTableBody>
               {sortedGradingStudents.map((student) => {
                 const isSelected = student.student_id === selectedStudentId
                 const scoreLabel =
@@ -1907,16 +1920,17 @@ export function TeacherTestsTab({
                   student.status === 'submitted' && !isReadOnly && !isCombinedTestActionsBusy
 
                 return (
-                  <tr
+                  <DataTableRow
                     key={student.student_id}
                     data-test-grading-student-row=""
+                    aria-selected={isSelected}
                     className={[
-                      'cursor-pointer border-t border-border transition-colors hover:bg-surface-hover',
-                      isSelected ? 'bg-surface-selected' : '',
+                      'cursor-pointer transition-colors',
+                      isSelected ? 'border-l-2 border-l-primary bg-surface-selected shadow-sm' : 'hover:bg-surface-hover',
                     ].join(' ')}
                     onClick={() => selectGradingStudent(student.student_id)}
                   >
-                    <td className="px-3 py-2">
+                    <DataTableCell className="px-3 py-2">
                       <input
                         type="checkbox"
                         checked={batchSelectedIds.has(student.student_id)}
@@ -1925,11 +1939,11 @@ export function TeacherTestsTab({
                         className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                         aria-label={`Select ${student.name || 'student'}`}
                       />
-                    </td>
-                    <td className="px-3 py-2">
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2">
                       <div className="font-medium text-text-default">{student.name || 'Student'}</div>
-                    </td>
-                    <td className="px-3 py-2">
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2">
                       {student.status === 'submitted' ? (
                         <Tooltip content={canUnsubmitStudent ? `${statusMeta.label}. Click to mark ${studentLabel} unsubmitted.` : statusMeta.label}>
                           <button
@@ -1956,8 +1970,8 @@ export function TeacherTestsTab({
                           </span>
                         </Tooltip>
                       )}
-                    </td>
-                    <td className="px-3 py-2">
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2">
                       <Tooltip content={`${accessTooltip}. ${accessActionTooltip}`}>
                         <button
                           type="button"
@@ -1972,9 +1986,9 @@ export function TeacherTestsTab({
                           <AccessIcon className={`h-4 w-4 ${accessIconClass}`} aria-hidden="true" />
                         </button>
                       </Tooltip>
-                    </td>
-                    <td className="px-3 py-2 text-text-default">{scoreLabel}</td>
-                    <td
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2 text-text-default">{scoreLabel}</DataTableCell>
+                    <DataTableCell
                       className={[
                         'px-3 py-2 tabular-nums',
                         formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
@@ -1990,8 +2004,8 @@ export function TeacherTestsTab({
                           {formattedLastActivity.value}
                         </span>
                       </Tooltip>
-                    </td>
-                    <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2 text-xs text-text-muted tabular-nums">
                       <Tooltip
                         content={
                           <div className="space-y-0.5">
@@ -2009,8 +2023,8 @@ export function TeacherTestsTab({
                           {exitsCount}
                         </span>
                       </Tooltip>
-                    </td>
-                    <td className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                    </DataTableCell>
+                    <DataTableCell className="px-3 py-2 text-xs text-text-muted tabular-nums">
                       <Tooltip content={`Away from test route for ${awayLabel} total.`}>
                         <span
                           className="cursor-help"
@@ -2019,13 +2033,13 @@ export function TeacherTestsTab({
                           {awayLabel}
                         </span>
                       </Tooltip>
-                    </td>
-                  </tr>
+                    </DataTableCell>
+                  </DataTableRow>
                 )
               })}
-            </tbody>
-          </table>
-        </div>
+            </DataTableBody>
+          </DataTable>
+        </KeyboardNavigableTable>
       )}
     </div>
   )

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1802,7 +1802,6 @@ export function TeacherTestsTab({
           rowKeys={gradingRowIds}
           selectedKey={selectedStudentId}
           onSelectKey={selectGradingStudent}
-          onDeselect={() => selectGradingStudent(null)}
           className="min-h-0 w-full flex-1 overflow-auto rounded-md border border-border bg-surface"
           data-testid="test-grading-student-scroll-pane"
           onScroll={preserveGradingStudentTableScrollPosition}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -211,14 +211,7 @@ export function EmptyStateRow({
  * Wrapper component that adds keyboard navigation (↑/↓ arrows) to a table.
  * Use this to wrap TableCard when you need row selection with keyboard support.
  */
-export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable<K extends string>({
-  children,
-  rowKeys,
-  selectedKey,
-  onSelectKey,
-  onDeselect,
-  wrap = true,
-}: {
+type KeyboardNavigableTableProps<K extends string> = {
   children: ReactNode
   /** Array of row keys in display order */
   rowKeys: K[]
@@ -230,7 +223,19 @@ export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable
   onDeselect?: () => void
   /** Whether to wrap around at the ends (default: true) */
   wrap?: boolean
-}, ref: Ref<HTMLDivElement>) {
+} & Omit<HTMLAttributes<HTMLDivElement>, 'onKeyDown' | 'onSelect'>
+
+export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable<K extends string>({
+  children,
+  rowKeys,
+  selectedKey,
+  onSelectKey,
+  onDeselect,
+  wrap = true,
+  className = '',
+  tabIndex,
+  ...props
+}: KeyboardNavigableTableProps<K>, ref: Ref<HTMLDivElement>) {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Escape' && selectedKey && onDeselect) {
@@ -275,20 +280,15 @@ export const KeyboardNavigableTable = forwardRef(function KeyboardNavigableTable
 
   return (
     <div
+      {...props}
       ref={ref}
-      tabIndex={0}
+      tabIndex={tabIndex ?? 0}
       onKeyDown={handleKeyDown}
-      className="rounded-card outline-none"
+      className={['rounded-card outline-none', className].filter(Boolean).join(' ')}
     >
       {children}
     </div>
   )
-}) as <K extends string>(props: {
-  children: ReactNode
-  rowKeys: K[]
-  selectedKey: K | null
-  onSelectKey: (key: K) => void
-  onDeselect?: () => void
-  wrap?: boolean
+}) as <K extends string>(props: KeyboardNavigableTableProps<K> & {
   ref?: Ref<HTMLDivElement>
 }) => ReactNode

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -204,6 +204,31 @@ function resultsFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   )
 }
 
+function makeGradingStudent(overrides: Record<string, unknown> = {}) {
+  return {
+    student_id: 'student-1',
+    name: 'Alice Zephyr',
+    first_name: 'Alice',
+    last_name: 'Zephyr',
+    email: 'alice@example.com',
+    status: 'submitted',
+    submitted_at: null,
+    last_activity_at: '2026-04-17T18:15:00.000Z',
+    points_earned: 3,
+    points_possible: 5,
+    percent: 60,
+    graded_open_responses: 0,
+    ungraded_open_responses: 1,
+    focus_summary: {
+      away_count: 1,
+      away_total_seconds: 45,
+      route_exit_attempts: 1,
+      window_unmaximize_attempts: 0,
+    },
+    ...overrides,
+  }
+}
+
 function makeResultsResponse(overrides?: {
   quizId?: string
   quizTitle?: string
@@ -231,29 +256,7 @@ function makeResultsResponse(overrides?: {
           },
         ],
       students:
-        overrides?.students ?? [
-          {
-            student_id: 'student-1',
-            name: 'Alice Zephyr',
-            first_name: 'Alice',
-            last_name: 'Zephyr',
-            email: 'alice@example.com',
-            status: 'submitted',
-            submitted_at: null,
-            last_activity_at: '2026-04-17T18:15:00.000Z',
-            points_earned: 3,
-            points_possible: 5,
-            percent: 60,
-            graded_open_responses: 0,
-            ungraded_open_responses: 1,
-            focus_summary: {
-              away_count: 1,
-              away_total_seconds: 45,
-              route_exit_attempts: 1,
-              window_unmaximize_attempts: 0,
-            },
-          },
-        ],
+        overrides?.students ?? [makeGradingStudent()],
       active_ai_grading_run: overrides?.activeRun ?? null,
     }),
   }
@@ -961,6 +964,50 @@ describe('TeacherTestsTab', () => {
       testId: 'test-1',
       studentId: 'student-1',
       studentName: 'Alice Zephyr',
+    })
+  })
+
+  it('moves the selected grading student with up and down arrows', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({
+        students: [
+          makeGradingStudent(),
+          makeGradingStudent({
+            student_id: 'student-2',
+            name: 'Bob Zulu',
+            first_name: 'Bob',
+            last_name: 'Zulu',
+            email: 'bob@example.com',
+            points_earned: 4,
+            percent: 80,
+          }),
+        ],
+      }))
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(await screen.findByText('Alice Zephyr'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-grading-panel')).toHaveTextContent('Grading panel for test-1:student-1')
+    })
+
+    const studentScrollPane = screen.getByTestId('test-grading-student-scroll-pane')
+    fireEvent.keyDown(studentScrollPane, { key: 'ArrowDown' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-grading-panel')).toHaveTextContent('Grading panel for test-1:student-2')
+    })
+
+    fireEvent.keyDown(studentScrollPane, { key: 'ArrowUp' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-grading-panel')).toHaveTextContent('Grading panel for test-1:student-1')
     })
   })
 

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1060,6 +1060,33 @@ describe('TeacherTestsTab', () => {
     })
   })
 
+  it('clears batch selection and the active grading student with Escape from the student table', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    fireEvent.click(await screen.findByLabelText('Select Alice Zephyr'))
+    fireEvent.click(await screen.findByText('Alice Zephyr'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-grading-panel')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Select Alice Zephyr')).toBeChecked()
+
+    fireEvent.keyDown(screen.getByTestId('test-grading-student-scroll-pane'), { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-test-grading-panel')).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Select Alice Zephyr')).not.toBeChecked()
+  })
+
   it('clears the selected grading row when clicking table chrome outside the highlighted row', async () => {
     fetchMock
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Move the teacher tests grading student list onto the shared keyboard-navigable DataTable primitives used by assignments.
- Allow the shared KeyboardNavigableTable wrapper to own scroll-pane props while preserving ArrowUp/ArrowDown selection behavior.
- Keep the tests tab-level Escape handler responsible for clearing both active row selection and batch selections.
- Add regression coverage for ArrowDown/ArrowUp navigation and the mixed Escape cleanup path.

## Root Cause
Assignments used the shared KeyboardNavigableTable wrapper, but the tests grading student list still had a handwritten table. That left tests without the shared arrow-key row selection behavior.

## Review Note
During self-review, I found that passing `onDeselect` into the shared wrapper could intercept Escape before the tests tab cleared batch selections. The follow-up commit removes that local wrapper Escape handling for tests and adds coverage for clearing both selected-row and batch-selected state from the student table.

## Validation
- PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/DataTable.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx
- pnpm lint
- E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests&testId=88a8b3b5-7559-417e-8d16-c53175a3d692&testMode=grading&testStudentId=23977f0b-efb8-4408-98cb-2e6887c4fd7e"
- Browser smoke check: clicked the selected student row, pressed ArrowDown, and confirmed URL, selected row, and grading inspector moved from Student1 to Student2.
- pnpm build
- pnpm test