### PR TITLE
[codex] Refactor creation modal shell

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,66 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Survey poll/results timing split
-
-**Completed:**
-- Added independent selected-survey controls for poll visibility (`Poll hidden/open/closed`) and result visibility (`Results hidden/visible`).
-- Allowed enrolled students to view survey class results before submitting when results are visible and the survey is open or closed; drafts and hidden/future polls stay unavailable.
-- Kept open surveys answerable for unsubmitted students even when class results are already visible.
-
-**Validation:**
-- `pnpm test tests/api/student/surveys-route.test.ts tests/components/TeacherSurveyWorkspace.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/StudentAssignmentsTab.test.tsx tests/unit/surveys.test.ts`
-- `pnpm test tests/components/SurveyModal.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3001 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Targeted screenshots/assertions: `/tmp/pika-survey-teacher-controls.png`, `/tmp/pika-survey-student-results-before-submit.png`, `/tmp/pika-survey-teacher-mobile-controls.png`.
-
-## 2026-05-14 — Direct survey draft creation
-
-**Completed:**
-- Changed `New > Survey` to create an untitled draft immediately and open the selected-survey workspace directly.
-- Defaulted newly created surveys to visual question editing instead of markdown/code mode.
-- Added inline title editing from the selected survey header; generated backend titles display as `Untitled` until the teacher enters a title.
-- Let the teacher survey POST endpoint generate `Untitled yyyy-MM-dd HH:mm:ss` when the title is blank or omitted.
-
-**Validation:**
-- `pnpm test tests/api/teacher/surveys-route.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/SurveyModal.test.tsx tests/api/student/surveys-route.test.ts tests/components/StudentSurveyPanel.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test` (known unrelated full-suite issue: `tests/components/TeacherGradebookTab.test.tsx` timed out/failed under load; isolated file passes)
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Targeted screenshots/assertions: `/tmp/pika-direct-survey-create-desktop.png`, `/tmp/pika-direct-survey-create-mobile.png`.
-
-## 2026-05-14 — Shared test/survey editable title creation
-
-**Completed:**
-- Changed `New Test` to create an untitled draft immediately and open the visual test authoring modal, removing the title-only modal step.
-- Added shared untitled-title helpers and a shared editable assessment title control used by both test and survey authoring.
-- Saved test title edits into the assessment draft so activation preserves the teacher-entered title.
-- Kept generated backend titles displayed as `Untitled` in both survey and test creation surfaces until the teacher enters a title.
-
-**Validation:**
-- `pnpm test tests/api/teacher/tests-route.test.ts tests/api/teacher/surveys-route.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3005 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
-- Targeted screenshots/assertions: `/tmp/pika-direct-test-create-desktop.png`, `/tmp/pika-direct-test-create-mobile.png`, `/tmp/pika-shared-survey-title-desktop.png`, `/tmp/pika-shared-survey-title-mobile.png`.
-
-## 2026-05-14 — Survey response length field removal
-
-**Completed:**
-- Removed the visible `Max characters` control from the survey question edit card for short-text and link questions.
-- Kept the existing/default `response_max_chars` value in save payloads so existing survey response limits remain compatible.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- Targeted Playwright screenshot/assertion: `/tmp/pika-survey-no-max-characters.png`.
-
 ## 2026-05-14 — Test modal header title placement
 
 **Completed:**
