### PR TITLE
[codex] Show student test total points

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Survey creation modal title focus
-
-**Completed:**
-- Fixed routed classroom state so creating a survey keeps the new survey authoring modal open instead of immediately clearing it.
-- Added an auto-edit path for newly created survey titles.
-- Displayed generated survey titles as `Untitled Survey` in authoring and selected the full title text on creation so teachers can replace it immediately.
-- Kept unchanged generated title blur from saving a literal `Untitled Survey`.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3006 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments'`
-- Targeted Playwright screenshot/assertion: `/tmp/pika-survey-create-modal-title-selected.png`.
-
 ## 2026-05-14 — Teacher selected-survey split actions
 
 **Completed:**
@@ -333,3 +318,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Additional student sidebar screenshot: `/tmp/pika-student-desktop-expanded.png`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-05-20 — Student test total points label
+
+**Completed:**
+- Added a student test overview label under the selected test title, showing question count and total points as `pts total`.
+- Rendered the label before the student starts a test and at the top of the active test attempt.
+- Added component coverage that the total-points label appears before start and during the attempt.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx` (Vitest ran the full suite: 272 files / 2263 tests passed)
+- `pnpm lint`
+- `pnpm e2e:auth`
+- `pnpm e2e:verify assessment-ux-parity`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests"`
+- Additional selected student test screenshots:
+  - `/tmp/pika-student-test-before-start.png`
+  - `/tmp/pika-student-test-active.png`
+  - `/tmp/pika-student-test-before-start-mobile.png`
+  - `/tmp/pika-student-test-active-mobile.png`

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -84,6 +84,25 @@ function createFocusSessionId(): string {
   return `focus_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
 }
 
+function formatPointsTotal(points: number): string {
+  const rounded = Math.round(points * 100) / 100
+  const formatted = Number.isInteger(rounded)
+    ? String(rounded)
+    : rounded.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')
+  const unit = Math.abs(rounded) === 1 ? 'pt' : 'pts'
+  return `${formatted} ${unit} total`
+}
+
+function formatTestOverviewLabel(questions: QuizQuestion[]): string {
+  const questionCount = questions.length
+  const totalPoints = questions.reduce((sum, question) => {
+    const points = Number(question.points ?? 0)
+    return Number.isFinite(points) ? sum + points : sum
+  }, 0)
+  const questionLabel = `${questionCount} question${questionCount === 1 ? '' : 's'}`
+  return `${questionLabel} · ${formatPointsTotal(totalPoints)}`
+}
+
 function isFullscreenActive(): boolean {
   return typeof document !== 'undefined' && Boolean(document.fullscreenElement)
 }
@@ -1154,6 +1173,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     const selectedTestPanelTitle = isViewingResults
       ? `${selectedTestTitle} Results`
       : selectedTestTitle
+    const selectedTestOverviewLabel = hasSelectedQuiz
+      ? formatTestOverviewLabel(selectedQuiz.questions)
+      : null
     const showSplitExamShell =
       hasSelectedQuiz &&
       !requiresStart &&
@@ -1386,7 +1408,12 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                       </div>
                     ) : hasSelectedQuiz ? (
                       <div className="space-y-4">
-                        <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
+                        <div className="space-y-1">
+                          <h2 className="text-xl font-bold text-text-default">{selectedTestPanelTitle}</h2>
+                          {selectedTestOverviewLabel ? (
+                            <p className="text-sm text-text-muted">{selectedTestOverviewLabel}</p>
+                          ) : null}
+                        </div>
 
                         {remoteClosureNotice ? (
                           <div className="rounded-xl border border-warning bg-warning-bg/20 p-4">
@@ -1510,6 +1537,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
                       <h2 className="truncate text-xl font-bold text-text-default">
                         {selectedTestPanelTitle}
                       </h2>
+                      {selectedTestOverviewLabel ? (
+                        <p className="mt-1 text-sm text-text-muted">{selectedTestOverviewLabel}</p>
+                      ) : null}
                       {allowedDocs.length > 0 && requiresStart ? (
                         <p className="mt-1 text-sm text-text-muted">
                           {allowedDocs.length} reference document{allowedDocs.length === 1 ? '' : 's'} will be available during the test.

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -180,6 +180,36 @@ describe('StudentQuizzesTab exam mode', () => {
     expect(screen.queryByText('Leave this test?')).not.toBeInTheDocument()
   })
 
+  it('shows total test points before starting and during the attempt', async () => {
+    queueTestList()
+    queueTestDetail()
+
+    render(<StudentQuizzesTab classroom={classroom} assessmentType="test" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Midterm Test')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Midterm Test'))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start the Test' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('1 question · 1 pt total')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start the Test' }))
+    await waitFor(() => {
+      expect(screen.getByText('Start this test?')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Start test'))
+
+    await waitFor(() => {
+      expect(screen.getByText('2 + 2 = ?')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('1 question · 1 pt total')).toBeInTheDocument()
+  })
+
   it('dispatches exam mode state changes for active test sessions', async () => {
     queueTestList()
     queueTestDetail()


### PR DESCRIPTION
## Summary

- Show a compact student test overview label under the selected test title with question count and total points, using `pts total` copy.
- Keep the label visible both before starting the test and during the active test attempt.
- Add component coverage for the before-start and active-attempt states.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx` (Vitest ran the full suite: 272 files / 2263 tests passed)
- `pnpm lint`
- `pnpm e2e:auth`
- `pnpm e2e:verify assessment-ux-parity`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests"`
- Additional selected student test screenshots checked on desktop and mobile:
  - `/tmp/pika-student-test-before-start.png`
  - `/tmp/pika-student-test-active.png`
  - `/tmp/pika-student-test-before-start-mobile.png`
  - `/tmp/pika-student-test-active-mobile.png`