### PR TITLE
[codex] Move AI worktree guidance to native Codex flow

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -11,7 +11,8 @@ Read this file at the start of every AI session. It is the compact continuity la
 ## Environment And Workflow Facts
 
 - Main hub checkout: `$HOME/Repos/pika`
-- Feature worktrees: `$HOME/Repos/.worktrees/pika/<branch-name>`
+- New named Pika worktrees: `$HOME/.codex/worktrees/pika/<branch-name>`
+- Codex Desktop may also use app-managed worktrees: `$HOME/.codex/worktrees/<id>/pika`
 - Shared env file: `$HOME/Repos/.env/pika/.env.local`
 - Runtime and package-manager requirements live in `.nvmrc`, `package.json`, and `scripts/verify-env.sh`
 - Worktree and shared-env setup are defined only in `docs/dev-workflow.md`
@@ -28,7 +29,7 @@ Read this file at the start of every AI session. It is the compact continuity la
 
 ## Known Hazards
 
-- Do not work in the hub checkout for non-trivial changes; bind to a worktree first
+- Do not work in the hub checkout for non-trivial changes; create or open a dedicated worktree first
 - Do not tail `.ai/JOURNAL-ARCHIVE.md` by default; it is intentionally large
 - Keep `.ai/SESSION-LOG.md` as a rolling recent log and run `node scripts/trim-session-log.mjs` after appending
 - Do not run `supabase db push`, `supabase db reset`, or other migration-application commands as an AI agent

--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -1771,7 +1771,7 @@
 ---
 ## 2026-01-08 10:02 [AI - Codex]
 **Goal:** Unify worktree workflow docs and path conventions; align with docs/dev-workflow.md.
-**Completed:** Updated worktree guidance to point to docs/dev-workflow.md, standardized $HOME/Repos paths, and aligned git examples with git -C "$PIKA_WORKTREE" usage; refreshed legacy worktrees.md with a deprecation banner.
+**Completed:** Updated worktree guidance to point to docs/dev-workflow.md, standardized $HOME/Repos paths, and aligned git examples with git -C "<worktree>" usage; refreshed legacy worktrees.md with a deprecation banner.
 **Status:** completed
 **Artifacts:**
 - Branch: `92-worktree-docs`
@@ -2092,7 +2092,7 @@
 **Completed:** Listed worktrees via `git worktree list --porcelain` and printed paths relative to `WORKTREE_ROOT`; updated ls and error output to use this list.
 **Status:** completed
 **Artifacts:**
-- Branch: chore/pika-worktree-menu
+- Branch: chore/worktree-menu
 - Files: scripts/pika
 **Tests:** Not run (manual check via `scripts/pika ls`).
 **Next:** Run `pika codex` to confirm menu shows `issue/...` entries.
@@ -2103,7 +2103,7 @@
 **Completed:** Added fallback to `ls -1t` when `git worktree list` fails and restored mtime-based ordering for nested worktrees.
 **Status:** completed
 **Artifacts:**
-- Branch: chore/pika-worktree-menu
+- Branch: chore/worktree-menu
 - Files: scripts/pika
 **Tests:** Not run (manual check recommended).
 **Next:** Run `scripts/pika codex` to confirm ordering and nested names.
@@ -2114,7 +2114,7 @@
 **Completed:** Switched mtime aggregation to use real tab separators so `cut -f2-` strips timestamps correctly.
 **Status:** completed
 **Artifacts:**
-- Branch: chore/pika-worktree-menu
+- Branch: chore/worktree-menu
 - Files: scripts/pika
 **Tests:** Not run (manual check recommended).
 **Next:** Re-run `scripts/pika ls` and `scripts/pika codex` to confirm clean labels.
@@ -7196,7 +7196,7 @@
 - Reworked the classroom shell height chain so authenticated pages use a true `min-h-dvh -> flex-1/min-h-0 -> h-full/min-h-0` flow in `src/components/AppShell.tsx`, `src/components/layout/ThreePanelShell.tsx`, `src/components/layout/MainContent.tsx`, `src/ui/TabContentTransition.tsx`, and `src/app/classrooms/[classroomId]/ClassroomPageClient.tsx`.
 - Updated `src/components/PageLayout.tsx` and `src/components/layout/MainContent.tsx` to merge override spacing classes correctly via `cn`, so tab-specific `pt-0`, `pt-1`, and `pb-0` overrides actually win over density defaults.
 - Converted student tests and both teacher/student calendar tabs to fill their available pane height using flex-based wrappers instead of viewport math in `src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx`, `src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx`, `src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx`, and `src/components/LessonCalendar.tsx`.
-- Added screenshots from the worktree dev server for student tests, student calendar, teacher tests, and teacher calendar under `/tmp/pika-worktree-*.png`.
+- Added screenshots from the worktree dev server for student tests, student calendar, teacher tests, and teacher calendar under `/tmp/worktree-*.png`.
 
 **Validation:**
 - `pnpm lint --file src/components/PageLayout.tsx --file src/components/layout/MainContent.tsx --file 'src/app/classrooms/[classroomId]/ClassroomPageClient.tsx' --file 'src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx' --file 'src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx' --file 'src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx' --file src/components/AppShell.tsx --file src/components/LessonCalendar.tsx --file src/components/layout/ThreePanelShell.tsx --file src/ui/TabContentTransition.tsx` (pass)
@@ -7210,7 +7210,7 @@
 - Audited `supabase/migrations` against `origin/main`; no new migration files were added on this branch and no duplicate migration prefixes were present, so no resequencing was needed.
 
 **Validation:**
-- `git -C "$PIKA_WORKTREE" diff --name-only --diff-filter=A origin/main -- supabase/migrations` (no output)
+- `git -C "<worktree>" diff --name-only --diff-filter=A origin/main -- supabase/migrations` (no output)
 - duplicate migration prefix check across `supabase/migrations` (no output)
 
 ## 2026-03-20 [AI - GPT-5 Codex]
@@ -7328,7 +7328,7 @@
 **Validation:**
 - `pnpm test` (all 1592 tests pass)
 - `pnpm test tests/components/StudentQuizForm.test.tsx` (3 tests pass, no unhandled errors)
-- `git -C "$PIKA_WORKTREE" log --oneline -1` → fdbe6cd fix: add safety check for scrollIntoView and add flagging E2E tests
+- `git -C "<worktree>" log --oneline -1` → fdbe6cd fix: add safety check for scrollIntoView and add flagging E2E tests
 
 **Blockers/Notes:**
 - User's last request: "change q7 mc option so its not using arrays" - unable to locate Q7 in codebase
@@ -7371,7 +7371,7 @@
 - Added a regression test covering an `ok: true` OpenAI response whose body is non-JSON text beginning with `An error occurred...`
 
 **Validation:**
-- `bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"` (179 test files, 1592 tests passing)
+- `bash "<worktree>/.codex/skills/pika-session-start/scripts/session_start.sh"` (179 test files, 1592 tests passing)
 - `pnpm test tests/unit/ai-test-grading.test.ts tests/api/teacher/tests-auto-grade.test.ts` (17 tests passing)
 
 **Notes:**
@@ -8664,9 +8664,9 @@
 - Targeted regression:
   - `corepack pnpm --dir /Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown exec vitest run tests/unit/ui-guidance-docs.test.ts`
 - Full session-start dry run:
-  - `PATH="/opt/homebrew/opt/node@24/bin:$PATH" PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/codex/ai-guidance-slimdown bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"`
+  - `PATH="/opt/homebrew/opt/node@24/bin:$PATH" bash "<worktree>/.codex/skills/pika-session-start/scripts/session_start.sh"`
 
-**Status:** The default AI startup path is now under the target budget, journal reads are on-demand, and the bound worktree session-start flow passes end-to-end.
+**Status:** The default AI startup path is now under the target budget, journal reads are on-demand, and the current-root session-start flow passes end-to-end.
 
 ## 2026-04-15 [AI - Codex]
 
@@ -8734,7 +8734,7 @@
 - Verified the main dependency families currently checked are internally aligned between manifest and lockfile.
 
 **Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` with `PIKA_WORKTREE=/Users/stew/.codex/worktrees/88c8/pika` (failed on Node version check)
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` from a local worktree (failed on Node version check)
 - `node -v` → `v22.21.1`
 - `pnpm -v` → `10.25.0`
 - `pnpm exec node -v` → `v22.21.1`
@@ -9193,7 +9193,7 @@
 **Validation:**
 - `pnpm test tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
 - `pnpm exec eslint src/components/StudentQuizForm.tsx tests/components/StudentQuizForm.test.tsx tests/components/StudentQuizzesTab.test.tsx`
-- `bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" 'classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests'` with `E2E_BASE_URL=http://localhost:3002`
+- `bash "<worktree>/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" 'classrooms/ed6bbfe1-5bb8-4173-a8e0-a2d7644db2d7?tab=tests'` with `E2E_BASE_URL=http://localhost:3002`
 - Manual Playwright screenshots:
 - `/tmp/pika-teacher-test-preview-submit-end.png`
 - `/tmp/pika-student-test-submit-end.png`
@@ -9649,7 +9649,7 @@
 **Validation:**
 - `pnpm lint`
 - `pnpm vitest run tests/unit/layout-config.test.ts tests/components/TeacherWorkspaceSplit.test.tsx tests/components/WorkspaceSplitPane.test.tsx tests/components/SummaryDetailWorkspaceShell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`
+- `bash "<worktree>/scripts/verify-env.sh"`
 - Cleared stale generated `.next` cache after a dev-server vendor chunk error,
   then reran Pika UI verification cleanly.
 - Pika UI verification for `/classrooms/8d9c9d0b-444f-4b6b-80e2-4522ec26681a?tab=attendance` on `http://localhost:3002`.
@@ -9766,7 +9766,7 @@
 **Validation:**
 - `pnpm test tests/ui/AppMessage.test.tsx tests/ui/StatusPrimitives.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSettingsTab.test.tsx`
 - `pnpm lint`
-- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)
+- `bash "<worktree>/scripts/verify-env.sh"` (235 files, 1951 tests)
 - Pika UI verification for classroom assignments and assignment grading workspace:
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`
@@ -9793,7 +9793,7 @@
 - Added a README license section that states the repository is publicly visible for review/evaluation only and links to `LICENSE`.
 
 **Validation:**
-- `bash "$PIKA_WORKTREE/scripts/verify-env.sh"` (235 files, 1951 tests)
+- `bash "<worktree>/scripts/verify-env.sh"` (235 files, 1951 tests)
 ## 2026-04-29 — Classroom navigation pending feedback
 
 **Completed:**
@@ -10037,7 +10037,7 @@
 - Added NavItems regression coverage for no assignment dropdown affordance or nested assignment buttons.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/remove-assignments-sidebar-dropdown bash scripts/verify-env.sh`
+- `bash scripts/verify-env.sh`
 - `pnpm exec vitest run tests/components/NavItems.test.tsx`
 - `pnpm lint`
 - `pnpm exec tsc --noEmit`
@@ -10123,7 +10123,7 @@
 - Added component regression coverage that switches from one overview student to another with a deferred load and verifies the batch apply source is cleared until the new student's data arrives.
 
 **Validation:**
