### PR TITLE
[codex] Freeze submitted assignment timing

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Teacher selected-survey split actions
-
-**Completed:**
-- Replaced the selected-survey teacher floating controls with a compact `SplitButton`.
-- Kept `Edit survey` as the primary action and moved poll open/close, results visibility, response editing, and delete into the action menu.
-- Added optional per-option styling to `SplitButton` so destructive menu actions can be shown distinctly.
-- Updated the teacher classroom test coverage to assert the new selected-survey action menu behavior and PATCH flow.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3021 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=167609a8-2111-482f-8be2-7bb74a8f548f'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-teacher-final.png`, `/tmp/pika-survey-actions-open.png`; temporary survey fixture was deleted afterward.
-
 ## 2026-05-14 — Teacher selected-survey icon controls
 
 **Completed:**
@@ -338,3 +323,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
   - `/tmp/pika-student-test-active.png`
   - `/tmp/pika-student-test-before-start-mobile.png`
   - `/tmp/pika-student-test-active-mobile.png`
+
+## 2026-05-20 — Freeze submitted assignment timing
+
+**Completed:**
+- Added submitted-aware assignment timing copy so submitted work freezes against `submitted_at` instead of continuing to count overdue time from the current date.
+- Updated student assignment cards and the standalone student assignment editor header to use the submitted-aware timing helper.
+- Added unit and component coverage for submitted timing, including late submissions freezing at the actual submission timestamp.
+
+**Validation:**
+- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
+- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -6,8 +6,8 @@ import { Button, Card, ContentDialog, EmptyState, RefreshingIndicator } from '@/
 import { Spinner } from '@/components/Spinner'
 import { PageActionBar, PageContent, PageLayout, PageStack } from '@/components/PageLayout'
 import {
+  formatAssignmentTiming,
   formatDueDate,
-  formatRelativeDueDate,
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
 } from '@/lib/assignments'
