### PR TITLE
[codex] Add survey preview mode

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-17 — Assignment modal close placement
-
-**Completed:**
-- Moved the assignment modal close button to an absolute upper-right corner position with minimal modal-edge padding.
-- Removed the close button from the title/due/action row.
-- Tightened the title input max width and matched compact due-date and post split-button widths.
-- Removed the reserved right-side content padding so the close button no longer consumes modal content width.
-- Made the close button borderless while keeping the same absolute corner hit target.
-- Updated the assignment instructions preview to a narrower student-content render: no footer Close button, no draft-only subtitle, and direct markdown output.
-
-**Validation:**
-- `pnpm lint`
-- `pnpm test tests/components/AssignmentModal.test.tsx`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Additional modal screenshots:
-  - `/tmp/pika-assignment-modal-desktop.png`
-  - `/tmp/pika-assignment-modal-mobile.png`
-  - `/tmp/pika-assignment-preview-dialog.png`
-
 ## 2026-05-14 — Survey experience cleanup
 
 **Completed:**
@@ -305,3 +286,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/unit/ai-startup-docs.test.ts`
+
+## 2026-05-19 — Survey creation preview option
+
+**Completed:**
+- Added a Preview mode to the teacher survey authoring modal with a student-style response layout for multiple-choice, text, and link questions.
+- Kept preview responses local to the modal so teachers can click through the survey without saving anything.
+- Added regression coverage for opening preview and selecting an option without issuing a survey PATCH.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-preview-teacher.png`, `/tmp/pika-survey-preview-teacher-mobile.png`; temporary survey fixtures were deleted afterward.

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type TextareaHTMLAttributes,
 } from 'react'
-import { Code, ExternalLink, Plus, RotateCcw, Trash2 } from 'lucide-react'
+import { Code, ExternalLink, Eye, Plus, RotateCcw, Trash2 } from 'lucide-react'
 import { Button, Card, ConfirmDialog, FormField, Input, Select } from '@/ui'
 import { AssessmentSetupCheckbox } from '@/components/assessment/AssessmentSetupForm'
 import { EditableAssessmentTitle } from '@/components/assessment/EditableAssessmentTitle'
@@ -50,6 +50,11 @@ type SurveyResultsPayload = {
     total_students: number
     responded: number
   }
