### PR TITLE
[codex] Fix AI draft comment refresh

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,26 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-14 — Survey question autosave controls
-
-**Completed:**
-- Removed the per-question `Save` button from survey authoring.
-- Added debounced automatic saving for edited survey question type, prompt, and options, with blur flushing for immediate persistence.
-- Kept failed autosave attempts retryable instead of suppressing the same payload after a transient error.
-- Moved the per-question delete action inline with the prompt row.
-- Updated selected-survey controls to use test-style green unlock/red lock icons for poll state and green/red color for visible/hidden results.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx`
-- `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3024 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=619428d0-644e-4f13-9681-bb0954e266b1'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-question-autosave-delete-inline.png`, `/tmp/pika-survey-question-autosaved.png`; confirmed `saveButtonCount: 0`, observed question PATCH on blur, and deleted the temporary survey fixture afterward.
-- `E2E_BASE_URL=http://localhost:3027 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-locked-controls.png`, `/tmp/pika-survey-hidden-results-control.png`; restored the seeded active survey to `show_results: true`.
-
 ## 2026-05-15 — Survey results card cleanup
 
 **Completed:**
@@ -344,3 +324,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `git diff --check`
 - `bash scripts/verify-env.sh`
+
+## 2026-05-20 — Assignment AI draft comment refresh fix
+
+**Completed:**
+- Prevented stale `ai_feedback_suggestion` values from being merged back into teacher comment drafts after a newer manual edit.
+- Manual assignment comment saves and sent comments now clear consumed AI suggestion metadata so refreshes load the teacher-edited draft as the source of truth.
+- Added UI and API coverage for edited AI comments, single-student saves, and selected-student comment saves.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts`
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts`
+- `pnpm lint`
+- `pnpm test`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
+- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-assignment-detail.png`
+- `pnpm build`

--- a/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
@@ -55,6 +55,9 @@ export const POST = withErrorHandler('PostTeacherAssignmentFeedbackReturn', asyn
       feedback: feedbackDraft,
       teacher_feedback_draft: feedbackDraft,
       teacher_feedback_draft_updated_at: now,
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
       feedback_returned_at: now,
     }, { onConflict: 'assignment_id,student_id' })
     .select('*')

--- a/src/components/assignment-workspace/useTeacherStudentWorkController.ts
+++ b/src/components/assignment-workspace/useTeacherStudentWorkController.ts
@@ -90,11 +90,42 @@ function serializeVisibleSections(sections: InspectorSectionId[]): string {
   return SECTION_ORDER.filter((section) => sections.includes(section)).join(',')
 }
 
-function mergeFeedbackDraft(baseDraft: string | null | undefined, aiSuggestion: string | null | undefined) {
+function parseOptionalTimestamp(value: string | null | undefined) {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function isFreshAiFeedbackSuggestion({
+  draftUpdatedAt,
+  suggestionUpdatedAt,
+}: {
+  draftUpdatedAt: string | null | undefined
+  suggestionUpdatedAt: string | null | undefined
+}) {
+  const draftTime = parseOptionalTimestamp(draftUpdatedAt)
+  const suggestionTime = parseOptionalTimestamp(suggestionUpdatedAt)
+
+  if (draftTime === null || suggestionTime === null) return true
+
+  return draftTime <= suggestionTime
+}
+
+function mergeFeedbackDraft(
+  baseDraft: string | null | undefined,
+  aiSuggestion: string | null | undefined,
+  timestamps?: {
+    draftUpdatedAt: string | null | undefined
+    suggestionUpdatedAt: string | null | undefined
+  },
+) {
   const base = (baseDraft ?? '').trim()
   const suggestion = (aiSuggestion ?? '').trim()
 
   if (!suggestion) return { value: baseDraft ?? '', hasFreshAI: false }
+  if (timestamps && !isFreshAiFeedbackSuggestion(timestamps)) {
+    return { value: baseDraft ?? '', hasFreshAI: false }
+  }
   if (!base) return { value: suggestion, hasFreshAI: true }
   if (base.includes(suggestion)) return { value: baseDraft ?? base, hasFreshAI: false }
 
@@ -420,7 +451,10 @@ export function useTeacherStudentWorkController({
     const nextScoreThinking = doc.score_thinking?.toString() ?? ''
     const nextScoreWorkflow = doc.score_workflow?.toString() ?? ''
     const baseDraft = mergeBaseDraft ?? doc.teacher_feedback_draft ?? doc.feedback ?? ''
-    const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion)
+    const mergedDraft = mergeFeedbackDraft(baseDraft, doc.ai_feedback_suggestion, {
+      draftUpdatedAt: doc.teacher_feedback_draft_updated_at,
+      suggestionUpdatedAt: doc.ai_feedback_suggested_at,
+    })
 
     setScoreCompletion(nextScoreCompletion)
     setScoreThinking(nextScoreThinking)

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -199,6 +199,9 @@ export function buildAssignmentGradeRows(opts: {
     if (shouldApplyComments) {
       row.teacher_feedback_draft = grade.feedback
       row.teacher_feedback_draft_updated_at = now
+      row.ai_feedback_suggestion = null
+      row.ai_feedback_suggested_at = null
+      row.ai_feedback_model = null
     }
 
     return row

--- a/tests/api/teacher/assignments-grade-selected.test.ts
+++ b/tests/api/teacher/assignments-grade-selected.test.ts
@@ -162,6 +162,9 @@ describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
       score_workflow: 9,
       teacher_feedback_draft: 'Shared feedback',
       teacher_feedback_draft_updated_at: expect.any(String),
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
       graded_at: expect.any(String),
       graded_by: 'teacher',
     }))
@@ -201,6 +204,9 @@ describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
     }))
     expect(capturedRows[0][0]).not.toHaveProperty('teacher_feedback_draft')
     expect(capturedRows[0][0]).not.toHaveProperty('teacher_feedback_draft_updated_at')
+    expect(capturedRows[0][0]).not.toHaveProperty('ai_feedback_suggestion')
+    expect(capturedRows[0][0]).not.toHaveProperty('ai_feedback_suggested_at')
+    expect(capturedRows[0][0]).not.toHaveProperty('ai_feedback_model')
   })
 
   it('applies only comments when apply_target is comments', async () => {
@@ -225,6 +231,9 @@ describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
       student_id: 'student-1',
       teacher_feedback_draft: 'Shared comments',
       teacher_feedback_draft_updated_at: expect.any(String),
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
     }))
     expect(capturedRows[0][0]).not.toHaveProperty('score_completion')
     expect(capturedRows[0][0]).not.toHaveProperty('score_thinking')
@@ -258,6 +267,9 @@ describe('POST /api/teacher/assignments/[id]/grade-selected', () => {
       score_thinking: 8,
       score_workflow: null,
       teacher_feedback_draft: 'Draft feedback',
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
       graded_at: null,
       graded_by: null,
     }))

--- a/tests/api/teacher/assignments-id-feedback-return.test.ts
+++ b/tests/api/teacher/assignments-id-feedback-return.test.ts
@@ -48,6 +48,9 @@ describe('POST /api/teacher/assignments/[id]/feedback-return', () => {
       is_submitted: true,
       submitted_at: '2026-03-20T12:00:00.000Z',
       teacher_feedback_draft: 'Draft feedback',
+      ai_feedback_suggestion: 'AI feedback suggestion',
+      ai_feedback_suggested_at: '2026-03-20T12:10:00.000Z',
+      ai_feedback_model: 'gpt-5-nano',
     }
 
     const upsert = vi.fn((payload: Record<string, unknown>) => ({
@@ -110,6 +113,9 @@ describe('POST /api/teacher/assignments/[id]/feedback-return', () => {
       is_submitted: true,
       submitted_at: '2026-03-20T12:00:00.000Z',
       feedback_returned_at: expect.any(String),
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
     }))
     expect(payload).not.toHaveProperty('teacher_cleared_at')
     expect(payload).not.toHaveProperty('returned_at')

--- a/tests/api/teacher/assignments-id-grade.test.ts
+++ b/tests/api/teacher/assignments-id-grade.test.ts
@@ -221,6 +221,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
     expect(response.status).toBe(200)
     expect(capturedUpsertPayload?.graded_at).toBeNull()
     expect(capturedUpsertPayload?.graded_by).toBeNull()
+    expect(capturedUpsertPayload?.ai_feedback_suggestion).toBeNull()
+    expect(capturedUpsertPayload?.ai_feedback_suggested_at).toBeNull()
+    expect(capturedUpsertPayload?.ai_feedback_model).toBeNull()
     expect(body.doc.graded_at).toBeNull()
   })
 
@@ -309,6 +312,9 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
       score_thinking: null,
       score_workflow: null,
       teacher_feedback_draft: 'Draft only',
+      ai_feedback_suggestion: null,
+      ai_feedback_suggested_at: null,
+      ai_feedback_model: null,
       graded_at: null,
       graded_by: null,
     })

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -60,7 +60,9 @@ function makeStudentWork(
     repoUrl?: string | null
     githubUsername?: string | null
     aiFeedbackSuggestion?: string | null
+    aiFeedbackSuggestedAt?: string | null
     teacherFeedbackDraft?: string | null
+    teacherFeedbackDraftUpdatedAt?: string | null
     feedbackEntries?: Array<{ id: string; body: string; returned_at: string }>
     repoReviewResult?: Record<string, any> | null
     authenticityScore?: number | null
@@ -95,12 +97,14 @@ function makeStudentWork(
           ? 'Nice work'
           : null,
     teacher_feedback_draft_updated_at:
-      opts.teacherFeedbackDraft !== undefined || opts.graded
+      opts.teacherFeedbackDraftUpdatedAt !== undefined
+        ? opts.teacherFeedbackDraftUpdatedAt
+        : opts.teacherFeedbackDraft !== undefined || opts.graded
         ? '2026-02-20T13:00:00Z'
         : null,
     feedback_returned_at: null,
     ai_feedback_suggestion: opts.aiFeedbackSuggestion ?? null,
-    ai_feedback_suggested_at: null,
+    ai_feedback_suggested_at: opts.aiFeedbackSuggestedAt ?? null,
     ai_feedback_model: null,
     graded_at: opts.graded ? '2026-02-20T13:00:00Z' : null,
     graded_by: opts.graded ? 'teacher@example.com' : null,
@@ -164,7 +168,9 @@ function mockFetchByStudent(
       repoUrl?: string | null
       githubUsername?: string | null
       aiFeedbackSuggestion?: string | null
+      aiFeedbackSuggestedAt?: string | null
       teacherFeedbackDraft?: string | null
+      teacherFeedbackDraftUpdatedAt?: string | null
       feedbackEntries?: Array<{ id: string; body: string; returned_at: string }>
       repoReviewResult?: Record<string, any> | null
       authenticityScore?: number | null
@@ -1077,6 +1083,34 @@ describe('TeacherStudentWorkPanel', () => {
     expect(draft).toHaveValue('AI feedback suggestion\n\nTeacher note')
     expect(draft).not.toHaveClass('border-primary')
     expect(draft).not.toHaveClass('bg-info-bg')
+    expect(screen.queryByText('AI draft')).not.toBeInTheDocument()
+  })
+
+  it('does not restore stale AI comments after the teacher edits the draft', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        teacherFeedbackDraft: 'Edited teacher comment',
+        teacherFeedbackDraftUpdatedAt: '2026-02-20T13:05:00Z',
+        aiFeedbackSuggestion: 'Original AI feedback',
+        aiFeedbackSuggestedAt: '2026-02-20T13:00:00Z',
+      },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    const draft = await screen.findByPlaceholderText('Teacher comment draft')
+    expect(draft).toHaveValue('Edited teacher comment')
     expect(screen.queryByText('AI draft')).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Fixes assignment comment drafts coming back after a teacher edits AI-generated feedback and refreshes the grading view.

## Root Cause

The teacher grading panel merged `ai_feedback_suggestion` into the editable comment draft on every load unless the current draft still contained the exact original AI text. If a teacher reworded or replaced the AI draft, the old suggestion was still persisted separately and got prepended again after refresh.

## Changes

- Treat AI feedback suggestions as fresh only when their timestamp is newer than or equal to the teacher draft timestamp.
- Clear consumed AI suggestion metadata when teacher comments are autosaved, batch-applied, or sent/returned.
- Keep untouched AI drafts intact so teachers can still use them as generated.
- Add UI/API regression coverage for stale AI suggestion handling and metadata clearing.
- Update the session log for this work.

## Validation

- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts`
- `pnpm lint`
- `pnpm test` (272 files / 2272 tests passed)
- `pnpm build`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-assignment-detail.png`