### PR TITLE
[codex] Preserve assignment student scroll

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,35 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-18 — Shared creation modal shell
-
-**Completed:**
-- Extracted `CreationModalShell` and `CreationModalTopRow` for assignment-style creation flows.
-- Reused the shared creation shell in assignment creation while keeping scheduling, autosave, and markdown behavior feature-local.
-- Applied the same title-first, no-visible-header, absolute-close, top-row primary-action creation UI to quiz/test and survey creation.
-- Added a dedicated survey creation modal so the shared creation shell fits the upstream survey workspace flow after creation.
-- Kept quiz/test and survey edit/settings modals compact instead of forcing them into the creation shell.
-- Added experimental UI guidance for the shared creation shell candidate.
-
-**Validation:**
-- `bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/components/AssignmentModal.test.tsx tests/components/QuizModal.test.tsx tests/components/SurveyModal.test.tsx tests/components/SurveyCreationModal.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx tests/unit/ai-startup-docs.test.ts`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3000 pnpm e2e:auth`
-- `E2E_BASE_URL=http://localhost:3000 bash /Users/stew/Repos/.worktrees/pika/creation-modal-shell/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Additional modal screenshots:
-  - `/tmp/pika-assignment-create-desktop.png`
-  - `/tmp/pika-test-create-desktop.png`
-  - `/tmp/pika-survey-create-desktop.png`
-  - `/tmp/pika-assignment-create-mobile.png`
-  - `/tmp/pika-test-create-mobile.png`
-  - `/tmp/pika-survey-create-mobile.png`
-- UI verification on `http://localhost:3001`:
-  - `E2E_BASE_URL=http://localhost:3001 bash /Users/stew/Repos/.worktrees/pika/fix-released-assignment-scheduling/.codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-  - Targeted live-assignment editor screenshot: `/tmp/pika-live-assignment-editor.png`
-
 ## 2026-05-16 — Native worktree AI guidance
 
 **Completed:**
@@ -333,3 +304,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/migration-filenames.test.ts tests/unit/ai-startup-docs.test.ts`
 - `pnpm lint`
 - `git diff --check`