+}
+
+type SurveyPreviewResponse = {
+  selectedOption?: number
+  responseText?: string
 }
 
 const QUESTION_TYPE_OPTIONS = [
@@ -322,6 +327,128 @@ export function TeacherSurveyResultsView({ payload }: { payload: SurveyResultsPa
   )
 }
 
+function TeacherSurveyPreview({
+  survey,
+  questions,
+}: {
+  survey: Survey
+  questions: SurveyQuestion[]
+}) {
+  const [responses, setResponses] = useState<Record<string, SurveyPreviewResponse>>({})
+
+  useEffect(() => {
+    setResponses({})
+  }, [questions, survey.id])
+
+  return (
+    <Card tone="panel" padding="lg" className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h2 className="text-xl font-semibold text-text-default">{survey.title}</h2>
+          <p className="mt-1 text-sm text-text-muted">Survey</p>
+        </div>
+        <span className="self-start rounded-badge bg-surface-2 px-2.5 py-1 text-xs font-semibold text-text-muted">
+          Student preview
+        </span>
+      </div>
+
+      {questions.length === 0 ? (
+        <p className="rounded-lg border border-border bg-surface px-3 py-4 text-center text-sm text-text-muted">
+          No questions to preview.
+        </p>
+      ) : (
+        <>
+          <div className="space-y-5">
+            {questions.map((question, index) => {
+              const response = responses[question.id] || {}
+              return (
+                <div key={question.id} className="space-y-2">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Q{index + 1}</p>
+                    <QuestionMarkdown content={question.question_text} />
+                  </div>
+
+                  {question.question_type === 'multiple_choice' ? (
+                    <div className="space-y-2">
+                      {question.options.map((option, optionIndex) => {
+                        const isSelected = response.selectedOption === optionIndex
+                        return (
+                          <button
+                            key={optionIndex}
+                            type="button"
+                            aria-pressed={isSelected}
+                            onClick={() => {
+                              setResponses((current) => ({
+                                ...current,
+                                [question.id]: { selectedOption: optionIndex },
+                              }))
+                            }}
+                            className={[
+                              'flex w-full items-center gap-3 rounded-lg border p-3 text-left text-sm transition-colors',
+                              isSelected
+                                ? 'border-primary bg-primary/5 text-text-default'
+                                : 'border-border bg-surface text-text-default hover:bg-surface-hover',
+                            ].join(' ')}
+                          >
+                            <span
+                              aria-hidden="true"
+                              className={[
+                                'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2',
+                                isSelected ? 'border-primary' : 'border-border',
+                              ].join(' ')}
+                            >
+                              {isSelected && <span className="h-2.5 w-2.5 rounded-full bg-primary" />}
+                            </span>
+                            <span>{option}</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  ) : question.question_type === 'link' ? (
+                    <Input
+                      type="url"
+                      aria-label={`Q${index + 1} link response preview`}
+                      value={response.responseText || ''}
+                      onChange={(event) => {
+                        setResponses((current) => ({
+                          ...current,
+                          [question.id]: { responseText: event.target.value },
+                        }))
+                      }}
+                      placeholder="https://example.com"
+                    />
+                  ) : (
+                    <textarea
+                      aria-label={`Q${index + 1} text response preview`}
+                      value={response.responseText || ''}
+                      onChange={(event) => {
+                        setResponses((current) => ({
+                          ...current,
+                          [question.id]: { responseText: event.target.value },
+                        }))
+                      }}
+                      rows={4}
+                      maxLength={question.response_max_chars}
+                      className="w-full rounded-control border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
+                      placeholder="Write your response..."
+                    />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="flex justify-end border-t border-border pt-4">
+            <Button type="button" disabled>
+              Submit
+            </Button>
+          </div>
+        </>
+      )}
+    </Card>
+  )
+}
+
 export function TeacherSurveyWorkspace({
   surveyId,
   isReadOnly = false,
@@ -345,7 +472,7 @@ export function TeacherSurveyWorkspace({
   const [titleSaving, setTitleSaving] = useState(false)
   const [responseSettingSaving, setResponseSettingSaving] = useState(false)
   const [titleError, setTitleError] = useState('')
-  const [surveyEditMode, setSurveyEditMode] = useState<'edit' | 'markdown'>('edit')
+  const [surveyEditMode, setSurveyEditMode] = useState<'edit' | 'markdown' | 'preview'>('edit')
   const [surveyMarkdown, setSurveyMarkdown] = useState('')
   const [surveyMarkdownDirty, setSurveyMarkdownDirty] = useState(false)
   const [surveyMarkdownSaving, setSurveyMarkdownSaving] = useState(false)
@@ -681,6 +808,19 @@ export function TeacherSurveyWorkspace({
               </AssessmentSetupCheckbox>
               <Button
                 size="sm"
+                variant={surveyEditMode === 'preview' ? 'subtle' : 'secondary'}
+                aria-pressed={surveyEditMode === 'preview'}
+                onClick={() => {
+                  setSurveyEditMode((current) => (current === 'preview' ? 'edit' : 'preview'))
+                  setSurveyMarkdownError('')
+                  setSurveyMarkdownInfo('')
+                }}
+              >
+                <Eye className="mr-1 h-4 w-4" aria-hidden="true" />
+                Preview
+              </Button>
+              <Button
+                size="sm"
                 variant={surveyEditMode === 'markdown' ? 'subtle' : 'secondary'}
                 aria-pressed={surveyEditMode === 'markdown'}
                 onClick={() => {
@@ -710,7 +850,7 @@ export function TeacherSurveyWorkspace({
               {error}
             </div>
           )}
-          {surveyMarkdownDirty && surveyEditMode === 'markdown' ? (
+          {surveyMarkdownDirty && surveyEditMode !== 'edit' ? (
             <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
               Markdown edits not applied
             </div>
@@ -778,6 +918,8 @@ export function TeacherSurveyWorkspace({
               spellCheck={false}
             />
           </Card>
+        ) : surveyEditMode === 'preview' ? (
+          <TeacherSurveyPreview survey={survey} questions={questions} />
         ) : (
           <>
             <Card tone="panel" padding="md" className="space-y-4">

--- a/tests/components/TeacherSurveyWorkspace.test.tsx
+++ b/tests/components/TeacherSurveyWorkspace.test.tsx
@@ -277,6 +277,69 @@ describe('TeacherSurveyWorkspace', () => {
     expect(fetchMock).not.toHaveBeenCalledWith('/api/teacher/surveys/survey-1/results')
   })
 
+  it('previews the survey from the authoring workspace without saving preview responses', async () => {
+    fetchMock.mockImplementation(async (url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/results')) {
+        return {
+          ok: true,
+          json: async () => ({
+            results: [],
+            stats: { total_students: 0, responded: 0 },
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          survey: makeSurvey({ title: 'Exit Ticket' }),
+          questions: [
+            {
+              id: 'question-1',
+              survey_id: 'survey-1',
+              question_type: 'multiple_choice',
+              question_text: 'Can you attend?',
+              options: ['Yes', 'No'],
+              response_max_chars: 1200,
+              position: 0,
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      }
+    })
+
+    render(
+      <TeacherSurveyWorkspace
+        classroomId="classroom-1"
+        surveyId="survey-1"
+        onBack={vi.fn()}
+        onSurveyUpdated={vi.fn()}
+        onSurveyDeleted={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Preview' }))
+
+    expect(screen.getByRole('heading', { name: 'Exit Ticket' })).toBeInTheDocument()
+    expect(screen.getByText('Student preview')).toBeInTheDocument()
+    expect(screen.getByText('Can you attend?')).toBeInTheDocument()
+
+    const yesOption = screen.getByRole('button', { name: 'Yes' })
+    expect(yesOption).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(yesOption)
+
+    expect(yesOption).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/teacher/surveys/survey-1',
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+  })
+
   it('saves editable response changes from the authoring workspace', async () => {
     let surveyState = makeSurvey({ dynamic_responses: true })
     const onSurveyUpdated = vi.fn()


### PR DESCRIPTION
## Summary
- Adds a Preview mode to the teacher survey authoring modal.
- Renders a student-style local preview for multiple-choice, short-text, and link questions.
- Keeps preview interactions local so clicking through the preview does not save responses.

## Validation
- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
- `pnpm lint`
- `pnpm build`
- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Targeted Playwright screenshots: `/tmp/pika-survey-preview-teacher.png`, `/tmp/pika-survey-preview-teacher-mobile.png`

## Notes
- Temporary survey fixtures created during visual verification were deleted afterward.