### PR TITLE
Guard returned assignment unsubmit state

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-22 — Gradebook identity column fixes
-
-**Completed:**
-- Defaulted the gradebook ID column to hidden while keeping it available in settings.
-- Added a strong separator after the last rendered identity column, including the First-only case.
-- Replaced fixed identity widths/sticky offsets with resizable First, Last, and ID column widths.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm test`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=gradebook'`
-- Playwright first-only separator and drag check on the seeded gradebook page
-
 ## 2026-05-23 — Gradebook Final column separator
 
 **Completed:**
@@ -387,3 +371,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
 - Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-detail.png`, `/tmp/pika-teacher-dark.png`
+
+## 2026-05-26 — Assignment unsubmit return-state guard
+
+**Completed:**
+- Added a shared assignment rule that only allows student unsubmit before the first teacher return.
+- Blocked `/api/assignment-docs/[id]/unsubmit` from clearing submitted state after returned work, preserving teacher return queues for returned/resubmitted cycles.
+- Updated student assignment action bars to hide `Unsubmit` when the returned submission state is no longer mutable.
+- Moved repeated student assignment reads through `fetchJSONWithCache` with zero TTL so the audit pattern is satisfied without caching the first-view side effect.
+
+**Validation:**
+- `pnpm test tests/api/assignment-docs/unsubmit.test.ts tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm test tests/api/assignment-docs tests/api/student/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignments.test.ts`
+- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a'`
+- Visual follow-up screenshots: `/tmp/pika-student-assignment-returned.png`, `/tmp/pika-teacher-assignment-loaded.png`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/api/assignment-docs/[id]/unsubmit/route.ts
+++ b/src/app/api/assignment-docs/[id]/unsubmit/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
-import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
+import { canUnsubmitAssignmentDoc, isAssignmentVisibleToStudents } from '@/lib/assignments'
 import { parseContentField } from '@/lib/tiptap-content'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { TiptapContent } from '@/types'
