### PR TITLE
[codex] Refresh student daily logs on load

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Developer feedback re-review fixes
-
-**Completed:**
-- Redacted direct identifiers from model-produced daily-log feedback candidate fields before storage.
-- Added `source_keys` tracking to the developer feedback migration so nightly reruns do not inflate signal or entry counts for an already-seen classroom/date source.
-- Restored `.ai/features.json` append-only entries and widened the startup-doc budget guard to fit the appended feature inventory.
-
-**Validation:**
-- `pnpm test tests/unit/developer-log-feedback.test.ts tests/api/feedback.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/developer-log-feedback.test.ts tests/api/feedback.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `bash scripts/verify-env.sh`
-- `node scripts/features.mjs validate`
-- `git diff --check`
-
 ## 2026-05-21 — Developer feedback idempotent last-seen fix
 
 **Completed:**
@@ -350,3 +334,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
 - Playwright artifact smoke: root `github.com/codepetca/pika` stayed `Repo`; nested `github.com/vercel/next.js/tree/canary` rendered/clicked as `Link`.
 - Screenshots: `/tmp/pika-teacher-artifact-types-loaded.png`, `/tmp/pika-artifact-link-hover.png`, `/tmp/pika-artifact-root-vs-link-hover.png`
+
+## 2026-05-26 — Student daily log background refresh
+
+**Completed:**
+- Changed the student Today tab so sessionStorage history is only an instant preview, not the final source of truth.
+- Added a direct capped background `/api/student/entries?limit=12` refresh on mount to update cross-device daily logs.
+- Guarded the editor so an in-flight refresh cannot overwrite a local edit started by the student.
+- Fixed the reverted-edit edge case so a refresh can apply server content after local text returns to the saved value.
+- Updated StudentTodayTab history coverage for preview-first refresh and local-edit protection.
+
+**Validation:**
+- `pnpm test tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=today'`
+- Warm screenshots reviewed: `/tmp/pika-student-today-final.png`, `/tmp/pika-teacher-mobile-warm.png`

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -79,6 +79,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   const entryIdRef = useRef<string | null>(null)
   const entryVersionRef = useRef(1)
   const todayRef = useRef('')
