### PR TITLE
[codex] Highlight test exits

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Teacher test grading closed-access refresh
-
-**Completed:**
-- Stopped the teacher tests grading workspace from starting the background grade poll when every student has closed effective access.
-- Reused the same effective-access helper for polling decisions, batch action counts, and row access icons.
-- Added regression coverage for an active test whose access is closed for all students so the `Refreshing grades` status does not appear.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/close-test-refresh-notice bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/close-test-refresh-notice E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
-- Closed selected test workspace browser check after 16.5s: no `Refreshing grades` status and no console errors; screenshots `/tmp/pika-teacher-closed-test-workspace.png` and `/tmp/pika-teacher-closed-test-selected-student.png`
-- `pnpm test`
-
 ## 2026-05-13 — Selected test pane scrolling
 
 **Completed:**
@@ -376,3 +361,34 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-mobile-1-students-grading-numbered-indicator.png`
   - `/tmp/pika-assignment-mobile-2-content-grading-numbered-indicator.png`
   - `/tmp/pika-assignment-mobile-3-students-content-numbered-indicator.png`
+
+## 2026-05-14 — Exit detection visibility
+
+**Completed:**
+- Rebasing checked `main` against `origin/main` and created worktree branch `codex/exit-detected-alert`.
+- Rebased `codex/exit-detected-alert` onto `origin/main` at `43b57445`.
+- Added a student exam-mode header pulse when the exits count increases, without pulsing on initial load.
+- Kept the student header pulse from sticking if the exits count is reset while the pulse timer is active.
+- Added a persistent cancellable teacher `Exit detected` alert for newly increased exits in test grading, targeting the first affected student row.
+- Highlighted unreviewed student rows with amber emphasis and made nonzero exit counts render as amber badges.
+- Cleared unreviewed row highlighting when the teacher clicks the alert or selects the affected row.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/AppHeader.test.tsx`
+- `pnpm test`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3002 pnpm e2e:auth`
+- `E2E_BASE_URL=http://localhost:3002 pnpm e2e:verify assessment-ux-parity`
+- Targeted Playwright screenshots:
+  - `/tmp/pika-exit-alert-teacher.png`
+  - `/tmp/pika-exit-pulse-student.png`
+- Chrome smoke:
+  - Teacher on `localhost:3002`: temporary active test loaded in grading, polled a student focus exit, showed `Exit detected`, and clicking the alert selected the student/cleared the banner.
+  - Student on `127.0.0.1:3002`: temporary active test started in exam mode and showed the exits indicator in Chrome.
+  - Temporary test was deleted after the smoke.
+  - Screenshots:
+    - `/tmp/pika-chrome-smoke-teacher-alert.png`
+    - `/tmp/pika-chrome-smoke-teacher-clicked.png`
+    - `/tmp/pika-chrome-smoke-student-pulse.png`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -16,7 +16,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Check, ClockAlert, Code, ExternalLink, Lock, LogOut, Pencil, Plus, RotateCcw, Send, Settings, Trash2, Unlock } from 'lucide-react'
+import { Check, ClockAlert, Code, ExternalLink, Lock, LogOut, Pencil, Plus, RotateCcw, Send, Settings, Trash2, Unlock, X } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
 import { QuizDetailPanel } from '@/components/QuizDetailPanel'
@@ -122,6 +122,10 @@ type TestEditSaveStatus = 'saved' | 'saving' | 'unsaved'
 type TestGradingSortColumn = 'first_name' | 'last_name'
 
 const GRADING_POLL_INTERVAL_MS = 15_000
