### PR TITLE
Add student exam route-exit e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,17 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Chrome plugin UI verification guidance
-
-**Completed:**
-- Documented Playwright as the required final path for E2E tests, UI verification scripts, and screenshot artifacts.
-- Clarified that Chrome plugin checks are supplemental for exploratory debugging, browser-profile behavior, remote auth, extension, cookie, and interactive inspection cases.
-- Updated the AI routing doc, UI testing guide, testing strategy, and Codex UI verification prompt.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/chrome-ui-guidance bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/ui-guidance-candidate-script.test.ts`
-
 ## 2026-05-13 — Classroom list edit control placement
 
 **Completed:**
@@ -389,3 +378,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed because the sandbox denied Next.js listening on `0.0.0.0:3000`.
 - `HOSTNAME=127.0.0.1 E2E_BASE_URL=http://127.0.0.1:3020 pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed for the same `listen EPERM` restriction on `0.0.0.0:3020`.
+
+## 2026-05-17 — Exam route-exit e2e review fix
+
+**Completed:**
+- Tightened the student exam-mode route-exit e2e telemetry assertion so it scopes to the test documents pane instead of matching any visible `Exits` badge.
+- Confirmed the narrow Playwright spec now runs successfully in the current environment.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Teacher test student arrow navigation
-
-**Completed:**
-- Put the selected teacher test grading student list on the shared `KeyboardNavigableTable` and `DataTable` primitives used by assignment student tables.
-- Extended `KeyboardNavigableTable` so it can own scroll-pane props like `className`, `data-testid`, and `onScroll` while preserving its arrow-key selection behavior.
-- Added regression coverage for moving the selected test student with ArrowDown and ArrowUp.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/DataTable.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/test-arrow-key-navigation bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests&testId=88a8b3b5-7559-417e-8d16-c53175a3d692&testMode=grading&testStudentId=23977f0b-efb8-4408-98cb-2e6887c4fd7e'`
-- Browser smoke check: clicked the selected student row, pressed ArrowDown, and confirmed the URL, selected row, and grading inspector moved from Student1 to Student2.
-- Temporary verification test `88a8b3b5-7559-417e-8d16-c53175a3d692` was deleted after screenshots and browser checks.
-- `pnpm build`
-- `pnpm test`
-
 ## 2026-05-13 — Chrome plugin UI verification guidance
 
 **Completed:**
@@ -392,3 +375,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - UI verification on `http://localhost:3001`:
   - `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
   - Targeted live-assignment editor screenshot: `/tmp/pika-live-assignment-editor.png`
+
+## 2026-05-17 — Student exam-mode route-exit e2e
+
+**Completed:**
+- Added focused Playwright coverage for an active student test that blocks Home navigation, records route-exit telemetry, and preserves an autosaved open-response draft.
+- Reused the existing student exam-mode e2e setup and cleanup helpers; no app logic or migrations changed.
+- Environment setup required ignored symlinks for shared `node_modules` and `.env.local`.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed because the sandbox denied Next.js listening on `0.0.0.0:3000`.
+- `HOSTNAME=127.0.0.1 E2E_BASE_URL=http://127.0.0.1:3020 pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed for the same `listen EPERM` restriction on `0.0.0.0:3020`.

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -276,7 +276,9 @@ test.describe('student exam mode', () => {
         const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
         return detail.focus_summary?.route_exit_attempts ?? 0
       }).toBeGreaterThanOrEqual(1)
-      await expect(page.getByLabel(/Exits [1-9]/)).toBeVisible()
+      await expect(
+        page.locator('[data-testid="student-test-documents-pane"]').getByLabel(/Exits [1-9]/)
+      ).toBeVisible()
     } finally {
       await cleanupTest(browser, testId)
     }

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -22,8 +22,18 @@ interface AssessmentDraftRecord {
   }
 }
 
+interface StudentTestDetailRecord {
+  focus_summary?: {
+    route_exit_attempts?: number
+  } | null
+}
+
 function uniqueTitle(): string {
   return `Exam Mode E2E ${Date.now()}`
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 async function loadJson<T>(page: Page, path: string): Promise<T> {
@@ -221,6 +231,53 @@ test.describe('student exam mode', () => {
       await expect(responseBox).toHaveValue('Draft survives exam-mode lock and reload.')
     } finally {
       await page.setViewportSize({ width: 1440, height: 900 }).catch(() => undefined)
+      await cleanupTest(browser, testId)
+    }
+  })
+
+  test('blocks home navigation during an active exam and preserves the draft response', async ({ browser, page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const classroom = await withTeacherPage(browser, async (teacherPage) => {
+        const shared = await findSharedClassroom(page, teacherPage)
+        const testRecord = await createActiveOpenResponseTest(teacherPage, shared.id, testTitle)
+        testId = testRecord.id
+        return shared
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      const splitShell = page.locator('[data-testid="student-test-split-container"]')
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+      const responseBox = page.locator('textarea[placeholder="Write your response..."]')
+      await expect(responseBox).toBeVisible()
+      await responseBox.fill('Draft remains visible after a blocked route exit.')
+      await expect(page.getByText('Saved')).toBeVisible({ timeout: 20_000 })
+
+      await page.getByRole('link', { name: 'Home' }).click()
+
+      await expect(page).toHaveURL(new RegExp(`/classrooms/${escapeRegExp(classroom.id)}\\?tab=tests`))
+      await expect(splitShell).toBeVisible()
+      await expect(responseBox).toHaveValue('Draft remains visible after a blocked route exit.')
+
+      await expect.poll(async () => {
+        if (!testId) return 0
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return detail.focus_summary?.route_exit_attempts ?? 0
+      }).toBeGreaterThanOrEqual(1)
+      await expect(page.getByLabel(/Exits [1-9]/)).toBeVisible()
+    } finally {
       await cleanupTest(browser, testId)
     }
   })


### PR DESCRIPTION
## Selected flow

Student exam mode route-exit handling: start an active test, autosave an open-response draft, attempt Home navigation, verify the route remains on the active test, verify route-exit telemetry increments, and verify the draft remains visible.

Chosen because existing e2e coverage already exercised sustained window loss and draft preservation, but did not cover blocked in-app navigation attempts during an active exam.

## Risk profile

- `exam-mode`
- `workspace-state`

The flow protects active test state from route exits and checks that draft content remains mounted/available after the blocked navigation.

## Tests added or updated

- Updated `e2e/student-exam-mode.spec.ts`
- Added `blocks home navigation during an active exam and preserves the draft response`

## Commands run

- `bash scripts/verify-env.sh`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed locally: sandbox denied Next.js listening on `0.0.0.0:3000`
- `HOSTNAME=127.0.0.1 E2E_BASE_URL=http://127.0.0.1:3020 pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop` failed locally with the same `listen EPERM` restriction on `0.0.0.0:3020`

## Seeded-data assumptions

Same as the existing student exam-mode e2e spec: `.auth/teacher.json` and `.auth/student.json` must authenticate teacher and student users with at least one shared classroom. The test creates and deletes its active open-response test through existing API routes.

## Residual coverage gaps

- Teacher-side telemetry display is not asserted in this e2e flow.
- Fullscreen/window-exit paths remain covered by the existing student exam-mode e2e flow, not this route-exit case.
- The narrow Playwright spec still needs a normal local or CI environment where Next.js can bind a dev-server port.