### PR TITLE
Simplify assessment draft question sync

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -320,3 +320,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=1bd43274-afe7-472c-90c9-5b704d83e4b2&assignmentStudentId=e0d9c4e7-2a88-4428-bd15-ba87f2d935b7"`
 - Targeted Playwright long-list check: selected Student65 and reloaded; `scrollTop` remained `1500`.
+## 2026-05-23 — Draft question sync helper
+
+**Completed:**
+- Refactored quiz/test draft question syncing to use a shared helper in `src/lib/server/assessment-drafts.ts` (keeps behavior + error strings the same, reduces drift risk).
+- Added unit coverage for the quiz sync insert-failure path.
+- Draft PR: https://github.com/codepetca/pika/pull/619
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/unit/assessment-drafts.test.ts`
+- `pnpm test`
+- `pnpm lint`

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -456,66 +456,30 @@ export async function syncQuizQuestionsFromDraft(
   quizId: string,
   content: QuizDraftContent
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-  const { data: existingRows, error: existingError } = await supabase
-    .from('quiz_questions')
-    .select('id')
-    .eq('quiz_id', quizId)
-
-  if (existingError) {
-    return { ok: false, status: 500, error: 'Failed to load quiz questions for sync' }
-  }
-
-  const existingIds = new Set<string>((existingRows || []).map((row: { id: string }) => row.id))
-  const nextIds = new Set(content.questions.map((question) => question.id))
-
-  for (const [position, question] of content.questions.entries()) {
-    if (existingIds.has(question.id)) {
-      const { error } = await supabase
-        .from('quiz_questions')
-        .update({
-          question_text: question.question_text,
-          options: question.options,
-          position,
-        })
-        .eq('quiz_id', quizId)
-        .eq('id', question.id)
-
-      if (error) {
-        return { ok: false, status: 500, error: 'Failed to update synced quiz question' }
-      }
-      continue
-    }
-
-    const { error } = await supabase
-      .from('quiz_questions')
-      .insert({
-        id: question.id,
-        quiz_id: quizId,
-        question_text: question.question_text,
-        options: question.options,
-        position,
-      })
-
-    if (error) {
-      return { ok: false, status: 500, error: 'Failed to insert synced quiz question' }
-    }
-  }
-
-  for (const existingId of existingIds) {
-    if (nextIds.has(existingId)) continue
-
-    const { error } = await supabase
-      .from('quiz_questions')
-      .delete()
-      .eq('quiz_id', quizId)
-      .eq('id', existingId)
-
-    if (error) {
-      return { ok: false, status: 500, error: 'Failed to delete removed quiz question' }
-    }
-  }
-
-  return { ok: true }
+  return syncAssessmentQuestionRowsFromDraft(supabase, {
+    table: 'quiz_questions',
+    foreignKey: 'quiz_id',
+    parentId: quizId,
+    questions: content.questions,
+    buildUpdatePayload: (question, position) => ({
+      question_text: question.question_text,
+      options: question.options,
+      position,
+    }),
+    buildInsertPayload: (question, position) => ({
+      id: question.id,
+      quiz_id: quizId,
+      question_text: question.question_text,
+      options: question.options,
+      position,
+    }),
+    errorMessages: {
+      load: 'Failed to load quiz questions for sync',
+      update: 'Failed to update synced quiz question',
+      insert: 'Failed to insert synced quiz question',
+      delete: 'Failed to delete removed quiz question',
+    },
+  })
 }
 
 export async function syncTestQuestionsFromDraft(
@@ -523,20 +487,12 @@ export async function syncTestQuestionsFromDraft(
   testId: string,
   content: TestDraftContent
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-  const { data: existingRows, error: existingError } = await supabase
-    .from('test_questions')
-    .select('id')
-    .eq('test_id', testId)
-
-  if (existingError) {
-    return { ok: false, status: 500, error: 'Failed to load test questions for sync' }
-  }
-
-  const existingIds = new Set<string>((existingRows || []).map((row: { id: string }) => row.id))
-  const nextIds = new Set(content.questions.map((question) => question.id))
-
-  for (const [position, question] of content.questions.entries()) {
-    const rowPayload = {
+  return syncAssessmentQuestionRowsFromDraft(supabase, {
+    table: 'test_questions',
+    foreignKey: 'test_id',
+    parentId: testId,
+    questions: content.questions,
+    buildUpdatePayload: (question, position) => ({
       question_type: question.question_type,
       question_text: question.question_text,
       options: question.options,
@@ -547,31 +503,79 @@ export async function syncTestQuestionsFromDraft(
       response_max_chars: question.response_max_chars,
       response_monospace: question.response_monospace,
       position,
-    }
+    }),
+    buildInsertPayload: (question, position) => ({
+      id: question.id,
+      test_id: testId,
+      question_type: question.question_type,
+      question_text: question.question_text,
+      options: question.options,
+      correct_option: question.correct_option,
+      answer_key: question.answer_key,
+      sample_solution: question.sample_solution,
+      points: question.points,
+      response_max_chars: question.response_max_chars,
+      response_monospace: question.response_monospace,
+      position,
+    }),
+    errorMessages: {
+      load: 'Failed to load test questions for sync',
+      update: 'Failed to update synced test question',
+      insert: 'Failed to insert synced test question',
+      delete: 'Failed to delete removed test question',
+    },
+  })
+}
 
+type SyncAssessmentQuestionRowsConfig<TQuestion extends { id: string }> = {
+  table: string
+  foreignKey: string
+  parentId: string
+  questions: TQuestion[]
+  buildUpdatePayload: (question: TQuestion, position: number) => Record<string, unknown>
+  buildInsertPayload: (question: TQuestion, position: number) => Record<string, unknown>
+  errorMessages: {
+    load: string
+    update: string
+    insert: string
+    delete: string
+  }
+}
+
+async function syncAssessmentQuestionRowsFromDraft<TQuestion extends { id: string }>(
+  supabase: SupabaseLike,
+  config: SyncAssessmentQuestionRowsConfig<TQuestion>
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  const { data: existingRows, error: existingError } = await supabase
+    .from(config.table)
+    .select('id')
+    .eq(config.foreignKey, config.parentId)
+
+  if (existingError) {
+    return { ok: false, status: 500, error: config.errorMessages.load }
+  }
+
+  const existingIds = new Set<string>((existingRows || []).map((row: { id: string }) => row.id))
+  const nextIds = new Set(config.questions.map((question) => question.id))
+
+  for (const [position, question] of config.questions.entries()) {
     if (existingIds.has(question.id)) {
       const { error } = await supabase
-        .from('test_questions')
-        .update(rowPayload)
-        .eq('test_id', testId)
+        .from(config.table)
+        .update(config.buildUpdatePayload(question, position))
+        .eq(config.foreignKey, config.parentId)
         .eq('id', question.id)
 
       if (error) {
-        return { ok: false, status: 500, error: 'Failed to update synced test question' }
+        return { ok: false, status: 500, error: config.errorMessages.update }
       }
       continue
     }
 
-    const { error } = await supabase
-      .from('test_questions')
-      .insert({
-        id: question.id,
-        test_id: testId,
-        ...rowPayload,
-      })
+    const { error } = await supabase.from(config.table).insert(config.buildInsertPayload(question, position))
 
     if (error) {
-      return { ok: false, status: 500, error: 'Failed to insert synced test question' }
+      return { ok: false, status: 500, error: config.errorMessages.insert }
     }
   }
 
@@ -579,13 +583,13 @@ export async function syncTestQuestionsFromDraft(
     if (nextIds.has(existingId)) continue
 
     const { error } = await supabase
-      .from('test_questions')
+      .from(config.table)
       .delete()
-      .eq('test_id', testId)
+      .eq(config.foreignKey, config.parentId)
       .eq('id', existingId)
 
     if (error) {
-      return { ok: false, status: 500, error: 'Failed to delete removed test question' }
+      return { ok: false, status: 500, error: config.errorMessages.delete }
     }
   }
 

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -516,4 +516,106 @@ describe('assessment drafts', () => {
       error: 'Failed to update synced test question',
     })
   })
+
+  it('syncs test questions by updating existing rows, inserting new rows, and deleting removed rows', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    const inserts: Array<Record<string, unknown>> = []
+    const deletes: Array<string> = []
+
+    const supabase = {
+      from: vi.fn((_table: string) => ({
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({
+            data: [{ id: TEST_ID_1 }, { id: TEST_ID_2 }],
+            error: null,
+          }),
+        })),
+        update: vi.fn((payload: Record<string, unknown>) => {
+          updates.push(payload)
+          return {
+            eq: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            })),
+          }
+        }),
+        insert: vi.fn((payload: Record<string, unknown>) => {
+          inserts.push(payload)
+          return Promise.resolve({ error: null })
+        }),
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn((_column: string, id: string) => {
+              deletes.push(id)
+              return Promise.resolve({ error: null })
+            }),
+          })),
+        })),
+      })),
+    }
+
+    await expect(
+      syncTestQuestionsFromDraft(supabase, 'test-1', {
+        title: 'Test',
+        show_results: false,
+        questions: [
+          {
+            id: TEST_ID_1,
+            question_type: 'multiple_choice',
+            question_text: 'Updated',
+            options: ['A', 'B'],
+            correct_option: 0,
+            answer_key: null,
+            sample_solution: null,
+            points: 2,
+            response_max_chars: 5000,
+            response_monospace: false,
+          },
+          {
+            id: '66666666-6666-4666-8666-666666666666',
+            question_type: 'open_response',
+            question_text: 'New',
+            options: [],
+            correct_option: null,
+            answer_key: 'Key',
+            sample_solution: null,
+            points: 1,
+            response_max_chars: 1200,
+            response_monospace: true,
+          },
+        ],
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(updates).toEqual([
+      {
+        question_type: 'multiple_choice',
+        question_text: 'Updated',
+        options: ['A', 'B'],
+        correct_option: 0,
+        answer_key: null,
+        sample_solution: null,
+        points: 2,
+        response_max_chars: 5000,
+        response_monospace: false,
+        position: 0,
+      },
+    ])
+    expect(inserts).toEqual([
+      {
+        id: '66666666-6666-4666-8666-666666666666',
+        test_id: 'test-1',
+        question_type: 'open_response',
+        question_text: 'New',
+        options: [],
+        correct_option: null,
+        answer_key: 'Key',
+        sample_solution: null,
+        points: 1,
+        response_max_chars: 1200,
+        response_monospace: true,
+        position: 1,
+      },
+    ])
+    expect(deletes).toEqual([TEST_ID_2])
+  })
 })

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -442,6 +442,36 @@ describe('assessment drafts', () => {
     expect(deletes).toEqual([QUIZ_ID_2])
   })
 
+  it('returns a 500 error when syncing quiz questions fails during insert', async () => {
+    const supabase = {
+      from: vi.fn((_table: string) => ({
+        select: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({
+            data: [{ id: QUIZ_ID_1 }],
+            error: null,
+          }),
+        })),
+        update: vi.fn(),
+        insert: vi.fn().mockResolvedValue({ error: { message: 'insert failed' } }),
+        delete: vi.fn(),
+      })),
+    }
+
+    await expect(
+      syncQuizQuestionsFromDraft(supabase, 'quiz-1', {
+        title: 'Quiz',
+        show_results: false,
+        questions: [
+          { id: '55555555-5555-4555-8555-555555555555', question_text: 'New', options: ['C', 'D'] },
+        ],
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: 'Failed to insert synced quiz question',
+    })
+  })
+
   it('returns a 500 error when syncing test questions fails during update', async () => {
     const supabase = {
       from: vi.fn((_table: string) => ({


### PR DESCRIPTION
## Hotspot
Duplicated quiz/test question-sync loops in `src/lib/server/assessment-drafts.ts` were a drift risk (two near-identical CRUD loops with different payloads/error strings).

## Why this change
A small edit (new fields, error handling tweaks) previously had to be done twice and could easily diverge.

## Risk profile
workspace-state (teacher quiz/test draft editing)

## Behavior
Preserved: still loads existing IDs, updates existing rows, inserts new rows, and deletes removed rows; error messages and status codes unchanged.

## Tests
- Added: insert-failure coverage for quiz sync
- Existing: unit coverage for happy-path sync and test-question update failure

## Commands
- `bash scripts/verify-env.sh`
- `pnpm test tests/unit/assessment-drafts.test.ts`
- `pnpm test`
- `pnpm lint`

## Follow-ups (intentionally out of scope)
- Add symmetric insert/delete failure tests for test question sync
