### PR TITLE
[codex] Improve assignment artifact links

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,34 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Worktree env symlink guidance
-
-**Completed:**
-- Created the missing `.env.local` symlink in the developer feedback worktree so local Next dev uses the shared Pika env file.
-- Updated startup guidance to require each worktree to symlink `.env.local` to `$HOME/Repos/.env/pika/.env.local`.
-- Updated the Codex session-start script to create the missing symlink before running environment verification.
-- Added regression coverage for the symlink guidance and session-start repair behavior.
-
-**Validation:**
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-- `bash -n .codex/skills/pika-session-start/scripts/session_start.sh scripts/verify-env.sh scripts/pika`
-- `node scripts/features.mjs validate`
-- `git diff --check`
-
-## 2026-05-21 — Send Feedback modal simplification
-
-**Completed:**
-- Removed visible Category and Description labels from the Send Feedback modal while preserving accessible control names.
-- Removed the build/version info row from the modal.
-- Disabled the modal footer Close button for Send Feedback, leaving the header X close affordance.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/UserMenu.test.tsx tests/ui/Dialog.test.tsx tests/api/feedback.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- Playwright screenshots: `/tmp/pika-feedback-teacher.png`, `/tmp/pika-feedback-student-mobile.png`
-
 ## 2026-05-21 — Developer feedback re-review fixes
 
 **Completed:**