+  const hasLocalEditSinceLoadRef = useRef(false)
 
   useEffect(() => {
     async function load() {
@@ -113,6 +114,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           const loadedContent = resolveEntryContent(todayEntry)
           setContent(loadedContent)
           lastSavedContentRef.current = JSON.stringify(loadedContent)
+          hasLocalEditSinceLoadRef.current = false
           setSaveStatus('saved')
           setSaveError('')
           setConflictEntry(null)
@@ -124,16 +126,30 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           setHistoryEntries(cached)
           const todayEntry = cached.find((e: Entry) => e.date === todayDate) || null
           applyEntryState(todayEntry)
-          await lessonPlanPromise
-          return
+          setLoading(false)
         }
 
-        const entriesPromise = fetch(
-          `/api/student/entries?classroom_id=${classroom.id}&limit=${historyLimit}`
-        )
-          .then(r => r.json())
+        const entriesUrl = `/api/student/entries?classroom_id=${classroom.id}&limit=${historyLimit}`
+        const entriesPromise = fetch(entriesUrl)
+          .then(response => {
+            if (!response.ok) {
+              throw new Error('Failed to load entries')
+            }
+            return response.json()
+          })
           .then(data => {
             const entries: Entry[] = data.entries || []
+            if (hasLocalEditSinceLoadRef.current) {
+              setHistoryEntries(prev => {
+                const currentTodayEntry = prev.find((e: Entry) => e.date === todayDate) || null
+                const next = currentTodayEntry
+                  ? upsertEntryIntoHistory(entries, currentTodayEntry, historyLimit)
+                  : entries
+                safeSessionSetJson(historyCacheKey, next)
+                return next
+              })
+              return
+            }
             setHistoryEntries(entries)
             safeSessionSetJson(historyCacheKey, entries)
             const todayEntry = entries.find((e: Entry) => e.date === todayDate) || null
@@ -326,6 +342,26 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
   function handleContentChange(newContent: TiptapContent) {
     setContent(newContent)
+
+    const newContentStr = JSON.stringify(newContent)
+    if (newContentStr === lastSavedContentRef.current || (!entryIdRef.current && isEmpty(newContent))) {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
+      }
+      if (throttledSaveTimeoutRef.current) {
+        clearTimeout(throttledSaveTimeoutRef.current)
+        throttledSaveTimeoutRef.current = null
+      }
+      lastSavedContentRef.current = newContentStr
+      pendingContentRef.current = null
+      hasLocalEditSinceLoadRef.current = false
+      setSaveStatus('saved')
+      setSaveError('')
+      return
+    }
+
+    hasLocalEditSinceLoadRef.current = true
     setSaveStatus('unsaved')
     pendingContentRef.current = newContent
 
@@ -359,6 +395,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
     const serverContent = resolveEntryContent(conflictEntry)
     setContent(serverContent)
     lastSavedContentRef.current = JSON.stringify(serverContent)
+    hasLocalEditSinceLoadRef.current = false
     entryIdRef.current = conflictEntry.id
     entryVersionRef.current = conflictEntry.version ?? entryVersionRef.current
     setSaveStatus('saved')

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -113,6 +113,16 @@ function mockJson(data: any, ok = true) {
   return Promise.resolve({ ok, json: () => Promise.resolve(data) }) as any
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
 describe('StudentTodayTab history section', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -191,17 +201,53 @@ describe('StudentTodayTab history section', () => {
     expect(screen.queryByText('Tue Dec 16')).not.toBeInTheDocument()
   })
 
-  it('uses sessionStorage cache for entries', async () => {
+  it('keeps an empty new entry marked saved', async () => {
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+
+    fireEvent.change(editor, { target: { value: '' } })
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/student/entries',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  })
+
+  it('renders cached entries immediately and refreshes them in the background', async () => {
     const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
     window.sessionStorage.setItem(cacheKey, JSON.stringify(entries))
+    const refreshedEntries = [
+      entries[0],
+      {
+        ...entries[1],
+        id: 'e2-refreshed',
+        text: 'Refreshed log from the server.',
+      },
+    ] as Entry[]
+    const entriesRequest = deferred<any>()
 
     const fetchMock = vi.fn((input: RequestInfo) => {
       const url = String(input)
       if (url.startsWith(`/api/student/entries?`)) {
-        return mockJson({ entries })
+        return entriesRequest.promise
       }
       if (url.includes('/lesson-plans')) {
-        return mockJson({ lessonPlans: [] })
+        return mockJson({ lesson_plans: [] })
       }
       throw new Error(`Unhandled fetch: ${url}`)
     })
@@ -210,13 +256,115 @@ describe('StudentTodayTab history section', () => {
     render(<StudentTodayTab classroom={classroom} />)
     await screen.findByText('Past logs')
     expect(screen.getByText('Mon Dec 15')).toBeInTheDocument()
+    expect(screen.getByText(entries[1].text)).toBeInTheDocument()
+
+    const entryFetchCalls = fetchMock.mock.calls.filter(([arg]) =>
+      String(arg).includes('/api/student/entries?')
+    )
+    expect(entryFetchCalls).toHaveLength(1)
+
+    entriesRequest.resolve(await mockJson({ entries: refreshedEntries }))
+
+    expect(await screen.findByText('Refreshed log from the server.')).toBeInTheDocument()
+    expect(window.sessionStorage.getItem(cacheKey)).toContain('Refreshed log from the server.')
+  })
+
+  it('does not overwrite local edits when the background refresh completes', async () => {
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
+    const cachedEntries = [
+      {
+        ...entries[0],
+        text: 'Cached today entry.',
+      },
+      entries[1],
+    ] as Entry[]
+    const refreshedEntries = [
+      {
+        ...entries[0],
+        text: 'Server refreshed today entry.',
+        version: 2,
+      },
+      {
+        ...entries[1],
+        text: 'Server refreshed past entry.',
+      },
+    ] as Entry[]
+    window.sessionStorage.setItem(cacheKey, JSON.stringify(cachedEntries))
+    const entriesRequest = deferred<any>()
+
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?`)) {
+        return entriesRequest.promise
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    expect(editor).toHaveValue('Cached today entry.')
+
+    fireEvent.change(editor, { target: { value: 'Local unsaved draft.' } })
+    entriesRequest.resolve(await mockJson({ entries: refreshedEntries }))
 
     await waitFor(() => {
-      const entryFetchCalls = fetchMock.mock.calls.filter(([arg]) =>
-        String(arg).includes('/api/student/entries?')
-      )
-      expect(entryFetchCalls).toHaveLength(0)
+      expect(window.sessionStorage.getItem(cacheKey)).toContain('Server refreshed past entry.')
     })
+    expect(window.sessionStorage.getItem(cacheKey)).toContain('Cached today entry.')
+    expect(window.sessionStorage.getItem(cacheKey)).not.toContain('Server refreshed today entry.')
+    expect(editor).toHaveValue('Local unsaved draft.')
+  })
+
+  it('applies refreshed today content after a local edit is reverted', async () => {
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
+    const cachedEntries = [
+      {
+        ...entries[0],
+        text: 'Cached today entry.',
+      },
+      entries[1],
+    ] as Entry[]
+    const refreshedEntries = [
+      {
+        ...entries[0],
+        text: 'Server refreshed today entry.',
+        version: 2,
+      },
+      entries[1],
+    ] as Entry[]
+    window.sessionStorage.setItem(cacheKey, JSON.stringify(cachedEntries))
+    const entriesRequest = deferred<any>()
+
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?`)) {
+        return entriesRequest.promise
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    expect(editor).toHaveValue('Cached today entry.')
+
+    fireEvent.change(editor, { target: { value: 'Temporary local draft.' } })
+    fireEvent.change(editor, { target: { value: 'Cached today entry.' } })
+    entriesRequest.resolve(await mockJson({ entries: refreshedEntries }))
+
+    await waitFor(() => {
+      expect(editor).toHaveValue('Server refreshed today entry.')
+    })
+    expect(window.sessionStorage.getItem(cacheKey)).toContain('Server refreshed today entry.')
   })
 
   it('saves against the current Toronto date when the mounted date is stale', async () => {


### PR DESCRIPTION
## Summary

- Treat the student Today tab's `sessionStorage` history as an instant preview instead of the final source of truth.
- Always revalidate the capped `/api/student/entries?limit=12` request in the background on mount so logs written on another computer appear after load.
- Preserve a student's local draft if the background refresh completes while they are editing.
- Keep empty new logs marked `Saved` so TipTap normalization does not show a false unsaved state.

## Root Cause

The Today tab returned early when sessionStorage had cached entries, so a student using multiple computers could keep seeing that device's cached history instead of the database-backed latest logs.

## Validation

- `pnpm test tests/components/StudentTodayTabHistory.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=today'`
- Warm student screenshot reviewed: `/tmp/pika-student-today-final.png`
- Warm teacher mobile screenshot reviewed: `/tmp/pika-teacher-mobile-warm.png`