### PR TITLE
[codex] Clean up gradebook font weights

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,19 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-23 — Draft question sync helper
-
-**Completed:**
-- Refactored quiz/test draft question syncing to use a shared helper in `src/lib/server/assessment-drafts.ts` (keeps behavior + error strings the same, reduces drift risk).
-- Added unit coverage for the quiz sync insert-failure path.
-- Draft PR: https://github.com/codepetca/pika/pull/619
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/unit/assessment-drafts.test.ts`
-- `pnpm test`
-- `pnpm lint`
-
 ## 2026-05-22 — Gradebook identity column fixes
 
 **Completed:**
@@ -387,3 +374,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-05-26 — Gradebook assessment font weight cleanup
+
+**Completed:**
+- Reduced gradebook assessment column labels, score cells, summary score cells, and selected-student assessment detail rows to regular font weight.
+- Kept student names and final marks emphasized so the gradebook still has clear scan anchors.
+
+**Validation:**
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
+- Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-detail.png`, `/tmp/pika-teacher-dark.png`

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -438,10 +438,10 @@ function StudentAssessmentPanel({
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="rounded-sm bg-surface-2 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-text-default">
+                        <span className="rounded-sm bg-surface-2 px-1.5 py-0.5 text-xs font-normal tabular-nums text-text-default">
                           {column.code}
                         </span>
-                        <span className="truncate text-sm font-semibold text-text-default" title={column.title}>
+                        <span className="truncate text-sm font-normal text-text-default" title={column.title}>
                           {column.title}
                         </span>
                       </div>
@@ -460,7 +460,7 @@ function StudentAssessmentPanel({
                     </div>
                     <div className="shrink-0 text-right">
                       <div className={[
-                        'text-sm font-semibold tabular-nums',
+                        'text-sm font-normal tabular-nums',
                         cell?.is_graded ? 'text-text-default' : 'text-text-muted',
                       ].join(' ')}>
                         {primaryScore}
@@ -1026,7 +1026,7 @@ function AssessmentMatrixTable({
                       <span
                         tabIndex={0}
                         className={[
-                          'inline-flex min-h-10 min-w-12 flex-col items-center justify-center rounded-sm px-1.5 py-0.5 font-semibold tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                          'inline-flex min-h-10 min-w-12 flex-col items-center justify-center rounded-sm px-1.5 py-0.5 font-normal tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-primary',
                           column.is_draft || !column.include_in_final
                             ? 'text-text-muted'
                             : 'text-text-default',
@@ -1038,7 +1038,7 @@ function AssessmentMatrixTable({
                         ].filter(Boolean).join(', ')}
                       >
                         <span>{column.code}</span>
-                        <span className="mt-0.5 min-h-3 text-[10px] font-medium leading-none text-text-muted">
+                        <span className="mt-0.5 min-h-3 text-[10px] font-normal leading-none text-text-muted">
                           {!hidden && column.due_at ? formatTorontoDateShort(column.due_at) : ''}
                         </span>
                       </span>
@@ -1119,7 +1119,7 @@ function AssessmentMatrixTable({
                         <span
                           className={[
                             'block truncate text-sm',
-                            column.key === 'id' || hidden ? '' : 'font-medium text-text-default',
+                            column.key === 'id' || hidden ? '' : 'font-semibold text-text-default',
                           ].join(' ')}
                           title={value === '—' ? undefined : value}
                         >
@@ -1139,7 +1139,7 @@ function AssessmentMatrixTable({
                       >
                         <span
                           className={[
-                            cell?.is_graded ? 'font-semibold' : '',
+                            'font-normal',
                             hidden || !cell?.is_graded ? 'text-text-muted' : 'text-text-default',
                           ].join(' ')}
                         >
@@ -1214,7 +1214,7 @@ function AssessmentMatrixTable({
                           key={`average:${column.assessment_type}:${column.assessment_id}`}
                           align="center"
                           className={[
-                            'min-w-16 px-2 text-xs font-semibold tabular-nums',
+                            'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
                             hidden ? 'text-text-muted' : 'text-text-default',
                           ].join(' ')}
@@ -1278,7 +1278,7 @@ function AssessmentMatrixTable({
                           key={`median:${column.assessment_type}:${column.assessment_id}`}
                           align="center"
                           className={[
-                            'min-w-16 px-2 text-xs font-semibold tabular-nums',
+                            'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
                             hidden ? 'text-text-muted' : 'text-text-default',
                           ].join(' ')}


### PR DESCRIPTION
## Summary

- Reduced gradebook assessment labels, score cells, summary score cells, and selected-student assessment detail rows to regular font weight.
- Kept student names and final marks emphasized so the gradebook still has clear scan anchors.
- Updated the AI session log and trimmed it per repo workflow.

## Validation

- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-detail.png`, `/tmp/pika-teacher-dark.png`