### PR TITLE
Add atomic bulk test-work delete

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-20 — Assignment repo follow-up
-
-**Completed:**
-- Changed assignment repo target resolution so pasted repo artifacts in current submission content take precedence over legacy `assignment_docs.repo_url` metadata.
-- Kept legacy repo metadata as a fallback only, leaving `repo_url`/`github_username` as deprecated fields for now.
-- Added unit coverage for artifact-over-legacy repo target precedence.
-- Trimmed the rolling session log to satisfy the 20-entry startup guard.
-
-**Validation:**
-- `pnpm test tests/unit/assignment-repo-targets.test.ts`
-- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/assignment-repo-targets.test.ts`
-- `pnpm lint`
-- `git diff --check`
-- `bash scripts/verify-env.sh`
-
 ## 2026-05-20 — Assignment AI draft comment refresh fix
 
 **Completed:**
@@ -305,3 +290,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Targeted Playwright screenshot: `/tmp/pika-roster-multi-delete-dropdown.png`
 - `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`
 - Playwright screenshots: `/tmp/pika-roster-dropdown.png`, `/tmp/pika-roster-remove-confirm.png`, `/tmp/pika-roster-dropdown-dark.png`
+
+## 2026-05-24 — Atomic selected test-work delete
+
+**Completed:**
+- Added migration `072_atomic_test_work_bulk_delete.sql` with `delete_student_test_attempts_atomic(p_test_id, p_student_ids)`.
+- Added a bulk selected test-work delete route that validates all selected students are enrolled and calls one RPC.
+- Updated the teacher Tests selected-delete flow to POST once instead of looping per-student DELETE calls.
+- Added API, migration, and component coverage for success, validation, missing-RPC guidance, and retry-safe failure state.
+
+**Validation:**
+- `pnpm test tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm test tests/api/teacher/tests-student-attempt-delete.test.ts tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/unit/migration-filenames.test.ts`
+- `pnpm lint`
+- `supabase migration list --local`
+- `supabase db lint --local --fail-on error` (passes; existing warning on `public.unsubmit_test_attempts_atomic` unused parameter)
+- `supabase migration up --local`
+- `supabase db query --local "select public.delete_student_test_attempts_atomic('00000000-0000-0000-0000-000000000001'::uuid, array['00000000-0000-0000-0000-000000000002'::uuid]) as result;"`
+- `pnpm build`
+- `pnpm test`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=tests'`
+- Focused Playwright screenshot: `/tmp/pika-test-work-bulk-delete-dialog.png`