-- `bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"` (235 files / 1958 tests before the focused regression was added)
+- `bash "<worktree>/.codex/skills/pika-session-start/scripts/session_start.sh"` (235 files / 1958 tests before the focused regression was added)
 - `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/ui/SplitButton.test.tsx`
 - `pnpm lint`
 
@@ -10794,7 +10794,7 @@
 **Validation:**
 - `pnpm test tests/components/StudentQuizzesTab.test.tsx`
 - `pnpm lint`
-- Pre-edit startup verification: `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/issue-548-doc-chevron bash scripts/verify-env.sh`
+- Pre-edit startup verification: `bash scripts/verify-env.sh`
 - Pika UI verification script on `http://localhost:3002/classrooms`:
   - `/tmp/pika-teacher.png`
   - `/tmp/pika-student.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,47 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Test modal header title placement
-
-**Completed:**
-- Moved the editable test title into the test creation/edit modal header where the fixed `Test` label was.
-- Display generated untitled test drafts as `Untitled Test` in the editable test title control.
-- Kept the same draft-backed title save path by portaling the existing `QuizDetailPanel` title editor into the modal header.
-
-**Validation:**
-- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3005 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests'`
-- Targeted screenshots/assertions: `/tmp/pika-test-title-header-desktop.png`, `/tmp/pika-test-title-header-mobile.png`.
-
-## 2026-05-14 — Survey selected-card results pane
-
-**Completed:**
-- Moved teacher survey results out of the authoring modal and into the selected survey Pika pane.
-- Moved teacher survey settings/actions into the selected-survey floating action bar: edit, code, poll visibility, results visibility, response editing, delete.
-- Changed survey cards to select the survey results pane instead of opening the authoring modal directly.
-- Updated student survey behavior so visible results render first, unsubmitted students can still open the response form, and submitted students get an edit-response FAB when response editing is allowed.
-- Fixed URL-selected survey modal state so the teacher action-bar edit/code buttons can open the authoring modal without being immediately cleared by the URL selection effect.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3005 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-teacher-survey-results-pane.png`, `/tmp/pika-teacher-survey-authoring-no-results.png`, `/tmp/pika-student-survey-results-respond.png`, `/tmp/pika-student-survey-results-edit.png`, `/tmp/pika-student-survey-edit-form.png`.
-
-## 2026-05-14 — Survey cleanup resumed validation
-
-**Completed:**
-- Resumed the survey cleanup worktree after an interrupted startup verification run.
-- Confirmed the real worktree branch remained `codex/survey-experience-cleanup`.
-- Loaded startup and UI guidance context without making further code changes.
-
-**Validation:**
-- `pnpm test` — 268 test files and 2235 tests passed.
-- `git diff --check`
-
 ## 2026-05-14 — Rebased survey cleanup onto origin/main
 
 **Completed:**
@@ -75,7 +34,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3006 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3006 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Targeted Playwright screenshot/assertion: `/tmp/pika-survey-create-modal-title-selected.png`.
 
 ## 2026-05-14 — Teacher selected-survey split actions
@@ -90,7 +49,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherClassroomView.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3021 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=167609a8-2111-482f-8be2-7bb74a8f548f'`
+- `E2E_BASE_URL=http://localhost:3021 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=167609a8-2111-482f-8be2-7bb74a8f548f'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-teacher-final.png`, `/tmp/pika-survey-actions-open.png`; temporary survey fixture was deleted afterward.
 
 ## 2026-05-14 — Teacher selected-survey icon controls
@@ -105,7 +64,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3022 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=47927a72-ffe7-45d8-a51d-9f60bd9696d6'`
+- `E2E_BASE_URL=http://localhost:3022 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=47927a72-ffe7-45d8-a51d-9f60bd9696d6'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-icon-controls.png`, `/tmp/pika-survey-edit-modal-settings.png`; temporary survey fixture was deleted afterward.
 
 ## 2026-05-14 — Survey hidden-results and live-change copy
@@ -119,7 +78,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3023 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=b04fcfbf-1071-4d14-af9f-592c35a9f02a'`
+- `E2E_BASE_URL=http://localhost:3023 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=b04fcfbf-1071-4d14-af9f-592c35a9f02a'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-hidden-results-icon.png`, `/tmp/pika-survey-edit-modal-live-changes-row.png`; temporary survey fixture was deleted afterward.
 
 ## 2026-05-14 — Survey question autosave controls
@@ -137,9 +96,9 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3024 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=619428d0-644e-4f13-9681-bb0954e266b1'`
+- `E2E_BASE_URL=http://localhost:3024 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=619428d0-644e-4f13-9681-bb0954e266b1'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-question-autosave-delete-inline.png`, `/tmp/pika-survey-question-autosaved.png`; confirmed `saveButtonCount: 0`, observed question PATCH on blur, and deleted the temporary survey fixture afterward.
-- `E2E_BASE_URL=http://localhost:3027 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
+- `E2E_BASE_URL=http://localhost:3027 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-locked-controls.png`, `/tmp/pika-survey-hidden-results-control.png`; restored the seeded active survey to `show_results: true`.
 
 ## 2026-05-15 — Survey results card cleanup
@@ -152,12 +111,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Stabilized the generated-title focus test with an explicit wait after the all-file startup run exposed a focus timing flake.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh` — one focus-timing test failed during the full suite before edits; the isolated test passed afterward and was stabilized.
+- `bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh` — one focus-timing test failed during the full suite before edits; the isolated test passed afterward and was stabilized.
 - `pnpm test tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
 - `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3028 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
+- `E2E_BASE_URL=http://localhost:3028 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-results-bars.png`, `/tmp/pika-survey-results-card-teacher.png`, `/tmp/pika-survey-results-card-student.png`; temporary multiple-choice survey response rows were deleted afterward.
 
 ## 2026-05-19 — Multiple-choice survey option cap
@@ -167,7 +126,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added a boundary unit test that accepts the configured maximum and rejects one option beyond it.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/surveys.test.ts tests/api/teacher/surveys-questions-route.test.ts tests/api/teacher/surveys-questions-id.test.ts`
 - `pnpm lint`
 - `pnpm build`
@@ -182,7 +141,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3030 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-experience-cleanup bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3030 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Targeted Playwright smoke created a temporary draft survey, confirmed `Open poll` was disabled before adding a question and enabled after adding the first question in the modal, then deleted the temporary survey. Screenshot: `/tmp/pika-survey-question-count-enabled.png`.
 
 ## 2026-05-19 — Survey PR merge prep
@@ -202,11 +161,11 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added regression coverage for opening preview and selecting an option without issuing a survey PATCH.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/survey-preview bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- `E2E_BASE_URL=http://localhost:3003 bash /Users/stew/Repos/.worktrees/pika/survey-preview/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-survey-preview-teacher.png`, `/tmp/pika-survey-preview-teacher-mobile.png`; temporary survey fixtures were deleted afterward.
 
 ## 2026-05-19 — Teacher Daily date picker arrows
@@ -216,10 +175,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added a regression test asserting the Daily picker no longer renders `Previous day` or `Next day` buttons.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows bash /Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash /Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows/.codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx`
 - `pnpm lint`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows E2E_BASE_URL=http://localhost:3017 bash /Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=attendance'`
+- `E2E_BASE_URL=http://localhost:3017 bash /Users/stew/Repos/.worktrees/pika/remove-daily-date-arrows/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=attendance'`
 - Warmed desktop screenshot: `/tmp/pika-teacher-final.png`; teacher desktop/mobile confirmed no forward/back date arrows, student mobile unaffected.
 - `pnpm test`
 
@@ -235,10 +194,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/AssignmentModal.test.tsx`
 - `pnpm lint`
 - `pnpm build`
-- `E2E_BASE_URL=http://localhost:3003 PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-preview-escape bash /Users/stew/Repos/.worktrees/pika/assignment-preview-escape/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3003 bash /Users/stew/Repos/.worktrees/pika/assignment-preview-escape/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Targeted Playwright screenshots/assertions: `/tmp/pika-assignment-instructions-preview.png`, `/tmp/pika-assignment-modal-after-preview-escape.png`.
 - `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Additional modal screenshots:
   - `/tmp/pika-teacher-assignment-markdown-modal.png`
   - `/tmp/pika-teacher-assignment-markdown-modal-mobile.png`
@@ -255,7 +214,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm lint`
 - `pnpm test tests/components/AssignmentModal.test.tsx`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Additional modal screenshots:
   - `/tmp/pika-assignment-modal-desktop.png`
   - `/tmp/pika-assignment-modal-mobile.png`
@@ -271,7 +230,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm lint`
 - `pnpm test tests/components/AssignmentModal.test.tsx`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Additional modal screenshots:
   - `/tmp/pika-assignment-modal-desktop.png`
   - `/tmp/pika-assignment-modal-mobile.png`
@@ -290,7 +249,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm lint`
 - `pnpm test tests/components/AssignmentModal.test.tsx`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/assignment-markdown-modal E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
+- `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/assignment-markdown-modal/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
 - Additional modal screenshots:
   - `/tmp/pika-assignment-modal-desktop.png`
   - `/tmp/pika-assignment-modal-mobile.png`
@@ -307,13 +266,13 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Added experimental UI guidance for the shared creation shell candidate.
 
 **Validation:**
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/creation-modal-shell bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm lint`
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/components/AssignmentModal.test.tsx tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/SurveyCreationModal.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/ai-startup-docs.test.ts`
 - `pnpm build`
 - `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
-- `PIKA_WORKTREE=/Users/stew/Repos/.worktrees/pika/creation-modal-shell E2E_BASE_URL=http://localhost:3000 bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- `E2E_BASE_URL=http://localhost:3000 bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Additional modal screenshots:
   - `/tmp/pika-assignment-create-desktop.png`
   - `/tmp/pika-test-create-desktop.png`
