### PR TITLE
[codex] Refine assignment markdown and creation modals

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,92 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-13 — Classroom list edit control placement
-
-**Completed:**
-- Moved the teacher classroom list edit pen from the top floating cluster into the bottom controls beside the Active/Archived segmented toggle.
-- Removed the no-longer-needed top padding on the classroom list and updated the focused component test to assert the new bottom placement.
-
-**Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/classroom-list-edit-pen bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Extra teacher edit-mode captures: `/tmp/pika-teacher-edit.png`, `/tmp/pika-teacher-mobile-edit.png`
-
-## 2026-05-13 — Classwork surveys
-
-**Completed:**
-- Added surveys as ungraded Classwork items with draft/active/closed status, classwork ordering, and teacher/student API routes.
-- Added survey question types for multiple choice, short text, and link responses, including response validation and link normalization.
-- Added a dynamic responses toggle so students can update answers while an active survey remains open.
-- Fixed the responded-student status priority so dynamic surveys remain updateable even when class results are visible.
-- Added teacher survey creation/settings, question editing, class results, survey cards, and student survey cards/response form/results support.
-- Added the Supabase migration `068_surveys_classwork.sql` for surveys, questions, responses, RLS, and mixed classwork ordering RPC support.
-- Kept Classwork assignment/material loading resilient if the surveys endpoint is unavailable before the migration is applied.
-- Rebased the worktree onto `origin/main` and resequenced the survey migration after `067_classwork_mixed_ordering.sql`.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/unit/surveys.test.ts tests/lib/classwork-order.test.ts tests/unit/classwork-migration-rpc-grants.test.ts`
-- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/surveys.test.ts`
-- `pnpm test tests/unit/surveys.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm test -- --maxWorkers=4`
-- `pnpm build`
-- `git rev-list --left-right --count origin/main...HEAD` -> `0 0`
-- Migration prefix duplicate check returned no duplicates.
-- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
-- Standard UI verify for live teacher/student Classwork pages:
-  - `/tmp/pika-teacher.png`
-  - `/tmp/pika-student.png`
-  - `/tmp/pika-teacher-mobile.png`
-- Mocked survey UI verification for migration-independent teacher/student survey states:
-  - `/tmp/pika-survey-teacher-classwork.png`
-  - `/tmp/pika-survey-teacher-modal.png`
-  - `/tmp/pika-survey-teacher-workspace.png`
-  - `/tmp/pika-survey-student-classwork.png`
-  - `/tmp/pika-survey-student-form.png`
-
-## 2026-05-13 — Quiz and survey source editors
-
-**Completed:**
-- Generalized the test editor-only/markdown-only authoring layout so quizzes can use the same modal Code toggle flow without test documents.
-- Added quiz markdown source serialization/parsing and draft source persistence for AI-friendly quiz authoring.
-- Added a survey Code view with markdown serialization/parsing for multiple-choice, short-text, and link questions, including title/results/dynamic settings.
-- Let survey question POST/PATCH accept explicit `position` so markdown apply preserves source order.
-- Added route, parser, and component coverage for the new quiz/survey source authoring paths.
-
-**Validation:**
-- `pnpm test tests/lib/quiz-markdown.test.ts tests/unit/surveys.test.ts tests/components/QuizDetailPanel.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/api/teacher/surveys-questions-route.test.ts tests/api/teacher/surveys-questions-id.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Additional teacher screenshots:
-  - `/tmp/pika-quiz-edit-modal.png`
-  - `/tmp/pika-quiz-code-modal.png`
-  - `/tmp/pika-survey-code.png`
-
-## 2026-05-13 — Survey setup parity
-
-**Completed:**
-- Extracted a shared assessment setup dialog shell and routed quiz/test setup plus survey setup through it.
-- Updated new survey creation to use the same full-screen assessment setup frame as quiz/test creation.
-- After creating a survey, route the teacher directly into the new survey workspace with Code authoring selected.
-- Added component coverage for survey setup chrome and the created-survey Code-mode handoff.
-
-**Validation:**
-- `pnpm test tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/surveys-classwork E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Additional teacher screenshots:
-  - `/tmp/pika-survey-create-modal.png`
-  - `/tmp/pika-survey-create-modal-mobile.png`
-  - `/tmp/pika-survey-created-code.png`
-
 ## 2026-05-13 — Survey workspace modal routing
 
 **Completed:**
@@ -339,7 +253,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Targeted Playwright screenshots:
   - `/tmp/pika-exit-alert-teacher.png`
   - `/tmp/pika-exit-pulse-student.png`
-- Chrome smoke:
+  - Chrome smoke:
   - Teacher on `localhost:3002`: temporary active test loaded in grading, polled a student focus exit, showed `Exit detected`, and clicking the alert selected the student/cleared the banner.
   - Student on `127.0.0.1:3002`: temporary active test started in exam mode and showed the exits indicator in Chrome.
   - Temporary test was deleted after the smoke.
