### PR TITLE
[codex] Harden Supabase auth exposure for WorkOS

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Returned assignment timing freeze
-
-**Completed:**
-- Fixed returned assignment timing so student-facing labels freeze against preserved `submitted_at` even after teacher return clears `is_submitted`.
-- Added regression coverage for returned late work with `is_submitted: false`, preserved `submitted_at`, and `returned_at`.
-- Rebuilt the fix on a fresh branch from current `origin/main` to avoid carrying stale already-merged commits.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm seed`
-- `pnpm e2e:auth`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/85d6177d-f695-4df2-bbad-2946876d8e16?tab=assignments"`
-- Reviewed `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-teacher-loaded.png`.
-- `pnpm test`
-
 ## 2026-05-21 — Developer feedback helper
 
 **Completed:**
@@ -340,3 +324,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `pnpm test`
+
+## 2026-05-25 — Supabase RLS/Auth hardening for WorkOS
+
+**Completed:**
+- Added migration `075_auth_rls_hardening.sql` with `users.workos_user_id` unique mapping while preserving local UUID user IDs.
+- Enabled RLS and explicit no-direct-access policies on announcements, announcement reads, gradebook settings, quiz score overrides, and report-card tables.
+- Revoked direct public table/sequence/function grants from `anon` and `authenticated`, preserved `service_role`, and hardened migration-owner default privileges.
+- Removed direct authenticated upload/delete storage policies for legacy public buckets while keeping public read behavior.
+- Set stable `search_path` on existing public functions surfaced by Supabase security advisors.
+- Updated architecture/AI guidance for the server-route authorization model and WorkOS posture.
+
+**Validation:**
+- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -1 -f supabase/migrations/075_auth_rls_hardening.sql`
+- Metadata checks for RLS, grants, policies, default privileges, and WorkOS index.
+- `supabase db lint --local --schema public,storage --fail-on none` (passes with pre-existing warnings only)
+- `supabase db advisors --local --type security --level warn --fail-on none`
+- `pnpm test tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/api/student/announcements.test.ts tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts tests/unit/auth-rls-hardening-migration.test.ts tests/unit/migration-filenames.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `git diff --check`

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -40,7 +40,8 @@ Inspect or modify source only after the startup set and the docs required by you
 - Platform: Next.js App Router, Supabase, Tailwind CSS, Vitest, Vercel
 - Vercel cron guardrail: on the Hobby plan, cron schedules must run at most once per day; do not add sub-daily repo-managed Vercel cron jobs
 - Timezone: all deadline and attendance logic uses `America/Toronto`
-- Auth: email verification codes plus password login; no OAuth providers
+- Auth: current runtime uses email verification codes plus password login; upcoming WorkOS AuthKit work must map WorkOS users to `public.users.workos_user_id` while preserving local `public.users.id` UUIDs
+- Supabase access: app authorization belongs in server routes via `requireAuth()` / `requireRole()` and the service-role client; do not add new browser-side Supabase table/RPC access without explicit review
 - Architecture: keep business logic out of UI components; prefer `src/lib/*` and server-side modules
 - API routes: use `withErrorHandler` from `@/lib/api-handler`
 - Repeated client-side reads: use `fetchJSONWithCache` from `@/lib/request-cache`

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -98,11 +98,12 @@ tests/                             # Vitest unit + API suites
   `border-border`, `text-primary`, `text-danger`, `text-success`, `text-warning`
 - Full token reference: `src/ui/README.md` | Design rules: `docs/core/design.md`
 
-### Authentication (Primary)
+### Authentication (Current And WorkOS-Ready)
 - **Signup**: `/api/auth/signup` stores a verification code (mock-emailed); `/verify-signup` validates; `/create-password` hashes password (bcrypt), sets session.
 - **Login**: `/api/auth/login` with email/password.
 - **Forgot/Reset**: `/api/auth/forgot-password` issues reset code; `/reset-password/verify` + `/confirm` update password.
 - **Session**: iron-session cookie (`pika_session`), HTTP-only, SameSite=Lax, secure in production.
+- **WorkOS migration posture**: keep `public.users.id` as Pika's internal UUID user id. Store the external WorkOS AuthKit id in `public.users.workos_user_id` and map WorkOS sessions to local users before authorization checks.
 
 ### Attendance Logic
 - Statuses: `present` or `absent` only. Presence is determined by existence of an entry for a class day where `is_class_day=true`.