@@ -321,3 +280,55 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-assignment-create-mobile.png`
   - `/tmp/pika-test-create-mobile.png`
   - `/tmp/pika-survey-create-mobile.png`
+- UI verification on `http://localhost:3001`:
+  - `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+  - Targeted live-assignment editor screenshot: `/tmp/pika-live-assignment-editor.png`
+
+## 2026-05-16 — Native worktree AI guidance
+
+**Completed:**
+- Removed the per-session worktree environment variable requirement from live AI startup docs, Codex prompts/skills, and Claude command docs.
+- Updated the startup, audit, and UI verification helper scripts to resolve the current git root directly.
+- Kept the hub guardrail: branch work must happen in a dedicated worktree, not `$HOME/Repos/pika`.
+- Removed remaining old worktree wording from live AI workflow docs.
+- Made the audit helper fail loudly when run outside a git checkout.
+- Added regression coverage for session-start rejecting the hub checkout and audit rejecting non-git directories.
+- Removed legacy env exports from `scripts/pika`, the parity challenge helper, and the production merge worktree-root override.
+- Sanitized tracked historical logs so repo-wide legacy env-var searches are clean.
+- Changed future Pika worktree creation to `$HOME/.codex/worktrees/pika/<worktree-name>` while leaving existing `$HOME/Repos/.worktrees/pika` checkouts resolvable.
+- Updated the production merge helper to reuse an already registered `production` worktree, otherwise create future production checkouts under `$HOME/.codex/worktrees/pika`.
+
+**Validation:**
+- `bash scripts/verify-env.sh` from the hub before edits
+- `pnpm install --offline` in the docs worktree to recreate local dependency links
+- `pnpm test -- tests/unit/ai-startup-docs.test.ts` (Vitest ran the full suite: 268 files / 2244 tests passed)
+- `pnpm test tests/unit/ai-startup-docs.test.ts` (7 tests)
+- `bash -n scripts/pika scripts/run-teacher-tests-parity-challenge.sh .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh .codex/skills/pika-audit/scripts/audit.sh .codex/skills/pika-session-start/scripts/session_start.sh .codex/skills/pika-ui-verify/scripts/ui_verify.sh`
+- `scripts/pika ls`
+- Exact legacy worktree env-var search across the repo returned no matches
+
+## 2026-05-19 — Codex worktree flow simplification
+
+**Completed:**
+- Simplified the canonical workflow so new named Pika worktrees live under `$HOME/.codex/worktrees/pika/<worktree-name>`, while Codex Desktop app-managed worktrees under `$HOME/.codex/worktrees/<id>/pika` are explicitly valid.
+- Updated cleanup guidance to resolve the registered worktree path from `git worktree list --porcelain` before removing it, so new and legacy worktrees clean up correctly.
+- Replaced stale Claude production-merge guidance with the shared production worktree helper flow.
+- Added regression coverage for the worktree-location distinction, path-discovered cleanup, and production-merge helper routing.
+
+**Validation:**
+- `pnpm test tests/unit/ai-startup-docs.test.ts`
+- `bash -n scripts/pika scripts/wt-add.sh scripts/run-teacher-tests-parity-challenge.sh .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh .codex/skills/pika-audit/scripts/audit.sh .codex/skills/pika-session-start/scripts/session_start.sh .codex/skills/pika-ui-verify/scripts/ui_verify.sh`
+- `scripts/pika ls`
+- `git diff --check`
+- Legacy worktree env-var and stale workflow phrase scans returned no live-source matches.
+
+## 2026-05-19 — Workflow friction automation
+
+**Completed:**
+- Created the active weekly `Pika Workflow Friction Review` Codex automation as a report-only review of recent workflow friction and guidance drift.
+- Updated the active `Weekly Pika Simplification` automation prompt to use the native worktree flow and stop relying on project-specific worktree environment variables.
+- Confirmed both automation configs were written under `/Users/stew/.codex/automations`.
+
+**Validation:**
+- Read back `/Users/stew/.codex/automations/weekly-pika-simplification/automation.toml`.
+- Read back `/Users/stew/.codex/automations/pika-workflow-friction-review/automation.toml`.

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -9,12 +9,13 @@
 ## Quick Checklist
 
 ```
-[ ] Verify worktree: echo $PIKA_WORKTREE (must NOT be $HOME/Repos/pika)
-[ ] Run: bash "$PIKA_WORKTREE/scripts/verify-env.sh"
-[ ] Check status: git -C "$PIKA_WORKTREE" status
+[ ] Resolve repo root: git rev-parse --show-toplevel
+[ ] Verify repo root is a feature worktree, not $HOME/Repos/pika for branch work
+[ ] Run: bash scripts/verify-env.sh
+[ ] Check status: git status --short --branch
 [ ] Read: .ai/CURRENT.md
 [ ] Read: docs/ai-instructions.md
-[ ] Check features: node "$PIKA_WORKTREE/scripts/features.mjs" next
+[ ] Check features: node scripts/features.mjs next
 [ ] Load task-specific docs routed by docs/ai-instructions.md
 [ ] Plan before coding: state task, propose approach, wait for approval
 ```
@@ -26,48 +27,43 @@ Read `.ai/SESSION-LOG.md` only for recent handoff context; `.ai/JOURNAL-ARCHIVE.
 
 ## Worktree Rules (MANDATORY)
 
-All agents are bound to exactly ONE worktree via `$PIKA_WORKTREE`.
+All agents operate from exactly one current repo checkout/worktree.
 
-- NEVER assume the shell cwd.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`.
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
+- Resolve the repo root with `git rev-parse --show-toplevel` before acting.
+- Use that resolved root consistently for git commands and file paths.
 - Never do branch work in `$HOME/Repos/pika/` (the hub).
+- If the current root is the hub and the task needs edits, create or open a dedicated worktree first.
 - Worktree creation, cleanup, and shared `.env.local` setup live in `docs/dev-workflow.md`.
-- For hub-level git commands (add/remove worktrees): `export PIKA_WORKTREE="$HOME/Repos/pika"`
+- Hub-level git commands for adding/removing worktrees must use `git -C "$HOME/Repos/pika" ...`.
 
 ---
 
 ## End of Session (MANDATORY)
 
-1. Append a concise session entry to `$PIKA_WORKTREE/.ai/SESSION-LOG.md`.
-2. Run `node "$PIKA_WORKTREE/scripts/trim-session-log.mjs"` to keep only the latest 20 entries.
+1. Append a concise session entry to `.ai/SESSION-LOG.md`.
+2. Run `node scripts/trim-session-log.mjs` to keep only the latest 20 entries.
 3. Update `.ai/features.json` if anything changed:
    ```bash
-   node "$PIKA_WORKTREE/scripts/features.mjs" pass <feature-id>
-   node "$PIKA_WORKTREE/scripts/features.mjs" fail <feature-id>
+   node scripts/features.mjs pass <feature-id>
+   node scripts/features.mjs fail <feature-id>
    ```
 4. Commit and push the session log + feature changes.
 5. If work was merged, clean up:
    ```bash
-   export PIKA_WORKTREE="$HOME/Repos/pika"
-   git -C "$PIKA_WORKTREE" fetch origin
-   git -C "$PIKA_WORKTREE" merge --ff-only origin/main
-   git -C "$PIKA_WORKTREE" worktree remove "$HOME/Repos/.worktrees/pika/<branch-name>"
-   git -C "$PIKA_WORKTREE" branch -D <branch-name>
+   HUB="$HOME/Repos/pika"
+   BRANCH="<branch-name>"
+   git -C "$HUB" fetch origin
+   git -C "$HUB" merge --ff-only origin/main
+   WT_PATH="$(git -C "$HUB" worktree list --porcelain | awk -v branch="$BRANCH" '/^worktree /{p=substr($0,10)} /^branch refs\/heads\// && substr($0,19)==branch{print p; exit}')"
+   [ -z "$WT_PATH" ] || git -C "$HUB" worktree remove "$WT_PATH"
+   git -C "$HUB" branch -D "$BRANCH"
    ```
 
 ---
 
 ## Document Hierarchy (When Conflicts Arise)
 
-Trust in this order:
-1. `.ai/features.json` — status authority
-2. `.ai/CURRENT.md` — compact current-state context
-3. `docs/core/architecture.md` — architecture and invariants
-4. `docs/core/tests.md` — testing requirements
-5. `docs/core/design.md` — UI/UX rules
-6. `docs/core/project-context.md` — setup and commands
-7. `docs/core/roadmap.md` — phase strategy
-8. `docs/core/decision-log.md` — historical rationale
-9. `.ai/SESSION-LOG.md` — recent handoff history (on demand)
-10. `.ai/JOURNAL-ARCHIVE.md` — historical investigation only
+Trust in order: `.ai/features.json`, `.ai/CURRENT.md`, core docs
+(`architecture`, `tests`, `design`, `project-context`, `roadmap`,
+`decision-log`), `.ai/SESSION-LOG.md` on demand, then
+`.ai/JOURNAL-ARCHIVE.md` only for historical investigation.

--- a/.claude/commands/add-api-route.md
+++ b/.claude/commands/add-api-route.md
@@ -2,10 +2,10 @@ Scaffold a new API route at the given path with best-practice patterns.
 
 Takes `$ARGUMENTS` as the route path (e.g. `teacher/widgets/[id]`).
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
+- Resolve paths under the current repo root.
 - Follow patterns from `docs/ai-instructions.md` and `docs/core/architecture.md`.
 - Every handler MUST use `withErrorHandler` from `@/lib/api-handler`.
 - Use Zod for request body validation.
@@ -16,7 +16,7 @@ Steps:
 
 1) Parse the target path
    - Extract from `$ARGUMENTS` (e.g. `teacher/widgets/[id]`).
-   - Compute full file path: `$PIKA_WORKTREE/src/app/api/<path>/route.ts`.
+   - Compute full file path: `src/app/api/<path>/route.ts`.
    - If the file already exists, stop and tell me.
 
 2) Determine route characteristics

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,18 +1,18 @@
 Pre-commit audit: scan changed files for common violations.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- Use absolute paths or paths relative to the current repo root.
 - Report ALL violations found, not just the first one.
 - Exit with a summary: pass/fail + violation count.
 
 Steps:
 
 1) Get changed files
-   - Run: `git -C "$PIKA_WORKTREE" diff --name-only HEAD` (staged + unstaged)
-   - Also check: `git -C "$PIKA_WORKTREE" diff --name-only --cached` (staged only)
+   - Run: `git diff --name-only HEAD` (staged + unstaged)
+   - Also check: `git diff --name-only --cached` (staged only)
    - Combine both lists, deduplicate.
    - Filter to only `.ts` and `.tsx` files.
    - If no changed files, report "No TypeScript files changed" and stop.

--- a/.claude/commands/commit-and-pr.md
+++ b/.claude/commands/commit-and-pr.md
@@ -1,10 +1,9 @@
 Commit staged/unstaged changes and create or update a PR.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
 - Run all commands directly.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
 - Never commit directly to `main` or `production`. If on these branches, stop and ask me to create a feature branch first.
 - Never force-push.
 - Generate commit message from diff using conventional commits format.
@@ -12,25 +11,25 @@ Rules:
 Steps:
 
 1) Verify environment
-   - Verify `$PIKA_WORKTREE` is set: `echo $PIKA_WORKTREE`
-   - If not set or equals `$HOME/Repos/pika` (hub), stop and tell me to bind a worktree first (`pika claude <worktree>`).
-   - Run: `git -C "$PIKA_WORKTREE" status -sb`, `git -C "$PIKA_WORKTREE" branch --show-current`
+   - Resolve the repo root with `git rev-parse --show-toplevel`.
+   - If it equals `$HOME/Repos/pika` (hub), stop and ask me to create or open a worktree first.
+   - Run: `git status -sb`, `git branch --show-current`
    - If on `main` or `production`, stop and ask me to create a feature branch.
    - If no changes (staged or unstaged), stop and tell me.
 
 2) Review changes
-   - Run: `git -C "$PIKA_WORKTREE" diff --stat` and `git -C "$PIKA_WORKTREE" diff` to understand the changes.
-   - Run: `git -C "$PIKA_WORKTREE" log --oneline -5` to understand commit message style.
+   - Run: `git diff --stat` and `git diff` to understand the changes.
+   - Run: `git log --oneline -5` to understand commit message style.
 
 3) Stage and commit
-   - Stage all changes: `git -C "$PIKA_WORKTREE" add -A`
+   - Stage all changes: `git add -A`
    - Generate a commit message from the diff using conventional commits (feat/fix/chore/docs/refactor/test).
-   - Commit with the generated message using `git -C "$PIKA_WORKTREE" commit -m "..."`.
+   - Commit with the generated message using `git commit -m "..."`.
    - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit.
 
 4) Push
-   - If branch has no upstream, push with `git -C "$PIKA_WORKTREE" push -u origin <branch>`.
-   - Otherwise, push with `git -C "$PIKA_WORKTREE" push`.
+   - If branch has no upstream, push with `git push -u origin <branch>`.
+   - Otherwise, push with `git push`.
 
 5) Create or update PR
    - Check if PR exists: `gh pr view --json url` (auto-detects repo from branch)

--- a/.claude/commands/follow-workflow.md
+++ b/.claude/commands/follow-workflow.md
@@ -2,21 +2,18 @@ STOP and re-read the workflow docs before continuing.
 
 You may have drifted from the required workflow. Follow these steps:
 
-1) Check environment first: `echo $PIKA_WORKTREE`
+1) Check the repo root first: `git rev-parse --show-toplevel`
 2) Read the workflow docs:
-   - Read `$PIKA_WORKTREE/.ai/START-HERE.md`
-   - Read `$PIKA_WORKTREE/docs/dev-workflow.md`
-   (If $PIKA_WORKTREE is unset, use `$HOME/Repos/pika`)
+   - Read `.ai/START-HERE.md`
+   - Read `docs/dev-workflow.md`
 
 Key rules to remember:
 
-- NEVER assume the shell cwd
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`
-- Verify `$PIKA_WORKTREE` is set before running commands
+- Resolve and use the current repo root consistently.
+- Use absolute paths or paths relative to the current repo root.
 - Hub (`$HOME/Repos/pika`) is for managing worktrees, NOT feature development
 
 After reading, confirm:
