### PR TITLE
[codex] Add announcement titles and composer fixes

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,114 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-11 — Add Daily quick date buttons
-
-**Completed:**
-- Added icon-only Daily tab quick-jump buttons for `Last class` and `Today` around the existing date picker arrows.
-- Simplified the quick-jump icons to `UndoDot` for `Last class` and `CircleDot` for `Today`.
-- Reused the existing Toronto date and class-day helpers so `Last class` targets the most recent class day before today.
-- Added focused component coverage for moving from the last class date to today and back.
-- Refreshed the Toronto `today` value on focus/visibility/interval and in quick-jump handlers so open tabs do not keep stale quick-jump dates after midnight.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherAttendanceTab.test.tsx`
-- `pnpm lint`
-- Added rollover coverage for `Today` and `Last class` quick jumps after the mocked Toronto date changes while the tab remains mounted.
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/751b1dfb-ec79-46fc-b4f6-24f97911ecea?tab=attendance'`
-- `E2E_BASE_URL=http://localhost:3002 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=attendance'`
-- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/daily-tab-quick-date-buttons bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=attendance'`
-- Tooltip hover checks:
-  - `/tmp/pika-tooltip-last-class.png`
-  - `/tmp/pika-tooltip-today.png`
-
-## 2026-05-12 — Preserve teacher assignment student-list scroll
-
-**Completed:**
-- Preserved the teacher assignment workspace class-pane scroll position while selecting students from the left student table.
-- Added regression coverage that remounts the left pane on student selection and verifies the stored scroll offset is restored.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3000 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/c4536d07-c76a-4a5b-a9c9-6340ed1678a9?tab=assignments&assignmentId=f2e7f53a-8399-42f7-9739-36a91fd837c1&assignmentStudentId=20d7927e-6c8d-4fe0-a31b-b3a4bd097f5e'`
-
-## 2026-05-12 — Continue teacher assignment scroll handoff
-
-**Completed:**
-- Audited the dirty `codex/teacher-assignments-scroll` worktree after the prior Codex session died.
-- Confirmed the assignment scroll fix preserves the class-pane scroll position before student selection and restores it after remount.
-- Seeded local Supabase and refreshed Playwright auth so UI verification used a live local classroom instead of a stale missing-classroom route.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/teacher-assignments-scroll E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/61164fb0-26d2-4862-abfe-5517ccdc685a?tab=assignments&assignmentId=9ff41b8e-bb7a-485b-a553-fb11dfd98545&assignmentStudentId=852830be-50b4-48fe-9b03-67e4d1d49a37'`
-- Delayed loaded-state teacher desktop screenshot: `/tmp/pika-teacher-loaded.png`
-
-## 2026-05-12 — Student Today past log expansion
-
-**Completed:**
-- Removed the parent collapse control from the student Today past-log section.
-- Changed the section to always show past logs, excluding the current Today entry.
-- Added per-log expand/collapse behavior: collapsed entries use a two-line clamp with ellipsis and clicking the log reveals the full text.
-- Split the student Today right pane into `Today` and `Last Class` lesson-plan sections, with the previous class day loaded from shared class-day state.
-- Updated focused Today history component coverage for default visibility, per-entry toggling, empty past-log state, and sessionStorage caching.
-- Added page-client coverage for the student Today sidebar showing both current and last-class lesson-plan content.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/StudentTodayTabHistory.test.tsx`
-- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx`
-- `pnpm lint`
-- `git diff --check`
-- Visual verification via temporary local harness after standard auth/seed path was blocked by local Supabase being down because Docker was not running:
-  - `/tmp/pika-student-today-mobile.png`
-  - `/tmp/pika-student-today-mobile-expanded.png`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/90c4fdd7-28c0-4474-998e-650eee270d57?tab=today'`
-- Additional desktop student pane capture:
-  - `/tmp/pika-student-today-desktop.png`
-
-## 2026-05-12 — Student Today split pane and richer seed logs
-
-**Completed:**
-- Moved the student Today lesson-plan panel out of the global right sidebar and into a teacher-style gapped split workspace.
-- Kept the Today and Last Class lesson-plan sections in a rounded right pane and rendered lesson-plan rich text flush, without the nested viewer border/padding.
-- Disabled the external Today right sidebar route config and expanded the student Today history fetch/cache limit to 12 entries.
-- Updated `seed` and `seed:fresh` to create 20 sample student logs across recent class days, including several long entries, and to seed lesson plans for both today and the last class.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/unit/layout-config.test.ts`
-- `pnpm lint`
-- `pnpm seed:fresh`
-- `pnpm e2e:auth`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
-- Additional desktop student split capture: `/tmp/pika-student-today-desktop-split-final.png`
-- `git diff --check`
-- `pnpm build`
-
-## 2026-05-12 — Student Today previous-day heading
-
-**Completed:**
-- Changed the student Today right-pane previous-class heading to show `Yesterday` when the previous class date is yesterday.
-- Moved the formatted date next to the heading instead of pinning it to the far right of the pane.
-- Kept the fallback copy as `Last class` for non-yesterday previous class days.
-
-**Validation:**
-- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/unit/layout-config.test.ts`
-- `pnpm lint`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3010 pnpm e2e:auth`
-- `E2E_BASE_URL=http://localhost:3010 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/today-log-history-expand bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/bdd3df5f-3596-4b8e-8acf-65004c9b2d66?tab=today'`
-- Additional desktop student split capture: `/tmp/pika-student-today-yesterday-desktop.png`
-- `pnpm build`
-
 ## 2026-05-13 — Announcement markdown rendering
 
 **Completed:**