@@ -297,3 +237,87 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-preview-escape bash /Users/stew/Repos/.worktrees/pika/assignment-preview-escape/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-assignment-instructions-preview.png`, `/tmp/pika-assignment-modal-after-preview-escape.png`.
+- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-teacher-assignment-markdown-modal.png`
+  - `/tmp/pika-teacher-assignment-markdown-modal-mobile.png`
+
+## 2026-05-15 — Assignment creation modal flow
+
+**Completed:**
+- Reworked the assignment modal into a narrower, more vertical authoring flow.
+- Kept title and due date on the same form row and removed due-date previous/next arrow controls.
+- Made assignment instructions always use the markdown editor toolbar.
+- Moved rendered markdown into a separate `Assignment Preview` dialog opened by a Preview button.
+- Updated assignment modal tests for the new preview dialog and always-visible markdown tools.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`
+
+## 2026-05-16 — Assignment modal top row tightening
+
+**Completed:**
+- Removed the visible assignment modal header above the title field.
+- Moved the post/schedule split button into the same first row as title and due date.
+- Shortened compact title/date/action widths so the same-row layout holds on mobile.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`
+
+## 2026-05-17 — Assignment modal close placement
+
+**Completed:**
+- Moved the assignment modal close button to an absolute upper-right corner position with minimal modal-edge padding.
+- Removed the close button from the title/due/action row.
+- Tightened the title input max width and matched compact due-date and post split-button widths.
+- Removed the reserved right-side content padding so the close button no longer consumes modal content width.
+- Made the close button borderless while keeping the same absolute corner hit target.
+- Updated the assignment instructions preview to a narrower student-content render: no footer Close button, no draft-only subtitle, and direct markdown output.
+
+**Validation:**
+- `pnpm lint`
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-modal-desktop.png`
+  - `/tmp/pika-assignment-modal-mobile.png`
+  - `/tmp/pika-assignment-preview-dialog.png`
+
+## 2026-05-18 — Shared creation modal shell
+
+**Completed:**
+- Extracted `CreationModalShell` and `CreationModalTopRow` for assignment-style creation flows.
+- Reused the shared creation shell in assignment creation while keeping scheduling, autosave, and markdown behavior feature-local.
+- Applied the same title-first, no-visible-header, absolute-close, top-row primary-action creation UI to quiz/test and survey creation.
+- Added a dedicated survey creation modal so the shared creation shell fits the upstream survey workspace flow after creation.
+- Kept quiz/test and survey edit/settings modals compact instead of forcing them into the creation shell.
+- Added experimental UI guidance for the shared creation shell candidate.
+
+**Validation:**
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/creation-modal-shell bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/SurveyCreationModal.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/ai-startup-docs.test.ts`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
+- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/creation-modal-shell E2E_BASE_URL=http://localhost:3000 bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Additional modal screenshots:
+  - `/tmp/pika-assignment-create-desktop.png`
+  - `/tmp/pika-test-create-desktop.png`
+  - `/tmp/pika-survey-create-desktop.png`
+  - `/tmp/pika-assignment-create-mobile.png`
+  - `/tmp/pika-test-create-mobile.png`
+  - `/tmp/pika-survey-create-mobile.png`

--- a/docs/guidance/ui/experimental/2026-05-creation-modal-shell.md
+++ b/docs/guidance/ui/experimental/2026-05-creation-modal-shell.md
@@ -1,0 +1,44 @@
+# Creation Modal Shell Candidate Guidance
+
+status: experimental
+human_review_required: true
+
+## Summary
+
+Creation modals for classroom work items should share one compact, authoring-first shell. The current reference is assignment creation: no visible header chrome above the title row, an absolute borderless close control in the upper-right corner, and the primary creation action on the same row as the title.
+
+## Affected Screens / Files
+
+- `src/components/AssignmentModal.tsx`
+- `src/components/AssignmentForm.tsx`
+- `src/components/QuizModal.tsx`
+- `src/components/surveys/SurveyCreationModal.tsx`
+- `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`
+- `src/components/creation/CreationModalShell.tsx`
+
+## Observed Pattern
+
+Teachers create assignments, tests, quizzes, and surveys from the same classroom workstream. The older assessment setup shell used a visible modal title bar and footer actions, while assignment creation moved toward a faster single-row start: title, scheduling or compact metadata when relevant, and the primary action.
+
+## Proposed Guidance
+
+- Use `CreationModalShell` for creation flows that benefit from assignment-style authoring.
+- Use `CreationModalTopRow` for title-first creation rows.
+- Keep the close button absolute and borderless so it does not consume layout width.
+- Put the primary creation action in the top row.
+- Keep feature-specific settings, validation, scheduling, markdown editing, and save behavior outside the shared shell.
+- Keep compact edit/settings modals separate unless the edit workflow genuinely matches the creation flow.
+
+## Why This Is Experimental
+
+The shell now covers assignment, quiz/test, and survey creation, but it has not yet been reviewed as a stable app-wide modal standard for every creation flow.
+
+## Human Review Required
+
+Confirm whether this shell should be promoted for all classroom creation modals or remain limited to classwork item creation.
+
+## Promotion Criteria
+
+- Assignment, quiz/test, and survey creation screenshots look coherent together on desktop and mobile.
+- The shell does not force sparse or awkward layouts for simple creation forms.
+- Users can complete creation faster than with the old header/footer assessment setup shell.

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -44,6 +44,7 @@ import { Spinner } from '@/components/Spinner'
 import { AssignmentModal } from '@/components/AssignmentModal'
 import { SortableAssignmentCard } from '@/components/SortableAssignmentCard'
 import { SortableSurveyCard } from '@/components/surveys/SortableSurveyCard'
