### PR TITLE
[codex] Improve assignment submission management

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -377,6 +377,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Removed the required-submissions `None` / item-count subline so the card header stays single-line.
 - Hid the per-submission Label and Instructions captions while keeping accessible labels; new submissions show the default label inside the textbox and `Optional helper text` as the helper textbox placeholder.
 - Made required-submission rows draggable from their grip handles and removed the up/down arrow reorder buttons.
+- Stabilized required-submission sortable IDs so rows keep identity during drop animations.
+- Guarded assignment autosave responses so older saves cannot replace newer local required-submission edits while a drag/reorder is in progress.
+- Added a confirmation dialog before removing persisted required submissions; unsaved newly added rows still remove immediately.
+- Switched the required-submissions add control to the shared green `SplitButton` success variant.
+- Updated required-submission split add labels to read `+ Link`, `+ Repo`, and `+ Image` with each type icon after the label.
+- Changed the required-submissions primary add label to `+ Add` and made that primary side open the type dropdown instead of defaulting to a link submission.
 
 **Validation:**
 - `pnpm test tests/components/AssignmentModal.test.tsx`
@@ -389,3 +395,9 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Final required submissions screenshots: `/tmp/pika-assignment-modal-required-submissions-final-desktop.png`, `/tmp/pika-assignment-modal-required-submissions-final-mobile.png`, `/tmp/pika-assignment-modal-required-submissions-final-menu.png`
 - Drag smoke screenshot: `/tmp/pika-assignment-modal-required-submissions-dragged.png`
 - Mobile draggable screenshot: `/tmp/pika-assignment-modal-required-submissions-draggable-mobile.png`
+- Stable drag screenshots: `/tmp/pika-assignment-modal-required-submissions-stable-before.png`, `/tmp/pika-assignment-modal-required-submissions-stable-during.png`, `/tmp/pika-assignment-modal-required-submissions-stable-after.png`
+- Settled student screenshot after UI verify timeout: `/tmp/pika-student-settled.png`
+- Removal confirmation screenshots: `/tmp/pika-teacher-settled.png`, `/tmp/pika-assignment-modal-remove-required-submission-confirm.png`
+- Green split button screenshot: `/tmp/pika-assignment-modal-green-submission-split-desktop.png`
+- Updated green split button label screenshots: `/tmp/pika-assignment-modal-green-submission-split-label-desktop.png`, `/tmp/pika-assignment-modal-green-submission-split-label-mobile.png`
+- Generic add dropdown screenshots: `/tmp/pika-assignment-modal-add-submission-dropdown-desktop.png`, `/tmp/pika-assignment-modal-add-submission-dropdown-mobile.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -351,3 +351,41 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=today'`
 - Warm screenshots reviewed: `/tmp/pika-student-today-final.png`, `/tmp/pika-teacher-mobile-warm.png`
+## 2026-05-26 — Teacher artifact table refresh
+
+**Completed:**
+- Added a refresh control to the teacher assignment workspace action bar so teachers can re-query selected assignment details after students submit structured artifacts.
+- Kept the refresh scoped to the selected assignment detail endpoint that already merges structured submission artifacts into the student table artifact cells.
+- Added component coverage confirming the action bar refresh performs a second assignment-detail fetch.
+
+**Validation:**
+- `pnpm test tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
+- Playwright screenshot after settled teacher load: `/tmp/pika-teacher-refresh-submissions.png`
+
+## 2026-05-26 — Assignment modal title row cleanup
+
+**Completed:**
+- Moved assignment preview into the title row beside the title and due-date controls.
+- Moved assignment autosave status into the title label row above the textbox.
+- Removed the separate Instructions label above the markdown editor.
+- Moved the required submissions editor above the instructions textarea.
+- Compressed the required submissions empty state into a one-line card with an icon split button for Link, Repo, and Image submissions.
+- Changed the primary split-button label to `+` plus the link icon and `link`.
+- Removed the required-submissions `None` / item-count subline so the card header stays single-line.
+- Hid the per-submission Label and Instructions captions while keeping accessible labels; new submissions show the default label inside the textbox and `Optional helper text` as the helper textbox placeholder.
+- Made required-submission rows draggable from their grip handles and removed the up/down arrow reorder buttons.
+
+**Validation:**
+- `pnpm test tests/components/AssignmentModal.test.tsx`
+- `pnpm test tests/ui/SplitButton.test.tsx tests/components/AssignmentModal.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
+- Modal screenshots: `/tmp/pika-assignment-modal-teacher.png`, `/tmp/pika-assignment-modal-teacher-mobile.png`
+- Required submissions screenshots: `/tmp/pika-assignment-modal-required-submissions.png`, `/tmp/pika-assignment-modal-required-submissions-menu.png`, `/tmp/pika-assignment-modal-required-submissions-mobile.png`, `/tmp/pika-assignment-modal-required-submissions-menu-mobile.png`, `/tmp/pika-assignment-modal-required-submissions-added-desktop.png`, `/tmp/pika-assignment-modal-required-submissions-added-mobile.png`
+- Final required submissions screenshots: `/tmp/pika-assignment-modal-required-submissions-final-desktop.png`, `/tmp/pika-assignment-modal-required-submissions-final-mobile.png`, `/tmp/pika-assignment-modal-required-submissions-final-menu.png`
+- Drag smoke screenshot: `/tmp/pika-assignment-modal-required-submissions-dragged.png`
+- Mobile draggable screenshot: `/tmp/pika-assignment-modal-required-submissions-draggable-mobile.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,29 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Developer feedback idempotent last-seen fix
-
-**Completed:**
-- Updated the developer feedback candidate upsert so duplicate classroom/date reruns preserve `last_seen_at` and `last_seen_date`.
-- Tightened the migration regression test to cover ranking timestamp preservation, not just count preservation.
-
-**Validation:**
-- `pnpm test tests/unit/developer-log-feedback.test.ts tests/api/cron/nightly-log-summaries.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-
-## 2026-05-21 — Developer feedback migration filename
-
-**Completed:**
-- Renamed the developer feedback migration from the timestamped Supabase filename to Pika's sequential migration convention: `070_developer_feedback_candidates.sql`.
-- Updated the migration regression test to read the renamed file.
-
-**Validation:**
-- `pnpm test tests/unit/developer-log-feedback.test.ts`
-- Migration duplicate-prefix check
-- Migration filename convention check
-
 ## 2026-05-21 — Migration filename CI guard
 
 **Completed:**