@@ -387,7 +387,7 @@ export function StudentAssignmentsTab({
                               {formatDueDate(assignment.due_at)}
                             </p>
                             <p className="mt-1 text-xs uppercase tracking-[0.16em] text-text-muted">
-                              {formatRelativeDueDate(assignment.due_at)}
+                              {formatAssignmentTiming(assignment.due_at, assignment.doc)}
                             </p>
                           </div>
                           <span

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -11,8 +11,8 @@ import { RichTextEditor, RichTextViewer } from '@/components/editor'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { ACTIONBAR_BUTTON_CLASSNAME, PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
 import {
+  formatAssignmentTiming,
   formatDueDate,
-  formatRelativeDueDate,
   calculateAssignmentStatus,
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
@@ -939,7 +939,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
                 {assignment.title}
               </div>
               <div className="text-xs text-text-muted truncate">
-                Due: {formatDueDate(assignment.due_at)} • {formatRelativeDueDate(assignment.due_at)}
+                Due: {formatDueDate(assignment.due_at)} • {formatAssignmentTiming(assignment.due_at, doc)}
               </div>
             </div>
             <div className="flex items-center gap-3">

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -352,6 +352,50 @@ export function formatRelativeDueDate(dueAt: string): string {
   }
 }
 
+type AssignmentTimingDoc = Pick<AssignmentDoc, 'is_submitted' | 'submitted_at'>
+
+function formatLateSubmissionDuration(diffMs: number): string {
+  const diffMins = Math.round(diffMs / 60000)
+  const diffHours = Math.round(diffMs / 3600000)
+  const diffDays = Math.round(diffMs / 86400000)
+
+  if (diffDays > 1) return `${diffDays} days late`
+  if (diffDays === 1) return '1 day late'
+  if (diffHours > 1) return `${diffHours} hours late`
+  if (diffHours === 1) return '1 hour late'
+  if (diffMins > 1) return `${diffMins} minutes late`
+  return 'just after due'
+}
+
+/**
+ * Format student-facing assignment timing.
+ *
+ * Unsubmitted work keeps counting relative to the due date. Submitted work is
+ * frozen at submitted_at so overdue text does not keep increasing after submit.
+ */
+export function formatAssignmentTiming(
+  dueAt: string,
+  doc: AssignmentTimingDoc | null | undefined
+): string {
+  if (!doc?.is_submitted) {
+    return formatRelativeDueDate(dueAt)
+  }
+
+  if (!doc.submitted_at) {
+    return 'Submitted'
+  }
+
+  const due = new Date(dueAt)
+  const submitted = new Date(doc.submitted_at)
+  const diffMs = submitted.getTime() - due.getTime()
+
+  if (diffMs <= 0) {
+    return 'Submitted on time'
+  }
+
+  return `Submitted ${formatLateSubmissionDuration(diffMs)}`
+}
+
 const GRADE_FIELDS = [
   'score_completion',
   'score_thinking',

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -269,4 +269,33 @@ describe('StudentAssignmentsTab', () => {
     expect(cards[0]).not.toHaveClass('border-primary/40')
     expect(cards[0].querySelector('.border-l-2')).not.toBeInTheDocument()
   })
+
+  it('freezes assignment card timing once work is submitted', async () => {
+    const submittedClassroom = { ...classroom, id: 'cls-submitted' }
+    mockFetchAssignments([
+      makeAssignment({
+        classroom_id: submittedClassroom.id,
+        due_at: '2024-10-20T12:00:00Z',
+        status: 'submitted_late',
+        doc: {
+          id: 'doc-1',
+          assignment_id: 'asgn-1',
+          student_id: 'stu-1',
+          content: { type: 'doc', content: [] },
+          is_submitted: true,
+          submitted_at: '2024-10-21T12:00:00Z',
+          viewed_at: '2024-06-01T00:00:00Z',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        } as any,
+      }),
+    ])
+
+    render(<StudentAssignmentsTab classroom={submittedClassroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Submitted 1 day late')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/days overdue/i)).not.toBeInTheDocument()
+  })
 })

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -22,6 +22,7 @@ import {
   hasAssignmentSubmissionContent,
   formatDueDate,
   isPastDue,
+  formatAssignmentTiming,
   formatRelativeDueDate,
   sanitizeDocForStudent,
 } from '@/lib/assignments'
@@ -1086,6 +1087,100 @@ describe('assignment utilities', () => {
 
         expect(result).toBe('Just passed')
       })
+    })
+  })
+
+  // ==========================================================================
+  // formatAssignmentTiming()
+  // ==========================================================================
+
+  describe('formatAssignmentTiming', () => {
+    it('keeps counting relative due time for unsubmitted work', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: false,
+        submitted_at: null,
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('5 days overdue')
+    })
+
+    it('freezes submitted on-time work instead of counting overdue days', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-18T12:00:00Z',
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('Submitted on time')
+    })
+
+    it('freezes submitted late work at the submission timestamp', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-21T12:00:00Z',
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('Submitted 1 day late')
+    })
+
+    it('shows multiple days late for older late submissions', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-23T12:00:00Z',
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('Submitted 3 days late')
+    })
+
+    it('shows singular and plural hour late durations', () => {
+      const oneHourLate = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-20T13:00:00Z',
+      })
+      const twoHoursLate = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-20T14:00:00Z',
+      })
+
+      expect(formatAssignmentTiming('2024-10-20T12:00:00Z', oneHourLate)).toBe('Submitted 1 hour late')
+      expect(formatAssignmentTiming('2024-10-20T12:00:00Z', twoHoursLate)).toBe('Submitted 2 hours late')
+    })
+
+    it('shows minute and immediate late durations', () => {
+      const minutesLate = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-20T12:02:00Z',
+      })
+      const justAfterDue = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2024-10-20T12:00:30Z',
+      })
+
+      expect(formatAssignmentTiming('2024-10-20T12:00:00Z', minutesLate)).toBe('Submitted 2 minutes late')
+      expect(formatAssignmentTiming('2024-10-20T12:00:00Z', justAfterDue)).toBe('Submitted just after due')
+    })
+
+    it('handles submitted docs that are missing submitted_at', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: true,
+        submitted_at: null,
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('Submitted')
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes the student assignments tab timing copy so submitted assignments stop counting up as overdue after the student submits.

## Root Cause

Student assignment cards and the standalone student assignment editor header rendered relative due-date text from `assignment.due_at` alone. That meant the copy kept comparing the original due date to the current time even when `doc.is_submitted` and `doc.submitted_at` showed the student had already submitted.

## Changes

- Added `formatAssignmentTiming()` in `src/lib/assignments.ts`.
- Kept existing live overdue countdown behavior for unsubmitted work.
- Freezes submitted work against `submitted_at`, showing copy like `Submitted on time` or `Submitted 1 day late`.
- Updated the student assignments summary card and standalone editor header to use the submitted-aware helper.
- Added unit and component coverage for submitted timing.

## Validation

- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
- `pnpm lint`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
- `pnpm test`