-1. What is `$PIKA_WORKTREE` set to?
+1. What repo root are you in?
 2. What branch are you on?
 3. What task are you working on?

--- a/.claude/commands/merge-main-into-production.md
+++ b/.claude/commands/merge-main-into-production.md
@@ -1,48 +1,32 @@
-Merge `main` into `production` via a PR branch.
+Merge `main` into `production` using the protected PR workflow.
 (Vercel production deploys from `production`.)
 
-This is a **hub-level operation** — it must run from the hub repo, not a worktree.
-
-Note: Hub path is assumed to be `$HOME/Repos/pika`.
+Use the repo helper and `docs/dev-workflow.md` as the canonical process. Do not
+switch the hub checkout between `main` and `production`; the helper uses a
+registered `production` worktree and creates one under
+`$HOME/.codex/worktrees/pika/production` only when needed.
 
 Rules:
-- Run all commands directly (do not output copy-pasteable commands).
-- ALL git commands MUST use: `git -C "$HOME/Repos/pika"`
+- Run all commands directly.
 - Never force-push.
 - Never rewrite `main` or `production`.
-- If conflicts occur, stop and ask for help resolving them.
+- If conflicts occur, stop and ask for help resolving them in the production worktree.
 
 Steps:
 
-1) Verify hub environment
-   - Verify this is the hub: `echo $PIKA_WORKTREE`
-   - If `$PIKA_WORKTREE` is set to a worktree path (not `$HOME/Repos/pika`), stop and tell me to run this from the hub instead.
-   - Run: `git -C "$HOME/Repos/pika" remote -v`, `git -C "$HOME/Repos/pika" status -sb`
-   - If `origin` doesn't point to the expected repo, stop and tell me what to fix.
+1) Confirm this task is specifically `main` into `production`.
 
-2) Update branches
-   - `git -C "$HOME/Repos/pika" fetch --all --prune`
-   - `git -C "$HOME/Repos/pika" switch main && git -C "$HOME/Repos/pika" pull --ff-only origin main`
-   - `git -C "$HOME/Repos/pika" switch production && git -C "$HOME/Repos/pika" pull --ff-only origin production`
+2) Run the helper from the current Pika checkout:
+   ```bash
+   bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
+   ```
 
-3) Create PR branch + merge
-   - Branch name: `merge/main-to-production-YYYYMMDD` (use today's date)
-   - `git -C "$HOME/Repos/pika" switch production`
-   - `git -C "$HOME/Repos/pika" switch -c merge/main-to-production-YYYYMMDD`
-   - `git -C "$HOME/Repos/pika" merge --no-ff main`
-   - If conflicts occur, run `git -C "$HOME/Repos/pika" status`, stop, and ask me for help.
+3) If the helper creates a PR, report its URL and ask the user to merge it or confirm that you should merge it.
 
-4) Sanity check + push
-   - Show: `git -C "$HOME/Repos/pika" diff --stat origin/production...HEAD`
-   - `git -C "$HOME/Repos/pika" push -u origin merge/main-to-production-YYYYMMDD`
+4) After the PR is merged, sync the local production worktree using the path printed by the helper:
+   ```bash
+   git -C <production-worktree> fetch origin production
+   git -C <production-worktree> merge --ff-only origin/production
+   ```
 
-5) Create PR with `gh pr create`
-   - Title: `Merge main into production (YYYY-MM-DD)`
-   - Body: Purpose is to deploy to Vercel production. Include summary of changes from diff stat.
-   - Recommend merging with a **merge commit** (not squash).
-
-6) Post-merge cleanup (tell me to run this after PR is merged)
-   - `git -C "$HOME/Repos/pika" switch production`
-   - `git -C "$HOME/Repos/pika" pull --ff-only origin production`
-   - `git -C "$HOME/Repos/pika" branch -d merge/main-to-production-YYYYMMDD`
-   - `git -C "$HOME/Repos/pika" push origin --delete merge/main-to-production-YYYYMMDD`
+5) Report the final `origin/production` commit SHA.

--- a/.claude/commands/migrate-error-handler.md
+++ b/.claude/commands/migrate-error-handler.md
@@ -1,11 +1,11 @@
 Migrate an API route from manual try/catch error handling to `withErrorHandler`.
 
-Takes `$ARGUMENTS` as the file path to migrate (relative to `$PIKA_WORKTREE` or absolute).
+Takes `$ARGUMENTS` as the file path to migrate, relative to the current repo root or absolute.
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
-- ALL file paths MUST be absolute or prefixed with `$PIKA_WORKTREE`.
+- Resolve paths under the current repo root.
 - Preserve all existing business logic exactly.
 - Do NOT change response shapes, status codes, or behavior.
 - Only refactor the error handling wrapper.
@@ -13,7 +13,7 @@ Rules:
 Steps:
 
 1) Resolve and read the target file
-   - If `$ARGUMENTS` is relative, prepend `$PIKA_WORKTREE/`.
+   - If `$ARGUMENTS` is relative, resolve it from the current repo root.
    - Read the file contents.
    - If it already uses `withErrorHandler`, stop and tell me.
    - Count how many exported handler functions exist (GET, POST, PATCH, PUT, DELETE).
@@ -66,5 +66,5 @@ Steps:
 
 5) Verify
    - Run: `pnpm tsc --noEmit` to confirm no type errors.
-   - If there are existing tests for this route, run them: `pnpm vitest run <test-file>`.
+   - If there are existing tests for this route, run them: `pnpm test <test-file>`.
    - Report: number of handlers migrated, any edge cases encountered.

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -3,36 +3,36 @@ Start a new AI session: validate environment, load context, identify next task.
 This command implements the `.ai/START-HERE.md` ritual as an automated checklist.
 
 Rules:
-- Verify `$PIKA_WORKTREE` is set and is NOT `$HOME/Repos/pika`.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"`
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- Stop if the resolved root is `$HOME/Repos/pika` for branch work.
 - Stop and report clearly if any check fails.
 
 Steps:
 
 1) Verify worktree environment
-   - Run: `echo $PIKA_WORKTREE`
-   - If unset or equals `$HOME/Repos/pika`: STOP — tell me to run `pika claude <worktree>` first.
-   - Run: `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`
+   - Run: `git rev-parse --show-toplevel`
+   - If it equals `$HOME/Repos/pika`: STOP — tell me to open or create a feature worktree first.
+   - Run: `bash scripts/verify-env.sh`
    - If verify-env.sh fails: STOP — report the failure.
 
 2) Recover recent context
-   - Run: `git -C "$PIKA_WORKTREE" log --oneline -10`
-   - Run: `git -C "$PIKA_WORKTREE" status -sb`
-   - Read `$PIKA_WORKTREE/.ai/CURRENT.md`.
-   - Read `$PIKA_WORKTREE/.ai/SESSION-LOG.md` only if recent handoff context is needed.
+   - Run: `git log --oneline -10`
+   - Run: `git status -sb`
+   - Read `.ai/CURRENT.md`.
+   - Read `.ai/SESSION-LOG.md` only if recent handoff context is needed.
    - Summarize: current branch, last few commits, uncommitted changes.
 
 3) Load documentation
    - Read in order:
-     1. `$PIKA_WORKTREE/.ai/START-HERE.md`
-     2. `$PIKA_WORKTREE/.ai/features.json`
-     3. `$PIKA_WORKTREE/docs/ai-instructions.md`
+     1. `.ai/START-HERE.md`
+     2. `.ai/features.json`
+     3. `docs/ai-instructions.md`
      4. Task-specific docs routed by `docs/ai-instructions.md`
    - Briefly confirm: current feature area being developed.
 
 4) Check feature inventory
-   - Run: `node "$PIKA_WORKTREE/scripts/features.mjs" summary`
-   - Run: `node "$PIKA_WORKTREE/scripts/features.mjs" next`
+   - Run: `node scripts/features.mjs summary`
+   - Run: `node scripts/features.mjs next`
 
 5) Identify task
    - Priority: GitHub issue ($ARGUMENTS if given) → next failing feature → ask me.

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -2,12 +2,12 @@ Guide TDD implementation: write failing tests first, then implement to pass them
 
 Takes a feature description as $ARGUMENTS (e.g. `parseContentField utility`).
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
 - Tests MUST be written before implementation code.
 - Prefer Vitest unit tests for pure functions; API route tests for route handlers.
-- Verify `$PIKA_WORKTREE` is set before running any commands.
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
 
 Steps:
 
@@ -29,7 +29,7 @@ Steps:
      - Edge cases (empty input, null, boundary values)
      - Error cases (invalid input, thrown errors)
    - Use `describe`/`it` blocks for organization.
-   - Run tests to confirm they FAIL: `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>`
+   - Run tests to confirm they FAIL: `pnpm test <test-file>`
 
 4) Write minimal implementation
    - Create the source file.
@@ -37,7 +37,7 @@ Steps:
    - Do NOT add features not covered by tests.
 
 5) Verify all tests pass
-   - Run: `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>`
+   - Run: `pnpm test <test-file>`
    - All tests should be green.
 
 6) Refactor if needed
@@ -45,6 +45,6 @@ Steps:
    - Re-run tests to confirm still green.
 
 7) Check coverage
-   - Run: `pnpm -C "$PIKA_WORKTREE" test:coverage`
+   - Run: `pnpm test:coverage`
    - Core utilities should reach 100% coverage.
    - Report: lines covered, any uncovered branches.

--- a/.claude/commands/ui-verify.md
+++ b/.claude/commands/ui-verify.md
@@ -2,10 +2,10 @@ Visual verification of UI changes using Playwright screenshots.
 
 Takes the page path as $ARGUMENTS (e.g. `classrooms/abc123`).
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
-- Verify `$PIKA_WORKTREE` is set before running any commands.
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
 - Requires dev server running at `localhost:3000`.
 - Must capture BOTH teacher and student views when applicable.
 - You MUST look at the screenshots and provide visual feedback.
