### PR TITLE
[codex] Move classroom edit control to bottom bar

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -340,3 +340,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/chrome-ui-guidance bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`
+## 2026-05-13 — Classroom list edit control placement
+
+**Completed:**
+- Moved the teacher classroom list edit pen from the top floating cluster into the bottom controls beside the Active/Archived segmented toggle.
+- Removed the no-longer-needed top padding on the classroom list and updated the focused component test to assert the new bottom placement.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
+- `pnpm lint`
+- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Extra teacher edit-mode captures: `/tmp/pika-teacher-edit.png`, `/tmp/pika-teacher-mobile-edit.png`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -21,7 +21,6 @@ import {
 import { useRouter, usePathname } from 'next/navigation'
 import { Archive, CircleDot, LoaderCircle, Plus } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
-import { TeacherWorkSurfaceFloatingActionCluster } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { Button, ConfirmDialog, SegmentedControl } from '@/ui'
 import { Spinner } from '@/components/Spinner'
@@ -313,23 +312,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
   return (
     <PageLayout className="mx-auto max-w-2xl">
-      <TeacherWorkSurfaceFloatingActionCluster>
-        <div className="flex flex-wrap items-center justify-center gap-1.5">
-          <TeacherEditModeControls
-            active={isEditingClassrooms}
-            onActiveChange={(active) => {
-              setIsEditingClassrooms(active)
-              if (!active) {
-                setDraggingClassroomId(null)
-              }
-            }}
-            disabled={openingClassroomId !== null}
-            variant="secondary"
-          />
-        </div>
-      </TeacherWorkSurfaceFloatingActionCluster>
-
-      <PageContent className="pb-24 pt-16">
+      <PageContent className="pb-24">
         {error && (
           <div className="mb-3 rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
             {error}
@@ -488,26 +471,41 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         ) : null}
       </PageContent>
 
-      <div className="fixed bottom-4 left-1/2 z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur">
-        <SegmentedControl<ViewMode>
-          ariaLabel="Classroom view"
-          value={view}
-          onChange={setView}
-          iconOnly={!isEditingClassrooms}
-          className="border border-border shadow-sm"
-          options={[
-            {
-              value: 'active',
-              label: 'Active',
-              icon: <CircleDot className="h-3.5 w-3.5" />,
-            },
-            {
-              value: 'archived',
-              label: 'Archived',
-              icon: <Archive className="h-3.5 w-3.5" />,
-            },
-          ]}
-        />
+      <div
+        data-testid="classroom-bottom-controls"
+        className="fixed bottom-4 left-1/2 z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur"
+      >
+        <div className="flex items-center gap-1">
+          <SegmentedControl<ViewMode>
+            ariaLabel="Classroom view"
+            value={view}
+            onChange={setView}
+            iconOnly={!isEditingClassrooms}
+            className="border border-border shadow-sm"
+            options={[
+              {
+                value: 'active',
+                label: 'Active',
+                icon: <CircleDot className="h-3.5 w-3.5" />,
+              },
+              {
+                value: 'archived',
+                label: 'Archived',
+                icon: <Archive className="h-3.5 w-3.5" />,
+              },
+            ]}
+          />
+          <TeacherEditModeControls
+            active={isEditingClassrooms}
+            onActiveChange={(active) => {
+              setIsEditingClassrooms(active)
+              if (!active) {
+                setDraggingClassroomId(null)
+              }
+            }}
+            disabled={openingClassroomId !== null}
+          />
+        </div>
       </div>
 
       <CreateClassroomModal

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -73,7 +73,10 @@ describe('TeacherClassroomsIndex', () => {
     const editButton = screen.getByRole('button', { name: 'Edit' })
     const card = screen.getByTestId('classroom-card')
 
-    expect(editButton.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(
+      within(screen.getByTestId('classroom-bottom-controls')).getByRole('button', { name: 'Edit' })
+    ).toBe(editButton)
+    expect(card.compareDocumentPosition(editButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
 
     fireEvent.click(editButton)


### PR DESCRIPTION
## Summary
- Move the teacher classroom list edit pen into the bottom floating controls beside the Active/Archived toggle.
- Remove the old top floating edit control and the extra top padding it required.
- Update the focused classroom index test to assert the edit control is in the bottom control cluster.

## Validation
- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
- `pnpm lint`
- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Extra teacher edit-mode screenshots: `/tmp/pika-teacher-edit.png`, `/tmp/pika-teacher-mobile-edit.png`