@@ -389,3 +303,76 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop`
+
+## 2026-05-15 — Assignment markdown modal
+
+**Completed:**
+- Moved teacher assignment-list markdown editing out of the right sidebar and into an `Edit Markdown` modal.
+- Added `Edit Markdown` to the assignment summary FAB split-button dropdown when markdown is enabled.
+- Reused the existing assignment markdown parse/save path, warning flow, and bulk sync API.
+- Updated assignment markdown tests for explicit dropdown-driven modal opening.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-bulk.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-teacher-assignment-markdown-modal.png`
+  - `/tmp/pika-teacher-assignment-markdown-modal-mobile.png`
+
+## 2026-05-15 — Assignment creation modal flow
+
+**Completed:**
+- Reworked the assignment modal into a narrower, more vertical authoring flow.
+- Kept title and due date on the same form row and removed due-date previous/next arrow controls.
+- Made assignment instructions always use the markdown editor toolbar.
+- Moved rendered markdown into a separate `Assignment Preview` dialog opened by a Preview button.
+- Updated assignment modal tests for the new preview dialog and always-visible markdown tools.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`
+
+## 2026-05-16 — Assignment modal top row tightening
+
+**Completed:**
+- Removed the visible assignment modal header above the title field.
+- Moved the post/schedule split button into the same first row as title and due date.
+- Shortened compact title/date/action widths so the same-row layout holds on mobile.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`
+
+## 2026-05-17 — Assignment modal close placement
+
+**Completed:**
+- Moved the assignment modal close button to an absolute upper-right corner position with minimal modal-edge padding.
+- Removed the close button from the title/due/action row.
+- Tightened the title input max width and matched compact due-date and post split-button widths.
+- Removed the reserved right-side content padding so the close button no longer consumes modal content width.
+- Made the close button borderless while keeping the same absolute corner hit target.
+- Updated the assignment instructions preview to a narrower student-content render: no footer Close button, no draft-only subtitle, and direct markdown output.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`

--- a/src/app/api/teacher/assignments/bulk/route.ts
+++ b/src/app/api/teacher/assignments/bulk/route.ts
@@ -72,7 +72,7 @@ function buildAssignmentPositions(
 /**
  * POST /api/teacher/assignments/bulk - Bulk create/update assignments
  *
- * Used by the markdown sidebar to sync assignments from markdown content.
+ * Used by the markdown editor to sync assignments from markdown content.
  * - Creates new assignments (entries without ID) as drafts
  * - Updates existing assignments (entries with ID)
  * - Allows draft→released and scheduled→draft

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { differenceInCalendarDays, format, parseISO } from 'date-fns'
 import { AppShell } from '@/components/AppShell'
-import { TeacherClassroomView, TeacherAssignmentsMarkdownSidebar, type AssignmentViewMode } from './TeacherClassroomView'
+import { TeacherClassroomView, TeacherAssignmentsMarkdownEditor, type AssignmentViewMode } from './TeacherClassroomView'
 import { assignmentsToMarkdown, markdownToAssignments } from '@/lib/assignment-markdown'
 import { StudentTodayTab } from './StudentTodayTab'
 import { StudentAssignmentsTab } from './StudentAssignmentsTab'
@@ -34,7 +34,7 @@ import {
   useMobileDrawer,
   useRightSidebar,
 } from '@/components/layout'
-import { DESKTOP_BREAKPOINT, getRouteKeyFromTab } from '@/lib/layout-config'
+import { getRouteKeyFromTab } from '@/lib/layout-config'
 import { RichTextViewer } from '@/components/editor'
 import { Spinner } from '@/components/Spinner'
 import {
@@ -45,10 +45,10 @@ import {
 } from '@/lib/events'
 import { TeacherTestPreviewPage } from '@/components/TeacherTestPreviewPage'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
-import { ConfirmDialog, TabContentTransition } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, TabContentTransition } from '@/ui'
 import { PageDensityProvider } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
-import { fetchJSONWithCache, prefetchJSON } from '@/lib/request-cache'
+import { fetchJSONWithCache, invalidateCachedJSON, prefetchJSON } from '@/lib/request-cache'
 import { markClassroomTabSwitchReady, markClassroomTabSwitchStart } from '@/lib/classroom-ux-metrics'
 import { getTodayInToronto } from '@/lib/timezone'
 import type {
@@ -354,7 +354,7 @@ function ClassroomPageContent({
   searchParams: URLSearchParams
   updateSearchParams: UpdateSearchParamsFn
 }) {
-  const { openLeft, openRight, close: closeMobileDrawer } = useMobileDrawer()
+  const { openLeft, close: closeMobileDrawer } = useMobileDrawer()
   const { setWidth: setRightSidebarWidth, isOpen: isRightSidebarOpen, setOpen: setRightSidebarOpen } = useRightSidebar()
   const { classDays } = useClassDaysContext()
   const { showMarkdown } = useMarkdownPreference()
@@ -599,10 +599,10 @@ function ClassroomPageContent({
     setTeacherTestPreview(null)
   }, [selectedQuiz, teacherTestPreview])
 
-  // State for markdown mode (teacher assignments tab - summary view only)
+  // State for markdown editing (teacher assignments tab - summary view only)
   const [assignmentViewMode, setAssignmentViewMode] = useState<AssignmentViewMode>('summary')
   const [assignmentEditMode, setAssignmentEditMode] = useState(false)
-  const [isMarkdownMode, setIsMarkdownMode] = useState(false)
+  const [isAssignmentMarkdownDialogOpen, setIsAssignmentMarkdownDialogOpen] = useState(false)
   const [markdownContent, setMarkdownContent] = useState('')
   const [markdownError, setMarkdownError] = useState<string | null>(null)
   const [markdownWarning, setMarkdownWarning] = useState<string | null>(null)
@@ -613,8 +613,6 @@ function ClassroomPageContent({
   const [assignmentsCache, setAssignmentsCache] = useState<Assignment[]>([])
 
   // Track previous states for detecting transitions
-  const prevSidebarOpenRef = useRef(false)
-  const prevAssignmentMarkdownAutoOpenReadyRef = useRef(false)
   const abortControllerRef = useRef<AbortController | null>(null)
   const markdownStaleRef = useRef(true) // Start stale so first open loads
 
@@ -674,7 +672,7 @@ function ClassroomPageContent({
     setAssignmentViewMode(mode)
     if (mode === 'assignment') {
       setAssignmentEditMode(false)
-      setIsMarkdownMode(false)
+      setIsAssignmentMarkdownDialogOpen(false)
       // Abort any in-flight markdown load to prevent it from re-enabling markdown mode
       abortControllerRef.current?.abort()
     }
@@ -692,7 +690,6 @@ function ClassroomPageContent({
     setMarkdownWarning(null)
     setWarningsAcknowledged(false)
     setMarkdownLoading(true)
-    setIsMarkdownMode(true)
 
     try {
       const data = await fetchJSONWithCache<{ assignments?: Assignment[] }>(
@@ -712,7 +709,6 @@ function ClassroomPageContent({
       const result = assignmentsToMarkdown(assignments)
       setMarkdownContent(result.markdown)
       setHasRichContent(result.hasRichContent)
-      setRightSidebarWidth('50%')
       markdownStaleRef.current = false
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
@@ -723,62 +719,29 @@ function ClassroomPageContent({
     } finally {
       setMarkdownLoading(false)
     }
-  }, [classroom.id, setRightSidebarWidth])
+  }, [classroom.id])
 
-  const openAssignmentsMarkdownPanel = useCallback(() => {
-    if (!showMarkdown) return
+  const closeAssignmentsMarkdownDialog = useCallback(() => {
+    setIsAssignmentMarkdownDialogOpen(false)
+  }, [])
 
-    setRightSidebarWidth('50%')
-    setRightSidebarOpen(true)
-    if (typeof window !== 'undefined' && window.innerWidth < DESKTOP_BREAKPOINT) {
-      openRight()
-    }
+  const openAssignmentsMarkdownDialog = useCallback(() => {
+    if (!showMarkdown || assignmentViewMode !== 'summary') return
 
-    if (markdownStaleRef.current || !isMarkdownMode) {
-      loadAssignmentsMarkdown()
-    } else {
-      setIsMarkdownMode(true)
+    setIsAssignmentMarkdownDialogOpen(true)
+    if (markdownStaleRef.current || !markdownContent) {
+      void loadAssignmentsMarkdown()
     }
   }, [
-    isMarkdownMode,
+    assignmentViewMode,
     loadAssignmentsMarkdown,
-    openRight,
+    markdownContent,
     showMarkdown,
-    setRightSidebarOpen,
-    setRightSidebarWidth,
   ])
 
   const handleAssignmentsEditModeChange = useCallback((active: boolean) => {
     setAssignmentEditMode(active)
   }, [])
-
-  const assignmentMarkdownAutoOpenReady =
-    showMarkdown && isTeacher && activeTab === 'assignments' && assignmentEditMode && assignmentViewMode === 'summary'
-
-  // Detect sidebar close for assignments tab. Markdown mode opens by default when summary edit mode starts.
-  useEffect(() => {
-    const wasOpen = prevSidebarOpenRef.current
-    prevSidebarOpenRef.current = isRightSidebarOpen
-
-    if (!isTeacher || activeTab !== 'assignments') return
-
-    if (!showMarkdown || !assignmentEditMode || assignmentViewMode !== 'summary') {
-      setIsMarkdownMode(false)
-      return
-    }
-
-    if (!isRightSidebarOpen && wasOpen) {
-      setIsMarkdownMode(false)
-    }
-  }, [isRightSidebarOpen, isTeacher, activeTab, assignmentEditMode, assignmentViewMode, showMarkdown])
-
-  useEffect(() => {
-    const wasReady = prevAssignmentMarkdownAutoOpenReadyRef.current
-    prevAssignmentMarkdownAutoOpenReadyRef.current = assignmentMarkdownAutoOpenReady
-
-    if (!assignmentMarkdownAutoOpenReady || wasReady) return
-    openAssignmentsMarkdownPanel()
-  }, [assignmentMarkdownAutoOpenReady, openAssignmentsMarkdownPanel])
 
   useEffect(() => {
     if (!isTeacher || activeTab === 'assignments') return
@@ -786,53 +749,38 @@ function ClassroomPageContent({
     if (assignmentEditMode) {
       setAssignmentEditMode(false)
     }
-    if (isMarkdownMode) {
-      setIsMarkdownMode(false)
+    if (isAssignmentMarkdownDialogOpen) {
+      setIsAssignmentMarkdownDialogOpen(false)
     }
-    if (assignmentEditMode || isMarkdownMode) {
+    if (assignmentEditMode || isAssignmentMarkdownDialogOpen) {
       abortControllerRef.current?.abort()
-    }
-    if (isMarkdownMode && isRightSidebarOpen) {
-      setRightSidebarOpen(false)
-      closeMobileDrawer()
     }
   }, [
     activeTab,
     assignmentEditMode,
-    closeMobileDrawer,
-    isMarkdownMode,
-    isRightSidebarOpen,
+    isAssignmentMarkdownDialogOpen,
     isTeacher,
-    setRightSidebarOpen,
   ])
 
   useEffect(() => {
     if (!isTeacher || activeTab !== 'assignments') return
-    if (showMarkdown && assignmentEditMode && assignmentViewMode === 'summary') return
+    if (showMarkdown && assignmentViewMode === 'summary') return
 
-    if (isMarkdownMode) {
-      setIsMarkdownMode(false)
+    if (isAssignmentMarkdownDialogOpen) {
+      setIsAssignmentMarkdownDialogOpen(false)
     }
     abortControllerRef.current?.abort()
-    if (isRightSidebarOpen) {
-      setRightSidebarOpen(false)
-      closeMobileDrawer()
-    }
   }, [
     activeTab,
-    assignmentEditMode,
     assignmentViewMode,
-    closeMobileDrawer,
-    isMarkdownMode,
-    isRightSidebarOpen,
+    isAssignmentMarkdownDialogOpen,
     isTeacher,
     showMarkdown,
-    setRightSidebarOpen,
   ])
 
   // Refresh markdown when assignments are updated
   useEffect(() => {
-    if (!showMarkdown || !isTeacher || activeTab !== 'assignments' || assignmentViewMode !== 'summary' || !assignmentEditMode || !isMarkdownMode) return
+    if (!showMarkdown || !isTeacher || activeTab !== 'assignments' || assignmentViewMode !== 'summary' || !isAssignmentMarkdownDialogOpen) return
 
     const handleAssignmentsUpdated = () => {
       markdownStaleRef.current = true
@@ -843,7 +791,7 @@ function ClassroomPageContent({
     return () => {
       window.removeEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
     }
-  }, [showMarkdown, isTeacher, activeTab, assignmentEditMode, assignmentViewMode, isMarkdownMode, loadAssignmentsMarkdown])
+  }, [showMarkdown, isTeacher, activeTab, assignmentViewMode, isAssignmentMarkdownDialogOpen, loadAssignmentsMarkdown])
 
   const handleMarkdownContentChange = useCallback((content: string) => {
     setMarkdownContent(content)
@@ -852,7 +800,7 @@ function ClassroomPageContent({
     setWarningsAcknowledged(false)
   }, [])
 
-  const handleMarkdownSave = useCallback(async () => {
+  const handleMarkdownSave = useCallback(async (options?: { ignoreWarnings?: boolean }) => {
     setMarkdownError(null)
     setBulkSaving(true)
 
@@ -865,7 +813,7 @@ function ClassroomPageContent({
         return
       }
 
-      if (result.warnings.length > 0 && !warningsAcknowledged) {
+      if (result.warnings.length > 0 && !warningsAcknowledged && !options?.ignoreWarnings) {
         setMarkdownWarning(result.warnings.join('\n'))
         setBulkSaving(false)
         return
@@ -887,8 +835,9 @@ function ClassroomPageContent({
         return
       }
 
-      setIsMarkdownMode(false)
-      setRightSidebarOpen(false)
+      invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+      markdownStaleRef.current = true
+      setIsAssignmentMarkdownDialogOpen(false)
       setMarkdownWarning(null)
       setWarningsAcknowledged(false)
 
@@ -903,11 +852,7 @@ function ClassroomPageContent({
     } finally {
       setBulkSaving(false)
     }
-  }, [markdownContent, assignmentsCache, classroom.id, setRightSidebarOpen, warningsAcknowledged])
-
-  const handleAcknowledgeWarnings = useCallback(() => {
-    setWarningsAcknowledged(true)
-  }, [])
+  }, [markdownContent, assignmentsCache, classroom.id, warningsAcknowledged])
 
   useEffect(() => {
     if (isTeacher && activeTab === 'assignments') {
@@ -922,7 +867,7 @@ function ClassroomPageContent({
   useEffect(() => {
     if (!isTeacher || activeTab !== 'assignments') return
     if (assignmentViewMode !== 'assignment') return
-    setIsMarkdownMode(false)
+    setIsAssignmentMarkdownDialogOpen(false)
     setRightSidebarOpen(false)
     closeMobileDrawer()
   }, [
@@ -1271,6 +1216,8 @@ function ClassroomPageContent({
                         onSelectAssignment={handleSelectAssignment}
                         onViewModeChange={handleViewModeChange}
                         onEditModeChange={handleAssignmentsEditModeChange}
+                        onOpenMarkdownEditor={openAssignmentsMarkdownDialog}
+                        showMarkdownEditorOption={showMarkdown && assignmentViewMode === 'summary'}
                         isActive={activeTab === 'assignments'}
                         selectedAssignmentId={assignmentIdParam}
                         selectedMaterialId={materialIdParam}
@@ -1458,9 +1405,7 @@ function ClassroomPageContent({
           hideDesktopHeader={false}
           minimalMobileHeader={false}
           title={
-            showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode
-              ? 'Assignments'
-              : isTeacher && activeTab === 'calendar' && calendarSidebarState
+            isTeacher && activeTab === 'calendar' && calendarSidebarState
               ? 'Calendar'
               : isTeacher && isAssessmentTab
               ? ''
@@ -1471,30 +1416,7 @@ function ClassroomPageContent({
               : 'Details'
           }
           headerActions={
-            showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
-              markdownWarning && !warningsAcknowledged ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    handleAcknowledgeWarnings()
-                    setTimeout(handleMarkdownSave, 0)
-                  }}
-                  disabled={bulkSaving}
-                  className="px-2 py-1 text-xs rounded bg-warning text-text-inverse hover:opacity-90 disabled:opacity-50"
-                >
-                  Save Anyway
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onClick={handleMarkdownSave}
-                  disabled={bulkSaving}
-                  className="px-2 py-1 text-xs rounded bg-primary text-text-inverse hover:bg-primary-hover disabled:opacity-50"
-                >
-                  {bulkSaving ? 'Saving...' : 'Save'}
-                </button>
-              )
-            ) : isTeacher && activeTab === 'calendar' && calendarSidebarState ? (
+            isTeacher && activeTab === 'calendar' && calendarSidebarState ? (
               <button
                 type="button"
                 onClick={calendarSidebarState.onSave}
@@ -1506,23 +1428,7 @@ function ClassroomPageContent({
             ) : undefined
           }
         >
-          {showMarkdown && isTeacher && activeTab === 'assignments' && isMarkdownMode ? (
-            markdownLoading ? (
-              <div className="flex items-center justify-center h-32">
-                <Spinner />
-              </div>
-            ) : (
-              <TeacherAssignmentsMarkdownSidebar
-                markdownContent={markdownContent}
-                markdownError={markdownError}
-                markdownWarning={markdownWarning}
-                hasRichContent={hasRichContent}
-                bulkSaving={bulkSaving}
-                onMarkdownChange={handleMarkdownContentChange}
-                onSave={handleMarkdownSave}
-              />
-            )
-          ) : isTeacher && activeTab === 'calendar' && calendarSidebarState ? (
+          {isTeacher && activeTab === 'calendar' && calendarSidebarState ? (
             <TeacherLessonCalendarSidebar {...calendarSidebarState} />
           ) : isTeacher && isAssessmentTab ? (
             null
@@ -1560,6 +1466,82 @@ function ClassroomPageContent({
         </RightSidebar>
         )}
       </ThreePanelShell>
+
+      <DialogPanel
+        isOpen={showMarkdown && isTeacher && activeTab === 'assignments' && isAssignmentMarkdownDialogOpen}
+        onClose={() => {
+          if (!bulkSaving) closeAssignmentsMarkdownDialog()
+        }}
+        maxWidth="max-w-5xl"
+        className="h-[85vh] overflow-hidden p-0"
+        viewportPaddingClassName="p-2 sm:p-4"
+        ariaLabelledBy="assignments-markdown-dialog-title"
+      >
+        <div className="flex flex-shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="min-w-0">
+            <h2 id="assignments-markdown-dialog-title" className="text-base font-semibold text-text-default">
+              Edit Markdown
+            </h2>
+            <p className="truncate text-xs text-text-muted">Assignments</p>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={closeAssignmentsMarkdownDialog}
+              disabled={bulkSaving}
+            >
+              Cancel
+            </Button>
+            {markdownWarning && !warningsAcknowledged ? (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => {
+                  setWarningsAcknowledged(true)
+                  void handleMarkdownSave({ ignoreWarnings: true })
+                }}
+                disabled={bulkSaving || markdownLoading}
+              >
+                {bulkSaving ? 'Saving...' : 'Save Anyway'}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => {
+                  void handleMarkdownSave()
+                }}
+                disabled={bulkSaving || markdownLoading}
+              >
+                {bulkSaving ? 'Saving...' : 'Save'}
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="min-h-0 flex-1">
+          {markdownLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            <TeacherAssignmentsMarkdownEditor
+              markdownContent={markdownContent}
+              markdownError={markdownError}
+              markdownWarning={markdownWarning}
+              hasRichContent={hasRichContent}
+              bulkSaving={bulkSaving}
+              onMarkdownChange={handleMarkdownContentChange}
+              onSave={() => {
+                void handleMarkdownSave()
+              }}
+            />
+          )}
+        </div>
+      </DialogPanel>
 
       <ConfirmDialog
         isOpen={!!pendingAssessmentDelete}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -146,6 +146,8 @@ interface Props {
   onSelectAssignment?: (assignment: { title: string; instructions: TiptapContent | string | null } | null) => void
   onViewModeChange?: (mode: AssignmentViewMode) => void
   onEditModeChange?: (active: boolean) => void
+  onOpenMarkdownEditor?: () => void
+  showMarkdownEditorOption?: boolean
   isActive?: boolean
   selectedAssignmentId?: string | null
   selectedMaterialId?: string | null
@@ -563,6 +565,8 @@ export function TeacherClassroomView({
   onSelectAssignment,
   onViewModeChange,
   onEditModeChange,
+  onOpenMarkdownEditor,
+  showMarkdownEditorOption = false,
   isActive = true,
   selectedAssignmentId: selectedAssignmentIdProp,
   selectedSurveyId: selectedSurveyIdProp,
@@ -2330,6 +2334,21 @@ export function TeacherClassroomView({
                       label: 'Survey',
                       onSelect: () => setIsSurveyModalOpen(true),
                     },
+                    ...(showMarkdownEditorOption
+                      ? [
+                          {
+                            id: 'edit-markdown',
+                            label: (
+                              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                                <FileText className="h-4 w-4" aria-hidden="true" />
+                                <span>Edit Markdown</span>
+                              </span>
+                            ),
+                            onSelect: () => onOpenMarkdownEditor?.(),
+                            disabled: !onOpenMarkdownEditor || isReadOnly,
+                          },
+                        ]
+                      : []),
                   ]}
                   disabled={isReadOnly}
                   toggleAriaLabel="Choose classwork type"
@@ -2650,8 +2669,7 @@ export function TeacherClassroomView({
   )
 }
 
-// Sidebar content component - rendered via page.tsx
-export function TeacherAssignmentsMarkdownSidebar({
+export function TeacherAssignmentsMarkdownEditor({
   markdownContent,
   markdownError,
   markdownWarning,
@@ -2699,6 +2717,7 @@ export function TeacherAssignmentsMarkdownSidebar({
       )}
 
       <textarea
+        aria-label="Assignments markdown"
         value={markdownContent}
         onChange={(e) => onMarkdownChange(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -2,10 +2,9 @@
 
 import { useId, useRef } from 'react'
 import type { KeyboardEvent, ReactNode, RefObject } from 'react'
+import { Eye } from 'lucide-react'
 import { Input, Button } from '@/ui'
 import { DateActionBar } from '@/components/DateActionBar'
-import { LimitedMarkdown } from '@/components/LimitedMarkdown'
-import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
 import { Code2Icon } from '@/components/tiptap-icons/code2-icon'
 import { ItalicIcon } from '@/components/tiptap-icons/italic-icon'
@@ -27,8 +26,7 @@ interface AssignmentFormProps {
   onInstructionsUndo: () => void
   onInstructionsRedo: () => void
   onDueAtChange: (next: string) => void
-  onPrevDate: () => void
-  onNextDate: () => void
+  onPreviewInstructions?: () => void
   disabled?: boolean
   error?: string
   titleInputRef?: RefObject<HTMLInputElement>
@@ -52,8 +50,7 @@ export function AssignmentForm({
   onInstructionsUndo,
   onInstructionsRedo,
   onDueAtChange,
-  onPrevDate,
-  onNextDate,
+  onPreviewInstructions,
   disabled = false,
   error,
   titleInputRef,
@@ -67,7 +64,12 @@ export function AssignmentForm({
 }: AssignmentFormProps) {
   const instructionsRef = useRef<HTMLTextAreaElement>(null)
   const titleFieldId = useId()
-  const { showMarkdown } = useMarkdownPreference()
+  const topRowGridClassName = topRowActions
+    ? 'grid-cols-[minmax(2.75rem,1fr)_auto_auto] sm:grid-cols-[minmax(9rem,1fr)_auto_auto]'
+    : 'grid-cols-[minmax(0,1fr)_auto]'
+  const titleFieldClassName = topRowActions
+    ? 'min-w-0 max-w-[22rem] space-y-1 sm:max-w-[24rem]'
+    : 'min-w-0 space-y-1'
 
   function applyWrapFormatting(prefix: string, suffix = prefix) {
     const textarea = instructionsRef.current
@@ -155,8 +157,8 @@ export function AssignmentForm({
 
   return (
     <div className={fillHeight ? 'flex h-full min-h-0 w-full flex-col gap-3' : 'space-y-3 w-full'}>
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_auto] lg:items-end lg:gap-x-8">
-        <div className="min-w-0 space-y-1">
+      <div className={`grid items-end gap-1.5 sm:gap-2 ${topRowGridClassName}`}>
+        <div className={titleFieldClassName}>
           <label htmlFor={titleFieldId} className="block text-sm font-medium text-text-default">
             Title
             <span className="ml-1 text-danger">*</span>
@@ -175,7 +177,7 @@ export function AssignmentForm({
           />
         </div>
 
-        <div className="space-y-1">
+        <div className="w-[6.75rem] space-y-1 sm:w-[8.25rem]">
           {(() => {
             const relative = getRelativeDueDate(dueAt, classDays)
             const labelText = relative ? `Due ${relative.text}` : 'Due Date'
@@ -185,7 +187,7 @@ export function AssignmentForm({
                 : 'text-primary'
               : 'text-text-muted'
             return (
-              <div className={`text-sm font-medium ${colorClass}`}>
+              <div className={`truncate text-sm font-medium ${colorClass}`}>
                 {labelText}
               </div>
             )
@@ -194,29 +196,39 @@ export function AssignmentForm({
             <DateActionBar
               value={dueAt}
               onChange={onDueAtChange}
-              onPrev={onPrevDate}
-              onNext={onNextDate}
               layout="compact"
             />
           </div>
         </div>
 
         {topRowActions && (
-          <div className="space-y-1 lg:justify-self-end lg:pl-2">
+          <div className="min-w-0">
             {topRowActions}
           </div>
         )}
       </div>
 
       <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col space-y-1' : 'space-y-1'}>
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <label className="block text-sm font-medium text-text-default">
             Instructions
           </label>
-          <div className="justify-self-center">
+          <div className="flex items-center gap-3">
             {statusContent}
+            {onPreviewInstructions && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={onPreviewInstructions}
+                disabled={disabled}
+                className="gap-1.5"
+              >
+                <Eye className="h-4 w-4" aria-hidden="true" />
+                Preview
+              </Button>
+            )}
           </div>
-          <div aria-hidden="true" />
         </div>
         <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border-strong' : 'rounded-lg border border-border-strong overflow-hidden'}>
           {markdownWarning && (
@@ -224,73 +236,43 @@ export function AssignmentForm({
               {markdownWarning}
             </div>
           )}
-          {showMarkdown ? (
-            <div className={fillHeight ? 'grid min-h-0 flex-1 gap-0 md:grid-cols-2' : 'grid min-h-[400px] gap-0 md:grid-cols-2 lg:min-h-[460px]'}>
-              <div className="flex h-full min-h-0 flex-col border-b border-border md:border-b-0 md:border-r md:border-border">
-                <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
-                  <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
-                    <Undo2Icon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={onInstructionsRedo} disabled={disabled || !canRedoInstructions} className="h-8 w-8 px-0" aria-label="Redo" title="Redo">
-                    <Redo2Icon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('### ')} disabled={disabled} className="h-8 w-8 px-0 text-sm font-bold" aria-label="Heading" title="Heading">
-                    H
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('**')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bold" title="Bold">
-                    <BoldIcon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('*')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Italic" title="Italic">
-                    <ItalicIcon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('- ')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bullet list" title="Bullet list">
-                    <ListIcon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyLinkFormatting()} disabled={disabled} className="h-8 w-8 px-0" aria-label="Link" title="Link">
-                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('`')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Inline code" title="Inline code">
-                    <Code2Icon className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                </div>
-                <textarea
-                  ref={instructionsRef}
-                  value={instructionsMarkdown}
-                  onChange={(e) => onInstructionsMarkdownChange(e.target.value)}
-                  onKeyDown={handleInstructionsKeyDown}
-                  onBlur={onBlur}
-                  placeholder="Assignment instructions"
-                  disabled={disabled}
-                  spellCheck={false}
-                  className={fillHeight ? 'h-full min-h-0 w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0' : 'h-full min-h-[360px] w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0 lg:min-h-[420px]'}
-                />
-              </div>
-              <div className="flex min-h-0 flex-col bg-page">
-                <div className="px-3 py-2 text-xs font-medium uppercase tracking-wide text-text-muted">
-                  Preview
-                </div>
-                <div className={fillHeight ? 'min-h-0 flex-1 overflow-y-auto px-3 pb-3' : 'min-h-[360px] px-3 pb-3 lg:min-h-[420px]'}>
-                  <LimitedMarkdown
-                    content={instructionsMarkdown}
-                    emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
-                  />
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className={fillHeight ? 'flex min-h-0 flex-1' : 'min-h-[400px] lg:min-h-[460px]'}>
-              <textarea
-                ref={instructionsRef}
-                value={instructionsMarkdown}
-                onChange={(e) => onInstructionsMarkdownChange(e.target.value)}
-                onKeyDown={handleInstructionsKeyDown}
-                onBlur={onBlur}
-                placeholder="Assignment instructions"
-                disabled={disabled}
-                className={fillHeight ? 'min-h-0 w-full flex-1 resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0' : 'min-h-[400px] w-full resize-none border-0 bg-surface p-3 text-sm leading-6 text-text-default focus:outline-none focus:ring-0 lg:min-h-[460px]'}
-              />
-            </div>
-          )}
+          <div className="flex flex-wrap gap-1 border-b border-border bg-surface px-2 py-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onInstructionsUndo} disabled={disabled || !canUndoInstructions} className="h-8 w-8 px-0" aria-label="Undo" title="Undo">
+              <Undo2Icon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={onInstructionsRedo} disabled={disabled || !canRedoInstructions} className="h-8 w-8 px-0" aria-label="Redo" title="Redo">
+              <Redo2Icon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('### ')} disabled={disabled} className="h-8 w-8 px-0 text-sm font-bold" aria-label="Heading" title="Heading">
+              H
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('**')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bold" title="Bold">
+              <BoldIcon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('*')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Italic" title="Italic">
+              <ItalicIcon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyLinePrefix('- ')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Bullet list" title="Bullet list">
+              <ListIcon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyLinkFormatting()} disabled={disabled} className="h-8 w-8 px-0" aria-label="Link" title="Link">
+              <LinkIcon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => applyWrapFormatting('`')} disabled={disabled} className="h-8 w-8 px-0" aria-label="Inline code" title="Inline code">
+              <Code2Icon className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+          <textarea
+            ref={instructionsRef}
+            value={instructionsMarkdown}
+            onChange={(e) => onInstructionsMarkdownChange(e.target.value)}
+            onKeyDown={handleInstructionsKeyDown}
+            onBlur={onBlur}
+            placeholder="Assignment instructions"
+            disabled={disabled}
+            spellCheck={false}
+            className={fillHeight ? 'min-h-0 w-full flex-1 resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0' : 'min-h-[420px] w-full resize-none border-0 bg-surface p-3 font-mono text-sm text-text-default focus:outline-none focus:ring-0'}
+          />
         </div>
       </div>
 

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -4,9 +4,10 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { X } from 'lucide-react'
 import type { Assignment, ClassDay } from '@/types'
 import { AssignmentForm } from '@/components/AssignmentForm'
