### PR TITLE
[codex] Remove assignment repo submission option

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -337,3 +337,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
 - Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
 - `pnpm test`
+## 2026-05-20 — Remove assignment repo submission option
+
+**Completed:**
+- Removed the separate student `Repo` action and GitHub repo metadata dialog from the assignment editor.
+- Stopped student assignment saves from writing `repo_url` / `github_username`; repo links now live in editor content as artifacts.
+- Changed submission validation so repo metadata alone is not submittable work.
+- Updated repo analysis target resolution to fall back to pasted GitHub repo artifacts and infer the GitHub username from the repo owner when no legacy username is present.
+- Kept teacher assignment artifact and repo-analysis surfaces working with pasted repo artifacts.
+- Hid the unfinished repository marking section from the teacher grading inspector and removed the batch repo-analysis action while leaving backend repo artifact extraction/analysis plumbing in place for a later rebuild.
+
+**Validation:**
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignment-repo-targets.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/assignment-docs/submit.test.ts tests/unit/assignments.test.ts`
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
+- Additional assignment screenshots: `/tmp/pika-student-assignment-editor.png`, `/tmp/pika-teacher-assignment-workspace.png`
+- Additional hidden-repo marking screenshots: `/tmp/pika-teacher-assignment-workspace-hidden-repo.png`, `/tmp/pika-teacher-assignment-actions-hidden-repo.png`
+- `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,35 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Teacher selected-survey icon controls
-
-**Completed:**
-- Replaced the selected-survey split button with direct icon buttons for poll open/close, results visibility, and edit survey.
-- Made the poll state action prominent with play/stop icons and primary/danger treatment.
-- Removed the selected-survey response-editing action and moved `Editable responses` into the survey authoring modal.
-- Updated tests for the direct icon controls and the editable-response setting PATCH flow.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3022 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=47927a72-ffe7-45d8-a51d-9f60bd9696d6'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-icon-controls.png`, `/tmp/pika-survey-edit-modal-settings.png`; temporary survey fixture was deleted afterward.
-
-## 2026-05-14 — Survey hidden-results and live-change copy
-
-**Completed:**
-- Replaced the hidden-results selected-survey icon with a slashed graph icon instead of an eye-off icon.
-- Renamed the survey response-editing setting to `Allow live changes`.
-- Moved `Allow live changes` onto the same survey authoring modal header row as the title, Code, and Delete controls.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3023 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=b04fcfbf-1071-4d14-af9f-592c35a9f02a'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-hidden-results-icon.png`, `/tmp/pika-survey-edit-modal-live-changes-row.png`; temporary survey fixture was deleted afterward.
-
 ## 2026-05-14 — Survey question autosave controls
 
 **Completed:**
@@ -337,6 +308,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
 - Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
 - `pnpm test`
+
 ## 2026-05-20 — Remove assignment repo submission option
 
 **Completed:**
@@ -357,3 +329,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Additional assignment screenshots: `/tmp/pika-student-assignment-editor.png`, `/tmp/pika-teacher-assignment-workspace.png`
 - Additional hidden-repo marking screenshots: `/tmp/pika-teacher-assignment-workspace-hidden-repo.png`, `/tmp/pika-teacher-assignment-actions-hidden-repo.png`
 - `git diff --check`