@@ -351,6 +328,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=today'`
 - Warm screenshots reviewed: `/tmp/pika-student-today-final.png`, `/tmp/pika-teacher-mobile-warm.png`
+
 ## 2026-05-26 — Teacher artifact table refresh
 
 **Completed:**
@@ -383,6 +361,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Switched the required-submissions add control to the shared green `SplitButton` success variant.
 - Updated required-submission split add labels to read `+ Link`, `+ Repo`, and `+ Image` with each type icon after the label.
 - Changed the required-submissions primary add label to `+ Add` and made that primary side open the type dropdown instead of defaulting to a link submission.
+- Replaced the required-submissions image option camera glyph with Lucide's image icon.
 
 **Validation:**
 - `pnpm test tests/components/AssignmentModal.test.tsx`
@@ -401,3 +380,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Green split button screenshot: `/tmp/pika-assignment-modal-green-submission-split-desktop.png`
 - Updated green split button label screenshots: `/tmp/pika-assignment-modal-green-submission-split-label-desktop.png`, `/tmp/pika-assignment-modal-green-submission-split-label-mobile.png`
 - Generic add dropdown screenshots: `/tmp/pika-assignment-modal-add-submission-dropdown-desktop.png`, `/tmp/pika-assignment-modal-add-submission-dropdown-mobile.png`