@@ -347,3 +239,102 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-05-14 — Announcement calendar titles
+
+**Completed:**
+- Added nullable announcement titles with shared normalization and a 60-character limit.
+- Wired title create/edit through teacher announcement APIs and UI, and displayed titles on teacher/student announcement cards.
+- Updated calendar announcement pills and focused-day presentation to use titles with truncation, falling back to `Announcement` or `Scheduled`.
+
+**Validation:**
+- `pnpm test tests/unit/announcements.test.ts tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/components/LessonDayCell.test.tsx tests/components/AnnouncementsMarkdown.test.tsx tests/components/LessonCalendar.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=calendar'`
+- Additional screenshots:
+  - `/tmp/pika-teacher-titled-announcement.png`
+  - `/tmp/pika-student-titled-announcement.png`
+  - `/tmp/pika-teacher-announcement-title-form.png`
+
+## 2026-05-14 — Interactive announcement calendar popups
+
+**Completed:**
+- Added an opt-in interactive mode to the shared tooltip wrapper so hoverable/clickable content is available without changing normal tooltip behavior.
+- Enabled interactive popup behavior for calendar announcement tooltips, including weekend announcement indicators.
+- Verified markdown links inside announcement popups remain reachable when moving the pointer from the calendar pill into the popup.
+
+**Validation:**
+- `pnpm test tests/components/LessonDayCell.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/components/LessonCalendar.test.tsx tests/components/AnnouncementsMarkdown.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=calendar'`
+- Targeted Playwright hover/click-actionability check with screenshot:
+  - `/tmp/pika-announcement-popup-link-hover.png`
+
+## 2026-05-14 — Announcement composer sizing
+
+**Completed:**
+- Increased teacher announcement create/edit textareas from 3 to 6 rows with a 10rem minimum height.
+- Enabled vertical resize and autogrow behavior from textarea scroll height for longer announcement drafts.
+- Added component coverage for the larger resizable creation textarea.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
+- Additional screenshots:
+  - `/tmp/pika-announcement-create-textarea.png`
+  - `/tmp/pika-announcement-create-textarea-mobile.png`
+
+## 2026-05-14 — Announcement newest-first ordering
+
+**Completed:**
+- Added a shared newest-first announcement sorter based on `created_at`.
+- Updated teacher announcement display so scheduled announcements no longer jump ahead of newer published announcements.
+- Applied the same client-side newest-first display ordering for student announcements.
+
+**Validation:**
+- `pnpm test tests/unit/announcements.test.ts tests/components/AnnouncementsMarkdown.test.tsx tests/api/teacher/announcements.test.ts tests/api/student/announcements.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
+- Targeted ordering screenshots:
+  - `/tmp/pika-announcements-newest-first.png`
+  - `/tmp/pika-student-announcements-newest-first.png`
+
+## 2026-05-14 — Announcement title placeholder
+
+**Completed:**
+- Added an opt-in hidden-label mode to `FormField` so labels remain available to assistive tech without being visually shown.
+- Removed the visible `Title` label above announcement title fields and changed the placeholder to `Title (optional)`.
+- Applied the behavior to both create and edit announcement title inputs.
+
+**Validation:**
+- `pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/unit/announcements.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
+- Targeted composer screenshot:
+  - `/tmp/pika-announcement-title-placeholder.png`
+
+## 2026-05-14 — Announcement composer ordering and split button
+
+**Completed:**
+- Moved the teacher announcement composer above the existing announcement list so the draft/new announcement area always stays at the top.
+- Replaced the local hand-rolled Post/Schedule control with the shared `@/ui` `SplitButton`.
+- Kept the existing schedule date/time picker by opening it from the shared split button's `Schedule...` menu item.
+
+**Validation:**
+- `pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/ui/SplitButton.test.tsx tests/unit/announcements.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3005 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcement-calendar-title bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
+- Targeted composer screenshots:
+  - `/tmp/pika-announcement-composer-top-splitbutton.png`
+  - `/tmp/pika-announcement-composer-top-splitbutton-mobile.png`

--- a/src/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/announcements/[announcementId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
+import { parseAnnouncementTitleInput } from '@/lib/announcements'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -45,10 +46,14 @@ export const PATCH = withErrorHandler('PatchAnnouncement', async (request, conte
   const user = await requireRole('teacher')
   const { id: classroomId, announcementId } = await context.params
   const body = await request.json()
-  const { content, scheduled_for } = body as { content?: string; scheduled_for?: string | null }
+  const { content, scheduled_for, title } = body as {
+    content?: string
+    scheduled_for?: string | null
+    title?: unknown
+  }
 
   // Require at least one field to update
-  if (content === undefined && scheduled_for === undefined) {
+  if (content === undefined && scheduled_for === undefined && title === undefined) {
     return NextResponse.json(
       { error: 'Content is required' },
       { status: 400 }
@@ -80,6 +85,14 @@ export const PATCH = withErrorHandler('PatchAnnouncement', async (request, conte
     }
   }
 
+  const parsedTitle = parseAnnouncementTitleInput(title)
+  if (!parsedTitle.ok) {
+    return NextResponse.json(
+      { error: parsedTitle.error },
+      { status: 400 }
+    )
+  }
+
   const ownership = await verifyAnnouncementOwnership(user.id, classroomId, announcementId)
   if (!ownership.ok) {
     return NextResponse.json(
@@ -98,12 +111,15 @@ export const PATCH = withErrorHandler('PatchAnnouncement', async (request, conte
   const supabase = getServiceRoleClient()
 
   // Build update object with only provided fields
-  const updateData: { content?: string; scheduled_for?: string | null } = {}
+  const updateData: { content?: string; scheduled_for?: string | null; title?: string | null } = {}
   if (content !== undefined) {
     updateData.content = content.trim()
   }
   if (scheduled_for !== undefined) {
     updateData.scheduled_for = scheduled_for
+  }
+  if (title !== undefined) {
+    updateData.title = parsedTitle.value ?? null
   }
 
   const { data: announcement, error } = await supabase

--- a/src/app/api/teacher/classrooms/[id]/announcements/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/announcements/route.ts
@@ -6,6 +6,7 @@ import {
   assertTeacherCanMutateClassroom,
 } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
+import { parseAnnouncementTitleInput } from '@/lib/announcements'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -47,7 +48,11 @@ export const POST = withErrorHandler('PostCreateAnnouncement', async (request, c
   const user = await requireRole('teacher')
   const { id: classroomId } = await context.params
   const body = await request.json()
-  const { content, scheduled_for } = body as { content?: string; scheduled_for?: string }
+  const { content, scheduled_for, title } = body as {
+    content?: string
+    scheduled_for?: string
+    title?: unknown
+  }
 
   if (!content || !content.trim()) {
     return NextResponse.json(
@@ -73,6 +78,14 @@ export const POST = withErrorHandler('PostCreateAnnouncement', async (request, c
     }
   }
 
+  const parsedTitle = parseAnnouncementTitleInput(title)
+  if (!parsedTitle.ok) {
+    return NextResponse.json(
+      { error: parsedTitle.error },
+      { status: 400 }
+    )
+  }
+
   const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
   if (!ownership.ok) {
     return NextResponse.json(
@@ -82,15 +95,25 @@ export const POST = withErrorHandler('PostCreateAnnouncement', async (request, c
   }
 
   const supabase = getServiceRoleClient()
+  const insertData: {
+    classroom_id: string
+    content: string
+    created_by: string
+    scheduled_for: string | null
+    title?: string
+  } = {
+    classroom_id: classroomId,
+    content: content.trim(),
+    created_by: user.id,
+    scheduled_for: scheduled_for || null,
+  }
+  if (parsedTitle.value) {
+    insertData.title = parsedTitle.value
+  }
 
   const { data: announcement, error } = await supabase
     .from('announcements')
-    .insert({
-      classroom_id: classroomId,
-      content: content.trim(),
-      created_by: user.id,
-      scheduled_for: scheduled_for || null,
-    })
+    .insert(insertData)
     .select()
     .single()
 

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -8,6 +8,7 @@ import { useStudentNotifications } from '@/components/StudentNotificationsProvid
 import type { Announcement, Classroom } from '@/types'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui/utils'
+import { normalizeAnnouncementTitle, sortAnnouncementsNewestFirst } from '@/lib/announcements'
 
 interface Props {
   classroom: Classroom
@@ -93,20 +94,31 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     )
   }
 
+  const sortedAnnouncements = sortAnnouncementsNewestFirst(announcements)
+
   return (
     <div className={cn('space-y-3', className ?? 'max-w-2xl mx-auto')}>
-      {(showAll ? announcements : announcements.slice(0, 5)).map((announcement) => (
-        <div
-          key={announcement.id}
-          className="bg-surface rounded-lg border border-border p-4"
-        >
-          <p className="text-[11px] text-text-muted mb-2">
-            {formatDate(announcement.created_at)}
-            {announcement.updated_at !== announcement.created_at && ' (edited)'}
-          </p>
-          <AnnouncementContent content={announcement.content} />
-        </div>
-      ))}
+      {(showAll ? sortedAnnouncements : sortedAnnouncements.slice(0, 5)).map((announcement) => {
+        const title = normalizeAnnouncementTitle(announcement.title)
+
+        return (
+          <div
+            key={announcement.id}
+            className="bg-surface rounded-lg border border-border p-4"
+          >
+            <p className="text-[11px] text-text-muted mb-2">
+              {formatDate(announcement.created_at)}
+              {announcement.updated_at !== announcement.created_at && ' (edited)'}
+            </p>
+            {title && (
+              <h3 className="mb-2 truncate text-sm font-semibold text-text-default">
+                {title}
+              </h3>
+            )}
+            <AnnouncementContent content={announcement.content} />
+          </div>
+        )
+      })}
 
       {!showAll && announcements.length > 5 && (
         <Button

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { Trash2, Plus, Clock, ChevronDown, Calendar } from 'lucide-react'
-import { Button, ConfirmDialog } from '@/ui'
+import { Trash2, Plus, Clock, Calendar } from 'lucide-react'
+import { Button, ConfirmDialog, FormField, Input, SplitButton } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
@@ -10,6 +10,11 @@ import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/T
 import type { Announcement, Classroom } from '@/types'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui/utils'
+import {
+  ANNOUNCEMENT_TITLE_MAX_LENGTH,
+  normalizeAnnouncementTitle,
+  sortAnnouncementsNewestFirst,
+} from '@/lib/announcements'
 import {
   combineScheduleDateTimeToIso,
   DEFAULT_SCHEDULE_TIME,
@@ -21,6 +26,18 @@ import {
 interface Props {
   classroom: Classroom
   className?: string
+}
+
+const ANNOUNCEMENT_TEXTAREA_MIN_HEIGHT_PX = 160
+
+function autoResizeAnnouncementTextarea(textarea: HTMLTextAreaElement | null) {
+  if (!textarea) return
+  textarea.style.height = `${ANNOUNCEMENT_TEXTAREA_MIN_HEIGHT_PX}px`
+  const measuredHeight = textarea.scrollHeight
+  const nextHeight = measuredHeight > ANNOUNCEMENT_TEXTAREA_MIN_HEIGHT_PX
+    ? measuredHeight
+    : ANNOUNCEMENT_TEXTAREA_MIN_HEIGHT_PX
+  textarea.style.height = `${nextHeight}px`
 }
 
 // Helper to check if announcement is scheduled (not yet published)
@@ -59,11 +76,14 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const [loading, setLoading] = useState(true)
   const [showAll, setShowAll] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
+  const [editTitle, setEditTitle] = useState('')
+  const [originalTitle, setOriginalTitle] = useState<string | null>(null)
   const [editContent, setEditContent] = useState('')
   const [originalContent, setOriginalContent] = useState('')
   const [editScheduleDateTime, setEditScheduleDateTime] = useState('')
   const [originalScheduledFor, setOriginalScheduledFor] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
+  const [newTitle, setNewTitle] = useState('')
   const [newContent, setNewContent] = useState('')
   const [saving, setSaving] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
@@ -116,12 +136,22 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     }
   }, [editingId])
 
+  useEffect(() => {
+    if (!editingId) return
+    autoResizeAnnouncementTextarea(editTextareaRef.current)
+  }, [editingId, editContent])
+
   // Focus textarea when creating
   useEffect(() => {
     if (isCreating && newTextareaRef.current) {
       newTextareaRef.current.focus()
     }
   }, [isCreating])
+
+  useEffect(() => {
+    if (!isCreating) return
+    autoResizeAnnouncementTextarea(newTextareaRef.current)
+  }, [isCreating, newContent])
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -152,6 +182,8 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   function startEditing(announcement: Announcement) {
     if (isReadOnly || saving) return
     setEditingId(announcement.id)
+    setEditTitle(announcement.title ?? '')
+    setOriginalTitle(announcement.title ?? null)
     setEditContent(announcement.content)
     setOriginalContent(announcement.content)
     // Convert ISO to local datetime-local format if scheduled
@@ -166,6 +198,8 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
 
   function cancelEditing() {
     setEditingId(null)
+    setEditTitle('')
+    setOriginalTitle(null)
     setEditContent('')
     setOriginalContent('')
     setEditScheduleDateTime('')
@@ -177,12 +211,14 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     if (!editingId || !editContent.trim() || saving) return
 
     // Check if anything changed
+    const normalizedEditTitle = normalizeAnnouncementTitle(editTitle)
     const contentChanged = editContent.trim() !== originalContent.trim()
+    const titleChanged = normalizedEditTitle !== normalizeAnnouncementTitle(originalTitle)
     const newScheduledFor = editScheduleDateTime ? new Date(editScheduleDateTime).toISOString() : null
     const scheduleChanged = newScheduledFor !== originalScheduledFor
 
     // Don't save if nothing changed
-    if (!contentChanged && !scheduleChanged) {
+    if (!contentChanged && !titleChanged && !scheduleChanged) {
       cancelEditing()
       return
     }
@@ -195,6 +231,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
         a.id === editingId
           ? {
               ...a,
+              title: normalizedEditTitle,
               content: editContent.trim(),
               scheduled_for: optimisticScheduledFor,
               updated_at: new Date().toISOString(),
@@ -203,7 +240,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       ),
     )
     try {
-      const body: { content?: string; scheduled_for?: string | null } = {}
+      const body: { content?: string; scheduled_for?: string | null; title?: string | null } = {}
+      if (titleChanged) {
+        body.title = normalizedEditTitle
+      }
       if (contentChanged) {
         body.content = editContent.trim()
       }
@@ -239,11 +279,13 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     if (!newContent.trim() || saving) return
 
     setSaving(true)
+    const normalizedNewTitle = normalizeAnnouncementTitle(newTitle)
     const tempId = `temp-${Date.now()}`
     const now = new Date().toISOString()
     const optimisticAnnouncement: Announcement = {
       id: tempId,
       classroom_id: classroom.id,
+      title: normalizedNewTitle,
       content: newContent.trim(),
       created_by: classroom.teacher_id,
       scheduled_for: scheduledFor ? new Date(scheduledFor).toISOString() : null,
@@ -252,7 +294,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     }
     setAnnouncements((prev) => [optimisticAnnouncement, ...prev])
     try {
-      const body: { content: string; scheduled_for?: string } = { content: newContent.trim() }
+      const body: { content: string; scheduled_for?: string; title?: string } = { content: newContent.trim() }
+      if (normalizedNewTitle) {
+        body.title = normalizedNewTitle
+      }
       if (scheduledFor) {
         body.scheduled_for = new Date(scheduledFor).toISOString()
       }
@@ -270,6 +315,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
       invalidateCachedJSON(`student-announcements:${classroom.id}`)
       setIsCreating(false)
+      setNewTitle('')
       setNewContent('')
       setScheduleDateTime('')
       setShowScheduleDropdown(false)
@@ -323,8 +369,21 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   function handleNewKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Escape') {
       setIsCreating(false)
+      setNewTitle('')
       setNewContent('')
     }
+  }
+
+  function openCreateSchedulePicker() {
+    setPendingScheduleDate(getTodayDate())
+    setPendingScheduleTime(DEFAULT_SCHEDULE_TIME)
+    setShowScheduleDropdown(true)
+  }
+
+  function openEditSchedulePicker() {
+    setPendingEditScheduleDate(getTodayDate())
+    setPendingEditScheduleTime(DEFAULT_SCHEDULE_TIME)
+    setShowEditScheduleDropdown(true)
   }
 
   if (loading) {
@@ -362,6 +421,119 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
         </div>
       )}
 
+      {/* New announcement form */}
+      {isCreating ? (
+        <div className="bg-surface rounded-lg border border-border p-4">
+          <FormField label="Title" className="mb-3" hideLabel>
+            <Input
+              value={newTitle}
+              onChange={(event) => setNewTitle(event.target.value)}
+              disabled={saving}
+              maxLength={ANNOUNCEMENT_TITLE_MAX_LENGTH}
+              placeholder="Title (optional)"
+            />
+          </FormField>
+          <textarea
+            ref={newTextareaRef}
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            onKeyDown={handleNewKeyDown}
+            disabled={saving}
+            rows={6}
+            className="max-h-[50vh] min-h-[10rem] w-full resize-y overflow-y-auto rounded-md border border-border bg-surface-2 px-3 py-2 text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
+            placeholder="Write an announcement..."
+          />
+          {scheduleDateTime && (
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  const { date, time } = parseDateTime(scheduleDateTime)
+                  setPendingScheduleDate(date)
+                  setPendingScheduleTime(time)
+                  setShowScheduleDropdown(true)
+                }}
+                className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
+              >
+                <Calendar className="h-4 w-4 flex-shrink-0" />
+                <span>{formatDate(scheduleDateTime)}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setScheduleDateTime('')}
+                className="text-xs text-text-muted hover:text-text-default"
+              >
+                Clear
+              </button>
+            </div>
+          )}
+          <div className="mt-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreating(false)
+                setNewTitle('')
+                setNewContent('')
+                setScheduleDateTime('')
+                setShowScheduleDropdown(false)
+              }}
+              className="text-sm text-text-muted hover:text-text-default"
+            >
+              Cancel
+            </button>
+            <div className="relative flex items-center" ref={dropdownRef}>
+              {scheduleDateTime ? (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => createAnnouncement(scheduleDateTime)}
+                  disabled={saving || !newContent.trim()}
+                >
+                  {saving ? 'Scheduling...' : 'Schedule'}
+                </Button>
+              ) : (
+                <SplitButton
+                  label={saving ? 'Posting...' : 'Post'}
+                  onPrimaryClick={() => createAnnouncement()}
+                  disabled={saving || !newContent.trim()}
+                  options={[
+                    {
+                      id: 'schedule',
+                      label: 'Schedule...',
+                      onSelect: openCreateSchedulePicker,
+                    },
+                  ]}
+                  toggleAriaLabel="Choose announcement action"
+                  primaryButtonProps={{
+                    onMouseDown: (e) => e.preventDefault(),
+                  }}
+                />
+              )}
+
+              {showScheduleDropdown && (
+                <ScheduleDateTimePicker
+                  className="absolute right-0 top-full z-10 mt-1 min-w-[220px]"
+                  date={pendingScheduleDate}
+                  time={pendingScheduleTime}
+                  minDate={getTodayDate()}
+                  isFutureValid={!pendingScheduleDate ? false : isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)}
+                  onDateChange={setPendingScheduleDate}
+                  onTimeChange={setPendingScheduleTime}
+                  onCancel={() => setShowScheduleDropdown(false)}
+                  onConfirm={() => {
+                    if (pendingScheduleDate && isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)) {
+                      setScheduleDateTime(combineDateTime(pendingScheduleDate, pendingScheduleTime))
+                      setShowScheduleDropdown(false)
+                    }
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       {/* Empty state */}
       {announcements.length === 0 && !isCreating && (
         <div className="rounded-lg border border-border bg-surface-2 p-4">
@@ -373,23 +545,14 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
 
       {/* Announcements list */}
       {announcements.length > 0 && (() => {
-        // Sort: scheduled announcements first (by scheduled_for), then published (by created_at)
-        const sortedAnnouncements = [...announcements].sort((a, b) => {
-          const aScheduled = isScheduled(a)
-          const bScheduled = isScheduled(b)
-          if (aScheduled && !bScheduled) return -1
-          if (!aScheduled && bScheduled) return 1
-          if (aScheduled && bScheduled) {
-            return new Date(a.scheduled_for!).getTime() - new Date(b.scheduled_for!).getTime()
-          }
-          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-        })
+        const sortedAnnouncements = sortAnnouncementsNewestFirst(announcements)
         const displayedAnnouncements = showAll ? sortedAnnouncements : sortedAnnouncements.slice(0, 5)
 
         return (
         <div className="space-y-3">
           {displayedAnnouncements.map((announcement) => {
             const scheduled = isScheduled(announcement)
+            const title = normalizeAnnouncementTitle(announcement.title)
 
             return (
               <div
@@ -400,19 +563,28 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
               >
                 {editingId === announcement.id ? (
                   // Editing mode
-                  <div>
+                  <div className="space-y-3">
+                    <FormField label="Title" hideLabel>
+                      <Input
+                        value={editTitle}
+                        onChange={(event) => setEditTitle(event.target.value)}
+                        disabled={saving}
+                        maxLength={ANNOUNCEMENT_TITLE_MAX_LENGTH}
+                        placeholder="Title (optional)"
+                      />
+                    </FormField>
                     <textarea
                       ref={editTextareaRef}
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       onKeyDown={handleEditKeyDown}
                       disabled={saving}
-                      rows={3}
-                      className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
+                      rows={6}
+                      className="max-h-[50vh] min-h-[10rem] w-full resize-y overflow-y-auto rounded-md border border-border bg-surface-2 px-3 py-2 text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
                     />
                     {/* Show scheduled date if set */}
                     {editScheduleDateTime && (
-                      <div className="flex items-center gap-2 mt-2">
+                      <div className="flex items-center gap-2">
                         <button
                           type="button"
                           onClick={() => {
@@ -437,7 +609,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                         </button>
                       </div>
                     )}
-                    <div className="flex items-center justify-between mt-2">
+                    <div className="flex items-center justify-between">
                       <button
                         type="button"
                         onClick={cancelEditing}
@@ -446,30 +618,33 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                         Cancel
                       </button>
                       <div className="relative flex items-center" ref={editDropdownRef}>
-                        <Button
-                          variant="primary"
-                          size="sm"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => saveEdit()}
-                          disabled={saving || !editContent.trim()}
-                          className={editScheduleDateTime ? '' : 'rounded-r-none'}
-                        >
-                          {saving ? 'Saving...' : (editScheduleDateTime ? 'Save' : 'Post')}
-                        </Button>
-                        {!editScheduleDateTime && (
-                          <button
-                            type="button"
+                        {editScheduleDateTime ? (
+                          <Button
+                            variant="primary"
+                            size="sm"
                             onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => {
-                              setPendingEditScheduleDate(getTodayDate())
-                              setPendingEditScheduleTime(DEFAULT_SCHEDULE_TIME)
-                              setShowEditScheduleDropdown(!showEditScheduleDropdown)
-                            }}
+                            onClick={() => saveEdit()}
                             disabled={saving || !editContent.trim()}
-                            className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
                           >
-                            <ChevronDown className="h-4 w-4" />
-                          </button>
+                            {saving ? 'Saving...' : 'Save'}
+                          </Button>
+                        ) : (
+                          <SplitButton
+                            label={saving ? 'Saving...' : 'Post'}
+                            onPrimaryClick={() => saveEdit()}
+                            disabled={saving || !editContent.trim()}
+                            options={[
+                              {
+                                id: 'schedule',
+                                label: 'Schedule...',
+                                onSelect: openEditSchedulePicker,
+                              },
+                            ]}
+                            toggleAriaLabel="Choose announcement action"
+                            primaryButtonProps={{
+                              onMouseDown: (e) => e.preventDefault(),
+                            }}
+                          />
                         )}
 
                         {/* Schedule dropdown */}
@@ -517,6 +692,11 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                           {announcement.updated_at !== announcement.created_at && ' (edited)'}
                         </p>
                       )}
+                      {title && (
+                        <h3 className="mb-2 truncate text-sm font-semibold text-text-default">
+                          {title}
+                        </h3>
+                      )}
                       <AnnouncementContent
                         content={announcement.content}
                         tone={scheduled ? 'muted' : 'default'}
@@ -551,106 +731,6 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
         </div>
         )
       })()}
-
-      {/* New announcement form */}
-      {isCreating ? (
-        <div className="bg-surface rounded-lg border border-border p-4">
-          <textarea
-            ref={newTextareaRef}
-            value={newContent}
-            onChange={(e) => setNewContent(e.target.value)}
-            onKeyDown={handleNewKeyDown}
-            disabled={saving}
-            rows={3}
-            className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-none"
-            placeholder="Write an announcement..."
-          />
-          {scheduleDateTime && (
-            <div className="mt-2 flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  const { date, time } = parseDateTime(scheduleDateTime)
-                  setPendingScheduleDate(date)
-                  setPendingScheduleTime(time)
-                  setShowScheduleDropdown(true)
-                }}
-                className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-700"
-              >
-                <Calendar className="h-4 w-4 flex-shrink-0" />
-                <span>{formatDate(scheduleDateTime)}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setScheduleDateTime('')}
-                className="text-xs text-text-muted hover:text-text-default"
-              >
-                Clear
-              </button>
-            </div>
-          )}
-          <div className="mt-2 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={() => {
-                setIsCreating(false)
-                setNewContent('')
-                setScheduleDateTime('')
-                setShowScheduleDropdown(false)
-              }}
-              className="text-sm text-text-muted hover:text-text-default"
-            >
-              Cancel
-            </button>
-            <div className="relative flex items-center" ref={dropdownRef}>
-              <Button
-                variant="primary"
-                size="sm"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => createAnnouncement(scheduleDateTime || undefined)}
-                disabled={saving || !newContent.trim()}
-                className={scheduleDateTime ? '' : 'rounded-r-none'}
-              >
-                {saving ? (scheduleDateTime ? 'Scheduling...' : 'Posting...') : (scheduleDateTime ? 'Schedule' : 'Post')}
-              </Button>
-              {!scheduleDateTime && (
-                <button
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => {
-                    setPendingScheduleDate(getTodayDate())
-                    setPendingScheduleTime(DEFAULT_SCHEDULE_TIME)
-                    setShowScheduleDropdown(!showScheduleDropdown)
-                  }}
-                  disabled={saving || !newContent.trim()}
-                  className="inline-flex items-center justify-center h-8 px-2 bg-primary text-white rounded-r-md border-l border-primary-hover hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ChevronDown className="h-4 w-4" />
-                </button>
-              )}
-
-              {showScheduleDropdown && (
-                <ScheduleDateTimePicker
-                  className="absolute right-0 top-full z-10 mt-1 min-w-[220px]"
-                  date={pendingScheduleDate}
-                  time={pendingScheduleTime}
-                  minDate={getTodayDate()}
-                  isFutureValid={!pendingScheduleDate ? false : isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)}
-                  onDateChange={setPendingScheduleDate}
-                  onTimeChange={setPendingScheduleTime}
-                  onCancel={() => setShowScheduleDropdown(false)}
-                  onConfirm={() => {
-                    if (pendingScheduleDate && isScheduleInFuture(pendingScheduleDate, pendingScheduleTime)) {
-                      setScheduleDateTime(combineDateTime(pendingScheduleDate, pendingScheduleTime))
-                      setShowScheduleDropdown(false)
-                    }
-                  }}
-                />
-              )}
-            </div>
-          </div>
-        </div>
-      ) : null}
 
       {/* Delete confirmation dialog */}
       <ConfirmDialog

--- a/src/components/LessonCalendar.tsx
+++ b/src/components/LessonCalendar.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight, PanelRight, PanelRightClose } from 'lucide-r
 import { LessonDayCell } from './LessonDayCell'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { normalizeAnnouncementTitle } from '@/lib/announcements'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { useKeyboardShortcutHint } from '@/hooks/use-keyboard-shortcut-hint'
 import { DialogPanel, SegmentedControl, Tooltip } from '@/ui'
@@ -653,13 +654,23 @@ export function LessonCalendar({
                     Announcements
                   </h3>
                   <div className="mt-4 space-y-4">
-                    {presentedDayDetails.announcements.map((announcement) => (
-                      <AnnouncementContent
-                        key={announcement.id}
-                        content={announcement.content}
-                        size="lg"
-                      />
-                    ))}
+                    {presentedDayDetails.announcements.map((announcement) => {
+                      const title = normalizeAnnouncementTitle(announcement.title)
+
+                      return (
+                        <div key={announcement.id}>
+                          {title && (
+                            <h4 className="mb-2 text-xl font-semibold text-text-default">
+                              {title}
+                            </h4>
+                          )}
+                          <AnnouncementContent
+                            content={announcement.content}
+                            size="lg"
+                          />
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               )}

--- a/src/components/LessonDayCell.tsx
+++ b/src/components/LessonDayCell.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { format } from 'date-fns'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
+import { getAnnouncementCalendarLabel, normalizeAnnouncementTitle } from '@/lib/announcements'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { getLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { Tooltip } from '@/ui'
@@ -18,13 +19,20 @@ function isScheduled(announcement: Announcement): boolean {
 function AnnouncementTooltipContent({ announcements }: { announcements: Announcement[] }) {
   return (
     <div className="w-[min(14rem,calc(100vw-2rem))] text-left text-sm leading-5 break-words">
-      {announcements.map((announcement, index) => (
-        <AnnouncementContent
-          key={announcement.id}
-          content={announcement.content}
-          className={index > 0 ? 'mt-3' : undefined}
-        />
-      ))}
+      {announcements.map((announcement, index) => {
+        const title = normalizeAnnouncementTitle(announcement.title)
+
+        return (
+          <div key={announcement.id} className={index > 0 ? 'mt-3' : undefined}>
+            {title && (
+              <p className="mb-1 text-xs font-semibold text-text-default">
+                {title}
+              </p>
+            )}
+            <AnnouncementContent content={announcement.content} />
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -293,6 +301,7 @@ export const LessonDayCell = memo(function LessonDayCell({
               content={<AnnouncementTooltipContent announcements={announcements} />}
               side="right"
               align="start"
+              interactive
             >
               <button
                 type="button"
@@ -371,12 +380,14 @@ export const LessonDayCell = memo(function LessonDayCell({
         <div className={`min-w-0 ${compact ? 'px-0.5 space-y-0.5' : 'px-1 pb-1 space-y-1'}`}>
           {announcements.map((announcement) => {
             const scheduled = isScheduled(announcement)
+            const calendarLabel = getAnnouncementCalendarLabel(announcement, scheduled)
 
             return (
               <Tooltip
                 key={announcement.id}
                 content={<AnnouncementTooltipContent announcements={[announcement]} />}
                 align="start"
+                interactive
               >
                 <button
                   type="button"
@@ -384,6 +395,8 @@ export const LessonDayCell = memo(function LessonDayCell({
                     e.stopPropagation()
                     onAnnouncementClick?.()
                   }}
+                  title={calendarLabel}
+                  aria-label={calendarLabel}
                   className={`w-full min-w-0 rounded font-medium text-center truncate ${
                     compact ? 'text-[10px] px-0.5 py-px' : 'text-xs px-2 py-1'
                   } ${
@@ -392,7 +405,7 @@ export const LessonDayCell = memo(function LessonDayCell({
                       : 'bg-amber-500 text-white hover:bg-amber-600'
                   }`}
                 >
-                  {compact ? (scheduled ? 'Scheduled' : 'Announcement') : (scheduled ? 'Scheduled' : 'Announcement')}
+                  {calendarLabel}
                 </button>
               </Tooltip>
             )

--- a/src/lib/announcements.ts
+++ b/src/lib/announcements.ts
@@ -1,0 +1,43 @@
+export const ANNOUNCEMENT_TITLE_MAX_LENGTH = 60
+
+export type AnnouncementTitleInputResult =
+  | { ok: true; value: string | null | undefined }
+  | { ok: false; error: string }
+
+export function normalizeAnnouncementTitle(title: string | null | undefined): string | null {
+  const trimmed = title?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function parseAnnouncementTitleInput(value: unknown): AnnouncementTitleInputResult {
+  if (value === undefined) return { ok: true, value: undefined }
+  if (value === null) return { ok: true, value: null }
+  if (typeof value !== 'string') {
+    return { ok: false, error: 'Title must be text' }
+  }
+
+  const title = normalizeAnnouncementTitle(value)
+  if (title && title.length > ANNOUNCEMENT_TITLE_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `Title must be ${ANNOUNCEMENT_TITLE_MAX_LENGTH} characters or fewer`,
+    }
+  }
+
+  return { ok: true, value: title }
+}
+
+export function getAnnouncementCalendarLabel(
+  announcement: { title?: string | null },
+  scheduled: boolean,
+): string {
+  return normalizeAnnouncementTitle(announcement.title) ?? (scheduled ? 'Scheduled' : 'Announcement')
+}
+
+export function sortAnnouncementsNewestFirst<T extends { created_at: string }>(
+  announcements: readonly T[],
+): T[] {
+  return [...announcements].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1000,6 +1000,7 @@ export interface LogSummary {
 export interface Announcement {
   id: string
   classroom_id: string
+  title?: string | null
   content: string
   created_by: string
   scheduled_for: string | null // NULL = published immediately, future timestamp = scheduled

--- a/src/ui/FormField.tsx
+++ b/src/ui/FormField.tsx
@@ -14,6 +14,8 @@ export interface FormFieldProps {
   hint?: string
   /** Show required indicator (*) after label */
   required?: boolean
+  /** Keep the label available to assistive tech without showing it visually */
+  hideLabel?: boolean
   /** The form control (Input, Select, Textarea, etc.) */
   children: ReactNode
   /** Additional class names for the wrapper */
@@ -46,6 +48,7 @@ export function FormField({
   error,
   hint,
   required,
+  hideLabel,
   children,
   className,
 }: FormFieldProps) {
@@ -67,7 +70,7 @@ export function FormField({
 
   return (
     <div className={cn('w-full', className)}>
-      <label htmlFor={fieldId} className={labelStyles}>
+      <label htmlFor={fieldId} className={cn(labelStyles, hideLabel && 'sr-only')}>
         {label}
         {required && <span className={requiredMarkerStyles}>*</span>}
       </label>

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -18,6 +18,8 @@ export interface TooltipProps {
   content: ReactNode
   /** The element that triggers the tooltip */
   children: ReactNode
+  /** Whether the tooltip content itself can be hovered/clicked */
+  interactive?: boolean
   /** Delay in ms before showing tooltip (default: 100) */
   delayDuration?: number
   /** Side of the trigger to render tooltip (default: 'bottom') */
@@ -40,20 +42,21 @@ export interface TooltipProps {
 export function Tooltip({
   content,
   children,
+  interactive = false,
   delayDuration = 100,
   side = 'bottom',
   align = 'center',
   className,
 }: TooltipProps) {
   return (
-    <TooltipPrimitive.Root delayDuration={delayDuration}>
+    <TooltipPrimitive.Root delayDuration={delayDuration} disableHoverableContent={!interactive}>
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>
         <TooltipPrimitive.Content
           side={side}
           align={align}
           sideOffset={4}
-          className={cn(tooltipContentStyles(), className)}
+          className={cn(tooltipContentStyles(), interactive && 'pointer-events-auto', className)}
         >
           {content}
         </TooltipPrimitive.Content>

--- a/supabase/migrations/069_announcement_titles.sql
+++ b/supabase/migrations/069_announcement_titles.sql
@@ -1,0 +1,7 @@
+-- Add an optional short title used for announcement calendar labels.
+ALTER TABLE announcements
+  ADD COLUMN title text;
+
+ALTER TABLE announcements
+  ADD CONSTRAINT announcements_title_length
+  CHECK (title IS NULL OR char_length(title) <= 60);

--- a/tests/api/teacher/announcements-id.test.ts
+++ b/tests/api/teacher/announcements-id.test.ts
@@ -14,8 +14,22 @@ const mockSupabaseClient = { from: vi.fn() }
 // Helper to create ownership check mock
 function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?: boolean } = {}) {
   const { found = true, owned = true, archived = false } = opts
+  const update = vi.fn((updateData: Record<string, string | null>) => ({
+    eq: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: 'a-1',
+            content: updateData.content ?? 'Content',
+            title: updateData.title ?? null,
+          },
+          error: null,
+        }),
+      })),
+    })),
+  }))
 
-  return vi.fn((table: string) => {
+  const from = vi.fn((table: string) => {
     if (table === 'announcements') {
       return {
         select: vi.fn(() => ({
@@ -34,16 +48,7 @@ function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?:
             error: found ? null : { code: 'PGRST116' },
           }),
         })),
-        update: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            select: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'a-1', content: 'Updated Content' },
-                error: null,
-              }),
-            })),
-          })),
-        })),
+        update,
         delete: vi.fn(() => ({
           eq: vi.fn().mockResolvedValue({ error: null }),
         })),
@@ -51,6 +56,8 @@ function mockOwnershipCheck(opts: { found?: boolean; owned?: boolean; archived?:
     }
     return { select: vi.fn() }
   })
+
+  return Object.assign(from, { update })
 }
 
 describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', () => {
@@ -75,6 +82,48 @@ describe('PATCH /api/teacher/classrooms/[id]/announcements/[announcementId]', ()
 
     const data = await response.json()
     expect(data.announcement).toBeDefined()
+  })
+
+  it('should update the optional announcement title', async () => {
+    const mockFrom = mockOwnershipCheck()
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: '  Calendar note  ' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcement.title).toBe('Calendar note')
+    expect(mockFrom.update).toHaveBeenCalledWith({ title: 'Calendar note' })
+  })
+
+  it('should clear the optional announcement title with a blank value', async () => {
+    const mockFrom = mockOwnershipCheck()
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements/a-1',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ title: '   ' }),
+      }
+    )
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: 'c-1', announcementId: 'a-1' }),
+    })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.announcement.title).toBeNull()
+    expect(mockFrom.update).toHaveBeenCalledWith({ title: null })
   })
 
   it('should return 400 when content is missing', async () => {

--- a/tests/api/teacher/announcements.test.ts
+++ b/tests/api/teacher/announcements.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, POST } from '@/app/api/teacher/classrooms/[id]/announcements/route'
 import { NextRequest } from 'next/server'
+import { ANNOUNCEMENT_TITLE_MAX_LENGTH } from '@/lib/announcements'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
@@ -121,18 +122,20 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
     const mockAnnouncement = {
       id: 'a-1',
       classroom_id: 'c-1',
+      title: 'Quiz reminder',
       content: 'Test Content',
       created_by: 'teacher-1',
       created_at: '2025-01-15T12:00:00Z',
       updated_at: '2025-01-15T12:00:00Z',
     }
+    const insert = vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({ data: mockAnnouncement, error: null }),
+      })),
+    }))
 
     const mockFrom = vi.fn(() => ({
-      insert: vi.fn(() => ({
-        select: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({ data: mockAnnouncement, error: null }),
-        })),
-      })),
+      insert,
     }))
     ;(mockSupabaseClient.from as any) = mockFrom
 
@@ -140,7 +143,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ content: 'Test Content' }),
+        body: JSON.stringify({ title: '  Quiz reminder  ', content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -148,7 +151,32 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
 
     const data = await response.json()
     expect(data.announcement.id).toBe('a-1')
+    expect(data.announcement.title).toBe('Quiz reminder')
     expect(data.announcement.content).toBe('Test Content')
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Quiz reminder',
+        content: 'Test Content',
+      }),
+    )
+  })
+
+  it('should reject titles that are too long', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'a'.repeat(ANNOUNCEMENT_TITLE_MAX_LENGTH + 1),
+          content: 'Test Content',
+        }),
+      }
+    )
+    const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
+    expect(response.status).toBe(400)
+
+    const data = await response.json()
+    expect(data.error).toBe(`Title must be ${ANNOUNCEMENT_TITLE_MAX_LENGTH} characters or fewer`)
   })
 
   it('should return 400 when content is missing', async () => {

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -40,6 +40,7 @@ const classroom: Classroom = {
 const markdownAnnouncement: Announcement = {
   id: 'announcement-1',
   classroom_id: classroom.id,
+  title: 'Unit update',
   content: 'Read the [course outline](https://example.com/outline) and **bring notes**.',
   created_by: classroom.teacher_id,
   scheduled_for: null,
@@ -47,7 +48,7 @@ const markdownAnnouncement: Announcement = {
   updated_at: '2026-05-13T12:00:00.000Z',
 }
 
-function mockAnnouncementFetch() {
+function mockAnnouncementFetch(announcements: Announcement[] = [markdownAnnouncement]) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -55,7 +56,7 @@ function mockAnnouncementFetch() {
         return new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 })
       }
 
-      return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+      return new Response(JSON.stringify({ announcements }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -80,6 +81,7 @@ describe('announcement markdown rendering', () => {
     const link = await screen.findByRole('link', { name: 'course outline' })
 
     expect(link).toHaveAttribute('href', 'https://example.com/outline')
+    expect(screen.getByText('Unit update')).toBeInTheDocument()
     expect(screen.getByText('bring notes')).toBeInTheDocument()
 
     fireEvent.click(link)
@@ -89,6 +91,66 @@ describe('announcement markdown rendering', () => {
     })
   })
 
+  it('renders a larger, vertically resizable creation textarea', async () => {
+    const { container } = render(<TeacherAnnouncementsSection classroom={classroom} />)
+
+    await screen.findByRole('link', { name: 'course outline' })
+    fireEvent.click(screen.getByRole('button', { name: 'New announcement' }))
+
+    const titleInput = screen.getByPlaceholderText('Title (optional)')
+    const titleLabel = container.querySelector(`label[for="${titleInput.id}"]`)
+    expect(titleLabel).toHaveClass('sr-only')
+    expect(screen.queryByPlaceholderText('Optional title')).not.toBeInTheDocument()
+    expect(titleInput.compareDocumentPosition(screen.getByText('Unit update')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    const textarea = screen.getByPlaceholderText('Write an announcement...')
+    expect(textarea).toHaveAttribute('rows', '6')
+    expect(textarea).toHaveClass('min-h-[10rem]')
+    expect(textarea).toHaveClass('resize-y')
+
+    fireEvent.change(textarea, { target: { value: 'Announcement draft' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Choose announcement action' }))
+    expect(screen.getByRole('menuitem', { name: 'Schedule...' })).toBeInTheDocument()
+  })
+
+  it('shows the newest teacher announcements first', async () => {
+    mockAnnouncementFetch([
+      {
+        ...markdownAnnouncement,
+        id: 'older-scheduled-announcement',
+        title: 'Older scheduled update',
+        scheduled_for: '2026-05-20T12:00:00.000Z',
+        created_at: '2026-05-12T12:00:00.000Z',
+        updated_at: '2026-05-12T12:00:00.000Z',
+      },
+      {
+        ...markdownAnnouncement,
+        id: 'newest-announcement',
+        title: 'Newest update',
+        scheduled_for: null,
+        created_at: '2026-05-14T12:00:00.000Z',
+        updated_at: '2026-05-14T12:00:00.000Z',
+      },
+      {
+        ...markdownAnnouncement,
+        id: 'middle-announcement',
+        title: 'Middle update',
+        scheduled_for: null,
+        created_at: '2026-05-13T12:00:00.000Z',
+        updated_at: '2026-05-13T12:00:00.000Z',
+      },
+    ])
+
+    render(<TeacherAnnouncementsSection classroom={classroom} />)
+
+    const newest = await screen.findByText('Newest update')
+    const middle = screen.getByText('Middle update')
+    const scheduled = screen.getByText('Older scheduled update')
+
+    expect(newest.compareDocumentPosition(middle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(middle.compareDocumentPosition(scheduled) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it('renders student announcements as markdown links', async () => {
     render(<StudentAnnouncementsSection classroom={classroom} />)
 
@@ -96,6 +158,7 @@ describe('announcement markdown rendering', () => {
 
     expect(link).toHaveAttribute('href', 'https://example.com/outline')
     expect(link).toHaveAttribute('target', '_blank')
+    expect(screen.getByText('Unit update')).toBeInTheDocument()
     expect(screen.getByText('bring notes')).toBeInTheDocument()
   })
 })

--- a/tests/components/LessonDayCell.test.tsx
+++ b/tests/components/LessonDayCell.test.tsx
@@ -43,6 +43,14 @@ const markdownAnnouncement: Announcement = {
   content: 'Read the [course outline](https://example.com/outline) before class.',
 }
 
+const titledAnnouncementTitle = 'Quiz reminder with a very long title that should truncate in the calendar'
+
+const titledAnnouncement: Announcement = {
+  ...longAnnouncement,
+  id: 'announcement-4',
+  title: titledAnnouncementTitle,
+}
+
 function renderWithTooltip(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>)
 }
@@ -204,6 +212,31 @@ describe('LessonDayCell', () => {
 
     const tooltip = await screen.findByRole('tooltip')
     expect(within(tooltip).getByText(longAnnouncement.content)).toBeInTheDocument()
+  })
+
+  it('uses the announcement title as the calendar label and keeps it truncated', async () => {
+    renderWithTooltip(
+      <LessonDayCell
+        date="2026-03-13"
+        day={new Date('2026-03-13T12:00:00.000Z')}
+        lessonPlan={null}
+        announcements={[titledAnnouncement]}
+        isWeekend={false}
+        isToday={false}
+        editable={false}
+        compact={false}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: titledAnnouncementTitle })
+    expect(button).toHaveClass('truncate')
+    expect(button).toHaveAttribute('title', titledAnnouncementTitle)
+
+    fireEvent.focus(button)
+
+    const tooltip = await screen.findByRole('tooltip')
+    expect(within(tooltip).getByText(titledAnnouncementTitle)).toBeInTheDocument()
+    expect(within(tooltip).getByText(titledAnnouncement.content)).toBeInTheDocument()
   })
 
   it('shows long announcement content without truncating it', async () => {

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ANNOUNCEMENT_TITLE_MAX_LENGTH,
+  getAnnouncementCalendarLabel,
+  normalizeAnnouncementTitle,
+  parseAnnouncementTitleInput,
+  sortAnnouncementsNewestFirst,
+} from '@/lib/announcements'
+
+describe('announcement helpers', () => {
+  it('normalizes blank announcement titles to null', () => {
+    expect(normalizeAnnouncementTitle('  Quiz reminder  ')).toBe('Quiz reminder')
+    expect(normalizeAnnouncementTitle('   ')).toBeNull()
+    expect(normalizeAnnouncementTitle(null)).toBeNull()
+  })
+
+  it('validates optional announcement title input', () => {
+    expect(parseAnnouncementTitleInput(undefined)).toEqual({ ok: true, value: undefined })
+    expect(parseAnnouncementTitleInput(null)).toEqual({ ok: true, value: null })
+    expect(parseAnnouncementTitleInput(' Calendar note ')).toEqual({ ok: true, value: 'Calendar note' })
+    expect(parseAnnouncementTitleInput('a'.repeat(ANNOUNCEMENT_TITLE_MAX_LENGTH + 1))).toEqual({
+      ok: false,
+      error: `Title must be ${ANNOUNCEMENT_TITLE_MAX_LENGTH} characters or fewer`,
+    })
+  })
+
+  it('uses the title for calendar labels before falling back to status labels', () => {
+    expect(getAnnouncementCalendarLabel({ title: 'Materials due' }, false)).toBe('Materials due')
+    expect(getAnnouncementCalendarLabel({ title: null }, false)).toBe('Announcement')
+    expect(getAnnouncementCalendarLabel({ title: '  ' }, true)).toBe('Scheduled')
+  })
+
+  it('sorts announcements newest first by creation date', () => {
+    const sorted = sortAnnouncementsNewestFirst([
+      {
+        id: 'older-scheduled',
+        created_at: '2026-05-12T12:00:00.000Z',
+        scheduled_for: '2026-05-20T12:00:00.000Z',
+      },
+      { id: 'newest', created_at: '2026-05-14T12:00:00.000Z', scheduled_for: null },
+      { id: 'older', created_at: '2026-05-13T12:00:00.000Z', scheduled_for: null },
+    ])
+
+    expect(sorted.map((announcement) => announcement.id)).toEqual(['newest', 'older', 'older-scheduled'])
+  })
+})


### PR DESCRIPTION
## Summary
- Add optional announcement titles with server-side validation, DB migration, API support, and teacher/student rendering.
- Use announcement titles for calendar labels with fallback text and truncation in the existing pill UI.
- Make calendar announcement popups interactive so links can be selected/clicked without the tooltip disappearing.
- Improve the teacher announcement composer: larger auto-growing/resizable textareas, title placeholder without a visible label, newest-first ordering, composer above the existing list, and the shared SplitButton for Post/Schedule actions.

## Why
Announcement calendar entries previously showed only generic labels, the calendar tooltip could not be interacted with, and the announcement composer controls had drifted from shared UI patterns.

## Validation
- pnpm test tests/unit/announcements.test.ts tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/components/LessonDayCell.test.tsx tests/components/AnnouncementsMarkdown.test.tsx tests/components/LessonCalendar.test.tsx
- pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/ui/SplitButton.test.tsx tests/unit/announcements.test.ts
- pnpm lint
- pnpm test
- pnpm build
- Pika UI verify screenshots for calendar and announcements teacher/student views
- Targeted Playwright screenshots for title placeholders, newest-first ordering, tooltip link hover, composer sizing, and shared split-button menu state
