### PR TITLE
[codex] Put destructive split actions last

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,19 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-21 — Migration filename CI guard
-
-**Completed:**
-- Added a Vitest guard for Supabase migration filenames so CI rejects non-`NNN_snake_case.sql` files.
-- The guard also rejects duplicate migration prefixes and gaps in the numeric sequence.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/migration-filenames.test.ts`
-- `pnpm test tests/unit/migration-filenames.test.ts tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `git diff --check`
-
 ## 2026-05-22 — Assignment student list scroll persistence
 
 **Completed:**
@@ -381,3 +368,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Updated green split button label screenshots: `/tmp/pika-assignment-modal-green-submission-split-label-desktop.png`, `/tmp/pika-assignment-modal-green-submission-split-label-mobile.png`
 - Generic add dropdown screenshots: `/tmp/pika-assignment-modal-add-submission-dropdown-desktop.png`, `/tmp/pika-assignment-modal-add-submission-dropdown-mobile.png`
 - Image icon dropdown screenshots: `/tmp/pika-assignment-modal-image-icon-dropdown-desktop.png`, `/tmp/pika-assignment-modal-image-icon-dropdown-mobile.png`
+
+## 2026-05-26 — Split-button destructive action placement
+
+**Completed:**
+- Added a `destructive` split-button option flag and centralized menu rendering so destructive options appear last under a separator.
+- Marked assignment delete, test-work delete, and roster removal split-button actions as destructive.
+- Added focused SplitButton coverage for reordering a destructive option supplied before normal actions.
+- Stabilized the assignment refresh test by waiting for the initial detail request before clicking refresh.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Playwright menu smoke: roster, assignment, and test action dropdowns all placed Remove/Delete last under a separator.
+- Screenshots: `/tmp/pika-roster-actions-menu.png`, `/tmp/pika-assignment-actions-menu.png`, `/tmp/pika-test-actions-menu.png`
+- `pnpm test`
+- `pnpm test:coverage`

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -2179,6 +2179,7 @@ export function TeacherClassroomView({
                 }
               },
               disabled: !activeSelectedAssignmentData || selectedAssignmentLoading || isReadOnly || isDeleting,
+              destructive: true,
             },
             {
               id: 'grade-selected',

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -387,6 +387,7 @@ export function TeacherRosterTab({ classroom }: Props) {
         label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
         onSelect: () => openRemoveStudentDialog(removalTargetRows),
         disabled: isReadOnly || loading || isRemoving,
+        destructive: true,
       })
     }
 
@@ -402,6 +403,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
       onSelect: () => openRemoveStudentDialog(removalTargetRows),
       disabled: isReadOnly || loading || isRemoving || removalTargetRows.length === 0,
+      destructive: true,
     })
 
     rosterActionOptions.push(

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -2332,6 +2332,7 @@ export function TeacherTestsTab({
           disabled:
             batchSelectedCount === 0 ||
             isCombinedTestActionsBusy,
+          destructive: true,
         },
       ]}
       variant="secondary"

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -22,6 +22,7 @@ export interface SplitButtonOption {
   icon?: ReactNode
   checked?: boolean
   dividerBefore?: boolean
+  destructive?: boolean
   onHoverChange?: (hovered: boolean) => void
 }
 
@@ -58,6 +59,10 @@ export function SplitButton({
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
   const menuId = useId()
+  const normalOptions = options.filter((option) => !option.destructive)
+  const destructiveOptions = options.filter((option) => option.destructive)
+  const orderedOptions = [...normalOptions, ...destructiveOptions]
+  const firstDestructiveOption = destructiveOptions[0] ?? null
   const hasLeadingVisual = options.some((option) => option.icon || option.checked !== undefined)
 
   const clearOptionHover = useCallback(() => {
@@ -157,9 +162,9 @@ export function SplitButton({
             menuPlacement === 'down' ? 'top-full mt-1' : 'bottom-full mb-1'
           )}
         >
-          {options.map((option) => (
+          {orderedOptions.map((option) => (
             <Fragment key={option.id}>
-              {option.dividerBefore ? (
+              {option.dividerBefore || option === firstDestructiveOption ? (
                 <div role="separator" className="my-1 border-t border-border" />
               ) : null}
               <button
@@ -175,7 +180,10 @@ export function SplitButton({
                   event.stopPropagation()
                   handleOptionSelect(option.onSelect)
                 }}
-                className="w-full rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+                className={cn(
+                  'w-full rounded-sm px-2 py-1.5 text-left text-sm text-text-default hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50',
+                  option.destructive ? 'text-danger hover:bg-danger-bg' : ''
+                )}
               >
                 <span className="inline-flex w-full items-center gap-2 whitespace-nowrap">
                   {hasLeadingVisual ? (

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -1084,9 +1084,9 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
+      expect(detailFetchCount).toBe(1)
       expect(screen.getByRole('button', { name: 'Refresh submissions' })).toBeEnabled()
     })
-    expect(detailFetchCount).toBe(1)
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh submissions' }))
 

--- a/tests/ui/SplitButton.test.tsx
+++ b/tests/ui/SplitButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { SplitButton } from '@/ui'
 
 describe('SplitButton', () => {
@@ -128,5 +128,32 @@ describe('SplitButton', () => {
     expect(screen.getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'false')
     expect(screen.getByRole('separator')).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Copy emails' })).toBeInTheDocument()
+  })
+
+  it('moves destructive menu options to the bottom under a separator', () => {
+    render(
+      <SplitButton
+        label="Actions"
+        onPrimaryClick={vi.fn()}
+        options={[
+          { id: 'delete-item', label: 'Delete', onSelect: vi.fn(), destructive: true },
+          { id: 'copy', label: 'Copy', onSelect: vi.fn() },
+          { id: 'archive', label: 'Archive', onSelect: vi.fn() },
+        ]}
+        toggleAriaLabel="More actions"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+
+    const menu = screen.getByRole('menu')
+    const items = within(menu).getAllByRole('menuitem')
+    expect(items.map((item) => item.textContent)).toEqual(['Copy', 'Archive', 'Delete'])
+
+    const children = Array.from(menu.children)
+    expect(children[0]).toBe(items[0])
+    expect(children[1]).toBe(items[1])
+    expect(children[2]).toHaveAttribute('role', 'separator')
+    expect(children[3]).toBe(items[2])
   })
 })


### PR DESCRIPTION
## Summary

- Add a `destructive` option to the shared `SplitButton` primitive.
- Render destructive split-button options after normal options with a separator above the destructive group.
- Mark assignment delete, test-work delete, and roster removal split-button actions as destructive.
- Add focused SplitButton coverage for destructive options supplied before normal actions.

## Impact

Delete and remove actions in split-button dropdowns are now consistently placed at the bottom under a separator, reducing accidental destructive clicks and aligning split buttons with existing action-menu behavior.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm lint`
- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Playwright menu smoke: roster, assignment, and test action dropdowns all placed Remove/Delete last under a separator.
- `pnpm test`