### PR TITLE
[codex] Clean up assignment artifact storage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Gradebook scroll containment
-
-**Completed:**
-- Fixed the teacher gradebook matrix so its table panel fills the workspace and owns both horizontal and vertical overflow.
-- Removed the flush table wrapper that clipped horizontal overflow before the gradebook scroll pane could expose it.
-- Kept the gradebook viewport-constrained in both grades and settings modes so long student lists and many assessment columns remain reachable.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- Mocked long-grid Playwright check with 48 students and 32 assessment columns; verified `gradebook-student-scroll-pane` can scroll on both axes and captured `/tmp/pika-gradebook-scroll-after.png` and `/tmp/pika-gradebook-settings-scroll-after.png`.
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/5fcf845d-220d-4321-8409-5afe9e9459c3?tab=gradebook"`
-- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
-
 ## 2026-05-21 — Returned assignment timing freeze
 
 **Completed:**
@@ -323,6 +308,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm test`
+
+## 2026-05-25 — Assignment artifact storage cleanup follow-up
+
+**Completed:**
+- Added best-effort teacher-side cleanup for `assignment-artifacts` image objects when image submission requirements are removed.
+- Added best-effort cleanup for image artifact objects after teacher assignment deletion succeeds.
+- Preserved storage objects when an image requirement is edited/reordered/renamed with the same requirement ID and type.
+- Added chunked Storage `remove()` calls with failure logging that does not fail successful teacher mutations.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/assignments-id.test.ts`
+- `pnpm test tests/lib/assignment-submission-artifacts.test.ts tests/api/assignment-docs/artifacts.test.ts`
+- `pnpm lint`
+- `pnpm build`
 - `pnpm build`
 - `pnpm exec vitest run tests/unit/assignment-submission-validation.test.ts`
 - `pnpm exec vitest run tests/lib/assignment-submission-artifacts.test.ts tests/unit/assignment-submission-validation.test.ts`

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -19,8 +19,11 @@ import {
   submissionArtifactsToAssignmentArtifacts,
 } from '@/lib/assignment-submission-requirements'
 import {
+  collectAssignmentImageArtifactStoragePaths,
+  collectRemovedImageArtifactStoragePaths,
   loadAssignmentSubmissionArtifactsForDocs,
   loadAssignmentSubmissionRequirements,
+  removeAssignmentArtifactStorageObjects,
   replaceAssignmentSubmissionRequirements,
 } from '@/lib/server/assignment-submission-artifacts'
 
@@ -376,6 +379,10 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
     )
   }
 