@@ -343,3 +315,38 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Playwright interaction smoke: first-column resize changed from `72` to `88`; first artifact pill text was `1`; chooser showed `4 work items`.
 - Playwright hover smoke: artifact tooltip showed `4 artifacts` as a stacked list.
 - Screenshots: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-artifact-icon-chooser.png`, `/tmp/pika-teacher-artifact-tooltip-list.png`
+
+## 2026-05-25 — Assignment artifact hover dropdown links
+
+**Completed:**
+- Made assignment artifact hover lists interactive so the pointer can move from an artifact pill into the dropdown.
+- Converted hover-list artifact rows into external links while preserving the existing pill-click chooser/direct-link behavior.
+- Added component coverage for clicking a hover-list artifact without opening the chooser or bubbling to parent row handlers.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
+- Playwright hover smoke: hovered artifact pill, moved into dropdown link, verified trial click to `https://github.com/vercel/next.js/tree/canary`.
+- Screenshots: `/tmp/pika-teacher-loaded.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-artifacts-hover.png`
+- `pnpm test`
+
+## 2026-05-26 — Nested GitHub artifact classification
+
+**Completed:**
+- Constrained inferred repo artifacts to root GitHub repository URLs only.
+- Kept nested GitHub URLs such as `/tree`, `/blob`, and `/issues` classified as normal links.
+- Preserved explicit structured `repo_link` artifacts and root GitHub repo links as repo artifacts.
+- Moved root-repo detection into the shared GitHub helper, fixed exact GitHub host matching, and blocked known GitHub product routes such as `/orgs`, `/topics`, and `/settings` from repo detection.
+
+**Validation:**
+- `pnpm test tests/lib/assignment-artifacts.test.ts tests/unit/assignment-repo-targets.test.ts tests/components/AssignmentArtifactsCell.test.tsx`
+- `pnpm test tests/lib/assignment-artifacts.test.ts tests/unit/select-and-github-repos.test.tsx tests/unit/assignment-repo-targets.test.ts tests/components/AssignmentArtifactsCell.test.tsx`
+- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/unit/repo-review.test.ts tests/unit/repo-review-validation.test.ts tests/api/assignment-docs/artifacts.test.ts`
+- `pnpm lint`
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` after a full-suite timeout in that unrelated file
+- `pnpm test tests/api/auth/verify-signup.test.ts` after a second full-suite timeout in that unrelated file
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
+- Playwright artifact smoke: root `github.com/codepetca/pika` stayed `Repo`; nested `github.com/vercel/next.js/tree/canary` rendered/clicked as `Link`.
+- Screenshots: `/tmp/pika-teacher-artifact-types-loaded.png`, `/tmp/pika-artifact-link-hover.png`, `/tmp/pika-artifact-root-vs-link-hover.png`

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -45,6 +45,10 @@ function ArtifactsTooltipList({
   artifacts: AssignmentArtifact[]
   activeIndex: number
 }) {
+  const handleArtifactClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation()
+  }
+
   return (
     <div className="w-72 max-w-[calc(100vw-2rem)]">
       <div className="mb-1 text-[11px] font-semibold text-text-muted">
@@ -52,13 +56,19 @@ function ArtifactsTooltipList({
       </div>
       <div className="space-y-1">
         {artifacts.map((artifact, index) => (
-          <div
+          <a
             key={`${artifact.url}:${index}`}
+            href={artifact.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleArtifactClick}
+            aria-label={`Open artifact ${index + 1}: ${getArtifactTypeLabel(artifact)} . ${getArtifactSummary(artifact)}`}
             className={[
               'flex min-w-0 items-start gap-2 rounded-md border px-2 py-1.5',
               index === activeIndex
                 ? 'border-primary/40 bg-surface-selected'
                 : 'border-border bg-surface-2',
+              'hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface',
             ].join(' ')}
           >
             <span className="mt-0.5 inline-flex h-5 min-w-8 shrink-0 items-center justify-center gap-1 rounded-full border border-border bg-surface text-[11px] font-medium text-text-default">
@@ -73,7 +83,7 @@ function ArtifactsTooltipList({
                 {artifact.url}
               </span>
             </span>
-          </div>
+          </a>
         ))}
       </div>
     </div>
@@ -107,6 +117,7 @@ export function AssignmentArtifactsCell({
           <Tooltip
             key={`${artifact.url}:${index}`}
             content={<ArtifactsTooltipList artifacts={artifacts} activeIndex={index} />}
+            interactive
             side="bottom"
             align="start"
           >

--- a/src/lib/assignment-artifacts.ts
+++ b/src/lib/assignment-artifacts.ts
@@ -1,5 +1,5 @@
 import type { TiptapContent, TiptapMark, TiptapNode } from '@/types'
-import { parseGitHubRepoReference } from '@/lib/github-repos'
+import { parseGitHubRepoRootReference } from '@/lib/github-repos'
 
 export type AssignmentArtifactType = 'image' | 'link' | 'repo'
 
@@ -145,7 +145,7 @@ export function extractAssignmentArtifactsFromContent(
   const byUrl = new Map<string, AssignmentArtifact>()
 
   const pushUrl = (url: string, source: ArtifactSource) => {
-    const parsedRepo = source === 'image' || isLikelyImageUrl(url) ? null : parseGitHubRepoReference(url)
+    const parsedRepo = source === 'image' || isLikelyImageUrl(url) ? null : parseGitHubRepoRootReference(url)
     const nextArtifact: AssignmentArtifact =
       source === 'image' || isLikelyImageUrl(url)
         ? { type: 'image', url }

--- a/src/lib/github-repos.ts
+++ b/src/lib/github-repos.ts
@@ -4,6 +4,36 @@ export interface ParsedGitHubRepo {
   normalizedUrl: string
 }
 
+const GITHUB_HOSTS = new Set(['github.com', 'www.github.com'])
+
+const RESERVED_GITHUB_ROOT_PATHS = new Set([
+  'about',
+  'apps',
+  'blog',
+  'business',
+  'collections',
+  'contact',
+  'customer-stories',
+  'events',
+  'explore',
+  'features',
+  'integrations',
+  'login',
+  'marketplace',
+  'new',
+  'notifications',
+  'organizations',
+  'orgs',
+  'pricing',
+  'pulls',
+  'search',
+  'security',
+  'settings',
+  'sponsors',
+  'topics',
+  'trending',
+])
+
 function buildParsedRepo(owner: string, name: string): ParsedGitHubRepo {
   return {
     owner,
@@ -12,12 +42,21 @@ function buildParsedRepo(owner: string, name: string): ParsedGitHubRepo {
   }
 }
 
+function isGitHubHost(hostname: string): boolean {
+  return GITHUB_HOSTS.has(hostname.toLowerCase())
+}
+
+function isReservedGitHubRootPath(segment: string): boolean {
+  return RESERVED_GITHUB_ROOT_PATHS.has(segment.toLowerCase())
+}
+
 export function parseGitHubRepoReference(input: string): ParsedGitHubRepo | null {
   const trimmed = input.trim()
   if (!trimmed) return null
 
   const shorthandMatch = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/)
   if (shorthandMatch) {
+    if (isReservedGitHubRootPath(shorthandMatch[1])) return null
     return buildParsedRepo(shorthandMatch[1], shorthandMatch[2].replace(/\.git$/i, ''))
   }
 
@@ -29,7 +68,7 @@ export function parseGitHubRepoReference(input: string): ParsedGitHubRepo | null
   }
 
   if (!/^https?:$/i.test(parsed.protocol)) return null
-  if (!/^www\./i.test(parsed.hostname) && parsed.hostname.toLowerCase() !== 'github.com') return null
+  if (!isGitHubHost(parsed.hostname)) return null
 
   const segments = parsed.pathname.split('/').filter(Boolean)
   if (segments.length < 2) return null
@@ -37,6 +76,32 @@ export function parseGitHubRepoReference(input: string): ParsedGitHubRepo | null
   const owner = segments[0]
   const rawRepo = segments[1]
   if (!owner || !rawRepo) return null
+  if (isReservedGitHubRootPath(owner)) return null
+
+  return buildParsedRepo(owner, rawRepo.replace(/\.git$/i, ''))
+}
+
+export function parseGitHubRepoRootReference(input: string): ParsedGitHubRepo | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+
+  if (!/^https?:$/i.test(parsed.protocol)) return null
+  if (!isGitHubHost(parsed.hostname)) return null
+
+  const segments = parsed.pathname.split('/').filter(Boolean)
+  if (segments.length !== 2) return null
+
+  const owner = segments[0]
+  const rawRepo = segments[1]
+  if (!owner || !rawRepo) return null
+  if (isReservedGitHubRootPath(owner)) return null
 
   return buildParsedRepo(owner, rawRepo.replace(/\.git$/i, ''))
 }
@@ -44,4 +109,3 @@ export function parseGitHubRepoReference(input: string): ParsedGitHubRepo | null
 export function normalizeGitHubRepoUrl(input: string): string | null {
   return parseGitHubRepoReference(input)?.normalizedUrl ?? null
 }
-

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { AssignmentArtifactsCell } from '@/components/AssignmentArtifactsCell'
 import type { AssignmentArtifact } from '@/lib/assignment-artifacts'
 import { TooltipProvider } from '@/ui'
@@ -98,6 +98,33 @@ describe('AssignmentArtifactsCell', () => {
     expect(screen.getAllByText(/Link . example.com\/docs/).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Image . cdn.example.com\/submission-images/).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Repo . github.com\/codepetca\/pika/).length).toBeGreaterThan(0)
+  })
+
+  it('allows clicking artifact links from the hover list without opening the chooser', async () => {
+    const user = userEvent.setup()
+    const onParentClick = vi.fn()
+    const artifacts: AssignmentArtifact[] = [
+      { type: 'link', url: 'https://example.com/docs' },
+      { type: 'image', url: 'https://cdn.example.com/submission-images/pic.png' },
+    ]
+
+    renderWithTooltipProvider(
+      <div onClick={onParentClick}>
+        <AssignmentArtifactsCell artifacts={artifacts} isCompact />
+      </div>
+    )
+    await user.hover(screen.getByRole('button', { name: /artifact 2 is image/i }))
+
+    const tooltipLinks = await screen.findAllByRole('link', {
+      name: /open artifact 2: image . cdn\.example\.com\/submission-images/i,
+    })
+    const tooltipLink = tooltipLinks[0]
+    expect(tooltipLink).toHaveAttribute('href', 'https://cdn.example.com/submission-images/pic.png')
+
+    await user.click(tooltipLink)
+
+    expect(onParentClick).not.toHaveBeenCalled()
+    expect(screen.queryByText('Open artifact')).not.toBeInTheDocument()
   })
 
   it('labels repo artifacts distinctly in direct-link mode', () => {

--- a/tests/lib/assignment-artifacts.test.ts
+++ b/tests/lib/assignment-artifacts.test.ts
@@ -113,7 +113,7 @@ describe('extractAssignmentArtifacts', () => {
     ])
   })
 
-  it('classifies supported GitHub repo links as repo artifacts', () => {
+  it('classifies root GitHub repo links as repo artifacts', () => {
     const content: TiptapContent = {
       type: 'doc',
       content: [
@@ -122,7 +122,7 @@ describe('extractAssignmentArtifacts', () => {
           content: [
             {
               type: 'text',
-              text: 'Repo https://github.com/codepetca/pika/issues/1 and root https://github.com/openai/openai-node.git',
+              text: 'Root repo https://github.com/openai/openai-node.git',
             },
           ],
         },
@@ -132,17 +132,107 @@ describe('extractAssignmentArtifacts', () => {
     expect(extractAssignmentArtifacts(content)).toEqual([
       {
         type: 'repo',
-        url: 'https://github.com/codepetca/pika/issues/1',
-        repo_owner: 'codepetca',
-        repo_name: 'pika',
-        normalized_url: 'https://github.com/codepetca/pika',
-      },
-      {
-        type: 'repo',
         url: 'https://github.com/openai/openai-node.git',
         repo_owner: 'openai',
         repo_name: 'openai-node',
         normalized_url: 'https://github.com/openai/openai-node',
+      },
+    ])
+  })
+
+  it('keeps nested GitHub URLs as link artifacts', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Issue https://github.com/codepetca/pika/issues/1 branch https://github.com/vercel/next.js/tree/canary file https://github.com/openai/openai-node/blob/master/README.md',
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      {
+        type: 'link',
+        url: 'https://github.com/codepetca/pika/issues/1',
+      },
+      {
+        type: 'link',
+        url: 'https://github.com/vercel/next.js/tree/canary',
+      },
+      {
+        type: 'link',
+        url: 'https://github.com/openai/openai-node/blob/master/README.md',
+      },
+    ])
+  })
+
+  it('keeps GitHub product pages as link artifacts', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Org https://github.com/orgs/codepetca topic https://github.com/topics/react settings https://github.com/settings/profile',
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      {
+        type: 'link',
+        url: 'https://github.com/orgs/codepetca',
+      },
+      {
+        type: 'link',
+        url: 'https://github.com/topics/react',
+      },
+      {
+        type: 'link',
+        url: 'https://github.com/settings/profile',
+      },
+    ])
+  })
+
+  it('classifies root GitHub links inside link marks as repo artifacts', () => {
+    const content: TiptapContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Click here',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: { href: 'https://github.com/codepetca/pika' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(extractAssignmentArtifacts(content)).toEqual([
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
       },
     ])
   })

--- a/tests/unit/select-and-github-repos.test.tsx
+++ b/tests/unit/select-and-github-repos.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { Select } from '@/ui'
-import { normalizeGitHubRepoUrl } from '@/lib/github-repos'
+import { normalizeGitHubRepoUrl, parseGitHubRepoRootReference } from '@/lib/github-repos'
 
 describe('Select', () => {
   it('renders placeholder and options with the expected disabled states', () => {
@@ -53,5 +53,20 @@ describe('normalizeGitHubRepoUrl', () => {
 
   it('returns null for invalid repository references', () => {
     expect(normalizeGitHubRepoUrl('not a repo')).toBeNull()
+    expect(normalizeGitHubRepoUrl('https://www.example.com/codepetca/pika')).toBeNull()
+    expect(normalizeGitHubRepoUrl('https://github.com/orgs/codepetca')).toBeNull()
+    expect(normalizeGitHubRepoUrl('https://github.com/topics/react')).toBeNull()
+  })
+})
+
+describe('parseGitHubRepoRootReference', () => {
+  it('accepts only root GitHub repository URLs', () => {
+    expect(parseGitHubRepoRootReference('https://github.com/codepetca/pika')).toEqual({
+      owner: 'codepetca',
+      name: 'pika',
+      normalizedUrl: 'https://github.com/codepetca/pika',
+    })
+    expect(parseGitHubRepoRootReference('https://github.com/codepetca/pika/issues/1')).toBeNull()
+    expect(parseGitHubRepoRootReference('https://github.com/orgs/codepetca')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- make assignment artifact hover dropdown rows clickable external links while preserving pill click behavior
- narrow freeform GitHub repo detection to root repository URLs so nested/product GitHub pages remain normal links
- add focused coverage for hover-list clicks and repo-vs-link classification

## Validation

- pnpm test tests/lib/assignment-artifacts.test.ts tests/unit/select-and-github-repos.test.tsx tests/components/AssignmentArtifactsCell.test.tsx
- pnpm lint
- git diff --check
- visual smoke of teacher assignment artifact hover/dropdown behavior