### PR TITLE
[codex] Show labels in mobile nav drawer

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,18 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-23 — Gradebook Final column separator
-
-**Completed:**
-- Added a strong separator before the Final grade column across gradebook header, student, and summary rows.
-- Covered the separator with focused gradebook component expectations.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=gradebook'`
-
 ## 2026-05-23 — Gradebook Final column resize
 
 **Completed:**
@@ -389,3 +377,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-05-26 — Mobile navigation drawer labels
+
+**Completed:**
+- Made the classroom mobile navigation drawer show tab labels beside icons even when the persisted desktop left rail is collapsed.
+- Kept desktop collapsed-rail behavior icon-only with screen-reader labels and tooltips.
+- Closed mobile drawer state when the viewport crosses to the desktop breakpoint so stale mobile state cannot affect the desktop rail.
+- Added NavItems regression coverage for mobile-open labels and desktop-collapsed hidden labels.
+
+**Validation:**
+- `pnpm test tests/components/NavItems.test.tsx`
+- `pnpm test tests/components/NavItems.test.tsx tests/components/ThreePanelProvider.test.tsx`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861"`
+- Playwright mobile drawer assertions for teacher and student labels.
+- Screenshots: `/tmp/pika-teacher-mobile-menu.png`, `/tmp/pika-student-mobile-menu.png`
+- `pnpm lint`
+- `pnpm test`

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -121,8 +121,9 @@ export function NavItems({
   updateSearchParams,
 }: NavItemsProps) {
   const { isExpanded } = useLeftSidebar()
-  const { close: closeMobileDrawer } = useMobileDrawer()
+  const { isLeftOpen, close: closeMobileDrawer } = useMobileDrawer()
   const notifications = useStudentNotifications()
+  const showLabels = isExpanded || isLeftOpen
 
   // Compute pulse states for student tabs
   const showTodayPulse =
@@ -195,7 +196,7 @@ export function NavItems({
         const isActive = activeTab === item.id
         const Icon = item.icon
         const href = tabHref(classroomId, item.id)
-        const layoutClass = getLayoutClass(!isExpanded)
+        const layoutClass = getLayoutClass(!showLabels)
 
         // Regular nav items
         const shouldPulse =
@@ -235,12 +236,12 @@ export function NavItems({
             ].join(' ')}
           >
             <NavIconWithDot Icon={Icon} showDot={shouldPulse} />
-            {isExpanded && <span className="truncate">{item.label}</span>}
-            {!isExpanded && <span className="sr-only">{item.label}</span>}
+            {showLabels && <span className="truncate">{item.label}</span>}
+            {!showLabels && <span className="sr-only">{item.label}</span>}
           </a>
         )
 
-        return !isExpanded ? (
+        return !showLabels ? (
           <Tooltip key={item.id} content={item.label}>{navLink}</Tooltip>
         ) : (
           <span key={item.id}>{navLink}</span>

--- a/src/components/layout/ThreePanelProvider.tsx
+++ b/src/components/layout/ThreePanelProvider.tsx
@@ -119,6 +119,12 @@ export function ThreePanelProvider({
     return () => window.removeEventListener('resize', checkDesktop)
   }, [])
 
+  useEffect(() => {
+    if (!isDesktop) return
+    setMobileLeftOpen(false)
+    setMobileRightOpen(false)
+  }, [isDesktop])
+
   // Force right sidebar open on desktop when desktopAlwaysOpen is true
   const desktopAlwaysOpen = config.rightSidebar.desktopAlwaysOpen ?? false
   const effectiveRightOpen = desktopAlwaysOpen && isDesktop ? true : rightOpen
@@ -167,6 +173,8 @@ export function ThreePanelProvider({
     setMobileLeftOpen(false)
     setMobileRightOpen(false)
   }, [])
+  const effectiveMobileLeftOpen = mobileLeftOpen && !isDesktop
+  const effectiveMobileRightOpen = mobileRightOpen && !isDesktop
 
   // Calculate CSS widths
   const widths = useMemo(() => {
@@ -206,8 +214,8 @@ export function ThreePanelProvider({
       routeKey,
       widths,
       mobileDrawer: {
-        isLeftOpen: mobileLeftOpen,
-        isRightOpen: mobileRightOpen,
+        isLeftOpen: effectiveMobileLeftOpen,
+        isRightOpen: effectiveMobileRightOpen,
         openLeft: openMobileLeft,
         openRight: openMobileRight,
         close: closeMobileDrawer,
@@ -226,8 +234,8 @@ export function ThreePanelProvider({
       config,
       routeKey,
       widths,
-      mobileLeftOpen,
-      mobileRightOpen,
+      effectiveMobileLeftOpen,
+      effectiveMobileRightOpen,
       openMobileLeft,
       openMobileRight,
       closeMobileDrawer,

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -12,10 +12,12 @@ type MockNotifications = {
 }
 
 let mockNotifications: MockNotifications | null = null
+let mockLeftSidebarExpanded = true
+let mockMobileLeftOpen = false
 
 vi.mock('@/components/layout/ThreePanelProvider', () => ({
-  useLeftSidebar: () => ({ isExpanded: true }),
-  useMobileDrawer: () => ({ close: vi.fn() }),
+  useLeftSidebar: () => ({ isExpanded: mockLeftSidebarExpanded }),
+  useMobileDrawer: () => ({ isLeftOpen: mockMobileLeftOpen, close: vi.fn() }),
 }))
 
 vi.mock('@/components/StudentNotificationsProvider', () => ({
@@ -56,6 +58,8 @@ function renderNav(role: 'student' | 'teacher', activeTab = 'today') {
 describe('NavItems notification dots', () => {
   beforeEach(() => {
     mockNotifications = baseNotifications()
+    mockLeftSidebarExpanded = true
+    mockMobileLeftOpen = false
   })
 
   it('shows dot and aria-label suffix for student today tab with new activity', () => {
@@ -98,6 +102,34 @@ describe('NavItems notification dots', () => {
     expect(assignmentsLink).not.toHaveAttribute('aria-expanded')
     expect(screen.getAllByRole('link', { name: 'Classwork' })).toHaveLength(1)
     expect(screen.queryByRole('button', { name: /assignment/i })).toBeNull()
+  })
+
+  it('shows nav labels in the mobile drawer when the desktop rail is collapsed', () => {
+    mockLeftSidebarExpanded = false
+    mockMobileLeftOpen = true
+
+    renderNav('teacher', 'attendance')
+
+    const dailyLabel = screen.getByText('Daily')
+    const dailyLink = screen.getByRole('link', { name: 'Daily' })
+
+    expect(dailyLabel).not.toHaveClass('sr-only')
+    expect(dailyLink).toHaveClass('gap-3')
+    expect(dailyLink).toHaveClass('px-3')
+    expect(dailyLink).not.toHaveClass('justify-center')
+  })
+
+  it('keeps nav labels visually hidden when the desktop rail is collapsed', () => {
+    mockLeftSidebarExpanded = false
+
+    renderNav('teacher', 'attendance')
+
+    const dailyLabel = screen.getByText('Daily')
+    const dailyLink = screen.getByRole('link', { name: 'Daily' })
+
+    expect(dailyLabel).toHaveClass('sr-only')
+    expect(dailyLink).toHaveClass('justify-center')
+    expect(dailyLink).not.toHaveClass('gap-3')
   })
 
   it('renders student assignments as a plain nav item instead of a nested assignment list', () => {

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act } from '@testing-library/react'
 import { useState } from 'react'
 import {
   ThreePanelProvider,
+  useMobileDrawer,
   useRightSidebar,
 } from '@/components/layout/ThreePanelProvider'
 import type { RouteKey } from '@/lib/layout-config'
@@ -41,6 +42,26 @@ function SidebarStatus() {
       <span data-testid="open">{String(isOpen)}</span>
     </div>
   )
+}
+
+function MobileDrawerStatus() {
+  const { isLeftOpen, openLeft } = useMobileDrawer()
+
+  return (
+    <div>
+      <button onClick={openLeft}>open-left-drawer</button>
+      <span data-testid="mobile-left-open">{String(isLeftOpen)}</span>
+    </div>
+  )
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  window.dispatchEvent(new Event('resize'))
 }
 
 describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
@@ -149,5 +170,27 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
 
     expect(screen.getByTestId('enabled').textContent).toBe('false')
     expect(screen.getByTestId('open').textContent).toBe('false')
+  })
+
+  it('closes mobile drawer state when crossing to the desktop breakpoint', () => {
+    act(() => {
+      setViewportWidth(390)
+    })
+
+    render(
+      <ThreePanelProvider routeKey="attendance" initialLeftExpanded={false}>
+        <MobileDrawerStatus />
+      </ThreePanelProvider>,
+    )
+
+    act(() => {
+      screen.getByText('open-left-drawer').click()
+    })
+    expect(screen.getByTestId('mobile-left-open').textContent).toBe('true')
+
+    act(() => {
+      setViewportWidth(1024)
+    })
+    expect(screen.getByTestId('mobile-left-open').textContent).toBe('false')
   })
 })


### PR DESCRIPTION
## Summary

- Show classroom nav labels in the mobile drawer even when the persisted desktop sidebar is collapsed.
- Keep the desktop collapsed rail icon-only with screen-reader labels and tooltips.
- Close/mask mobile drawer state at the desktop breakpoint so stale mobile state cannot affect the desktop rail.
- Add regression coverage for mobile-open nav labels, desktop-collapsed hidden labels, and breakpoint drawer cleanup.

## Root Cause

The mobile drawer reused `NavItems`, but `NavItems` only looked at the persisted left-sidebar expanded state. When that desktop state was collapsed, the mobile drawer also rendered the collapsed icon-only layout despite having enough drawer width for labels.

## Validation

- `pnpm test tests/components/NavItems.test.tsx`
- `pnpm test tests/components/NavItems.test.tsx tests/components/ThreePanelProvider.test.tsx`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861"`
- Playwright mobile drawer assertions for visible teacher and student labels
- Screenshots: `/tmp/pika-teacher-mobile-menu.png`, `/tmp/pika-student-mobile-menu.png`
- `pnpm lint`
- `pnpm test`
