### PR TITLE
[codex] Move roster removal into FAB menu

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,27 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-20 — Remove assignment repo submission option
-
-**Completed:**
-- Removed the separate student `Repo` action and GitHub repo metadata dialog from the assignment editor.
-- Stopped student assignment saves from writing `repo_url` / `github_username`; repo links now live in editor content as artifacts.
-- Changed submission validation so repo metadata alone is not submittable work.
-- Updated repo analysis target resolution to fall back to pasted GitHub repo artifacts and infer the GitHub username from the repo owner when no legacy username is present.
-- Kept teacher assignment artifact and repo-analysis surfaces working with pasted repo artifacts.
-- Hid the unfinished repository marking section from the teacher grading inspector and removed the batch repo-analysis action while leaving backend repo artifact extraction/analysis plumbing in place for a later rebuild.
-
-**Validation:**
-- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignment-repo-targets.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/assignment-docs/submit.test.ts tests/unit/assignments.test.ts`
-- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
-- Additional assignment screenshots: `/tmp/pika-student-assignment-editor.png`, `/tmp/pika-teacher-assignment-workspace.png`
-- Additional hidden-repo marking screenshots: `/tmp/pika-teacher-assignment-workspace-hidden-repo.png`, `/tmp/pika-teacher-assignment-actions-hidden-repo.png`
-- `git diff --check`
-
 ## 2026-05-20 — Assignment repo follow-up
 
 **Completed:**
@@ -305,6 +284,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop`
 - `pnpm lint`
+
 ## 2026-05-23 — Roster delete action in FAB menu
 
 **Completed:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,6 +7,67 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
+## 2026-05-19 — Workflow friction automation
+
+**Completed:**
+- Created the active weekly `Pika Workflow Friction Review` Codex automation as a report-only review of recent workflow friction and guidance drift.
+- Updated the active `Weekly Pika Simplification` automation prompt to use the native worktree flow and stop relying on project-specific worktree environment variables.
+- Confirmed both automation configs were written under `/Users/stew/.codex/automations`.
+
+**Validation:**
+- Read back `/Users/stew/.codex/automations/weekly-pika-simplification/automation.toml`.
+- Read back `/Users/stew/.codex/automations/pika-workflow-friction-review/automation.toml`.
+
+## 2026-05-19 — Remove student legacy quizzes nav plumbing
+
+**Completed:**
+- Removed legacy `activeQuizzesCount` from student sidebar notification state and the `/api/student/notifications` response.
+- Kept the student assessment sidebar focused on Tests and added coverage that no student Quizzes nav item is rendered.
+- Added coverage that legacy `?tab=quizzes` URLs fall back to the default student Today tab and clear quiz-specific params.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/NavItems.test.tsx tests/components/StudentNotificationsProvider.test.tsx tests/api/student/notifications.test.ts tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=today"`
+- Additional student sidebar screenshot: `/tmp/pika-student-desktop-expanded.png`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-20 — Student test total points label
+
+**Completed:**
+- Added a student test overview label under the selected test title, showing question count and total points as `pts total`.
+- Rendered the label before the student starts a test and at the top of the active test attempt.
+- Added component coverage that the total-points label appears before start and during the attempt.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx` (Vitest ran the full suite: 272 files / 2263 tests passed)
+- `pnpm lint`
+- `pnpm e2e:auth`
+- `pnpm e2e:verify assessment-ux-parity`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests"`
+- Additional selected student test screenshots:
+  - `/tmp/pika-student-test-before-start.png`
+  - `/tmp/pika-student-test-active.png`
+  - `/tmp/pika-student-test-before-start-mobile.png`
+  - `/tmp/pika-student-test-active-mobile.png`
+
+## 2026-05-20 — Freeze submitted assignment timing
+
+**Completed:**
+- Added submitted-aware assignment timing copy so submitted work freezes against `submitted_at` instead of continuing to count overdue time from the current date.
+- Updated student assignment cards and the standalone student assignment editor header to use the submitted-aware timing helper.
+- Added unit and component coverage for submitted timing, including late submissions freezing at the actual submission timestamp.
+
+**Validation:**
+- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
+- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
+- `pnpm test`
+
 ## 2026-05-20 — Remove assignment repo submission option
 
 **Completed:**
@@ -305,3 +366,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop`
 - `pnpm lint`
+## 2026-05-23 — Roster delete action in FAB menu
+
+**Completed:**
+- Moved roster removal from the details pane into the floating roster actions dropdown.
+- Reused the existing `ConfirmDialog` and DELETE route behavior for single-row and selected multi-row removal.
+- Added component coverage for opening the roster FAB dropdown, choosing Remove student/students, and confirming deletion.
+
+**Validation:**
+- `pnpm test tests/components/TeacherRosterTab.test.tsx`
+- `pnpm lint`
+- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts`
+- Targeted Playwright screenshot: `/tmp/pika-roster-multi-delete-dropdown.png`
+- `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`
+- Playwright screenshots: `/tmp/pika-roster-dropdown.png`, `/tmp/pika-roster-remove-confirm.png`, `/tmp/pika-roster-dropdown-dark.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -309,14 +309,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Completed:**
 - Moved roster removal from the details pane into the floating roster actions dropdown.
-- Reused the existing `ConfirmDialog` and DELETE route behavior for single-row and selected multi-row removal.
+- Added an atomic roster removal RPC plus a bulk-delete action route so selected multi-row removal is one server-side operation.
+- Updated the existing single-row DELETE route to use the same atomic roster removal path.
 - Added component coverage for opening the roster FAB dropdown, choosing Remove student/students, and confirming deletion.
-- Addressed review feedback so partial multi-row deletion failures keep only failed/not-yet-attempted rows in the retry dialog.
+- Updated retry behavior so failed bulk deletion keeps the full selected set pending instead of retrying partial client-side deletes.
 
 **Validation:**
 - `pnpm test tests/components/TeacherRosterTab.test.tsx`
 - `pnpm lint`
 - `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts`
+- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts tests/api/teacher/roster-bulk-delete.test.ts tests/unit/roster-removal-migration.test.ts tests/unit/migration-filenames.test.ts`
+- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -f supabase/migrations/071_atomic_roster_bulk_removal.sql`
+- `select public.remove_classroom_roster_entries_atomic('00000000-0000-0000-0000-000000000000'::uuid, array[]::uuid[])`
 - `git diff --check`
 - Targeted Playwright screenshot: `/tmp/pika-roster-multi-delete-dropdown.png`
 - `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,67 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-19 — Workflow friction automation