+
+## 2026-05-20 — Assignment repo follow-up
+
+**Completed:**
+- Changed assignment repo target resolution so pasted repo artifacts in current submission content take precedence over legacy `assignment_docs.repo_url` metadata.
+- Kept legacy repo metadata as a fallback only, leaving `repo_url`/`github_username` as deprecated fields for now.
+- Added unit coverage for artifact-over-legacy repo target precedence.
+- Trimmed the rolling session log to satisfy the 20-entry startup guard.
+
+**Validation:**
+- `pnpm test tests/unit/assignment-repo-targets.test.ts`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/assignment-repo-targets.test.ts`
+- `pnpm lint`
+- `git diff --check`
+- `bash scripts/verify-env.sh`

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -191,8 +191,6 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
     content: TiptapContent
     trigger?: AssignmentDocHistoryTrigger
   }
-  const repoUrl = typeof body.repo_url === 'string' ? body.repo_url.trim() : undefined
-  const githubUsername = typeof body.github_username === 'string' ? body.github_username.trim() : undefined
   // Clamp client-reported tracking values to non-negative integers
   const paste_word_count = Math.max(0, Math.round(Number(body.paste_word_count) || 0))
   const keystroke_count = Math.max(0, Math.round(Number(body.keystroke_count) || 0))
@@ -253,7 +251,7 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
   // Fetch doc to enforce ownership and submission rules
   const { data: existingDoc, error: docFetchError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, is_submitted, content, repo_url, github_username')
+    .select('id, student_id, is_submitted, content')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -266,8 +264,8 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
           assignment_id: assignmentId,
           student_id: user.id,
           content,
-          repo_url: repoUrl ?? null,
-          github_username: githubUsername ?? null,
+          repo_url: null,
+          github_username: null,
           is_submitted: false,
           submitted_at: null,
         })
@@ -320,8 +318,6 @@ export const PATCH = withErrorHandler('PatchAssignmentDoc', async (request, cont
     .from('assignment_docs')
     .update({
       content,
-      ...(repoUrl !== undefined ? { repo_url: repoUrl || null } : {}),
-      ...(githubUsername !== undefined ? { github_username: githubUsername || null } : {}),
     })
     .eq('id', existingDoc.id)
     .select()

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -50,7 +50,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   // Check if doc exists
   const { data: existingDoc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content, repo_url, github_username')
+    .select('id, student_id, content')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()

--- a/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
+++ b/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/repo-review'
 import { gradeRepoReviewFeedback } from '@/lib/repo-review-ai'
 import {
+  extractRepoArtifactsFromContent,
   resolveAssignmentRepoTarget,
   saveAssignmentRepoTarget,
   validatePublicGitHubRepo,
@@ -117,6 +118,7 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
     const studentId = enrollment.student_id
     const doc = docMap.get(studentId)
     const resolved = resolveAssignmentRepoTarget({
+      candidateRepos: extractRepoArtifactsFromContent(doc?.content),
       submittedRepoUrl: typeof doc?.repo_url === 'string' ? doc.repo_url : null,
       submittedGitHubUsername: typeof doc?.github_username === 'string' ? doc.github_username : null,
       target: repoTargetMap.get(studentId) || null,

--- a/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler, apiErrors } from '@/lib/api-handler'
 import {
+  extractRepoArtifactsFromContent,
   loadAssignmentRepoTarget,
+  resolveAssignmentRepoTarget,
   saveAssignmentRepoTarget,
   validatePublicGitHubRepo,
 } from '@/lib/server/assignment-repo-targets'
@@ -26,12 +28,19 @@ export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (req
 
   const { data: existingDoc } = await supabase
     .from('assignment_docs')
-    .select('repo_url, github_username')
+    .select('content, repo_url, github_username')
     .eq('assignment_id', assignmentId)
     .eq('student_id', studentId)
     .maybeSingle()
 
   let repoTarget = await loadAssignmentRepoTarget(assignmentId, studentId)
+  const repoSelection = resolveAssignmentRepoTarget({
+    candidateRepos: extractRepoArtifactsFromContent(existingDoc?.content),
+    submittedRepoUrl: existingDoc?.repo_url ?? null,
+    submittedGitHubUsername: existingDoc?.github_username ?? null,
+    target: repoTarget,
+  })
+
   if (selectionMode === 'auto' && !selectedRepoUrl && !overrideGitHubUsername) {
     if (repoTarget?.id) {
       await supabase
@@ -41,7 +50,7 @@ export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (req
       repoTarget = null
     }
   } else {
-    const submittedRepoUrl = existingDoc?.repo_url?.trim() || ''
+    const submittedRepoUrl = repoSelection.submittedRepoUrl?.trim() || ''
     const repoUrlToValidate = selectedRepoUrl || submittedRepoUrl
     if (!repoUrlToValidate) {
       throw apiErrors.badRequest('selected_repo_url is required when saving a repo target')
@@ -63,7 +72,7 @@ export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (req
 
   return NextResponse.json({
     repo_target: repoTarget,
-    submitted_repo_url: existingDoc?.repo_url || null,
-    submitted_github_username: existingDoc?.github_username || null,
+    submitted_repo_url: repoSelection.submittedRepoUrl || null,
+    submitted_github_username: repoSelection.submittedGitHubUsername || null,
   })
 })

--- a/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { calculateAssignmentStatus } from '@/lib/assignments'
 import {
+  extractRepoArtifactsFromContent,
   loadAssignmentRepoTarget,
   resolveAssignmentRepoTarget,
 } from '@/lib/server/assignment-repo-targets'
@@ -90,6 +91,7 @@ export const GET = withErrorHandler('GetTeacherAssignmentStudent', async (reques
 
   const status = calculateAssignmentStatus(assignment, doc)
   const repoSelection = resolveAssignmentRepoTarget({
+    candidateRepos: extractRepoArtifactsFromContent(doc?.content),
     submittedRepoUrl: doc?.repo_url ?? null,
     submittedGitHubUsername: doc?.github_username ?? null,
     target: repoTarget,

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Pencil } from 'lucide-react'
 import { Button, Card, ContentDialog, EmptyState, RefreshingIndicator } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
@@ -53,7 +52,7 @@ export function StudentAssignmentsTab({
   const [hasLoaded, setHasLoaded] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
-  const [editorState, setEditorState] = useState({ isSubmitted: false, canSubmit: false, submitting: false, hasRepoMetadata: false })
+  const [editorState, setEditorState] = useState({ isSubmitted: false, canSubmit: false, submitting: false })
   const editorRef = useRef<StudentAssignmentEditorHandle>(null)
   const wasActiveRef = useRef(isActive)
   const showBlockingSpinner = useDelayedBusy(
@@ -256,14 +255,6 @@ export function StudentAssignmentsTab({
             <div className="flex items-center gap-2">
               <Button size="sm" variant="secondary" onClick={() => setShowInstructions(true)}>
                 Instructions
-              </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => editorRef.current?.openRepoDialog()}
-              >
-                <Pencil className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
-                Repo
               </Button>
             </div>
           }

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -676,7 +676,6 @@ export function TeacherClassroomView({
   // Batch grading state
   const [isAutoGrading, setIsAutoGrading] = useState(false)
   const [isGradeSelectedSaving, setIsGradeSelectedSaving] = useState(false)
-  const [isArtifactRepoAnalyzing, setIsArtifactRepoAnalyzing] = useState(false)
   const [isReturning, setIsReturning] = useState(false)
   const [batchProgressCount, setBatchProgressCount] = useState(0)
   const [showReturnConfirm, setShowReturnConfirm] = useState(false)
@@ -1562,38 +1561,6 @@ export function TeacherClassroomView({
     }
   }
 
-  async function handleBatchArtifactRepoAnalyze() {
-    if (!selectedAssignmentData || batchSelectedCount === 0) return
-    setBatchProgressCount(batchSelectedCount)
-    setIsArtifactRepoAnalyzing(true)
-    setError('')
-    setInfo('')
-    try {
-      const res = await fetch(`/api/teacher/assignments/${selectedAssignmentData.assignment.id}/artifact-repo/run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: Array.from(batchSelectedIds) }),
-      })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Repo analysis failed')
-
-      const skipSummary = Object.entries((data.skipped_reasons || {}) as Record<string, number>)
-        .map(([reason, count]) => `${count} ${reason}`)
-        .join(' • ')
-      setInfo(
-        `Analyzed ${data.analyzed_students ?? 0} student(s) across ${data.repo_groups ?? 0} repo group(s)${
-          skipSummary ? ` • ${skipSummary}` : ''
-        }`
-      )
-      batchClearSelection()
-      setRefreshCounter((c) => c + 1)
-    } catch (err: any) {
-      setError(err.message || 'Repo analysis failed')
-    } finally {
-      setIsArtifactRepoAnalyzing(false)
-    }
-  }
-
   async function handleBatchReturn() {
     if (!selectedAssignmentData || batchSelectedCount === 0) return
     setBatchProgressCount(batchSelectedCount)
@@ -2082,7 +2049,6 @@ export function TeacherClassroomView({
     isGradeSelectedSaving ||
     isAutoGrading ||
     hasActiveAssignmentAiRun ||
-    isArtifactRepoAnalyzing ||
     isReturning ||
     isReadOnly ||
     batchSelectedCount === 0 ||
@@ -2092,7 +2058,6 @@ export function TeacherClassroomView({
     isGradeSelectedSaving ||
     isAutoGrading ||
     hasActiveAssignmentAiRun ||
-    isArtifactRepoAnalyzing ||
     isReturning ||
     isReadOnly ||
     batchSelectedCount === 0 ||
@@ -2111,13 +2076,11 @@ export function TeacherClassroomView({
     gradeSelectedConfirmTarget === 'comments' ? 'Applying comments' : 'Applying grade'
   const activeWorkMessage = showAssignmentAiRunOverlay
     ? assignmentAiRunOverlayLabel
-    : isArtifactRepoAnalyzing
-      ? `Analyzing repos for ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-      : isReturning
-        ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-        : isGradeSelectedSaving
-          ? `${gradeSelectedSavingLabel} to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
-          : ''
+    : isReturning
+      ? `Returning to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+      : isGradeSelectedSaving
+        ? `${gradeSelectedSavingLabel} to ${batchProgressCount} student${batchProgressCount === 1 ? '' : 's'}…`
+        : ''
   useOverlayMessage(!!activeWorkMessage, activeWorkMessage, { tone: 'loading' })
 
   const studentBusyOverlay = activeWorkMessage ? (
@@ -2237,19 +2200,6 @@ export function TeacherClassroomView({
                 setGradeSelectedConfirmTarget('comments')
               },
               disabled: isApplyCommentsSelectedDisabled,
-            },
-            {
-              id: 'repo-analysis',
-              label: (
-                <span className="inline-flex items-center gap-2">
-                  <BarChart3 className="h-4 w-4" aria-hidden="true" />
-                  <span>Repo analysis</span>
-                </span>
-              ),
-              onSelect: () => {
-                void handleBatchArtifactRepoAnalyze()
-              },
-              disabled: isArtifactRepoAnalyzing || isGradeSelectedSaving || hasActiveAssignmentAiRun || isReadOnly || batchSelectedCount === 0,
             },
             {
               id: 'return',

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useImperativeHandle, forwardRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button, ContentDialog, FormField, Input, Tooltip } from '@/ui'
+import { Button, Tooltip } from '@/ui'
 import { Card } from '@/ui/Card'
 import { EmptyState } from '@/ui/EmptyState'
 import { History } from 'lucide-react'
@@ -27,7 +27,6 @@ import type { Assignment, AssignmentDoc, AssignmentDocHistoryEntry, AssignmentFe
 export interface StudentAssignmentEditorHandle {
   submit: () => Promise<void>
   unsubmit: () => Promise<void>
-  openRepoDialog: () => void
   isSubmitted: boolean
   canSubmit: boolean
   submitting: boolean
@@ -38,7 +37,7 @@ interface Props {
   assignmentId: string
   variant?: 'standalone' | 'embedded'
   onExit?: () => void
-  onStateChange?: (state: { isSubmitted: boolean; canSubmit: boolean; submitting: boolean; hasRepoMetadata: boolean }) => void
+  onStateChange?: (state: { isSubmitted: boolean; canSubmit: boolean; submitting: boolean }) => void
 }
 
 export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle, Props>(function StudentAssignmentEditor({
@@ -59,8 +58,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const [doc, setDoc] = useState<AssignmentDoc | null>(null)
   const [feedbackEntries, setFeedbackEntries] = useState<AssignmentFeedbackEntry[]>([])
   const [content, setContent] = useState<TiptapContent>({ type: 'doc', content: [] })
-  const [repoUrl, setRepoUrl] = useState('')
-  const [githubUsername, setGithubUsername] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [historyEntries, setHistoryEntries] = useState<AssignmentDocHistoryEntry[]>([])
@@ -72,15 +69,12 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const [isHistoryOpen, setIsHistoryOpen] = useState(true)
   const [showRestoreModal, setShowRestoreModal] = useState(false)
   const [restoringId, setRestoringId] = useState<string | null>(null)
-  const [showRepoDialog, setShowRepoDialog] = useState(false)
 
   // Save state
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
   const [submitting, setSubmitting] = useState(false)
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSavedContentRef = useRef('')
-  const lastSavedRepoUrlRef = useRef('')
-  const lastSavedGitHubUsernameRef = useRef('')
   const throttledSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAttemptAtRef = useRef(0)
   const pendingContentRef = useRef<TiptapContent | null>(null)
@@ -105,13 +99,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       setDoc(data.doc)
       setFeedbackEntries(data.feedback_entries || [])
       setContent(data.doc?.content || { type: 'doc', content: [] })
-      const nextRepoUrl = data.doc?.repo_url || ''
-      const nextGithubUsername = data.doc?.github_username || ''
-      setRepoUrl(nextRepoUrl)
-      setGithubUsername(nextGithubUsername)
       lastSavedContentRef.current = JSON.stringify(data.doc?.content || { type: 'doc', content: [] })
-      lastSavedRepoUrlRef.current = nextRepoUrl
-      lastSavedGitHubUsernameRef.current = nextGithubUsername
 
       // Decrement notification count only if this was the first view (server confirmed)
       if (data.wasFirstView) {
@@ -158,16 +146,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   // Autosave with debouncing
   const saveContent = useCallback(async (
     newContent: TiptapContent,
-    newRepoUrl: string,
-    newGitHubUsername: string,
     options?: { trigger?: 'autosave' | 'blur' }
   ) => {
     const newContentStr = JSON.stringify(newContent)
-    if (
-      newContentStr === lastSavedContentRef.current
-      && newRepoUrl === lastSavedRepoUrlRef.current
-      && newGitHubUsername === lastSavedGitHubUsernameRef.current
-    ) {
+    if (newContentStr === lastSavedContentRef.current) {
       setSaveStatus('saved')
       return
     }
@@ -181,8 +163,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           content: newContent,
-          repo_url: newRepoUrl,
-          github_username: newGitHubUsername,
           trigger: options?.trigger ?? 'autosave',
           paste_word_count: pasteWordCountRef.current,
           keystroke_count: keystrokeCountRef.current,
@@ -212,8 +192,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
         setPreviewEntry(prev => (prev?.id === historyEntry.id ? historyEntry : prev))
       }
       lastSavedContentRef.current = newContentStr
-      lastSavedRepoUrlRef.current = newRepoUrl
-      lastSavedGitHubUsernameRef.current = newGitHubUsername
       pasteWordCountRef.current = 0
       keystrokeCountRef.current = 0
       setSaveStatus('saved')
@@ -238,7 +216,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     const msSinceLastAttempt = now - lastSaveAttemptAtRef.current
 
     if (options?.force || msSinceLastAttempt >= AUTOSAVE_MIN_INTERVAL_MS) {
-      void saveContent(newContent, repoUrl, githubUsername, { trigger: options?.trigger })
+      void saveContent(newContent, { trigger: options?.trigger })
       return
     }
 
@@ -247,10 +225,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       throttledSaveTimeoutRef.current = null
       const latest = pendingContentRef.current
       if (latest) {
-        void saveContent(latest, repoUrl, githubUsername, { trigger: options?.trigger })
+        void saveContent(latest, { trigger: options?.trigger })
       }
     }, waitMs)
-  }, [AUTOSAVE_MIN_INTERVAL_MS, githubUsername, repoUrl, saveContent])
+  }, [AUTOSAVE_MIN_INTERVAL_MS, saveContent])
 
   function handleContentChange(newContent: TiptapContent) {
     if (previewEntry) return
@@ -274,34 +252,10 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     }
   }
 
-  function handleRepoFieldChange(field: 'repo_url' | 'github_username', value: string) {
-    if (field === 'repo_url') setRepoUrl(value)
-    if (field === 'github_username') setGithubUsername(value)
-    pendingContentRef.current = content
-    setSaveStatus('unsaved')
-  }
-
-  const openRepoDialog = useCallback(() => {
-    setShowRepoDialog(true)
-  }, [])
-
-  const closeRepoDialog = useCallback(() => {
-    setShowRepoDialog(false)
-  }, [])
-
-  const handleRepoDialogDone = useCallback(async () => {
-    await saveContent(content, repoUrl, githubUsername, { trigger: 'blur' })
-    setShowRepoDialog(false)
-  }, [content, githubUsername, repoUrl, saveContent])
-
   const handleSubmit = useCallback(async () => {
     // Save first if there are unsaved changes
-    if (
-      JSON.stringify(content) !== lastSavedContentRef.current
-      || repoUrl !== lastSavedRepoUrlRef.current
-      || githubUsername !== lastSavedGitHubUsernameRef.current
-    ) {
-      await saveContent(content, repoUrl, githubUsername, { trigger: 'autosave' })
+    if (JSON.stringify(content) !== lastSavedContentRef.current) {
+      await saveContent(content, { trigger: 'autosave' })
     }
 
     setSubmitting(true)
@@ -320,8 +274,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       setDoc(data.doc)
       // Update lastSavedContentRef to match the current content after successful submit
       lastSavedContentRef.current = JSON.stringify(content)
-      lastSavedRepoUrlRef.current = repoUrl
-      lastSavedGitHubUsernameRef.current = githubUsername
       setSaveStatus('saved')
     } catch (err: any) {
       console.error('Error submitting:', err)
@@ -329,7 +281,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     } finally {
       setSubmitting(false)
     }
-  }, [assignmentId, content, githubUsername, repoUrl, saveContent])
+  }, [assignmentId, content, saveContent])
 
   const handleUnsubmit = useCallback(async () => {
     setSubmitting(true)
@@ -346,15 +298,13 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       }
 
       setDoc(data.doc)
-      lastSavedRepoUrlRef.current = data.doc?.repo_url || repoUrl
-      lastSavedGitHubUsernameRef.current = data.doc?.github_username || githubUsername
     } catch (err: any) {
       console.error('Error unsubmitting:', err)
       setError(err.message || 'Failed to unsubmit')
     } finally {
       setSubmitting(false)
     }
-  }, [assignmentId, githubUsername, repoUrl])
+  }, [assignmentId])
 
   function updatePreview(entry: AssignmentDocHistoryEntry): boolean {
     if (!draftBeforePreviewRef.current) {
@@ -435,11 +385,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       }
       setDoc(data.doc)
       setContent(data.doc?.content || { type: 'doc', content: [] })
-      setRepoUrl(data.doc?.repo_url || '')
-      setGithubUsername(data.doc?.github_username || '')
       lastSavedContentRef.current = JSON.stringify(data.doc?.content || { type: 'doc', content: [] })
-      lastSavedRepoUrlRef.current = data.doc?.repo_url || ''
-      lastSavedGitHubUsernameRef.current = data.doc?.github_username || ''
       setSaveStatus('saved')
       await loadHistory()
       handleExitPreview({ restoreDraft: false })
@@ -455,25 +401,21 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const isSubmitted = doc?.is_submitted || false
   const canSubmit = hasAssignmentSubmissionContent({
     content,
-    repo_url: repoUrl,
-    github_username: githubUsername,
   }) && !previewEntry
-  const hasRepoMetadata = !!repoUrl.trim() || !!githubUsername.trim()
 
   // Expose imperative handle for parent components
   useImperativeHandle(ref, () => ({
     submit: handleSubmit,
     unsubmit: handleUnsubmit,
-    openRepoDialog,
     isSubmitted,
     canSubmit,
     submitting,
-  }), [handleSubmit, handleUnsubmit, openRepoDialog, isSubmitted, canSubmit, submitting])
+  }), [handleSubmit, handleUnsubmit, isSubmitted, canSubmit, submitting])
 
   // Notify parent of state changes
   useEffect(() => {
-    onStateChange?.({ isSubmitted, canSubmit, submitting, hasRepoMetadata })
-  }, [isSubmitted, canSubmit, submitting, hasRepoMetadata, onStateChange])
+    onStateChange?.({ isSubmitted, canSubmit, submitting })
+  }, [isSubmitted, canSubmit, submitting, onStateChange])
 
   if (loading) {
     if (isEmbedded) {
@@ -573,30 +515,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
               <div className="text-sm font-medium text-text-muted truncate">
                 {assignment.title}
               </div>
-              {hasRepoMetadata && (
-                <div className="mt-1 min-w-0 space-y-0.5">
-                  <div className="truncate text-sm text-text-default">
-                    <span className="text-text-muted">Repo </span>
-                    {repoUrl.trim() ? (
-                      <a
-                        href={repoUrl.trim()}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-primary hover:underline"
-                      >
-                        {repoUrl.trim()}
-                      </a>
-                    ) : (
-                      '—'
-                    )}
-                  </div>
-                  <div className="truncate text-sm text-text-muted">
-                    <span className="font-medium text-text-default">
-                      {githubUsername.trim() ? `@${githubUsername.trim()}` : '—'}
-                    </span>
-                  </div>
-                </div>
-              )}
             </div>
             <div
               className={`text-xs ${
@@ -777,46 +695,6 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
           </div>
         </div>
       )}
-
-      <ContentDialog
-        isOpen={showRepoDialog}
-        onClose={closeRepoDialog}
-        title="Add GitHub Repository"
-        maxWidth="max-w-md"
-        showHeaderClose={false}
-        showFooterClose={false}
-      >
-        <div className="space-y-4">
-          <FormField label="GitHub Repo Link">
-            <Input
-              value={repoUrl}
-              onChange={(event) => handleRepoFieldChange('repo_url', event.target.value)}
-              onBlur={flushAutosave}
-              placeholder="https://github.com/owner/repo"
-              disabled={submitting || !!previewEntry || isSubmitted}
-            />
-          </FormField>
-          <FormField label="GitHub Username">
-            <Input
-              value={githubUsername}
-              onChange={(event) => handleRepoFieldChange('github_username', event.target.value)}
-              onBlur={flushAutosave}
-              placeholder="github username"
-              disabled={submitting || !!previewEntry || isSubmitted}
-            />
-          </FormField>
-          <div className="flex justify-end gap-2">
-            <Button variant="secondary" onClick={closeRepoDialog}>
-              Cancel
-            </Button>
-            {!isSubmitted && (
-              <Button onClick={() => { void handleRepoDialogDone() }}>
-                Done
-              </Button>
-            )}
-          </div>
-        </div>
-      </ContentDialog>
 
       {/* Comments panel */}
       {feedbackVisible && (

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -110,9 +110,7 @@ export function TeacherStudentWorkPanel({
     showDraftAutosavedNotice,
     gradeError,
     feedbackReturning,
-    repoAnalyzing,
     feedbackEntries,
-    repoReviewResult,
     totalScore,
     totalPercent,
     expandedSections,
@@ -131,7 +129,6 @@ export function TeacherStudentWorkPanel({
     toggleSectionVisibility,
     handleReturnFeedback,
     handleSetGradeMode,
-    handleAnalyzeRepo,
   } = useTeacherStudentWorkController({
     classroomId,
     assignmentId,
@@ -263,7 +260,6 @@ export function TeacherStudentWorkPanel({
       onHistoryMouseLeave={handleHistoryMouseLeave}
       isPreviewLocked={isPreviewLocked}
       onExitPreview={handleExitPreview}
-      repoReviewResult={repoReviewResult}
       scoreCompletion={scoreCompletion}
       setScoreCompletion={setScoreCompletion}
       scoreThinking={scoreThinking}
@@ -282,7 +278,6 @@ export function TeacherStudentWorkPanel({
       feedbackReturning={feedbackReturning}
       gradeSaving={gradeSaving}
       showDraftAutosavedNotice={showDraftAutosavedNotice}
-      repoAnalyzing={repoAnalyzing}
       highlightedSections={highlightedInspectorSections}
       expandedSections={expandedSections}
       visibleSections={visibleSections}
@@ -291,7 +286,6 @@ export function TeacherStudentWorkPanel({
       onToggleSectionVisibility={toggleSectionVisibility}
       handleReturnFeedback={handleReturnFeedback}
       handleSetGradeMode={handleSetGradeMode}
-      handleAnalyzeRepo={handleAnalyzeRepo}
     />
   )
 

--- a/src/components/assignment-workspace/TeacherWorkInspector.tsx
+++ b/src/components/assignment-workspace/TeacherWorkInspector.tsx
@@ -9,7 +9,6 @@ import { Button, SegmentedControl, Tooltip } from '@/ui'
 import type {
   AssignmentDocHistoryEntry,
   AssignmentFeedbackEntry,
-  AssignmentRepoReviewResult,
   AuthenticityFlag,
 } from '@/types'
 import type { InspectorSectionId, StudentWorkData } from './types'
@@ -74,32 +73,6 @@ function AuthenticityGauge({ score, flags }: { score: number | null; flags: Auth
     >
       <div>{bar}</div>
     </Tooltip>
-  )
-}
-
-function RepoMetricBar({
-  label,
-  value,
-  tone = 'primary',
-}: {
-  label: string
-  value: number
-  tone?: 'primary' | 'muted'
-}) {
-  const percentage = Math.max(0, Math.min(100, Math.round(value * 100)))
-  const fillClass = tone === 'primary' ? 'bg-primary' : 'bg-surface-hover'
-
-  return (
-    <div className="relative h-6 overflow-hidden rounded-full border border-border bg-surface">
-      <div
-        className={`absolute inset-y-0 left-0 rounded-full transition-[width] ${fillClass}`}
-        style={{ width: `${percentage}%` }}
-      />
-      <div className="absolute inset-0 z-10 flex items-center justify-between px-3 text-[10px] font-semibold leading-none">
-        <span className="text-text-default">{label}</span>
-        <span className="text-text-default">{percentage}%</span>
-      </div>
-    </div>
   )
 }
 
@@ -373,30 +346,6 @@ function AnimatedSectionContent({
   )
 }
 
-function RepoSummary({
-  repoReviewResult,
-  hasRepoConnection,
-}: {
-  repoReviewResult: AssignmentRepoReviewResult | null
-  hasRepoConnection: boolean
-}) {
-  if (!hasRepoConnection) {
-    return <RepoMetricBar label="No repo linked" value={0} tone="muted" />
-  }
-
-  if (!repoReviewResult) {
-    return <RepoMetricBar label="Analysis not run" value={0} tone="muted" />
-  }
-
-  const compositeScore =
-    ((repoReviewResult.relative_contribution_share || 0) +
-      (repoReviewResult.spread_score || 0) +
-      (repoReviewResult.iteration_score || 0)) /
-    3
-
-  return <RepoMetricBar label="Repo analysis" value={compositeScore} />
-}
-
 function ScoreTotalBox({ value, total }: { value: number; total: number }) {
   return (
     <div className="grid h-8 grid-cols-[1fr_auto] overflow-hidden rounded border border-border bg-surface-2">
@@ -477,7 +426,6 @@ export function TeacherWorkInspector({
   onHistoryMouseLeave,
   isPreviewLocked,
   onExitPreview,
-  repoReviewResult,
   scoreCompletion,
   setScoreCompletion,
   scoreThinking,
@@ -496,7 +444,6 @@ export function TeacherWorkInspector({
   feedbackReturning,
   gradeSaving,
   showDraftAutosavedNotice,
-  repoAnalyzing,
   highlightedSections = [],
   expandedSections,
   visibleSections,
@@ -505,7 +452,6 @@ export function TeacherWorkInspector({
   onToggleSectionVisibility,
   handleReturnFeedback,
   handleSetGradeMode,
-  handleAnalyzeRepo,
 }: {
   data: StudentWorkData
   historyEntries: AssignmentDocHistoryEntry[]
@@ -517,7 +463,6 @@ export function TeacherWorkInspector({
   onHistoryMouseLeave: () => void
   isPreviewLocked: boolean
   onExitPreview: () => void
-  repoReviewResult: AssignmentRepoReviewResult | null
   scoreCompletion: string
   setScoreCompletion: (value: string) => void
   scoreThinking: string
@@ -536,7 +481,6 @@ export function TeacherWorkInspector({
   feedbackReturning: boolean
   gradeSaving: boolean
   showDraftAutosavedNotice: boolean
-  repoAnalyzing: boolean
   highlightedSections?: readonly InspectorSectionId[]
   expandedSections: InspectorSectionId[]
   visibleSections: InspectorSectionId[]
@@ -545,11 +489,7 @@ export function TeacherWorkInspector({
   onToggleSectionVisibility: (section: InspectorSectionId) => void
   handleReturnFeedback: () => Promise<void>
   handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
-  handleAnalyzeRepo: () => Promise<void>
 }) {
-  const hasRepoConnection = !!(
-    data.repo_target.effectiveRepoUrl || data.repo_target.effectiveGitHubUsername
-  )
   const gradeStatusLabel = gradeSaving
     ? `Saving ${gradeMode === 'graded' ? 'graded' : 'draft'}...`
     : data.doc?.graded_at
@@ -606,72 +546,6 @@ export function TeacherWorkInspector({
             </div>
           )}
         </Fragment>
-      ),
-    },
-    {
-      id: 'repo',
-      title: 'Repo',
-      summary: (
-        <RepoSummary
-          repoReviewResult={repoReviewResult}
-          hasRepoConnection={hasRepoConnection}
-        />
-      ),
-      content: repoReviewResult ? (
-        <div className="space-y-3">
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={() => {
-                void handleAnalyzeRepo()
-              }}
-              disabled={
-                repoAnalyzing ||
-                !data.repo_target.effectiveRepoUrl ||
-                !data.repo_target.effectiveGitHubUsername
-              }
-            >
-              {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
-            </Button>
-          </div>
-          <RepoMetricBar
-            label="Contribution"
-            value={repoReviewResult.relative_contribution_share || 0}
-          />
-          <RepoMetricBar
-            label="Consistency"
-            value={repoReviewResult.spread_score || 0}
-          />
-          <RepoMetricBar
-            label="Iteration"
-            value={repoReviewResult.iteration_score || 0}
-          />
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={() => {
-                void handleAnalyzeRepo()
-              }}
-              disabled={
-                repoAnalyzing ||
-                !data.repo_target.effectiveRepoUrl ||
-                !data.repo_target.effectiveGitHubUsername
-              }
-            >
-              {repoAnalyzing ? 'Analyzing...' : 'Analyze Repo'}
-            </Button>
-          </div>
-          <p className="text-sm text-text-muted">
-            {hasRepoConnection
-              ? 'Run repo analysis to see contribution, consistency, and iteration details.'
-              : 'No repository metadata is available for this submission yet.'}
-          </p>
-        </div>
       ),
     },
     {

--- a/src/components/assignment-workspace/types.ts
+++ b/src/components/assignment-workspace/types.ts
@@ -9,7 +9,7 @@ import type {
   AssignmentStatus,
 } from '@/types'
 
-export type InspectorSectionId = 'history' | 'repo' | 'grades' | 'comments'
+export type InspectorSectionId = 'history' | 'grades' | 'comments'
 
 export interface StudentWorkData {
   assignment: Assignment

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -9,14 +9,13 @@ import type {
   AssignmentDoc,
   AssignmentDocHistoryEntry,
   AssignmentFeedbackEntry,
-  AssignmentRepoReviewResult,
   TiptapContent,
 } from '@/types'
 import type { InspectorSectionId, StudentWorkData } from './types'
 
 type GradeSaveMode = 'draft' | 'graded'
 
-const SECTION_ORDER: InspectorSectionId[] = ['history', 'repo', 'grades', 'comments']
+const SECTION_ORDER: InspectorSectionId[] = ['history', 'grades', 'comments']
 const DEFAULT_EXPANDED_SECTIONS: InspectorSectionId[] = ['grades', 'comments']
 const DEFAULT_VISIBLE_SECTIONS: InspectorSectionId[] = SECTION_ORDER
 const INSPECTOR_SECTIONS_COOKIE_PREFIX = 'pika_teacher_student_work_sections'
@@ -196,9 +195,7 @@ export interface TeacherStudentWorkController {
   gradeError: string
   autoGrading: boolean
   feedbackReturning: boolean
-  repoAnalyzing: boolean
   feedbackEntries: AssignmentFeedbackEntry[]
-  repoReviewResult: AssignmentRepoReviewResult | null
   totalScore: number
   totalPercent: number
   expandedSections: InspectorSectionId[]
@@ -218,7 +215,6 @@ export interface TeacherStudentWorkController {
   handleAutoGrade: () => Promise<void>
   handleReturnFeedback: () => Promise<void>
   handleSetGradeMode: (mode: GradeSaveMode) => Promise<void>
-  handleAnalyzeRepo: () => Promise<void>
 }
 
 export function useTeacherStudentWorkController({
@@ -260,7 +256,6 @@ export function useTeacherStudentWorkController({
   const [gradeError, setGradeError] = useState('')
   const [autoGrading, setAutoGrading] = useState(false)
   const [feedbackReturning, setFeedbackReturning] = useState(false)
-  const [repoAnalyzing, setRepoAnalyzing] = useState(false)
   const [expandedSections, setExpandedSections] = useState<InspectorSectionId[]>(() =>
     parseExpandedSections(readCookie(getInspectorSectionsCookieName(classroomId))),
   )
@@ -806,38 +801,7 @@ export function useTeacherStudentWorkController({
     studentId,
   ])
 
-  const handleAnalyzeRepo = useCallback(async () => {
-    if (!data) return
-
-    setRepoAnalyzing(true)
-    setGradeError('')
-    try {
-      const response = await fetch(`/api/teacher/assignments/${assignmentId}/artifact-repo/run`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_ids: [studentId] }),
-      })
-      const result = await response.json()
-      if (!response.ok) throw new Error(result.error || 'Repo analysis failed')
-      const refreshed = await loadStudentWork()
-      dispatchGradeUpdated(refreshed?.doc ?? null)
-      if ((result.analyzed_students ?? 0) === 0 && result.skipped_reasons) {
-        const message = Object.entries(result.skipped_reasons as Record<string, number>)
-          .map(([reason, count]) => `${count} ${reason}`)
-          .join(' ')
-        if (message) {
-          setGradeError(message)
-        }
-      }
-    } catch (err: any) {
-      setGradeError(err.message || 'Repo analysis failed')
-    } finally {
-      setRepoAnalyzing(false)
-    }
-  }, [assignmentId, data, dispatchGradeUpdated, loadStudentWork, studentId])
-
   const feedbackEntries = data?.feedback_entries || []
-  const repoReviewResult = data?.repo_target.latest_result || null
 
   const totalScore = useMemo(() => {
     const sc = Number(scoreCompletion) || 0
@@ -870,9 +834,7 @@ export function useTeacherStudentWorkController({
     gradeError,
     autoGrading,
     feedbackReturning,
-    repoAnalyzing,
     feedbackEntries,
-    repoReviewResult,
     totalScore,
     totalPercent,
     expandedSections,
@@ -892,6 +854,5 @@ export function useTeacherStudentWorkController({
     handleAutoGrade,
     handleReturnFeedback,
     handleSetGradeMode,
-    handleAnalyzeRepo,
   }
 }

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -97,12 +97,8 @@ export function isAssignmentReturnable(
 
 export function hasAssignmentSubmissionContent(input: {
   content: TiptapContent
-  repo_url?: string | null
-  github_username?: string | null
 }): boolean {
   return !isEmpty(input.content)
-    || Boolean(input.repo_url?.trim())
-    || Boolean(input.github_username?.trim())
 }
 
 export function isAssignmentAlreadyReturnedWithoutResubmission(

--- a/src/lib/server/assignment-repo-targets.ts
+++ b/src/lib/server/assignment-repo-targets.ts
@@ -65,8 +65,10 @@ export function resolveAssignmentRepoTarget(opts: {
     ? (candidateRepo.normalized_url || candidateRepo.url).trim() || null
     : null
   const artifactGitHubUsername = candidateRepo?.repo_owner?.trim() || null
-  const submittedRepoUrl = opts.submittedRepoUrl?.trim() || artifactRepoUrl
-  const submittedGitHubUsername = opts.submittedGitHubUsername?.trim() || artifactGitHubUsername
+  const legacySubmittedRepoUrl = opts.submittedRepoUrl?.trim() || null
+  const legacySubmittedGitHubUsername = opts.submittedGitHubUsername?.trim() || null
+  const submittedRepoUrl = artifactRepoUrl || legacySubmittedRepoUrl
+  const submittedGitHubUsername = artifactGitHubUsername || legacySubmittedGitHubUsername
   const normalizedSubmittedRepoUrl = submittedRepoUrl ? normalizeGitHubRepoUrl(submittedRepoUrl) : null
 
   if (

--- a/src/lib/server/assignment-repo-targets.ts
+++ b/src/lib/server/assignment-repo-targets.ts
@@ -59,9 +59,14 @@ export function resolveAssignmentRepoTarget(opts: {
   target: AssignmentRepoTarget | null
 }): ResolvedAssignmentRepoTarget {
   const candidateRepos = opts.candidateRepos || []
+  const candidateRepo = candidateRepos[0] ?? null
   const target = opts.target
-  const submittedRepoUrl = opts.submittedRepoUrl?.trim() || null
-  const submittedGitHubUsername = opts.submittedGitHubUsername?.trim() || null
+  const artifactRepoUrl = candidateRepo
+    ? (candidateRepo.normalized_url || candidateRepo.url).trim() || null
+    : null
+  const artifactGitHubUsername = candidateRepo?.repo_owner?.trim() || null
+  const submittedRepoUrl = opts.submittedRepoUrl?.trim() || artifactRepoUrl
+  const submittedGitHubUsername = opts.submittedGitHubUsername?.trim() || artifactGitHubUsername
   const normalizedSubmittedRepoUrl = submittedRepoUrl ? normalizeGitHubRepoUrl(submittedRepoUrl) : null
 
   if (
@@ -95,7 +100,7 @@ export function resolveAssignmentRepoTarget(opts: {
       repoName: null,
       selectionMode: target?.selection_mode ?? 'auto',
       validationStatus: 'missing',
-      validationMessage: 'No repo link has been submitted yet.',
+      validationMessage: 'No repo artifact has been submitted yet.',
     }
   }
 

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -117,9 +117,27 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     expect(response.status).toBe(400)
   })
 
-  it('allows late submission when the saved work is repo metadata only', async () => {
+  it('rejects saved repo metadata only because repo links must be in assignment content', async () => {
     const historyInsert = vi.fn(async () => ({ error: null }))
     const emptyContent = { type: 'doc', content: [] }
+    const updateDoc = vi.fn((payload: Record<string, unknown>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'doc-1',
+              student_id: 'student-1',
+              content: emptyContent,
+              repo_url: 'https://github.com/codepetca/student-work',
+              github_username: 'student1',
+              is_submitted: true,
+              submitted_at: payload.submitted_at,
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -159,24 +177,7 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
               })),
             })),
           })),
-          update: vi.fn((payload: Record<string, unknown>) => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({
-                  data: {
-                    id: 'doc-1',
-                    student_id: 'student-1',
-                    content: emptyContent,
-                    repo_url: 'https://github.com/codepetca/student-work',
-                    github_username: 'student1',
-                    is_submitted: true,
-                    submitted_at: payload.submitted_at,
-                  },
-                  error: null,
-                }),
-              })),
-            })),
-          })),
+          update: updateDoc,
         }
       }
 
@@ -197,22 +198,10 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
       method: 'POST',
     }), { params: { id: 'assign-1' } })
-    const data = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(data.doc).toEqual(expect.objectContaining({
-      id: 'doc-1',
-      is_submitted: true,
-      submitted_at: expect.any(String),
-      repo_url: 'https://github.com/codepetca/student-work',
-    }))
-    expect(historyInsert).toHaveBeenCalledWith(expect.objectContaining({
-      assignment_doc_id: 'doc-1',
-      snapshot: emptyContent,
-      word_count: 0,
-      char_count: 0,
-      trigger: 'submit',
-    }))
+    expect(response.status).toBe(400)
+    expect(updateDoc).not.toHaveBeenCalled()
+    expect(historyInsert).not.toHaveBeenCalled()
   })
 
   it('submits work, records history, and attaches authenticity results', async () => {

--- a/tests/api/teacher/assignments-artifact-repo-run.test.ts
+++ b/tests/api/teacher/assignments-artifact-repo-run.test.ts
@@ -5,6 +5,7 @@ const {
   mockSupabaseClient,
   mockAnalyzeRepoReviewAssignment,
   mockGradeRepoReviewFeedback,
+  mockExtractRepoArtifactsFromContent,
   mockResolveAssignmentRepoTarget,
   mockSaveAssignmentRepoTarget,
   mockValidatePublicGitHubRepo,
@@ -13,6 +14,7 @@ const {
   mockSupabaseClient: { from: vi.fn() },
   mockAnalyzeRepoReviewAssignment: vi.fn(),
   mockGradeRepoReviewFeedback: vi.fn(),
+  mockExtractRepoArtifactsFromContent: vi.fn(),
   mockResolveAssignmentRepoTarget: vi.fn(),
   mockSaveAssignmentRepoTarget: vi.fn(),
   mockValidatePublicGitHubRepo: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock('@/lib/repo-review-ai', () => ({
 }))
 
 vi.mock('@/lib/server/assignment-repo-targets', () => ({
+  extractRepoArtifactsFromContent: mockExtractRepoArtifactsFromContent,
   resolveAssignmentRepoTarget: mockResolveAssignmentRepoTarget,
   saveAssignmentRepoTarget: mockSaveAssignmentRepoTarget,
   validatePublicGitHubRepo: mockValidatePublicGitHubRepo,
@@ -141,6 +144,7 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.from.mockReset()
+    mockExtractRepoArtifactsFromContent.mockReturnValue([])
     mockAssertTeacherOwnsAssignment.mockResolvedValue({
       id: 'assignment-1',
       classroom_id: 'classroom-1',
@@ -175,7 +179,7 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
     mockResolveAssignmentRepoTarget.mockReturnValue({
       effectiveRepoUrl: null,
       effectiveGitHubUsername: null,
-      validationMessage: 'No repo link has been submitted yet.',
+      validationMessage: 'No repo artifact has been submitted yet.',
     })
     installRepoRunTables({
       enrollments: [{ student_id: 'student-1', users: { email: 's1@example.com' } }],
@@ -195,12 +199,20 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
     expect(data).toEqual({
       analyzed_students: 0,
       repo_groups: 0,
-      skipped_reasons: { 'No repo link has been submitted yet.': 1 },
+      skipped_reasons: { 'No repo artifact has been submitted yet.': 1 },
     })
     expect(mockValidatePublicGitHubRepo).not.toHaveBeenCalled()
   })
 
   it('groups valid repos, saves run results, and upserts draft grades', async () => {
+    const candidateRepo = {
+      type: 'repo',
+      url: 'https://github.com/codepetca/pika',
+      repo_owner: 'codepetca',
+      repo_name: 'pika',
+      normalized_url: 'https://github.com/codepetca/pika',
+    }
+    mockExtractRepoArtifactsFromContent.mockReturnValue([candidateRepo])
     mockResolveAssignmentRepoTarget.mockReturnValue({
       effectiveRepoUrl: 'https://github.com/codepetca/pika',
       effectiveGitHubUsername: 'student-login',
@@ -269,6 +281,9 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({ analyzed_students: 1, repo_groups: 1, skipped_reasons: {} })
+    expect(mockResolveAssignmentRepoTarget).toHaveBeenCalledWith(expect.objectContaining({
+      candidateRepos: [candidateRepo],
+    }))
     expect(mockSaveAssignmentRepoTarget).toHaveBeenCalledWith(expect.objectContaining({
       assignmentId: 'assignment-1',
       studentId: 'student-1',

--- a/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
+++ b/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
@@ -171,7 +171,7 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     expect(screen.getByText('Strong effort and clear structure.')).toBeInTheDocument()
   })
 
-  it('shows saved repo metadata under the assignment title when present', async () => {
+  it('does not show saved repo metadata as separate assignment chrome', async () => {
     mockLoadResponses(
       makeDoc({
         repo_url: 'https://github.com/codepetca/pika',
@@ -182,9 +182,9 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Repo', { exact: false })).toBeInTheDocument()
+      expect(screen.getByText('Assignment Title')).toBeInTheDocument()
     })
-    expect(screen.getByRole('link', { name: 'https://github.com/codepetca/pika' })).toHaveAttribute('href', 'https://github.com/codepetca/pika')
-    expect(screen.getByText('@student1-demo')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'https://github.com/codepetca/pika' })).not.toBeInTheDocument()
+    expect(screen.queryByText('@student1-demo')).not.toBeInTheDocument()
   })
 })

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -26,13 +26,12 @@ vi.mock('@/components/StudentAssignmentEditor', () => ({
     useImperativeHandle(ref, () => ({
       submit: vi.fn(),
       unsubmit: vi.fn(),
-      openRepoDialog: vi.fn(),
       isSubmitted: false,
       canSubmit: false,
       submitting: false,
     }))
     useEffect(() => {
-      props.onStateChange?.({ isSubmitted: false, canSubmit: false, submitting: false, hasRepoMetadata: false })
+      props.onStateChange?.({ isSubmitted: false, canSubmit: false, submitting: false })
     }, [props.onStateChange])
     return <div data-testid="student-editor">Editor</div>
   }),
@@ -213,7 +212,7 @@ describe('StudentAssignmentsTab', () => {
     })
   })
 
-  it('shows Repo action when editing an assignment', async () => {
+  it('does not show a separate Repo action when editing an assignment', async () => {
     const viewed = makeAssignment({
       doc: {
         id: 'doc-1',
@@ -238,8 +237,9 @@ describe('StudentAssignmentsTab', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Repo' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Instructions' })).toBeInTheDocument()
     })
+    expect(screen.queryByRole('button', { name: 'Repo' })).not.toBeInTheDocument()
   })
 
   it('renders materials and assignments in shared classwork order', async () => {

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -301,19 +301,19 @@ describe('TeacherStudentWorkPanel', () => {
     ).map((element) => element.getAttribute('data-testid'))
     expect(sectionIds).toEqual([
       'inspector-section-history',
-      'inspector-section-repo',
       'inspector-section-grades',
       'inspector-section-comments',
     ])
 
     const gradesSection = screen.getByTestId('inspector-section-grades')
     expect(screen.getByText('Authenticity 64%')).toBeInTheDocument()
-    expect(screen.getByText('No repo linked')).toBeInTheDocument()
     expect(within(gradesSection).getByText('0%')).toBeInTheDocument()
     expect(within(gradesSection).getByText('Total')).toBeInTheDocument()
     expect(within(gradesSection).getByText('30')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument()
     expect(screen.queryByText('No draft')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('inspector-section-repo')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Repo' })).not.toBeInTheDocument()
 
     expect(screen.getByLabelText('Completion score')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Teacher comment draft')).toBeInTheDocument()
@@ -352,19 +352,18 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const repoSection = await screen.findByTestId('inspector-section-repo')
-    const repoVisibility = within(repoSection).getByRole('checkbox', { name: 'Show Repo card' })
-    expect(repoVisibility).toBeChecked()
-    expect(within(repoSection).getByText('No repo linked')).toBeInTheDocument()
+    const historySection = await screen.findByTestId('inspector-section-history')
+    const historyVisibility = within(historySection).getByRole('checkbox', { name: 'Show History card' })
+    expect(historyVisibility).toBeChecked()
+    expect(screen.queryByTestId('inspector-section-repo')).not.toBeInTheDocument()
 
-    await user.click(repoVisibility)
+    await user.click(historyVisibility)
 
-    expect(repoVisibility).not.toBeChecked()
-    expect(within(repoSection).queryByText('No repo linked')).not.toBeInTheDocument()
+    expect(historyVisibility).not.toBeChecked()
 
     rerender(<TeacherStudentWorkPanel {...panelProps} />)
 
-    expect(screen.queryByTestId('inspector-section-repo')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('inspector-section-history')).not.toBeInTheDocument()
 
     rerender(
       <TeacherStudentWorkPanel
@@ -373,19 +372,19 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const hiddenRepoSection = screen.getByTestId('inspector-section-repo')
-    const hiddenRepoVisibility = within(hiddenRepoSection).getByRole('checkbox', {
-      name: 'Show Repo card',
+    const hiddenHistorySection = screen.getByTestId('inspector-section-history')
+    const hiddenHistoryVisibility = within(hiddenHistorySection).getByRole('checkbox', {
+      name: 'Show History card',
     })
-    expect(hiddenRepoVisibility).not.toBeChecked()
+    expect(hiddenHistoryVisibility).not.toBeChecked()
 
-    await user.click(hiddenRepoVisibility)
+    await user.click(hiddenHistoryVisibility)
 
-    expect(hiddenRepoVisibility).toBeChecked()
+    expect(hiddenHistoryVisibility).toBeChecked()
 
     rerender(<TeacherStudentWorkPanel {...panelProps} />)
 
-    expect(screen.getByTestId('inspector-section-repo')).toBeInTheDocument()
+    expect(screen.getByTestId('inspector-section-history')).toBeInTheDocument()
   })
 
   it('collapses inspector cards when edit mode is entered', async () => {
@@ -826,7 +825,7 @@ describe('TeacherStudentWorkPanel', () => {
   })
 
   it('keeps classroom-specific section state isolated', async () => {
-    writeInspectorSectionsCookie('classroom-2', 'history,repo')
+    writeInspectorSectionsCookie('classroom-2', 'history')
     mockFetchByStudent({
       'student-1': { graded: false },
     })
@@ -848,7 +847,7 @@ describe('TeacherStudentWorkPanel', () => {
     expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
   })
 
-  it('reveals repo metrics only when the repo section is expanded and keeps Analyze Repo there', async () => {
+  it('hides the repo marking section even when repo data exists', async () => {
     mockFetchByStudent({
       'student-1': {
         graded: false,
@@ -863,7 +862,6 @@ describe('TeacherStudentWorkPanel', () => {
       },
     })
 
-    const user = userEvent.setup()
     render(
       <TeacherStudentWorkPanel
         classroomId="classroom-1"
@@ -876,16 +874,13 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const repoSection = await screen.findByTestId('inspector-section-repo')
-    expect(within(repoSection).queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
+    await screen.findByTestId('grading-inspector-pane')
+    expect(screen.queryByTestId('inspector-section-repo')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Repo' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
     expect(screen.queryByText('Contribution')).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Repo' }))
-
-    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
-    expect(within(repoSection).getByText('Contribution')).toBeInTheDocument()
-    expect(within(repoSection).getByText('Consistency')).toBeInTheDocument()
-    expect(within(repoSection).getByText('Iteration')).toBeInTheDocument()
+    expect(screen.queryByText('Consistency')).not.toBeInTheDocument()
+    expect(screen.queryByText('Iteration')).not.toBeInTheDocument()
   })
 
   it('toggles collapsed cards when clicking the header summary area', async () => {
@@ -906,12 +901,16 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    const repoSection = await screen.findByTestId('inspector-section-repo')
-    expect(within(repoSection).queryByRole('button', { name: 'Analyze Repo' })).not.toBeInTheDocument()
+    const historySection = await screen.findByTestId('inspector-section-history')
+    expect(screen.queryByTestId('history-list')).not.toBeInTheDocument()
 
-    await user.click(within(repoSection).getByText('No repo linked'))
+    const historySummary = within(historySection)
+      .getAllByText((_, node) => node?.textContent === 'Authenticity —')
+      .find((node) => node.tagName.toLowerCase() === 'span')
+    expect(historySummary).toBeTruthy()
+    await user.click(historySummary!)
 
-    expect(within(repoSection).getByRole('button', { name: 'Analyze Repo' })).toBeInTheDocument()
+    expect(screen.getByTestId('history-list')).toBeInTheDocument()
   })
 
   it('updates the individual-mode preview when hovering a history entry', async () => {
@@ -1120,7 +1119,6 @@ describe('TeacherStudentWorkPanel', () => {
     await screen.findByTestId('grading-inspector-pane')
 
     expect(screen.getByTestId('inspector-section-history')).not.toHaveAttribute('data-highlighted')
-    expect(screen.getByTestId('inspector-section-repo')).not.toHaveAttribute('data-highlighted')
     expect(screen.getByTestId('inspector-section-grades')).toHaveAttribute('data-highlighted', 'true')
     expect(screen.getByTestId('inspector-section-comments')).toHaveAttribute('data-highlighted', 'true')
   })

--- a/tests/unit/assignment-repo-targets.test.ts
+++ b/tests/unit/assignment-repo-targets.test.ts
@@ -124,6 +124,31 @@ describe('assignment repo target helpers', () => {
     }))
   })
 
+  it('prefers pasted repo artifacts over legacy submitted repo metadata', () => {
+    const resolved = resolveAssignmentRepoTarget({
+      candidateRepos: [{
+        type: 'repo',
+        url: 'https://github.com/current/student-work',
+        repo_owner: 'current',
+        repo_name: 'student-work',
+        normalized_url: 'https://github.com/current/student-work',
+      }],
+      submittedRepoUrl: 'https://github.com/legacy/old-work',
+      submittedGitHubUsername: 'legacy-login',
+      target: null,
+    })
+
+    expect(resolved).toEqual(expect.objectContaining({
+      submittedRepoUrl: 'https://github.com/current/student-work',
+      submittedGitHubUsername: 'current',
+      effectiveRepoUrl: 'https://github.com/current/student-work',
+      effectiveGitHubUsername: 'current',
+      selectionMode: 'auto',
+      validationStatus: 'valid',
+      validationMessage: null,
+    }))
+  })
+
   it('reports actionable missing and invalid states before repo analysis can run', () => {
     expect(resolveAssignmentRepoTarget({
       submittedRepoUrl: null,

--- a/tests/unit/assignment-repo-targets.test.ts
+++ b/tests/unit/assignment-repo-targets.test.ts
@@ -99,6 +99,31 @@ describe('assignment repo target helpers', () => {
     }))
   })
 
+  it('uses the first pasted repo artifact when explicit repo metadata is absent', () => {
+    const resolved = resolveAssignmentRepoTarget({
+      candidateRepos: [{
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
+      }],
+      submittedRepoUrl: null,
+      submittedGitHubUsername: null,
+      target: null,
+    })
+
+    expect(resolved).toEqual(expect.objectContaining({
+      submittedRepoUrl: 'https://github.com/codepetca/pika',
+      submittedGitHubUsername: 'codepetca',
+      effectiveRepoUrl: 'https://github.com/codepetca/pika',
+      effectiveGitHubUsername: 'codepetca',
+      selectionMode: 'auto',
+      validationStatus: 'valid',
+      validationMessage: null,
+    }))
+  })
+
   it('reports actionable missing and invalid states before repo analysis can run', () => {
     expect(resolveAssignmentRepoTarget({
       submittedRepoUrl: null,
@@ -109,7 +134,7 @@ describe('assignment repo target helpers', () => {
       effectiveGitHubUsername: 'student-login',
       selectionMode: 'auto',
       validationStatus: 'missing',
-      validationMessage: 'No repo link has been submitted yet.',
+      validationMessage: 'No repo artifact has been submitted yet.',
     }))
 
     expect(resolveAssignmentRepoTarget({

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -406,19 +406,21 @@ describe('assignment utilities', () => {
   })
 
   describe('hasAssignmentSubmissionContent', () => {
-    it('allows repo metadata to count as submittable work', () => {
+    it('allows pasted repo links in content to count as submittable work', () => {
       expect(hasAssignmentSubmissionContent({
-        content: { type: 'doc', content: [] },
-        repo_url: 'https://github.com/codepetca/pika-student',
-        github_username: null,
+        content: {
+          type: 'doc',
+          content: [{
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'https://github.com/codepetca/pika-student' }],
+          }],
+        },
       })).toBe(true)
     })
 
-    it('rejects docs with no written work or repo metadata', () => {
+    it('rejects docs with no written work', () => {
       expect(hasAssignmentSubmissionContent({
         content: { type: 'doc', content: [] },
-        repo_url: '   ',
-        github_username: null,
       })).toBe(false)
     })
   })


### PR DESCRIPTION
## Summary

- Remove the separate student assignment Repo action and GitHub metadata dialog.
- Stop student assignment autosaves from writing `repo_url` / `github_username`; repo links now live in assignment editor content as artifacts.
- Keep teacher repo analysis working by resolving pasted GitHub repo artifacts from assignment content and falling back to legacy metadata only when present.
- Update submission validation and tests so metadata-only repo submissions are rejected.

## Validation

- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignment-repo-targets.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/assignment-docs/submit.test.ts tests/unit/assignments.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
- Additional screenshots: `/tmp/pika-student-assignment-editor.png`, `/tmp/pika-teacher-assignment-workspace.png`
- `git diff --check`