### PR TITLE
[codex] Remove student legacy quizzes nav plumbing

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Rebased survey cleanup onto origin/main
-
-**Completed:**
-- Stashed dirty work, fetched `origin/main`, and rebased `codex/survey-experience-cleanup`.
-- Re-applied local changes and resolved the single conflict in `src/app/classrooms/[classroomId]/TeacherClassroomView.tsx`.
-- Kept upstream assignment split-pane behavior and branch survey results/action-bar behavior together.
-- Confirmed no branch-added Supabase migrations needed resequencing.
-- Dropped the temporary `pre-rebase-main-20260514-131209` stash after validation.
-
-**Validation:**
-- `pnpm lint`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/StudentAssignmentsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-14 — Survey creation modal title focus
 
 **Completed:**
@@ -332,3 +317,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - Read back `/Users/stew/.codex/automations/weekly-pika-simplification/automation.toml`.
 - Read back `/Users/stew/.codex/automations/pika-workflow-friction-review/automation.toml`.
+
+## 2026-05-19 — Remove student legacy quizzes nav plumbing
+
+**Completed:**
+- Removed legacy `activeQuizzesCount` from student sidebar notification state and the `/api/student/notifications` response.
+- Kept the student assessment sidebar focused on Tests and added coverage that no student Quizzes nav item is rendered.
+- Added coverage that legacy `?tab=quizzes` URLs fall back to the default student Today tab and clear quiz-specific params.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/NavItems.test.tsx tests/components/StudentNotificationsProvider.test.tsx tests/api/student/notifications.test.ts tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=today"`
+- Additional student sidebar screenshot: `/tmp/pika-student-desktop-expanded.png`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/api/student/notifications/route.ts
+++ b/src/app/api/student/notifications/route.ts
@@ -5,7 +5,6 @@ import { getTodayInToronto } from '@/lib/timezone'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
-import { isQuizVisibleToStudents } from '@/lib/server/quizzes'
 import { withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
@@ -133,124 +132,69 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     }
   }
 
