### PR TITLE
[codex] Clarify Chrome plugin UI verification guidance

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-10 — Submitted-aware test unsubmit action
-
-**Completed:**
-- Confirmed selected-student test-work deletion does not close/open student access; it deletes attempt data only and leaves `test_student_availability` unchanged.
-- Changed the selected-test `Unsubmit Selected` action to enable only when selected rows include submitted work.
-- Filtered batch unsubmit requests so mixed selections submit only the selected students whose work is currently submitted.
-- Added focused component coverage for disabled no-submitted selection and mixed-selection submitted-only unsubmit requests.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-markdown-editor-default E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=tests'`
-- Targeted visual captures:
-  - `/tmp/pika-unsubmit-disabled-no-submitted-selected.png`
-  - `/tmp/pika-unsubmit-enabled-submitted-selected.png`
-- `pnpm build`
-
 ## 2026-05-10 — Test action menu counts
 
 **Completed:**
@@ -347,3 +329,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Temporary verification test `88a8b3b5-7559-417e-8d16-c53175a3d692` was deleted after screenshots and browser checks.
 - `pnpm build`
 - `pnpm test`
+
+## 2026-05-13 — Chrome plugin UI verification guidance
+
+**Completed:**
+- Documented Playwright as the required final path for E2E tests, UI verification scripts, and screenshot artifacts.
+- Clarified that Chrome plugin checks are supplemental for exploratory debugging, browser-profile behavior, remote auth, extension, cookie, and interactive inspection cases.
+- Updated the AI routing doc, UI testing guide, testing strategy, and Codex UI verification prompt.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/chrome-ui-guidance bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`

--- a/.codex/prompts/ui-verify.md
+++ b/.codex/prompts/ui-verify.md
@@ -2,6 +2,8 @@ Visually verify UI changes for the page path in `$ARGUMENTS`.
 
 Use the repo guide for expectations: `docs/guides/ai-ui-testing.md`.
 
+Playwright is the required final verification path. Chrome plugin/browser-profile checks may be used only as supplemental exploratory debugging and do not replace Playwright screenshots or verification scripts.
+
 Preferred path:
 ```bash
 bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" "$ARGUMENTS"

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -63,7 +63,7 @@ Inspect or modify source only after the startup set and the docs required by you
 | Scaffold API route | `/add-api-route` | `.codex/prompts/add-api-route.md` |
 | Merge `main` into `production` | `/merge-main-into-production` | `.codex/prompts/merge-main-into-production.md` |
 
-UI changes must be visually verified before commit. Use [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) for the verification workflow.
+UI changes require Playwright final verification before commit. Chrome plugin checks are supplemental. See [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md).
 
 ## Source Of Truth Order
 

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -136,7 +136,7 @@ Focus on **critical user flows**:
    - Create assignment and see student statuses update after submit/unsubmit
    - Export CSV
 
-**Tools**: Consider Playwright for 1-2 E2E tests (optional).
+**Tools**: Consider Playwright for 1-2 E2E tests (optional). Keep Playwright as the canonical E2E tool because tests need to be reproducible locally and in CI.
 
 ### UI Snapshot Runs (Playwright)
 
@@ -147,7 +147,7 @@ For visual review (spacing/aesthetics), we also support a **manual** Playwright 
 
 ### AI-Assisted UI Testing (Playwright CLI)
 
-For visual UI verification during development, AI agents can use the Playwright CLI to take screenshots.
+For visual UI verification during development, AI agents use the Playwright CLI to take screenshots. Chrome plugin checks may supplement this for exploratory debugging or browser-profile-specific issues, but they do not replace Playwright screenshots, verification scripts, or E2E tests.
 
 **Quick Start:**
 

--- a/docs/guides/ai-ui-testing.md
+++ b/docs/guides/ai-ui-testing.md
@@ -10,6 +10,12 @@ This guide explains how to use Playwright for AI-assisted UI verification in Pik
 2. Check **BOTH** teacher and student views (if applicable)
 3. Iterate on aesthetics/styling until it looks good
 
+## Tooling Policy
+
+Playwright is the required path for final UI/UX verification. Use Playwright for E2E tests, `pnpm e2e:verify` scenarios, reproducible screenshots, teacher/student auth-state checks, and artifacts that another agent or CI can rerun.
+
+Chrome plugin checks are supplemental. Use Chrome when you need exploratory debugging, the user's real browser profile, authenticated remote sessions, extension behavior, cookie/session inspection, or fast interactive inspection. Do not replace the Playwright verification artifact with a Chrome-only check before committing UI/UX changes.
+
 ## Prerequisites
 
 1. **Dev server running**: `pnpm dev`


### PR DESCRIPTION
## Summary

Clarifies the UI verification tooling policy for AI agents:

- Keeps Playwright as the required final path for E2E tests, UI verification scripts, and screenshot artifacts.
- Documents Chrome plugin checks as supplemental for exploratory debugging, browser-profile behavior, authenticated remote sessions, extension behavior, cookies, and interactive inspection.
- Updates the AI routing doc, UI testing guide, testing strategy, Codex UI verification prompt, and rolling session log.

## Why

The repo guidance already relies on Playwright for reproducible verification. This change makes the relationship between Playwright and the Chrome plugin explicit so agents can use Chrome where it helps without replacing the required Playwright artifacts.

## Validation

- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/chrome-ui-guidance bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`

## Notes

- Startup docs are at 14,887 bytes, under the 15,000 byte budget enforced by `tests/unit/ai-startup-docs.test.ts`.