@@ -14,32 +14,32 @@ Steps:
 
 1) Ensure dev server is running
    - Check: `curl -s http://localhost:3000/api/auth/me > /dev/null && echo ok || echo not running`
-   - If not running: `pnpm -C "$PIKA_WORKTREE" dev &` and wait 5s.
+   - If not running: `pnpm dev &` and wait 5s.
 
 2) Ensure auth states exist
-   - Check: `ls "$PIKA_WORKTREE/.auth/"` for teacher.json and student.json.
-   - If missing: `pnpm -C "$PIKA_WORKTREE" e2e:auth`
+   - Check: `ls .auth/` for teacher.json and student.json.
+   - If missing: `pnpm e2e:auth`
 
 3) Take screenshots for BOTH roles
    - Teacher view:
      ```bash
      npx playwright screenshot "http://localhost:3000/$ARGUMENTS" \
        /tmp/pika-teacher.png \
-       --load-storage "$PIKA_WORKTREE/.auth/teacher.json" \
+       --load-storage ".auth/teacher.json" \
        --viewport-size 1440,900
      ```
    - Student view:
      ```bash
      npx playwright screenshot "http://localhost:3000/$ARGUMENTS" \
        /tmp/pika-student.png \
-       --load-storage "$PIKA_WORKTREE/.auth/student.json" \
+       --load-storage ".auth/student.json" \
        --viewport-size 390,844
      ```
    - Mobile teacher (if responsive):
      ```bash
      npx playwright screenshot "http://localhost:3000/$ARGUMENTS" \
        /tmp/pika-teacher-mobile.png \
-       --load-storage "$PIKA_WORKTREE/.auth/teacher.json" \
+       --load-storage ".auth/teacher.json" \
        --viewport-size 390,844
      ```
 

--- a/.claude/commands/work-on-issue.md
+++ b/.claude/commands/work-on-issue.md
@@ -2,11 +2,11 @@ Load a GitHub issue, set up a worktree, and prepare a plan before coding.
 
 Takes the issue number as $ARGUMENTS (e.g. `382`).
 
-This command operates on the bound worktree (`$PIKA_WORKTREE`).
+This command operates on the current repo/worktree.
 
 Rules:
-- Verify `$PIKA_WORKTREE` is set before running any commands.
-- ALL git commands MUST use: `git -C "$PIKA_WORKTREE"` or hub path.
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- Use the hub path only for creating a new worktree.
 - Plan before coding — wait for my approval before writing any files.
 
 Steps:
@@ -16,9 +16,9 @@ Steps:
    - Read and summarize: title, description, acceptance criteria, affected areas.
 
 2) Read relevant docs
-   - `$PIKA_WORKTREE/docs/ai-instructions.md` (if not already read this session)
-   - `$PIKA_WORKTREE/docs/core/architecture.md` (relevant sections)
-   - Any guidance doc under `$PIKA_WORKTREE/docs/guidance/` related to the issue.
+   - `docs/ai-instructions.md` (if not already read this session)
+   - `docs/core/architecture.md` (relevant sections)
+   - Any guidance doc under `docs/guidance/` related to the issue.
 
 3) Explore affected code
    - Identify which files will likely change (API routes, components, lib utilities, tests).
@@ -40,8 +40,8 @@ Steps:
 
 6) After approval: set up worktree (if not already on correct branch)
    ```bash
-   export PIKA_WORKTREE="$HOME/Repos/pika"
-   git -C "$PIKA_WORKTREE" fetch origin
-   git -C "$PIKA_WORKTREE" worktree add "$HOME/Repos/.worktrees/pika/issue-$ARGUMENTS-<slug>" -b "issue/$ARGUMENTS-<slug>" origin/main
+   HUB="$HOME/Repos/pika"
+   git -C "$HUB" fetch origin
+   git -C "$HUB" worktree add "$HOME/.codex/worktrees/pika/issue-$ARGUMENTS-<slug>" -b "issue/$ARGUMENTS-<slug>" origin/main
    ```
-   Then tell me to: `pika claude issue-$ARGUMENTS-<slug>` to bind the new worktree.
+   Then open the new worktree before editing.

--- a/.codex/prompts/add-api-route.md
+++ b/.codex/prompts/add-api-route.md
@@ -8,9 +8,9 @@ Use `docs/ai-instructions.md` and `docs/core/architecture.md` for the canonical 
 - Keep the happy path only inside the handler
 
 Steps:
-1. Resolve the target path to `$PIKA_WORKTREE/src/app/api/<path>/route.ts`.
+1. Resolve the target path to `src/app/api/<path>/route.ts` under the current repo root.
 2. Stop if the file already exists.
 3. Infer role requirements and whether `context.params` is needed from the path.
 4. Generate a minimal route with a `GET` handler by default.
 5. Use a PascalCase route name for `withErrorHandler`.
-6. Create parent directories if needed, then verify with `pnpm -C "$PIKA_WORKTREE" tsc --noEmit`.
+6. Create parent directories if needed, then verify with `pnpm tsc --noEmit`.

--- a/.codex/prompts/audit.md
+++ b/.codex/prompts/audit.md
@@ -2,7 +2,7 @@ Run the repo audit for changed files and report every violation found.
 
 Preferred path:
 ```bash
-bash "$PIKA_WORKTREE/.codex/skills/pika-audit/scripts/audit.sh"
+bash .codex/skills/pika-audit/scripts/audit.sh
 ```
 
 Focus on the full result set, not only the first failure. The audit checks the highest-drift patterns: manual API-route error handling, illegal `dark:` classes, duplicated `parseContentField`, `console.log`, and related violations.

--- a/.codex/prompts/commit-and-pr.md
+++ b/.codex/prompts/commit-and-pr.md
@@ -1,6 +1,6 @@
 Commit the current worktree changes and create or update the PR.
 
-Use the bound-worktree rules from `docs/dev-workflow.md`. Task-specific safeguards:
+Use the dedicated-worktree rules from `docs/dev-workflow.md`. Task-specific safeguards:
 
 - Never commit directly to `main` or `production`
 - Never force-push
@@ -8,7 +8,7 @@ Use the bound-worktree rules from `docs/dev-workflow.md`. Task-specific safeguar
 
 Steps:
 1. Confirm the current branch and stop if it is `main` or `production`.
-2. Review `git -C "$PIKA_WORKTREE" diff --stat`, `git -C "$PIKA_WORKTREE" diff`, and recent commit style.
+2. Review `git diff --stat`, `git diff`, and recent commit style.
 3. Stage the intended files, generate a conventional-commit message, and commit.
 4. Push the branch, setting upstream if needed.
 5. If a PR already exists, report its URL. Otherwise create one with a concise summary and test plan.

--- a/.codex/prompts/follow-workflow.md
+++ b/.codex/prompts/follow-workflow.md
@@ -1,12 +1,12 @@
 Stop and reload the canonical workflow context before continuing.
 
 Read these files in order:
-1. `$PIKA_WORKTREE/.ai/START-HERE.md`
-2. `$PIKA_WORKTREE/.ai/CURRENT.md`
-3. `$PIKA_WORKTREE/docs/ai-instructions.md`
-4. `$PIKA_WORKTREE/docs/dev-workflow.md`
+1. `.ai/START-HERE.md`
+2. `.ai/CURRENT.md`
+3. `docs/ai-instructions.md`
+4. `docs/dev-workflow.md`
 
 After reading, confirm:
-1. What is `$PIKA_WORKTREE` set to?
+1. What repo root does `git rev-parse --show-toplevel` report?
 2. What branch are you on?
 3. What task are you working on?

--- a/.codex/prompts/merge-main-into-production.md
+++ b/.codex/prompts/merge-main-into-production.md
@@ -1,6 +1,8 @@
 Merge `main` into `production` using the protected PR workflow.
 
 Use the dedicated repo skill and `docs/dev-workflow.md` as the canonical process reference.
+Do not switch the hub checkout between `main` and `production`; the helper uses
+a registered production worktree.
 
 Primary command:
 ```bash

--- a/.codex/prompts/migrate-error-handler.md
+++ b/.codex/prompts/migrate-error-handler.md
@@ -8,4 +8,4 @@ Steps:
 3. Convert `export async function X(...)` to `export const X = withErrorHandler(...)`.
 4. Add `import { withErrorHandler } from '@/lib/api-handler'` if missing.
 5. If the old `catch` contained custom domain behavior, move it inline with `ApiError` or `apiErrors`.
-6. Verify with `pnpm -C "$PIKA_WORKTREE" tsc --noEmit` and run nearby tests when available.
+6. Verify with `pnpm tsc --noEmit` and run nearby tests when available.

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -4,13 +4,13 @@ Canonical startup rules live in `.ai/START-HERE.md`, `.ai/CURRENT.md`, `docs/ai-
 
 Preferred path:
 ```bash
-bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"
+bash .codex/skills/pika-session-start/scripts/session_start.sh
 ```
 
 Manual fallback:
-1. Verify `$PIKA_WORKTREE` is set and is not `$HOME/Repos/pika`.
-2. Run `bash "$PIKA_WORKTREE/scripts/verify-env.sh"`.
-3. Review `git -C "$PIKA_WORKTREE" status -sb` and `git -C "$PIKA_WORKTREE" log --oneline -8`.
+1. Resolve the repo root with `git rev-parse --show-toplevel` and verify it is not `$HOME/Repos/pika` for branch work.
+2. Run `bash scripts/verify-env.sh`.
+3. Review `git status -sb` and `git log --oneline -8`.
 4. Read `.ai/START-HERE.md`, `.ai/CURRENT.md`, `.ai/features.json`, and `docs/ai-instructions.md`.
 5. Read `.ai/SESSION-LOG.md` only if recent handoff context is needed; use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 6. Load only the task-specific docs routed by `docs/ai-instructions.md`.

--- a/.codex/prompts/tdd.md
+++ b/.codex/prompts/tdd.md
@@ -6,7 +6,7 @@ If the task touches workspace state, async grading, exam mode, or runtime/platfo
 Steps:
 1. Identify the target test file under `tests/lib/`, `tests/api/`, `tests/hooks/`, or `tests/components/`.
 2. Write the failing test first.
-3. Run `pnpm -C "$PIKA_WORKTREE" vitest run <test-file>` and confirm it fails for the expected reason.
+3. Run `pnpm test <test-file>` and confirm it fails for the expected reason.
 4. Implement the minimum code needed to pass.
 5. Re-run the focused test, then refactor as needed.
 6. Re-run the focused test and any nearby regression tests.

--- a/.codex/prompts/ui-verify.md
+++ b/.codex/prompts/ui-verify.md
@@ -6,7 +6,7 @@ Playwright is the required final verification path. Chrome plugin/browser-profil
 
 Preferred path:
 ```bash
-bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" "$ARGUMENTS"
+bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "$ARGUMENTS"
 ```
 
 After screenshots are captured:

--- a/.codex/prompts/work-on-issue.md
+++ b/.codex/prompts/work-on-issue.md
@@ -12,4 +12,4 @@ Steps:
 3. Inspect the affected files and the nearest tests without editing anything yet.
 4. Draft the plan: worktree or branch name, files to change, tests to write first, and whether a migration file is needed.
 5. Present the plan and wait for approval.
-6. After approval, create or bind the worktree using `docs/dev-workflow.md`, then continue the work from that bound worktree.
+6. After approval, create or open the dedicated worktree using `docs/dev-workflow.md`, then continue the work from that worktree.

