### PR TITLE
Fix critical date and archive mutation risks

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-22 — Assignment student list scroll persistence
-
-**Completed:**
-- Persisted assignment student-list scroll memory to session storage for the teacher assignment workspace.
-- Made scroll restoration run across the next layout frames so split-pane refreshes and route reloads do not leave the list at the top.
-- Added hook regression coverage for session-backed scroll restoration after remount.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/hooks/useScrollPositionMemory.test.tsx`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherAssignmentStudentTable.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=1bd43274-afe7-472c-90c9-5b704d83e4b2&assignmentStudentId=e0d9c4e7-2a88-4428-bd15-ba87f2d935b7"`
-- Targeted Playwright long-list check: selected Student65 and reloaded; `scrollTop` remained `1500`.
-
 ## 2026-05-23 — Draft question sync helper
 
 **Completed:**
@@ -386,3 +370,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Screenshots: `/tmp/pika-roster-actions-menu.png`, `/tmp/pika-assignment-actions-menu.png`, `/tmp/pika-test-actions-menu.png`
 - `pnpm test`
 - `pnpm test:coverage`
+
+## 2026-05-26 — Critical risk fixes
+
+**Completed:**
+- Fixed `getTodayInToronto()` to format the current instant directly in `America/Toronto`, avoiding UTC-host double conversion.
+- Added archived-classroom mutation guards for assignment grading, selected grading, return, feedback return, AI grading, AI grading ticks, repo target overrides, and artifact repo analysis.
+- Preserved read-only assignment ownership checks for archived classrooms while adding a mutation-specific guard.
+- Added regression coverage for the UTC-host Toronto date edge and archived assignment mutation rejection.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/timezone.test.ts tests/unit/server-repo-review.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
+- `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-id-students-studentId.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
+++ b/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
@@ -18,7 +18,7 @@ import {
 } from '@/lib/server/assignment-repo-targets'
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
 import { loadAssignmentSubmissionArtifactsForDocs } from '@/lib/server/assignment-submission-artifacts'
-import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
+import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
 import type { AssignmentRepoReviewConfig, AssignmentSubmissionArtifact } from '@/types'
 
 type GroupedStudent = {
@@ -53,7 +53,7 @@ function createConfigForResolvedRepo(opts: {
 export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: assignmentId } = await context.params
-  const assignment = await assertTeacherOwnsAssignment(user.id, assignmentId)
+  const assignment = await assertTeacherCanMutateAssignment(user.id, assignmentId)
   const body: unknown = await request.json()
   const studentIds = Array.isArray((body as { student_ids?: unknown[] })?.student_ids)
     ? ((body as { student_ids: unknown[] }).student_ids.filter((value: unknown): value is string => typeof value === 'string'))
@@ -349,18 +349,18 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
 
       analyzedStudents += results.length
       repoGroups += 1
-    } catch (error) {
+    } catch (analysisError) {
       await supabase
         .from('assignment_repo_review_runs')
         .update({
           status: 'failed',
           completed_at: new Date().toISOString(),
           warnings_json: [
-            { code: 'run-failed', message: error instanceof Error ? error.message : 'Repo analysis failed' },
+            { code: 'run-failed', message: analysisError instanceof Error ? analysisError.message : 'Repo analysis failed' },
           ],
         })
         .eq('id', run.id)
-      throw error
+      throw analysisError
     }
   }
 

--- a/src/app/api/teacher/assignments/[id]/auto-grade-runs/[runId]/tick/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade-runs/[runId]/tick/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { tickAssignmentAiGradingRun } from '@/lib/server/assignment-ai-grading-runs'
-import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
+import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -12,7 +12,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGradeRunTick', as
   const user = await requireRole('teacher')
   const { id: assignmentId, runId } = await context.params
 
-  await assertTeacherOwnsAssignment(user.id, assignmentId)
+  await assertTeacherCanMutateAssignment(user.id, assignmentId)
   const result = await tickAssignmentAiGradingRun({ assignmentId, runId })
 
   return NextResponse.json({

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -11,7 +11,7 @@ import {
   markAssignmentDocMissingGrade,
 } from '@/lib/server/assignment-ai-grading-runs'
 import { loadAssignmentSubmissionArtifactsForDoc } from '@/lib/server/assignment-submission-artifacts'
-import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
+import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -34,7 +34,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
     return NextResponse.json({ error: 'Cannot auto-grade more than 100 students at once' }, { status: 400 })
   }
 
-  const assignment = await assertTeacherOwnsAssignment(user.id, id)
+  const assignment = await assertTeacherCanMutateAssignment(user.id, id)
   const supabase = getServiceRoleClient()
   const { data: enrollments, error: enrollmentError } = await supabase
     .from('classroom_enrollments')
@@ -136,11 +136,11 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
         studentId,
       },
     })
-  } catch (error) {
+  } catch (gradingError) {
     return NextResponse.json({
       graded_count: 0,
       skipped_count: 1,
-      errors: [error instanceof Error ? `${studentId}: ${error.message}` : `${studentId}: Auto-grade failed`],
+      errors: [gradingError instanceof Error ? `${studentId}: ${gradingError.message}` : `${studentId}: Auto-grade failed`],
     })
   }
 

--- a/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/feedback-return/route.ts
@@ -2,13 +2,13 @@ import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler, apiErrors } from '@/lib/api-handler'
 import { appendAssignmentFeedbackEntry } from '@/lib/server/assignment-feedback'
-import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
+import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
 import { getServiceRoleClient } from '@/lib/supabase'
 
 export const POST = withErrorHandler('PostTeacherAssignmentFeedbackReturn', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: assignmentId } = await context.params
-  const assignment = await assertTeacherOwnsAssignment(user.id, assignmentId)
+  const assignment = await assertTeacherCanMutateAssignment(user.id, assignmentId)
   const body = await request.json()
   const studentId = typeof body.student_id === 'string' ? body.student_id : ''
 

--- a/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
@@ -10,13 +10,13 @@ import {
 } from '@/lib/server/assignment-repo-targets'
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
 import { loadAssignmentSubmissionArtifactsForDoc } from '@/lib/server/assignment-submission-artifacts'
-import { assertTeacherOwnsAssignment } from '@/lib/server/repo-review'
+import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
 import { getServiceRoleClient } from '@/lib/supabase'
 
 export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: assignmentId, studentId } = await context.params
-  await assertTeacherOwnsAssignment(user.id, assignmentId)
+  await assertTeacherCanMutateAssignment(user.id, assignmentId)
 
   const body = await request.json()
   const selectionMode = body.selection_mode === 'teacher_override' ? 'teacher_override'

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -7,6 +7,7 @@ import {
   getAssignmentRubricState,
   isAssignmentAlreadyReturnedWithoutResubmission,
 } from '@/lib/assignments'
+import { loadTeacherOwnedAssignmentForGrade } from '@/lib/server/assignment-grades'
 import { isMissingAssignmentTeacherClearedAtColumnError } from '@/lib/server/assignments'
 
 export const dynamic = 'force-dynamic'
@@ -77,20 +78,11 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
 
   const supabase = getServiceRoleClient()
 
-  // Verify teacher owns this assignment
-  const { data: assignment, error: assignmentError } = await supabase
-    .from('assignments')
-    .select('*, classrooms!inner(teacher_id)')
-    .eq('id', id)
-    .single()
-
-  if (assignmentError || !assignment) {
-    return NextResponse.json({ error: 'Assignment not found' }, { status: 404 })
-  }
-
-  if (assignment.classrooms.teacher_id !== user.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
-  }
+  const assignment = await loadTeacherOwnedAssignmentForGrade({
+    supabase,
+    assignmentId: id,
+    teacherId: user.id,
+  })
 
   const { data: docs, error: docsError } = await supabase
     .from('assignment_docs')

--- a/src/lib/server/assignment-grades.ts
+++ b/src/lib/server/assignment-grades.ts
@@ -115,7 +115,8 @@ export async function loadTeacherOwnedAssignmentForGrade(opts: {
     .select(`
       *,
       classrooms!inner (
-        teacher_id
+        teacher_id,
+        archived_at
       )
     `)
     .eq('id', assignmentId)
@@ -127,6 +128,10 @@ export async function loadTeacherOwnedAssignmentForGrade(opts: {
 
   if (assignment.classrooms.teacher_id !== teacherId) {
     throw new ApiError(403, 'Unauthorized')
+  }
+
+  if (assignment.classrooms.archived_at) {
+    throw new ApiError(403, 'Classroom is archived')
   }
 
   return assignment

--- a/src/lib/server/repo-review.ts
+++ b/src/lib/server/repo-review.ts
@@ -37,3 +37,13 @@ export async function assertTeacherOwnsAssignment(teacherId: string, assignmentI
 
   return data as AssignmentWithClassroom
 }
+
+export async function assertTeacherCanMutateAssignment(teacherId: string, assignmentId: string): Promise<AssignmentWithClassroom> {
+  const assignment = await assertTeacherOwnsAssignment(teacherId, assignmentId)
+
+  if (assignment.classrooms.archived_at) {
+    throw new ApiError(403, 'Classroom is archived')
+  }
+
+  return assignment
+}

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,5 +1,5 @@
 import { format, parse } from 'date-fns'
-import { toZonedTime, fromZonedTime } from 'date-fns-tz'
+import { toZonedTime, fromZonedTime, formatInTimeZone } from 'date-fns-tz'
 
 const TIMEZONE = 'America/Toronto'
 
@@ -64,5 +64,5 @@ export function isOnTime(updatedAt: Date, dateString: string): boolean {
  * Gets today's date in Toronto timezone as YYYY-MM-DD
  */
 export function getTodayInToronto(): string {
-  return formatDateInToronto(nowInToronto())
+  return formatInTimeZone(new Date(), TIMEZONE, 'yyyy-MM-dd')
 }

--- a/tests/api/teacher/assignment-auto-grade-runs.test.ts
+++ b/tests/api/teacher/assignment-auto-grade-runs.test.ts
@@ -6,7 +6,8 @@ const { getAssignmentAiGradingRunSummary, tickAssignmentAiGradingRun } = vi.hois
   tickAssignmentAiGradingRun: vi.fn(),
 }))
 
-const { assertTeacherOwnsAssignment } = vi.hoisted(() => ({
+const { assertTeacherCanMutateAssignment, assertTeacherOwnsAssignment } = vi.hoisted(() => ({
+  assertTeacherCanMutateAssignment: vi.fn(),
   assertTeacherOwnsAssignment: vi.fn(),
 }))
 
@@ -15,6 +16,7 @@ vi.mock('@/lib/auth', () => ({
 }))
 
 vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherCanMutateAssignment,
   assertTeacherOwnsAssignment,
 }))
 
@@ -33,6 +35,11 @@ describe('assignment auto-grade run routes', () => {
       id: 'assignment-1',
       classroom_id: 'classroom-1',
       classrooms: { teacher_id: 'teacher-1' },
+    })
+    assertTeacherCanMutateAssignment.mockResolvedValue({
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+      classrooms: { teacher_id: 'teacher-1', archived_at: null },
     })
   })
 

--- a/tests/api/teacher/assignments-artifact-repo-run.test.ts
+++ b/tests/api/teacher/assignments-artifact-repo-run.test.ts
@@ -9,7 +9,7 @@ const {
   mockResolveAssignmentRepoTarget,
   mockSaveAssignmentRepoTarget,
   mockValidatePublicGitHubRepo,
-  mockAssertTeacherOwnsAssignment,
+  mockAssertTeacherCanMutateAssignment,
 } = vi.hoisted(() => ({
   mockSupabaseClient: { from: vi.fn() },
   mockAnalyzeRepoReviewAssignment: vi.fn(),
@@ -18,7 +18,7 @@ const {
   mockResolveAssignmentRepoTarget: vi.fn(),
   mockSaveAssignmentRepoTarget: vi.fn(),
   mockValidatePublicGitHubRepo: vi.fn(),
-  mockAssertTeacherOwnsAssignment: vi.fn(),
+  mockAssertTeacherCanMutateAssignment: vi.fn(),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -49,7 +49,7 @@ vi.mock('@/lib/server/assignment-repo-targets', () => ({
 }))
 
 vi.mock('@/lib/server/repo-review', () => ({
-  assertTeacherOwnsAssignment: mockAssertTeacherOwnsAssignment,
+  assertTeacherCanMutateAssignment: mockAssertTeacherCanMutateAssignment,
 }))
 
 import { POST } from '@/app/api/teacher/assignments/[id]/artifact-repo/run/route'
@@ -145,7 +145,7 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
     vi.clearAllMocks()
     mockSupabaseClient.from.mockReset()
     mockExtractRepoArtifactsFromContent.mockReturnValue([])
-    mockAssertTeacherOwnsAssignment.mockResolvedValue({
+    mockAssertTeacherCanMutateAssignment.mockResolvedValue({
       id: 'assignment-1',
       classroom_id: 'classroom-1',
       title: 'Repo review',

--- a/tests/api/teacher/assignments-auto-grade.test.ts
+++ b/tests/api/teacher/assignments-auto-grade.test.ts
@@ -11,8 +11,8 @@ const {
   markAssignmentDocMissingGrade: vi.fn(),
 }))
 
-const { assertTeacherOwnsAssignment } = vi.hoisted(() => ({
-  assertTeacherOwnsAssignment: vi.fn(),
+const { assertTeacherCanMutateAssignment } = vi.hoisted(() => ({
+  assertTeacherCanMutateAssignment: vi.fn(),
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -34,7 +34,7 @@ vi.mock('@/lib/server/assignment-ai-grading-runs', () => ({
 }))
 
 vi.mock('@/lib/server/repo-review', () => ({
-  assertTeacherOwnsAssignment,
+  assertTeacherCanMutateAssignment,
 }))
 
 import { POST } from '@/app/api/teacher/assignments/[id]/auto-grade/route'
@@ -79,7 +79,7 @@ function mockAutoGradeTables(opts: {
 describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    assertTeacherOwnsAssignment.mockResolvedValue({
+    assertTeacherCanMutateAssignment.mockResolvedValue({
       id: 'assignment-1',
       classroom_id: 'classroom-1',
       title: 'Portfolio Site',

--- a/tests/api/teacher/assignments-id-feedback-return.test.ts
+++ b/tests/api/teacher/assignments-id-feedback-return.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/assignments/[id]/feedback-return/route'
 
-const { appendAssignmentFeedbackEntry, assertTeacherOwnsAssignment } = vi.hoisted(() => ({
+const { appendAssignmentFeedbackEntry, assertTeacherCanMutateAssignment } = vi.hoisted(() => ({
   appendAssignmentFeedbackEntry: vi.fn(),
-  assertTeacherOwnsAssignment: vi.fn(),
+  assertTeacherCanMutateAssignment: vi.fn(),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -24,7 +24,7 @@ vi.mock('@/lib/server/assignment-feedback', () => ({
 }))
 
 vi.mock('@/lib/server/repo-review', () => ({
-  assertTeacherOwnsAssignment,
+  assertTeacherCanMutateAssignment,
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -33,7 +33,7 @@ describe('POST /api/teacher/assignments/[id]/feedback-return', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     appendAssignmentFeedbackEntry.mockResolvedValue({ id: 'entry-1' })
-    assertTeacherOwnsAssignment.mockResolvedValue({
+    assertTeacherCanMutateAssignment.mockResolvedValue({
       id: 'assignment-1',
       classroom_id: 'classroom-1',
     })

--- a/tests/api/teacher/assignments-id-grade.test.ts
+++ b/tests/api/teacher/assignments-id-grade.test.ts
@@ -139,6 +139,52 @@ describe('POST /api/teacher/assignments/[id]/grade', () => {
     expect(response.status).toBe(400)
   })
 
+  it('returns 403 when grading an assignment in an archived classroom', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: {
+                    teacher_id: 'teacher-1',
+                    archived_at: '2026-05-01T12:00:00.000Z',
+                  },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_id: 'student-1',
+        score_completion: 8,
+        score_thinking: 8,
+        score_workflow: 8,
+        feedback: 'Archived class',
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('Classroom is archived')
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+  })
+
   it('saves as draft when save_mode is draft (clears graded fields)', async () => {
     let capturedUpsertPayload: Record<string, unknown> | null = null
 

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -239,6 +239,48 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     )
   })
 
+  it('returns 403 when returning work from an archived classroom', async () => {
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: {
+                    teacher_id: 'teacher-1',
+                    archived_at: '2026-05-01T12:00:00.000Z',
+                  },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('Classroom is archived')
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+  })
+
   it('returns graded missing work even when it was never submitted', async () => {
     const docs = [
       {

--- a/tests/unit/server-repo-review.test.ts
+++ b/tests/unit/server-repo-review.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '@/lib/api-handler'
+
+const { mockSupabaseClient } = vi.hoisted(() => ({
+  mockSupabaseClient: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+import {
+  assertTeacherCanMutateAssignment,
+  assertTeacherOwnsAssignment,
+} from '@/lib/server/repo-review'
+
+function installAssignmentLookup(assignment: unknown) {
+  mockSupabaseClient.from.mockReturnValue({
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: assignment,
+          error: null,
+        }),
+      })),
+    })),
+  })
+}
+
+describe('assignment ownership guards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset()
+  })
+
+  it('allows read ownership checks for archived assignments', async () => {
+    const assignment = {
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+      classrooms: {
+        id: 'classroom-1',
+        title: 'Archived class',
+        teacher_id: 'teacher-1',
+        archived_at: '2026-05-01T12:00:00.000Z',
+      },
+    }
+    installAssignmentLookup(assignment)
+
+    await expect(assertTeacherOwnsAssignment('teacher-1', 'assignment-1')).resolves.toEqual(assignment)
+  })
+
+  it('rejects mutation checks for archived assignments', async () => {
+    installAssignmentLookup({
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+      classrooms: {
+        id: 'classroom-1',
+        title: 'Archived class',
+        teacher_id: 'teacher-1',
+        archived_at: '2026-05-01T12:00:00.000Z',
+      },
+    })
+
+    await expect(assertTeacherCanMutateAssignment('teacher-1', 'assignment-1')).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Classroom is archived',
+    } satisfies Partial<ApiError>)
+  })
+})

--- a/tests/unit/timezone.test.ts
+++ b/tests/unit/timezone.test.ts
@@ -4,6 +4,7 @@ import { isOnTime, formatDateInToronto, getTodayInToronto, nowInToronto } from '
 describe('timezone utilities', () => {
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllEnvs()
   })
 
   describe('isOnTime', () => {
@@ -84,6 +85,14 @@ describe('timezone utilities', () => {
       const now = nowInToronto()
       expect(now).toBeInstanceOf(Date)
       expect(getTodayInToronto()).toBe('2024-11-15')
+    })
+
+    it('should return the Toronto date on a UTC host without double-converting', () => {
+      vi.stubEnv('TZ', 'UTC')
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-11-16T05:30:00Z')) // 2024-11-16 00:30 in Toronto (UTC-5)
+
+      expect(getTodayInToronto()).toBe('2024-11-16')
     })
   })
 })


### PR DESCRIPTION
## Summary
- fix Toronto date calculation so UTC-hosted runtimes do not return yesterday near midnight
- block teacher secondary assignment mutations when the classroom is archived
- cover archived assignment guards and the UTC-host date regression with focused tests

## Verification
- pnpm test tests/unit/timezone.test.ts tests/unit/server-repo-review.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts
- pnpm test tests/api/teacher
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm lint
- pnpm test
- pnpm build