### PR TITLE
[codex] Fix gradebook scrolling

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-15 — Survey results card cleanup
-
-**Completed:**
-- Removed the separate title/status card from the teacher selected-survey results pane.
-- Removed the selected-survey workspace parent border/background so survey results sit directly on the page.
-- Moved the survey title into the results card and removed the aggregate responded-count line from results.
-- Added shared survey option result bars that place percentages inside the indicator bars for teacher and student results.
-- Stabilized the generated-title focus test with an explicit wait after the all-file startup run exposed a focus timing flake.
-
-**Validation:**
-- `bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh` — one focus-timing test failed during the full suite before edits; the isolated test passed afterward and was stabilized.
-- `pnpm test tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm test tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3028 bash /Users/stew/Repos/pika/.codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments&surveyId=a7b4279f-d18e-4277-b4de-b1950e24e892'`
-- Targeted Playwright screenshots/assertions: `/tmp/pika-survey-results-bars.png`, `/tmp/pika-survey-results-card-teacher.png`, `/tmp/pika-survey-results-card-student.png`; temporary multiple-choice survey response rows were deleted afterward.
-
 ## 2026-05-19 — Multiple-choice survey option cap
 
 **Completed:**
@@ -341,3 +323,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
 - Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-assignment-detail.png`
 - `pnpm build`
+
+## 2026-05-21 — Gradebook scroll containment
+
+**Completed:**
+- Fixed the teacher gradebook matrix so its table panel fills the workspace and owns both horizontal and vertical overflow.
+- Removed the flush table wrapper that clipped horizontal overflow before the gradebook scroll pane could expose it.
+- Kept the gradebook viewport-constrained in both grades and settings modes so long student lists and many assessment columns remain reachable.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm lint`
+- Mocked long-grid Playwright check with 48 students and 32 assessment columns; verified `gradebook-student-scroll-pane` can scroll on both axes and captured `/tmp/pika-gradebook-scroll-after.png` and `/tmp/pika-gradebook-settings-scroll-after.png`.
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=gradebook"`
+- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1073,8 +1073,9 @@ function ClassroomPageContent({
       (activeTab === 'assignments' && !!assignmentIdParam && !!assignmentStudentIdParam) ||
       (activeTab === 'tests' && !!testIdParam && testModeParam === 'grading' && !!testStudentIdParam)
     )
+  const hasTeacherViewportGrid = isTeacher && activeTab === 'gradebook'
   const hasConstrainedWorkspace =
-    hasActiveTeacherSplitPanes || (!isTeacher && activeTab === 'today')
+    hasActiveTeacherSplitPanes || hasTeacherViewportGrid || (!isTeacher && activeTab === 'today')
 
   async function handleRequestAssessmentDelete() {
     if (!selectedQuiz) return

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -27,7 +27,6 @@ import {
   DataTableRow,
   EmptyStateRow,
   SortableHeaderCell,
-  TableCard,
 } from '@/components/DataTable'
 import {
   fetchJSONWithCache,
@@ -488,12 +487,11 @@ function AssessmentMatrixTable({
   return (
     <div
       ref={scrollContainerRef}
-      className="h-full min-h-0 overflow-auto"
+      className="h-full min-h-0 min-w-0 overflow-auto"
       data-testid="gradebook-student-scroll-pane"
       onScroll={onScrollContainerScroll}
     >
-      <TableCard chrome="flush">
-        <DataTable density="tight" className="min-w-max">
+      <DataTable density="tight" className="min-w-max">
           <DataTableHead>
             {editMode ? (
               <DataTableRow className="border-b border-border">
@@ -970,8 +968,7 @@ function AssessmentMatrixTable({
               </>
             )}
           </DataTableBody>
-        </DataTable>
-      </TableCard>
+      </DataTable>
     </div>
   )
 }
@@ -1239,7 +1236,7 @@ export function TeacherGradebookTab({
   )
 
   const gradebookTable = (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-surface">
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-surface">
       <AssessmentMatrixTable
         students={sortedStudents}
         columns={assessmentColumns}
@@ -1286,7 +1283,7 @@ export function TeacherGradebookTab({
     </div>
   ) : (
     <TeacherWorkspaceSplit
-      className="flex-1"
+      className="h-full flex-1"
       splitVariant="gapped"
       primary={gradebookTable}
       inspector={studentAssessmentPanel}


### PR DESCRIPTION
## Summary

Fixes the teacher gradebook matrix so long student rosters and wide assessment sets stay reachable.

## Root Cause

The gradebook table already had an internal `overflow-auto` container, but the surrounding workspace was not always constrained to viewport height and the flush table wrapper clipped horizontal overflow before the scroll pane could expose it. In settings mode especially, the grid could grow to its content size instead of letting the matrix scroll.

## Changes

- Make the gradebook matrix scroll pane own both horizontal and vertical overflow.
- Remove the flush table wrapper that clipped horizontal overflow.
- Ensure the gradebook workspace is viewport-constrained in both grades and settings modes.
- Add the required AI session-log entry and trim the rolling log.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- Mocked long-grid Playwright check with 48 students and 32 assessment columns; verified `gradebook-student-scroll-pane` scrolls on both axes.
- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=gradebook"`