+import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { getRelativeDueDate } from '@/lib/assignment-relative-date'
-import { Button, ConfirmDialog, DialogPanel, SplitButton } from '@/ui'
+import { Button, ConfirmDialog, ContentDialog, DialogPanel, SplitButton } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
 import { format, isValid, parse } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
@@ -104,6 +105,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
   const [markdownWarning, setMarkdownWarning] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [creating, setCreating] = useState(false)
+  const [showInstructionsPreview, setShowInstructionsPreview] = useState(false)
 
   const defaultDueAt = addDaysToDateString(getTodayInToronto(), 1)
   const { dueAt, error, updateDueDate, setDueAt, setError } = useAssignmentDateValidation(defaultDueAt)
@@ -172,7 +174,10 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
   } = scheduling
 
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen) {
+      setShowInstructionsPreview(false)
+      return
+    }
 
     // Reset state when modal opens
     setError('')
@@ -529,20 +534,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     scheduleAutosave({ title, instructionsMarkdown, dueAt: newDueAt })
   }
 
-  function handlePrevDate() {
-    const today = getTodayInToronto()
-    const base = dueAt || today
-    const newDueAt = addDaysToDateString(base, -1)
-    handleDueAtChange(newDueAt)
-  }
-
-  function handleNextDate() {
-    const today = getTodayInToronto()
-    const base = dueAt || today
-    const newDueAt = addDaysToDateString(base, 1)
-    handleDueAtChange(newDueAt)
-  }
-
   function flushAutosave() {
     if (saveStatus === 'unsaved' && pendingValuesRef.current) {
       if (saveTimeoutRef.current) {
@@ -638,6 +629,8 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
   }
 
   async function handleClose() {
+    setShowInstructionsPreview(false)
+
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current)
       saveTimeoutRef.current = null
@@ -677,14 +670,28 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       : 'primary'
     : 'muted'
   const scheduleDueDateValidationMessage = getScheduleDueDateValidationMessage(scheduleIso, dueAt, isScheduleValid)
+  const previewSubtitle = isLive ? title.trim() || undefined : undefined
   const editorPanelClass =
-    '!h-[calc(100dvh-0.5rem)] !max-h-[calc(100dvh-0.5rem)] !w-[calc(100vw-0.5rem)] !max-w-[calc(100vw-0.5rem)] overflow-hidden p-0 sm:!h-[calc(100dvh-1rem)] sm:!max-h-[calc(100dvh-1rem)] sm:!w-[calc(100vw-1rem)] sm:!max-w-[calc(100vw-1rem)]'
+    'relative !max-h-[calc(100dvh-1rem)] overflow-hidden p-0 sm:!max-h-[calc(100dvh-2rem)]'
+  const saveStatusContent = (
+    <span
+      className={`text-xs ${
+        saveStatus === 'saved'
+          ? 'text-success'
+          : saveStatus === 'saving'
+            ? 'text-text-muted'
+            : 'text-warning'
+      }`}
+    >
+      {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
+    </span>
+  )
   const closeAssignmentModalButton = (
     <Button
       type="button"
-      variant="surface"
+      variant="ghost"
       size="sm"
-      className="h-9 w-9 flex-shrink-0 px-0"
+      className="absolute right-1 top-1 z-20 h-9 w-9 px-0 text-text-default"
       onClick={() => {
         void handleClose()
       }}
@@ -701,14 +708,16 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       <DialogPanel
         isOpen={isOpen}
         onClose={handleClose}
-        maxWidth="max-w-none"
+        maxWidth="!max-w-4xl"
         className={editorPanelClass}
-        viewportPaddingClassName="p-1 sm:p-2"
+        viewportPaddingClassName="p-2 sm:p-4"
         ariaLabelledBy="assignment-modal-title"
       >
         <h2 id="assignment-modal-title" className="sr-only">
           {modalTitle}
         </h2>
+
+        {closeAssignmentModalButton}
 
         <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
           <AssignmentForm
@@ -721,8 +730,7 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             onInstructionsUndo={handleInstructionsUndo}
             onInstructionsRedo={handleInstructionsRedo}
             onDueAtChange={handleDueAtChange}
-            onPrevDate={handlePrevDate}
-            onNextDate={handleNextDate}
+            onPreviewInstructions={() => setShowInstructionsPreview(true)}
             disabled={saving || releasing || creating}
             error={error}
             titleInputRef={titleInputRef}
@@ -730,56 +738,58 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
             markdownWarning={markdownWarning}
             canUndoInstructions={instructionsHistoryIndexRef.current > 0}
             canRedoInstructions={instructionsHistoryIndexRef.current < instructionsHistoryRef.current.length - 1}
-            fillHeight
             statusContent={(
-              <span
-                className={`text-xs ${
-                  saveStatus === 'saved'
-                    ? 'text-success'
-                    : saveStatus === 'saving'
-                      ? 'text-text-muted'
-                      : 'text-warning'
-                }`}
-              >
-                {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
+              <span className="inline-flex items-center gap-2">
+                {saveStatusContent}
+                {currentAssignment && isScheduled && currentAssignment.released_at && (
+                  <span className="text-xs font-medium text-warning">
+                    {formatReleaseDate(currentAssignment.released_at)}
+                  </span>
+                )}
               </span>
             )}
             topRowActions={
-              <div className="flex flex-col items-start gap-2 lg:items-end">
-                {currentAssignment && isScheduled && currentAssignment.released_at && (
-                  <div className="text-xs font-medium text-warning">
-                    {formatReleaseDate(currentAssignment.released_at)}
-                  </div>
-                )}
-                <div className="flex items-center gap-2">
-                  {currentAssignment && !isLive ? (
-                    <SplitButton
-                      label={primaryLabel}
-                      onPrimaryClick={() => {
-                        void handleTriggerPrimaryAction()
-                      }}
-                      variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
-                      size="md"
-                      disabled={creating || releasing || saving || !currentAssignment}
-                      className="shadow-sm"
-                      toggleAriaLabel="Choose assignment action"
-                      menuPlacement="down"
-                      primaryButtonProps={{
-                        className: 'w-[9rem] justify-center font-semibold',
-                      }}
-                      options={splitOptions.map((option) => ({
-                        ...option,
-                        onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
-                      }))}
-                    />
-                  ) : null}
-                  {closeAssignmentModalButton}
+              currentAssignment && !isLive ? (
+                <div className="flex items-end">
+                  <SplitButton
+                    label={primaryLabel}
+                    onPrimaryClick={() => {
+                      void handleTriggerPrimaryAction()
+                    }}
+                    variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
+                    size="md"
+                    disabled={creating || releasing || saving || !currentAssignment}
+                    className="shadow-sm"
+                    toggleAriaLabel="Choose assignment action"
+                    menuPlacement="down"
+                    primaryButtonProps={{
+                      className: 'w-[4.25rem] justify-center font-semibold sm:w-[5.75rem]',
+                    }}
+                    options={splitOptions.map((option) => ({
+                      ...option,
+                      onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
+                    }))}
+                  />
                 </div>
-              </div>
+              ) : null
             }
           />
         </div>
       </DialogPanel>
+
+      <ContentDialog
+        isOpen={isOpen && showInstructionsPreview}
+        onClose={() => setShowInstructionsPreview(false)}
+        title="Instructions"
+        subtitle={previewSubtitle}
+        maxWidth="!max-w-2xl"
+        showFooterClose={false}
+      >
+        <LimitedMarkdown
+          content={instructionsMarkdown}
+          emptyPlaceholder={<div className="text-sm text-text-muted">No assignment details provided.</div>}
+        />
+      </ContentDialog>
 
       <DialogPanel
         isOpen={showCreateScheduleModal}

--- a/src/components/DateActionBar.tsx
+++ b/src/components/DateActionBar.tsx
@@ -2,14 +2,11 @@
 
 import { useRef } from 'react'
 import { format, parseISO } from 'date-fns'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { ACTIONBAR_BUTTON_CLASSNAME, ACTIONBAR_ICON_BUTTON_CLASSNAME } from '@/components/PageLayout'
+import { ACTIONBAR_BUTTON_CLASSNAME } from '@/components/PageLayout'
 
 interface DateActionBarProps {
   value: string
   onChange: (next: string) => void
-  onPrev: () => void
-  onNext: () => void
   rightActions?: React.ReactNode
   className?: string
   layout?: 'default' | 'compact'
@@ -18,8 +15,6 @@ interface DateActionBarProps {
 export function DateActionBar({
   value,
   onChange,
-  onPrev,
-  onNext,
   rightActions,
   className = '',
   layout = 'default',
@@ -30,14 +25,13 @@ export function DateActionBar({
   const containerClassName = isCompact
     ? 'flex items-center gap-2'
     : 'flex w-full flex-wrap items-center justify-between gap-4'
+  const buttonClassName = isCompact
+    ? `${ACTIONBAR_BUTTON_CLASSNAME} w-[6.75rem] text-center sm:w-[8.25rem]`
+    : `${ACTIONBAR_BUTTON_CLASSNAME} min-w-[7rem] text-center`
 
   return (
     <div className={[containerClassName, className].join(' ')}>
       <div className="flex flex-wrap items-center gap-2">
-        <button type="button" className={ACTIONBAR_ICON_BUTTON_CLASSNAME} onClick={onPrev} aria-label="Previous day">
-          <ChevronLeft className="h-5 w-5" aria-hidden="true" />
-        </button>
-
         <input
           ref={dateInputRef}
           type="date"
@@ -49,14 +43,10 @@ export function DateActionBar({
 
         <button
           type="button"
-          className={`${ACTIONBAR_BUTTON_CLASSNAME} min-w-[7rem] text-center`}
+          className={buttonClassName}
           onClick={() => dateInputRef.current?.showPicker()}
         >
           {formattedDate || 'Select date'}
-        </button>
-
-        <button type="button" className={ACTIONBAR_ICON_BUTTON_CLASSNAME} onClick={onNext} aria-label="Next day">
-          <ChevronRight className="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
 

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -65,10 +65,12 @@ describe('AssignmentModal', () => {
       expect(screen.getByLabelText(/Title/)).toHaveValue('Original title')
       expect(screen.getByDisplayValue('2025-01-15')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Wed Jan 15' })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Previous day' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Next day' })).not.toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Close assignment modal' })).toBeInTheDocument()
     })
 
-    it('renders a markdown-only instructions editor with formatting buttons', () => {
+    it('renders a markdown-only instructions editor with formatting buttons and a preview modal', async () => {
       render(
         <AssignmentModal
           isOpen={true}
@@ -90,6 +92,7 @@ describe('AssignmentModal', () => {
       expect(screen.getByRole('button', { name: 'Bullet list' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Inline code' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
 
       const instructions = screen.getByPlaceholderText('Assignment instructions') as HTMLTextAreaElement
       instructions.focus()
@@ -108,9 +111,18 @@ describe('AssignmentModal', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Redo' }))
 
       expect(instructions).toHaveValue('**Original** instructions')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+
+      const previewDialog = await screen.findByRole('dialog', { name: 'Instructions' })
+      expect(within(previewDialog).getByText((_content, element) => (
+        element?.tagName.toLowerCase() === 'p' && element.textContent === 'Original instructions'
+      ))).toBeInTheDocument()
+      expect(within(previewDialog).queryByText('Original title')).not.toBeInTheDocument()
+      expect(within(previewDialog).queryByText('Close')).not.toBeInTheDocument()
     })
 
-    it('hides markdown instruction tools when the user preference is off', async () => {
+    it('keeps markdown instruction tools visible when the user preference is off', async () => {
       window.localStorage.setItem('pika_show_markdown', 'false')
 
       render(
@@ -126,10 +138,10 @@ describe('AssignmentModal', () => {
       )
 
       await waitFor(() => {
-        expect(screen.queryByRole('button', { name: 'Heading' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Heading' })).toBeInTheDocument()
       })
-      expect(screen.queryByRole('button', { name: 'Bold' })).not.toBeInTheDocument()
-      expect(screen.queryByText('Preview')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Bold' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
       expect(screen.getByPlaceholderText('Assignment instructions')).toHaveValue('Original instructions')
     })
 

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -12,11 +12,22 @@ const mockClassDays = vi.hoisted(() => [
 ])
 
 vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
-  TeacherClassroomView: ({ onEditModeChange, onSelectAssignment, onViewModeChange }: any) => (
+  TeacherClassroomView: ({
+    onEditModeChange,
+    onOpenMarkdownEditor,
+    onSelectAssignment,
+    onViewModeChange,
+    showMarkdownEditorOption,
+  }: any) => (
     <div>
       <button type="button" onClick={() => onEditModeChange?.(true)}>
         Set assignment edit active
       </button>
+      {showMarkdownEditorOption ? (
+        <button type="button" onClick={onOpenMarkdownEditor}>
+          Edit Markdown
+        </button>
+      ) : null}
       <button type="button" onClick={() => onEditModeChange?.(false)}>
         Set assignment edit inactive
       </button>
@@ -31,7 +42,7 @@ vi.mock('@/app/classrooms/[classroomId]/TeacherClassroomView', () => ({
       </button>
     </div>
   ),
-  TeacherAssignmentsMarkdownSidebar: ({ markdownContent }: any) => (
+  TeacherAssignmentsMarkdownEditor: ({ markdownContent }: any) => (
     <div>Markdown editor: {markdownContent}</div>
   ),
 }))
@@ -131,7 +142,15 @@ vi.mock('@/lib/timezone', () => ({
 }))
 
 vi.mock('@/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
   ConfirmDialog: () => null,
+  DialogPanel: ({ isOpen, children, ariaLabelledBy }: any) => (
+    isOpen ? (
+      <div role="dialog" aria-labelledby={ariaLabelledBy}>
+        {children}
+      </div>
+    ) : null
+  ),
   TabContentTransition: ({ children, isActive }: any) => (isActive ? <>{children}</> : null),
 }))
 
@@ -347,20 +366,21 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     })
   })
 
-  it('opens assignment markdown when assignment edit mode activates and closes it when edit mode turns off', async () => {
+  it('opens assignment markdown from the assignments FAB dropdown and closes it from the modal', async () => {
     renderClient()
 
     expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
     expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
 
     await waitFor(() => {
       expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
     })
+    expect(screen.getByRole('dialog', { name: 'Edit Markdown' })).toBeInTheDocument()
     expect(mockFetchJSONWithCache).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit inactive' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => {
       expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
@@ -478,30 +498,20 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
   })
 
-  it('does not reopen assignment markdown after the teacher manually closes the panel', async () => {
+  it('does not open assignment markdown when assignment edit mode activates', async () => {
     renderClient()
 
     fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
-
-    await waitFor(() => {
-      expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
-    })
-
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
-    expect(mockFetchJSONWithCache).toHaveBeenCalledTimes(1)
+    expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
   })
 
   it('clears assignment edit and markdown mode when route navigation leaves assignments', async () => {
     renderClient()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
 
     await waitFor(() => {
       expect(screen.getByText('Markdown editor: ## Assignment One')).toBeInTheDocument()
@@ -520,11 +530,14 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     window.localStorage.setItem('pika_show_markdown', 'false')
     renderClient()
 
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Edit Markdown' })).not.toBeInTheDocument()
+    })
+
     fireEvent.click(screen.getByRole('button', { name: 'Set assignment edit active' }))
 
-    await waitFor(() => {
-      expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
-    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(mockFetchJSONWithCache).not.toHaveBeenCalled()
     expect(screen.queryByText(/Markdown editor:/)).not.toBeInTheDocument()
   })
 })

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -603,14 +603,17 @@ describe('TeacherClassroomView', () => {
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
   })
 
-  it('keeps New visible without a Code action while edit mode is active', async () => {
+  it('keeps New visible with an Edit Markdown dropdown action while edit mode is active', async () => {
     const onEditModeChange = vi.fn()
+    const onOpenMarkdownEditor = vi.fn()
 
     render(
       <TeacherClassroomView
         classroom={classroom}
         selectedAssignmentId={null}
         onEditModeChange={onEditModeChange}
+        onOpenMarkdownEditor={onOpenMarkdownEditor}
+        showMarkdownEditorOption
       />,
     )
 
@@ -619,13 +622,18 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.getByRole('button', { name: 'New assignment' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
     expect(screen.getByTestId('assignment-summary-actionbar-center')).toHaveClass('grid')
     expect(screen.getByRole('button', { name: 'New assignment' }).closest('.fixed')).toHaveClass('fixed')
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
+    expect(onOpenMarkdownEditor).toHaveBeenCalledTimes(1)
+
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
 
     expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
     expect(onEditModeChange).toHaveBeenLastCalledWith(true)
 


### PR DESCRIPTION
## Summary
- Move teacher assignment markdown editing from the sidebar into an explicit Edit Markdown dialog opened from the assignment FAB dropdown
- Rework assignment creation/editing into a compact vertical authoring modal with title, due date, and post controls aligned in the first row
- Make instructions markdown-first, remove due-date arrow controls, and add a student-shaped rendered instructions preview without footer Close chrome

## Validation
- `pnpm lint`
- `pnpm test tests/components/AssignmentModal.test.tsx`
- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-bulk.test.ts`
- `git diff --check`
- Playwright UI verification screenshots for teacher, student, teacher-mobile, and assignment modal/preview flows

## Notes
- Draft assignment previews intentionally do not show draft-only title/status context because students cannot see draft assignments. The preview renders the same markdown body students see in the instructions dialog.
