### PR TITLE
[codex] Improve assignment artifact table UX

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,41 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Developer feedback helper
-
-**Completed:**
-- Added a private Supabase-backed developer feedback candidate queue for sanitized Pika improvement requests extracted from daily logs.
-- Extended the nightly log summary cron to opportunistically extract and dedupe developer candidates without blocking summary generation.
-- Added the agent-operated `scripts/dev-feedback.mjs` helper, `$pika-dev-feedback` Codex skill, and Claude `/dev-feedback` mirror command for numbered approve/dismiss/work-on flows.
-- Kept the existing Send Feedback UI in place and routed direct bug/feature submissions into the same developer triage queue with sanitized page metadata.
-- Updated docs, env examples, and feature inventory for the new developer feedback workflow.
-
-**Validation:**
-- `pnpm test tests/unit/developer-log-feedback.test.ts tests/api/feedback.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `/usr/bin/python3 /Users/stew/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/pika-dev-feedback`
-- `node scripts/dev-feedback.mjs help`
-- `node scripts/features.mjs validate`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-- `pnpm test`
-- `git diff --check`
-
-## 2026-05-21 — Developer feedback PR review fixes
-
-**Completed:**
-- Moved daily-log feedback candidate dedupe/merge into an atomic Supabase RPC to avoid dropped or lost concurrent classroom signals.
-- Hardened `/api/feedback` request validation so malformed JSON shapes return 400 instead of falling through to 500.
-- Added focused tests for the RPC storage path and malformed direct feedback bodies.
-
-**Validation:**
-- `pnpm test tests/unit/developer-log-feedback.test.ts tests/api/feedback.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `node scripts/features.mjs validate`
-- `pnpm test`
-- `git diff --check`
-
 ## 2026-05-21 — Worktree env symlink guidance
 
 **Completed:**
