### PR TITLE
[codex] Refine classroom list footer controls

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Announcement markdown rendering
-
-**Completed:**
-- Added shared announcement markdown rendering with safe links, headings, lists, bold, italic, and inline code via the existing limited markdown parser.
-- Updated teacher/student announcement tabs and calendar announcement previews/tooltips to render markdown without changing the database schema or API payload shape.
-- Kept teacher announcement link clicks from entering edit mode.
-- Updated architecture docs to record announcements as markdown text rather than Tiptap JSON.
-
-**Validation:**
-- `pnpm test tests/components/AnnouncementContent.test.tsx tests/components/AnnouncementsMarkdown.test.tsx tests/components/LessonDayCell.test.tsx tests/components/LessonCalendar.test.tsx`
-- `pnpm lint`
-- `bash scripts/verify-env.sh`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/announcements-markdown E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=announcements'`
-- Additional loaded desktop teacher capture: `/tmp/pika-teacher-ready.png`
-
 ## 2026-05-13 — Teacher test list closed-access badge
 
 **Completed:**
@@ -338,3 +323,29 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Targeted composer screenshots:
   - `/tmp/pika-announcement-composer-top-splitbutton.png`
   - `/tmp/pika-announcement-composer-top-splitbutton-mobile.png`
+
+## 2026-05-14 — Classroom list footer cleanup
+
+**Completed:**
+- Removed the classroom `New` action from archived view, including edit mode and the empty archived state.
+- Hid the Active/Archived classroom view segmented control outside classroom edit mode.
+- Restyled the fixed classroom footer as a classroom-card-width card with the view control centered and the edit icon anchored to the right edge.
+- Removed the footer card outline while preserving the floating surface and shadow.
+- Reset the classroom list back to Active whenever classroom edit mode is turned off from Archived view.
+- Updated classroom index component tests for the new edit-mode-only view toggle behavior.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx`
+- `pnpm lint`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-footer-edit-mode E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-footer-edit-mode E2E_BASE_URL=http://localhost:3010 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- `npx playwright screenshot http://localhost:3010/classrooms /tmp/pika-teacher-footer-no-outline.png --load-storage .auth/teacher.json --viewport-size 1440,900 --wait-for-timeout 3000`
+- Targeted Playwright flow: Edit → Archived → Edit off, confirmed `groupVisible=false` and `activeClassroomVisible=true`.
+- Additional Playwright screenshots:
+  - `/tmp/pika-teacher-edit.png`
+  - `/tmp/pika-teacher-archived-edit.png`
+  - `/tmp/pika-teacher-archived-view.png`
+  - `/tmp/pika-teacher-edit-right.png`
+  - `/tmp/pika-teacher-footer-no-outline.png`
+  - `/tmp/pika-teacher-archived-exit-active.png`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -178,6 +178,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     function clearEditMode() {
       setIsEditingClassrooms(false)
       setDraggingClassroomId(null)
+      setView('active')
     }
 
     function handleKeyDown(event: KeyboardEvent) {
@@ -303,7 +304,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     : 'Confirm'
 
   const dialogVariant = pendingAction?.mode === 'delete' ? 'danger' : 'default'
-  const showCreateClassroomButton = activeClassrooms.length === 0 || isEditingClassrooms
+  const showCreateClassroomButton = view === 'active' && (activeClassrooms.length === 0 || isEditingClassrooms)
 
   const openClassroom = useCallback((classroom: Classroom) => {
     setOpeningClassroomId(classroom.id)
@@ -473,37 +474,42 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
       <div
         data-testid="classroom-bottom-controls"
-        className="fixed bottom-4 left-1/2 z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur"
+        className="fixed bottom-4 left-1/2 z-40 w-[calc(100vw-3.5rem)] max-w-[40.5rem] -translate-x-1/2 rounded-card bg-surface/95 py-2 pl-3 pr-1 shadow-elevated backdrop-blur"
       >
-        <div className="flex items-center gap-1">
-          <SegmentedControl<ViewMode>
-            ariaLabel="Classroom view"
-            value={view}
-            onChange={setView}
-            iconOnly={!isEditingClassrooms}
-            className="border border-border shadow-sm"
-            options={[
-              {
-                value: 'active',
-                label: 'Active',
-                icon: <CircleDot className="h-3.5 w-3.5" />,
-              },
-              {
-                value: 'archived',
-                label: 'Archived',
-                icon: <Archive className="h-3.5 w-3.5" />,
-              },
-            ]}
-          />
+        <div className="relative min-h-9">
+          {isEditingClassrooms ? (
+            <div className="absolute left-1/2 -translate-x-1/2">
+              <SegmentedControl<ViewMode>
+                ariaLabel="Classroom view"
+                value={view}
+                onChange={setView}
+                className="border border-border shadow-sm"
+                options={[
+                  {
+                    value: 'active',
+                    label: 'Active',
+                    icon: <CircleDot className="h-3.5 w-3.5" />,
+                  },
+                  {
+                    value: 'archived',
+                    label: 'Archived',
+                    icon: <Archive className="h-3.5 w-3.5" />,
+                  },
+                ]}
+              />
+            </div>
+          ) : null}
           <TeacherEditModeControls
             active={isEditingClassrooms}
             onActiveChange={(active) => {
               setIsEditingClassrooms(active)
               if (!active) {
                 setDraggingClassroomId(null)
+                setView('active')
               }
             }}
             disabled={openingClassroomId !== null}
+            className="absolute right-0 top-1/2 -translate-y-1/2"
           />
         </div>
       </div>

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -50,7 +50,7 @@ describe('TeacherClassroomsIndex', () => {
     expect(classroomFetchCalls).toHaveLength(0)
   })
 
-  it('keeps the create button available in archived view when there are no active classrooms', async () => {
+  it('never shows the create button in archived view', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -60,10 +60,11 @@ describe('TeacherClassroomsIndex', () => {
 
     renderTeacherClassroomsIndex([])
 
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
 
     expect(await screen.findByRole('button', { name: /^Archived/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
   })
 
   it('hides the create button after the first classroom unless edit mode is enabled', async () => {
@@ -85,14 +86,12 @@ describe('TeacherClassroomsIndex', () => {
     expect(card.compareDocumentPosition(newButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('always shows the classroom view toggle while hiding row edit controls until edit is enabled', async () => {
+  it('shows the classroom view toggle only while classroom edit mode is enabled', async () => {
     const classrooms = [createMockClassroom({ id: 'c1', title: 'Math 101' })]
     renderTeacherClassroomsIndex(classrooms)
 
-    expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Archived' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Active' })).not.toHaveAttribute('title')
-    expect(screen.getByRole('button', { name: 'Archived' })).not.toHaveAttribute('title')
+    expect(screen.queryByRole('button', { name: 'Active' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Archived' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Drag to reorder Math 101' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Archive Math 101' })).not.toBeInTheDocument()
 
@@ -107,9 +106,14 @@ describe('TeacherClassroomsIndex', () => {
     expect(archivedButton).not.toHaveAttribute('title')
     expect(screen.getByRole('button', { name: 'Drag to reorder Math 101' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Archive Math 101' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.queryByRole('button', { name: 'Active' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Archived' })).not.toBeInTheDocument()
   })
 
-  it('keeps the selected classroom view when edit mode is turned off', async () => {
+  it('returns to active view when edit mode is turned off from archived view', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -119,14 +123,20 @@ describe('TeacherClassroomsIndex', () => {
 
     renderTeacherClassroomsIndex([])
 
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
     expect(await screen.findByRole('button', { name: /^Archived/ })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.queryByRole('group', { name: 'Classroom view' })).not.toBeInTheDocument()
+    expect(screen.getByText('Create your first classroom')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
 
     expect(
-      within(screen.getByRole('group', { name: 'Classroom view' })).getByRole('button', { name: 'Archived' })
+      within(screen.getByRole('group', { name: 'Classroom view' })).getByRole('button', { name: 'Active' })
     ).toHaveAttribute('aria-pressed', 'true')
   })
 


### PR DESCRIPTION
## Summary

- Hide the classroom Active/Archived view toggle outside classroom edit mode.
- Remove `New` actions from archived view and reset back to Active when edit mode is turned off from Archived.
- Restyle the classroom list footer as a card-width floating surface with the edit icon anchored right and no outline.
- Update classroom index tests for the revised footer and view-toggle behavior.

## Validation

- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/StudentClassroomsIndex.test.tsx`
- `pnpm lint`
- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-footer-edit-mode E2E_BASE_URL=http://localhost:3010 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Targeted Playwright flow: Edit -> Archived -> Edit off returns to Active view

## Screenshots

- `/tmp/pika-teacher.png`
- `/tmp/pika-teacher-mobile.png`
- `/tmp/pika-teacher-archived-exit-active.png`
- `/tmp/pika-teacher-footer-no-outline.png`