--- a/.codex/skills/pika-audit/SKILL.md
+++ b/.codex/skills/pika-audit/SKILL.md
@@ -11,10 +11,10 @@ Scan changed TypeScript files for codebase violations before committing. Catches
 
 ## Workflow
 
-1. Confirm you are in the Pika repo (`$PIKA_WORKTREE` is set).
+1. Confirm you are in the Pika repo with `git rev-parse --show-toplevel`.
 2. Run the audit script:
    ```bash
-   bash "$PIKA_WORKTREE/.codex/skills/pika-audit/scripts/audit.sh"
+   bash .codex/skills/pika-audit/scripts/audit.sh
    ```
 3. Review any violations reported.
 4. Fix violations before committing (use `/migrate-error-handler` for withErrorHandler issues).

--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -4,7 +4,13 @@
 # Exit 0 = clean. Exit 1 = violations found.
 set -euo pipefail
 
-WORKTREE="${PIKA_WORKTREE:-$PWD}"
+if WORKTREE="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  echo "Pika Audit must be run from inside a git checkout." >&2
+  exit 1
+fi
+WORKTREE="$(cd "$WORKTREE" && pwd)"
 VIOLATIONS=0
 PASS="\033[0;32m✅\033[0m"
 FAIL="\033[0;31m❌\033[0m"

--- a/.codex/skills/pika-main-to-production-merge/SKILL.md
+++ b/.codex/skills/pika-main-to-production-merge/SKILL.md
@@ -15,9 +15,9 @@ Execute a deterministic `main` -> `production` merge flow that respects Pika wor
 2. Run the preflight and merge helper script:
    - `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
 3. If the script reports a created PR URL, share it.
-4. Merge the PR (manually or with `gh pr merge`) and then sync local `production`:
-   - `git -C /Users/stew/Repos/.worktrees/pika/production fetch origin production`
-   - `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
+4. Merge the PR (manually or with `gh pr merge`) and then sync local `production` using the production worktree path printed by the script:
+   - `git -C <production-worktree> fetch origin production`
+   - `git -C <production-worktree> merge --ff-only origin/production`
 5. Report final `origin/production` commit SHA.
 
 ## Conflict Handling

--- a/.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
+++ b/.codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 HUB_REPO="${PIKA_HUB_REPO:-$HOME/Repos/pika}"
-WORKTREE_ROOT="${PIKA_WORKTREE_ROOT:-$HOME/Repos/.worktrees/pika}"
+WORKTREE_ROOT="${PIKA_PROD_WT_ROOT:-$HOME/.codex/worktrees/pika}"
 PROD_WT="$WORKTREE_ROOT/production"
 DATE_TAG="$(date +%Y%m%d)"
 BRANCH_NAME="codex/merge-main-into-production-${DATE_TAG}"
@@ -20,7 +20,7 @@ Usage: $0 [--dry-run]
 
 Env overrides:
   PIKA_HUB_REPO       Hub checkout path (default: $HOME/Repos/pika)
-  PIKA_WORKTREE_ROOT  Worktree root (default: $HOME/Repos/.worktrees/pika)
+  PIKA_PROD_WT_ROOT   Production worktree root for new checkouts (default: $HOME/.codex/worktrees/pika)
 USAGE
 }
 
@@ -65,7 +65,14 @@ fi
 run git -C "$HUB_REPO" fetch origin
 run git -C "$HUB_REPO" worktree prune
 
+EXISTING_PROD_WT="$(git -C "$HUB_REPO" worktree list --porcelain \
+  | awk '/^worktree / { path=$2 } /^branch refs\/heads\/production$/ { print path; exit }')"
+if [[ -n "$EXISTING_PROD_WT" ]]; then
+  PROD_WT="$EXISTING_PROD_WT"
+fi
+
 if [[ ! -d "$PROD_WT" ]]; then
+  run mkdir -p "$(dirname "$PROD_WT")"
   run git -C "$HUB_REPO" worktree add "$PROD_WT" production
 fi
 

--- a/.codex/skills/pika-session-start/SKILL.md
+++ b/.codex/skills/pika-session-start/SKILL.md
@@ -13,7 +13,7 @@ Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with 
 
 1. Run the session start script:
    ```bash
-   bash "$PIKA_WORKTREE/.codex/skills/pika-session-start/scripts/session_start.sh"
+   bash .codex/skills/pika-session-start/scripts/session_start.sh
    ```
 2. Review the output — confirm worktree, branch, `.ai/CURRENT.md`, and feature status.
 3. If an issue number is provided, load it with `gh issue view <number>`.
@@ -21,10 +21,11 @@ Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with 
 
 ## Guardrails
 
-- STOP if `$PIKA_WORKTREE` is unset or equals `$HOME/Repos/pika` (the hub).
+- Run from the current Pika worktree root, not the hub checkout.
+- STOP if the resolved repo root equals `$HOME/Repos/pika` (the hub).
 - STOP if `verify-env.sh` fails.
 - Do NOT write any code until a plan is approved.
-- ALL git commands must use `git -C "$PIKA_WORKTREE"`.
+- Use the resolved repo root consistently for git commands and file paths.
 
 ## Script
 

--- a/.codex/skills/pika-session-start/scripts/session_start.sh
+++ b/.codex/skills/pika-session-start/scripts/session_start.sh
@@ -27,26 +27,36 @@ echo ""
 
 # ── 1. Verify worktree ──────────────────────────────
 echo "── 1. Worktree check"
-if [[ -z "${PIKA_WORKTREE:-}" ]]; then
-  echo -e "${FAIL} PIKA_WORKTREE is not set."
-  echo "   Run: pika codex <worktree>"
+
+if WORKTREE=$(git rev-parse --show-toplevel 2>/dev/null); then
+  WORKTREE=$(cd "$WORKTREE" && pwd -P)
+else
+  echo -e "${FAIL} Current directory is not inside a git checkout."
+  echo "   Open a Pika worktree and re-run this script from inside it."
   exit 1
 fi
 
 HUB="${HOME}/Repos/pika"
-if [[ "$PIKA_WORKTREE" == "$HUB" ]]; then
-  echo -e "${FAIL} PIKA_WORKTREE is the hub ($HUB). Do not work in the hub."
-  echo "   Run: pika codex <worktree>"
+WORKTREE_REAL="$(cd "$WORKTREE" && pwd -P)"
+if [[ -d "$HUB" ]]; then
+  HUB_REAL="$(cd "$HUB" && pwd -P)"
+else
+  HUB_REAL="$HUB"
+fi
+
+if [[ "$WORKTREE_REAL" == "$HUB_REAL" ]]; then
+  echo -e "${FAIL} Current repo is the hub ($HUB). Do not do branch work in the hub."
+  echo "   Create or open a dedicated worktree, then re-run this script from that checkout."
   exit 1
 fi
 
-echo -e "${PASS} PIKA_WORKTREE = $PIKA_WORKTREE"
+echo -e "${PASS} Worktree = $WORKTREE"
 
 # ── 2. Verify environment ───────────────────────────
 echo ""
 echo "── 2. Environment check"
-if [[ -f "$PIKA_WORKTREE/scripts/verify-env.sh" ]]; then
-  bash "$PIKA_WORKTREE/scripts/verify-env.sh" && \
+if [[ -f "$WORKTREE/scripts/verify-env.sh" ]]; then
+  bash "$WORKTREE/scripts/verify-env.sh" && \
     echo -e "${PASS} verify-env.sh passed" || \
     { echo -e "${FAIL} verify-env.sh failed. Fix before proceeding."; exit 1; }
 else
@@ -56,18 +66,18 @@ fi
 # ── 3. Git context ──────────────────────────────────
 echo ""
 echo "── 3. Git context"
-BRANCH=$(git -C "$PIKA_WORKTREE" branch --show-current)
+BRANCH=$(git -C "$WORKTREE" branch --show-current)
 echo -e "${INFO} Branch: $BRANCH"
 echo ""
-git -C "$PIKA_WORKTREE" log --oneline -8
+git -C "$WORKTREE" log --oneline -8
 echo ""
-git -C "$PIKA_WORKTREE" status -sb
+git -C "$WORKTREE" status -sb
 
 # ── 4. Required startup docs ────────────────────────
-START_HERE="$PIKA_WORKTREE/.ai/START-HERE.md"
-CURRENT="$PIKA_WORKTREE/.ai/CURRENT.md"
-FEATURES_FILE="$PIKA_WORKTREE/.ai/features.json"
-AI_INSTRUCTIONS="$PIKA_WORKTREE/docs/ai-instructions.md"
+START_HERE="$WORKTREE/.ai/START-HERE.md"
+CURRENT="$WORKTREE/.ai/CURRENT.md"
+FEATURES_FILE="$WORKTREE/.ai/features.json"
+AI_INSTRUCTIONS="$WORKTREE/docs/ai-instructions.md"
 
 print_required_doc "4. Startup contract (.ai/START-HERE.md)" "$START_HERE" '1,200p'
 print_required_doc "5. Current context (.ai/CURRENT.md)" "$CURRENT" '1,220p'
@@ -77,7 +87,7 @@ print_required_doc "7. AI routing (docs/ai-instructions.md)" "$AI_INSTRUCTIONS" 
 # ── 8. Feature summary ──────────────────────────────
 echo ""
 echo "── 8. Feature summary"
-FEATURES_SCRIPT="$PIKA_WORKTREE/scripts/features.mjs"
+FEATURES_SCRIPT="$WORKTREE/scripts/features.mjs"
 if [[ -f "$FEATURES_SCRIPT" ]]; then
   node "$FEATURES_SCRIPT" summary 2>/dev/null || echo "(features.mjs summary unavailable)"
   echo ""

--- a/.codex/skills/pika-ui-verify/SKILL.md
+++ b/.codex/skills/pika-ui-verify/SKILL.md
@@ -14,7 +14,7 @@ Takes Playwright screenshots of a given Pika page from both teacher and student 
 1. Ensure the dev server is running (`pnpm dev`).
 2. Run the UI verify script with the page path:
    ```bash
-   bash "$PIKA_WORKTREE/.codex/skills/pika-ui-verify/scripts/ui_verify.sh" "classrooms/abc123"
+   bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/abc123"
    ```
 3. Review screenshots in `/tmp/pika-*.png`.
 4. If issues found: fix code and re-run.

--- a/.codex/skills/pika-ui-verify/scripts/ui_verify.sh
+++ b/.codex/skills/pika-ui-verify/scripts/ui_verify.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 PAGE="${1:-}"
-WORKTREE="${PIKA_WORKTREE:-$PWD}"
+WORKTREE="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WORKTREE="$(cd "$WORKTREE" && pwd)"
 BASE_URL="${E2E_BASE_URL:-http://localhost:3000}"
 AUTH_DIR="$WORKTREE/.auth"
 OUT_DIR="/tmp"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Use `docs/guides/ai-ui-testing.md` and `.codex/prompts/ui-verify.md` for the act
 
 - Never switch branches inside an existing feature checkout.
 - Use one worktree per branch.
