### PR TITLE
[codex] Add assignment split-pane view toggle

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,19 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Teacher test list closed-access badge
-
-**Completed:**
-- Fixed teacher test list cards so an active test with access closed for every enrolled student displays a `Closed` badge instead of `Open`.
-- Kept the underlying test lifecycle status unchanged and updated list access counts locally after open/close-all actions.
-- Added focused utility and component coverage for the all-students-closed display case.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/quizzes.test.ts tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-test-open-badge E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
-
 ## 2026-05-13 — Teacher test grading closed-access refresh
 
 **Completed:**
@@ -349,3 +336,43 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-teacher-edit-right.png`
   - `/tmp/pika-teacher-footer-no-outline.png`
   - `/tmp/pika-teacher-archived-exit-active.png`
+
+## 2026-05-14 — Assignment workspace split-pane toggle
+
+**Completed:**
+- Replaced the assignment workspace class/individual segmented control with one cycling split-pane button for Students + grading, Content + grading, and Students + content.
+- Updated the cycle button to show a compact numbered view indicator: `1` + grade icon, `2` + content icon, and `3` + table icon.
+- Persisted the selected assignment pane view in browser session storage while keeping pane resizing on the shared teacher workspace split primitive.
+- Added regression coverage for view cycling, session restore, and the updated panel composition.
+
+**Validation:**
+- `pnpm test tests/unit/assignment-grading-layout.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/unit/assignment-grading-layout.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3100 pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/student-assignment-split-views E2E_BASE_URL=http://localhost:3100 bash /Users/stew/Repos/.worktrees/pika/student-assignment-split-views/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional selected-workspace screenshots:
+  - `/tmp/pika-assignment-view-1-students-grading.png`
+  - `/tmp/pika-assignment-view-2-content-grading.png`
+  - `/tmp/pika-assignment-view-3-students-content.png`
+  - `/tmp/pika-assignment-mobile-view-1.png`
+  - `/tmp/pika-assignment-mobile-view-2.png`
+  - `/tmp/pika-assignment-desktop-1-students-grading-icons.png`
+  - `/tmp/pika-assignment-desktop-2-content-grading-icons.png`
+  - `/tmp/pika-assignment-desktop-3-students-content-icons.png`
+  - `/tmp/pika-assignment-mobile-1-students-grading-icons.png`
+  - `/tmp/pika-assignment-mobile-2-content-grading-icons.png`
+  - `/tmp/pika-assignment-mobile-3-students-content-icons.png`
+  - `/tmp/pika-assignment-desktop-1-students-grading-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-desktop-2-content-grading-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-desktop-3-students-content-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-mobile-1-students-grading-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-mobile-2-content-grading-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-mobile-3-students-content-simple-icons-loaded.png`
+  - `/tmp/pika-assignment-desktop-1-students-grading-numbered-indicator.png`
+  - `/tmp/pika-assignment-desktop-2-content-grading-numbered-indicator.png`
+  - `/tmp/pika-assignment-desktop-3-students-content-numbered-indicator.png`
+  - `/tmp/pika-assignment-mobile-1-students-grading-numbered-indicator.png`
+  - `/tmp/pika-assignment-mobile-2-content-grading-numbered-indicator.png`
+  - `/tmp/pika-assignment-mobile-3-students-content-numbered-indicator.png`

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -24,17 +24,18 @@ import {
   ChevronLeft,
   ChevronRight,
   Copy,
+  FileCheck,
+  FileText,
   GripVertical,
   LoaderCircle,
   MessageSquare,
   Pencil,
   Plus,
   Send,
+  Table,
   Trash2,
-  User,
-  Users,
 } from 'lucide-react'
-import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SegmentedControl, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -70,8 +71,13 @@ import { useAssignmentGradingLayout } from '@/hooks/use-assignment-grading-layou
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
+  getAssignmentSplitPaneViewSessionKey,
   getAssignmentWorkspaceStudentCookieName,
+  getDefaultAssignmentSplitPaneView,
+  getNextAssignmentSplitPaneView,
+  parseAssignmentSplitPaneView,
   parseAssignmentWorkspaceStudentId,
+  type AssignmentSplitPaneView,
   type AssignmentWorkspaceMode,
 } from '@/lib/assignment-grading-layout'
 import { buildOrderedClassworkItems } from '@/lib/classwork-order'