+  const removedRequirementImageStoragePaths = hasSubmissionRequirementsUpdate
+    ? await collectRemovedImageArtifactStoragePaths(supabase, id, submission_requirements as any[])
+    : []
+
   let assignment = existing
   if (Object.keys(updates).length > 0) {
     const { data: updatedAssignment, error } = await supabase
@@ -398,6 +405,14 @@ export const PATCH = withErrorHandler('PatchTeacherAssignment', async (request, 
   const submissionRequirements = hasSubmissionRequirementsUpdate
     ? await replaceAssignmentSubmissionRequirements(supabase, id, submission_requirements as any[])
     : await loadAssignmentSubmissionRequirements(supabase, id)
+
+  if (hasSubmissionRequirementsUpdate && removedRequirementImageStoragePaths.length > 0) {
+    await removeAssignmentArtifactStorageObjects(
+      supabase,
+      removedRequirementImageStoragePaths,
+      `assignment:${id}:removed-submission-requirements`
+    )
+  }
 
   return NextResponse.json({
     assignment: {
@@ -447,6 +462,8 @@ export const DELETE = withErrorHandler('DeleteTeacherAssignment', async (request
     )
   }
 
+  const assignmentImageStoragePaths = await collectAssignmentImageArtifactStoragePaths(supabase, id)
+
   const { error } = await supabase
     .from('assignments')
     .delete()
@@ -457,6 +474,14 @@ export const DELETE = withErrorHandler('DeleteTeacherAssignment', async (request
     return NextResponse.json(
       { error: 'Failed to delete assignment' },
       { status: 500 }
+    )
+  }
+
+  if (assignmentImageStoragePaths.length > 0) {
+    await removeAssignmentArtifactStorageObjects(
+      supabase,
+      assignmentImageStoragePaths,
+      `assignment:${id}:delete`
     )
   }
 

--- a/src/lib/server/assignment-submission-artifacts.ts
+++ b/src/lib/server/assignment-submission-artifacts.ts
@@ -9,6 +9,7 @@ import type {
 
 const ASSIGNMENT_ARTIFACTS_BUCKET = 'assignment-artifacts'
 const SIGNED_IMAGE_URL_EXPIRES_SECONDS = 60 * 60
+const STORAGE_REMOVE_CHUNK_SIZE = 1000
 
 type SupabaseClientLike = any
 type SupabaseSchemaError = {
@@ -126,6 +127,136 @@ export async function loadAssignmentSubmissionArtifactsForDocs(
   } catch (error) {
     if (isMissingAssignmentSubmissionSchemaError(error)) return []
     throw error
+  }
+}
+
+function uniqueStoragePaths(paths: Array<string | null | undefined>): string[] {
+  const unique = new Set<string>()
+  for (const path of paths) {
+    const trimmed = path?.trim()
+    if (trimmed) unique.add(trimmed)
+  }
+  return Array.from(unique)
+}
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+export function getRemovedImageSubmissionRequirementIds(
+  existingRequirements: AssignmentSubmissionRequirement[],
+  drafts: AssignmentSubmissionRequirementDraft[]
+): string[] {
+  const normalizedDrafts = normalizeAssignmentSubmissionRequirementDrafts(drafts)
+  const existingById = new Map(existingRequirements.map((requirement) => [requirement.id, requirement]))
+  const preservedIds = new Set<string>()
+
+  for (const draft of normalizedDrafts) {
+    if (!draft.id) continue
+    const existing = existingById.get(draft.id)
+    if (existing && existing.type === draft.type) {
+      preservedIds.add(existing.id)
+    }
+  }
+
+  return existingRequirements
+    .filter((requirement) => requirement.type === 'image' && !preservedIds.has(requirement.id))
+    .map((requirement) => requirement.id)
+}
+
+export async function loadImageArtifactStoragePathsForRequirements(
+  supabase: SupabaseClientLike,
+  requirementIds: string[]
+): Promise<string[]> {
+  if (requirementIds.length === 0) return []
+
+  try {
+    const query = supabase.from('assignment_submission_artifacts')
+    if (!query) return []
+    const { data, error } = await query
+      .select('storage_path')
+      .eq('type', 'image')
+      .not('storage_path', 'is', null)
+      .in('requirement_id', requirementIds)
+
+    if (error) {
+      if (isMissingAssignmentSubmissionSchemaError(error)) return []
+      throw new Error('Failed to load assignment artifact storage paths')
+    }
+
+    return uniqueStoragePaths((data || []).map((row: { storage_path?: string | null }) => row.storage_path))
+  } catch (error) {
+    if (isMissingAssignmentSubmissionSchemaError(error)) return []
+    throw error
+  }
+}
+
+export async function collectRemovedImageArtifactStoragePaths(
+  supabase: SupabaseClientLike,
+  assignmentId: string,
+  drafts: AssignmentSubmissionRequirementDraft[]
+): Promise<string[]> {
+  try {
+    const existingRequirements = await loadAssignmentSubmissionRequirements(supabase, assignmentId)
+    const removedImageRequirementIds = getRemovedImageSubmissionRequirementIds(existingRequirements, drafts)
+    return loadImageArtifactStoragePathsForRequirements(supabase, removedImageRequirementIds)
+  } catch (error) {
+    console.error('Failed to collect removed assignment image artifact storage paths:', error)
+    return []
+  }
+}
+
+export async function collectAssignmentImageArtifactStoragePaths(
+  supabase: SupabaseClientLike,
+  assignmentId: string
+): Promise<string[]> {
+  try {
+    const existingRequirements = await loadAssignmentSubmissionRequirements(supabase, assignmentId)
+    const imageRequirementIds = existingRequirements
+      .filter((requirement) => requirement.type === 'image')
+      .map((requirement) => requirement.id)
+
+    return loadImageArtifactStoragePathsForRequirements(supabase, imageRequirementIds)
+  } catch (error) {
+    console.error('Failed to collect assignment image artifact storage paths:', error)
+    return []
+  }
+}
+
+export async function removeAssignmentArtifactStorageObjects(
+  supabase: SupabaseClientLike,
+  storagePaths: string[],
+  context: string
+): Promise<void> {
+  const paths = uniqueStoragePaths(storagePaths)
+  if (paths.length === 0) return
+
+  for (const chunk of chunkArray(paths, STORAGE_REMOVE_CHUNK_SIZE)) {
+    try {
+      const { error } = await supabase.storage
+        .from(ASSIGNMENT_ARTIFACTS_BUCKET)
+        .remove(chunk)
+
+      if (error) {
+        console.error('Failed to remove assignment artifact storage objects:', {
+          context,
+          bucket: ASSIGNMENT_ARTIFACTS_BUCKET,
+          paths: chunk,
+          error,
+        })
+      }
+    } catch (error) {
+      console.error('Failed to remove assignment artifact storage objects:', {
+        context,
+        bucket: ASSIGNMENT_ARTIFACTS_BUCKET,
+        paths: chunk,
+        error,
+      })
+    }
   }
 }
 

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -12,7 +12,84 @@ vi.mock('@/lib/server/assignment-ai-grading-runs', () => ({
   getActiveAssignmentAiGradingRunSummary: vi.fn(async () => null),
 }))
 
-const mockSupabaseClient = { from: vi.fn() }
+const mockSupabaseClient = {
+  from: vi.fn(),
+  rpc: vi.fn(),
+  storage: { from: vi.fn() },
+}
+
+function makeAssignment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'a-1',
+    title: 'Assignment 1',
+    description: 'Write it up',
+    instructions_markdown: 'Write it up',
+    rich_instructions: null,
+    due_at: '2099-03-10T23:59:00.000Z',
+    position: 0,
+    is_draft: false,
+    released_at: null,
+    track_authenticity: true,
+    created_by: 'teacher-1',
+    created_at: '2026-03-01T00:00:00.000Z',
+    updated_at: '2026-03-02T00:00:00.000Z',
+    classrooms: { teacher_id: 'teacher-1', archived_at: null },
+    ...overrides,
+  }
+}
+
+function makeRequirement(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-link',
+    assignment_id: 'a-1',
+    type: 'link',
+    label: 'Public link',
+    instructions: '',
+    required: true,
+    position: 0,
+    validation_policy_json: {},
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeAssignmentSelectTable(existing = makeAssignment()) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({ data: existing, error: null }),
+      })),
+    })),
+  }
+}
+
+function makeRequirementsTable(requirements: unknown[]) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        order: vi.fn(() => ({
+          order: vi.fn().mockResolvedValue({ data: requirements, error: null }),
+        })),
+      })),
+    })),
+  }
+}
+
+function makeImageArtifactsTable(paths: string[]) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        not: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: paths.map((storage_path) => ({ storage_path })),
+            error: null,
+          }),
+        })),
+      })),
+    })),
+  }
+}
 
 describe('GET /api/teacher/assignments/[id]', () => {
   beforeEach(() => { vi.clearAllMocks() })
@@ -443,6 +520,83 @@ describe('PATCH /api/teacher/assignments/[id]', () => {
     expect(response.status).toBe(200)
     expect(capturedUpdate).toEqual({ is_draft: true, released_at: null })
   })
+
+  it('removes image artifact storage after an image requirement is removed', async () => {
+    const remove = vi.fn(async () => ({ error: null }))
+    const remainingRequirement = makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link' })
+    ;(mockSupabaseClient.rpc as any) = vi.fn(async () => ({
+      data: [remainingRequirement],
+      error: null,
+    }))
+    ;(mockSupabaseClient.storage as any) = {
+      from: vi.fn(() => ({ remove })),
+    }
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return makeAssignmentSelectTable()
+      if (table === 'assignment_submission_requirements') {
+        return makeRequirementsTable([
+          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot', position: 0 }),
+          makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link', position: 1 }),
+        ])
+      }
+      if (table === 'assignment_submission_artifacts') {
+        return makeImageArtifactsTable(['student-1/a-1/req-image.png'])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        submission_requirements: [
+          { id: 'req-link', type: 'link', label: 'Demo link', position: 0 },
+        ],
+      }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(200)
+    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
+  })
+
+  it('preserves image artifact storage when the image requirement id is kept', async () => {
+    const remove = vi.fn(async () => ({ error: null }))
+    const updatedRequirement = makeRequirement({ id: 'req-image', type: 'image', label: 'Updated screenshot' })
+    ;(mockSupabaseClient.rpc as any) = vi.fn(async () => ({
+      data: [updatedRequirement],
+      error: null,
+    }))
+    ;(mockSupabaseClient.storage as any) = {
+      from: vi.fn(() => ({ remove })),
+    }
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') return makeAssignmentSelectTable()
+      if (table === 'assignment_submission_requirements') {
+        return makeRequirementsTable([
+          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot', position: 0 }),
+        ])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        submission_requirements: [
+          { id: 'req-image', type: 'image', label: 'Updated screenshot', position: 1 },
+        ],
+      }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(200)
+    expect(remove).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('assignment_submission_artifacts')
+  })
 })
 
 describe('DELETE /api/teacher/assignments/[id]', () => {
@@ -471,5 +625,101 @@ describe('DELETE /api/teacher/assignments/[id]', () => {
 
     const response = await DELETE(request, { params: { id: 'a-1' } })
     expect(response.status).toBe(403)
+  })
+
+  it('removes related image artifact storage after deleting an assignment', async () => {
+    const remove = vi.fn(async () => ({ error: null }))
+    const deleteEq = vi.fn(async () => ({ error: null }))
+    ;(mockSupabaseClient.storage as any) = {
+      from: vi.fn(() => ({ remove })),
+    }
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: makeAssignment(), error: null }),
+            })),
+          })),
+          delete: vi.fn(() => ({
+            eq: deleteEq,
+          })),
+        }
+      }
+      if (table === 'assignment_submission_requirements') {
+        return makeRequirementsTable([
+          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot' }),
+          makeRequirement({ id: 'req-link', type: 'link', label: 'Demo link' }),
+        ])
+      }
+      if (table === 'assignment_submission_artifacts') {
+        return makeImageArtifactsTable(['student-1/a-1/req-image.png'])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'DELETE',
+    })
+
+    const response = await DELETE(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(200)
+    expect(deleteEq).toHaveBeenCalledWith('id', 'a-1')
+    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
+    expect(remove.mock.invocationCallOrder[0]).toBeGreaterThan(deleteEq.mock.invocationCallOrder[0])
+  })
+
+  it('logs storage removal failures without failing a successful assignment delete', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const removeError = { message: 'storage unavailable' }
+    const remove = vi.fn(async () => ({ error: removeError }))
+    const deleteEq = vi.fn(async () => ({ error: null }))
+    ;(mockSupabaseClient.storage as any) = {
+      from: vi.fn(() => ({ remove })),
+    }
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: makeAssignment(), error: null }),
+            })),
+          })),
+          delete: vi.fn(() => ({
+            eq: deleteEq,
+          })),
+        }
+      }
+      if (table === 'assignment_submission_requirements') {
+        return makeRequirementsTable([
+          makeRequirement({ id: 'req-image', type: 'image', label: 'Screenshot' }),
+        ])
+      }
+      if (table === 'assignment_submission_artifacts') {
+        return makeImageArtifactsTable(['student-1/a-1/req-image.png'])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1', {
+      method: 'DELETE',
+    })
+
+    const response = await DELETE(request, { params: { id: 'a-1' } })
+
+    expect(response.status).toBe(200)
+    expect(remove).toHaveBeenCalledWith(['student-1/a-1/req-image.png'])
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to remove assignment artifact storage objects:',
+      expect.objectContaining({
+        context: 'assignment:a-1:delete',
+        error: removeError,
+        paths: ['student-1/a-1/req-image.png'],
+      })
+    )
+    consoleError.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- Adds teacher-side cleanup for image artifact objects in the private `assignment-artifacts` Supabase Storage bucket when image submission requirements are removed.
- Adds the same best-effort cleanup after teacher assignment deletion succeeds.
- Preserves existing image artifacts when a requirement is edited, renamed, or reordered while keeping the same requirement `id` and `type`.
- Chunks Storage `remove()` calls and logs cleanup failures without failing successful teacher mutations.

## Why

Assignment submission artifacts cascade out of the database when requirements or assignments are deleted, but Supabase Storage objects are not removed by DB cascades. That left student-uploaded requirement images orphaned in storage.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/api/teacher/assignments-id.test.ts`
- `pnpm test tests/lib/assignment-submission-artifacts.test.ts tests/api/assignment-docs/artifacts.test.ts`
- `pnpm lint`
- `pnpm build`
- `git diff --check`