@@ -116,8 +117,8 @@ tests/                             # Vitest unit + API suites
 
 ### Route Protection
 - Role check via `requireRole('student' | 'teacher')` in API routes.
-- Classroom ownership/enrollment enforced in route logic and RLS.
-- Service role Supabase client used in API routes; iron-session used for identity.
+- Classroom ownership/enrollment enforced in route logic using the local Pika user id.
+- Server routes use the Supabase service-role client and iron-session identity. Browser-side Supabase table/RPC access is not a supported app data path.
 
 ### API Route Error Handling (Required Pattern)
 All API routes **must** use the `withErrorHandler` wrapper from `@/lib/api-handler`:
@@ -339,10 +340,10 @@ Existing indexes (migration 038):
 
 ---
 
-## Database Schema (Migrations 001–045+)
+## Database Schema (Migrations 001–075+)
 
 ### Core
-- `users` — `id`, `email`, `role`, `email_verified_at`, `password_hash`, timestamps
+- `users` — `id`, `email`, `role`, `email_verified_at`, `password_hash`, `workos_user_id`, timestamps
 - `verification_codes` — signup/reset codes with expiry/attempts
 - `student_profiles` — student metadata linked to `users`
 - `classrooms` — owned by teacher (`teacher_id`); `name`, `join_code`, `allow_enrollment`
@@ -375,9 +376,11 @@ Existing indexes (migration 038):
 - `developer_feedback_candidates` — server-managed, sanitized Pika improvement candidates from daily logs and direct Send Feedback submissions for developer review
 
 **RLS Highlights**
-- Auth tables (`verification_codes`) are server-managed only (service role).
-- All other tables: RLS disabled; app enforces ownership/enrollment via `requireRole` + service role checks.
-- Assignments/docs: teachers of the classroom read-all; students read/write their own docs only.
+- `public` is exposed through Supabase's Data API, so public tables should have RLS enabled even when app traffic is server-routed.
+- App data access is server-managed: API routes authorize with `requireAuth()` / `requireRole()` and use the service-role Supabase client.
+- `anon` and `authenticated` direct table/RPC privileges are revoked by the auth hardening migration; new direct browser data paths must be explicitly designed and reviewed.
+- Some legacy RLS policies still contain `auth.uid()` expressions as defense-in-depth for old Supabase-auth-compatible paths. Do not deepen this pattern for new app authorization, because WorkOS AuthKit sessions do not populate Supabase Auth context automatically.
+- Server-managed tables that have no supported direct access path use explicit no-direct-access policies.
 
 ---
 
@@ -400,7 +403,8 @@ Existing indexes (migration 038):
 ## Deployment Notes
 
 - Vercel for frontend + API; Supabase for DB.
-- Use service role key server-side only; publishable key client-side.
+- Use the Supabase service-role/secret key server-side only. Do not expose it to browsers.
+- Supabase public-read storage URLs are product behavior for legacy public buckets, but uploads/deletes should go through server API routes.
 - Iron-session cookie (`pika_session`) must be secure in production with a 32+ char secret.
 
 ---