+
+## 2026-05-22 — Assignment student list scroll persistence
+
+**Completed:**
+- Persisted assignment student-list scroll memory to session storage for the teacher assignment workspace.
+- Made scroll restoration run across the next layout frames so split-pane refreshes and route reloads do not leave the list at the top.
+- Added hook regression coverage for session-backed scroll restoration after remount.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/hooks/useScrollPositionMemory.test.tsx`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=1bd43274-afe7-472c-90c9-5b704d83e4b2&assignmentStudentId=e0d9c4e7-2a88-4428-bd15-ba87f2d935b7"`
+- Targeted Playwright long-list check: selected Student65 and reloaded; `scrollTop` remained `1500`.

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1808,6 +1808,9 @@ export function TeacherClassroomView({
   } = useScrollPositionMemory<HTMLDivElement>({
     key: selectedAssignmentId,
     enabled: splitPaneView !== 'content-grading',
+    storageKey: selectedAssignmentId
+      ? `teacher-assignment-student-scroll:${classroom.id}:${selectedAssignmentId}`
+      : null,
     restoreToken: [
       activeSelectedStudentId ?? 'none',
       currentStudentRows.length,

--- a/src/hooks/useScrollPositionMemory.ts
+++ b/src/hooks/useScrollPositionMemory.ts
@@ -1,11 +1,13 @@
 'use client'
 
 import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
+import { safeSessionGetJson, safeSessionSetJson } from '@/lib/client-storage'
 
 interface UseScrollPositionMemoryOptions {
   key: string | null
   enabled?: boolean
   restoreToken?: string | number | boolean | null
+  storageKey?: string | null
 }
 
 interface UseScrollPositionMemoryResult<T extends HTMLElement> {
@@ -18,37 +20,63 @@ export function useScrollPositionMemory<T extends HTMLElement>({
   key,
   enabled = true,
   restoreToken = null,
+  storageKey = null,
 }: UseScrollPositionMemoryOptions): UseScrollPositionMemoryResult<T> {
   const scrollRef = useRef<T | null>(null)
   const scrollTopByKeyRef = useRef<Record<string, number>>({})
+
+  const readStoredScrollTop = useCallback(() => {
+    if (!storageKey) return null
+    const storedValue = safeSessionGetJson<unknown>(storageKey)
+    if (typeof storedValue !== 'number' || !Number.isFinite(storedValue)) return null
+    return Math.max(0, storedValue)
+  }, [storageKey])
 
   const preserveScrollPosition = useCallback(() => {
     if (!enabled || !key) return
     const node = scrollRef.current
     if (!node) return
-    scrollTopByKeyRef.current[key] = node.scrollTop
-  }, [enabled, key])
+    const nextScrollTop = node.scrollTop
+    scrollTopByKeyRef.current[key] = nextScrollTop
+    if (storageKey) {
+      safeSessionSetJson(storageKey, nextScrollTop)
+    }
+  }, [enabled, key, storageKey])
 
   const restoreScrollPosition = useCallback(() => {
     if (!enabled || !key) return
     const node = scrollRef.current
     if (!node) return
-    const storedScrollTop = scrollTopByKeyRef.current[key] ?? 0
+    const storedScrollTop = scrollTopByKeyRef.current[key] ?? readStoredScrollTop() ?? 0
     if (node.scrollTop !== storedScrollTop) {
       node.scrollTop = storedScrollTop
     }
-  }, [enabled, key])
+  }, [enabled, key, readStoredScrollTop])
 
   useLayoutEffect(() => {
     restoreScrollPosition()
+    let secondFrameId: number | null = null
     const frameId =
       typeof window.requestAnimationFrame === 'function'
-        ? window.requestAnimationFrame(restoreScrollPosition)
+        ? window.requestAnimationFrame(() => {
+            restoreScrollPosition()
+            secondFrameId = window.requestAnimationFrame(restoreScrollPosition)
+          })
+        : null
+    const timeoutId =
+      typeof window.setTimeout === 'function'
+        ? window.setTimeout(restoreScrollPosition, 50)
         : null
 
     return () => {
       if (frameId !== null && typeof window.cancelAnimationFrame === 'function') {
         window.cancelAnimationFrame(frameId)
+      }
+      if (secondFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(secondFrameId)
+      }
+      if (timeoutId !== null && typeof window.clearTimeout === 'function') {
+        window.clearTimeout(timeoutId)
       }
     }
   }, [enabled, key, restoreScrollPosition, restoreToken])

--- a/tests/hooks/useScrollPositionMemory.test.tsx
+++ b/tests/hooks/useScrollPositionMemory.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
+
+function ScrollMemoryHarness({
+  memoryKey = 'assignment-1',
+  storageKey = 'teacher-assignment-student-scroll:classroom-1:assignment-1',
+}: {
+  memoryKey?: string | null
+  storageKey?: string | null
+}) {
+  const { scrollRef, preserveScrollPosition } = useScrollPositionMemory<HTMLDivElement>({
+    key: memoryKey,
+    storageKey,
+    restoreToken: memoryKey,
+  })
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="scroll-pane"
+      onScroll={preserveScrollPosition}
+    />
+  )
+}
+
+describe('useScrollPositionMemory', () => {
+  afterEach(() => {
+    window.sessionStorage.clear()
+  })
+
+  it('restores a persisted scroll position after the scroll pane remounts', () => {
+    const { unmount } = render(<ScrollMemoryHarness />)
+    const scrollPane = screen.getByTestId('scroll-pane') as HTMLDivElement
+    scrollPane.scrollTop = 520
+    fireEvent.scroll(scrollPane)
+
+    unmount()
+    render(<ScrollMemoryHarness />)
+
+    expect(screen.getByTestId('scroll-pane')).toHaveProperty('scrollTop', 520)
+  })
+
+  it('keeps persisted scroll positions scoped by storage key', () => {
+    window.sessionStorage.setItem(
+      'teacher-assignment-student-scroll:classroom-1:assignment-1',
+      JSON.stringify(520),
+    )
+    window.sessionStorage.setItem(
+      'teacher-assignment-student-scroll:classroom-1:assignment-2',
+      JSON.stringify(120),
+    )
+
+    render(
+      <ScrollMemoryHarness
+        memoryKey="assignment-2"
+        storageKey="teacher-assignment-student-scroll:classroom-1:assignment-2"
+      />,
+    )
+
+    expect(screen.getByTestId('scroll-pane')).toHaveProperty('scrollTop', 120)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the teacher assignment workspace so selecting a student from a long list refreshes the grading pane without losing the left-pane scroll position.

## Root Cause

The assignment student list only remembered scroll position in a component ref. Normal re-renders were covered, but route/search-param refreshes or split-pane remount timing could drop the remembered value and restore before the pane had finished sizing.

## Changes

- Added optional session-backed storage to `useScrollPositionMemory`.
- Restored scroll position across immediate, animation-frame, second animation-frame, and short delayed layout passes.
- Enabled session-backed scroll memory for the teacher assignment student pane, scoped by classroom and assignment.
- Added hook regression coverage for restoring persisted scroll position after remount.
- Updated the session log.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/hooks/useScrollPositionMemory.test.tsx`
- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
- `pnpm lint`
- `pnpm test`
- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=1bd43274-afe7-472c-90c9-5b704d83e4b2&assignmentStudentId=e0d9c4e7-2a88-4428-bd15-ba87f2d935b7"`
- Targeted Playwright long-list check: selected Student65 and reloaded; `scrollTop` remained `1500`.