@@ -48,7 +48,7 @@ export const POST = withErrorHandler('PostAssignmentDocUnsubmit', async (request
   // Fetch doc first to enforce ownership
   const { data: existingDoc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id')
+    .select('id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -65,6 +65,20 @@ export const POST = withErrorHandler('PostAssignmentDocUnsubmit', async (request
     return NextResponse.json(
       { error: 'Failed to fetch assignment doc' },
       { status: 500 }
+    )
+  }
+
+  if (!existingDoc.is_submitted) {
+    return NextResponse.json(
+      { error: 'Assignment is not submitted' },
+      { status: 400 }
+    )
+  }
+
+  if (!canUnsubmitAssignmentDoc(existingDoc)) {
+    return NextResponse.json(
+      { error: 'Returned submissions cannot be unsubmitted' },
+      { status: 400 }
     )
   }
 

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -52,7 +52,12 @@ export function StudentAssignmentsTab({
   const [hasLoaded, setHasLoaded] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
-  const [editorState, setEditorState] = useState({ isSubmitted: false, canSubmit: false, submitting: false })
+  const [editorState, setEditorState] = useState({
+    isSubmitted: false,
+    canSubmit: false,
+    canUnsubmit: false,
+    submitting: false,
+  })
   const editorRef = useRef<StudentAssignmentEditorHandle>(null)
   const wasActiveRef = useRef(isActive)
   const showBlockingSpinner = useDelayedBusy(
@@ -259,16 +264,18 @@ export function StudentAssignmentsTab({
             </div>
           }
           trailing={
-            <Button
-              size="sm"
-              variant={editorState.isSubmitted ? 'secondary' : 'primary'}
-              onClick={editorState.isSubmitted ? handleUnsubmit : handleSubmit}
-              disabled={editorState.submitting || (!editorState.isSubmitted && !editorState.canSubmit)}
-            >
-              {editorState.submitting
-                ? (editorState.isSubmitted ? 'Unsubmitting...' : 'Submitting...')
-                : (editorState.isSubmitted ? 'Unsubmit' : 'Submit')}
-            </Button>
+            !editorState.isSubmitted || editorState.canUnsubmit ? (
+              <Button
+                size="sm"
+                variant={editorState.isSubmitted ? 'secondary' : 'primary'}
+                onClick={editorState.isSubmitted ? handleUnsubmit : handleSubmit}
+                disabled={editorState.submitting || (!editorState.isSubmitted && !editorState.canSubmit)}
+              >
+                {editorState.submitting
+                  ? (editorState.isSubmitted ? 'Unsubmitting...' : 'Submitting...')
+                  : (editorState.isSubmitted ? 'Unsubmit' : 'Submit')}
+              </Button>
+            ) : null
           }
         />
       ) : selectedMaterial ? (

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -14,11 +14,13 @@ import {
   formatAssignmentTiming,
   formatDueDate,
   calculateAssignmentStatus,
+  canUnsubmitAssignmentDoc,
   getAssignmentStatusLabel,
   getAssignmentStatusBadgeClass,
   hasAssignmentSubmissionContent,
 } from '@/lib/assignments'
 import { reconstructAssignmentDocContent } from '@/lib/assignment-doc-history'
+import { fetchJSONWithCache } from '@/lib/request-cache'
 import { formatInTimeZone } from 'date-fns-tz'
 import { HistoryList } from '@/components/HistoryList'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
@@ -43,6 +45,7 @@ export interface StudentAssignmentEditorHandle {
   unsubmit: () => Promise<void>
   isSubmitted: boolean
   canSubmit: boolean
+  canUnsubmit: boolean
   submitting: boolean
 }
 
@@ -51,7 +54,21 @@ interface Props {
   assignmentId: string
   variant?: 'standalone' | 'embedded'
   onExit?: () => void
-  onStateChange?: (state: { isSubmitted: boolean; canSubmit: boolean; submitting: boolean }) => void
+  onStateChange?: (state: { isSubmitted: boolean; canSubmit: boolean; canUnsubmit: boolean; submitting: boolean }) => void
+}
+
+type AssignmentDocResponse = {
+  assignment: Assignment
+  doc: AssignmentDoc | null
+  feedback_entries?: AssignmentFeedbackEntry[]
+  submission_requirements?: AssignmentSubmissionRequirement[]
+  submission_artifacts?: AssignmentSubmissionArtifact[]
+  github_identity?: UserGitHubIdentity | null
+  wasFirstView?: boolean
+}
+
+type AssignmentDocHistoryResponse = {
+  history?: AssignmentDocHistoryEntry[]
 }
 
 export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle, Props>(function StudentAssignmentEditor({
@@ -105,12 +122,20 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     setLoading(true)
     setError('')
     try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}`)
-      const data = await response.json()
+      const data = await fetchJSONWithCache<AssignmentDocResponse>(
+        `assignment-doc:${assignmentId}`,
+        async () => {
+          const response = await fetch(`/api/assignment-docs/${assignmentId}`)
+          const data = await response.json()
 
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to load assignment')
-      }
+          if (!response.ok) {
+            throw new Error(data.error || 'Failed to load assignment')
+          }
+
+          return data
+        },
+        0,
+      )
 
       setAssignment(data.assignment)
       setDoc(data.doc)
@@ -137,11 +162,18 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     setHistoryLoading(true)
     setHistoryError('')
     try {
-      const response = await fetch(`/api/assignment-docs/${assignmentId}/history`)
-      const data = await response.json()
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to load history')
-      }
+      const data = await fetchJSONWithCache<AssignmentDocHistoryResponse>(
+        `assignment-doc-history:${assignmentId}`,
+        async () => {
+          const response = await fetch(`/api/assignment-docs/${assignmentId}/history`)
+          const data = await response.json()
+          if (!response.ok) {
+            throw new Error(data.error || 'Failed to load history')
+          }
+          return data
+        },
+        0,
+      )
       setHistoryEntries(data.history || [])
     } catch (err: any) {
       setHistoryError(err.message || 'Failed to load history')
@@ -425,6 +457,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
   const hasStructuredSubmissionArtifact = submissionArtifacts.some(isSubmissionArtifactPresent)
   const structuredRequirementsSatisfied = submissionRequirements.length === 0 || submissionCompletion.canSubmit
   const isSubmitted = doc?.is_submitted || false
+  const canUnsubmit = canUnsubmitAssignmentDoc(doc)
   const canSubmit = (
     hasAssignmentSubmissionContent({ content }) || hasStructuredSubmissionArtifact
   ) && structuredRequirementsSatisfied && !previewEntry
@@ -435,13 +468,14 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
     unsubmit: handleUnsubmit,
     isSubmitted,
     canSubmit,
+    canUnsubmit,
     submitting,
-  }), [handleSubmit, handleUnsubmit, isSubmitted, canSubmit, submitting])
+  }), [handleSubmit, handleUnsubmit, isSubmitted, canSubmit, canUnsubmit, submitting])
 
   // Notify parent of state changes
   useEffect(() => {
-    onStateChange?.({ isSubmitted, canSubmit, submitting })
-  }, [isSubmitted, canSubmit, submitting, onStateChange])
+    onStateChange?.({ isSubmitted, canSubmit, canUnsubmit, submitting })
+  }, [isSubmitted, canSubmit, canUnsubmit, submitting, onStateChange])
 
   if (loading) {
     if (isEmbedded) {
@@ -862,15 +896,15 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
               <span className={`px-3 py-1 rounded text-sm font-medium ${getAssignmentStatusBadgeClass(status)}`}>
                 {getAssignmentStatusLabel(status)}
               </span>
-              {isSubmitted ? (
+              {canUnsubmit ? (
                 <Button size="sm" onClick={handleUnsubmit} variant="secondary" disabled={submitting || !!previewEntry}>
                   {submitting ? 'Unsubmitting...' : 'Unsubmit'}
                 </Button>
-              ) : (
+              ) : !isSubmitted ? (
                 <Button size="sm" onClick={handleSubmit} disabled={submitting || !canSubmit}>
                   {submitting ? 'Submitting...' : 'Submit'}
                 </Button>
-              )}
+              ) : null}
             </div>
           </div>
         }

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -113,6 +113,14 @@ export function isAssignmentAlreadyReturnedWithoutResubmission(
   return new Date(doc.submitted_at).getTime() <= new Date(fullReturnAt).getTime()
 }
 
+export function canUnsubmitAssignmentDoc(
+  doc: AssignmentReturnDoc | null | undefined
+): boolean {
+  if (!doc?.is_submitted) return false
+
+  return !getAssignmentFullReturnAt(doc)
+}
+
 /**
  * Calculate the status of an assignment for a student
  *

--- a/tests/api/assignment-docs/unsubmit.test.ts
+++ b/tests/api/assignment-docs/unsubmit.test.ts
@@ -94,7 +94,15 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
           select: vi.fn(() => ({
             eq: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({
-              data: { id: 'doc-1', student_id: 'student-1', assignment_id: 'assign-1' },
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                assignment_id: 'assign-1',
+                is_submitted: true,
+                submitted_at: '2026-05-01T12:00:00.000Z',
+                returned_at: null,
+                teacher_cleared_at: null,
+              },
               error: null,
             }),
           })),
@@ -119,5 +127,55 @@ describe('POST /api/assignment-docs/[id]/unsubmit', () => {
 
     const response = await POST(request, { params: { id: 'assign-1' } })
     expect(response.status).toBe(200)
+  })
+
+  it('rejects unsubmit after a returned assignment has been resubmitted', async () => {
+    const update = vi.fn()
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'doc-1',
+                student_id: 'student-1',
+                assignment_id: 'assign-1',
+                is_submitted: true,
+                submitted_at: '2026-05-02T12:00:00.000Z',
+                returned_at: '2026-05-01T12:00:00.000Z',
+                teacher_cleared_at: '2026-05-01T12:00:00.000Z',
+              },
+              error: null,
+            }),
+          })),
+          update,
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/unsubmit', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: { id: 'assign-1' } })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('Returned submissions cannot be unsubmitted')
+    expect(update).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -8,6 +8,12 @@ import type { Classroom, AssignmentWithStatus, ClassworkMaterial } from '@/types
 
 const mockPush = vi.fn()
 let searchParamsMap = new Map<string, string>()
+let mockEditorState = {
+  isSubmitted: false,
+  canSubmit: false,
+  canUnsubmit: false,
+  submitting: false,
+}
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
@@ -26,12 +32,10 @@ vi.mock('@/components/StudentAssignmentEditor', () => ({
     useImperativeHandle(ref, () => ({
       submit: vi.fn(),
       unsubmit: vi.fn(),
-      isSubmitted: false,
-      canSubmit: false,
-      submitting: false,
+      ...mockEditorState,
     }))
     useEffect(() => {
-      props.onStateChange?.({ isSubmitted: false, canSubmit: false, submitting: false })
+      props.onStateChange?.(mockEditorState)
     }, [props.onStateChange])
     return <div data-testid="student-editor">Editor</div>
   }),
@@ -114,6 +118,12 @@ describe('StudentAssignmentsTab', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
     searchParamsMap = new Map()
+    mockEditorState = {
+      isSubmitted: false,
+      canSubmit: false,
+      canUnsubmit: false,
+      submitting: false,
+    }
     mockPush.mockClear()
   })
 
@@ -240,6 +250,45 @@ describe('StudentAssignmentsTab', () => {
       expect(screen.getByRole('button', { name: 'Instructions' })).toBeInTheDocument()
     })
     expect(screen.queryByRole('button', { name: 'Repo' })).not.toBeInTheDocument()
+  })
+
+  it('hides Unsubmit after submitted work has been returned', async () => {
+    mockEditorState = {
+      isSubmitted: true,
+      canSubmit: false,
+      canUnsubmit: false,
+      submitting: false,
+    }
+    const viewed = makeAssignment({
+      doc: {
+        id: 'doc-1',
+        assignment_id: 'asgn-1',
+        student_id: 'stu-1',
+        content: { type: 'doc', content: [] },
+        is_submitted: true,
+        submitted_at: '2024-10-23T12:00:00Z',
+        returned_at: '2024-10-22T12:00:00Z',
+        teacher_cleared_at: '2024-10-22T12:00:00Z',
+        viewed_at: '2024-06-01T00:00:00Z',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      } as any,
+    })
+    searchParamsMap.set('assignmentId', 'asgn-1')
+    mockFetchAssignments([viewed])
+
+    render(
+      <StudentAssignmentsTab
+        classroom={classroom}
+        selectedAssignmentId={searchParamsMap.get('assignmentId') ?? null}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Instructions' })).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Unsubmit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument()
   })
 
   it('renders materials and assignments in shared classwork order', async () => {

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
+  canUnsubmitAssignmentDoc,
   calculateAssignmentStatus,
   calculateAssignmentStats,
   getAssignmentStatusLabel,
@@ -841,6 +842,24 @@ describe('assignment utilities', () => {
 
     it('does not treat resubmitted work as already returned', () => {
       expect(isAssignmentAlreadyReturnedWithoutResubmission({
+        is_submitted: true,
+        submitted_at: '2026-04-21T12:00:00.000Z',
+        returned_at: '2026-04-20T13:00:00.000Z',
+        teacher_cleared_at: '2026-04-20T13:00:00.000Z',
+      })).toBe(false)
+    })
+
+    it('allows unsubmit before the first teacher return', () => {
+      expect(canUnsubmitAssignmentDoc({
+        is_submitted: true,
+        submitted_at: '2026-04-20T12:00:00.000Z',
+        returned_at: null,
+        teacher_cleared_at: null,
+      })).toBe(true)
+    })
+
+    it('blocks unsubmit after a teacher return, including resubmitted work', () => {
+      expect(canUnsubmitAssignmentDoc({
         is_submitted: true,
         submitted_at: '2026-04-21T12:00:00.000Z',
         returned_at: '2026-04-20T13:00:00.000Z',


### PR DESCRIPTION
## Summary
- add a shared assignment rule that only allows student unsubmit before teacher return
- block unsubmit from clearing returned/resubmitted assignment docs and hiding teacher return queues
- hide student Unsubmit controls when the returned submission state is no longer mutable
- move repeated student assignment reads through fetchJSONWithCache with zero TTL for first-view freshness

## Verification
- pnpm test tests/api/assignment-docs/unsubmit.test.ts tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx
- pnpm test tests/api/assignment-docs tests/api/student/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignments.test.ts
- E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a"
- Visual follow-up screenshots: /tmp/pika-student-assignment-returned.png, /tmp/pika-teacher-assignment-loaded.png
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm lint
- pnpm test
- pnpm build