### PR TITLE
[codex] Fix released assignment scheduling controls

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Selected test pane scrolling
-
-**Completed:**
-- Updated the selected teacher test grading workspace to frame the grading table and response inspector with the same full-height pane pattern used by assignment workspaces.
-- Made the student grading table fill the left pane and keep its own scroll container.
-- Made the selected student response inspector keep its own right-pane scroll container.
-- Added regression coverage for the selected test grading pane scroll containers.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-pane-scroll bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-pane-scroll bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests&testId=92120fed-7145-4118-a8ad-117e7962d679&testMode=grading&testStudentId=23977f0b-efb8-4408-98cb-2e6887c4fd7e'`
-- DOM scroll check: window stayed at `scrollY=0`, left table pane filled the workspace, right inspector reported `overflow-y: auto` with independent scroll.
-- Temporary sample tests were seeded for the visual capture and removed afterward; the shared classroom test list returned to empty.
-- `pnpm test`
-
 ## 2026-05-13 — Teacher test student arrow navigation
 
 **Completed:**
@@ -392,3 +375,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
     - `/tmp/pika-chrome-smoke-teacher-alert.png`
     - `/tmp/pika-chrome-smoke-teacher-clicked.png`
     - `/tmp/pika-chrome-smoke-student-pulse.png`
+
+## 2026-05-15 — Released assignment scheduling controls
+
+**Completed:**
+- Removed post/schedule split controls from the live assignment editor while keeping normal edit autosave/close behavior.
+- Guarded assignment scheduling hook actions so live assignments do not attempt post, schedule, or revert-to-draft requests.
+- Added regression coverage for live assignment edits saving without release fields and for live assignments exposing no scheduling actions.
+
+**Validation:**
+- `pnpm test tests/hooks/useAssignmentScheduling.test.ts tests/components/AssignmentModal.test.tsx`
+- `pnpm lint`
+- `pnpm test tests/api/teacher/assignments-id.test.ts tests/lib/assignment-schedule-validation.test.ts tests/unit/assignments.test.ts`
+- `pnpm test`
+- `pnpm build`
+- UI verification on `http://localhost:3001`:
+  - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+  - Targeted live-assignment editor screenshot: `/tmp/pika-live-assignment-editor.png`

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -752,7 +752,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
                   </div>
                 )}
                 <div className="flex items-center gap-2">