-- Use `docs/dev-workflow.md` for creation, cleanup, and the `pika` command workflow.
+- Use `docs/dev-workflow.md` for worktree creation, cleanup, and optional `pika` command helpers.
 - Avoid the legacy `scripts/wt-add.sh` helper.
 
 ## Environment Files (.env.local)

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -47,7 +47,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: do non-trivial work in a bound worktree, plan before coding, append a concise `.ai/SESSION-LOG.md` entry, and trim it with `node scripts/trim-session-log.mjs`
+- Workflow: do non-trivial work in a dedicated worktree, plan before coding, append a concise `.ai/SESSION-LOG.md` entry, and trim it with `node scripts/trim-session-log.mjs`
 - Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -18,6 +18,8 @@ Pika is developed using:
 - AI agents (Claude, Codex)
 
 Relying on shell cwd, terminal tabs, or human memory does not scale.
+Codex can use its current checkout/worktree directly; no project-specific
+environment variable is required for it to know where it is working.
 
 This workflow exists to ensure:
 - correctness
@@ -47,17 +49,31 @@ Used for:
 
 ---
 
-### Worktrees
+### Worktree locations
 
-Each feature branch lives in its own worktree:
+New named Pika feature worktrees live under:
 
 ```
-$HOME/Repos/.worktrees/pika/<worktree-name>
+$HOME/.codex/worktrees/pika/<worktree-name>
 ```
+
+Codex Desktop may also create app-managed Pika worktrees under:
+
+```
+$HOME/.codex/worktrees/<id>/pika
+```
+
+Both are valid Codex-native worktrees. Agents should discover the current
+checkout with `git rev-parse --show-toplevel` and then operate from that root.
 
 Rules:
 - One worktree per feature branch
 - Agents operate on exactly one worktree
+- Older worktrees may still exist under `$HOME/Repos/.worktrees/pika`; leave them in place, but create new named worktrees under `$HOME/.codex/worktrees/pika`.
+
+Do not depend on project-specific worktree environment variables. If an
+external script needs a path, pass it explicitly or run it from inside the
+intended worktree.
 
 ---
 
@@ -76,17 +92,18 @@ Each worktree must symlink `.env.local` to that canonical path to avoid drift.
 ## The `pika` command
 
 The `pika` script is a thin router that:
-- binds commands to a specific worktree
-- removes reliance on shell cwd
-- provides a stable contract for AI agents
+- launches commands in a specific worktree
+- helps humans avoid opening agents in the hub by mistake
+- keeps human-launched AI sessions on a named worktree
+
+It is a convenience wrapper, not a requirement for Codex. Codex should create or
+open a git worktree natively and then operate from that worktree root.
 
 ### Quick start
 
 ```bash
 pika ls
 pika claude <worktree>
-# or
-pika codex <worktree>
 ```
 
 ### Available commands
@@ -95,31 +112,22 @@ pika codex <worktree>
   Lists available worktrees.
 
 - `pika claude <worktree> [-- <args...>]`
-  Launches Claude bound to the given worktree.
-  Exports:
-  - `PIKA_PROJECT`
-  - `PIKA_WORKTREE`
-  - `PIKA_WORKTREE_NAME`
+  Launches Claude in the given worktree.
 
   Alias: `pika ai <worktree>` (legacy)
 
 - `pika codex <worktree> [-- <args...>]`
-  Launches Codex bound to the given worktree.
-  Exports:
-  - `PIKA_PROJECT`
-  - `PIKA_WORKTREE`
-  - `PIKA_WORKTREE_NAME`
+  Optional compatibility helper for launching Codex in the given named worktree.
+  Codex Desktop sessions do not need this.
 
 - `pika git <worktree> <git args...>`
-  Runs git safely using:
-  ```bash
-  git -C "$PIKA_WORKTREE" <git args...>
-  ```
+  Runs git in the resolved named worktree. Resolution checks
+  `$HOME/.codex/worktrees/pika` first, then the legacy
+  `$HOME/Repos/.worktrees/pika` path while old worktrees exist.
 
 Use `--` to pass through engine flags, for example:
 ```bash
 pika claude my-worktree -- --model sonnet
-pika codex my-worktree -- --max-output-tokens 1200
 ```
 
 ---
@@ -128,18 +136,14 @@ pika codex my-worktree -- --max-output-tokens 1200
 
 Agents **must** follow these rules:
 
-- NEVER assume the shell cwd
-- ALL git commands MUST use:
-  ```bash
-  git -C "$PIKA_WORKTREE"
-  ```
-- ALL file paths must be absolute or prefixed with:
-  ```bash
-  $PIKA_WORKTREE
-  ```
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- Treat that resolved root as the only checkout for the task.
+- Use absolute paths or paths relative to that root.
+- Do not do feature or branch work in `$HOME/Repos/pika` (the hub).
+- For non-trivial edits started from the hub, create a dedicated worktree first.
 
 If unsure which worktree to use:
-- Ask the user to run `pika ls`
+- Run `git worktree list` from the hub or ask the user which worktree to use.
 
 ---
 
@@ -193,37 +197,56 @@ git merge --no-ff <branch>   # creates merge commit (rejected on main)
 After a feature PR is merged to `main`, clean up from the hub checkout:
 
 ```bash
-export PIKA_WORKTREE="$HOME/Repos/pika"
-git -C "$PIKA_WORKTREE" fetch origin
-git -C "$PIKA_WORKTREE" merge --ff-only origin/main
-git -C "$PIKA_WORKTREE" worktree remove "$HOME/Repos/.worktrees/pika/<branch-name>"
-git -C "$PIKA_WORKTREE" branch -D <branch-name>
+HUB="$HOME/Repos/pika"
+BRANCH="<branch-name>"
+git -C "$HUB" fetch origin
+git -C "$HUB" merge --ff-only origin/main
+WT_PATH="$(git -C "$HUB" worktree list --porcelain \
+  | awk -v branch="$BRANCH" '
+      /^worktree / { path=substr($0, 10) }
+      /^branch refs\/heads\// {
+        ref=substr($0, 19)
+        if (ref == branch) { print path; exit }
+      }')"
+if [ -n "$WT_PATH" ]; then
+  git -C "$HUB" worktree remove "$WT_PATH"
+fi
+git -C "$HUB" branch -D "$BRANCH"
 ```
 
-This keeps the hub checkout fast-forwarded to the merged `main` before removing the finished worktree and branch.
+This keeps the hub checkout fast-forwarded to the merged `main` before removing
+the finished worktree and branch. Resolving the path from Git metadata lets
+cleanup handle both new Codex worktrees and older legacy worktrees.
 
 ---
 
 ## Merging `main` into `production` (PR-required)
 
 `production` is branch-protected and rejects direct pushes. Always merge through a PR.
+Prefer the helper script in `.codex/skills/pika-main-to-production-merge`; the
+manual flow below documents the same behavior.
 
 ### 1) Prepare hub + production worktree
 
 ```bash
-export PIKA_WORKTREE="$HOME/Repos/pika"   # hub checkout
-git -C "$PIKA_WORKTREE" fetch origin
-git -C "$PIKA_WORKTREE" worktree prune
+HUB="$HOME/Repos/pika"
+WT_ROOT="$HOME/.codex/worktrees/pika"
+git -C "$HUB" fetch origin
+git -C "$HUB" worktree prune
 
-if [ ! -d "$HOME/Repos/.worktrees/pika/production" ]; then
-  git -C "$PIKA_WORKTREE" worktree add "$HOME/Repos/.worktrees/pika/production" production
+PROD_WT="$(git -C "$HUB" worktree list --porcelain \
+  | awk '/^worktree / { path=$2 } /^branch refs\/heads\/production$/ { print path; exit }')"
+
+if [ -z "$PROD_WT" ]; then
+  PROD_WT="$WT_ROOT/production"
+  mkdir -p "$(dirname "$PROD_WT")"
+  git -C "$HUB" worktree add "$PROD_WT" production
 fi
 ```
 
 ### 2) Merge latest remote branches in production worktree
 
 ```bash
-export PROD_WT="$HOME/Repos/.worktrees/pika/production"
 git -C "$PROD_WT" fetch origin main production
 git -C "$PROD_WT" merge --ff-only origin/production
 git -C "$PROD_WT" merge origin/main

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -16,7 +16,7 @@ gh issue view <number> --json number,title,body,labels,comments
 5. If the issue affects teacher assignments, teacher quizzes, or teacher tests, also read `docs/guidance/ui/teacher-work-surfaces.md` and `docs/guidance/ui/audit-teacher-work-surfaces.md`.
 
 ## 3) Branch & PR Setup
-- Create or bind a dedicated worktree using `docs/dev-workflow.md`.
+- Create or open a dedicated worktree using `docs/dev-workflow.md`.
 - Prefer a draft PR early; include `Closes #<number>` in the body.
 
 ## 4) Plan Before Coding (MANDATORY)

--- a/scripts/pika
+++ b/scripts/pika
@@ -13,7 +13,8 @@
 
 set -euo pipefail
 
-WORKTREE_ROOT="$HOME/Repos/.worktrees/pika"
+WORKTREE_ROOT="$HOME/.codex/worktrees/pika"
+LEGACY_WORKTREE_ROOT="$HOME/Repos/.worktrees/pika"
 HUB_REPO="$HOME/Repos/pika"
 ENV_CANONICAL="$HOME/Repos/.env/pika/.env.local"
 HUB_SENTINEL="__hub__"
