### PR TITLE
Freeze returned assignment timing

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,18 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-19 — Multiple-choice survey option cap
-
-**Completed:**
-- Raised the multiple-choice survey option cap from 6 to 50 in the shared survey validation.
-- Added a boundary unit test that accepts the configured maximum and rejects one option beyond it.
-
-**Validation:**
-- `bash /Users/stew/Repos/pika/.codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/surveys.test.ts tests/api/teacher/surveys-questions-route.test.ts tests/api/teacher/surveys-questions-id.test.ts`
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-05-19 — Survey open-state question-count refresh
 
 **Completed:**
@@ -338,3 +326,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Mocked long-grid Playwright check with 48 students and 32 assessment columns; verified `gradebook-student-scroll-pane` can scroll on both axes and captured `/tmp/pika-gradebook-scroll-after.png` and `/tmp/pika-gradebook-settings-scroll-after.png`.
 - `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=gradebook"`
 - Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+
+## 2026-05-21 — Returned assignment timing freeze
+
+**Completed:**
+- Fixed returned assignment timing so student-facing labels freeze against preserved `submitted_at` even after teacher return clears `is_submitted`.
+- Added regression coverage for returned late work with `is_submitted: false`, preserved `submitted_at`, and `returned_at`.
+- Rebuilt the fix on a fresh branch from current `origin/main` to avoid carrying stale already-merged commits.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm seed`
+- `pnpm e2e:auth`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/85d6177d-f695-4df2-bbad-2946876d8e16?tab=assignments"`
+- Reviewed `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-loaded.png`.
+- `pnpm test`

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -366,19 +366,20 @@ function formatLateSubmissionDuration(diffMs: number): string {
 /**
  * Format student-facing assignment timing.
  *
- * Unsubmitted work keeps counting relative to the due date. Submitted work is
- * frozen at submitted_at so overdue text does not keep increasing after submit.
+ * Work without a submission timestamp keeps counting relative to the due date.
+ * Once a submission exists, timing is frozen at submitted_at so overdue text
+ * does not keep increasing after submit or teacher return.
  */
 export function formatAssignmentTiming(
   dueAt: string,
   doc: AssignmentTimingDoc | null | undefined
 ): string {
-  if (!doc?.is_submitted) {
+  if (!doc) {
     return formatRelativeDueDate(dueAt)
   }
 
   if (!doc.submitted_at) {
-    return 'Submitted'
+    return doc.is_submitted ? 'Submitted' : formatRelativeDueDate(dueAt)
   }
 
   const due = new Date(dueAt)

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -298,4 +298,35 @@ describe('StudentAssignmentsTab', () => {
     })
     expect(screen.queryByText(/days overdue/i)).not.toBeInTheDocument()
   })
+
+  it('freezes returned late assignment card timing at the original submission timestamp', async () => {
+    const returnedClassroom = { ...classroom, id: 'cls-returned' }
+    mockFetchAssignments([
+      makeAssignment({
+        classroom_id: returnedClassroom.id,
+        due_at: '2024-10-20T12:00:00Z',
+        status: 'returned',
+        doc: {
+          id: 'doc-1',
+          assignment_id: 'asgn-1',
+          student_id: 'stu-1',
+          content: { type: 'doc', content: [] },
+          is_submitted: false,
+          submitted_at: '2024-10-21T12:00:00Z',
+          returned_at: '2024-10-22T12:00:00Z',
+          viewed_at: '2024-06-01T00:00:00Z',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        } as any,
+      }),
+    ])
+
+    render(<StudentAssignmentsTab classroom={returnedClassroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Submitted 1 day late')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Returned')).toBeInTheDocument()
+    expect(screen.queryByText(/days overdue/i)).not.toBeInTheDocument()
+  })
 })

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -1133,6 +1133,19 @@ describe('assignment utilities', () => {
       expect(result).toBe('Submitted 1 day late')
     })
 
+    it('freezes returned late work at the original submission timestamp', () => {
+      vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
+      const doc = createMockAssignmentDoc({
+        is_submitted: false,
+        submitted_at: '2024-10-21T12:00:00Z',
+        returned_at: '2024-10-22T12:00:00Z',
+      })
+
+      const result = formatAssignmentTiming('2024-10-20T12:00:00Z', doc)
+
+      expect(result).toBe('Submitted 1 day late')
+    })
+
     it('shows multiple days late for older late submissions', () => {
       vi.setSystemTime(new Date('2024-10-25T12:00:00Z'))
       const doc = createMockAssignmentDoc({


### PR DESCRIPTION
## Summary

Fixes the student assignment timing label for work that was submitted late and then returned by the teacher.

Teacher return clears `is_submitted` while preserving `submitted_at`. The student-facing timing helper was using `is_submitted` as the freeze signal, so returned late work could fall back to the live overdue counter and keep increasing. The helper now freezes whenever a submission timestamp exists, while true unsubmitted work still counts relative to the due date.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
- `pnpm seed`
- `pnpm e2e:auth`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/85d6177d-f695-4df2-bbad-2946876d8e16?tab=assignments"`
- Reviewed `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-loaded.png`
- `pnpm test`
- `git diff --check`