-                  {currentAssignment ? (
+                  {currentAssignment && !isLive ? (
                     <SplitButton
                       label={primaryLabel}
                       onPrimaryClick={() => {

--- a/src/hooks/useAssignmentScheduling.ts
+++ b/src/hooks/useAssignmentScheduling.ts
@@ -129,7 +129,7 @@ export function useAssignmentScheduling({
         : saving
           ? 'Saving...'
           : 'Draft'
-  const splitOptions: SplitOption[] = isScheduled
+  const splitOptions: SplitOption[] = isScheduled || isLive
     ? []
     : [
         { id: 'post', label: 'Post', onSelect: () => handleActionSelection('post') },
@@ -187,6 +187,7 @@ export function useAssignmentScheduling({
       if (releasing) return
       const assignmentToRelease = currentAssignment
       if (!assignmentToRelease) return
+      if (isAssignmentLive(assignmentToRelease)) return
 
       onError('')
       setReleasing(true)
@@ -222,6 +223,7 @@ export function useAssignmentScheduling({
       if (releasing) return
       const assignmentToSchedule = currentAssignment
       if (!assignmentToSchedule || !scheduleDate) return
+      if (isAssignmentLive(assignmentToSchedule)) return
 
       const releaseIso = combineScheduleDateTimeToIso(scheduleDate, scheduleTime)
       if (!isScheduleIsoInFuture(releaseIso)) {
@@ -278,6 +280,7 @@ export function useAssignmentScheduling({
     if (releasing) return
     const assignmentToUpdate = currentAssignment
     if (!assignmentToUpdate || assignmentToUpdate.is_draft) return
+    if (isAssignmentLive(assignmentToUpdate)) return
 
     onError('')
     setReleasing(true)
@@ -337,6 +340,7 @@ export function useAssignmentScheduling({
 
   const openScheduleModalWithSave = useCallback(async () => {
     if (!currentAssignment || saving || releasing || creating) return
+    if (isAssignmentLive(currentAssignment)) return
     try {
       await flushPendingChanges()
       syncScheduleInputsFromAssignment()
@@ -357,6 +361,7 @@ export function useAssignmentScheduling({
   const triggerPrimaryAction = useCallback(
     async (action: CreateSubmitAction = primaryAction) => {
       if (!currentAssignment || creating || saving || releasing) return
+      if (isAssignmentLive(currentAssignment)) return
 
       if (action === 'post') {
         setShowPostNowConfirm(true)

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -167,6 +167,75 @@ describe('AssignmentModal', () => {
       expect(screen.getByRole('menuitem', { name: 'Draft' })).toBeInTheDocument()
     })
 
+    it('does not show release or scheduling controls for live assignments', () => {
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={{
+            ...baseAssignment,
+            is_draft: false,
+            released_at: '2025-01-01T12:00:00.000Z',
+          }}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Saved')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Close assignment modal' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Post' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Schedule' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Choose assignment action' })).not.toBeInTheDocument()
+    })
+
+    it('saves live assignment edits without sending release fields', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const liveAssignment = {
+        ...baseAssignment,
+        is_draft: false,
+        released_at: '2025-01-01T12:00:00.000Z',
+      }
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          assignment: {
+            ...liveAssignment,
+            title: 'Updated live title',
+          },
+        }),
+      })
+      const onSuccess = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={liveAssignment}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />
+      )
+
+      fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'Updated live title' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Close assignment modal' }))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+      })
+
+      const [url, options] = fetchMock.mock.calls[0]
+      expect(url).toBe('/api/teacher/assignments/assignment-1')
+      expect(options.method).toBe('PATCH')
+      expect(JSON.parse(options.body)).toEqual({ title: 'Updated live title' })
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled()
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
+
     it('schedules release for draft assignments', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       fetchMock.mockResolvedValueOnce({

--- a/tests/hooks/useAssignmentScheduling.test.ts
+++ b/tests/hooks/useAssignmentScheduling.test.ts
@@ -82,6 +82,13 @@ describe('useAssignmentScheduling', () => {
       expect(result.current.isScheduled).toBe(false)
     })
 
+    it('does not expose scheduling actions for a live assignment', () => {
+      const { result } = renderHook(() =>
+        useAssignmentScheduling(makeOptions(makeLiveAssignment()))
+      )
+      expect(result.current.splitOptions).toHaveLength(0)
+    })
+
     it('isScheduled is true when released_at is in the future', () => {
       const { result } = renderHook(() =>
         useAssignmentScheduling(makeOptions(makeScheduledAssignment()))
@@ -209,13 +216,10 @@ describe('useAssignmentScheduling', () => {
   })
 
   describe('revertAssignmentToDraft', () => {
-    it('sets primaryAction to "post" after reverting', async () => {
+    it('does nothing for a live assignment', async () => {
       const live = makeLiveAssignment()
-      const updatedDraft = makeDraftAssignment({ id: live.id })
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ assignment: updatedDraft }),
-      }))
+      const fetchSpy = vi.fn()
+      vi.stubGlobal('fetch', fetchSpy)
 
       const opts = makeOptions(live)
       const { result } = renderHook(() => useAssignmentScheduling(opts))
@@ -224,9 +228,8 @@ describe('useAssignmentScheduling', () => {
         await result.current.revertAssignmentToDraft()
       })
 
-      await waitFor(() => {
-        expect(result.current.primaryAction).toBe('post')
-      })
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(opts.onAssignmentChange).not.toHaveBeenCalled()
       vi.unstubAllGlobals()
     })
 


### PR DESCRIPTION
## Summary

- Hide post/schedule release controls when editing an assignment that is already live.
- Guard assignment scheduling hook actions so live assignments cannot post, schedule, or revert-to-draft through the hook.
- Add regression coverage for live assignment edits saving without release fields and for live assignments exposing no scheduling actions.

## Root Cause

The live assignment editor still rendered the same release split-button used by draft and scheduled assignments. That let a released assignment invoke scheduling paths, which the API correctly rejected even though normal assignment edits had already been saved.

## Validation

- `pnpm test tests/hooks/useAssignmentScheduling.test.ts tests/components/AssignmentModal.test.tsx`
- `pnpm lint`
- `pnpm test tests/api/teacher/assignments-id.test.ts tests/lib/assignment-schedule-validation.test.ts tests/unit/assignments.test.ts`
- `pnpm test`
- `pnpm build`
- Playwright visual check with `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Targeted live assignment editor screenshot: `/tmp/pika-live-assignment-editor.png`