-  async function countActiveUnanswered(
-    table: 'quizzes' | 'tests',
+  async function countActiveUnansweredTests(
     opts?: { tolerateMissingTable?: boolean }
   ): Promise<{ count: number; error: boolean }> {
     const tolerateMissingTable = opts?.tolerateMissingTable === true
 
-    let activeIds: string[] = []
+    const { data: activeRows, error: activeError } = await supabase
+      .from('tests')
+      .select('id')
+      .eq('classroom_id', classroomId)
+      .eq('status', 'active')
 
-    if (table === 'quizzes') {
-      const { data: activeRows, error: activeError } = await supabase
-        .from('quizzes')
-        .select('id,opens_at')
-        .eq('classroom_id', classroomId)
-        .eq('status', 'active')
-
-      if (activeError) {
-        if (tolerateMissingTable && activeError.code === 'PGRST205') {
-          return { count: 0, error: false }
-        }
-        console.error(`Error fetching ${table}:`, activeError)
-        return { count: 0, error: true }
+    if (activeError) {
+      if (tolerateMissingTable && activeError.code === 'PGRST205') {
+        return { count: 0, error: false }
       }
-
-      activeIds = (activeRows || [])
-        .filter((row) =>
-          isQuizVisibleToStudents({
-            status: 'active',
-            opens_at: row.opens_at ?? null,
-          })
-        )
-        .map((row) => row.id)
-    } else {
-      const { data: activeRows, error: activeError } = await supabase
-        .from('tests')
-        .select('id')
-        .eq('classroom_id', classroomId)
-        .eq('status', 'active')
-
-      if (activeError) {
-        if (tolerateMissingTable && activeError.code === 'PGRST205') {
-          return { count: 0, error: false }
-        }
-        console.error(`Error fetching ${table}:`, activeError)
-        return { count: 0, error: true }
-      }
-
-      activeIds = (activeRows || []).map((row) => row.id)
+      console.error('Error fetching tests:', activeError)
+      return { count: 0, error: true }
     }
+
+    const activeIds = (activeRows || []).map((row) => row.id)
 
     if (activeIds.length === 0) {
       return { count: 0, error: false }
     }
 
-    let responses:
-      | Array<{ quiz_id: string }>
-      | Array<{ test_id: string; selected_option: unknown; response_text: unknown }>
-      | null = null
-    let responsesError: { code?: string; message?: string; details?: string; hint?: string } | null = null
+    const testResponsesResult = await supabase
+      .from('test_responses')
+      .select('test_id, selected_option, response_text')
+      .eq('student_id', user.id)
+      .in('test_id', activeIds)
 
-    if (table === 'tests') {
-      const testResponsesResult = await supabase
-        .from('test_responses')
-        .select('test_id, selected_option, response_text')
-        .eq('student_id', user.id)
-        .in('test_id', activeIds)
-
-      responses = (testResponsesResult.data as typeof responses) || null
-      responsesError = testResponsesResult.error
-    } else {
-      const quizResponsesResult = await supabase
-        .from('quiz_responses')
-        .select('quiz_id')
-        .eq('student_id', user.id)
-        .in('quiz_id', activeIds)
-
-      responses = (quizResponsesResult.data as typeof responses) || null
-      responsesError = quizResponsesResult.error
-    }
+    const responses =
+      (testResponsesResult.data as Array<{ test_id: string; selected_option: unknown; response_text: unknown }> | null) || []
+    const responsesError = testResponsesResult.error
 
     if (responsesError) {
       if (tolerateMissingTable && responsesError.code === 'PGRST205') {
         return { count: 0, error: false }
       }
-      console.error(`Error fetching ${table} responses:`, responsesError)
+      console.error('Error fetching test responses:', responsesError)
       return { count: 0, error: true }
     }
 
     const respondedIds = new Set<string>()
     for (const row of responses || []) {
-      let assessmentId: string | null = null
-      if (table === 'tests') {
-        if (!hasMeaningfulTestResponse(row)) continue
-        assessmentId = (row as { test_id: string }).test_id
-      } else {
-        assessmentId = (row as { quiz_id: string }).quiz_id
-      }
-
-      if (assessmentId) {
-        respondedIds.add(assessmentId)
-      }
+      if (!hasMeaningfulTestResponse(row)) continue
+      respondedIds.add(row.test_id)
     }
 
-    if (table === 'tests') {
-      const { data: submittedAttempts, error: attemptsError } = await supabase
-        .from('test_attempts')
-        .select('test_id, is_submitted')
-        .eq('student_id', user.id)
-        .in('test_id', activeIds)
+    const { data: submittedAttempts, error: attemptsError } = await supabase
+      .from('test_attempts')
+      .select('test_id, is_submitted')
+      .eq('student_id', user.id)
+      .in('test_id', activeIds)
 
-      if (attemptsError && attemptsError.code !== 'PGRST205') {
-        console.error('Error fetching test_attempts:', attemptsError)
-        return { count: 0, error: true }
-      }
+    if (attemptsError && attemptsError.code !== 'PGRST205') {
+      console.error('Error fetching test_attempts:', attemptsError)
+      return { count: 0, error: true }
+    }
 
-      for (const attempt of submittedAttempts || []) {
-        if (attempt.is_submitted && attempt.test_id) {
-          respondedIds.add(attempt.test_id)
-        }
+    for (const attempt of submittedAttempts || []) {
+      if (attempt.is_submitted && attempt.test_id) {
+        respondedIds.add(attempt.test_id)
       }
     }
 
@@ -260,18 +204,7 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     }
   }
 
-  const activeQuizzesResult = await countActiveUnanswered(
-    'quizzes',
-  )
-  if (activeQuizzesResult.error) {
-    return NextResponse.json(
-      { error: 'Failed to check notifications' },
-      { status: 500 }
-    )
-  }
-
-  const activeTestsResult = await countActiveUnanswered(
-    'tests',
+  const activeTestsResult = await countActiveUnansweredTests(
     { tolerateMissingTable: true }
   )
   if (activeTestsResult.error) {
@@ -322,7 +255,6 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
   return NextResponse.json({
     hasTodayEntry,
     unviewedAssignmentsCount: unviewedCount,
-    activeQuizzesCount: activeQuizzesResult.count,
     activeTestsCount: activeTestsResult.count,
     unreadAnnouncementsCount,
   })

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -782,8 +782,6 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     setRemoteClosureNotice(null)
     if (isTestsView) {
       notifications?.clearActiveTestsCount()
-    } else {
-      notifications?.clearActiveQuizzesCount()
     }
     void loadQuizzes()
 

--- a/src/components/StudentNotificationsProvider.tsx
+++ b/src/components/StudentNotificationsProvider.tsx
@@ -14,14 +14,12 @@ import {
 type NotificationState = {
   hasTodayEntry: boolean
   unviewedAssignmentsCount: number
-  activeQuizzesCount: number
   activeTestsCount: number
   unreadAnnouncementsCount: number
   loading: boolean
   refresh: () => Promise<void>
   markTodayComplete: () => void
   decrementUnviewedCount: () => void
-  clearActiveQuizzesCount: () => void
   clearActiveTestsCount: () => void
   markAnnouncementsRead: () => void
 }
@@ -37,7 +35,6 @@ export function StudentNotificationsProvider({
 }) {
   const [hasTodayEntry, setHasTodayEntry] = useState(true) // Assume complete to avoid flash
   const [unviewedAssignmentsCount, setUnviewedAssignmentsCount] = useState(0)
-  const [activeQuizzesCount, setActiveQuizzesCount] = useState(0)
   const [activeTestsCount, setActiveTestsCount] = useState(0)
   const [unreadAnnouncementsCount, setUnreadAnnouncementsCount] = useState(0)
   const [loading, setLoading] = useState(true)
@@ -54,7 +51,6 @@ export function StudentNotificationsProvider({
       const data = await res.json()
       setHasTodayEntry(data.hasTodayEntry)
       setUnviewedAssignmentsCount(data.unviewedAssignmentsCount)
-      setActiveQuizzesCount(data.activeQuizzesCount ?? 0)
       setActiveTestsCount(data.activeTestsCount ?? 0)
       setUnreadAnnouncementsCount(data.unreadAnnouncementsCount ?? 0)
       lastFetchRef.current = Date.now()
@@ -92,10 +88,6 @@ export function StudentNotificationsProvider({
     setUnviewedAssignmentsCount((prev) => Math.max(0, prev - 1))
   }, [])
 
-  const clearActiveQuizzesCount = useCallback(() => {
-    setActiveQuizzesCount(0)
-  }, [])
-
   const clearActiveTestsCount = useCallback(() => {
     setActiveTestsCount(0)
   }, [])
@@ -108,28 +100,24 @@ export function StudentNotificationsProvider({
     () => ({
       hasTodayEntry,
       unviewedAssignmentsCount,
-      activeQuizzesCount,
       activeTestsCount,
       unreadAnnouncementsCount,
       loading,
       refresh,
       markTodayComplete,
       decrementUnviewedCount,
-      clearActiveQuizzesCount,
       clearActiveTestsCount,
       markAnnouncementsRead,
     }),
     [
       hasTodayEntry,
       unviewedAssignmentsCount,
-      activeQuizzesCount,
       activeTestsCount,
       unreadAnnouncementsCount,
       loading,
       refresh,
       markTodayComplete,
       decrementUnviewedCount,
-      clearActiveQuizzesCount,
       clearActiveTestsCount,
       markAnnouncementsRead,
     ]

--- a/tests/api/student/notifications.test.ts
+++ b/tests/api/student/notifications.test.ts
@@ -448,45 +448,6 @@ describe('GET /api/student/notifications', () => {
       expect(data.error).toBe('Failed to check notifications')
     })
 
-    it('should return 500 when quizzes query fails', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: null, error: { message: 'Database error' } },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(500)
-      expect(data.error).toBe('Failed to check notifications')
-    })
-
-    it('should return 500 when quiz_responses query fails', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: [{ id: 'quiz-1' }], error: null },
-        quiz_responses: { data: null, error: { message: 'Database error' } },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(500)
-      expect(data.error).toBe('Failed to check notifications')
-    })
-
     it('should return 500 when tests query fails (non-migration error)', async () => {
       ;(mockSupabaseClient.from as any) = createTableMock({
         class_days: { data: { is_class_day: true }, error: null },
@@ -505,93 +466,6 @@ describe('GET /api/student/notifications', () => {
 
       expect(response.status).toBe(500)
       expect(data.error).toBe('Failed to check notifications')
-    })
-  })
-
-  describe('active quizzes count', () => {
-    it('should count active quizzes with no student response', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: [{ id: 'quiz-1' }, { id: 'quiz-2' }], error: null },
-        quiz_responses: { data: [], error: null },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.activeQuizzesCount).toBe(2)
-    })
-
-    it('should exclude quizzes the student has responded to', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: [{ id: 'quiz-1' }, { id: 'quiz-2' }, { id: 'quiz-3' }], error: null },
-        quiz_responses: {
-          data: [{ quiz_id: 'quiz-1' }, { quiz_id: 'quiz-3' }],
-          error: null,
-        },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.activeQuizzesCount).toBe(1)
-    })
-
-    it('should return 0 when no active quizzes exist', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: [], error: null },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.activeQuizzesCount).toBe(0)
-    })
-
-    it('should return 0 when student has responded to all active quizzes', async () => {
-      ;(mockSupabaseClient.from as any) = createTableMock({
-        class_days: { data: { is_class_day: true }, error: null },
-        entries: { data: { id: 'entry-1' }, error: null },
-        assignments: { data: [], error: null },
-        quizzes: { data: [{ id: 'quiz-1' }, { id: 'quiz-2' }], error: null },
-        quiz_responses: {
-          data: [{ quiz_id: 'quiz-1' }, { quiz_id: 'quiz-2' }],
-          error: null,
-        },
-      })
-
-      const request = new NextRequest(
-        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
-      )
-
-      const response = await GET(request)
-      const data = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(data.activeQuizzesCount).toBe(0)
     })
   })
 
@@ -635,7 +509,7 @@ describe('GET /api/student/notifications', () => {
       const data = await response.json()
 
       expect(response.status).toBe(200)
-      expect(data.activeQuizzesCount).toBe(1)
+      expect(data.activeQuizzesCount).toBeUndefined()
       expect(data.activeTestsCount).toBe(0)
     })
 

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -460,6 +460,21 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
   })
 