--- a/src/app/api/teacher/tests/[id]/students/attempts/bulk-delete/route.ts
+++ b/src/app/api/teacher/tests/[id]/students/attempts/bulk-delete/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { getServiceRoleClient } from '@/lib/supabase'
+import {
+  deleteStudentTestAttemptsAtomic,
+  getKnownTestWorkDeletionRpcError,
+  MAX_TEST_WORK_DELETIONS_PER_REQUEST,
+  normalizeStudentIds,
+} from '@/lib/server/test-work-deletion'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+// POST /api/teacher/tests/[id]/students/attempts/bulk-delete - Atomically delete selected students' test work
+export const POST = withErrorHandler('BulkDeleteTeacherTestStudentAttempts', async (request, context) => {
+  const user = await requireRole('teacher')
+  const { id: testId } = await context.params
+  const body = await request.json()
+  const studentIds = normalizeStudentIds(body?.student_ids)
+
+  if (studentIds.length === 0) {
+    return NextResponse.json({ error: 'student_ids array is required' }, { status: 400 })
+  }
+
+  if (studentIds.length > MAX_TEST_WORK_DELETIONS_PER_REQUEST) {
+    return NextResponse.json(
+      { error: `Cannot delete test work for more than ${MAX_TEST_WORK_DELETIONS_PER_REQUEST} students at once` },
+      { status: 400 }
+    )
+  }
+
+  const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: enrollmentRows, error: enrollmentError } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', access.test.classroom_id)
+    .in('student_id', studentIds)
+
+  if (enrollmentError) {
+    console.error('Error validating enrollment for selected test work deletion:', enrollmentError)
+    return NextResponse.json({ error: 'Failed to validate selected students' }, { status: 500 })
+  }
+
+  const enrolledStudentIds = new Set((enrollmentRows || []).map((row) => row.student_id))
+  const allSelectedStudentsAreEnrolled = studentIds.every((studentId) => enrolledStudentIds.has(studentId))
+  if (!allSelectedStudentsAreEnrolled) {
+    return NextResponse.json(
+      { error: 'One or more selected students are not enrolled in this classroom' },
+      { status: 400 }
+    )
+  }
+
+  const { data, error } = await deleteStudentTestAttemptsAtomic({
+    supabase,
+    testId,
+    studentIds,
+  })
+
+  if (error) {
+    const knownError = getKnownTestWorkDeletionRpcError(error)
+    if (knownError) {
+      return NextResponse.json({ error: knownError.message }, { status: knownError.status })
+    }
+
+    console.error('Error bulk deleting selected student test work:', error)
+    return NextResponse.json({ error: 'Failed to delete selected student test work' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    success: true,
+    requested_count: Number(data?.requested_count ?? studentIds.length),
+    deleted_student_count: Number(data?.deleted_student_count ?? 0),
+    deleted_attempts: Number(data?.deleted_attempts ?? 0),
+    deleted_responses: Number(data?.deleted_responses ?? 0),
+    deleted_focus_events: Number(data?.deleted_focus_events ?? 0),
+    deleted_ai_grading_items: Number(data?.deleted_ai_grading_items ?? 0),
+  })
+})

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1606,23 +1606,17 @@ export function TeacherTestsTab({
     setGradingError('')
     setGradingInfo('')
     try {
-      let deletedCount = 0
-      for (const studentId of targetStudentIds) {
-        const response = await fetch(`${apiBasePath}/${selectedTestId}/students/${studentId}/attempt`, {
-          method: 'DELETE',
-        })
-        const data = await response.json()
-        if (!response.ok) {
-          throw new Error(data.error || 'Delete failed')
-        }
-
-        const deletedAttempts = Number(data.deleted_attempts ?? 0)
-        const deletedResponses = Number(data.deleted_responses ?? 0)
-        if (deletedAttempts > 0 || deletedResponses > 0) {
-          deletedCount += 1
-        }
+      const response = await fetch(`${apiBasePath}/${selectedTestId}/students/attempts/bulk-delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student_ids: targetStudentIds }),
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Delete failed')
       }
 
+      const deletedCount = Number(data.deleted_student_count ?? 0)
       setGradingInfo(`Deleted test work for ${deletedCount} student${deletedCount === 1 ? '' : 's'}`)
       if (selectedStudentId && targetStudentIds.includes(selectedStudentId)) {
         selectGradingStudent(null)

--- a/src/lib/server/test-work-deletion.ts
+++ b/src/lib/server/test-work-deletion.ts
@@ -1,0 +1,60 @@
+export const MAX_TEST_WORK_DELETIONS_PER_REQUEST = 100
+
+export interface TestWorkDeletionResult {
+  requested_count: number
+  deleted_student_count: number
+  deleted_attempts: number
+  deleted_responses: number
+  deleted_focus_events: number
+  deleted_ai_grading_items: number
+}
+
+export function normalizeStudentIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+        .map((item) => item.trim())
+    )
+  )
+}
+
+export function getKnownTestWorkDeletionRpcError(error: {
+  code?: string
+  message?: string
+  details?: string | null
+  hint?: string | null
+} | null | undefined): { status: number; message: string } | null {
+  if (!error) return null
+
+  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+
+  if (
+    error.code === '42883' ||
+    error.code === 'PGRST202' ||
+    combined.includes('delete_student_test_attempts_atomic')
+  ) {
+    return {
+      status: 400,
+      message: 'Deleting selected student test work requires migration 072 to be applied',
+    }
+  }
+
+  return null
+}
+
+export async function deleteStudentTestAttemptsAtomic({
+  supabase,
+  testId,
+  studentIds,
+}: {
+  supabase: any
+  testId: string
+  studentIds: string[]
+}) {
+  return supabase.rpc('delete_student_test_attempts_atomic', {
+    p_test_id: testId,
+    p_student_ids: studentIds,
+  })
+}

--- a/supabase/migrations/072_atomic_test_work_bulk_delete.sql
+++ b/supabase/migrations/072_atomic_test_work_bulk_delete.sql
@@ -1,0 +1,111 @@
+-- Atomically delete selected students' test work for one test.
+
+create or replace function public.delete_student_test_attempts_atomic(
+  p_test_id uuid,
+  p_student_ids uuid[]
+)
+returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_requested_count integer := 0;
+  v_student_ids uuid[] := array[]::uuid[];
+  v_deleted_student_ids uuid[] := array[]::uuid[];
+  v_deleted_student_count integer := 0;
+  v_deleted_ai_items integer := 0;
+  v_deleted_responses integer := 0;
+  v_deleted_focus_events integer := 0;
+  v_deleted_attempts integer := 0;
+  v_deleted_ids uuid[] := array[]::uuid[];
+begin
+  with requested as (
+    select distinct student_id
+    from unnest(coalesce(p_student_ids, array[]::uuid[])) as requested(student_id)
+  )
+  select
+    count(*),
+    coalesce(array_agg(student_id), array[]::uuid[])
+  into v_requested_count, v_student_ids
+  from requested;
+
+  if v_requested_count = 0 then
+    return jsonb_build_object(
+      'requested_count', 0,
+      'deleted_student_count', 0,
+      'deleted_attempts', 0,
+      'deleted_responses', 0,
+      'deleted_focus_events', 0,
+      'deleted_ai_grading_items', 0
+    );
+  end if;
+
+  with deleted_ai_items as (
+    delete from public.test_ai_grading_run_items
+    where test_id = p_test_id
+      and student_id = any(v_student_ids)
+    returning student_id
+  )
+  select
+    count(*),
+    coalesce(array_agg(distinct student_id), array[]::uuid[])
+  into v_deleted_ai_items, v_deleted_ids
+  from deleted_ai_items;
+  v_deleted_student_ids := v_deleted_student_ids || v_deleted_ids;
+
+  with deleted_responses as (
+    delete from public.test_responses
+    where test_id = p_test_id
+      and student_id = any(v_student_ids)
+    returning student_id
+  )
+  select
+    count(*),
+    coalesce(array_agg(distinct student_id), array[]::uuid[])
+  into v_deleted_responses, v_deleted_ids
+  from deleted_responses;
+  v_deleted_student_ids := v_deleted_student_ids || v_deleted_ids;
+
+  with deleted_focus_events as (
+    delete from public.test_focus_events
+    where test_id = p_test_id
+      and student_id = any(v_student_ids)
+    returning student_id
+  )
+  select
+    count(*),
+    coalesce(array_agg(distinct student_id), array[]::uuid[])
+  into v_deleted_focus_events, v_deleted_ids
+  from deleted_focus_events;
+  v_deleted_student_ids := v_deleted_student_ids || v_deleted_ids;
+
+  with deleted_attempts as (
+    delete from public.test_attempts
+    where test_id = p_test_id
+      and student_id = any(v_student_ids)
+    returning student_id
+  )
+  select
+    count(*),
+    coalesce(array_agg(distinct student_id), array[]::uuid[])
+  into v_deleted_attempts, v_deleted_ids
+  from deleted_attempts;
+  v_deleted_student_ids := v_deleted_student_ids || v_deleted_ids;
+
+  select count(distinct student_id)
+  into v_deleted_student_count
+  from unnest(v_deleted_student_ids) as deleted(student_id);
+
+  return jsonb_build_object(
+    'requested_count', v_requested_count,
+    'deleted_student_count', v_deleted_student_count,
+    'deleted_attempts', v_deleted_attempts,
+    'deleted_responses', v_deleted_responses,
+    'deleted_focus_events', v_deleted_focus_events,
+    'deleted_ai_grading_items', v_deleted_ai_items
+  );
+end;
+$$;
+
+revoke all on function public.delete_student_test_attempts_atomic(uuid, uuid[]) from public, anon, authenticated;
+grant execute on function public.delete_student_test_attempts_atomic(uuid, uuid[]) to service_role;

--- a/tests/api/teacher/tests-student-attempts-bulk-delete.test.ts
+++ b/tests/api/teacher/tests-student-attempts-bulk-delete.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/teacher/tests/[id]/students/attempts/bulk-delete/route'
+import { assertTeacherOwnsTest } from '@/lib/server/tests'
+
+const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/tests', async () => {
+  const actual = await vi.importActual<any>('@/lib/server/tests')
+  return {
+    ...actual,
+    assertTeacherOwnsTest: vi.fn(async () => ({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        status: 'active',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      },
+    })),
+  }
+})
+
+function makeRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/teacher/tests/test-1/students/attempts/bulk-delete', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+const params = { params: Promise.resolve({ id: 'test-1' }) }
+
+function mockEnrollmentRows(studentIds: string[]) {
+  ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn(async () => ({
+            data: studentIds.map((student_id) => ({ student_id })),
+            error: null,
+          })),
+        })),
+      }
+    }
+
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
+describe('POST /api/teacher/tests/[id]/students/attempts/bulk-delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.rpc = vi.fn(async () => ({
+      data: {
+        requested_count: 2,
+        deleted_student_count: 2,
+        deleted_attempts: 2,
+        deleted_responses: 4,
+        deleted_focus_events: 3,
+        deleted_ai_grading_items: 1,
+      },
+      error: null,
+    }))
+  })
+
+  it('validates student_ids input', async () => {
+    const missing = await POST(makeRequest({}), params)
+    expect(missing.status).toBe(400)
+    await expect(missing.json()).resolves.toEqual({ error: 'student_ids array is required' })
+
+    const tooMany = await POST(
+      makeRequest({ student_ids: Array.from({ length: 101 }, (_, index) => `student-${index}`) }),
+      params
+    )
+    expect(tooMany.status).toBe(400)
+    await expect(tooMany.json()).resolves.toEqual({
+      error: 'Cannot delete test work for more than 100 students at once',
+    })
+  })
+
+  it('requires every selected student to be enrolled before deleting anything', async () => {
+    mockEnrollmentRows(['student-1'])
+
+    const response = await POST(makeRequest({ student_ids: ['student-1', 'student-2'] }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'One or more selected students are not enrolled in this classroom',
+    })
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+  })
+
+  it('deletes selected student test work through one atomic RPC', async () => {
+    mockEnrollmentRows(['student-1', 'student-2'])
+
+    const response = await POST(
+      makeRequest({ student_ids: ['student-1', 'student-2', 'student-1', '  student-2  '] }),
+      params
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledTimes(1)
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('delete_student_test_attempts_atomic', {
+      p_test_id: 'test-1',
+      p_student_ids: ['student-1', 'student-2'],
+    })
+    expect(data).toEqual({
+      success: true,
+      requested_count: 2,
+      deleted_student_count: 2,
+      deleted_attempts: 2,
+      deleted_responses: 4,
+      deleted_focus_events: 3,
+      deleted_ai_grading_items: 1,
+    })
+  })
+
+  it('returns migration guidance when the atomic bulk delete RPC is missing', async () => {
+    mockEnrollmentRows(['student-1'])
+    mockSupabaseClient.rpc = vi.fn(async () => ({
+      data: null,
+      error: {
+        code: 'PGRST202',
+        message: 'Could not find function delete_student_test_attempts_atomic',
+      },
+    }))
+
+    const response = await POST(makeRequest({ student_ids: ['student-1'] }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Deleting selected student test work requires migration 072 to be applied',
+    })
+  })
+
+  it('does not fall back to partial route-code deletion when the atomic RPC fails', async () => {
+    mockEnrollmentRows(['student-1', 'student-2'])
+    mockSupabaseClient.rpc = vi.fn(async () => ({
+      data: null,
+      error: { message: 'transaction aborted' },
+    }))
+
+    const response = await POST(makeRequest({ student_ids: ['student-1', 'student-2'] }), params)
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to delete selected student test work',
+    })
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledTimes(1)
+    expect(mockSupabaseClient.from).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects archived classrooms through the ownership check', async () => {
+    vi.mocked(assertTeacherOwnsTest).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      error: 'Cannot modify archived classroom',
+    })
+
+    const response = await POST(makeRequest({ student_ids: ['student-1'] }), params)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Cannot modify archived classroom' })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -2178,6 +2178,8 @@ describe('TeacherTestsTab', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          requested_count: 1,
+          deleted_student_count: 1,
           deleted_attempts: 1,
           deleted_responses: 2,
           deleted_focus_events: 1,
@@ -2225,11 +2227,66 @@ describe('TeacherTestsTab', () => {
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        '/api/teacher/tests/test-1/students/student-1/attempt',
-        expect.objectContaining({ method: 'DELETE' })
+        '/api/teacher/tests/test-1/students/attempts/bulk-delete',
+        expect.objectContaining({ method: 'POST' })
       )
     })
+    const deleteCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/tests/test-1/students/attempts/bulk-delete'
+    )
+    expect(JSON.parse(deleteCall?.[1]?.body as string)).toEqual({ student_ids: ['student-1'] })
     expect(await screen.findByLabelText('Status Not started')).toBeInTheDocument()
+  })
+
+  it('keeps selected test work pending when the atomic bulk delete fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse({
+        students: [
+          makeGradingStudent(),
+          makeGradingStudent({
+            student_id: 'student-2',
+            name: 'Bob Yellow',
+            first_name: 'Bob',
+            last_name: 'Yellow',
+            email: 'bob@example.com',
+          }),
+        ],
+      }))
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Failed to delete selected student test work' }),
+      })
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Select Alice Zephyr'))
+    fireEvent.click(screen.getByLabelText('Select Bob Yellow'))
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /Delete Selected/ }))
+
+    expect(await screen.findByText('Delete 2 selected test work items?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Work' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/teacher/tests/test-1/students/attempts/bulk-delete',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+    const deleteCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url === '/api/teacher/tests/test-1/students/attempts/bulk-delete'
+    )
+    expect(JSON.parse(deleteCall?.[1]?.body as string).student_ids.sort()).toEqual(['student-1', 'student-2'])
+    expect(await screen.findByText('Failed to delete selected student test work')).toBeInTheDocument()
+    expect(screen.getByText('Delete 2 selected test work items?')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
   })
 
   it('starts a background AI grading run, polls it, and refreshes rows on completion', async () => {

--- a/tests/unit/test-work-bulk-delete-migration.test.ts
+++ b/tests/unit/test-work-bulk-delete-migration.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readBulkDeleteMigration() {
+  const migrationsDir = resolve(process.cwd(), 'supabase/migrations')
+  const migration = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .find((file) => {
+      const contents = readFileSync(resolve(migrationsDir, file), 'utf8')
+      return contents.includes('delete_student_test_attempts_atomic')
+    })
+
+  expect(migration).toBeTruthy()
+  return readFileSync(resolve(migrationsDir, migration as string), 'utf8')
+}
+
+describe('atomic test work bulk delete migration', () => {
+  it('keeps the bulk delete RPC behind the service-role API boundary', () => {
+    const migration = readBulkDeleteMigration()
+
+    expect(migration).toContain('create or replace function public.delete_student_test_attempts_atomic')
+    expect(migration).toContain(
+      'revoke all on function public.delete_student_test_attempts_atomic(uuid, uuid[]) from public, anon, authenticated;',
+    )
+    expect(migration).toContain(
+      'grant execute on function public.delete_student_test_attempts_atomic(uuid, uuid[]) to service_role;',
+    )
+  })
+
+  it('deletes all selected test-work tables in one RPC and reports distinct affected students', () => {
+    const migration = readBulkDeleteMigration()
+
+    expect(migration).toContain('unnest(coalesce(p_student_ids, array[]::uuid[]))')
+    expect(migration).toContain('delete from public.test_ai_grading_run_items')
+    expect(migration).toContain('delete from public.test_responses')
+    expect(migration).toContain('delete from public.test_focus_events')
+    expect(migration).toContain('delete from public.test_attempts')
+    expect(migration).toContain("'deleted_student_count', v_deleted_student_count")
+  })
+})


### PR DESCRIPTION
## Summary
- Add migration 072 with service-role-only delete_student_test_attempts_atomic(test_id, student_ids)
- Add a bulk selected test-work delete API route that validates all selected students before one RPC call
- Update the teacher Tests selected-delete UI to POST once and keep the pending dialog open on RPC failure

Closes #623

## Validation
- pnpm test tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/components/TeacherTestsTab.test.tsx
- pnpm test tests/api/teacher/tests-student-attempt-delete.test.ts tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/unit/migration-filenames.test.ts
- pnpm lint
- supabase migration list --local
- supabase db lint --local --fail-on error
- supabase migration up --local
- supabase db query --local "select public.delete_student_test_attempts_atomic('00000000-0000-0000-0000-000000000001'::uuid, array['00000000-0000-0000-0000-000000000002'::uuid]) as result;"
- pnpm build
- pnpm test
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=tests'
- Focused Playwright screenshot: /tmp/pika-test-work-bulk-delete-dialog.png

## Notes
- Supabase local lint still reports an existing warning for public.unsubmit_test_attempts_atomic unused parameter p_updated_by.