--- a/supabase/migrations/075_auth_rls_hardening.sql
+++ b/supabase/migrations/075_auth_rls_hardening.sql
@@ -1,0 +1,139 @@
+-- Harden direct Supabase Data API access ahead of WorkOS AuthKit migration.
+--
+-- Pika's application authorization happens in Next.js API routes with
+-- requireAuth()/requireRole() and the Supabase service-role client. WorkOS user
+-- IDs must map to local public.users.id UUIDs instead of replacing them.
+
+alter table public.users
+  add column if not exists workos_user_id text;
+
+create unique index if not exists users_workos_user_id_unique
+  on public.users (workos_user_id)
+  where workos_user_id is not null;
+
+comment on column public.users.workos_user_id is
+  'External WorkOS AuthKit user id. public.users.id remains Pika''s internal app user id.';
+
+alter table public.announcements enable row level security;
+alter table public.announcement_reads enable row level security;
+alter table public.gradebook_settings enable row level security;
+alter table public.quiz_student_scores enable row level security;
+alter table public.report_cards enable row level security;
+alter table public.report_card_rows enable row level security;
+
+drop policy if exists "No direct access to announcements" on public.announcements;
+create policy "No direct access to announcements"
+  on public.announcements
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "No direct access to announcement_reads" on public.announcement_reads;
+create policy "No direct access to announcement_reads"
+  on public.announcement_reads
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "No direct access to gradebook_settings" on public.gradebook_settings;
+create policy "No direct access to gradebook_settings"
+  on public.gradebook_settings
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "No direct access to quiz_student_scores" on public.quiz_student_scores;
+create policy "No direct access to quiz_student_scores"
+  on public.quiz_student_scores
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "No direct access to report_cards" on public.report_cards;
+create policy "No direct access to report_cards"
+  on public.report_cards
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "No direct access to report_card_rows" on public.report_card_rows;
+create policy "No direct access to report_card_rows"
+  on public.report_card_rows
+  for all
+  to public
+  using (false)
+  with check (false);
+
+-- Existing app code does not use browser-side Supabase table/RPC access.
+-- Keep server API routes working by preserving the service_role boundary, and
+-- remove direct PostgREST/GraphQL/RPC privileges from anon/authenticated.
+revoke all privileges on all tables in schema public from public, anon, authenticated;
+revoke all privileges on all sequences in schema public from public, anon, authenticated;
+revoke all privileges on all functions in schema public from public, anon, authenticated;
+
+grant usage on schema public to service_role;
+grant all privileges on all tables in schema public to service_role;
+grant all privileges on all sequences in schema public to service_role;
+grant execute on all functions in schema public to service_role;
+
+-- Security advisor hardening for existing public functions.
+alter function public.reorder_assignments_preserve_materials(p_classroom_id uuid, p_assignment_ids jsonb) set search_path = public;
+alter function public.reorder_classwork_items(p_classroom_id uuid, p_items jsonb) set search_path = public;
+alter function public.return_assignment_docs_atomic(p_assignment_id uuid, p_student_ids uuid[], p_teacher_id uuid, p_now timestamp with time zone) set search_path = public;
+alter function public.set_classwork_material_position() set search_path = public;
+alter function public.set_survey_position() set search_path = public;
+alter function public.update_announcements_updated_at() set search_path = public;
+alter function public.update_assessment_drafts_updated_at() set search_path = public;
+alter function public.update_assignment_ai_grading_updated_at() set search_path = public;
+alter function public.update_assignment_docs_updated_at() set search_path = public;
+alter function public.update_assignment_repo_targets_updated_at() set search_path = public;
+alter function public.update_assignment_submission_artifacts_updated_at() set search_path = public;
+alter function public.update_assignment_submission_requirements_updated_at() set search_path = public;
+alter function public.update_assignments_updated_at() set search_path = public;
+alter function public.update_classwork_materials_updated_at() set search_path = public;
+alter function public.update_course_blueprints_updated_at() set search_path = public;
+alter function public.update_gradebook_settings_updated_at() set search_path = public;
+alter function public.update_quiz_questions_updated_at() set search_path = public;
+alter function public.update_quiz_student_scores_updated_at() set search_path = public;
+alter function public.update_quizzes_updated_at() set search_path = public;
+alter function public.update_report_card_rows_updated_at() set search_path = public;
+alter function public.update_report_cards_updated_at() set search_path = public;
+alter function public.update_survey_questions_updated_at() set search_path = public;
+alter function public.update_survey_responses_updated_at() set search_path = public;
+alter function public.update_surveys_updated_at() set search_path = public;
+alter function public.update_test_ai_grading_updated_at() set search_path = public;
+alter function public.update_test_attempts_updated_at() set search_path = public;
+alter function public.update_test_questions_updated_at() set search_path = public;
+alter function public.update_test_student_availability_updated_at() set search_path = public;
+alter function public.update_tests_updated_at() set search_path = public;
+alter function public.update_updated_at_column() set search_path = public;
+alter function public.update_user_github_identities_updated_at() set search_path = public;
+alter function public.validate_test_response_shape() set search_path = public;
+
+-- Pika schema changes are migration-managed and owned by postgres in local and
+-- hosted Supabase migration runs.
+alter default privileges for role postgres in schema public
+  revoke all on tables from public, anon, authenticated;
+alter default privileges for role postgres in schema public
+  revoke all on sequences from public, anon, authenticated;
+alter default privileges for role postgres in schema public
+  revoke all on functions from public, anon, authenticated;
+alter default privileges for role postgres in schema public
+  grant all on tables to service_role;
+alter default privileges for role postgres in schema public
+  grant all on sequences to service_role;
+alter default privileges for role postgres in schema public
+  grant execute on functions to service_role;
+
+-- These buckets are intentionally public-read because existing product URLs use
+-- getPublicUrl(). Uploads/deletes now go through server API routes with the
+-- service-role client instead of direct authenticated storage policies.
+drop policy if exists "Allow authenticated uploads" on storage.objects;
+drop policy if exists "Allow owner deletes" on storage.objects;
+drop policy if exists "Allow authenticated uploads for test documents" on storage.objects;
+drop policy if exists "Allow owner deletes for test documents" on storage.objects;