+  it('falls back from the legacy quizzes tab to the default student tab', async () => {
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=quizzes&quizId=quiz-1')
+
+    renderStudentClient({
+      initialTab: 'quizzes',
+      initialSearchParams: { tab: 'quizzes', quizId: 'quiz-1' },
+    })
+
+    await waitFor(() => {
+      const params = new URLSearchParams(window.location.search)
+      expect(params.get('tab')).toBe('today')
+      expect(params.has('quizId')).toBe(false)
+    })
+  })
+
   it('does not pin the tests summary label in the app shell title slot', () => {
     window.history.replaceState({}, '', '/classrooms/classroom-1?tab=tests')
 

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -6,7 +6,6 @@ import { NavItems } from '@/components/layout/NavItems'
 type MockNotifications = {
   hasTodayEntry: boolean
   unviewedAssignmentsCount: number
-  activeQuizzesCount: number
   activeTestsCount: number
   unreadAnnouncementsCount: number
   loading: boolean
@@ -35,7 +34,6 @@ function baseNotifications(overrides: Partial<MockNotifications> = {}): MockNoti
   return {
     hasTodayEntry: true,
     unviewedAssignmentsCount: 0,
-    activeQuizzesCount: 0,
     activeTestsCount: 0,
     unreadAnnouncementsCount: 0,
     loading: false,
@@ -78,6 +76,13 @@ describe('NavItems notification dots', () => {
     expect(screen.queryByRole('link', { name: 'Quizzes' })).toBeNull()
   })
 
+  it('does not render a student quizzes nav item', () => {
+    renderNav('student', 'today')
+
+    expect(screen.getByRole('link', { name: 'Tests' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Quizzes' })).toBeNull()
+  })
+
   it('uses dot path for student assignments nav item', () => {
     mockNotifications = baseNotifications({ unviewedAssignmentsCount: 2 })
     renderNav('student', 'assignments')
@@ -116,7 +121,6 @@ describe('NavItems notification dots', () => {
     mockNotifications = baseNotifications({
       hasTodayEntry: false,
       unviewedAssignmentsCount: 3,
-      activeQuizzesCount: 2,
       activeTestsCount: 1,
       unreadAnnouncementsCount: 4,
     })

--- a/tests/components/StudentNotificationsProvider.test.tsx
+++ b/tests/components/StudentNotificationsProvider.test.tsx
@@ -17,7 +17,6 @@ describe('StudentNotificationsProvider', () => {
       json: async () => ({
         hasTodayEntry: true,
         unviewedAssignmentsCount: 0,
-        activeQuizzesCount: 0,
         activeTestsCount: 0,
         unreadAnnouncementsCount: 0,
       }),


### PR DESCRIPTION
## Summary
- remove legacy `activeQuizzesCount` from the student notifications API and provider state
- keep the student classroom sidebar focused on `Tests`, with coverage that `Quizzes` is not rendered
- add student fallback coverage for legacy `?tab=quizzes` URLs so they return to `Today` and clear quiz params

## Why
The visible student Quizzes tab has been removed from the classroom experience, with surveys now covering that loose use case. This removes the leftover sidebar notification plumbing so active quiz state no longer affects student navigation behavior.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/NavItems.test.tsx tests/components/StudentNotificationsProvider.test.tsx tests/api/student/notifications.test.ts tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
- `pnpm lint`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=today"`
- visual check of `/tmp/pika-student-desktop-expanded.png` confirmed the student sidebar shows Today, Classwork, Tests, Calendar, Syllabus, and Announcements, with no Quizzes item
- `pnpm test`
- `pnpm build`

## Review
Self-review found no blocking issues. The remaining quiz code paths are left intact for legacy/API compatibility and teacher-side quiz surfaces.