@@ -66,13 +67,13 @@ require_tty_or_die() {
 }
 
 list_worktrees() {
-    if [[ ! -d "$WORKTREE_ROOT" ]]; then
+    if [[ ! -d "$WORKTREE_ROOT" && ! -d "$LEGACY_WORKTREE_ROOT" ]]; then
         return 0
     fi
 
     local lines=""
     if ! lines="$(git -C "$HUB_REPO" worktree list --porcelain 2>/dev/null)"; then
-        ls -1t "$WORKTREE_ROOT" 2>/dev/null || true
+        { ls -1t "$WORKTREE_ROOT" 2>/dev/null || true; ls -1t "$LEGACY_WORKTREE_ROOT" 2>/dev/null || true; } | sort -u
         return 0
     fi
 
@@ -82,10 +83,12 @@ list_worktrees() {
         case "$line" in
             worktree\ *)
                 local path="${line#worktree }"
-                if [[ "$path" == "$WORKTREE_ROOT" || "$path" != "$WORKTREE_ROOT/"* ]]; then
-                    continue
+                local rel=""
+                if [[ "$path" != "$WORKTREE_ROOT" && "$path" == "$WORKTREE_ROOT/"* ]]; then
+                    rel="${path#"$WORKTREE_ROOT/"}"
+                elif [[ "$path" != "$LEGACY_WORKTREE_ROOT" && "$path" == "$LEGACY_WORKTREE_ROOT/"* ]]; then
+                    rel="${path#"$LEGACY_WORKTREE_ROOT/"}"
                 fi
-                local rel="${path#"$WORKTREE_ROOT/"}"
                 if [[ -n "$rel" ]]; then
                     paths+=("$rel")
                 fi
@@ -100,7 +103,8 @@ list_worktrees() {
     local mtime_lines=""
     local rel=""
     for rel in "${paths[@]}"; do
-        local path="$WORKTREE_ROOT/$rel"
+        local path=""
+        path="$(resolve_worktree_path "$rel" 2>/dev/null || echo "$WORKTREE_ROOT/$rel")"
         local mtime=""
         if mtime="$(stat -f %m "$path" 2>/dev/null)"; then
             :
@@ -113,9 +117,22 @@ list_worktrees() {
     done
 
     if [[ -n "$mtime_lines" ]]; then
-        printf "%s" "$mtime_lines" | sort -rn | cut -f2-
+        printf "%s" "$mtime_lines" | sort -rn | cut -f2- | awk '!seen[$0]++'
     fi
     return 0
+}
+
+resolve_worktree_path() {
+    local name="$1"
+    if [[ -d "$WORKTREE_ROOT/$name" ]]; then
+        echo "$WORKTREE_ROOT/$name"
+        return 0
+    fi
+    if [[ -d "$LEGACY_WORKTREE_ROOT/$name" ]]; then
+        echo "$LEGACY_WORKTREE_ROOT/$name"
+        return 0
+    fi
+    return 1
 }
 
 slugify() {
@@ -139,8 +156,8 @@ find_issue_worktree() {
     local issue_num="$1"
     # Look for existing worktree starting with issue number
     local match=""
-    match="$(ls -1 "$WORKTREE_ROOT" 2>/dev/null | grep -E "^${issue_num}(-|$)" | head -n 1)"
-    if [[ -n "$match" && -d "$WORKTREE_ROOT/$match" ]]; then
+    match="$(list_worktrees | grep -E "^${issue_num}(-|$)" | head -n 1)"
+    if [[ -n "$match" ]] && resolve_worktree_path "$match" >/dev/null 2>&1; then
         echo "$match"
         return 0
     fi
@@ -386,6 +403,7 @@ create_worktree() {
         echo "error: worktree path already exists: $path" >&2
         return 1
     fi
+    mkdir -p "$(dirname "$path")"
 
     if git -C "$HUB_REPO" show-ref --verify --quiet "refs/heads/$name"; then
         if ! git -C "$HUB_REPO" worktree add "$path" "$name" >&2; then
@@ -713,7 +731,7 @@ cmd_claude() {
         name="$(ensure_issue_worktree "$name")" || exit 1
     elif [[ -z "$name" ]]; then
         name="$(prompt_for_worktree "" "usage: pika claude <worktree> [-- <args...>]")" || exit 1
-    elif [[ ! -d "$WORKTREE_ROOT/$name" ]]; then
+    elif ! resolve_worktree_path "$name" >/dev/null 2>&1; then
         if [[ "$name" == "main" || "$name" == "hub" ]]; then
             name="$HUB_SENTINEL"
         else
@@ -729,12 +747,8 @@ cmd_claude() {
         path="$HUB_REPO"
         name="main"
     else
-        path="$WORKTREE_ROOT/$name"
+        path="$(resolve_worktree_path "$name")"
     fi
-
-    export PIKA_PROJECT="pika"
-    export PIKA_WORKTREE="$path"
-    export PIKA_WORKTREE_NAME="$name"
 
     cd "$path"
     if (( ${#args[@]} > 0 )); then
@@ -760,7 +774,7 @@ cmd_codex() {
         name="$(ensure_issue_worktree "$name")" || exit 1
     elif [[ -z "$name" ]]; then
         name="$(prompt_for_worktree "" "usage: pika codex <worktree> [-- <args...>]")" || exit 1
-    elif [[ ! -d "$WORKTREE_ROOT/$name" ]]; then
+    elif ! resolve_worktree_path "$name" >/dev/null 2>&1; then
         if [[ "$name" == "main" || "$name" == "hub" ]]; then
             name="$HUB_SENTINEL"
         else
@@ -776,12 +790,8 @@ cmd_codex() {
         path="$HUB_REPO"
         name="main"
     else
-        path="$WORKTREE_ROOT/$name"
+        path="$(resolve_worktree_path "$name")"
     fi
-
-    export PIKA_PROJECT="pika"
-    export PIKA_WORKTREE="$path"
-    export PIKA_WORKTREE_NAME="$name"
 
     cd "$path"
     if (( ${#args[@]} > 0 )); then
@@ -793,9 +803,9 @@ cmd_codex() {
 cmd_git() {
     local name="$1"
     shift
-    local path="$WORKTREE_ROOT/$name"
+    local path=""
 
-    [[ -d "$path" ]] || die "worktree '$name' does not exist"
+    path="$(resolve_worktree_path "$name")" || die "worktree '$name' does not exist"
 
     exec git -C "$path" "$@"
 }

--- a/scripts/run-teacher-tests-parity-challenge.sh
+++ b/scripts/run-teacher-tests-parity-challenge.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORKTREE="${PIKA_WORKTREE:-$(pwd)}"
+WORKTREE="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WORKTREE="$(cd "$WORKTREE" && pwd -P)"
 HUB="${HOME}/Repos/pika"
 MODEL="gpt-5.4"
 REFRESH_AUTH=0
@@ -40,7 +41,13 @@ if [[ ! -d "$WORKTREE" ]]; then
   exit 1
 fi
 
-if [[ "$WORKTREE" == "$HUB" ]]; then
+if [[ -d "$HUB" ]]; then
+  HUB_REAL="$(cd "$HUB" && pwd -P)"
+else
+  HUB_REAL="$HUB"
+fi
+
+if [[ "$WORKTREE" == "$HUB_REAL" ]]; then
   echo "Refusing to run in the hub checkout: $HUB" >&2
   exit 1
 fi
@@ -112,7 +119,7 @@ CHALLENGE_EXIT_CODE=0
 set +e
 (
   cd "$WORKTREE"
-  env PIKA_WORKTREE="$WORKTREE" python3 - "$WORKTREE" "$MODEL" "$REFERENCE_IMAGE" "$BEFORE_IMAGE" "$LAST_MESSAGE" "$PROMPT_COPY" "$TIMEOUT_SECONDS" >"$RUN_LOG" 2>&1 <<'PY'
+  python3 - "$WORKTREE" "$MODEL" "$REFERENCE_IMAGE" "$BEFORE_IMAGE" "$LAST_MESSAGE" "$PROMPT_COPY" "$TIMEOUT_SECONDS" >"$RUN_LOG" 2>&1 <<'PY'
 import subprocess
 import sys
 from pathlib import Path

--- a/scripts/wt-add.sh
+++ b/scripts/wt-add.sh
@@ -11,7 +11,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 BRANCH_NAME="$1"
-WORKTREE_BASE="$HOME/Repos/.worktrees/pika"
+WORKTREE_BASE="$HOME/.codex/worktrees/pika"
 WORKTREE_PATH="$WORKTREE_BASE/$BRANCH_NAME"
 CANONICAL_ENV="$HOME/Repos/.env/pika/.env.local"
 

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -73,7 +73,7 @@ describe('AI startup docs', () => {
 
     for (const file of files) {
       const content = readRepoFile(file)
-      expect(content).not.toMatch(/tail -\d+ "\$PIKA_WORKTREE\/\.ai\/JOURNAL/)
+      expect(content).not.toMatch(/tail -\d+ ".*\.ai\/JOURNAL/)
       expect(content).not.toContain('Append to `.ai/JOURNAL.md`')
     }
   })
@@ -96,7 +96,47 @@ describe('AI startup docs', () => {
     }
   })
 
-  it('renders the required startup docs in order in the automated session-start path', () => {
+  it('documents both named and app-managed Codex worktree locations', () => {
+    const workflow = readRepoFile('docs/dev-workflow.md')
+    const current = readRepoFile('.ai/CURRENT.md')
+
+    for (const content of [workflow, current]) {
+      expect(content).toContain('$HOME/.codex/worktrees/pika/')
+      expect(content).toContain('$HOME/.codex/worktrees/<id>/pika')
+    }
+    expect(workflow).toContain('git rev-parse --show-toplevel')
+  })
+
+  it('documents cleanup by resolving the registered worktree path', () => {
+    const files = ['.ai/START-HERE.md', 'docs/dev-workflow.md']
+
+    for (const file of files) {
+      const content = readRepoFile(file)
+
+      expect(content).toContain('worktree list --porcelain')
+      expect(content).toContain('awk -v branch="$BRANCH"')
+      expect(content).not.toContain('worktree remove "$HOME/.codex/worktrees/pika/<branch-name>"')
+      expect(content).not.toContain('worktree remove "$WT_ROOT/<branch-name>"')
+    }
+  })
+
+  it('keeps production merge prompts on the production-worktree helper flow', () => {
+    const files = [
+      '.claude/commands/merge-main-into-production.md',
+      '.codex/prompts/merge-main-into-production.md',
+    ]
+
+    for (const file of files) {
+      const content = readRepoFile(file)
+
+      expect(content).toContain('merge_main_into_production.sh')
+      expect(content).not.toContain('hub-level operation')
+      expect(content).not.toContain('git -C "$HOME/Repos/pika" switch main')
+      expect(content).not.toContain('git -C "$HOME/Repos/pika" switch production')
+    }
+  })
+
+  it('renders the required startup docs in order from the current git root', () => {
     const repoRoot = makeFixtureWorktree()
     const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
 
@@ -106,7 +146,6 @@ describe('AI startup docs', () => {
         env: {
           ...process.env,
           HOME: repoRoot,
-          PIKA_WORKTREE: repoRoot,
         },
         encoding: 'utf8',
       })
@@ -125,6 +164,50 @@ describe('AI startup docs', () => {
       expect(output).toContain('FEATURE NEXT MARKER')
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects the hub checkout for automated session-start', () => {
+    const homeRoot = mkdtempSync(join(tmpdir(), 'pika-session-hub-'))
+    const hubRoot = join(homeRoot, 'Repos/pika')
+    mkdirSync(hubRoot, { recursive: true })
+
+    execFileSync('git', ['init'], { cwd: hubRoot })
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: hubRoot,
+        env: {
+          ...process.env,
+          HOME: homeRoot,
+        },
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('Current repo is the hub')
+    } finally {
+      rmSync(homeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('makes the audit script fail outside a git checkout', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'pika-audit-nongit-'))
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: tempRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'Pika Audit must be run from inside a git checkout.',
+      )
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
## Summary
- Removes the Pika-specific worktree environment-variable contract from AI guidance, prompts, skills, and helper scripts.
- Moves the forward worktree flow to native Codex usage: named Pika worktrees under `/Users/stew/.codex/worktrees/pika/<name>` and Codex Desktop app-managed worktrees under `/Users/stew/.codex/worktrees/<id>/pika`.
- Keeps legacy worktrees resolvable while making cleanup path-discovery based via `git worktree list --porcelain`.
- Updates the production merge guidance/helper to use a registered production worktree instead of switching the hub checkout.
- Adds weekly workflow-friction automation coverage in the session log and regression tests for the AI startup/worktree guidance.

## Impact
Codex should now operate from the resolved git root natively instead of relying on a Pika-specific binding environment. Humans can still use `pika` as a named-worktree convenience, and older `/Users/stew/Repos/.worktrees/pika` checkouts are left in place until normal cleanup.

## Validation
- `pnpm test tests/unit/ai-startup-docs.test.ts`
- `bash -n scripts/pika scripts/wt-add.sh scripts/run-teacher-tests-parity-challenge.sh .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh .codex/skills/pika-audit/scripts/audit.sh .codex/skills/pika-session-start/scripts/session_start.sh .codex/skills/pika-ui-verify/scripts/ui_verify.sh`
- `git diff --check`
- `scripts/pika ls`
- Legacy worktree env-var scan returned no matches.