--- a/tests/unit/auth-rls-hardening-migration.test.ts
+++ b/tests/unit/auth-rls-hardening-migration.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readMigration() {
+  return readFileSync(resolve(process.cwd(), 'supabase/migrations/075_auth_rls_hardening.sql'), 'utf8')
+}
+
+describe('auth RLS hardening migration', () => {
+  it('adds a unique WorkOS mapping while keeping the local Pika user id', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain('add column if not exists workos_user_id text')
+    expect(migration).toContain('create unique index if not exists users_workos_user_id_unique')
+    expect(migration).toContain('public.users.id remains Pika')
+  })
+
+  it('enables no-direct-access RLS on server-managed announcement and gradebook tables', () => {
+    const migration = readMigration()
+
+    for (const tableName of [
+      'announcements',
+      'announcement_reads',
+      'gradebook_settings',
+      'quiz_student_scores',
+      'report_cards',
+      'report_card_rows',
+    ]) {
+      expect(migration).toContain(`alter table public.${tableName} enable row level security;`)
+      expect(migration).toContain(`No direct access to ${tableName}`)
+      expect(migration).toContain('using (false)')
+      expect(migration).toContain('with check (false)')
+    }
+  })
+
+  it('revokes direct Data API and RPC grants from anon and authenticated roles', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain(
+      'revoke all privileges on all tables in schema public from public, anon, authenticated;',
+    )
+    expect(migration).toContain(
+      'revoke all privileges on all sequences in schema public from public, anon, authenticated;',
+    )
+    expect(migration).toContain(
+      'revoke all privileges on all functions in schema public from public, anon, authenticated;',
+    )
+    expect(migration).toContain('grant all privileges on all tables in schema public to service_role;')
+    expect(migration).toContain('grant execute on all functions in schema public to service_role;')
+  })
+
+  it('sets stable search paths on public functions surfaced by Supabase advisors', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain('alter function public.update_announcements_updated_at() set search_path = public;')
+    expect(migration).toContain(
+      'alter function public.return_assignment_docs_atomic(p_assignment_id uuid, p_student_ids uuid[], p_teacher_id uuid, p_now timestamp with time zone) set search_path = public;',
+    )
+    expect(migration).toContain('alter function public.validate_test_response_shape() set search_path = public;')
+  })
+
+  it('keeps legacy public storage reads but removes direct client writes', () => {
+    const migration = readMigration()
+
+    expect(migration).toContain('drop policy if exists "Allow authenticated uploads" on storage.objects;')
+    expect(migration).toContain('drop policy if exists "Allow owner deletes" on storage.objects;')
+    expect(migration).toContain(
+      'drop policy if exists "Allow authenticated uploads for test documents" on storage.objects;',
+    )
+    expect(migration).toContain(
+      'drop policy if exists "Allow owner deletes for test documents" on storage.objects;',
+    )
+    expect(migration).not.toContain('drop policy if exists "Allow public read access"')
+    expect(migration).not.toContain('drop policy if exists "Allow public read access for test documents"')
+  })
+})


### PR DESCRIPTION
## Summary
- add `public.users.workos_user_id` as a unique external WorkOS AuthKit mapping while preserving local UUID app user IDs
- enable RLS and explicit no-direct-access policies for announcements, announcement reads, gradebook settings, quiz score overrides, and report-card tables
- revoke direct `anon`/`authenticated` public table, sequence, and function access while preserving the service-role API boundary
- keep legacy public storage reads for existing product URLs, but remove direct client upload/delete policies for legacy public buckets
- update architecture and AI guidance to document the WorkOS-ready server-route authorization model

## Validation
- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -1 -f supabase/migrations/075_auth_rls_hardening.sql`
- metadata checks for target table RLS, grants, storage policies, default privileges, and WorkOS index
- `supabase db lint --local --schema public,storage --fail-on none` (pre-existing warnings only)
- `supabase db advisors --local --type security --level warn --fail-on none`
- `pnpm test tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/api/student/announcements.test.ts tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts tests/unit/auth-rls-hardening-migration.test.ts tests/unit/migration-filenames.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `git diff --check`

## Notes
- No remote migrations were applied.
- `assignment-artifacts` storage policies are intentionally untouched to keep this separate from the assignment artifact cleanup follow-up.