### PR TITLE
[codex] Standardize remaining API route handlers

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,18 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-23 — Gradebook Final column separator
-
-**Completed:**
-- Added a strong separator before the Final grade column across gradebook header, student, and summary rows.
-- Covered the separator with focused gradebook component expectations.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=gradebook'`
-
 ## 2026-05-23 — Gradebook Final column resize
 
 **Completed:**
@@ -355,6 +343,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/timezone.test.ts tests/unit/server-repo-review.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
 - `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-id-students-studentId.test.ts`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — API route error-handler drift cleanup
+
+**Completed:**
+- Migrated the classroom reorder route and test clear-open-grades route from manual `try/catch` blocks to `withErrorHandler`.
+- Preserved existing validation, access, and database error response behavior while centralizing auth/unknown error handling.
+- Added a unit standards test that scans every API `route.ts` export and fails on unwrapped HTTP handlers, while allowing aliases to already wrapped handlers.
+
+**Validation:**
+- `pnpm test tests/api/teacher/tests-clear-open-grades.test.ts tests/api/teacher/classrooms-reorder.test.ts tests/unit/api-route-standards.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm tsc --noEmit`
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`

--- a/src/app/api/teacher/classrooms/reorder/route.ts
+++ b/src/app/api/teacher/classrooms/reorder/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { withErrorHandler } from '@/lib/api-handler'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { getNextTeacherClassroomPosition } from '@/lib/server/classroom-order'
@@ -8,76 +9,63 @@ export const revalidate = 0
 
 // POST /api/teacher/classrooms/reorder
 // body: { classroom_ids: string[] }
-export async function POST(request: NextRequest) {
-  try {
-    const user = await requireRole('teacher')
-    const body = await request.json()
-    const { classroom_ids } = body as {
-      classroom_ids?: string[]
-    }
-
-    if (!Array.isArray(classroom_ids)) {
-      return NextResponse.json({ error: 'classroom_ids is required' }, { status: 400 })
-    }
-
-    const uniqueIds = Array.from(new Set(classroom_ids.filter(Boolean)))
-    if (uniqueIds.length !== classroom_ids.length) {
-      return NextResponse.json({ error: 'classroom_ids must be unique' }, { status: 400 })
-    }
-
-    const supabase = getServiceRoleClient()
-    const hasPositionColumn = await getNextTeacherClassroomPosition(supabase, user.id)
-    if (hasPositionColumn === null) {
-      return NextResponse.json(
-        { error: 'Apply the classroom ordering migration before reordering classrooms' },
-        { status: 409 }
-      )
-    }
-
-    const { data: classrooms, error: classroomsError } = await supabase
-      .from('classrooms')
-      .select('id')
-      .eq('teacher_id', user.id)
-      .is('archived_at', null)
-
-    if (classroomsError) {
-      console.error('Error verifying classrooms:', classroomsError)
-      return NextResponse.json({ error: 'Failed to verify classrooms' }, { status: 500 })
-    }
-
-    const activeIds = (classrooms || []).map((classroom) => classroom.id)
-    const activeIdSet = new Set(activeIds)
-
-    if (uniqueIds.length !== activeIds.length || uniqueIds.some((id) => !activeIdSet.has(id))) {
-      return NextResponse.json(
-        { error: 'classroom_ids must include every active classroom exactly once' },
-        { status: 400 }
-      )
-    }
-
-    const results = await Promise.all(
-      uniqueIds.map((id, index) =>
-        supabase.from('classrooms').update({ position: index }).eq('id', id)
-      )
-    )
-    const updateError = results.find((r) => r.error)?.error ?? null
-
-    if (updateError) {
-      console.error('Error reordering classrooms:', updateError)
-      return NextResponse.json({ error: 'Failed to reorder classrooms' }, { status: 500 })
-    }
-
-    return NextResponse.json({ success: true })
-  } catch (error: any) {
-    if (error.name === 'AuthenticationError') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    if (error.name === 'AuthorizationError') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-
-    console.error('Reorder classrooms error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+export const POST = withErrorHandler('PostTeacherClassroomsReorder', async (request: NextRequest) => {
+  const user = await requireRole('teacher')
+  const body = await request.json()
+  const { classroom_ids } = body as {
+    classroom_ids?: string[]
   }
-}
+
+  if (!Array.isArray(classroom_ids)) {
+    return NextResponse.json({ error: 'classroom_ids is required' }, { status: 400 })
+  }
+
+  const uniqueIds = Array.from(new Set(classroom_ids.filter(Boolean)))
+  if (uniqueIds.length !== classroom_ids.length) {
+    return NextResponse.json({ error: 'classroom_ids must be unique' }, { status: 400 })
+  }
+
+  const supabase = getServiceRoleClient()
+  const hasPositionColumn = await getNextTeacherClassroomPosition(supabase, user.id)
+  if (hasPositionColumn === null) {
+    return NextResponse.json(
+      { error: 'Apply the classroom ordering migration before reordering classrooms' },
+      { status: 409 }
+    )
+  }
+
+  const { data: classrooms, error: classroomsError } = await supabase
+    .from('classrooms')
+    .select('id')
+    .eq('teacher_id', user.id)
+    .is('archived_at', null)
+
+  if (classroomsError) {
+    console.error('Error verifying classrooms:', classroomsError)
+    return NextResponse.json({ error: 'Failed to verify classrooms' }, { status: 500 })
+  }
+
+  const activeIds = (classrooms || []).map((classroom) => classroom.id)
+  const activeIdSet = new Set(activeIds)
+
+  if (uniqueIds.length !== activeIds.length || uniqueIds.some((id) => !activeIdSet.has(id))) {
+    return NextResponse.json(
+      { error: 'classroom_ids must include every active classroom exactly once' },
+      { status: 400 }
+    )
+  }
+
+  const results = await Promise.all(
+    uniqueIds.map((id, index) =>
+      supabase.from('classrooms').update({ position: index }).eq('id', id)
+    )
+  )
+  const updateError = results.find((r) => r.error)?.error ?? null
+
+  if (updateError) {
+    console.error('Error reordering classrooms:', updateError)
+    return NextResponse.json({ error: 'Failed to reorder classrooms' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+})

--- a/src/app/api/teacher/tests/[id]/clear-open-grades/route.ts
+++ b/src/app/api/teacher/tests/[id]/clear-open-grades/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { withErrorHandler } from '@/lib/api-handler'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
@@ -7,102 +8,88 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 // POST /api/teacher/tests/[id]/clear-open-grades - Clear open-response scores/feedback for selected students
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const user = await requireRole('teacher')
-    const { id: testId } = await params
-    const body = await request.json()
+export const POST = withErrorHandler('ClearTestOpenResponseGrades', async (request: NextRequest, context) => {
+  const user = await requireRole('teacher')
+  const { id: testId } = await context.params
+  const body = await request.json()
 
-    if (!Array.isArray(body?.student_ids) || body.student_ids.length === 0) {
-      return NextResponse.json({ error: 'student_ids array is required' }, { status: 400 })
-    }
-
-    const studentIds: string[] = Array.from(
-      new Set(
-        body.student_ids
-          .filter((value: unknown): value is string => typeof value === 'string' && value.trim().length > 0)
-          .map((value: string) => value.trim())
-      )
-    )
-
-    if (studentIds.length === 0) {
-      return NextResponse.json({ error: 'student_ids array is required' }, { status: 400 })
-    }
-    if (studentIds.length > 100) {
-      return NextResponse.json(
-        { error: 'Cannot clear grades for more than 100 students at once' },
-        { status: 400 }
-      )
-    }
-
-    const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
-    if (!access.ok) {
-      return NextResponse.json({ error: access.error }, { status: access.status })
-    }
-
-    const supabase = getServiceRoleClient()
-    const { data: openQuestionRows, error: openQuestionError } = await supabase
-      .from('test_questions')
-      .select('id')
-      .eq('test_id', testId)
-      .eq('question_type', 'open_response')
-
-    if (openQuestionError) {
-      console.error('Error loading open test questions for clearing:', openQuestionError)
-      return NextResponse.json({ error: 'Failed to load test questions' }, { status: 500 })
-    }
-
-    const openQuestionIds = (openQuestionRows || []).map((row) => row.id)
-    if (openQuestionIds.length === 0) {
-      return NextResponse.json({
-        cleared_students: 0,
-        skipped_students: studentIds.length,
-        cleared_responses: 0,
-      })
-    }
-
-    const { data: clearedRows, error: clearError } = await supabase
-      .from('test_responses')
-      .update({
-        score: null,
-        feedback: null,
-        graded_at: null,
-        graded_by: null,
-        ai_grading_basis: null,
-        ai_reference_answers: null,
-        ai_model: null,
-      })
-      .eq('test_id', testId)
-      .in('student_id', studentIds)
-      .in('question_id', openQuestionIds)
-      .select('id, student_id')
-
-    if (clearError) {
-      console.error('Error clearing open-response grades:', clearError)
-      return NextResponse.json({ error: 'Failed to clear open-response grades' }, { status: 500 })
-    }
-
-    const clearedResponses = (clearedRows || []).length
-    const clearedStudentIds = new Set((clearedRows || []).map((row) => row.student_id))
-    const clearedStudents = clearedStudentIds.size
-    const skippedStudents = studentIds.length - clearedStudents
-
-    return NextResponse.json({
-      cleared_students: clearedStudents,
-      skipped_students: skippedStudents,
-      cleared_responses: clearedResponses,
-    })
-  } catch (error: any) {
-    if (error.name === 'AuthenticationError') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-    if (error.name === 'AuthorizationError') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-    console.error('Clear test open-response grades error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  if (!Array.isArray(body?.student_ids) || body.student_ids.length === 0) {
+    return NextResponse.json({ error: 'student_ids array is required' }, { status: 400 })
   }
-}
+
+  const studentIds: string[] = Array.from(
+    new Set(
+      body.student_ids
+        .filter((value: unknown): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value: string) => value.trim())
+    )
+  )
+
+  if (studentIds.length === 0) {
+    return NextResponse.json({ error: 'student_ids array is required' }, { status: 400 })
+  }
+  if (studentIds.length > 100) {
+    return NextResponse.json(
+      { error: 'Cannot clear grades for more than 100 students at once' },
+      { status: 400 }
+    )
+  }
+
+  const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const { data: openQuestionRows, error: openQuestionError } = await supabase
+    .from('test_questions')
+    .select('id')
+    .eq('test_id', testId)
+    .eq('question_type', 'open_response')
+
+  if (openQuestionError) {
+    console.error('Error loading open test questions for clearing:', openQuestionError)
+    return NextResponse.json({ error: 'Failed to load test questions' }, { status: 500 })
+  }
+
+  const openQuestionIds = (openQuestionRows || []).map((row) => row.id)
+  if (openQuestionIds.length === 0) {
+    return NextResponse.json({
+      cleared_students: 0,
+      skipped_students: studentIds.length,
+      cleared_responses: 0,
+    })
+  }
+
+  const { data: clearedRows, error: clearError } = await supabase
+    .from('test_responses')
+    .update({
+      score: null,
+      feedback: null,
+      graded_at: null,
+      graded_by: null,
+      ai_grading_basis: null,
+      ai_reference_answers: null,
+      ai_model: null,
+    })
+    .eq('test_id', testId)
+    .in('student_id', studentIds)
+    .in('question_id', openQuestionIds)
+    .select('id, student_id')
+
+  if (clearError) {
+    console.error('Error clearing open-response grades:', clearError)
+    return NextResponse.json({ error: 'Failed to clear open-response grades' }, { status: 500 })
+  }
+
+  const clearedResponses = (clearedRows || []).length
+  const clearedStudentIds = new Set((clearedRows || []).map((row) => row.student_id))
+  const clearedStudents = clearedStudentIds.size
+  const skippedStudents = studentIds.length - clearedStudents
+
+  return NextResponse.json({
+    cleared_students: clearedStudents,
+    skipped_students: skippedStudents,
+    cleared_responses: clearedResponses,
+  })
+})

--- a/tests/unit/api-route-standards.test.ts
+++ b/tests/unit/api-route-standards.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const routeRoot = resolve(process.cwd(), 'src/app/api')
+const exportedHandlerPattern = /export\s+(?:async\s+function|const)\s+(GET|POST|PATCH|PUT|DELETE)\b/g
+const wrappedHandlerPattern = /export\s+const\s+(GET|POST|PATCH|PUT|DELETE)\s*=\s*withErrorHandler\b/g
+const aliasHandlerPattern = /export\s+const\s+(GET|POST|PATCH|PUT|DELETE)\s*=\s*(GET|POST|PATCH|PUT|DELETE)\b/g
+
+function collectRouteFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectRouteFiles(entryPath)
+    }
+
+    return entry.name === 'route.ts' ? [entryPath] : []
+  })
+}
+
+describe('API route standards', () => {
+  it('wraps exported HTTP handlers with withErrorHandler', () => {
+    const violations = collectRouteFiles(routeRoot).flatMap((filePath) => {
+      const source = readFileSync(filePath, 'utf8')
+      const exportedHandlers = Array.from(source.matchAll(exportedHandlerPattern), (match) => match[1])
+      const wrappedHandlers = new Set(
+        Array.from(source.matchAll(wrappedHandlerPattern), (match) => match[1])
+      )
+      const aliasedHandlers = new Map(
+        Array.from(source.matchAll(aliasHandlerPattern), (match) => [match[1], match[2]])
+      )
+
+      return exportedHandlers
+        .filter((method) => {
+          const aliasedMethod = aliasedHandlers.get(method)
+
+          return !wrappedHandlers.has(method) && !(aliasedMethod && wrappedHandlers.has(aliasedMethod))
+        })
+        .map((method) => `${relative(process.cwd(), filePath)} exports ${method} without withErrorHandler`)
+    })
+
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Move the remaining manual API route try/catch handlers onto `withErrorHandler`
- Preserve existing route-level validation and database error responses
- Add a unit standards test that scans API route exports for unwrapped handlers while allowing aliases to wrapped handlers

## Validation
- `pnpm test tests/api/teacher/tests-clear-open-grades.test.ts tests/api/teacher/classrooms-reorder.test.ts tests/unit/api-route-standards.test.ts`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm tsc --noEmit`
- `pnpm lint`
- `pnpm test`
- `pnpm build`