-
-**Completed:**
-- Created the active weekly `Pika Workflow Friction Review` Codex automation as a report-only review of recent workflow friction and guidance drift.
-- Updated the active `Weekly Pika Simplification` automation prompt to use the native worktree flow and stop relying on project-specific worktree environment variables.
-- Confirmed both automation configs were written under `/Users/stew/.codex/automations`.
-
-**Validation:**
-- Read back `/Users/stew/.codex/automations/weekly-pika-simplification/automation.toml`.
-- Read back `/Users/stew/.codex/automations/pika-workflow-friction-review/automation.toml`.
-
-## 2026-05-19 — Remove student legacy quizzes nav plumbing
-
-**Completed:**
-- Removed legacy `activeQuizzesCount` from student sidebar notification state and the `/api/student/notifications` response.
-- Kept the student assessment sidebar focused on Tests and added coverage that no student Quizzes nav item is rendered.
-- Added coverage that legacy `?tab=quizzes` URLs fall back to the default student Today tab and clear quiz-specific params.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/NavItems.test.tsx tests/components/StudentNotificationsProvider.test.tsx tests/api/student/notifications.test.ts tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=today"`
-- Additional student sidebar screenshot: `/tmp/pika-student-desktop-expanded.png`
-- `pnpm test`
-- `pnpm build`
-
-## 2026-05-20 — Student test total points label
-
-**Completed:**
-- Added a student test overview label under the selected test title, showing question count and total points as `pts total`.
-- Rendered the label before the student starts a test and at the top of the active test attempt.
-- Added component coverage that the total-points label appears before start and during the attempt.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test -- tests/components/StudentQuizzesTab.test.tsx` (Vitest ran the full suite: 272 files / 2263 tests passed)
-- `pnpm lint`
-- `pnpm e2e:auth`
-- `pnpm e2e:verify assessment-ux-parity`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=tests"`
-- Additional selected student test screenshots:
-  - `/tmp/pika-student-test-before-start.png`
-  - `/tmp/pika-student-test-active.png`
-  - `/tmp/pika-student-test-before-start-mobile.png`
-  - `/tmp/pika-student-test-active-mobile.png`
-
-## 2026-05-20 — Freeze submitted assignment timing
-
-**Completed:**
-- Added submitted-aware assignment timing copy so submitted work freezes against `submitted_at` instead of continuing to count overdue time from the current date.
-- Updated student assignment cards and the standalone student assignment editor header to use the submitted-aware timing helper.
-- Added unit and component coverage for submitted timing, including late submissions freezing at the actual submission timestamp.
-
-**Validation:**
-- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=assignments"`
-- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`
-- `pnpm test`
-
 ## 2026-05-20 — Remove assignment repo submission option
 
 **Completed:**
@@ -372,11 +311,13 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Moved roster removal from the details pane into the floating roster actions dropdown.
 - Reused the existing `ConfirmDialog` and DELETE route behavior for single-row and selected multi-row removal.
 - Added component coverage for opening the roster FAB dropdown, choosing Remove student/students, and confirming deletion.
+- Addressed review feedback so partial multi-row deletion failures keep only failed/not-yet-attempted rows in the retry dialog.
 
 **Validation:**
 - `pnpm test tests/components/TeacherRosterTab.test.tsx`
 - `pnpm lint`
 - `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts`
+- `git diff --check`
 - Targeted Playwright screenshot: `/tmp/pika-roster-multi-delete-dropdown.png`
 - `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`
 - Playwright screenshots: `/tmp/pika-roster-dropdown.png`, `/tmp/pika-roster-remove-confirm.png`, `/tmp/pika-roster-dropdown-dark.png`

--- a/src/app/api/teacher/classrooms/[id]/roster/[rosterId]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/[rosterId]/route.ts
@@ -3,6 +3,10 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
+import {
+  getKnownRosterRemovalRpcError,
+  removeClassroomRosterEntriesAtomic,
+} from '@/lib/server/roster-removal'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -85,105 +89,31 @@ export const DELETE = withErrorHandler('DeleteRosterEntry', async (_request, con
     )
   }
 
-  const { data: rosterEntry, error: rosterFetchError } = await supabase
-    .from('classroom_roster')
-    .select('id, email')
-    .eq('id', rosterId)
-    .eq('classroom_id', classroomId)
-    .single()
+  const { data, error } = await removeClassroomRosterEntriesAtomic({
+    supabase,
+    classroomId,
+    rosterIds: [rosterId],
+  })
 
-  if (rosterFetchError || !rosterEntry) {
-    return NextResponse.json(
-      { error: 'Roster entry not found' },
-      { status: 404 }
-    )
+  if (error) {
+    const knownError = getKnownRosterRemovalRpcError(error)
+    if (knownError) {
+      const status = knownError.message === 'One or more roster entries not found in classroom'
+        ? 404
+        : knownError.status
+      return NextResponse.json({ error: knownError.message }, { status })
+    }
+
+    console.error('Error removing roster entry:', error)
+    return NextResponse.json({ error: 'Failed to remove roster entry' }, { status: 500 })
   }
 
-  const email = String(rosterEntry.email || '').toLowerCase().trim()
-
-  const { data: existingUser } = await supabase
-    .from('users')
-    .select('id')
-    .eq('email', email)
-    .single()
-
-  // If the user exists, remove classroom data (logs + assignment docs) and enrollment.
-  // We keep the user account intact so they can still sign in (and be re-added later).
-  const studentId = existingUser?.id ?? null
-
-  if (studentId) {
-    const { error: entryDeleteError } = await supabase
-      .from('entries')
-      .delete()
-      .eq('classroom_id', classroomId)
-      .eq('student_id', studentId)
-
-    if (entryDeleteError) {
-      console.error('Error deleting student entries:', entryDeleteError)
-      return NextResponse.json(
-        { error: 'Failed to delete student entries' },
-        { status: 500 }
-      )
-    }
-
-    const { data: assignments, error: assignmentsError } = await supabase
-      .from('assignments')
-      .select('id')
-      .eq('classroom_id', classroomId)
-
-    if (assignmentsError) {
-      console.error('Error fetching classroom assignments:', assignmentsError)
-      return NextResponse.json(
-        { error: 'Failed to fetch classroom assignments' },
-        { status: 500 }
-      )
-    }
-
-    const assignmentIds = (assignments || []).map(a => a.id)
-    if (assignmentIds.length > 0) {
-      const { error: docsDeleteError } = await supabase
-        .from('assignment_docs')
-        .delete()
-        .eq('student_id', studentId)
-        .in('assignment_id', assignmentIds)
-
-      if (docsDeleteError) {
-        console.error('Error deleting student assignment docs:', docsDeleteError)
-        return NextResponse.json(
-          { error: 'Failed to delete student assignment docs' },
-          { status: 500 }
-        )
-      }
-    }
-
-    const { error: deleteError } = await supabase
-      .from('classroom_enrollments')
-      .delete()
-      .eq('classroom_id', classroomId)
-      .eq('student_id', studentId)
-
-    if (deleteError) {
-      console.error('Error removing student enrollment:', deleteError)
-      return NextResponse.json(
-        { error: 'Failed to remove student' },
-        { status: 500 }
-      )
-    }
-  }
-
-  const { error: rosterDeleteError } = await supabase
-    .from('classroom_roster')
-    .delete()
-    .eq('id', rosterId)
-    .eq('classroom_id', classroomId)
-
-  if (rosterDeleteError) {
-    console.error('Error removing roster entry:', rosterDeleteError)
-    return NextResponse.json(
-      { error: 'Failed to remove roster entry' },
-      { status: 500 }
-    )
-  }
-
-  return NextResponse.json({ success: true })
+  return NextResponse.json({
+    success: true,
+    requested_count: Number(data?.requested_count ?? 1),
+    deleted_roster_entries: Number(data?.deleted_roster_entries ?? 0),
+    deleted_entries: Number(data?.deleted_entries ?? 0),
+    deleted_assignment_docs: Number(data?.deleted_assignment_docs ?? 0),
+    deleted_enrollments: Number(data?.deleted_enrollments ?? 0),
+  })
 })

--- a/src/app/api/teacher/classrooms/[id]/roster/bulk-delete/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/bulk-delete/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+import { getServiceRoleClient } from '@/lib/supabase'
+import {
+  getKnownRosterRemovalRpcError,
+  MAX_ROSTER_REMOVALS_PER_REQUEST,
+  normalizeRosterIds,
+  removeClassroomRosterEntriesAtomic,
+} from '@/lib/server/roster-removal'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// POST /api/teacher/classrooms/[id]/roster/bulk-delete - Atomically remove selected roster entries
+export const POST = withErrorHandler('PostTeacherRosterBulkDelete', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id: classroomId } = await context.params
+  const body = await request.json()
+  const rosterIds = normalizeRosterIds(body?.roster_ids)
+
+  if (rosterIds.length === 0) {
+    return NextResponse.json({ error: 'roster_ids array is required' }, { status: 400 })
+  }
+
+  if (rosterIds.length > MAX_ROSTER_REMOVALS_PER_REQUEST) {
+    return NextResponse.json(
+      { error: `Cannot remove more than ${MAX_ROSTER_REMOVALS_PER_REQUEST} roster entries at once` },
+      { status: 400 }
+    )
+  }
+
+  const ownership = await assertTeacherCanMutateClassroom(user.id, classroomId)
+  if (!ownership.ok) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data, error } = await removeClassroomRosterEntriesAtomic({
+    supabase,
+    classroomId,
+    rosterIds,
+  })
+
+  if (error) {
+    const knownError = getKnownRosterRemovalRpcError(error)
+    if (knownError) {
+      return NextResponse.json({ error: knownError.message }, { status: knownError.status })
+    }
+
+    console.error('Error bulk deleting roster entries:', error)
+    return NextResponse.json({ error: 'Failed to remove students' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    success: true,
+    requested_count: Number(data?.requested_count ?? rosterIds.length),
+    deleted_roster_entries: Number(data?.deleted_roster_entries ?? 0),
+    deleted_entries: Number(data?.deleted_entries ?? 0),
+    deleted_assignment_docs: Number(data?.deleted_assignment_docs ?? 0),
+    deleted_enrollments: Number(data?.deleted_enrollments ?? 0),
+  })
+})

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -178,27 +178,22 @@ export function TeacherRosterTab({ classroom }: Props) {
     if (isReadOnly) return
     setIsRemoving(true)
     setError('')
-    const rowsToRemove = pendingRemoval.rows
-    const remainingRows = [...rowsToRemove]
+    const fallbackError = pendingRemoval.rows.length > 1 ? 'Failed to remove students' : 'Failed to remove student'
 
     try {
-      for (const row of rowsToRemove) {
-        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${row.rosterId}`, {
-          method: 'DELETE',
-        })
-        const data = await res.json().catch(() => ({}))
-        if (!res.ok) {
-          throw new Error(data.error || 'Failed to remove student')
-        }
-        remainingRows.shift()
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/bulk-delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roster_ids: pendingRemoval.rows.map((row) => row.rosterId) }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(data.error || fallbackError)
       }
       setPendingRemoval(null)
       await loadRoster()
     } catch (err: any) {
-      const message = err.message || 'Failed to remove student'
-      setPendingRemoval(remainingRows.length > 0 ? { rows: remainingRows } : null)
-      await loadRoster()
-      setError(message)
+      setError(err.message || fallbackError)
     } finally {
       setIsRemoving(false)
     }

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { Button, ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
+import { ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
@@ -41,6 +41,14 @@ interface RosterRow {
   joined: boolean
   student_id: string | null
   joined_at: string | null
+}
+
+interface RemovalTarget {
+  rosterId: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  joined: boolean
 }
 
 interface Props {
@@ -95,11 +103,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     direction: 'asc' | 'desc'
   }>({ column: 'last_name', direction: 'asc' })
   const [pendingRemoval, setPendingRemoval] = useState<{
-    rosterId: string
-    email: string
-    firstName: string | null
-    lastName: string | null
-    joined: boolean
+    rows: RemovalTarget[]
   } | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
   const [selectedRosterId, setSelectedRosterId] = useState<string | null>(null)
@@ -170,18 +174,20 @@ export function TeacherRosterTab({ classroom }: Props) {
   }, [classroom.id])
 
   async function confirmRemoveStudent() {
-    if (!pendingRemoval) return
+    if (!pendingRemoval || pendingRemoval.rows.length === 0) return
     if (isReadOnly) return
     setIsRemoving(true)
     setError('')
 
     try {
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${pendingRemoval.rosterId}`, {
-        method: 'DELETE',
-      })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        throw new Error(data.error || 'Failed to remove student')
+      for (const row of pendingRemoval.rows) {
+        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${row.rosterId}`, {
+          method: 'DELETE',
+        })
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to remove student')
+        }
       }
       setPendingRemoval(null)
       await loadRoster()