+import { SurveyCreationModal } from '@/components/surveys/SurveyCreationModal'
 import { TeacherSurveyWorkspace } from '@/components/surveys/TeacherSurveyWorkspace'
 import { TeacherSurveyResultsPane } from '@/components/surveys/TeacherSurveyResultsPane'
 import {
@@ -608,7 +609,7 @@ export function TeacherClassroomView({
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(false)
-  const [isCreatingSurvey, setIsCreatingSurvey] = useState(false)
+  const [isSurveyCreateModalOpen, setIsSurveyCreateModalOpen] = useState(false)
   const [editMaterial, setEditMaterial] = useState<ClassworkMaterial | null>(null)
   const [pendingMaterialDelete, setPendingMaterialDelete] = useState<ClassworkMaterial | null>(null)
   const [isDeletingMaterial, setIsDeletingMaterial] = useState(false)
@@ -828,27 +829,6 @@ export function TeacherClassroomView({
       )
     )
   }, [classroom.id])
-
-  const createSurveyDraft = useCallback(async () => {
-    if (isCreatingSurvey || isReadOnly) return
-
-    setIsCreatingSurvey(true)
-    setError('')
-    try {
-      const response = await fetch('/api/teacher/surveys', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ classroom_id: classroom.id }),
-      })
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data.error || 'Failed to create survey')
-      handleSurveySaved(data.survey as Survey, { initialEditMode: 'edit', focusTitle: true })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create survey')
-    } finally {
-      setIsCreatingSurvey(false)
-    }
-  }, [classroom.id, handleSurveySaved, isCreatingSurvey, isReadOnly])
 
   const openSurveyModal = useCallback((surveyId: string) => {
     setSurveyModalId(surveyId)
@@ -2525,11 +2505,8 @@ export function TeacherClassroomView({
                     },
                     {
                       id: 'survey',
-                      label: isCreatingSurvey ? 'Creating survey...' : 'Survey',
-                      onSelect: () => {
-                        void createSurveyDraft()
-                      },
-                      disabled: isCreatingSurvey,
+                      label: 'Survey',
+                      onSelect: () => setIsSurveyCreateModalOpen(true),
                     },
                     ...(showMarkdownEditorOption
                       ? [
@@ -2815,6 +2792,16 @@ export function TeacherClassroomView({
         }}
         onSaved={handleMaterialSaved}
         onRequestDelete={setPendingMaterialDelete}
+      />
+
+      <SurveyCreationModal
+        isOpen={isSurveyCreateModalOpen}
+        classroomId={classroom.id}
+        onClose={() => setIsSurveyCreateModalOpen(false)}
+        onSuccess={(survey) => {
+          setIsSurveyCreateModalOpen(false)
+          handleSurveySaved(survey, { initialEditMode: 'edit' })
+        }}
       />
 
       <DialogPanel

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useId, useRef } from 'react'
+import { useRef } from 'react'
 import type { KeyboardEvent, ReactNode, RefObject } from 'react'
 import { Eye } from 'lucide-react'
-import { Input, Button } from '@/ui'
+import { Button } from '@/ui'
+import { CreationModalTopRow } from '@/components/creation/CreationModalShell'
 import { DateActionBar } from '@/components/DateActionBar'
 import { BoldIcon } from '@/components/tiptap-icons/bold-icon'
 import { Code2Icon } from '@/components/tiptap-icons/code2-icon'
@@ -63,13 +64,6 @@ export function AssignmentForm({
   fillHeight = false,
 }: AssignmentFormProps) {
   const instructionsRef = useRef<HTMLTextAreaElement>(null)
-  const titleFieldId = useId()
-  const topRowGridClassName = topRowActions
-    ? 'grid-cols-[minmax(2.75rem,1fr)_auto_auto] sm:grid-cols-[minmax(9rem,1fr)_auto_auto]'
-    : 'grid-cols-[minmax(0,1fr)_auto]'
-  const titleFieldClassName = topRowActions
-    ? 'min-w-0 max-w-[22rem] space-y-1 sm:max-w-[24rem]'
-    : 'min-w-0 space-y-1'
 
   function applyWrapFormatting(prefix: string, suffix = prefix) {
     const textarea = instructionsRef.current
@@ -157,56 +151,41 @@ export function AssignmentForm({
 
   return (
     <div className={fillHeight ? 'flex h-full min-h-0 w-full flex-col gap-3' : 'space-y-3 w-full'}>
-      <div className={`grid items-end gap-1.5 sm:gap-2 ${topRowGridClassName}`}>
-        <div className={titleFieldClassName}>
-          <label htmlFor={titleFieldId} className="block text-sm font-medium text-text-default">
-            Title
-            <span className="ml-1 text-danger">*</span>
-          </label>
-          <Input
-            id={titleFieldId}
-            ref={titleInputRef}
-            type="text"
-            value={title}
-            onChange={(e) => onTitleChange(e.target.value)}
-            onBlur={onBlur}
-            required
-            disabled={disabled}
-            placeholder="Add a title"
-            className="flex-1"
-          />
-        </div>
-
-        <div className="w-[6.75rem] space-y-1 sm:w-[8.25rem]">
-          {(() => {
-            const relative = getRelativeDueDate(dueAt, classDays)
-            const labelText = relative ? `Due ${relative.text}` : 'Due Date'
-            const colorClass = relative
-              ? relative.isPast
-                ? 'text-warning'
-                : 'text-primary'
-              : 'text-text-muted'
-            return (
-              <div className={`truncate text-sm font-medium ${colorClass}`}>
-                {labelText}
-              </div>
-            )
-          })()}
-          <div className="flex">
-            <DateActionBar
-              value={dueAt}
-              onChange={onDueAtChange}
-              layout="compact"
-            />
-          </div>
-        </div>
-
-        {topRowActions && (
-          <div className="min-w-0">
-            {topRowActions}
+      <CreationModalTopRow
+        title={title}
+        titlePlaceholder="Add a title"
+        titleDisabled={disabled}
+        titleInputRef={titleInputRef}
+        titleInputClassName="flex-1"
+        onTitleChange={onTitleChange}
+        onTitleBlur={onBlur}
+        afterTitle={(
+          <div className="w-[6.25rem] space-y-1 sm:w-[8.25rem]">
+            {(() => {
+              const relative = getRelativeDueDate(dueAt, classDays)
+              const labelText = relative ? `Due ${relative.text}` : 'Due Date'
+              const colorClass = relative
+                ? relative.isPast
+                  ? 'text-warning'
+                  : 'text-primary'
+                : 'text-text-muted'
+              return (
+                <div className={`truncate text-sm font-medium ${colorClass}`}>
+                  {labelText}
+                </div>
+              )
+            })()}
+            <div className="flex">
+              <DateActionBar
+                value={dueAt}
+                onChange={onDueAtChange}
+                layout="compact"
+              />
+            </div>
           </div>
         )}
-      </div>
+        actions={topRowActions}
+      />
 
       <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col space-y-1' : 'space-y-1'}>
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { X } from 'lucide-react'
 import type { Assignment, ClassDay } from '@/types'
 import { AssignmentForm } from '@/components/AssignmentForm'
+import { CreationModalShell } from '@/components/creation/CreationModalShell'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { getRelativeDueDate } from '@/lib/assignment-relative-date'
-import { Button, ConfirmDialog, ContentDialog, DialogPanel, SplitButton } from '@/ui'
+import { ConfirmDialog, ContentDialog, DialogPanel, SplitButton } from '@/ui'
 import { formatDateInToronto, getTodayInToronto, toTorontoEndOfDayIso, nowInToronto } from '@/lib/timezone'
 import { format, isValid, parse } from 'date-fns'
 import { addDaysToDateString } from '@/lib/date-string'
@@ -671,8 +671,6 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
     : 'muted'
   const scheduleDueDateValidationMessage = getScheduleDueDateValidationMessage(scheduleIso, dueAt, isScheduleValid)
   const previewSubtitle = isLive ? title.trim() || undefined : undefined
-  const editorPanelClass =
-    'relative !max-h-[calc(100dvh-1rem)] overflow-hidden p-0 sm:!max-h-[calc(100dvh-2rem)]'
   const saveStatusContent = (
     <span
       className={`text-xs ${
@@ -686,26 +684,10 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
       {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
     </span>
   )
-  const closeAssignmentModalButton = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      className="absolute right-1 top-1 z-20 h-9 w-9 px-0 text-text-default"
-      onClick={() => {
-        void handleClose()
-      }}
-      disabled={saving || releasing}
-      aria-label="Close assignment modal"
-      title="Close"
-    >
-      <X className="h-4 w-4" aria-hidden="true" />
-    </Button>
-  )
 
   return (
     <>
-      <DialogPanel
+      <CreationModalShell
         isOpen={isOpen}
         onClose={() => {
           if (showInstructionsPreview) {
@@ -714,74 +696,66 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
           }
           void handleClose()
         }}
-        maxWidth="!max-w-4xl"
-        className={editorPanelClass}
-        viewportPaddingClassName="p-2 sm:p-4"
-        ariaLabelledBy="assignment-modal-title"
+        title={modalTitle}
+        titleId="assignment-modal-title"
+        closeLabel="Close assignment modal"
+        closeDisabled={saving || releasing}
       >
-        <h2 id="assignment-modal-title" className="sr-only">
-          {modalTitle}
-        </h2>
-
-        {closeAssignmentModalButton}
-
-        <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
-          <AssignmentForm
-            title={title}
-            instructionsMarkdown={instructionsMarkdown}
-            dueAt={dueAt}
-            classDays={classDays}
-            onTitleChange={handleTitleChange}
-            onInstructionsMarkdownChange={handleInstructionsMarkdownChange}
-            onInstructionsUndo={handleInstructionsUndo}
-            onInstructionsRedo={handleInstructionsRedo}
-            onDueAtChange={handleDueAtChange}
-            onPreviewInstructions={() => setShowInstructionsPreview(true)}
-            disabled={saving || releasing || creating}
-            error={error}
-            titleInputRef={titleInputRef}
-            onBlur={flushAutosave}
-            markdownWarning={markdownWarning}
-            canUndoInstructions={instructionsHistoryIndexRef.current > 0}
-            canRedoInstructions={instructionsHistoryIndexRef.current < instructionsHistoryRef.current.length - 1}
-            statusContent={(
-              <span className="inline-flex items-center gap-2">
-                {saveStatusContent}
-                {currentAssignment && isScheduled && currentAssignment.released_at && (
-                  <span className="text-xs font-medium text-warning">
-                    {formatReleaseDate(currentAssignment.released_at)}
-                  </span>
-                )}
-              </span>
-            )}
-            topRowActions={
-              currentAssignment && !isLive ? (
-                <div className="flex items-end">
-                  <SplitButton
-                    label={primaryLabel}
-                    onPrimaryClick={() => {
-                      void handleTriggerPrimaryAction()
-                    }}
-                    variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
-                    size="md"
-                    disabled={creating || releasing || saving || !currentAssignment}
-                    className="shadow-sm"
-                    toggleAriaLabel="Choose assignment action"
-                    menuPlacement="down"
-                    primaryButtonProps={{
-                      className: 'w-[4.25rem] justify-center font-semibold sm:w-[5.75rem]',
-                    }}
-                    options={splitOptions.map((option) => ({
-                      ...option,
-                      onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
-                    }))}
-                  />
-                </div>
-              ) : null
-            }
-          />
-        </div>
-      </DialogPanel>
+        <AssignmentForm
+          title={title}
+          instructionsMarkdown={instructionsMarkdown}
+          dueAt={dueAt}
+          classDays={classDays}
+          onTitleChange={handleTitleChange}
+          onInstructionsMarkdownChange={handleInstructionsMarkdownChange}
+          onInstructionsUndo={handleInstructionsUndo}
+          onInstructionsRedo={handleInstructionsRedo}
+          onDueAtChange={handleDueAtChange}
+          onPreviewInstructions={() => setShowInstructionsPreview(true)}
+          disabled={saving || releasing || creating}
+          error={error}
+          titleInputRef={titleInputRef}
+          onBlur={flushAutosave}
+          markdownWarning={markdownWarning}
+          canUndoInstructions={instructionsHistoryIndexRef.current > 0}
+          canRedoInstructions={instructionsHistoryIndexRef.current < instructionsHistoryRef.current.length - 1}
+          statusContent={(
+            <span className="inline-flex items-center gap-2">
+              {saveStatusContent}
+              {currentAssignment && isScheduled && currentAssignment.released_at && (
+                <span className="text-xs font-medium text-warning">
+                  {formatReleaseDate(currentAssignment.released_at)}
+                </span>
+              )}
+            </span>
+          )}
+          topRowActions={
+            currentAssignment && !isLive ? (
+              <div className="flex items-end">
+                <SplitButton
+                  label={primaryLabel}
+                  onPrimaryClick={() => {
+                    void handleTriggerPrimaryAction()
+                  }}
+                  variant={effectivePrimaryAction === 'post' ? 'success' : 'primary'}
+                  size="md"
+                  disabled={creating || releasing || saving || !currentAssignment}
+                  className="shadow-sm"
+                  toggleAriaLabel="Choose assignment action"
+                  menuPlacement="down"
+                  primaryButtonProps={{
+                    className: 'w-[3.5rem] justify-center font-semibold sm:w-[5.75rem]',
+                  }}
+                  options={splitOptions.map((option) => ({
+                    ...option,
+                    onSelect: () => handleSplitActionSelection(option.id as CreateSubmitAction),
+                  }))}
+                />
+              </div>
+            ) : null
+          }
+        />
+      </CreationModalShell>
 
       <ContentDialog
         isOpen={isOpen && showInstructionsPreview}

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { AssessmentSetupDialog } from '@/components/assessment/AssessmentSetupDialog'
 import { AssessmentSetupCheckbox, AssessmentSetupForm } from '@/components/assessment/AssessmentSetupForm'
+import { CreationModalShell, CreationModalTopRow } from '@/components/creation/CreationModalShell'
+import { Button } from '@/ui'
 import type { Quiz, QuizAssessmentType } from '@/types'
 
 interface QuizModalProps {
@@ -101,18 +103,53 @@ export function QuizModal({
     }
   }
 
+  if (!isEditMode) {
+    return (
+      <CreationModalShell
+        isOpen={isOpen}
+        onClose={onClose}
+        title={`New ${assessmentLabel}`}
+        titleId="quiz-modal-title"
+        closeLabel={`Close ${assessmentLabel.toLowerCase()} modal`}
+        closeDisabled={saving}
+        maxWidth="!max-w-2xl"
+      >
+        <form onSubmit={handleSubmit} className="w-full space-y-4">
+          <CreationModalTopRow
+            title={title}
+            titlePlaceholder={`Enter ${assessmentLabel.toLowerCase()} title`}
+            titleError={error}
+            titleDisabled={saving}
+            titleInputRef={titleInputRef}
+            onTitleChange={setTitle}
+            actions={(
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-[5.75rem] justify-center font-semibold"
+                disabled={saving}
+              >
+                {saving ? 'Saving...' : 'Create'}
+              </Button>
+            )}
+          />
+        </form>
+      </CreationModalShell>
+    )
+  }
+
   return (
     <AssessmentSetupDialog
       isOpen={isOpen}
       onClose={onClose}
-      isCompact={isEditMode}
+      isCompact
       title={isEditMode ? `Edit ${assessmentLabel}` : `New ${assessmentLabel}`}
       titleId="quiz-modal-title"
       closeLabel={`Close ${assessmentLabel.toLowerCase()} modal`}
       closeDisabled={saving}
     >
       <AssessmentSetupForm
-        isCompact={isEditMode}
+        isCompact
         title={title}
         titlePlaceholder={`Enter ${assessmentLabel.toLowerCase()} title`}
         titleError={error}

--- a/src/components/creation/CreationModalShell.tsx
+++ b/src/components/creation/CreationModalShell.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import type { ReactNode, Ref } from 'react'
+import { X } from 'lucide-react'
+import { Button, DialogPanel, FormField, Input } from '@/ui'
+import { cn } from '@/ui/utils'
+
+interface CreationModalShellProps {
+  isOpen: boolean
+  title: string
+  titleId: string
+  closeLabel: string
+  closeDisabled?: boolean
+  maxWidth?: string
+  contentClassName?: string
+  onClose: () => void
+  children: ReactNode
+}
+
+interface CreationModalTopRowProps {
+  title: string
+  titleLabel?: string
+  titlePlaceholder: string
+  titleError?: string
+  titleRequired?: boolean
+  titleDisabled?: boolean
+  titleInputRef?: Ref<HTMLInputElement>
+  titleInputClassName?: string
+  titleFieldClassName?: string
+  afterTitle?: ReactNode
+  actions?: ReactNode
+  className?: string
+  onTitleChange: (value: string) => void
+  onTitleBlur?: () => void
+}
+
+const CREATION_PANEL_CLASS =
+  'relative !max-h-[calc(100dvh-1rem)] overflow-hidden p-0 sm:!max-h-[calc(100dvh-2rem)]'
+
+function getTopRowGridClassName(hasAfterTitle: boolean, hasActions: boolean) {
+  if (hasAfterTitle && hasActions) {
+    return 'grid-cols-[minmax(2.75rem,1fr)_auto_auto] sm:grid-cols-[minmax(9rem,1fr)_auto_auto]'
+  }
+
+  if (hasAfterTitle || hasActions) {
+    return 'grid-cols-[minmax(2.75rem,1fr)_auto] sm:grid-cols-[minmax(9rem,1fr)_auto]'
+  }
+
+  return 'grid-cols-1'
+}
+
+export function CreationModalShell({
+  isOpen,
+  title,
+  titleId,
+  closeLabel,
+  closeDisabled = false,
+  maxWidth = '!max-w-4xl',
+  contentClassName,
+  onClose,
+  children,
+}: CreationModalShellProps) {
+  function handleRequestClose() {
+    if (closeDisabled) return
+    onClose()
+  }
+
+  return (
+    <DialogPanel
+      isOpen={isOpen}
+      onClose={handleRequestClose}
+      maxWidth={maxWidth}
+      className={CREATION_PANEL_CLASS}
+      viewportPaddingClassName="p-2 sm:p-4"
+      ariaLabelledBy={titleId}
+    >
+      <h2 id={titleId} className="sr-only">
+        {title}
+      </h2>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="absolute right-1 top-1 z-20 h-9 w-9 px-0 text-text-default"
+        onClick={handleRequestClose}
+        disabled={closeDisabled}
+        aria-label={closeLabel}
+        title="Close"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </Button>
+
+      <div className={cn('min-h-0 flex-1 overflow-y-auto p-3 sm:p-4', contentClassName)}>
+        {children}
+      </div>
+    </DialogPanel>
+  )
+}
+
+export function CreationModalTopRow({
+  title,
+  titleLabel = 'Title',
+  titlePlaceholder,
+  titleError,
+  titleRequired = true,
+  titleDisabled = false,
+  titleInputRef,
+  titleInputClassName,
+  titleFieldClassName,
+  afterTitle,
+  actions,
+  className,
+  onTitleChange,
+  onTitleBlur,
+}: CreationModalTopRowProps) {
+  const gridClassName = getTopRowGridClassName(Boolean(afterTitle), Boolean(actions))
+
+  return (
+    <div className={cn('grid items-end gap-1.5 sm:gap-2', gridClassName, className)}>
+      <FormField
+        label={titleLabel}
+        required={titleRequired}
+        error={titleError}
+        className={cn('min-w-0 max-w-[22rem] sm:max-w-[24rem]', titleFieldClassName)}
+      >
+        <Input
+          ref={titleInputRef}
+          type="text"
+          value={title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          onBlur={onTitleBlur}
+          required={titleRequired}
+          disabled={titleDisabled}
+          placeholder={titlePlaceholder}
+          className={titleInputClassName}
+        />
+      </FormField>
+
+      {afterTitle}
+
+      {actions && (
+        <div className="min-w-0">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/surveys/SurveyCreationModal.tsx
+++ b/src/components/surveys/SurveyCreationModal.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { AssessmentSetupCheckbox } from '@/components/assessment/AssessmentSetupForm'
+import { CreationModalShell, CreationModalTopRow } from '@/components/creation/CreationModalShell'
+import { Button } from '@/ui'
+import type { Survey } from '@/types'
+
+interface SurveyCreationModalProps {
+  isOpen: boolean
+  classroomId: string
+  onClose: () => void
+  onSuccess: (survey: Survey) => void
+}
+
+export function SurveyCreationModal({
+  isOpen,
+  classroomId,
+  onClose,
+  onSuccess,
+}: SurveyCreationModalProps) {
+  const titleInputRef = useRef<HTMLInputElement>(null)
+  const [title, setTitle] = useState('')
+  const [showResults, setShowResults] = useState(true)
+  const [dynamicResponses, setDynamicResponses] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!isOpen) return
+    setTitle('')
+    setShowResults(true)
+    setDynamicResponses(false)
+    setError('')
+
+    setTimeout(() => {
+      titleInputRef.current?.focus()
+    }, 100)
+  }, [isOpen])
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!title.trim()) {
+      setError('Title is required')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+
+    try {
+      const response = await fetch('/api/teacher/surveys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classroom_id: classroomId,
+          title: title.trim(),
+          show_results: showResults,
+          dynamic_responses: dynamicResponses,
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Failed to create survey')
+      onSuccess(data.survey as Survey)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create survey')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <CreationModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      title="New Survey"
+      titleId="survey-create-modal-title"
+      closeLabel="Close survey modal"
+      closeDisabled={saving}
+      maxWidth="!max-w-2xl"
+    >
+      <form onSubmit={handleSubmit} className="w-full space-y-4">
+        <CreationModalTopRow
+          title={title}
+          titlePlaceholder="Enter survey title"
+          titleError={error}
+          titleDisabled={saving}
+          titleInputRef={titleInputRef}
+          onTitleChange={setTitle}
+          actions={(
+            <Button
+              type="submit"
+              variant="primary"
+              className="w-[5.75rem] justify-center font-semibold"
+              disabled={saving}
+            >
+              {saving ? 'Saving...' : 'Create'}
+            </Button>
+          )}
+        />
+
+        <div className="max-w-xl space-y-3">
+          <AssessmentSetupCheckbox
+            checked={showResults}
+            disabled={saving}
+            onChange={setShowResults}
+          >
+            Show class results to students
+          </AssessmentSetupCheckbox>
+
+          <AssessmentSetupCheckbox
+            checked={dynamicResponses}
+            disabled={saving}
+            onChange={setDynamicResponses}
+          >
+            Allow students to update answers while open
+          </AssessmentSetupCheckbox>
+        </div>
+      </form>
+    </CreationModalShell>
+  )
+}

--- a/tests/components/QuizModal.test.tsx
+++ b/tests/components/QuizModal.test.tsx
@@ -18,7 +18,10 @@ describe('QuizModal', () => {
 
     expect(screen.getByRole('heading', { name: 'New Test' })).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Enter test title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Close test modal' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveClass('!max-w-2xl')
   })
 
   it('keeps quiz-specific title copy when editing a quiz', () => {

--- a/tests/components/SurveyCreationModal.test.tsx
+++ b/tests/components/SurveyCreationModal.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SurveyCreationModal } from '@/components/surveys/SurveyCreationModal'
+
+describe('SurveyCreationModal', () => {
+  it('uses the shared creation modal chrome when creating a survey', () => {
+    render(
+      <SurveyCreationModal
+        isOpen={true}
+        classroomId="classroom-1"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'New Survey' })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter survey title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Show class results to students')).toBeInTheDocument()
+    expect(screen.getByLabelText('Allow students to update answers while open')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveClass('!max-w-2xl')
+  })
+})

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -908,7 +908,7 @@ describe('TeacherClassroomView', () => {
     })
   })
 
-  it('creates a draft survey directly from the New menu and opens visual editing', async () => {
+  it('creates a draft survey from the New menu and opens visual editing', async () => {
     mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
       if (key === `teacher-assignments:${classroom.id}`) {
         return Promise.resolve({
@@ -931,7 +931,7 @@ describe('TeacherClassroomView', () => {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({
-        survey: makeSurveySummary('survey-new', 'Untitled 2026-05-14 10:15:30'),
+        survey: makeSurveySummary('survey-new', 'Class feedback'),
       }),
     })
     const updateSearchParams = vi.fn()
@@ -945,17 +945,27 @@ describe('TeacherClassroomView', () => {
 
     await screen.findByRole('button', { name: 'Assignment One' })
     fireEvent.click(screen.getByRole('button', { name: 'Survey' }))
+    const createDialog = await screen.findByRole('dialog')
+    fireEvent.change(within(createDialog).getByPlaceholderText('Enter survey title'), {
+      target: { value: 'Class feedback' },
+    })
+    fireEvent.click(within(createDialog).getByRole('button', { name: 'Create' }))
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         '/api/teacher/surveys',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ classroom_id: classroom.id }),
+          body: JSON.stringify({
+            classroom_id: classroom.id,
+            title: 'Class feedback',
+            show_results: true,
+            dynamic_responses: false,
+          }),
         }),
       )
     })
-    expect(await screen.findByRole('dialog')).toHaveTextContent('Survey workspace survey-new mode edit auto title')
+    expect(await screen.findByRole('dialog')).toHaveTextContent('Survey workspace survey-new mode edit')
 
     const { params } = applySearchParamsUpdate(updateSearchParams.mock.calls[0])
     expect(params.get('surveyId')).toBeNull()


### PR DESCRIPTION
## Summary
- extract a shared `CreationModalShell`/`CreationModalTopRow` for assignment-style creation flows
- reuse the shared shell for assignment creation plus quiz/test creation
- add a dedicated survey creation modal that uses the shared shell and then opens the survey workspace flow
- document the shell pattern as experimental UI guidance

## Validation
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/SurveyCreationModal.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/ai-startup-docs.test.ts`
- `pnpm build`
- prior Playwright UI verification for teacher/student classroom surfaces and targeted assignment/test/survey creation modal screenshots