@@ -97,6 +103,7 @@ import { applyDirection, compareByNameFields, toggleSort as toggleSortState } fr
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { readCookie, writeCookie } from '@/lib/cookies'
+import { safeSessionGetJson, safeSessionSetJson } from '@/lib/client-storage'
 
 interface AssignmentWithStats extends Assignment {
   stats: AssignmentStats
@@ -110,7 +117,6 @@ type GradeSelectedUpdatedDoc = NonNullable<StudentSubmissionRow['doc']> & {
   updated_at?: string | null
 }
 type GradeSelectedApplyTarget = 'grade' | 'comments'
-type AssignmentLeftPaneView = 'class' | 'individual'
 type UpdateSearchParamsFn = (
   updater: (params: URLSearchParams) => void,
   options?: { replace?: boolean },
@@ -119,6 +125,21 @@ type UpdateSearchParamsFn = (
 export type AssignmentViewMode = 'summary' | 'assignment'
 
 const EMPTY_DOC: TiptapContent = { type: 'doc', content: [] }
+
+const ASSIGNMENT_SPLIT_PANE_VIEW_LABELS: Record<AssignmentSplitPaneView, string> = {
+  'students-grading': 'Students + grading',
+  'content-grading': 'Content + grading',
+  'students-content': 'Students + content',
+}
+
+const ASSIGNMENT_SPLIT_PANE_VIEW_INDICATORS: Record<
+  AssignmentSplitPaneView,
+  { index: 1 | 2 | 3; icon: 'students' | 'grading' | 'content' }
+> = {
+  'students-grading': { index: 1, icon: 'grading' },
+  'content-grading': { index: 2, icon: 'content' },
+  'students-content': { index: 3, icon: 'students' },
+}
 
 interface Props {
   classroom: Classroom
@@ -147,6 +168,22 @@ function MetricBar({ value }: { value: number }) {
       />
     </div>
   )
+}
+
+function AssignmentSplitPaneIcon({
+  pane,
+}: {
+  pane: 'students' | 'grading' | 'content'
+}) {
+  if (pane === 'students') {
+    return <Table className="h-4 w-4" aria-hidden="true" />
+  }
+
+  if (pane === 'grading') {
+    return <FileCheck className="h-4 w-4" aria-hidden="true" />
+  }
+
+  return <FileText className="h-4 w-4" aria-hidden="true" />
 }
 
 function TeacherMaterialCard({
@@ -590,7 +627,13 @@ export function TeacherClassroomView({
     studentName: string
     characterCount: number
   } | null>(null)
-  const [leftPaneView, setLeftPaneView] = useState<AssignmentLeftPaneView>('class')
+  const [splitPaneViewState, setSplitPaneViewState] = useState<{
+    key: string | null
+    view: AssignmentSplitPaneView
+  }>({
+    key: null,
+    view: getDefaultAssignmentSplitPaneView(),
+  })
   const [editAssignment, setEditAssignment] = useState<Assignment | null>(null)
   const [error, setError] = useState('')
   const [info, setInfo] = useState('')
@@ -820,7 +863,7 @@ export function TeacherClassroomView({
 
     observer.observe(node)
     return () => observer.disconnect()
-  }, [selection.mode, leftPaneView, selectedStudentId])
+  }, [selection.mode, selectedStudentId, splitPaneViewState.view])
 
   const classworkItems = useMemo(
     () => buildOrderedClassworkItems(assignments, materials, surveys),
@@ -1056,7 +1099,6 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
-      setLeftPaneView('class')
       setSelectedStudentId(null)
       setWorkspaceLoading(false)
       return
@@ -1293,7 +1335,6 @@ export function TeacherClassroomView({
 
   useEffect(() => {
     if (selection.mode !== 'assignment') return
-    setLeftPaneView('class')
     setSelectedStudentId(null)
     setWorkspaceLoading(false)
     batchClearSelection()
@@ -1662,13 +1703,51 @@ export function TeacherClassroomView({
   }, [currentStudentRows, selectedStudentId])
   const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
   const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
+  const splitPaneViewSessionKey = selectedAssignmentId
+    ? getAssignmentSplitPaneViewSessionKey(classroom.id, selectedAssignmentId)
+    : null
+  const splitPaneView = splitPaneViewState.key === splitPaneViewSessionKey
+    ? splitPaneViewState.view
+    : getDefaultAssignmentSplitPaneView()
+
+  useEffect(() => {
+    const nextView = splitPaneViewSessionKey
+      ? parseAssignmentSplitPaneView(safeSessionGetJson<unknown>(splitPaneViewSessionKey))
+      : getDefaultAssignmentSplitPaneView()
+    setSplitPaneViewState({
+      key: splitPaneViewSessionKey,
+      view: nextView,
+    })
+  }, [splitPaneViewSessionKey])
+
+  const setPersistedSplitPaneView = useCallback((
+    next:
+      | AssignmentSplitPaneView
+      | ((current: AssignmentSplitPaneView) => AssignmentSplitPaneView),
+  ) => {
+    setSplitPaneViewState((current) => {
+      const currentView = current.key === splitPaneViewSessionKey
+        ? current.view
+        : getDefaultAssignmentSplitPaneView()
+      const nextView = typeof next === 'function' ? next(currentView) : next
+
+      if (splitPaneViewSessionKey) {
+        safeSessionSetJson(splitPaneViewSessionKey, nextView)
+      }
+
+      return {
+        key: splitPaneViewSessionKey,
+        view: nextView,
+      }
+    })
+  }, [splitPaneViewSessionKey])
 
   const {
     scrollRef: classPaneScrollRef,
     preserveScrollPosition: preserveClassPaneScrollPosition,
   } = useScrollPositionMemory<HTMLDivElement>({
     key: selectedAssignmentId,
-    enabled: leftPaneView === 'class',
+    enabled: splitPaneView !== 'content-grading',
     restoreToken: [
       activeSelectedStudentId ?? 'none',
       currentStudentRows.length,
@@ -1759,21 +1838,22 @@ export function TeacherClassroomView({
     return currentStudentRows[0]?.student_id ?? null
   }, [classroom.id, currentStudentRows, selectedStudentId, selection])
 
-  const handleSwitchLeftPaneView = useCallback((nextView: AssignmentLeftPaneView) => {
-    if (nextView === leftPaneView) return
+  const handleCycleSplitPaneView = useCallback(() => {
+    const nextView = getNextAssignmentSplitPaneView(splitPaneView)
 
-    if (nextView === 'individual') {
+    if (nextView !== 'students-grading') {
       const nextStudentId = resolveDetailsStudentId()
       if (!nextStudentId) return
       setIndividualHeaderMeta(null)
       setSelectedStudentAndNavigate(nextStudentId, { replace: true })
     }
 
-    setLeftPaneView(nextView)
+    setPersistedSplitPaneView(nextView)
   }, [
-    leftPaneView,
     resolveDetailsStudentId,
+    setPersistedSplitPaneView,
     setSelectedStudentAndNavigate,
+    splitPaneView,
   ])
 
   useEffect(() => {
@@ -1882,7 +1962,7 @@ export function TeacherClassroomView({
         ? `${individualHeaderMeta.characterCount} chars`
         : 'Loading…'
       : null
-  const activeWorkspaceMode: AssignmentWorkspaceMode = leftPaneView === 'individual' ? 'details' : 'overview'
+  const activeWorkspaceMode: AssignmentWorkspaceMode = splitPaneView === 'content-grading' ? 'details' : 'overview'
   const activeWorkspaceLayout = assignmentGradingLayout[activeWorkspaceMode]
   const highlightedInspectorSections =
     highlightedApplyTarget === 'grade'
@@ -1890,7 +1970,7 @@ export function TeacherClassroomView({
       : highlightedApplyTarget === 'comments'
         ? (['comments'] as const)
         : undefined
-  const canOpenIndividual =
+  const canCycleSplitPaneView =
     selection.mode === 'assignment' &&
     !selectedAssignmentLoading &&
     currentStudentRows.length > 0
@@ -1990,115 +2070,117 @@ export function TeacherClassroomView({
 
   const classPaneActions = (
     <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
-      <SplitButton
-        label={
-          <span className="inline-flex items-center gap-2">
-            <Check className="h-4 w-4" aria-hidden="true" />
-            <span>AI Grade</span>
-          </span>
-        }
-        onPrimaryClick={() => {
-          void handleBatchAutoGrade()
-        }}
-        options={[
-          {
-            id: 'edit-assignment',
-            label: (
-              <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                <Pencil className="h-4 w-4" aria-hidden="true" />
-                <span>Edit Assignment</span>
-              </span>
-            ),
-            onSelect: () => {
-              if (activeSelectedAssignmentData) {
-                setEditAssignment(activeSelectedAssignmentData.assignment)
-              }
+      <span className="inline-flex">
+        <SplitButton
+          label={
+            <span className="inline-flex items-center gap-2">
+              <Check className="h-4 w-4" aria-hidden="true" />
+              <span>AI Grade</span>
+            </span>
+          }
+          onPrimaryClick={() => {
+            void handleBatchAutoGrade()
+          }}
+          options={[
+            {
+              id: 'edit-assignment',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
+                  <span>Edit Assignment</span>
+                </span>
+              ),
+              onSelect: () => {
+                if (activeSelectedAssignmentData) {
+                  setEditAssignment(activeSelectedAssignmentData.assignment)
+                }
+              },
+              disabled: !canEditAssignment,
             },
-            disabled: !canEditAssignment,
-          },
-          {
-            id: 'delete-assignment',
-            label: (
-              <span className="inline-flex items-center gap-2 whitespace-nowrap text-danger">
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-                <span>Delete Assignment</span>
-              </span>
-            ),
-            onSelect: () => {
-              if (activeSelectedAssignmentData) {
-                setPendingDelete({
-                  id: activeSelectedAssignmentData.assignment.id,
-                  title: activeSelectedAssignmentData.assignment.title,
-                })
-              }
+            {
+              id: 'delete-assignment',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap text-danger">
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  <span>Delete Assignment</span>
+                </span>
+              ),
+              onSelect: () => {
+                if (activeSelectedAssignmentData) {
+                  setPendingDelete({
+                    id: activeSelectedAssignmentData.assignment.id,
+                    title: activeSelectedAssignmentData.assignment.title,
+                  })
+                }
+              },
+              disabled: !activeSelectedAssignmentData || selectedAssignmentLoading || isReadOnly || isDeleting,
             },
-            disabled: !activeSelectedAssignmentData || selectedAssignmentLoading || isReadOnly || isDeleting,
-          },
-          {
-            id: 'grade-selected',
-            label: (
-              <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                <Copy className="h-4 w-4" aria-hidden="true" />
-                <span>Apply Grade to Selected Students</span>
-              </span>
-            ),
-            onHoverChange: (active) => setHighlightedApplyTarget(active ? 'grade' : null),
-            onSelect: () => {
-              setHighlightedApplyTarget(null)
-              setGradeSelectedConfirmTarget('grade')
+            {
+              id: 'grade-selected',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                  <span>Apply Grade to Selected Students</span>
+                </span>
+              ),
+              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'grade' : null),
+              onSelect: () => {
+                setHighlightedApplyTarget(null)
+                setGradeSelectedConfirmTarget('grade')
+              },
+              disabled: isApplyGradeSelectedDisabled,
             },
-            disabled: isApplyGradeSelectedDisabled,
-          },
-          {
-            id: 'comments-selected',
-            label: (
-              <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                <MessageSquare className="h-4 w-4" aria-hidden="true" />
-                <span>Apply Comments to Selected Students</span>
-              </span>
-            ),
-            onHoverChange: (active) => setHighlightedApplyTarget(active ? 'comments' : null),
-            onSelect: () => {
-              setHighlightedApplyTarget(null)
-              setGradeSelectedConfirmTarget('comments')
+            {
+              id: 'comments-selected',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <MessageSquare className="h-4 w-4" aria-hidden="true" />
+                  <span>Apply Comments to Selected Students</span>
+                </span>
+              ),
+              onHoverChange: (active) => setHighlightedApplyTarget(active ? 'comments' : null),
+              onSelect: () => {
+                setHighlightedApplyTarget(null)
+                setGradeSelectedConfirmTarget('comments')
+              },
+              disabled: isApplyCommentsSelectedDisabled,
             },
-            disabled: isApplyCommentsSelectedDisabled,
-          },
-          {
-            id: 'repo-analysis',
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                <span>Repo analysis</span>
-              </span>
-            ),
-            onSelect: () => {
-              void handleBatchArtifactRepoAnalyze()
+            {
+              id: 'repo-analysis',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
+                  <span>Repo analysis</span>
+                </span>
+              ),
+              onSelect: () => {
+                void handleBatchArtifactRepoAnalyze()
+              },
+              disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
             },
-            disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
-          },
-          {
-            id: 'return',
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <Send className="h-4 w-4" aria-hidden="true" />
-                <span>Return</span>
-              </span>
-            ),
-            onSelect: () => {
-              setShowReturnConfirm(true)
+            {
+              id: 'return',
+              label: (
+                <span className="inline-flex items-center gap-2">
+                  <Send className="h-4 w-4" aria-hidden="true" />
+                  <span>Return</span>
+                </span>
+              ),
+              onSelect: () => {
+                setShowReturnConfirm(true)
+              },
+              disabled: isReturnDisabled,
             },
-            disabled: isReturnDisabled,
-          },
-        ]}
-        className="inline-flex"
-        toggleAriaLabel={`More assignment actions${workspaceActionLabelSuffix}`}
-        menuPlacement="down"
-        primaryButtonProps={{
-          'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
-          disabled: isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
-        }}
-      />
+          ]}
+          className="inline-flex"
+          toggleAriaLabel={`More assignment actions${workspaceActionLabelSuffix}`}
+          menuPlacement="down"
+          primaryButtonProps={{
+            'aria-label': `AI Grade${workspaceActionLabelSuffix}`,
+            disabled: isAutoGrading || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
+          }}
+        />
+      </span>
     </Tooltip>
   )
 
@@ -2157,26 +2239,57 @@ export function TeacherClassroomView({
     />
   )
 
+  const splitPaneViewLabel = ASSIGNMENT_SPLIT_PANE_VIEW_LABELS[splitPaneView]
+  const nextSplitPaneView = getNextAssignmentSplitPaneView(splitPaneView)
+  const nextSplitPaneViewLabel = ASSIGNMENT_SPLIT_PANE_VIEW_LABELS[nextSplitPaneView]
+  const splitPaneViewIndicator = ASSIGNMENT_SPLIT_PANE_VIEW_INDICATORS[splitPaneView]
+
   const assignmentWorkspaceControls = selection.mode === 'assignment' ? (
     <div
       data-testid="assignment-workspace-actionbar-center"
       className="relative flex min-w-0 items-center justify-center gap-2"
     >
-      <SegmentedControl<AssignmentLeftPaneView>
-        ariaLabel="Assignment workspace view"
-        value={leftPaneView}
-        onChange={handleSwitchLeftPaneView}
-        iconOnly
-        options={[
-          { value: 'class', label: 'Class', icon: <Users className="h-4 w-4" /> },
-          {
-            value: 'individual',
-            label: 'Individual',
-            icon: <User className="h-4 w-4" />,
-            disabled: !canOpenIndividual,
-          },
-        ]}
-      />
+      <Tooltip
+        content={
+          canCycleSplitPaneView
+            ? `Current: ${splitPaneViewLabel}. Next: ${nextSplitPaneViewLabel}.`
+            : 'No students available for split views yet.'
+        }
+      >
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="inline-flex min-w-0 items-center gap-1.5"
+            onClick={handleCycleSplitPaneView}
+            disabled={!canCycleSplitPaneView}
+            aria-label={`Assignment panes: ${splitPaneViewLabel}. Switch to ${nextSplitPaneViewLabel}.`}
+          >
+            <span
+              className="inline-flex items-center gap-1.5"
+              data-testid="assignment-split-pane-indicator"
+              data-view-index={splitPaneViewIndicator.index}
+              data-view-icon={splitPaneViewIndicator.icon}
+            >
+              <span
+                className="min-w-3 text-center text-xs font-semibold tabular-nums"
+                data-testid="assignment-split-pane-index"
+                aria-hidden="true"
+              >
+                {splitPaneViewIndicator.index}
+              </span>
+              <span
+                className="inline-flex"
+                data-testid="assignment-split-pane-icon"
+              >
+                <AssignmentSplitPaneIcon pane={splitPaneViewIndicator.icon} />
+              </span>
+            </span>
+            <span className="sr-only">{splitPaneViewLabel}</span>
+          </Button>
+        </span>
+      </Tooltip>
       {classPaneActions}
       {workspaceStatus}
     </div>
@@ -2325,8 +2438,6 @@ export function TeacherClassroomView({
     </TeacherWorkItemList>
   )
 
-  const leftPaneHeader = leftPaneView === 'individual' ? selectedStudentControls : null
-
   const workspaceContent = selectedAssignmentId == null ? null : activeSelectedStudentId ? (
     <TeacherStudentWorkPanel
       classroomId={classroom.id}
@@ -2334,8 +2445,8 @@ export function TeacherClassroomView({
       studentId={activeSelectedStudentId}
       mode="workspace"
       classPane={classPane}
-      leftPaneView={leftPaneView}
-      leftHeader={leftPaneHeader}
+      splitPaneView={splitPaneView}
+      studentHeader={selectedStudentControls}
       inspectorCollapsed={false}
       inspectorWidth={activeWorkspaceLayout.inspectorWidth}
       refreshKey={gradeSelectedRefreshCounter}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -10,6 +10,7 @@ import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/Teacher
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentWorkspacePaneLayout,
+  type AssignmentSplitPaneView,
   type AssignmentWorkspaceMode,
   type AssignmentWorkspacePaneLayout,
 } from '@/lib/assignment-grading-layout'
@@ -23,8 +24,8 @@ interface TeacherStudentWorkPanelProps {
   refreshKey?: number
   mode?: AssignmentWorkspaceMode | 'workspace'
   classPane?: ReactNode
-  leftPaneView?: 'class' | 'individual'
-  leftHeader?: ReactNode
+  splitPaneView?: AssignmentSplitPaneView
+  studentHeader?: ReactNode
   inspectorCollapsed?: boolean
   inspectorWidth?: number
   totalWidth?: number
@@ -77,8 +78,8 @@ export function TeacherStudentWorkPanel({
   refreshKey = 0,
   mode = 'details',
   classPane,
-  leftPaneView = 'class',
-  leftHeader,
+  splitPaneView = 'students-grading',
+  studentHeader,
   inspectorCollapsed = false,
   inspectorWidth = ASSIGNMENT_GRADING_LAYOUT.defaultInspectorWidth,
   totalWidth = 0,
@@ -139,9 +140,10 @@ export function TeacherStudentWorkPanel({
     onLoadingStateChange,
   })
   const previousInspectorEditModeRef = useRef(inspectorEditMode)
+  const hasGradingPane = mode !== 'workspace' || splitPaneView !== 'students-content'
   const layoutMode: AssignmentWorkspaceMode =
     mode === 'workspace'
-      ? leftPaneView === 'individual'
+      ? splitPaneView === 'content-grading'
         ? 'details'
         : 'overview'
       : mode
@@ -177,7 +179,10 @@ export function TeacherStudentWorkPanel({
   }, [collapseAllSections, inspectorEditMode])
 
   useEffect(() => {
-    if (mode === 'overview' || showInitialSpinner || error || !data) {
+    const hasStudentContentPane = mode !== 'overview' && (
+      mode !== 'workspace' || splitPaneView !== 'students-grading'
+    )
+    if (!hasStudentContentPane || showInitialSpinner || error || !data) {
       onDetailsMetaChange?.(null)
       return
     }
@@ -193,14 +198,14 @@ export function TeacherStudentWorkPanel({
       studentName: nextStudentDisplayName,
       characterCount: nextCharacterCount,
     })
-  }, [data, error, leftPaneView, mode, onDetailsMetaChange, previewContent, showInitialSpinner])
+  }, [data, error, mode, onDetailsMetaChange, previewContent, showInitialSpinner, splitPaneView])
 
   useEffect(() => {
     return () => onGradeTemplateChange?.(null)
   }, [onGradeTemplateChange])
 
   useEffect(() => {
-    const shouldReportGradeTemplate = mode === 'overview' || mode === 'workspace'
+    const shouldReportGradeTemplate = (mode === 'overview' || mode === 'workspace') && hasGradingPane
     if (!shouldReportGradeTemplate || showInitialSpinner || error || !data || data.student.id !== studentId) {
       onGradeTemplateChange?.(null)
       return
@@ -219,6 +224,7 @@ export function TeacherStudentWorkPanel({
     error,
     feedbackDraft,
     gradeMode,
+    hasGradingPane,
     mode,
     onGradeTemplateChange,
     scoreCompletion,
@@ -323,10 +329,23 @@ export function TeacherStudentWorkPanel({
   }
 
   if (mode === 'workspace') {
-    const primaryPane = leftPaneView === 'individual' ? workPane : classPane ?? workPane
-    const primaryMinPx = leftPaneView === 'individual'
+    const primaryPane = splitPaneView === 'content-grading'
+      ? workPane
+      : classPane ?? workPane
+    const inspectorPane = splitPaneView === 'students-content'
+      ? workPane
+      : inspector
+    const primaryHeader = splitPaneView === 'content-grading' ? studentHeader : undefined
+    const inspectorHeader = splitPaneView === 'students-content' ? studentHeader : undefined
+    const primaryMinPx = splitPaneView === 'content-grading'
       ? ASSIGNMENT_GRADING_LAYOUT.detailsPrimaryMinPx
       : ASSIGNMENT_GRADING_LAYOUT.overviewPrimaryMinPx
+    const dividerLabel =
+      splitPaneView === 'students-grading'
+        ? 'Resize students and grading panes'
+        : splitPaneView === 'content-grading'
+          ? 'Resize content and grading panes'
+          : 'Resize students and content panes'
 
     return (
       <TeacherWorkspaceSplit
@@ -351,15 +370,15 @@ export function TeacherStudentWorkPanel({
             inspectorWidth: nextInspectorWidth,
           }))
         }}
-        dividerLabel="Resize assignment workspace panes"
+        dividerLabel={dividerLabel}
         primary={
-          <AssignmentWorkspacePaneFrame header={leftHeader}>
+          <AssignmentWorkspacePaneFrame header={primaryHeader}>
             {primaryPane}
           </AssignmentWorkspacePaneFrame>
         }
         inspector={
-          <AssignmentWorkspacePaneFrame>
-            {inspector}
+          <AssignmentWorkspacePaneFrame header={inspectorHeader}>
+            {inspectorPane}
           </AssignmentWorkspacePaneFrame>
         }
       />

--- a/src/lib/assignment-grading-layout.ts
+++ b/src/lib/assignment-grading-layout.ts
@@ -1,4 +1,8 @@
 export type AssignmentWorkspaceMode = 'overview' | 'details'
+export type AssignmentSplitPaneView =
+  | 'students-grading'
+  | 'content-grading'
+  | 'students-content'
 
 export interface AssignmentWorkspacePaneLayout {
   inspectorCollapsed: boolean
@@ -20,6 +24,12 @@ export const ASSIGNMENT_GRADING_LAYOUT = {
   overviewPrimaryMinPx: 420,
   detailsPrimaryMinPx: 360,
 } as const
+
+export const ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE: readonly AssignmentSplitPaneView[] = [
+  'students-grading',
+  'content-grading',
+  'students-content',
+] as const
 
 const DEFAULT_PANE_LAYOUT: AssignmentWorkspacePaneLayout = {
   inspectorCollapsed: false,
@@ -81,6 +91,35 @@ export function getAssignmentWorkspaceStudentCookieName(
   assignmentId: string,
 ): string {
   return `pika_assignment_workspace_student:${classroomId}:${assignmentId}`
+}
+
+export function getAssignmentSplitPaneViewSessionKey(
+  classroomId: string,
+  assignmentId: string,
+): string {
+  return `pika_assignment_split_pane_view:${classroomId}:${assignmentId}`
+}
+
+export function getDefaultAssignmentSplitPaneView(): AssignmentSplitPaneView {
+  return ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE[0]
+}
+
+export function parseAssignmentSplitPaneView(
+  value: unknown,
+): AssignmentSplitPaneView {
+  return ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE.includes(value as AssignmentSplitPaneView)
+    ? value as AssignmentSplitPaneView
+    : getDefaultAssignmentSplitPaneView()
+}
+
+export function getNextAssignmentSplitPaneView(
+  current: AssignmentSplitPaneView,
+): AssignmentSplitPaneView {
+  const currentIndex = ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE.indexOf(current)
+  const nextIndex = currentIndex === -1
+    ? 0
+    : (currentIndex + 1) % ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE.length
+  return ASSIGNMENT_SPLIT_PANE_VIEW_SEQUENCE[nextIndex]
 }
 
 export function serializeAssignmentGradingLayout(

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -210,8 +210,8 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
     studentId,
     mode,
     classPane,
-    leftPaneView = 'class',
-    leftHeader,
+    splitPaneView = 'students-grading',
+    studentHeader,
     inspectorWidth,
     onLayoutChange,
     onDetailsMetaChange,
@@ -220,15 +220,15 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
   }: any) => {
     useEffect(() => {
       onDetailsMetaChange?.(
-        mode === 'details' || mode === 'workspace'
+        mode === 'details' || (mode === 'workspace' && splitPaneView !== 'students-grading')
           ? { studentName: `${studentId} Student`, characterCount: 17 }
           : null,
       )
-    }, [leftPaneView, mode, onDetailsMetaChange, studentId])
+    }, [mode, onDetailsMetaChange, splitPaneView, studentId])
 
     useEffect(() => {
       onGradeTemplateChange?.(
-        mode === 'overview' || mode === 'workspace'
+        mode === 'overview' || (mode === 'workspace' && splitPaneView !== 'students-content')
           ? {
               studentId,
               scoreCompletion: '7',
@@ -239,7 +239,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
             }
           : null,
       )
-    }, [mode, onGradeTemplateChange, studentId])
+    }, [mode, onGradeTemplateChange, splitPaneView, studentId])
 
     if (mode === 'workspace') {
       return (
@@ -247,6 +247,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
           data-testid="teacher-work-panel"
           data-highlighted-sections={highlightedInspectorSections.join(',')}
         >
+          <div data-testid="assignment-split-pane-view">{splitPaneView}</div>
           <div data-testid="assignment-workspace-inspector-width">{inspectorWidth}</div>
           <button
             type="button"
@@ -256,11 +257,24 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
           </button>
           <div>{`overview:${assignmentId}:${studentId}`}</div>
           <div key={studentId} data-testid="assignment-left-pane">
-            {leftHeader}
-            {leftPaneView === 'class' ? classPane : <div>{`work:${assignmentId}:${studentId}`}</div>}
+            {splitPaneView === 'content-grading' ? (
+              <>
+                {studentHeader}
+                <div>{`work:${assignmentId}:${studentId}`}</div>
+              </>
+            ) : (
+              classPane
+            )}
           </div>
           <div data-testid="assignment-right-pane">
-            <div>{`grading:${assignmentId}:${studentId}`}</div>
+            {splitPaneView === 'students-content' ? (
+              <>
+                {studentHeader}
+                <div>{`work:${assignmentId}:${studentId}`}</div>
+              </>
+            ) : (
+              <div>{`grading:${assignmentId}:${studentId}`}</div>
+            )}
           </div>
         </div>
       )
@@ -496,6 +510,29 @@ function clearSelectionCookie() {
   document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=; Path=/; Max-Age=0; SameSite=Lax`
 }
 
+function expectAssignmentSplitPaneIndicator({
+  index,
+  icon,
+  iconClass,
+}: {
+  index: string
+  icon: string
+  iconClass: string
+}) {
+  const indicator = screen.getByTestId('assignment-split-pane-indicator')
+  const iconNode = screen.getByTestId('assignment-split-pane-icon')
+  const svg = iconNode.querySelector('svg')
+
+  if (!svg) {
+    throw new Error('Expected assignment split-pane toggle icon to render an SVG')
+  }
+
+  expect(indicator).toHaveAttribute('data-view-index', index)
+  expect(indicator).toHaveAttribute('data-view-icon', icon)
+  expect(screen.getByTestId('assignment-split-pane-index')).toHaveTextContent(index)
+  expect(svg).toHaveClass(iconClass)
+}
+
 function applySearchParamsUpdate(
   call: [(params: URLSearchParams) => void, { replace?: boolean } | undefined],
   initial = 'tab=assignments',
@@ -525,6 +562,7 @@ describe('TeacherClassroomView', () => {
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
     mockStudentSelectionState.selectedCount = 0
+    window.sessionStorage.clear()
     clearSelectionCookie()
     mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
       if (key === `teacher-assignments:${classroom.id}`) {
@@ -549,6 +587,7 @@ describe('TeacherClassroomView', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+    window.sessionStorage.clear()
     clearSelectionCookie()
   })
 
@@ -1162,7 +1201,7 @@ describe('TeacherClassroomView', () => {
     })
   })
 
-  it('renders the class-individual switch and grading split button in the selected-assignment action bar', async () => {
+  it('renders the split-pane cycle button and grading split button in the selected-assignment action bar', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -1194,11 +1233,18 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    const workspaceControls = within(screen.getByRole('group', { name: 'Assignment workspace view' }))
-    expect(workspaceControls.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
-    expect(workspaceControls.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', {
+      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
+    })).toBeInTheDocument()
+    expectAssignmentSplitPaneIndicator({
+      index: '1',
+      icon: 'grading',
+      iconClass: 'lucide-file-check',
+    })
+    expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-grading')
     expect(screen.queryByRole('group', { name: 'Left pane view' })).not.toBeInTheDocument()
     expect(screen.queryByRole('group', { name: 'Right pane view' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('group', { name: 'Assignment workspace view' })).not.toBeInTheDocument()
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
@@ -1574,7 +1620,7 @@ describe('TeacherClassroomView', () => {
     expect(mockClearSelection).not.toHaveBeenCalled()
   })
 
-  it('switches to individual mode with student controls in the action bar', async () => {
+  it('cycles to content and grading with student controls in the content pane', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -1606,12 +1652,18 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' }))
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
+    }))
 
     await waitFor(() => {
+      expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('content-grading')
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('work:assignment-1:student-1')
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
+    expect(JSON.parse(
+      window.sessionStorage.getItem(`pika_assignment_split_pane_view:${classroom.id}:assignment-1`) ?? 'null',
+    )).toBe('content-grading')
 
     expect(screen.getByTestId('assignment-workspace-inspector-width')).toHaveTextContent('64')
     fireEvent.click(screen.getByRole('button', { name: 'Mock resize split' }))
@@ -1620,7 +1672,14 @@ describe('TeacherClassroomView', () => {
       inspectorCollapsed: false,
       inspectorWidth: 61,
     })
-    expect(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', {
+      name: 'Assignment panes: Content + grading. Switch to Students + content.',
+    })).toBeInTheDocument()
+    expectAssignmentSplitPaneIndicator({
+      index: '2',
+      icon: 'content',
+      iconClass: 'lucide-file-text',
+    })
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()
     expect(screen.getByText('student-1 Student')).toBeInTheDocument()
@@ -1631,7 +1690,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByRole('button', { name: 'Next student' })).toBeInTheDocument()
   })
 
-  it('keeps the right pane on grading when switching the action bar view control', async () => {
+  it('cycles through all three requested split-pane views', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -1663,18 +1722,97 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' }))
+    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
 
     await waitFor(() => {
+      expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('content-grading')
+      expectAssignmentSplitPaneIndicator({
+        index: '2',
+        icon: 'content',
+        iconClass: 'lucide-file-text',
+      })
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('work:assignment-1:student-1')
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    expect(within(screen.getByRole('group', { name: 'Assignment workspace view' })).getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByText('student-1 Student')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-content')
+      expectAssignmentSplitPaneIndicator({
+        index: '3',
+        icon: 'students',
+        iconClass: 'lucide-table',
+      })
+      expect(screen.getByTestId('assignment-left-pane')).toHaveTextContent('student-1')
+      expect(screen.getByTestId('assignment-right-pane')).toHaveTextContent('work:assignment-1:student-1')
+      expect(screen.getByTestId('assignment-right-pane')).not.toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-grading')
+      expectAssignmentSplitPaneIndicator({
+        index: '1',
+        icon: 'grading',
+        iconClass: 'lucide-file-check',
+      })
+      expect(screen.getByTestId('assignment-left-pane')).toHaveTextContent('student-1')
+      expect(screen.getByTestId('assignment-right-pane')).toHaveTextContent('grading:assignment-1:student-1')
+      expect(screen.getByTestId('assignment-right-pane')).not.toHaveTextContent('work:assignment-1:student-1')
+    })
   })
 
-  it('keeps class mode active when clicking a student row', async () => {
+  it('restores the assignment split-pane view from browser session storage', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+    window.sessionStorage.setItem(
+      `pika_assignment_split_pane_view:${classroom.id}:assignment-1`,
+      JSON.stringify('students-content'),
+    )
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-content')
+      expectAssignmentSplitPaneIndicator({
+        index: '3',
+        icon: 'students',
+        iconClass: 'lucide-table',
+      })
+      expect(screen.getByTestId('assignment-left-pane')).toHaveTextContent('student-1')
+      expect(screen.getByTestId('assignment-right-pane')).toHaveTextContent('work:assignment-1:student-1')
+      expect(screen.getByTestId('assignment-right-pane')).not.toHaveTextContent('grading:assignment-1:student-1')
+    })
+    expect(screen.getByRole('button', {
+      name: 'Assignment panes: Students + content. Switch to Students + grading.',
+    })).toBeInTheDocument()
+  })
+
+  it('keeps the students and grading view active when clicking a student row', async () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input)
 
@@ -1736,9 +1874,10 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-2')
     })
 
-    const leftPaneControls = within(screen.getByRole('group', { name: 'Assignment workspace view' }))
-    expect(leftPaneControls.getByRole('button', { name: 'Class' })).toHaveAttribute('aria-pressed', 'true')
-    expect(leftPaneControls.getByRole('button', { name: 'Individual' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-grading')
+    expect(screen.getByRole('button', {
+      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
+    })).toBeInTheDocument()
   })
 
   it('restores the class-pane scroll position after selecting a lower student row', async () => {

--- a/tests/unit/assignment-grading-layout.test.ts
+++ b/tests/unit/assignment-grading-layout.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
   clampAssignmentGradingLayout,
+  getAssignmentSplitPaneViewSessionKey,
   getAssignmentGradingLayoutCookieName,
   getAssignmentWorkspaceStudentCookieName,
   getDefaultAssignmentGradingLayout,
+  getDefaultAssignmentSplitPaneView,
   getEffectiveInspectorWidthPercent,
+  getNextAssignmentSplitPaneView,
+  parseAssignmentSplitPaneView,
   parseAssignmentGradingLayout,
   parseAssignmentWorkspaceStudentId,
   serializeAssignmentGradingLayout,
@@ -102,6 +106,9 @@ describe('assignment grading layout helpers', () => {
     expect(getAssignmentWorkspaceStudentCookieName('classroom-1', 'assignment-9')).toBe(
       'pika_assignment_workspace_student:classroom-1:assignment-9',
     )
+    expect(getAssignmentSplitPaneViewSessionKey('classroom-1', 'assignment-9')).toBe(
+      'pika_assignment_split_pane_view:classroom-1:assignment-9',
+    )
   })
 
   it('parses remembered student ids defensively', () => {
@@ -120,5 +127,19 @@ describe('assignment grading layout helpers', () => {
 
     expect(overviewInspectorPx).toBeGreaterThanOrEqual(ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx)
     expect(detailsInspectorPx).toBeGreaterThanOrEqual(ASSIGNMENT_GRADING_LAYOUT.inspectorMinPx)
+  })
+
+  it('cycles assignment split pane views in the requested order', () => {
+    expect(getDefaultAssignmentSplitPaneView()).toBe('students-grading')
+    expect(getNextAssignmentSplitPaneView('students-grading')).toBe('content-grading')
+    expect(getNextAssignmentSplitPaneView('content-grading')).toBe('students-content')
+    expect(getNextAssignmentSplitPaneView('students-content')).toBe('students-grading')
+  })
+
+  it('parses assignment split pane view memory defensively', () => {
+    expect(parseAssignmentSplitPaneView('content-grading')).toBe('content-grading')
+    expect(parseAssignmentSplitPaneView('students-content')).toBe('students-content')
+    expect(parseAssignmentSplitPaneView('bad')).toBe(getDefaultAssignmentSplitPaneView())
+    expect(parseAssignmentSplitPaneView(null)).toBe(getDefaultAssignmentSplitPaneView())
   })
 })


### PR DESCRIPTION
## Summary
- Replace the assignment workspace class/individual segmented control with one cycling split-pane button.
- Add the three requested pane pairings: students table + grading, student content + grading, and students table + student content.
- Persist the selected pane view in browser session storage and keep the shared resizable split layout.
- Use compact numbered view indicators: 1 + FileCheck for table/grading, 2 + FileText for content/grading, and 3 + Table for table/content.

## Validation
- pnpm test tests/components/TeacherClassroomView.test.tsx tests/unit/assignment-grading-layout.test.ts
- pnpm test tests/unit/ai-startup-docs.test.ts tests/components/TeacherClassroomView.test.tsx tests/unit/assignment-grading-layout.test.ts
- pnpm lint
- pnpm build
- E2E_BASE_URL=http://localhost:3100 pnpm e2e:auth
- Pika UI verify for teacher/student assignment views
- Focused desktop/mobile Playwright screenshots for all three selected-assignment pane states