@@ -344,3 +309,37 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `git diff --check`
+
+## 2026-05-25 — Assignment artifact open behavior
+
+**Completed:**
+- Changed assignment artifact pills so a single artifact opens directly as an external link.
+- Replaced the multi-artifact preview carousel with a narrow chooser dialog listing each artifact as a direct external link.
+- Added component coverage for direct-link mode and the multi-artifact chooser.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test -- tests/components/AssignmentArtifactsCell.test.tsx` (ran full suite; pass)
+- `pnpm lint`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=f2bc083c-cec5-4b36-8659-603f84e11ff6'`
+- Playwright interaction smoke: multi-artifact chooser opens; single-artifact row opens `https://github.com/codepetca/pika`
+- Screenshot: `/tmp/pika-teacher-artifact-chooser.png`
+
+## 2026-05-25 — Assignment student table artifact UX
+
+**Completed:**
+- Rebased `codex/assignment-artifact-open-behavior` onto `origin/main` after assignment submission requirements landed.
+- Updated the teacher assignment student table to use compact `First`, `Last`, `Status`, and `Grade` columns with keyboard/pointer resize handles.
+- Converted artifact cells to icon-number pills so the table shows repo/link/image type plus `1`, `2`, `3`, etc. without URL text.
+- Changed artifact pill hover tooltips to show the full artifact set as a compact stacked list, with the hovered item highlighted.
+- Kept single artifacts opening directly and multi-artifact rows opening the narrow chooser dialog.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`
+- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
+- Playwright interaction smoke: first-column resize changed from `72` to `88`; first artifact pill text was `1`; chooser showed `4 work items`.
+- Playwright hover smoke: artifact tooltip showed `4 artifacts` as a stacked list.
+- Screenshots: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-artifact-icon-chooser.png`, `/tmp/pika-teacher-artifact-tooltip-list.png`

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { ExternalLink, FolderGit2, Image as ImageIcon, Link2 } from 'lucide-react'
 import {
   summarizeArtifactUrl,
@@ -22,6 +22,12 @@ function getArtifactSummary(artifact: AssignmentArtifact): string {
   return summarizeArtifactUrl(artifact.url)
 }
 
+function getArtifactTypeLabel(artifact: AssignmentArtifact): string {
+  if (artifact.type === 'image') return 'Image'
+  if (artifact.type === 'repo') return 'Repo'
+  return 'Link'
+}
+
 function ArtifactTypeIcon({ artifact }: { artifact: AssignmentArtifact }) {
   if (artifact.type === 'image') {
     return <ImageIcon className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
@@ -32,45 +38,63 @@ function ArtifactTypeIcon({ artifact }: { artifact: AssignmentArtifact }) {
   return <Link2 className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
 }
 
-function getBackgroundImageStyle(url: string): { backgroundImage: string } {
-  return { backgroundImage: `url("${encodeURI(url)}")` }
-}
-
-function ArtifactTooltipContent({ artifact }: { artifact: AssignmentArtifact }) {
-  const label = getArtifactLabel(artifact)
-
-  if (artifact.type === 'image') {
-    return (
-      <div className="w-44">
-        <div className="mb-1 rounded border border-border bg-surface p-1">
-          <div
-            className="h-24 w-full rounded bg-surface-2 bg-contain bg-center bg-no-repeat"
-            style={getBackgroundImageStyle(artifact.url)}
-          />
-        </div>
-        <div className="truncate text-[11px] text-text-default">{label}</div>
-      </div>
-    )
-  }
-
+function ArtifactsTooltipList({
+  artifacts,
+  activeIndex,
+}: {
+  artifacts: AssignmentArtifact[]
+  activeIndex: number
+}) {
   return (
-    <div className="max-w-56">
-      <div className="truncate text-[11px] font-medium text-text-default">{label}</div>
-      <div className="truncate text-[11px] text-text-muted">{artifact.url}</div>
+    <div className="w-72 max-w-[calc(100vw-2rem)]">
+      <div className="mb-1 text-[11px] font-semibold text-text-muted">
+        {artifacts.length} artifact{artifacts.length === 1 ? '' : 's'}
+      </div>
+      <div className="space-y-1">
+        {artifacts.map((artifact, index) => (
+          <div
+            key={`${artifact.url}:${index}`}
+            className={[
+              'flex min-w-0 items-start gap-2 rounded-md border px-2 py-1.5',
+              index === activeIndex
+                ? 'border-primary/40 bg-surface-selected'
+                : 'border-border bg-surface-2',
+            ].join(' ')}
+          >
+            <span className="mt-0.5 inline-flex h-5 min-w-8 shrink-0 items-center justify-center gap-1 rounded-full border border-border bg-surface text-[11px] font-medium text-text-default">
+              <ArtifactTypeIcon artifact={artifact} />
+              {index + 1}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[11px] font-medium text-text-default">
+                {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+              </span>
+              <span className="block truncate text-[11px] text-text-muted">
+                {artifact.url}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
 
 export function AssignmentArtifactsCell({
   artifacts,
-  isCompact,
 }: AssignmentArtifactsCellProps) {
-  const [modalIndex, setModalIndex] = useState<number | null>(null)
-  const selectedArtifact = modalIndex !== null ? artifacts[modalIndex] : null
+  const [isChooserOpen, setIsChooserOpen] = useState(false)
 
-  const visibleArtifacts = useMemo(() => (isCompact ? [] : artifacts), [artifacts, isCompact])
-  const compactArtifact = artifacts[0] ?? null
-  const compactRemainingCount = Math.max(artifacts.length - 1, 0)
+  const hasMultipleArtifacts = artifacts.length > 1
+
+  const handleOpenChooser = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    setIsChooserOpen(true)
+  }
+
+  const handleOpenSingle = (event: React.MouseEvent) => {
+    event.stopPropagation()
+  }
 
   if (artifacts.length === 0) {
     return <span className="text-text-muted">-</span>
@@ -78,122 +102,74 @@ export function AssignmentArtifactsCell({
 
   return (
     <>
-      {isCompact ? (
-        <button
-          type="button"
-          onClick={(event) => {
-            event.stopPropagation()
-            setModalIndex(0)
-          }}
-          className="inline-flex w-full max-w-full items-center gap-1.5 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
-          aria-label={`View ${artifacts.length} work item${artifacts.length === 1 ? '' : 's'}`}
-        >
-          {compactArtifact && (
-            <>
-              <ArtifactTypeIcon artifact={compactArtifact} />
-              <span className="min-w-0 flex-1 truncate text-left">
-                {getArtifactSummary(compactArtifact)}
-              </span>
-            </>
-          )}
-          {compactRemainingCount > 0 && (
-            <span className="shrink-0 text-text-muted">+{compactRemainingCount}</span>
-          )}
-        </button>
-      ) : (
-        <div className="flex w-full max-w-[32rem] flex-wrap gap-1">
-          {visibleArtifacts.map((artifact, index) => (
-            <Tooltip key={`${artifact.url}:${index}`} content={<ArtifactTooltipContent artifact={artifact} />} side="top" align="start">
+      <div className="flex w-full max-w-full flex-wrap gap-1">
+        {artifacts.map((artifact, index) => (
+          <Tooltip
+            key={`${artifact.url}:${index}`}
+            content={<ArtifactsTooltipList artifacts={artifacts} activeIndex={index} />}
+            side="bottom"
+            align="start"
+          >
+            {hasMultipleArtifacts ? (
               <button
                 type="button"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  setModalIndex(index)
-                }}
-                className="inline-flex w-full max-w-[10rem] items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 text-xs text-text-default hover:bg-surface-hover"
-                aria-label={`Preview ${getArtifactLabel(artifact)}`}
+                onClick={handleOpenChooser}
+                className="inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border border-border bg-surface-2 px-1.5 text-xs font-medium text-text-default hover:bg-surface-hover"
+                aria-label={`View work items; artifact ${index + 1} is ${getArtifactLabel(artifact)}`}
               >
                 <ArtifactTypeIcon artifact={artifact} />
-                <span className="ml-1 truncate">{getArtifactSummary(artifact)}</span>
+                <span>{index + 1}</span>
               </button>
-            </Tooltip>
-          ))}
-        </div>
-      )}
-
-      <ContentDialog
-        isOpen={selectedArtifact !== null}
-        onClose={() => setModalIndex(null)}
-        title={
-          selectedArtifact?.type === 'image'
-            ? 'Image Preview'
-            : selectedArtifact?.type === 'repo'
-              ? 'Repo Preview'
-              : 'Link Preview'
-        }
-        subtitle={
-          modalIndex !== null
-            ? `${modalIndex + 1} of ${artifacts.length}`
-            : undefined
-        }
-        maxWidth="max-w-3xl"
-      >
-        {selectedArtifact && (
-          <div className="space-y-3">
-            {artifacts.length > 1 && modalIndex !== null && (
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setModalIndex((current) => (current !== null && current > 0 ? current - 1 : current))}
-                  disabled={modalIndex === 0}
-                  className="rounded border border-border px-2 py-1 text-xs text-text-default disabled:opacity-50"
-                >
-                  Prev
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setModalIndex((current) =>
-                      current !== null && current < artifacts.length - 1 ? current + 1 : current
-                    )
-                  }
-                  disabled={modalIndex >= artifacts.length - 1}
-                  className="rounded border border-border px-2 py-1 text-xs text-text-default disabled:opacity-50"
-                >
-                  Next
-                </button>
-              </div>
-            )}
-
-            {selectedArtifact.type === 'image' ? (
-              <div className="rounded border border-border bg-surface p-2">
-                <div
-                  className="h-[60vh] w-full rounded bg-surface-2 bg-contain bg-center bg-no-repeat"
-                  style={getBackgroundImageStyle(selectedArtifact.url)}
-                />
-              </div>
             ) : (
-              <div className="rounded border border-border bg-surface p-3">
-                <p className="text-sm text-text-default break-all">{selectedArtifact.url}</p>
-              </div>
-            )}
-
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-xs text-text-muted truncate">
-                {getArtifactLabel(selectedArtifact)}
-              </p>
               <a
-                href={selectedArtifact.url}
+                href={artifact.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-text-default hover:bg-surface-hover"
+                onClick={handleOpenSingle}
+                className="inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border border-border bg-surface-2 px-1.5 text-xs font-medium text-text-default hover:bg-surface-hover"
+                aria-label={`Open artifact ${index + 1}: ${getArtifactLabel(artifact)}`}
               >
-                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-                Open
+                <ArtifactTypeIcon artifact={artifact} />
+                <span>{index + 1}</span>
               </a>
-            </div>
-          </div>
-        )}
+            )}
+          </Tooltip>
+        ))}
+      </div>
+
+      <ContentDialog
+        isOpen={isChooserOpen}
+        onClose={() => setIsChooserOpen(false)}
+        title="Open artifact"
+        subtitle={`${artifacts.length} work items`}
+        maxWidth="max-w-md"
+        showFooterClose={false}
+      >
+        <div className="space-y-2">
+          {artifacts.map((artifact, index) => (
+            <a
+              key={`${artifact.url}:${index}`}
+              href={artifact.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setIsChooserOpen(false)}
+              className="flex min-w-0 items-center gap-3 rounded-md border border-border bg-surface p-2.5 text-left hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
+            >
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-surface-2">
+                <ArtifactTypeIcon artifact={artifact} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-text-default">
+                  {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+                </span>
+                <span className="mt-0.5 block truncate text-xs text-text-muted">
+                  {artifact.url}
+                </span>
+              </span>
+              <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+            </a>
+          ))}
+        </div>
       </ContentDialog>
     </>
   )

--- a/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
+++ b/src/components/assignment-workspace/TeacherAssignmentStudentTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode, Ref } from 'react'
+import { useState, type CSSProperties, type KeyboardEvent, type PointerEvent, type ReactNode, type Ref } from 'react'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import {
   AssessmentStatusIndicator,
@@ -16,10 +16,10 @@ import {
   DataTableRow,
   EmptyStateRow,
   KeyboardNavigableTable,
-  SortableHeaderCell,
   TableCard,
 } from '@/components/DataTable'
 import { Spinner } from '@/components/Spinner'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Tooltip } from '@/ui'
 import {
   hasDraftSavedGrade,
@@ -71,11 +71,162 @@ interface TeacherAssignmentStudentTableProps {
   busyOverlay?: ReactNode
 }
 
+type ResizableColumnKey = 'first' | 'last' | 'status' | 'grade'
+
+type ColumnWidths = Record<ResizableColumnKey, number>
+
+const COLUMN_LIMITS: Record<ResizableColumnKey, { defaultWidth: number; min: number; max: number }> = {
+  first: { defaultWidth: 72, min: 58, max: 160 },
+  last: { defaultWidth: 72, min: 58, max: 160 },
+  status: { defaultWidth: 78, min: 70, max: 110 },
+  grade: { defaultWidth: 62, min: 56, max: 88 },
+}
+
+const DEFAULT_COLUMN_WIDTHS: ColumnWidths = {
+  first: COLUMN_LIMITS.first.defaultWidth,
+  last: COLUMN_LIMITS.last.defaultWidth,
+  status: COLUMN_LIMITS.status.defaultWidth,
+  grade: COLUMN_LIMITS.grade.defaultWidth,
+}
+
 function getRowClassName(isSelected: boolean): string {
   if (isSelected) {
     return 'cursor-pointer border-l-2 border-l-primary bg-surface-selected shadow-sm'
   }
   return 'cursor-pointer hover:bg-surface-hover'
+}
+
+function clampColumnWidth(column: ResizableColumnKey, width: number): number {
+  const limits = COLUMN_LIMITS[column]
+  return Math.min(limits.max, Math.max(limits.min, Math.round(width)))
+}
+
+function getColumnStyle(width: number): CSSProperties {
+  return { width: `${width}px`, maxWidth: `${width}px` }
+}
+
+function ResizeHandle({
+  column,
+  label,
+  width,
+  onResize,
+}: {
+  column: ResizableColumnKey
+  label: string
+  width: number
+  onResize: (column: ResizableColumnKey, width: number) => void
+}) {
+  function handlePointerDown(event: PointerEvent<HTMLSpanElement>) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const startX = event.clientX
+    const startWidth = width
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      onResize(column, startWidth + moveEvent.clientX - startX)
+    }
+
+    const handlePointerUp = () => {
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLSpanElement>) {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+    event.preventDefault()
+    event.stopPropagation()
+    onResize(column, width + (event.key === 'ArrowRight' ? 8 : -8))
+  }
+
+  return (
+    <span
+      role="separator"
+      aria-label={`Resize ${label} column`}
+      aria-orientation="vertical"
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+      className="absolute inset-y-1 right-0 z-10 w-2 cursor-col-resize rounded-sm outline-none transition-colors hover:bg-border-strong focus:bg-primary"
+    />
+  )
+}
+
+function ResizableSortableHeaderCell({
+  column,
+  label,
+  isActive,
+  direction,
+  onSort,
+  width,
+  onResize,
+}: {
+  column: ResizableColumnKey
+  label: string
+  isActive: boolean
+  direction: SortDirection
+  onSort: () => void
+  width: number
+  onResize: (column: ResizableColumnKey, width: number) => void
+}) {
+  const Icon = direction === 'asc' ? ChevronUp : ChevronDown
+  const ariaSort = isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+
+  return (
+    <DataTableHeaderCell
+      className="relative !p-0"
+      style={getColumnStyle(width)}
+      aria-sort={ariaSort}
+    >
+      <button
+        type="button"
+        onClick={onSort}
+        className="relative flex w-full items-center py-2 pl-1.5 pr-4 text-left transition-colors hover:bg-surface-hover"
+      >
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        <Icon
+          className={[
+            'pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 shrink-0 text-text-muted',
+            isActive ? '' : 'opacity-0',
+          ].join(' ')}
+          aria-hidden="true"
+        />
+      </button>
+      <ResizeHandle column={column} label={label} width={width} onResize={onResize} />
+    </DataTableHeaderCell>
+  )
+}
+
+function ResizableHeaderCell({
+  column,
+  label,
+  width,
+  onResize,
+}: {
+  column: ResizableColumnKey
+  label: string
+  width: number
+  onResize: (column: ResizableColumnKey, width: number) => void
+}) {
+  return (
+    <DataTableHeaderCell
+      className="relative !py-2 !pl-1.5 !pr-3"
+      style={getColumnStyle(width)}
+    >
+      <span className="block truncate">{label}</span>
+      <ResizeHandle column={column} label={label} width={width} onResize={onResize} />
+    </DataTableHeaderCell>
+  )
 }
 
 function StatusIcon({ display }: { display: AssessmentWorkStatusDisplay }) {
@@ -119,6 +270,15 @@ export function TeacherAssignmentStudentTable({
   emptyMessage = 'No students enrolled',
   busyOverlay,
 }: TeacherAssignmentStudentTableProps) {
+  const [columnWidths, setColumnWidths] = useState<ColumnWidths>(DEFAULT_COLUMN_WIDTHS)
+
+  function handleColumnResize(column: ResizableColumnKey, width: number) {
+    setColumnWidths((current) => ({
+      ...current,
+      [column]: clampColumnWidth(column, width),
+    }))
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <KeyboardNavigableTable
@@ -140,10 +300,18 @@ export function TeacherAssignmentStudentTable({
           ) : (
             <div className="relative">
               {busyOverlay}
-              <DataTable density={density}>
+              <DataTable density={density} className="table-fixed">
+                <colgroup>
+                  <col style={{ width: '40px' }} />
+                  <col style={{ width: `${columnWidths.first}px` }} />
+                  <col style={{ width: `${columnWidths.last}px` }} />
+                  <col style={{ width: `${columnWidths.status}px` }} />
+                  <col style={{ width: `${columnWidths.grade}px` }} />
+                  <col />
+                </colgroup>
                 <DataTableHead>
                   <DataTableRow>
-                    <DataTableHeaderCell className="w-10">
+                    <DataTableHeaderCell className="w-10 !px-2">
                       <input
                         type="checkbox"
                         checked={allSelected}
@@ -153,29 +321,42 @@ export function TeacherAssignmentStudentTable({
                         aria-label="Select all students"
                       />
                     </DataTableHeaderCell>
-                    <SortableHeaderCell
-                      label="First Name"
+                    <ResizableSortableHeaderCell
+                      column="first"
+                      label="First"
                       isActive={sortColumn === 'first'}
                       direction={sortDirection}
-                      onClick={() => onToggleSort('first')}
-                      className="w-[7rem]"
+                      onSort={() => onToggleSort('first')}
+                      width={columnWidths.first}
+                      onResize={handleColumnResize}
                     />
-                    <SortableHeaderCell
-                      label="Last Name"
+                    <ResizableSortableHeaderCell
+                      column="last"
+                      label="Last"
                       isActive={sortColumn === 'last'}
                       direction={sortDirection}
-                      onClick={() => onToggleSort('last')}
-                      className="w-[7rem]"
+                      onSort={() => onToggleSort('last')}
+                      width={columnWidths.last}
+                      onResize={handleColumnResize}
                     />
-                    <SortableHeaderCell
+                    <ResizableSortableHeaderCell
+                      column="status"
                       label="Status"
                       isActive={sortColumn === 'status'}
                       direction={sortDirection}
-                      onClick={() => onToggleSort('status')}
-                      className="w-[5.75rem]"
+                      onSort={() => onToggleSort('status')}
+                      width={columnWidths.status}
+                      onResize={handleColumnResize}
                     />
-                    <DataTableHeaderCell className="w-[4.75rem]">Grade</DataTableHeaderCell>
-                    <DataTableHeaderCell className="w-[11rem]">Artifacts</DataTableHeaderCell>
+                    <ResizableHeaderCell
+                      column="grade"
+                      label="Grade"
+                      width={columnWidths.grade}
+                      onResize={handleColumnResize}
+                    />
+                    <DataTableHeaderCell className="whitespace-nowrap !px-1.5 !py-2">
+                      <span className="block truncate">Artifacts</span>
+                    </DataTableHeaderCell>
                   </DataTableRow>
                 </DataTableHead>
                 <DataTableBody>
@@ -210,7 +391,7 @@ export function TeacherAssignmentStudentTable({
                         className={getRowClassName(isSelected)}
                         onClick={() => onSelectStudent(student.student_id)}
                       >
-                        <DataTableCell>
+                        <DataTableCell className="!px-2">
                           <input
                             type="checkbox"
                             checked={selectedIds.has(student.student_id)}
@@ -220,31 +401,31 @@ export function TeacherAssignmentStudentTable({
                             aria-label={`Select ${student.student_first_name ?? ''} ${student.student_last_name ?? ''}`}
                           />
                         </DataTableCell>
-                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                        <DataTableCell className="truncate !px-1.5" style={getColumnStyle(columnWidths.first)}>
                           {student.student_first_name ? (
                             <Tooltip content={`${student.student_first_name} ${student.student_last_name ?? ''}`}>
-                              <span>{student.student_first_name}</span>
+                              <span className="block truncate">{student.student_first_name}</span>
                             </Tooltip>
                           ) : '—'}
                         </DataTableCell>
-                        <DataTableCell className="w-[7rem] max-w-[7rem] truncate">
+                        <DataTableCell className="truncate !px-1.5" style={getColumnStyle(columnWidths.last)}>
                           {student.student_last_name ? (
                             <Tooltip content={student.student_last_name}>
-                              <span>{student.student_last_name}</span>
+                              <span className="block truncate">{student.student_last_name}</span>
                             </Tooltip>
                           ) : '—'}
                         </DataTableCell>
-                        <DataTableCell className="w-[5.75rem]">
+                        <DataTableCell align="center" className="!px-1" style={getColumnStyle(columnWidths.status)}>
                           <Tooltip content={statusLabel}>
                             <span className="inline-flex" role="img" aria-label={statusLabel}>
                               <StatusIcon display={statusDisplay} />
                             </span>
                           </Tooltip>
                         </DataTableCell>
-                        <DataTableCell className="w-[4.75rem] whitespace-nowrap text-text-muted">
+                        <DataTableCell align="center" className="whitespace-nowrap !px-1.5 text-text-muted" style={getColumnStyle(columnWidths.grade)}>
                           {totalScore !== null ? `${Math.round((totalScore / 30) * 100)}` : '—'}
                         </DataTableCell>
-                        <DataTableCell className="w-[11rem] max-w-[11rem] align-top">
+                        <DataTableCell className="align-top !px-1.5">
                           <AssignmentArtifactsCell
                             artifacts={student.artifacts || []}
                             isCompact={density === 'tight'}

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
 import { describe, expect, it } from 'vitest'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
@@ -15,7 +16,7 @@ describe('AssignmentArtifactsCell', () => {
     expect(screen.getByText('-')).toBeInTheDocument()
   })
 
-  it('renders one pill per artifact in non-compact mode', () => {
+  it('renders one icon pill per artifact', () => {
     const artifacts: AssignmentArtifact[] = [
       { type: 'link', url: 'https://example.com/a' },
       { type: 'link', url: 'https://example.com/b' },
@@ -25,33 +26,81 @@ describe('AssignmentArtifactsCell', () => {
     ]
 
     renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact={false} />)
-    expect(screen.getAllByRole('button', { name: /preview/i })).toHaveLength(5)
+    const buttons = screen.getAllByRole('button', { name: /view work items; artifact/i })
+    expect(buttons).toHaveLength(5)
+    expect(buttons.map((button) => button.textContent)).toEqual(['1', '2', '3', '4', '5'])
+    expect(screen.queryByText('example.com/a')).not.toBeInTheDocument()
   })
 
-  it('renders compact summary in compact mode', () => {
+  it('uses the same icon pills in compact mode', () => {
     const artifacts: AssignmentArtifact[] = [
       { type: 'link', url: 'https://example.com/a' },
       { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
     ]
 
     renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
-    const button = screen.getByRole('button', { name: /view 2 work items/i })
-    expect(button).toHaveTextContent('example.com/a')
-    expect(button).toHaveTextContent('+1')
+    expect(screen.getAllByRole('button', { name: /view work items; artifact/i }).map((button) => button.textContent)).toEqual(['1', '2'])
   })
 
-  it('opens a link preview modal when a pill is clicked', () => {
+  it('renders a single artifact as a direct external link', () => {
     const artifacts: AssignmentArtifact[] = [
       { type: 'link', url: 'https://example.com/docs' },
     ]
 
     renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact={false} />)
-    fireEvent.click(screen.getByRole('button', { name: /preview link/i }))
-    expect(screen.getByText('Link Preview')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute('href', 'https://example.com/docs')
+    const artifactLink = screen.getByRole('link', { name: /open artifact 1: link/i })
+    expect(artifactLink).toHaveAttribute('href', 'https://example.com/docs')
+    expect(artifactLink).toHaveTextContent('1')
+    fireEvent.click(artifactLink)
+    expect(screen.queryByText('Open artifact')).not.toBeInTheDocument()
   })
 
-  it('labels repo artifacts distinctly', () => {
+  it('opens a narrow chooser dialog for multiple artifacts', () => {
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/docs' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
+      },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
+    fireEvent.click(screen.getByRole('button', { name: /artifact 1 is link/i }))
+    expect(screen.getByText('Open artifact')).toBeInTheDocument()
+    expect(screen.getByText('3 work items')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /link . example.com\/docs/i })).toHaveAttribute('href', 'https://example.com/docs')
+    expect(screen.getByRole('link', { name: /image . cdn.example.com\/submission-images/i })).toHaveAttribute('href', 'https://cdn.example.com/submission-images/pic.png')
+    expect(screen.getByRole('link', { name: /repo . github.com\/codepetca\/pika/i })).toHaveAttribute('href', 'https://github.com/codepetca/pika')
+  })
+
+  it('shows all artifacts in a stacked tooltip list on hover', async () => {
+    const user = userEvent.setup()
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/docs' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
+      },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
+    await user.hover(screen.getByRole('button', { name: /artifact 2 is image/i }))
+
+    expect((await screen.findAllByText('3 artifacts')).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Link . example.com\/docs/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Image . cdn.example.com\/submission-images/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Repo . github.com\/codepetca\/pika/).length).toBeGreaterThan(0)
+  })
+
+  it('labels repo artifacts distinctly in direct-link mode', () => {
     const artifacts: AssignmentArtifact[] = [
       {
         type: 'repo',
@@ -63,8 +112,6 @@ describe('AssignmentArtifactsCell', () => {
     ]
 
     renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact={false} />)
-    fireEvent.click(screen.getByRole('button', { name: /preview repo/i }))
-    expect(screen.getByText('Repo Preview')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /open/i })).toHaveAttribute('href', 'https://github.com/codepetca/pika')
+    expect(screen.getByRole('link', { name: /open artifact 1: repo/i })).toHaveAttribute('href', 'https://github.com/codepetca/pika')
   })
 })

--- a/tests/components/TeacherAssignmentStudentTable.test.tsx
+++ b/tests/components/TeacherAssignmentStudentTable.test.tsx
@@ -62,8 +62,16 @@ describe('TeacherAssignmentStudentTable', () => {
 
     expect(screen.getByText('Ada')).toBeInTheDocument()
     expect(screen.getByText('Lovelace')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /first/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /last/i })).toBeInTheDocument()
+    expect(screen.queryByText('First Name')).not.toBeInTheDocument()
+    expect(screen.queryByText('Last Name')).not.toBeInTheDocument()
     expect(screen.getByText('90')).toBeInTheDocument()
     expect(screen.getAllByText('Artifacts')).toHaveLength(2)
+    expect(screen.getByRole('separator', { name: 'Resize First column' })).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize Last column' })).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize Status column' })).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize Grade column' })).toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: 'Select all students' })).toBeChecked()
   })
 


### PR DESCRIPTION
## Summary

- Compact the teacher assignment student table by renaming `First Name` / `Last Name` to `First` / `Last`, narrowing `Status` and `Grade`, and adding resize handles for those columns.
- Replace artifact URL/text pills with compact icon-number pills for repo/link/image artifacts.
- Preserve the artifact open behavior: one artifact opens directly, multiple artifacts open a narrow chooser dialog.
- Add a hover tooltip that shows all artifacts for the student row in a stacked list.

## Why

The table was spending too much horizontal space on name/status/grade columns and artifact URLs made the roster hard to scan. The compact columns and icon pills give teachers more artifact room while preserving quick access to full artifact details.

## Validation

- `pnpm exec vitest run tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
- UI verification screenshots for teacher desktop/mobile and student views
- Playwright smoke checks for resize, chooser, and artifact tooltip list