@@ -199,6 +205,7 @@ export function TeacherRosterTab({ classroom }: Props) {
   const selectedStudentEmails = selectedRows.map((r) => r.email)
   const selectedCounselorEmails = selectedRows.map((r) => r.counselor_email).filter(Boolean) as string[]
   const selectedRosterRow = sortedRoster.find((row) => row.id === selectedRosterId) ?? null
+  const removalTargetRows = selectedRows.length > 0 ? selectedRows : selectedRosterRow ? [selectedRosterRow] : []
   const {
     scrollRef: rosterTableScrollRef,
     preserveScrollPosition: preserveRosterTableScrollPosition,
@@ -301,6 +308,53 @@ export function TeacherRosterTab({ classroom }: Props) {
     }
   }
 
+  function toRemovalTarget(row: RosterRow): RemovalTarget {
+    return {
+      rosterId: row.id,
+      email: row.email,
+      firstName: row.first_name,
+      lastName: row.last_name,
+      joined: row.joined,
+    }
+  }
+
+  function openRemoveStudentDialog(rows: RosterRow[]) {
+    if (rows.length === 0 || isReadOnly) return
+    setPendingRemoval({ rows: rows.map(toRemovalTarget) })
+  }
+
+  function getRemovalMenuLabel(rowCount: number) {
+    return rowCount > 1 ? 'Remove students' : 'Remove student'
+  }
+
+  function formatRemovalTargetName(row: RemovalTarget) {
+    return [row.firstName, row.lastName].filter(Boolean).join(' ') || 'Unnamed student'
+  }
+
+  function getRemovalDescription(rows: RemovalTarget[]) {
+    if (rows.length === 0) return undefined
+
+    if (rows.length === 1) {
+      const row = rows[0]
+      return `${formatRemovalTargetName(row)}\n${row.email}\n\n${
+        row.joined
+          ? 'They are currently joined. This will delete their classroom data (logs and assignment docs).'
+          : 'They are not joined yet.'
+      }`
+    }
+
+    const previewRows = rows.slice(0, 5)
+    const preview = previewRows.map((row) => `${formatRemovalTargetName(row)} - ${row.email}`).join('\n')
+    const remaining = rows.length > previewRows.length ? `\n+ ${rows.length - previewRows.length} more` : ''
+    const joinedCount = rows.filter((row) => row.joined).length
+
+    return `${preview}${remaining}\n\n${
+      joinedCount > 0
+        ? `${joinedCount} ${joinedCount === 1 ? 'student is' : 'students are'} currently joined. This will delete their classroom data (logs and assignment docs).`
+        : 'These students are not joined yet.'
+    }`
+  }
+
   const rosterActionOptions: SplitButtonOption[] = someSelected
     ? [
         {
@@ -326,6 +380,15 @@ export function TeacherRosterTab({ classroom }: Props) {
       ]
 
   if (!someSelected) {
+    if (removalTargetRows.length > 0) {
+      rosterActionOptions.push({
+        id: 'remove-student',
+        label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
+        onSelect: () => openRemoveStudentDialog(removalTargetRows),
+        disabled: isReadOnly || loading || isRemoving,
+      })
+    }
+
     rosterActionOptions.push({
       id: 'email-placeholder',
       label: 'Select students to email',
@@ -333,6 +396,13 @@ export function TeacherRosterTab({ classroom }: Props) {
       disabled: true,
     })
   } else {
+    rosterActionOptions.push({
+      id: 'remove-student',
+      label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
+      onSelect: () => openRemoveStudentDialog(removalTargetRows),
+      disabled: isReadOnly || loading || isRemoving || removalTargetRows.length === 0,
+    })
+
     rosterActionOptions.push(
       {
         id: 'copy-student-emails',
@@ -440,23 +510,6 @@ export function TeacherRosterTab({ classroom }: Props) {
           <div className="text-text-default">{formatRosterDate(selectedRosterRow.joined_at)}</div>
         </div>
       </div>
-      <Button
-        type="button"
-        size="sm"
-        variant="danger"
-        disabled={isReadOnly}
-        onClick={() => {
-          setPendingRemoval({
-            rosterId: selectedRosterRow.id,
-            email: selectedRosterRow.email,
-            firstName: selectedRosterRow.first_name,
-            lastName: selectedRosterRow.last_name,
-            joined: selectedRosterRow.joined,
-          })
-        }}
-      >
-        Remove
-      </Button>
     </div>
   ) : (
     <div className="space-y-4 p-4">
@@ -702,20 +755,8 @@ export function TeacherRosterTab({ classroom }: Props) {
 
       <ConfirmDialog
         isOpen={!!pendingRemoval}
-        title="Remove student?"
-        description={
-          pendingRemoval
-            ? `${
-                pendingRemoval.firstName || pendingRemoval.lastName
-                  ? `${pendingRemoval.firstName ?? ''} ${pendingRemoval.lastName ?? ''}`.trim()
-                  : 'Unnamed student'
-              }\n${pendingRemoval.email}\n\n${
-                pendingRemoval.joined
-                  ? 'They are currently joined. This will delete their classroom data (logs and assignment docs).'
-                  : 'They are not joined yet.'
-              }`
-            : undefined
-        }
+        title={pendingRemoval && pendingRemoval.rows.length > 1 ? 'Remove students?' : 'Remove student?'}
+        description={pendingRemoval ? getRemovalDescription(pendingRemoval.rows) : undefined}
         confirmLabel={isRemoving ? 'Removing...' : 'Remove'}
         cancelLabel="Cancel"
         confirmVariant="danger"

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -178,9 +178,11 @@ export function TeacherRosterTab({ classroom }: Props) {
     if (isReadOnly) return
     setIsRemoving(true)
     setError('')
+    const rowsToRemove = pendingRemoval.rows
+    const remainingRows = [...rowsToRemove]
 
     try {
-      for (const row of pendingRemoval.rows) {
+      for (const row of rowsToRemove) {
         const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${row.rosterId}`, {
           method: 'DELETE',
         })
@@ -188,11 +190,15 @@ export function TeacherRosterTab({ classroom }: Props) {
         if (!res.ok) {
           throw new Error(data.error || 'Failed to remove student')
         }
+        remainingRows.shift()
       }
       setPendingRemoval(null)
       await loadRoster()
     } catch (err: any) {
-      setError(err.message || 'Failed to remove student')
+      const message = err.message || 'Failed to remove student'
+      setPendingRemoval(remainingRows.length > 0 ? { rows: remainingRows } : null)
+      await loadRoster()
+      setError(message)
     } finally {
       setIsRemoving(false)
     }

--- a/src/lib/server/roster-removal.ts
+++ b/src/lib/server/roster-removal.ts
@@ -1,0 +1,63 @@
+export const MAX_ROSTER_REMOVALS_PER_REQUEST = 100
+
+export interface RosterRemovalResult {
+  requested_count: number
+  deleted_roster_entries: number
+  deleted_entries: number
+  deleted_assignment_docs: number
+  deleted_enrollments: number
+}
+
+export function normalizeRosterIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+        .map((item) => item.trim())
+    )
+  )
+}
+
+export function getKnownRosterRemovalRpcError(error: {
+  code?: string
+  message?: string
+  details?: string | null
+  hint?: string | null
+} | null | undefined): { status: number; message: string } | null {
+  if (!error) return null
+
+  const message = (error.message || '').toLowerCase()
+
+  if (error.message === 'One or more roster entries not found in classroom') {
+    return { status: 400, message: error.message }
+  }
+
+  if (
+    error.code === '42883' ||
+    error.code === 'PGRST202' ||
+    message.includes('remove_classroom_roster_entries_atomic')
+  ) {
+    return {
+      status: 400,
+      message: 'Roster removal requires migration 071 to be applied',
+    }
+  }
+
+  return null
+}
+
+export async function removeClassroomRosterEntriesAtomic({
+  supabase,
+  classroomId,
+  rosterIds,
+}: {
+  supabase: any
+  classroomId: string
+  rosterIds: string[]
+}) {
+  return supabase.rpc('remove_classroom_roster_entries_atomic', {
+    p_classroom_id: classroomId,
+    p_roster_ids: rosterIds,
+  })
+}

--- a/supabase/migrations/071_atomic_roster_bulk_removal.sql
+++ b/supabase/migrations/071_atomic_roster_bulk_removal.sql
@@ -1,0 +1,123 @@
+-- Atomically remove one or more classroom roster entries and classroom-scoped student data.
+
+create or replace function public.remove_classroom_roster_entries_atomic(
+  p_classroom_id uuid,
+  p_roster_ids uuid[]
+)
+returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_requested_count integer := 0;
+  v_roster_count integer := 0;
+  v_student_ids uuid[] := array[]::uuid[];
+  v_assignment_ids uuid[] := array[]::uuid[];
+  v_deleted_entries integer := 0;
+  v_deleted_assignment_docs integer := 0;
+  v_deleted_enrollments integer := 0;
+  v_deleted_roster_entries integer := 0;
+begin
+  with requested as (
+    select distinct roster_id
+    from unnest(coalesce(p_roster_ids, array[]::uuid[])) as requested(roster_id)
+  )
+  select count(*) into v_requested_count
+  from requested;
+
+  if v_requested_count = 0 then
+    return jsonb_build_object(
+      'requested_count', 0,
+      'deleted_roster_entries', 0,
+      'deleted_entries', 0,
+      'deleted_assignment_docs', 0,
+      'deleted_enrollments', 0
+    );
+  end if;
+
+  with requested as (
+    select distinct roster_id
+    from unnest(coalesce(p_roster_ids, array[]::uuid[])) as requested(roster_id)
+  ),
+  target_roster as materialized (
+    select roster.id, lower(trim(roster.email)) as email
+    from public.classroom_roster roster
+    join requested on requested.roster_id = roster.id
+    where roster.classroom_id = p_classroom_id
+    for update of roster
+  )
+  select
+    count(*),
+    coalesce(array_agg(users.id) filter (where users.id is not null), array[]::uuid[])
+  into v_roster_count, v_student_ids
+  from target_roster
+  left join public.users users
+    on lower(trim(users.email)) = target_roster.email;
+
+  if v_roster_count <> v_requested_count then
+    raise exception 'One or more roster entries not found in classroom'
+      using errcode = '22023';
+  end if;
+
+  if coalesce(array_length(v_student_ids, 1), 0) > 0 then
+    with deleted_entries as (
+      delete from public.entries
+      where classroom_id = p_classroom_id
+        and student_id = any(v_student_ids)
+      returning id
+    )
+    select count(*) into v_deleted_entries
+    from deleted_entries;
+
+    select coalesce(array_agg(id), array[]::uuid[])
+    into v_assignment_ids
+    from public.assignments
+    where classroom_id = p_classroom_id;
+
+    if coalesce(array_length(v_assignment_ids, 1), 0) > 0 then
+      with deleted_assignment_docs as (
+        delete from public.assignment_docs
+        where student_id = any(v_student_ids)
+          and assignment_id = any(v_assignment_ids)
+        returning id
+      )
+      select count(*) into v_deleted_assignment_docs
+      from deleted_assignment_docs;
+    end if;
+
+    with deleted_enrollments as (
+      delete from public.classroom_enrollments
+      where classroom_id = p_classroom_id
+        and student_id = any(v_student_ids)
+      returning id
+    )
+    select count(*) into v_deleted_enrollments
+    from deleted_enrollments;
+  end if;
+
+  with requested as (
+    select distinct roster_id
+    from unnest(coalesce(p_roster_ids, array[]::uuid[])) as requested(roster_id)
+  ),
+  deleted_roster as (
+    delete from public.classroom_roster roster
+    using requested
+    where roster.classroom_id = p_classroom_id
+      and roster.id = requested.roster_id
+    returning roster.id
+  )
+  select count(*) into v_deleted_roster_entries
+  from deleted_roster;
+
+  return jsonb_build_object(
+    'requested_count', v_requested_count,
+    'deleted_roster_entries', v_deleted_roster_entries,
+    'deleted_entries', v_deleted_entries,
+    'deleted_assignment_docs', v_deleted_assignment_docs,
+    'deleted_enrollments', v_deleted_enrollments
+  );
+end;
+$$;
+
+revoke all on function public.remove_classroom_roster_entries_atomic(uuid, uuid[]) from public, anon, authenticated;
+grant execute on function public.remove_classroom_roster_entries_atomic(uuid, uuid[]) to service_role;

--- a/tests/api/teacher/roster-bulk-delete.test.ts
+++ b/tests/api/teacher/roster-bulk-delete.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/classrooms/[id]/roster/bulk-delete/route'
+import { assertTeacherCanMutateClassroom } from '@/lib/server/classrooms'
+
+const mockSupabaseClient = { rpc: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({ id: 'teacher-1', role: 'teacher' })),
+}))
+
+vi.mock('@/lib/server/classrooms', () => ({
+  assertTeacherCanMutateClassroom: vi.fn(async () => ({
+    ok: true,
+    classroom: { id: 'c-1', teacher_id: 'teacher-1', archived_at: null },
+  })),
+}))
+
+function makeRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/bulk-delete', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+const params = { params: Promise.resolve({ id: 'c-1' }) }
+
+describe('POST /api/teacher/classrooms/[id]/roster/bulk-delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.rpc = vi.fn().mockResolvedValue({
+      data: {
+        requested_count: 2,
+        deleted_roster_entries: 2,
+        deleted_entries: 4,
+        deleted_assignment_docs: 5,
+        deleted_enrollments: 2,
+      },
+      error: null,
+    })
+  })
+
+  it('validates roster_ids input', async () => {
+    const missing = await POST(makeRequest({}), params)
+    expect(missing.status).toBe(400)
+    await expect(missing.json()).resolves.toEqual({ error: 'roster_ids array is required' })
+
+    const tooMany = await POST(
+      makeRequest({ roster_ids: Array.from({ length: 101 }, (_, index) => `roster-${index}`) }),
+      params,
+    )
+    expect(tooMany.status).toBe(400)
+    await expect(tooMany.json()).resolves.toEqual({
+      error: 'Cannot remove more than 100 roster entries at once',
+    })
+  })
+
+  it('returns classroom mutation failures before calling the RPC', async () => {
+    vi.mocked(assertTeacherCanMutateClassroom).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Classroom is archived',
+    })
+
+    const response = await POST(makeRequest({ roster_ids: ['r-1'] }), params)
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Classroom is archived' })
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+  })
+
+  it('removes selected roster entries atomically through the RPC', async () => {
+    const response = await POST(makeRequest({ roster_ids: ['r-1', 'r-2', 'r-1', '  r-2  '] }), params)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('remove_classroom_roster_entries_atomic', {
+      p_classroom_id: 'c-1',
+      p_roster_ids: ['r-1', 'r-2'],
+    })
+    expect(data).toEqual({
+      success: true,
+      requested_count: 2,
+      deleted_roster_entries: 2,
+      deleted_entries: 4,
+      deleted_assignment_docs: 5,
+      deleted_enrollments: 2,
+    })
+  })
+
+  it('maps known RPC validation errors to client errors', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'One or more roster entries not found in classroom' },
+    })
+
+    const response = await POST(makeRequest({ roster_ids: ['r-1', 'r-2'] }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'One or more roster entries not found in classroom',
+    })
+  })
+
+  it('returns migration guidance when the atomic removal RPC is missing', async () => {
+    mockSupabaseClient.rpc.mockResolvedValueOnce({
+      data: null,
+      error: {
+        code: 'PGRST202',
+        message: 'Could not find function remove_classroom_roster_entries_atomic',
+      },
+    })
+
+    const response = await POST(makeRequest({ roster_ids: ['r-1'] }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Roster removal requires migration 071 to be applied',
+    })
+  })
+})

--- a/tests/api/teacher/roster-rosterId.test.ts
+++ b/tests/api/teacher/roster-rosterId.test.ts
@@ -15,12 +15,13 @@ vi.mock('@/lib/server/classrooms', () => ({
   })),
 }))
 
-const mockSupabaseClient = { from: vi.fn() }
+const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }
 
 describe('PATCH /api/teacher/classrooms/[id]/roster/[rosterId]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.from = vi.fn()
+    mockSupabaseClient.rpc = vi.fn()
   })
 
   it('validates counselor_email input and requires a valid update field', async () => {
@@ -108,101 +109,77 @@ describe('DELETE /api/teacher/classrooms/[id]/roster/[rosterId]', () => {
 
     const response = await DELETE(request, { params: { id: 'c-1', rosterId: 'r-1' } })
     expect(response.status).toBe(403)
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
   })
 
-  it('deletes classroom data, removes enrollment, and deletes roster entry', async () => {
-    const fromImpl = (table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({ data: { teacher_id: 'teacher-1' }, error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'classroom_roster') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                single: vi.fn().mockResolvedValue({ data: { id: 'r-1', email: 's1@student.com' }, error: null }),
-              })),
-            })),
-          })),
-          delete: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn().mockResolvedValue({ error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({ data: { id: 's-1' }, error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'entries') {
-        return {
-          delete: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn().mockResolvedValue({ error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'assignments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ data: [{ id: 'a-1' }, { id: 'a-2' }], error: null }),
-          })),
-        }
-      }
-
-      if (table === 'assignment_docs') {
-        return {
-          delete: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              in: vi.fn().mockResolvedValue({ error: null }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'classroom_enrollments') {
-        return {
-          delete: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn().mockResolvedValue({ error: null }),
-            })),
-          })),
-        }
-      }
-
-      throw new Error(`Unexpected table: ${table}`)
-    }
-
-    ;(mockSupabaseClient.from as any) = vi.fn(fromImpl)
+  it('removes one roster entry through the atomic roster removal RPC', async () => {
+    mockSupabaseClient.rpc = vi.fn().mockResolvedValue({
+      data: {
+        requested_count: 1,
+        deleted_roster_entries: 1,
+        deleted_entries: 2,
+        deleted_assignment_docs: 3,
+        deleted_enrollments: 1,
+      },
+      error: null,
+    })
 
     const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/s-1', {
       method: 'DELETE',
     })
 
     const response = await DELETE(request, { params: { id: 'c-1', rosterId: 'r-1' } })
+    const data = await response.json()
     expect(response.status).toBe(200)
+    expect(data).toEqual({
+      success: true,
+      requested_count: 1,
+      deleted_roster_entries: 1,
+      deleted_entries: 2,
+      deleted_assignment_docs: 3,
+      deleted_enrollments: 1,
+    })
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('remove_classroom_roster_entries_atomic', {
+      p_classroom_id: 'c-1',
+      p_roster_ids: ['r-1'],
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
 
-    expect(mockSupabaseClient.from).toHaveBeenCalledWith('classroom_roster')
-    expect(mockSupabaseClient.from).toHaveBeenCalledWith('entries')
-    expect(mockSupabaseClient.from).toHaveBeenCalledWith('assignments')
-    expect(mockSupabaseClient.from).toHaveBeenCalledWith('assignment_docs')
-    expect(mockSupabaseClient.from).toHaveBeenCalledWith('classroom_enrollments')
+  it('returns 404 when the atomic removal RPC reports a missing roster entry', async () => {
+    mockSupabaseClient.rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'One or more roster entries not found in classroom' },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/s-1', {
+      method: 'DELETE',
+    })
+
+    const response = await DELETE(request, { params: { id: 'c-1', rosterId: 'r-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('One or more roster entries not found in classroom')
+  })
+
+  it('returns migration guidance when the atomic removal RPC is missing', async () => {
+    mockSupabaseClient.rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: 'PGRST202',
+        message: 'Could not find function remove_classroom_roster_entries_atomic',
+      },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1/roster/s-1', {
+      method: 'DELETE',
+    })
+
+    const response = await DELETE(request, { params: { id: 'c-1', rosterId: 'r-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Roster removal requires migration 071 to be applied')
   })
 })

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TeacherRosterTab } from '@/app/classrooms/[classroomId]/TeacherRosterTab'
+import type { Classroom } from '@/types'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
+
+vi.mock('@/components/AddStudentsModal', () => ({
+  AddStudentsModal: () => null,
+}))
+
+vi.mock('@/components/UploadRosterModal', () => ({
+  UploadRosterModal: () => null,
+}))
+
+const classroom: Classroom = {
+  id: 'classroom-1',
+  teacher_id: 'teacher-1',
+  title: 'Roster Classroom',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'hidden',
+  archived_at: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+}
+
+const rosterRow = {
+  id: 'roster-1',
+  email: 'ada@example.com',
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  student_number: '1001',
+  counselor_email: 'counselor@example.com',
+  created_at: '2026-01-02T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  joined: true,
+  student_id: 'student-1',
+  joined_at: '2026-01-03T00:00:00.000Z',
+}
+
+const secondRosterRow = {
+  id: 'roster-2',
+  email: 'grace@example.com',
+  first_name: 'Grace',
+  last_name: 'Hopper',
+  student_number: '1002',
+  counselor_email: null,
+  created_at: '2026-01-02T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  joined: true,
+  student_id: 'student-2',
+  joined_at: '2026-01-03T00:00:00.000Z',
+}
+
+function mockJson(data: unknown, ok = true) {
+  return Promise.resolve({
+    ok,
+    status: ok ? 200 : 500,
+    json: () => Promise.resolve(data),
+  }) as any
+}
+
+function mockRosterFetch() {
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+
+    if (url === `/api/teacher/classrooms/${classroom.id}/roster` && method === 'GET') {
+      return mockJson({ roster: [rosterRow, secondRosterRow] })
+    }
+
+    if (
+      [
+        `/api/teacher/classrooms/${classroom.id}/roster/${rosterRow.id}`,
+        `/api/teacher/classrooms/${classroom.id}/roster/${secondRosterRow.id}`,
+      ].includes(url) &&
+      method === 'DELETE'
+    ) {
+      return mockJson({ success: true })
+    }
+
+    throw new Error(`Unhandled fetch: ${method} ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function renderRoster() {
+  return render(
+    <TooltipProvider>
+      <AppMessageProvider>
+        <TeacherRosterTab classroom={classroom} />
+      </AppMessageProvider>
+    </TooltipProvider>,
+  )
+}
+
+function getDeleteCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(([input, init]) => {
+    return (
+      String(input).startsWith(`/api/teacher/classrooms/${classroom.id}/roster/`) &&
+      (init as RequestInit | undefined)?.method === 'DELETE'
+    )
+  })
+}
+
+describe('TeacherRosterTab', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens single-student removal from the floating roster actions dropdown with confirmation', async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockRosterFetch()
+
+    renderRoster()
+
+    await screen.findByText('Ada')
+
+    await user.click(screen.getByText('Ada'))
+
+    expect(screen.queryByRole('button', { name: /^Remove$/ })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Roster actions' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Remove student' }))
+
+    expect(getDeleteCalls(fetchMock)).toHaveLength(0)
+
+    const dialog = screen.getByRole('dialog', { name: 'Remove student?' })
+    expect(dialog).toBeInTheDocument()
+    expect(within(dialog).getByText(/ada@example\.com/)).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(getDeleteCalls(fetchMock)).toHaveLength(1)
+    })
+  })
+
+  it('shows and confirms removal for multiple checked students from the floating actions dropdown', async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockRosterFetch()
+
+    renderRoster()
+
+    await screen.findByText('Ada')
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select Grace Hopper' }))
+    await user.click(screen.getByRole('button', { name: 'Roster actions' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Remove students' }))
+
+    expect(getDeleteCalls(fetchMock)).toHaveLength(0)
+
+    const dialog = screen.getByRole('dialog', { name: 'Remove students?' })
+    expect(dialog).toBeInTheDocument()
+    expect(within(dialog).getByText(/ada@example\.com/)).toBeInTheDocument()
+    expect(within(dialog).getByText(/grace@example\.com/)).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(getDeleteCalls(fetchMock)).toHaveLength(2)
+    })
+  })
+})

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -169,4 +169,62 @@ describe('TeacherRosterTab', () => {
       expect(getDeleteCalls(fetchMock)).toHaveLength(2)
     })
   })
+
+  it('keeps only remaining students pending when a multi-student removal partially fails', async () => {
+    const user = userEvent.setup()
+    let failAdaOnce = true
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster` && method === 'GET') {
+        return mockJson({ roster: [rosterRow, secondRosterRow] })
+      }
+
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster/${rosterRow.id}` && method === 'DELETE') {
+        if (failAdaOnce) {
+          failAdaOnce = false
+          return mockJson({ error: 'Failed to remove Ada' }, false)
+        }
+        return mockJson({ success: true })
+      }
+
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster/${secondRosterRow.id}` && method === 'DELETE') {
+        return mockJson({ success: true })
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderRoster()
+
+    await screen.findByText('Ada')
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Select Grace Hopper' }))
+    await user.click(screen.getByRole('button', { name: 'Roster actions' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Remove students' }))
+
+    const multiDialog = screen.getByRole('dialog', { name: 'Remove students?' })
+    await user.click(within(multiDialog).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to remove Ada')).toBeInTheDocument()
+    })
+
+    const retryDialog = screen.getByRole('dialog', { name: 'Remove student?' })
+    expect(within(retryDialog).getByText(/ada@example\.com/)).toBeInTheDocument()
+    expect(within(retryDialog).queryByText(/grace@example\.com/)).not.toBeInTheDocument()
+
+    await user.click(within(retryDialog).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    const deleteUrls = getDeleteCalls(fetchMock).map(([input]) => String(input))
+    expect(deleteUrls.filter((url) => url.endsWith(`/${secondRosterRow.id}`))).toHaveLength(1)
+    expect(deleteUrls.filter((url) => url.endsWith(`/${rosterRow.id}`))).toHaveLength(2)
+  })
 })

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -74,13 +74,7 @@ function mockRosterFetch() {
       return mockJson({ roster: [rosterRow, secondRosterRow] })
     }
 
-    if (
-      [
-        `/api/teacher/classrooms/${classroom.id}/roster/${rosterRow.id}`,
-        `/api/teacher/classrooms/${classroom.id}/roster/${secondRosterRow.id}`,
-      ].includes(url) &&
-      method === 'DELETE'
-    ) {
+    if (url === `/api/teacher/classrooms/${classroom.id}/roster/bulk-delete` && method === 'POST') {
       return mockJson({ success: true })
     }
 
@@ -100,13 +94,26 @@ function renderRoster() {
   )
 }
 
-function getDeleteCalls(fetchMock: ReturnType<typeof vi.fn>) {
+function getIndividualDeleteCalls(fetchMock: ReturnType<typeof vi.fn>) {
   return fetchMock.mock.calls.filter(([input, init]) => {
     return (
       String(input).startsWith(`/api/teacher/classrooms/${classroom.id}/roster/`) &&
       (init as RequestInit | undefined)?.method === 'DELETE'
     )
   })
+}
+
+function getBulkDeleteCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(([input, init]) => {
+    return (
+      String(input) === `/api/teacher/classrooms/${classroom.id}/roster/bulk-delete` &&
+      (init as RequestInit | undefined)?.method === 'POST'
+    )
+  })
+}
+
+function getRequestBody(call: unknown[]) {
+  return JSON.parse(String((call[1] as RequestInit).body))
 }
 
 describe('TeacherRosterTab', () => {
@@ -130,7 +137,7 @@ describe('TeacherRosterTab', () => {
     await user.click(screen.getByRole('button', { name: 'Roster actions' }))
     await user.click(screen.getByRole('menuitem', { name: 'Remove student' }))
 
-    expect(getDeleteCalls(fetchMock)).toHaveLength(0)
+    expect(getBulkDeleteCalls(fetchMock)).toHaveLength(0)
 
     const dialog = screen.getByRole('dialog', { name: 'Remove student?' })
     expect(dialog).toBeInTheDocument()
@@ -139,8 +146,10 @@ describe('TeacherRosterTab', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
 
     await waitFor(() => {
-      expect(getDeleteCalls(fetchMock)).toHaveLength(1)
+      expect(getBulkDeleteCalls(fetchMock)).toHaveLength(1)
     })
+    expect(getRequestBody(getBulkDeleteCalls(fetchMock)[0]).roster_ids).toEqual([rosterRow.id])
+    expect(getIndividualDeleteCalls(fetchMock)).toHaveLength(0)
   })
 
   it('shows and confirms removal for multiple checked students from the floating actions dropdown', async () => {
@@ -156,7 +165,7 @@ describe('TeacherRosterTab', () => {
     await user.click(screen.getByRole('button', { name: 'Roster actions' }))
     await user.click(screen.getByRole('menuitem', { name: 'Remove students' }))
 
-    expect(getDeleteCalls(fetchMock)).toHaveLength(0)
+    expect(getBulkDeleteCalls(fetchMock)).toHaveLength(0)
 
     const dialog = screen.getByRole('dialog', { name: 'Remove students?' })
     expect(dialog).toBeInTheDocument()
@@ -166,13 +175,17 @@ describe('TeacherRosterTab', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
 
     await waitFor(() => {
-      expect(getDeleteCalls(fetchMock)).toHaveLength(2)
+      expect(getBulkDeleteCalls(fetchMock)).toHaveLength(1)
     })
+    expect(getRequestBody(getBulkDeleteCalls(fetchMock)[0]).roster_ids).toEqual(
+      expect.arrayContaining([rosterRow.id, secondRosterRow.id])
+    )
+    expect(getIndividualDeleteCalls(fetchMock)).toHaveLength(0)
   })
 
-  it('keeps only remaining students pending when a multi-student removal partially fails', async () => {
+  it('keeps the full selected set pending when bulk removal fails', async () => {
     const user = userEvent.setup()
-    let failAdaOnce = true
+    let failBulkOnce = true
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       const method = init?.method ?? 'GET'
@@ -181,15 +194,11 @@ describe('TeacherRosterTab', () => {
         return mockJson({ roster: [rosterRow, secondRosterRow] })
       }
 
-      if (url === `/api/teacher/classrooms/${classroom.id}/roster/${rosterRow.id}` && method === 'DELETE') {
-        if (failAdaOnce) {
-          failAdaOnce = false
-          return mockJson({ error: 'Failed to remove Ada' }, false)
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster/bulk-delete` && method === 'POST') {
+        if (failBulkOnce) {
+          failBulkOnce = false
+          return mockJson({ error: 'Failed to remove students' }, false)
         }
-        return mockJson({ success: true })
-      }
-
-      if (url === `/api/teacher/classrooms/${classroom.id}/roster/${secondRosterRow.id}` && method === 'DELETE') {
         return mockJson({ success: true })
       }
 
@@ -210,12 +219,12 @@ describe('TeacherRosterTab', () => {
     await user.click(within(multiDialog).getByRole('button', { name: 'Remove' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to remove Ada')).toBeInTheDocument()
+      expect(screen.getByText('Failed to remove students')).toBeInTheDocument()
     })
 
-    const retryDialog = screen.getByRole('dialog', { name: 'Remove student?' })
+    const retryDialog = screen.getByRole('dialog', { name: 'Remove students?' })
     expect(within(retryDialog).getByText(/ada@example\.com/)).toBeInTheDocument()
-    expect(within(retryDialog).queryByText(/grace@example\.com/)).not.toBeInTheDocument()
+    expect(within(retryDialog).getByText(/grace@example\.com/)).toBeInTheDocument()
 
     await user.click(within(retryDialog).getByRole('button', { name: 'Remove' }))
 
@@ -223,8 +232,7 @@ describe('TeacherRosterTab', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
-    const deleteUrls = getDeleteCalls(fetchMock).map(([input]) => String(input))
-    expect(deleteUrls.filter((url) => url.endsWith(`/${secondRosterRow.id}`))).toHaveLength(1)
-    expect(deleteUrls.filter((url) => url.endsWith(`/${rosterRow.id}`))).toHaveLength(2)
+    expect(getBulkDeleteCalls(fetchMock)).toHaveLength(2)
+    expect(getIndividualDeleteCalls(fetchMock)).toHaveLength(0)
   })
 })

--- a/tests/unit/roster-removal-migration.test.ts
+++ b/tests/unit/roster-removal-migration.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readMigration() {
+  return readFileSync(resolve(process.cwd(), 'supabase/migrations/071_atomic_roster_bulk_removal.sql'), 'utf8')
+}
+
+describe('atomic roster removal migration', () => {
+  it('keeps the roster removal RPC behind the service-role API boundary', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain('create or replace function public.remove_classroom_roster_entries_atomic')
+    expect(migration).toContain(
+      'revoke all on function public.remove_classroom_roster_entries_atomic(uuid, uuid[]) from public, anon, authenticated;',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.remove_classroom_roster_entries_atomic(uuid, uuid[]) to service_role;',
+    )
+  })
+
+  it('locks and validates roster rows before deleting classroom-scoped student data', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain('for update of roster')
+    expect(migration).toContain('One or more roster entries not found in classroom')
+    expect(migration).toContain('delete from public.entries')
+    expect(migration).toContain('delete from public.assignment_docs')
+    expect(migration).toContain('delete from public.classroom_enrollments')
+    expect(migration).toContain('delete from public.classroom_roster')
+  })
+})


### PR DESCRIPTION
## Summary
- Move roster removal from the right-side details pane into the floating roster actions dropdown.
- Support checked multi-selection by showing a `Remove students` action and confirming the selected roster rows.
- Add `POST /api/teacher/classrooms/[id]/roster/bulk-delete` backed by the `remove_classroom_roster_entries_atomic` RPC so multi-row removal is one server-side atomic operation across roster rows, enrollments, log entries, and assignment docs.
- Update the existing single-row roster DELETE route to use the same atomic removal path.
- Add component, API, and migration coverage for the FAB action, bulk route, single route, RPC grants, and migration filename sequencing.

## Follow-up
- Related selected test-work batch deletion is intentionally out of scope for this roster PR and is tracked in #623.

## Validation
- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts tests/api/teacher/roster-bulk-delete.test.ts tests/unit/roster-removal-migration.test.ts tests/unit/migration-filenames.test.ts`
- `pnpm test tests/unit/ai-startup-docs.test.ts`
- `pnpm lint`
- `git diff --check`
- `psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -v ON_ERROR_STOP=1 -f supabase/migrations/071_atomic_roster_bulk_removal.sql`
- `select public.remove_classroom_roster_entries_atomic('00000000-0000-0000-0000-000000000000'::uuid, array[]::uuid[])`
- `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`
- Playwright screenshots reviewed: `/tmp/pika-roster-dropdown.png`, `/tmp/pika-roster-remove-confirm.png`, `/tmp/pika-roster-dropdown-dark.png`, `/tmp/pika-roster-multi-delete-dropdown.png`