+- Image icon dropdown screenshots: `/tmp/pika-assignment-modal-image-icon-dropdown-desktop.png`, `/tmp/pika-assignment-modal-image-icon-dropdown-mobile.png`

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -32,6 +32,7 @@ import {
   MessageSquare,
   Pencil,
   Plus,
+  RefreshCw,
   Send,
   Table,
   Trash2,
@@ -1165,6 +1166,11 @@ export function TeacherClassroomView({
       ? selectedAssignmentData
       : null
   }, [selectedAssignmentData, selection])
+
+  const handleRefreshSelectedAssignment = useCallback(() => {
+    if (selection.mode !== 'assignment') return
+    setRefreshCounter((count) => count + 1)
+  }, [selection])
 
   const activeAssignmentAiRun = useMemo(() => {
     if (selection.mode !== 'assignment' || !assignmentAiGradingRun) return null
@@ -2334,6 +2340,22 @@ export function TeacherClassroomView({
             </span>
             <span className="sr-only">{splitPaneViewLabel}</span>
           </Button>
+        </span>
+      </Tooltip>
+      <Tooltip content="Refresh submissions">
+        <span className="inline-flex">
+          <button
+            type="button"
+            className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
+            onClick={handleRefreshSelectedAssignment}
+            disabled={selectedAssignmentLoading}
+            aria-label="Refresh submissions"
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${selectedAssignmentLoading ? 'animate-spin' : ''}`}
+              aria-hidden="true"
+            />
+          </button>
         </span>
       </Tooltip>
       {classPaneActions}

--- a/src/components/AssignmentForm.tsx
+++ b/src/components/AssignmentForm.tsx
@@ -157,43 +157,11 @@ export function AssignmentForm({
         titleDisabled={disabled}
         titleInputRef={titleInputRef}
         titleInputClassName="flex-1"
+        titleStatus={statusContent}
         onTitleChange={onTitleChange}
         onTitleBlur={onBlur}
         afterTitle={(
-          <div className="w-[6.25rem] space-y-1 sm:w-[8.25rem]">
-            {(() => {
-              const relative = getRelativeDueDate(dueAt, classDays)
-              const labelText = relative ? `Due ${relative.text}` : 'Due Date'
-              const colorClass = relative
-                ? relative.isPast
-                  ? 'text-warning'
-                  : 'text-primary'
-                : 'text-text-muted'
-              return (
-                <div className={`truncate text-sm font-medium ${colorClass}`}>
-                  {labelText}
-                </div>
-              )
-            })()}
-            <div className="flex">
-              <DateActionBar
-                value={dueAt}
-                onChange={onDueAtChange}
-                layout="compact"
-              />
-            </div>
-          </div>
-        )}
-        actions={topRowActions}
-      />
-
-      <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col space-y-1' : 'space-y-1'}>
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <label className="block text-sm font-medium text-text-default">
-            Instructions
-          </label>
-          <div className="flex items-center gap-3">
-            {statusContent}
+          <div className="flex items-end gap-2">
             {onPreviewInstructions && (
               <Button
                 type="button"
@@ -201,14 +169,44 @@ export function AssignmentForm({
                 size="sm"
                 onClick={onPreviewInstructions}
                 disabled={disabled}
-                className="gap-1.5"
+                className="h-9 w-9 px-0 sm:w-auto sm:px-3 sm:gap-1.5"
+                aria-label="Preview"
               >
                 <Eye className="h-4 w-4" aria-hidden="true" />
-                Preview
+                <span className="hidden sm:inline">Preview</span>
               </Button>
             )}
+            <div className="w-[6.25rem] space-y-1 sm:w-[8.25rem]">
+              {(() => {
+                const relative = getRelativeDueDate(dueAt, classDays)
+                const labelText = relative ? `Due ${relative.text}` : 'Due Date'
+                const colorClass = relative
+                  ? relative.isPast
+                    ? 'text-warning'
+                    : 'text-primary'
+                  : 'text-text-muted'
+                return (
+                  <div className={`truncate text-sm font-medium ${colorClass}`}>
+                    {labelText}
+                  </div>
+                )
+              })()}
+              <div className="flex">
+                <DateActionBar
+                  value={dueAt}
+                  onChange={onDueAtChange}
+                  layout="compact"
+                />
+              </div>
+            </div>
           </div>
-        </div>
+        )}
+        actions={topRowActions}
+      />
+
+      {extraFields}
+
+      <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col' : ''}>
         <div className={fillHeight ? 'flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-border-strong' : 'rounded-lg border border-border-strong overflow-hidden'}>
           {markdownWarning && (
             <div className="border-b border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
@@ -254,8 +252,6 @@ export function AssignmentForm({
           />
         </div>
       </div>
-
-      {extraFields}
 
       {error && <p className="text-sm text-warning">{error}</p>}
     </div>

--- a/src/components/AssignmentModal.tsx
+++ b/src/components/AssignmentModal.tsx
@@ -59,6 +59,13 @@ function serializeRequirementDrafts(requirements: AssignmentSubmissionRequiremen
   })))
 }
 
+function areAssignmentEditorValuesEqual(a: AssignmentEditorValues, b: AssignmentEditorValues): boolean {
+  return a.title === b.title
+    && a.instructionsMarkdown === b.instructionsMarkdown
+    && a.dueAt === b.dueAt
+    && serializeRequirementDrafts(a.submissionRequirements) === serializeRequirementDrafts(b.submissionRequirements)
+}
+
 function validateAssignmentValues(values: AssignmentEditorValues): string | null {
   if (!values.dueAt) return 'Due date is required.'
 
@@ -459,6 +466,11 @@ export function AssignmentModal({ isOpen, classroomId, assignment, classDays, on
 
         const updatedAssignment = data.assignment as Assignment
         savedAssignment = updatedAssignment
+        const latestPendingValues = pendingValuesRef.current
+        if (latestPendingValues && !areAssignmentEditorValuesEqual(latestPendingValues, values)) {
+          return
+        }
+
         const resolvedInstructions = getAssignmentInstructionsMarkdown(updatedAssignment)
         const updatedRequirements = getAssignmentRequirementDrafts(updatedAssignment)
         setCurrentAssignment(updatedAssignment)

--- a/src/components/AssignmentSubmissionRequirementsEditor.tsx
+++ b/src/components/AssignmentSubmissionRequirementsEditor.tsx
@@ -18,7 +18,8 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Camera, FolderGit2, GripVertical, Link2, Trash2 } from 'lucide-react'
-import { Button, FormField, Input, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
+import { useRef, useState } from 'react'
+import { Button, ConfirmDialog, FormField, Input, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
 import {
   DEFAULT_REQUIREMENT_LABELS,
   type AssignmentSubmissionRequirementDraft,
@@ -46,6 +47,19 @@ function RequirementIcon({ type }: { type: AssignmentSubmissionRequirementType }
   return <Link2 className="h-4 w-4" aria-hidden="true" />
 }
 
+function AddRequirementLabel({ type, label }: {
+  type: AssignmentSubmissionRequirementType
+  label: string
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span aria-hidden="true">+</span>
+      {label}
+      <RequirementIcon type={type} />
+    </span>
+  )
+}
+
 function withPositions(requirements: AssignmentSubmissionRequirementDraft[]) {
   return requirements.map((requirement, position) => ({ ...requirement, position }))
 }
@@ -57,7 +71,7 @@ interface SortableRequirementRowProps {
   totalRequirements: number
   disabled: boolean
   onUpdate: (index: number, patch: Partial<AssignmentSubmissionRequirementDraft>) => void
-  onRemove: (index: number) => void
+  onRemove: (index: number, sortableId: string) => void
 }
 
 function SortableRequirementRow({
@@ -147,7 +161,7 @@ function SortableRequirementRow({
             size="sm"
             className="px-2 text-danger"
             disabled={disabled}
-            onClick={() => onRemove(index)}
+            onClick={() => onRemove(index, sortableId)}
             aria-label="Remove requirement"
           >
             <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -163,6 +177,9 @@ export function AssignmentSubmissionRequirementsEditor({
   onChange,
   disabled = false,
 }: AssignmentSubmissionRequirementsEditorProps) {
+  const nextSortableIdRef = useRef(0)
+  const sortableIdsRef = useRef<string[]>([])
+  const [pendingRemoval, setPendingRemoval] = useState<{ sortableId: string; label: string } | null>(null)
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -173,7 +190,21 @@ export function AssignmentSubmissionRequirementsEditor({
       coordinateGetter: sortableKeyboardCoordinates,
     })
   )
-  const sortableIds = requirements.map((_, index) => `requirement-${index}`)
+
+  if (sortableIdsRef.current.length < requirements.length) {
+    sortableIdsRef.current = [
+      ...sortableIdsRef.current,
+      ...Array.from({ length: requirements.length - sortableIdsRef.current.length }, () => {
+        const id = `requirement-${nextSortableIdRef.current}`
+        nextSortableIdRef.current += 1
+        return id
+      }),
+    ]
+  } else if (sortableIdsRef.current.length > requirements.length) {
+    sortableIdsRef.current = sortableIdsRef.current.slice(0, requirements.length)
+  }
+
+  const sortableIds = sortableIdsRef.current
 
   function updateRequirement(index: number, patch: Partial<AssignmentSubmissionRequirementDraft>) {
     onChange(requirements.map((requirement, currentIndex) =>
@@ -184,6 +215,9 @@ export function AssignmentSubmissionRequirementsEditor({
   }
 
   function addRequirement(type: AssignmentSubmissionRequirementType) {
+    const sortableId = `requirement-${nextSortableIdRef.current}`
+    nextSortableIdRef.current += 1
+    sortableIdsRef.current = [...sortableIdsRef.current, sortableId]
     onChange([
       ...requirements,
       {
@@ -198,9 +232,35 @@ export function AssignmentSubmissionRequirementsEditor({
   }
 
   function removeRequirement(index: number) {
+    sortableIdsRef.current = sortableIdsRef.current.filter((_, currentIndex) => currentIndex !== index)
     onChange(
       withPositions(requirements.filter((_, currentIndex) => currentIndex !== index))
     )
+  }
+
+  function requestRemoveRequirement(index: number, sortableId: string) {
+    const requirement = requirements[index]
+    if (!requirement) return
+
+    if (requirement.id) {
+      setPendingRemoval({
+        sortableId,
+        label: requirement.label || DEFAULT_REQUIREMENT_LABELS[requirement.type],
+      })
+      return
+    }
+
+    removeRequirement(index)
+  }
+
+  function confirmPendingRemoval() {
+    if (!pendingRemoval) return
+
+    const index = sortableIdsRef.current.indexOf(pendingRemoval.sortableId)
+    setPendingRemoval(null)
+    if (index === -1) return
+
+    removeRequirement(index)
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -213,6 +273,7 @@ export function AssignmentSubmissionRequirementsEditor({
     const newIndex = sortableIds.indexOf(String(over.id))
     if (oldIndex === -1 || newIndex === -1) return
 
+    sortableIdsRef.current = arrayMove(sortableIdsRef.current, oldIndex, newIndex)
     onChange(withPositions(arrayMove(requirements, oldIndex, newIndex)))
   }
 
@@ -227,27 +288,25 @@ export function AssignmentSubmissionRequirementsEditor({
             label={(
               <span className="inline-flex items-center gap-1">
                 <span aria-hidden="true">+</span>
-                <Link2 className="h-4 w-4" aria-hidden="true" />
-                link
+                Add
               </span>
             )}
-            onPrimaryClick={() => addRequirement('link')}
+            primaryOpensMenu
             options={TYPE_OPTIONS.map((option) => ({
               id: option.type,
-              label: option.label,
-              icon: <RequirementIcon type={option.type} />,
+              label: <AddRequirementLabel type={option.type} label={option.label} />,
               onSelect: () => addRequirement(option.type),
             }))}
-            variant="secondary"
+            variant="success"
             size="sm"
             disabled={disabled}
             menuPlacement="down"
             toggleAriaLabel="Choose submission type"
             toggleButtonClassName="!px-2"
             primaryButtonProps={{
-              'aria-label': 'Add link submission',
+              'aria-label': 'Add submission',
               className: 'justify-center gap-1 !px-2',
-              title: 'Add public link submission',
+              title: 'Add required submission',
             }}
           />
         </div>
@@ -269,7 +328,7 @@ export function AssignmentSubmissionRequirementsEditor({
                     totalRequirements={requirements.length}
                     disabled={disabled}
                     onUpdate={updateRequirement}
-                    onRemove={removeRequirement}
+                    onRemove={requestRemoveRequirement}
                   />
                 ))}
               </div>
@@ -277,6 +336,16 @@ export function AssignmentSubmissionRequirementsEditor({
           </DndContext>
         ) : null}
       </div>
+      <ConfirmDialog
+        isOpen={Boolean(pendingRemoval)}
+        title="Remove required submission?"
+        description={pendingRemoval ? `This removes "${pendingRemoval.label}" from the assignment.` : undefined}
+        confirmLabel="Remove"
+        cancelLabel="Keep"
+        confirmVariant="danger"
+        onCancel={() => setPendingRemoval(null)}
+        onConfirm={confirmPendingRemoval}
+      />
     </TooltipProvider>
   )
 }

--- a/src/components/AssignmentSubmissionRequirementsEditor.tsx
+++ b/src/components/AssignmentSubmissionRequirementsEditor.tsx
@@ -17,7 +17,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Camera, FolderGit2, GripVertical, Link2, Trash2 } from 'lucide-react'
+import { FolderGit2, GripVertical, ImageIcon, Link2, Trash2 } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { Button, ConfirmDialog, FormField, Input, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
 import {
@@ -43,7 +43,7 @@ const TYPE_OPTIONS: Array<{
 
 function RequirementIcon({ type }: { type: AssignmentSubmissionRequirementType }) {
   if (type === 'repo_link') return <FolderGit2 className="h-4 w-4" aria-hidden="true" />
-  if (type === 'image') return <Camera className="h-4 w-4" aria-hidden="true" />
+  if (type === 'image') return <ImageIcon className="h-4 w-4" aria-hidden="true" />
   return <Link2 className="h-4 w-4" aria-hidden="true" />
 }
 

--- a/src/components/AssignmentSubmissionRequirementsEditor.tsx
+++ b/src/components/AssignmentSubmissionRequirementsEditor.tsx
@@ -1,7 +1,24 @@
 'use client'
 
-import { Camera, ChevronDown, ChevronUp, FolderGit2, GripVertical, Link2, Plus, Trash2 } from 'lucide-react'
-import { Button, FormField, Input, Tooltip, TooltipProvider } from '@/ui'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Camera, FolderGit2, GripVertical, Link2, Trash2 } from 'lucide-react'
+import { Button, FormField, Input, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
 import {
   DEFAULT_REQUIREMENT_LABELS,
   type AssignmentSubmissionRequirementDraft,
@@ -17,11 +34,10 @@ interface AssignmentSubmissionRequirementsEditorProps {
 const TYPE_OPTIONS: Array<{
   type: AssignmentSubmissionRequirementType
   label: string
-  description: string
 }> = [
-  { type: 'repo_link', label: 'Repo link', description: 'GitHub repository URL' },
-  { type: 'link', label: 'Public link', description: 'Public URL' },
-  { type: 'image', label: 'Image', description: 'Screenshot upload' },
+  { type: 'link', label: 'Link' },
+  { type: 'repo_link', label: 'Repo' },
+  { type: 'image', label: 'Image' },
 ]
 
 function RequirementIcon({ type }: { type: AssignmentSubmissionRequirementType }) {
@@ -30,11 +46,135 @@ function RequirementIcon({ type }: { type: AssignmentSubmissionRequirementType }
   return <Link2 className="h-4 w-4" aria-hidden="true" />
 }
 
+function withPositions(requirements: AssignmentSubmissionRequirementDraft[]) {
+  return requirements.map((requirement, position) => ({ ...requirement, position }))
+}
+
+interface SortableRequirementRowProps {
+  sortableId: string
+  requirement: AssignmentSubmissionRequirementDraft
+  index: number
+  totalRequirements: number
+  disabled: boolean
+  onUpdate: (index: number, patch: Partial<AssignmentSubmissionRequirementDraft>) => void
+  onRemove: (index: number) => void
+}
+
+function SortableRequirementRow({
+  sortableId,
+  requirement,
+  index,
+  totalRequirements,
+  disabled,
+  onUpdate,
+  onRemove,
+}: SortableRequirementRowProps) {
+  const isDragDisabled = disabled || totalRequirements < 2
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: sortableId, disabled: isDragDisabled })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: isDragging ? undefined : transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'grid gap-3 px-3 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto]',
+        isDragging ? 'relative z-10 bg-surface shadow-lg' : ''
+      )}
+    >
+      <div className="flex items-center gap-2 text-text-muted">
+        <button
+          type="button"
+          className={cn(
+            '-ml-1 rounded p-1 touch-none transition-colors',
+            isDragDisabled
+              ? 'cursor-default opacity-50'
+              : 'cursor-grab hover:bg-surface-hover hover:text-text-default active:cursor-grabbing'
+          )}
+          disabled={isDragDisabled}
+          aria-label={`Drag to reorder ${requirement.label || DEFAULT_REQUIREMENT_LABELS[requirement.type]}`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <RequirementIcon type={requirement.type} />
+      </div>
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto]">
+        <FormField label="Label" hideLabel>
+          <Input
+            value={requirement.label ?? ''}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { label: event.target.value })}
+            placeholder="Submission label"
+          />
+        </FormField>
+        <FormField label="Instructions" hideLabel>
+          <Input
+            value={requirement.instructions ?? ''}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { instructions: event.target.value })}
+            placeholder="Optional helper text"
+          />
+        </FormField>
+        <label className="flex items-end gap-2 pb-2 text-sm text-text-default">
+          <input
+            type="checkbox"
+            checked={requirement.required !== false}
+            disabled={disabled}
+            onChange={(event) => onUpdate(index, { required: event.target.checked })}
+            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+          />
+          Required
+        </label>
+      </div>
+      <div className="flex items-center justify-end gap-1">
+        <Tooltip content="Remove">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="px-2 text-danger"
+            disabled={disabled}
+            onClick={() => onRemove(index)}
+            aria-label="Remove requirement"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
 export function AssignmentSubmissionRequirementsEditor({
   requirements,
   onChange,
   disabled = false,
 }: AssignmentSubmissionRequirementsEditorProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 6,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
+  const sortableIds = requirements.map((_, index) => `requirement-${index}`)
+
   function updateRequirement(index: number, patch: Partial<AssignmentSubmissionRequirementDraft>) {
     onChange(requirements.map((requirement, currentIndex) =>
       currentIndex === index
@@ -59,133 +199,84 @@ export function AssignmentSubmissionRequirementsEditor({
 
   function removeRequirement(index: number) {
     onChange(
-      requirements
-        .filter((_, currentIndex) => currentIndex !== index)
-        .map((requirement, position) => ({ ...requirement, position }))
+      withPositions(requirements.filter((_, currentIndex) => currentIndex !== index))
     )
   }
 
-  function moveRequirement(index: number, direction: -1 | 1) {
-    const nextIndex = index + direction
-    if (nextIndex < 0 || nextIndex >= requirements.length) return
-    const next = [...requirements]
-    const [item] = next.splice(index, 1)
-    next.splice(nextIndex, 0, item)
-    onChange(next.map((requirement, position) => ({ ...requirement, position })))
+  function handleDragEnd(event: DragEndEvent) {
+    if (disabled) return
+
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = sortableIds.indexOf(String(active.id))
+    const newIndex = sortableIds.indexOf(String(over.id))
+    if (oldIndex === -1 || newIndex === -1) return
+
+    onChange(withPositions(arrayMove(requirements, oldIndex, newIndex)))
   }
 
   return (
     <TooltipProvider>
-    <div className="rounded-lg border border-border-strong bg-surface">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-3 py-2">
-        <div>
-          <div className="text-sm font-medium text-text-default">Required submissions</div>
-          <div className="text-xs text-text-muted">Shown to students as a turn-in checklist.</div>
+      <div role="group" aria-label="Required submissions" className="rounded-lg border border-border-strong bg-surface">
+        <div className="flex items-center justify-between gap-3 px-3 py-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-text-default">Required submissions</div>
+          </div>
+          <SplitButton
+            label={(
+              <span className="inline-flex items-center gap-1">
+                <span aria-hidden="true">+</span>
+                <Link2 className="h-4 w-4" aria-hidden="true" />
+                link
+              </span>
+            )}
+            onPrimaryClick={() => addRequirement('link')}
+            options={TYPE_OPTIONS.map((option) => ({
+              id: option.type,
+              label: option.label,
+              icon: <RequirementIcon type={option.type} />,
+              onSelect: () => addRequirement(option.type),
+            }))}
+            variant="secondary"
+            size="sm"
+            disabled={disabled}
+            menuPlacement="down"
+            toggleAriaLabel="Choose submission type"
+            toggleButtonClassName="!px-2"
+            primaryButtonProps={{
+              'aria-label': 'Add link submission',
+              className: 'justify-center gap-1 !px-2',
+              title: 'Add public link submission',
+            }}
+          />
         </div>
-        <div className="flex flex-wrap gap-1.5">
-          {TYPE_OPTIONS.map((option) => (
-            <Tooltip key={option.type} content={option.description}>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="gap-1.5"
-                disabled={disabled}
-                onClick={() => addRequirement(option.type)}
-              >
-                <Plus className="h-3.5 w-3.5" aria-hidden="true" />
-                {option.label}
-              </Button>
-            </Tooltip>
-          ))}
-        </div>
-      </div>
 
-      {requirements.length === 0 ? (
-        <div className="px-3 py-4 text-sm text-text-muted">
-          No structured submissions required.
-        </div>
-      ) : (
-        <div className="divide-y divide-border">
-          {requirements.map((requirement, index) => (
-            <div key={`${requirement.id ?? requirement.type}:${index}`} className="grid gap-3 px-3 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto]">
-              <div className="flex items-center gap-2 text-text-muted">
-                <GripVertical className="h-4 w-4" aria-hidden="true" />
-                <RequirementIcon type={requirement.type} />
-              </div>
-              <div className="grid gap-2 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto]">
-                <FormField label="Label">
-                  <Input
-                    value={requirement.label ?? ''}
+        {requirements.length > 0 ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+              <div className="divide-y divide-border border-t border-border">
+                {requirements.map((requirement, index) => (
+                  <SortableRequirementRow
+                    key={sortableIds[index]}
+                    sortableId={sortableIds[index]}
+                    requirement={requirement}
+                    index={index}
+                    totalRequirements={requirements.length}
                     disabled={disabled}
-                    onChange={(event) => updateRequirement(index, { label: event.target.value })}
+                    onUpdate={updateRequirement}
+                    onRemove={removeRequirement}
                   />
-                </FormField>
-                <FormField label="Instructions">
-                  <Input
-                    value={requirement.instructions ?? ''}
-                    disabled={disabled}
-                    onChange={(event) => updateRequirement(index, { instructions: event.target.value })}
-                    placeholder="Optional helper text"
-                  />
-                </FormField>
-                <label className="flex items-end gap-2 pb-2 text-sm text-text-default">
-                  <input
-                    type="checkbox"
-                    checked={requirement.required !== false}
-                    disabled={disabled}
-                    onChange={(event) => updateRequirement(index, { required: event.target.checked })}
-                    className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                  />
-                  Required
-                </label>
+                ))}
               </div>
-              <div className="flex items-center justify-end gap-1">
-                <Tooltip content="Move up">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="px-2"
-                    disabled={disabled || index === 0}
-                    onClick={() => moveRequirement(index, -1)}
-                    aria-label="Move requirement up"
-                  >
-                    <ChevronUp className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                </Tooltip>
-                <Tooltip content="Move down">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="px-2"
-                    disabled={disabled || index === requirements.length - 1}
-                    onClick={() => moveRequirement(index, 1)}
-                    aria-label="Move requirement down"
-                  >
-                    <ChevronDown className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                </Tooltip>
-                <Tooltip content="Remove">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="px-2 text-danger"
-                    disabled={disabled}
-                    onClick={() => removeRequirement(index)}
-                    aria-label="Remove requirement"
-                  >
-                    <Trash2 className="h-4 w-4" aria-hidden="true" />
-                  </Button>
-                </Tooltip>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+            </SortableContext>
+          </DndContext>
+        ) : null}
+      </div>
     </TooltipProvider>
   )
 }

--- a/src/components/creation/CreationModalShell.tsx
+++ b/src/components/creation/CreationModalShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode, Ref } from 'react'
+import { useId, type ReactNode, type Ref } from 'react'
 import { X } from 'lucide-react'
 import { Button, DialogPanel, FormField, Input } from '@/ui'
 import { cn } from '@/ui/utils'
@@ -27,6 +27,7 @@ interface CreationModalTopRowProps {
   titleInputRef?: Ref<HTMLInputElement>
   titleInputClassName?: string
   titleFieldClassName?: string
+  titleStatus?: ReactNode
   afterTitle?: ReactNode
   actions?: ReactNode
   className?: string
@@ -108,6 +109,7 @@ export function CreationModalTopRow({
   titleInputRef,
   titleInputClassName,
   titleFieldClassName,
+  titleStatus,
   afterTitle,
   actions,
   className,
@@ -115,27 +117,56 @@ export function CreationModalTopRow({
   onTitleBlur,
 }: CreationModalTopRowProps) {
   const gridClassName = getTopRowGridClassName(Boolean(afterTitle), Boolean(actions))
+  const titleFieldId = useId()
+  const titleErrorId = titleError ? `${titleFieldId}-error` : undefined
+  const titleInput = (
+    <Input
+      ref={titleInputRef}
+      id={titleFieldId}
+      type="text"
+      value={title}
+      onChange={(event) => onTitleChange(event.target.value)}
+      onBlur={onTitleBlur}
+      required={titleRequired}
+      disabled={titleDisabled}
+      placeholder={titlePlaceholder}
+      hasError={Boolean(titleError)}
+      aria-invalid={titleError ? 'true' : undefined}
+      aria-describedby={titleErrorId}
+      className={titleInputClassName}
+    />
+  )
 
   return (
     <div className={cn('grid items-end gap-1.5 sm:gap-2', gridClassName, className)}>
-      <FormField
-        label={titleLabel}
-        required={titleRequired}
-        error={titleError}
-        className={cn('min-w-0 max-w-[22rem] sm:max-w-[24rem]', titleFieldClassName)}
-      >
-        <Input
-          ref={titleInputRef}
-          type="text"
-          value={title}
-          onChange={(event) => onTitleChange(event.target.value)}
-          onBlur={onTitleBlur}
+      {titleStatus ? (
+        <div className={cn('min-w-0 max-w-[22rem] sm:max-w-[24rem]', titleFieldClassName)}>
+          <div className="mb-1 flex min-h-5 items-center justify-between gap-2">
+            <label htmlFor={titleFieldId} className="block text-sm font-medium text-text-default">
+              {titleLabel}
+              {titleRequired && <span className="ml-1 text-danger">*</span>}
+            </label>
+            <div className="min-w-0 shrink-0">
+              {titleStatus}
+            </div>
+          </div>
+          {titleInput}
+          {titleError && (
+            <p id={titleErrorId} className="mt-1 text-sm text-danger" role="alert">
+              {titleError}
+            </p>
+          )}
+        </div>
+      ) : (
+        <FormField
+          label={titleLabel}
           required={titleRequired}
-          disabled={titleDisabled}
-          placeholder={titlePlaceholder}
-          className={titleInputClassName}
-        />
-      </FormField>
+          error={titleError}
+          className={cn('min-w-0 max-w-[22rem] sm:max-w-[24rem]', titleFieldClassName)}
+        >
+          {titleInput}
+        </FormField>
+      )}
 
       {afterTitle}
 

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -27,8 +27,9 @@ export interface SplitButtonOption {
 
 export interface SplitButtonProps {
   label: ReactNode
-  onPrimaryClick: () => void
+  onPrimaryClick?: () => void
   options: SplitButtonOption[]
+  primaryOpensMenu?: boolean
   variant?: NonNullable<ButtonProps['variant']>
   size?: NonNullable<ButtonProps['size']>
   disabled?: boolean
@@ -43,6 +44,7 @@ export function SplitButton({
   label,
   onPrimaryClick,
   options,
+  primaryOpensMenu = false,
   variant = 'primary',
   size = 'sm',
   disabled = false,
@@ -96,14 +98,32 @@ export function SplitButton({
     onSelect()
   }
 
+  function toggleMenu() {
+    setIsOpen((prev) => {
+      if (prev) clearOptionHover()
+      return !prev
+    })
+  }
+
   return (
     <div ref={containerRef} className={cn('relative inline-flex', className)}>
       <Button
         type="button"
         variant={variant}
         size={size}
-        onClick={onPrimaryClick}
-        disabled={disabled}
+        aria-haspopup={primaryOpensMenu ? 'menu' : undefined}
+        aria-controls={primaryOpensMenu ? menuId : undefined}
+        aria-expanded={primaryOpensMenu ? isOpen : undefined}
+        onClick={(event) => {
+          if (!primaryOpensMenu) {
+            onPrimaryClick?.()
+            return
+          }
+
+          event.stopPropagation()
+          toggleMenu()
+        }}
+        disabled={disabled || (primaryOpensMenu && options.length === 0)}
         className={cn('rounded-r-none', primaryClassName)}
         {...restPrimaryButtonProps}
       >
@@ -119,10 +139,7 @@ export function SplitButton({
         aria-label={toggleAriaLabel}
         onClick={(event) => {
           event.stopPropagation()
-          setIsOpen((prev) => {
-            if (prev) clearOptionHover()
-            return !prev
-          })
+          toggleMenu()
         }}
         disabled={disabled || options.length === 0}
         className={cn('rounded-l-none border-l border-black/15 px-3', toggleButtonClassName)}

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -34,6 +34,7 @@ export interface SplitButtonProps {
   disabled?: boolean
   className?: string
   toggleAriaLabel?: string
+  toggleButtonClassName?: string
   menuPlacement?: 'up' | 'down'
   primaryButtonProps?: Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'type'>
 }
@@ -47,6 +48,7 @@ export function SplitButton({
   disabled = false,
   className,
   toggleAriaLabel = 'More actions',
+  toggleButtonClassName,
   menuPlacement = 'up',
   primaryButtonProps,
 }: SplitButtonProps) {
@@ -123,7 +125,7 @@ export function SplitButton({
           })
         }}
         disabled={disabled || options.length === 0}
-        className="rounded-l-none border-l border-black/15 px-3"
+        className={cn('rounded-l-none border-l border-black/15 px-3', toggleButtonClassName)}
       >
         <ChevronDown className="h-4 w-4" aria-hidden="true" />
       </Button>

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -175,11 +175,14 @@ describe('AssignmentModal', () => {
       expect(requirementsGroup.queryByText('None')).not.toBeInTheDocument()
       expect(screen.queryByText('No structured submissions required.')).not.toBeInTheDocument()
 
-      const addLinkButton = requirementsGroup.getByRole('button', { name: 'Add link submission' })
-      expect(addLinkButton).toHaveTextContent('+')
-      expect(addLinkButton).toHaveTextContent('link')
+      const addButton = requirementsGroup.getByRole('button', { name: 'Add submission' })
+      expect(addButton).toHaveTextContent('+')
+      expect(addButton).toHaveTextContent('Add')
+      expect(addButton).not.toHaveTextContent('Link')
 
-      fireEvent.click(addLinkButton)
+      fireEvent.click(addButton)
+      expect(screen.getByRole('menuitem', { name: 'Link' })).toHaveTextContent('+')
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
 
       expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
       expect(requirementsGroup.getByPlaceholderText('Optional helper text')).toBeInTheDocument()
@@ -188,12 +191,115 @@ describe('AssignmentModal', () => {
       expect(requirementsGroup.queryByRole('button', { name: 'Move requirement down' })).not.toBeInTheDocument()
 
       fireEvent.click(requirementsGroup.getByRole('button', { name: 'Choose submission type' }))
-      expect(screen.getByRole('menuitem', { name: 'Image' })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: 'Image' })).toHaveTextContent('+')
       fireEvent.click(screen.getByRole('menuitem', { name: 'Repo' }))
 
       expect(requirementsGroup.getByDisplayValue('Repo link')).toBeInTheDocument()
       expect(requirementsGroup.queryByText('2 items')).not.toBeInTheDocument()
       expect(requirementsGroup.getAllByRole('button', { name: /Drag to reorder/ })).toHaveLength(2)
+    })
+
+    it('keeps newer required submission edits when an older autosave resolves', async () => {
+      vi.useFakeTimers()
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      let resolveFirstSave: (value: unknown) => void = () => {}
+      fetchMock.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirstSave = resolve
+      }))
+
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={baseAssignment}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      const requirementsGroup = within(screen.getByRole('group', { name: 'Required submissions' }))
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Add submission' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Choose submission type' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Repo' }))
+
+      await act(async () => {
+        resolveFirstSave({
+          ok: true,
+          json: async () => ({
+            assignment: {
+              ...baseAssignment,
+              submission_requirements: [{
+                id: 'requirement-link',
+                assignment_id: baseAssignment.id,
+                type: 'link',
+                label: 'Public link',
+                instructions: '',
+                required: true,
+                position: 0,
+                validation_policy_json: {},
+                created_at: '2025-01-01T00:00:00.000Z',
+                updated_at: '2025-01-01T00:00:00.000Z',
+              }],
+            },
+          }),
+        })
+        await Promise.resolve()
+      })
+
+      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+      expect(requirementsGroup.getByDisplayValue('Repo link')).toBeInTheDocument()
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    })
+
+    it('confirms before removing an existing required submission', () => {
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={{
+            ...baseAssignment,
+            submission_requirements: [{
+              id: 'requirement-link',
+              assignment_id: baseAssignment.id,
+              type: 'link',
+              label: 'Public link',
+              instructions: '',
+              required: true,
+              position: 0,
+              validation_policy_json: {},
+              created_at: '2025-01-01T00:00:00.000Z',
+              updated_at: '2025-01-01T00:00:00.000Z',
+            }],
+          }}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      const requirementsGroup = within(screen.getByRole('group', { name: 'Required submissions' }))
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Remove requirement' }))
+
+      let dialog = screen.getByRole('dialog', { name: 'Remove required submission?' })
+      expect(within(dialog).getByText('This removes "Public link" from the assignment.')).toBeInTheDocument()
+
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Keep' }))
+      expect(screen.queryByRole('dialog', { name: 'Remove required submission?' })).not.toBeInTheDocument()
+      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Remove requirement' }))
+      dialog = screen.getByRole('dialog', { name: 'Remove required submission?' })
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
+      expect(screen.queryByRole('dialog', { name: 'Remove required submission?' })).not.toBeInTheDocument()
+      expect(requirementsGroup.queryByDisplayValue('Public link')).not.toBeInTheDocument()
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
     })
 
     it('shows save status indicator', () => {

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -86,6 +86,7 @@ describe('AssignmentModal', () => {
       expect(screen.queryByText('Author Markdown')).not.toBeInTheDocument()
       expect(screen.queryByText(/Legacy Rich Text Editor/i)).not.toBeInTheDocument()
       expect(screen.queryByText(/Supported markdown:/i)).not.toBeInTheDocument()
+      expect(screen.queryByText('Instructions')).not.toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Heading' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled()
       expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled()
@@ -153,6 +154,46 @@ describe('AssignmentModal', () => {
       expect(screen.getByRole('button', { name: 'Bold' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
       expect(screen.getByPlaceholderText('Assignment instructions')).toHaveValue('Original instructions')
+    })
+
+    it('places required submissions above instructions with compact split add actions', () => {
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={baseAssignment}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      const requiredSubmissions = screen.getByText('Required submissions')
+      const requirementsGroup = within(screen.getByRole('group', { name: 'Required submissions' }))
+      const instructions = screen.getByPlaceholderText('Assignment instructions')
+
+      expect(requiredSubmissions.compareDocumentPosition(instructions) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      expect(requirementsGroup.queryByText('None')).not.toBeInTheDocument()
+      expect(screen.queryByText('No structured submissions required.')).not.toBeInTheDocument()
+
+      const addLinkButton = requirementsGroup.getByRole('button', { name: 'Add link submission' })
+      expect(addLinkButton).toHaveTextContent('+')
+      expect(addLinkButton).toHaveTextContent('link')
+
+      fireEvent.click(addLinkButton)
+
+      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+      expect(requirementsGroup.getByPlaceholderText('Optional helper text')).toBeInTheDocument()
+      expect(requirementsGroup.queryByText('1 item')).not.toBeInTheDocument()
+      expect(requirementsGroup.queryByRole('button', { name: 'Move requirement up' })).not.toBeInTheDocument()
+      expect(requirementsGroup.queryByRole('button', { name: 'Move requirement down' })).not.toBeInTheDocument()
+
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Choose submission type' }))
+      expect(screen.getByRole('menuitem', { name: 'Image' })).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Repo' }))
+
+      expect(requirementsGroup.getByDisplayValue('Repo link')).toBeInTheDocument()
+      expect(requirementsGroup.queryByText('2 items')).not.toBeInTheDocument()
+      expect(requirementsGroup.getAllByRole('button', { name: /Drag to reorder/ })).toHaveLength(2)
     })
 
     it('shows save status indicator', () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1056,6 +1056,45 @@ describe('TeacherClassroomView', () => {
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
 
+  it('refreshes selected assignment details from the workspace action bar', async () => {
+    let detailFetchCount = 0
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        detailFetchCount += 1
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeAssignmentDetails('assignment-1', 'Assignment One', 'student-1'),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="assignment-1"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh submissions' })).toBeEnabled()
+    })
+    expect(detailFetchCount).toBe(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh submissions' }))
+
+    await waitFor(() => {
+      expect(detailFetchCount).toBe(2)
+    })
+  })
+
   it('keeps draft and scheduled assignments opening the editor in normal mode', async () => {
     mockIsVisibleAtNow.mockReturnValue(false)
     mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {

--- a/tests/ui/SplitButton.test.tsx
+++ b/tests/ui/SplitButton.test.tsx
@@ -45,6 +45,26 @@ describe('SplitButton', () => {
     expect(screen.queryByRole('menuitem', { name: 'Schedule' })).not.toBeInTheDocument()
   })
 
+  it('can use the primary button to open the menu', () => {
+    const onPrimaryClick = vi.fn()
+
+    render(
+      <SplitButton
+        label="Add"
+        onPrimaryClick={onPrimaryClick}
+        primaryOpensMenu
+        options={[
+          { id: 'link', label: 'Link', onSelect: vi.fn() },
+        ]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Link' })).toBeInTheDocument()
+    expect(onPrimaryClick).not.toHaveBeenCalled()
+  })
+
   it('renders dropdown below when menuPlacement is down', () => {
     render(
       <SplitButton


### PR DESCRIPTION
## Summary

- Refines the assignment modal required-submissions UI into a compact editor above instructions.
- Adds draggable required-submission rows, confirmation before removing persisted requirements, and stale autosave protection so older saves do not overwrite newer local edits.
- Uses the shared green split button for adding required submissions, with the primary `+ Add` side opening the type menu and menu options for `+ Link`, `+ Repo`, and `+ Image`.
- Adds a teacher action-bar refresh control for assignment submissions.

## Validation

- `pnpm test tests/ui/SplitButton.test.tsx tests/components/AssignmentModal.test.tsx`
- `pnpm test tests/components/TeacherClassroomView.test.tsx`
- `pnpm lint`
- `git diff --check`
- Visual verification with Pika UI screenshots and targeted desktop/mobile assignment modal screenshots:
  - `/tmp/pika-assignment-modal-add-submission-dropdown-desktop.png`
  - `/tmp/pika-assignment-modal-add-submission-dropdown-mobile.png`