+
+function getTestGradingExitCount(student: TestGradingStudentRow): number {
+  return getQuizExitCount(student.focus_summary)
+}
 
 function TestWorkspacePaneFrame({ children }: { children: ReactNode }) {
   return (
@@ -306,6 +310,10 @@ export function TeacherTestsTab({
     selectedTestId: null,
   })
   const latestGradingRequestIdRef = useRef(0)
+  const gradingExitCountsRef = useRef<{ testId: string | null; counts: Map<string, number> }>({
+    testId: null,
+    counts: new Map(),
+  })
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
   const selectedTestIdRef = useRef<string | null>(null)
   const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(null)
@@ -327,6 +335,8 @@ export function TeacherTestsTab({
   const [isDeletingTest, setIsDeletingTest] = useState(false)
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
+  const [unreviewedExitCounts, setUnreviewedExitCounts] = useState<Record<string, number>>({})
+  const [exitAlertStudentId, setExitAlertStudentId] = useState<string | null>(null)
   const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
   const [gradingServerTestStatus, setGradingServerTestStatus] = useState<Quiz['status'] | null>(null)
   const [gradingServerTestId, setGradingServerTestId] = useState<string | null>(null)
@@ -477,6 +487,23 @@ export function TeacherTestsTab({
       ),
     [selectedTestWorkspace?.status, sortedGradingStudents]
   )
+  const exitAlertStudent = useMemo(
+    () =>
+      exitAlertStudentId
+        ? sortedGradingStudents.find((student) => student.student_id === exitAlertStudentId) ?? null
+        : null,
+    [exitAlertStudentId, sortedGradingStudents]
+  )
+
+  const clearUnreviewedExitForStudent = useCallback((studentId: string) => {
+    setUnreviewedExitCounts((prev) => {
+      if (!(studentId in prev)) return prev
+      const next = { ...prev }
+      delete next[studentId]
+      return next
+    })
+    setExitAlertStudentId((prev) => (prev === studentId ? null : prev))
+  }, [])
 
   const setSelectedStudentId = useCallback((nextStudentId: string | null) => {
     setInternalSelectedStudentId(nextStudentId)
@@ -547,6 +574,86 @@ export function TeacherTestsTab({
     selectedTestId,
     selectedWorkspaceTab,
   ])
+
+  const scrollToGradingStudent = useCallback((studentId: string) => {
+    const scrollPane = gradingStudentTableScrollRef.current
+    if (!scrollPane) return
+
+    const row = Array.from(scrollPane.querySelectorAll('[data-test-grading-student-row-id]')).find(
+      (node) => node.getAttribute('data-test-grading-student-row-id') === studentId
+    )
+    if (row instanceof HTMLElement && typeof row.scrollIntoView === 'function') {
+      row.scrollIntoView({ block: 'center' })
+    }
+  }, [gradingStudentTableScrollRef])
+
+  const handleGradingStudentSelect = useCallback((studentId: string) => {
+    clearUnreviewedExitForStudent(studentId)
+    selectGradingStudent(studentId)
+  }, [clearUnreviewedExitForStudent, selectGradingStudent])
+
+  const handleExitAlertClick = useCallback(() => {
+    if (!exitAlertStudentId) return
+    clearUnreviewedExitForStudent(exitAlertStudentId)
+    selectGradingStudent(exitAlertStudentId)
+    const scrollAfterSelect = () => {
+      scrollToGradingStudent(exitAlertStudentId)
+    }
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(scrollAfterSelect)
+      return
+    }
+    scrollAfterSelect()
+  }, [clearUnreviewedExitForStudent, exitAlertStudentId, scrollToGradingStudent, selectGradingStudent])
+
+  const dismissExitAlert = useCallback(() => {
+    setExitAlertStudentId(null)
+  }, [])
+
+  const recordGradingExitCountChanges = useCallback((
+    testId: string,
+    students: TestGradingStudentRow[]
+  ) => {
+    const nextCounts = new Map(
+      students.map((student) => [student.student_id, getTestGradingExitCount(student)])
+    )
+    const previousSnapshot = gradingExitCountsRef.current
+
+    if (previousSnapshot.testId !== testId || previousSnapshot.counts.size === 0) {
+      gradingExitCountsRef.current = { testId, counts: nextCounts }
+      setUnreviewedExitCounts({})
+      setExitAlertStudentId(null)
+      return
+    }
+
+    const increasedStudents = students.filter((student) => {
+      const previousCount = previousSnapshot.counts.get(student.student_id) ?? 0
+      const nextCount = nextCounts.get(student.student_id) ?? 0
+      return nextCount > previousCount
+    })
+
+    gradingExitCountsRef.current = { testId, counts: nextCounts }
+
+    setUnreviewedExitCounts((prev) => {
+      const next: Record<string, number> = {}
+      for (const [studentId, exitCount] of Object.entries(prev)) {
+        if ((nextCounts.get(studentId) ?? 0) >= exitCount) {
+          next[studentId] = exitCount
+        }
+      }
+      for (const student of increasedStudents) {
+        next[student.student_id] = nextCounts.get(student.student_id) ?? 0
+      }
+      return next
+    })
+
+    if (increasedStudents.length > 0) {
+      setExitAlertStudentId((current) => {
+        if (current && nextCounts.has(current)) return current
+        return increasedStudents[0].student_id
+      })
+    }
+  }, [])
 
   const batchAutoGradePreflight = useMemo(() => {
     const selectedCount = batchSelectedStudents.length
@@ -640,6 +747,9 @@ export function TeacherTestsTab({
       setGradingServerTestId(null)
       setTestAiGradingRun(null)
       setGradingRefreshing(false)
+      gradingExitCountsRef.current = { testId: null, counts: new Map() }
+      setUnreviewedExitCounts({})
+      setExitAlertStudentId(null)
       return
     }
 
@@ -683,7 +793,9 @@ export function TeacherTestsTab({
           )
         )
       }
-      setGradingStudents((data.students || []) as TestGradingStudentRow[])
+      const nextStudents = (data.students || []) as TestGradingStudentRow[]
+      recordGradingExitCountChanges(requestedTestId, nextStudents)
+      setGradingStudents(nextStudents)
       setGradingQuestions(
         Array.isArray(data.questions)
           ? data.questions.map((question: any) => ({
@@ -707,7 +819,7 @@ export function TeacherTestsTab({
       setGradingLoading(false)
       setGradingRefreshing(false)
     }
-  }, [selectedTestId])
+  }, [recordGradingExitCountChanges, selectedTestId])
 
   useEffect(() => {
     void loadTests()
@@ -747,6 +859,9 @@ export function TeacherTestsTab({
   useEffect(() => {
     selectedTestDraftSummaryRef.current = null
     setSelectedTestDraftSummary(null)
+    gradingExitCountsRef.current = { testId: selectedTestId, counts: new Map() }
+    setUnreviewedExitCounts({})
+    setExitAlertStudentId(null)
     setPendingUnsubmitStudent(null)
     setPendingOpenAccessStudent(null)
     setPendingCloseAccessStudent(null)
@@ -756,6 +871,12 @@ export function TeacherTestsTab({
     setPendingCloseAccessStudentIds(null)
     setPendingDeleteStudentAttemptIds(null)
   }, [selectedTestId])
+
+  useEffect(() => {
+    if (!exitAlertStudentId) return
+    if (gradingStudents.some((student) => student.student_id === exitAlertStudentId)) return
+    setExitAlertStudentId(null)
+  }, [exitAlertStudentId, gradingStudents])
 
   useEffect(() => {
     if (previousTestsTabClickTokenRef.current === testsTabClickToken) return
@@ -781,6 +902,9 @@ export function TeacherTestsTab({
       setGradingLoading(false)
       setGradingRefreshing(false)
       setTestAiGradingRun(null)
+      gradingExitCountsRef.current = { testId: null, counts: new Map() }
+      setUnreviewedExitCounts({})
+      setExitAlertStudentId(null)
       clearBatchSelection()
       return
     }
@@ -1783,6 +1907,32 @@ export function TeacherTestsTab({
       className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden"
       onPointerDownCapture={handleGradingTablePointerDown}
     >
+      {exitAlertStudent ? (
+        <div
+          className="border-b border-warning bg-warning-bg px-3 py-2"
+          aria-live="polite"
+          data-testid="test-exit-detected-alert"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={handleExitAlertClick}
+              className="inline-flex min-w-0 items-center gap-2 rounded-control px-2 py-1 text-sm font-semibold text-warning transition-colors hover:bg-surface/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-warning"
+            >
+              <LogOut className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <span>Exit detected</span>
+            </button>
+            <button
+              type="button"
+              onClick={dismissExitAlert}
+              className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-control text-warning transition-colors hover:bg-surface/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-warning"
+              aria-label="Dismiss exit detected alert"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+      ) : null}
       {gradingRefreshing ? (
         <RefreshingIndicator label="Refreshing grades" className="px-3 py-2" />
       ) : null}
@@ -1801,7 +1951,7 @@ export function TeacherTestsTab({
           ref={gradingStudentTableScrollRef}
           rowKeys={gradingRowIds}
           selectedKey={selectedStudentId}
-          onSelectKey={selectGradingStudent}
+          onSelectKey={handleGradingStudentSelect}
           className="min-h-0 w-full flex-1 overflow-auto rounded-md border border-border bg-surface"
           data-testid="test-grading-student-scroll-pane"
           onScroll={preserveGradingStudentTableScrollPosition}
@@ -1885,7 +2035,7 @@ export function TeacherTestsTab({
                 const awayLabel = `${awayMinutes}:${String(awayRemainder).padStart(2, '0')}`
                 const routeExitAttempts = student.focus_summary?.route_exit_attempts ?? 0
                 const windowUnmaximizeAttempts = student.focus_summary?.window_unmaximize_attempts ?? 0
-                const exitsCount = getQuizExitCount(student.focus_summary)
+                const exitsCount = getTestGradingExitCount(student)
                 const formattedLastActivity = formatTorontoTime(student.last_activity_at)
                 const effectiveAccess = getEffectiveTestAccess(student, selectedTestWorkspace?.status)
                 const accessSource = student.access_source || 'test'
@@ -1917,17 +2067,35 @@ export function TeacherTestsTab({
                       : `Click to open access for ${studentLabel}.`
                 const canUnsubmitStudent =
                   student.status === 'submitted' && !isReadOnly && !isCombinedTestActionsBusy
+                const hasUnreviewedExit = unreviewedExitCounts[student.student_id] !== undefined
+                const exitsClassName = exitsCount > 0
+                  ? 'inline-flex min-w-6 cursor-help items-center justify-center rounded-badge border border-warning bg-warning-bg px-2 py-0.5 text-xs font-semibold text-warning'
+                  : 'cursor-help text-text-muted'
 
                 return (
                   <DataTableRow
                     key={student.student_id}
                     data-test-grading-student-row=""
+                    data-test-grading-student-row-id={student.student_id}
+                    data-testid={`test-grading-student-row-${student.student_id}`}
                     aria-selected={isSelected}
                     className={[
                       'cursor-pointer transition-colors',
-                      isSelected ? 'border-l-2 border-l-primary bg-surface-selected shadow-sm' : 'hover:bg-surface-hover',
+                      isSelected
+                        ? 'border-l-2 border-l-primary bg-surface-selected shadow-sm'
+                        : hasUnreviewedExit
+                          ? 'border-l-2 border-l-warning bg-warning-bg hover:bg-warning-bg'
+                          : 'hover:bg-surface-hover',
                     ].join(' ')}
-                    onClick={() => selectGradingStudent(student.student_id)}
+                    style={
+                      !isSelected && hasUnreviewedExit
+                        ? {
+                            boxShadow:
+                              'inset 4px 0 0 var(--color-warning), inset 0 0 0 9999px color-mix(in srgb, var(--color-warning) 14%, transparent)',
+                          }
+                        : undefined
+                    }
+                    onClick={() => handleGradingStudentSelect(student.student_id)}
                   >
                     <DataTableCell className="px-3 py-2">
                       <input
@@ -2004,7 +2172,7 @@ export function TeacherTestsTab({
                         </span>
                       </Tooltip>
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                    <DataTableCell className="px-3 py-2 text-xs tabular-nums">
                       <Tooltip
                         content={
                           <div className="space-y-0.5">
@@ -2016,7 +2184,7 @@ export function TeacherTestsTab({
                         }
                       >
                         <span
-                          className="cursor-help"
+                          className={exitsClassName}
                           aria-label={`Exits ${exitsCount}. Away/focus ${awayCount}, in-app exits ${routeExitAttempts}, window/full-screen exits ${windowUnmaximizeAttempts}.`}
                         >
                           {exitsCount}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { ClockAlert, LogOut, Maximize, Menu, Minimize } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
 import { ClassroomDropdown } from './ClassroomDropdown'
 import { UserMenu } from './UserMenu'
@@ -44,6 +44,8 @@ function formatDuration(totalSeconds: number): string {
   return `${Math.floor(safe / 3600)}h`
 }
 
+const EXIT_COUNT_PULSE_MS = 1600
+
 /**
  * Compact global header (48px) with logo, classroom selector, date, and user menu.
  */
@@ -59,6 +61,8 @@ export function AppHeader({
   pageTitle,
 }: AppHeaderProps) {
   const [now, setNow] = useState(() => new Date())
+  const [exitCountPulseActive, setExitCountPulseActive] = useState(false)
+  const previousExamExitCountRef = useRef<number | null>(null)
   const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
   const hints = useKeyboardShortcutHint()
 
@@ -68,6 +72,7 @@ export function AppHeader({
   }, [])
 
   const isExamMode = Boolean(examModeHeader)
+  const examExitCount = examModeHeader?.exitsCount ?? null
   const isTextPageTitle = typeof pageTitle === 'string'
   const pageTitleClassName =
     pageTitle === 'Classrooms'
@@ -89,6 +94,31 @@ export function AppHeader({
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [toggleFullscreen, isExamMode])
+
+  useEffect(() => {
+    if (examExitCount === null) {
+      previousExamExitCountRef.current = null
+      setExitCountPulseActive(false)
+      return
+    }
+
+    const previousExitCount = previousExamExitCountRef.current
+    previousExamExitCountRef.current = examExitCount
+
+    if (previousExitCount === null) return
+
+    if (examExitCount <= previousExitCount) {
+      setExitCountPulseActive(false)
+      return
+    }
+
+    setExitCountPulseActive(true)
+    const timeoutId = window.setTimeout(() => {
+      setExitCountPulseActive(false)
+    }, EXIT_COUNT_PULSE_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [examExitCount])
 
   return (
     <header className="sticky top-0 z-50 h-12 bg-surface border-b border-border grid grid-cols-[1fr_minmax(0,1fr)_1fr] items-center px-4">
@@ -143,9 +173,19 @@ export function AppHeader({
           <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-6 text-sm text-text-default">
             <span className="truncate font-semibold">{examModeHeader.testTitle}</span>
             <div className="inline-flex items-center gap-3 whitespace-nowrap text-text-muted tabular-nums">
-              <span className="inline-flex items-center gap-1">
+              <span
+                className={[
+                  'inline-flex items-center gap-1 rounded-md border px-2 py-1 transition-all duration-300',
+                  exitCountPulseActive
+                    ? 'motion-safe:scale-[1.03] border-warning bg-warning font-semibold text-text-inverse shadow-sm ring-2 ring-warning'
+                    : 'border-transparent text-text-muted',
+                ].join(' ')}
+                aria-label={`Exits ${examModeHeader.exitsCount}`}
+                aria-live="polite"
+              >
                 <LogOut className="h-3.5 w-3.5" />
                 <span>{examModeHeader.exitsCount}</span>
+                {exitCountPulseActive ? <span className="sr-only">Exit detected</span> : null}
               </span>
               <span className="inline-flex items-center gap-1">
                 <ClockAlert className="h-3.5 w-3.5" />

--- a/tests/components/AppHeader.test.tsx
+++ b/tests/components/AppHeader.test.tsx
@@ -1,0 +1,54 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { AppHeader } from '@/components/AppHeader'
+import { ThemeProvider } from '@/contexts/ThemeContext'
+import { TooltipProvider } from '@/ui'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider>
+      <TooltipProvider>{children}</TooltipProvider>
+    </ThemeProvider>
+  )
+}
+
+describe('AppHeader exam mode', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('briefly highlights the exit count only when the exam exit count increases', () => {
+    vi.useFakeTimers()
+
+    const { rerender } = render(
+      <AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 1, awayTotalSeconds: 0 }} />,
+      { wrapper: Wrapper }
+    )
+
+    expect(screen.getByLabelText('Exits 1')).toHaveClass('text-text-muted')
+    expect(screen.queryByText('Exit detected')).not.toBeInTheDocument()
+
+    rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 2, awayTotalSeconds: 0 }} />)
+
+    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning')
+    expect(screen.getByText('Exit detected')).toHaveClass('sr-only')
+
+    rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 1, awayTotalSeconds: 0 }} />)
+
+    expect(screen.getByLabelText('Exits 1')).toHaveClass('text-text-muted')
+    expect(screen.queryByText('Exit detected')).not.toBeInTheDocument()
+
+    rerender(<AppHeader examModeHeader={{ testTitle: 'Unit Test', exitsCount: 2, awayTotalSeconds: 0 }} />)
+
+    expect(screen.getByLabelText('Exits 2')).toHaveClass('bg-warning')
+    expect(screen.getByText('Exit detected')).toHaveClass('sr-only')
+
+    act(() => {
+      vi.advanceTimersByTime(1600)
+    })
+
+    expect(screen.getByLabelText('Exits 2')).toHaveClass('text-text-muted')
+    expect(screen.queryByText('Exit detected')).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1382,6 +1382,91 @@ describe('TeacherTestsTab', () => {
     })
   })
 
+  it('shows a simple exit alert and unreviewed row highlight when polling detects a new exit', async () => {
+    let intervalCallback: (() => void) | null = null
+    let resolvePoll:
+      | ((value: { ok: boolean; json: () => Promise<any> }) => void)
+      | null = null
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => true)
+    vi.spyOn(window, 'setInterval').mockImplementation(((callback: TimerHandler) => {
+      intervalCallback = callback as () => void
+      return 1
+    }) as typeof window.setInterval)
+
+    const pollResultsPromise = new Promise<{ ok: boolean; json: () => Promise<any> }>((resolve) => {
+      resolvePoll = resolve
+    })
+    const focusSummary = {
+      exit_count: 0,
+      away_count: 0,
+      away_total_seconds: 0,
+      route_exit_attempts: 0,
+      window_unmaximize_attempts: 0,
+      last_away_started_at: null,
+      last_away_ended_at: null,
+    }
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({
+        students: [makeGradingStudent({ focus_summary: focusSummary })],
+      }))
+      .mockImplementationOnce(() => pollResultsPromise as unknown as Promise<Response>)
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    const row = await screen.findByTestId('test-grading-student-row-student-1')
+    expect(screen.queryByTestId('test-exit-detected-alert')).not.toBeInTheDocument()
+    expect(within(row).getByLabelText(/Exits 0\./)).toHaveClass('text-text-muted')
+
+    await act(async () => {
+      intervalCallback?.()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      resolvePoll?.(
+        makeResultsResponse({
+          students: [
+            makeGradingStudent({
+              focus_summary: {
+                ...focusSummary,
+                exit_count: 1,
+                away_count: 1,
+                away_total_seconds: 12,
+              },
+            }),
+          ],
+        })
+      )
+      await Promise.resolve()
+    })
+
+    const alert = await screen.findByRole('button', { name: 'Exit detected' })
+    const highlightedRow = screen.getByTestId('test-grading-student-row-student-1')
+    expect(highlightedRow).toHaveClass('bg-warning-bg')
+    expect(within(highlightedRow).getByLabelText(/Exits 1\./)).toHaveClass('text-warning')
+
+    fireEvent.click(alert)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-test-grading-panel')).toHaveTextContent('Grading panel for test-1:student-1')
+    })
+    expect(screen.queryByTestId('test-exit-detected-alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('test-grading-student-row-student-1')).toHaveClass('bg-surface-selected')
+    expect(screen.getByTestId('test-grading-student-row-student-1')).not.toHaveClass('bg-warning-bg')
+  })
+
   it('does not start polling when the server reports the test is closed', async () => {
     let visibilityState: DocumentVisibilityState = 'visible'
     let hasFocus = true


### PR DESCRIPTION
## Summary

- Pulse the student exam header exits indicator when the count increases, without alerting on initial load.
- Add a persistent, cancellable teacher `Exit detected` alert in test grading when polling sees a new student exit.
- Highlight unreviewed rows and render nonzero exit counts as amber badges until the teacher clicks the alert or row.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/AppHeader.test.tsx`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `E2E_BASE_URL=http://localhost:3002 pnpm e2e:auth`
- `E2E_BASE_URL=http://localhost:3002 pnpm e2e:verify assessment-ux-parity`
- Chrome smoke for teacher and student exit visibility
