### PR TITLE
[codex] Retire gradebook category settings

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,36 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-23 — Gradebook Final column resize
-
-**Completed:**
-- Made the Final grade column resizable from the separator line before it.
-- Kept the Final column width synchronized across header, student rows, and summary rows.
-- Added keyboard-accessible resize coverage for the Final column.
-
-**Validation:**
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=gradebook'`
-- Playwright Final separator drag check on the seeded gradebook page
-
-## 2026-05-23 — Gradebook split FAB actions
-
-**Completed:**
-- Replaced the gradebook floating score/settings controls with a split-button FAB.
-- Moved Show % / Show Raw into the split menu and kept Settings as the no-selection primary action.
-- Added selected-student actions for default email, Gmail, Outlook, and copying selected student emails.
-- Refactored the shared SplitButton menu options to support checked states, leading icons, and dividers; gradebook uses those shared props for the score/email grouping.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm test`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=gradebook'`
-- Playwright checks for unselected and selected gradebook action menus, including checked score state and divider count
-
 ## 2026-05-24 — Student exam away-focus e2e
 
 **Completed:**
@@ -343,6 +313,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/timezone.test.ts tests/unit/server-repo-review.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
 - `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-id-students-studentId.test.ts`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — Gradebook category settings retirement
+
+**Completed:**
+- Stopped the in-app gradebook route from loading legacy category settings that no longer affect final calculations.
+- Kept per-assessment weight PATCH support and now rejects retired category-weight updates with a clear response.
+- Updated published actual-course grading summaries to use the same per-assessment weights instead of `gradebook_settings`.
+- Carried `gradebook_weight` through classroom blueprint source data for actual course site grading.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/hooks/useGradebookData.test.ts`
+- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts tests/lib/server/course-sites.test.ts tests/lib/server/classroom-blueprint-source.test.ts`
+- `pnpm tsc --noEmit`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`

--- a/src/app/api/teacher/gradebook/route.ts
+++ b/src/app/api/teacher/gradebook/route.ts
@@ -42,13 +42,6 @@ type GradebookAssessmentCell = {
   status?: GradebookAssessmentStatus | null
 }
 
-type GradebookSettingsRow = {
-  use_weights: boolean
-  assignments_weight: number
-  quizzes_weight: number
-  tests_weight?: number | null
-}
-
 function mentionsMissingField(
   error: { code?: string; message?: string; details?: string; hint?: string } | null | undefined,
   field: string
@@ -68,16 +61,6 @@ function isMissingTableError(
   if (!error) return false
   const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
   return error.code === 'PGRST205' || combined.includes('could not find the table') || combined.includes('does not exist')
-}
-
-function normalizeSettings(row: GradebookSettingsRow | null | undefined) {
-  if (!row) return DEFAULT_SETTINGS
-  return {
-    use_weights: row.use_weights,
-    assignments_weight: Number(row.assignments_weight ?? DEFAULT_SETTINGS.assignments_weight),
-    quizzes_weight: Number(row.quizzes_weight ?? DEFAULT_SETTINGS.quizzes_weight),
-    tests_weight: Number(row.tests_weight ?? 0),
-  }
 }
 
 function round2(value: number): number {
@@ -259,35 +242,6 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
   }
 
   const supabase = getServiceRoleClient()
-
-  const { data: settingsWithTests, error: settingsWithTestsError } = await supabase
-    .from('gradebook_settings')
-    .select('use_weights, assignments_weight, quizzes_weight, tests_weight')
-    .eq('classroom_id', classroomId)
-    .maybeSingle()
-
-  let settingsRow = settingsWithTests as GradebookSettingsRow | null
-  if (settingsWithTestsError) {
-    if (!mentionsMissingField(settingsWithTestsError, 'tests_weight')) {
-      console.error('Error loading gradebook settings:', settingsWithTestsError)
-      return NextResponse.json({ error: 'Failed to load gradebook settings' }, { status: 500 })
-    }
-
-    const { data: legacySettingsRow, error: legacySettingsError } = await supabase
-      .from('gradebook_settings')
-      .select('use_weights, assignments_weight, quizzes_weight')
-      .eq('classroom_id', classroomId)
-      .maybeSingle()
-
-    if (legacySettingsError) {
-      console.error('Error loading legacy gradebook settings:', settingsWithTestsError, legacySettingsError)
-      return NextResponse.json({ error: 'Failed to load gradebook settings' }, { status: 500 })
-    }
-
-    settingsRow = legacySettingsRow as GradebookSettingsRow | null
-  }
-
-  const settings = normalizeSettings(settingsRow)
 
   const { data: enrollments, error: enrollmentError } = await supabase
     .from('classroom_enrollments')
@@ -914,9 +868,9 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     const testRows = testRowsByStudent.get(studentId) || []
     const calc = calculateFinalPercent({
       useWeights: false,
-      assignmentsWeight: settings.assignments_weight,
-      quizzesWeight: settings.quizzes_weight,
-      testsWeight: settings.tests_weight,
+      assignmentsWeight: DEFAULT_SETTINGS.assignments_weight,
+      quizzesWeight: DEFAULT_SETTINGS.quizzes_weight,
+      testsWeight: DEFAULT_SETTINGS.tests_weight,
       assignments: assignmentRows,
       quizzes: quizRows,
       tests: testRows,
@@ -1064,7 +1018,7 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     .filter((value): value is number => value != null)
 
   return NextResponse.json({
-    settings,
+    settings: DEFAULT_SETTINGS,
     assessment_columns: assessmentColumns,
     students,
     selected_student: selectedStudent
@@ -1144,6 +1098,11 @@ export const PATCH = withErrorHandler('PatchGradebook', async (request: NextRequ
     body.assessment_type != null ||
     body.assessment_id != null ||
     body.gradebook_weight != null
+  const hasLegacyCategorySettingsUpdate =
+    body.use_weights != null ||
+    body.assignments_weight != null ||
+    body.quizzes_weight != null ||
+    body.tests_weight != null
 
   if (hasAssessmentWeightUpdate) {
     if (!isGradebookAssessmentType(body.assessment_type)) {
@@ -1201,65 +1160,12 @@ export const PATCH = withErrorHandler('PatchGradebook', async (request: NextRequ
     })
   }
 
-  const useWeights = body.use_weights == null ? DEFAULT_SETTINGS.use_weights : Boolean(body.use_weights)
-  const assignmentsWeight = body.assignments_weight == null
-    ? DEFAULT_SETTINGS.assignments_weight
-    : Number(body.assignments_weight)
-  const quizzesWeight = body.quizzes_weight == null
-    ? DEFAULT_SETTINGS.quizzes_weight
-    : Number(body.quizzes_weight)
-  const testsWeight = body.tests_weight == null
-    ? DEFAULT_SETTINGS.tests_weight
-    : Number(body.tests_weight)
-
-  if (!Number.isInteger(assignmentsWeight) || assignmentsWeight < 0 || assignmentsWeight > 100) {
-    return NextResponse.json({ error: 'assignments_weight must be an integer 0-100' }, { status: 400 })
+  if (hasLegacyCategorySettingsUpdate) {
+    return NextResponse.json(
+      { error: 'Category gradebook weights are retired; update assessment weights instead' },
+      { status: 410 }
+    )
   }
 
-  if (!Number.isInteger(quizzesWeight) || quizzesWeight < 0 || quizzesWeight > 100) {
-    return NextResponse.json({ error: 'quizzes_weight must be an integer 0-100' }, { status: 400 })
-  }
-
-  if (!Number.isInteger(testsWeight) || testsWeight < 0 || testsWeight > 100) {
-    return NextResponse.json({ error: 'tests_weight must be an integer 0-100' }, { status: 400 })
-  }
-
-  if (useWeights && assignmentsWeight + quizzesWeight + testsWeight !== 100) {
-    return NextResponse.json({ error: 'assignments_weight + quizzes_weight + tests_weight must equal 100' }, { status: 400 })
-  }
-
-  const supabase = getServiceRoleClient()
-  let { data, error } = await supabase
-    .from('gradebook_settings')
-    .upsert({
-      classroom_id: classroomId,
-      use_weights: useWeights,
-      assignments_weight: assignmentsWeight,
-      quizzes_weight: quizzesWeight,
-      tests_weight: testsWeight,
-    }, { onConflict: 'classroom_id' })
-    .select('use_weights, assignments_weight, quizzes_weight, tests_weight')
-    .single()
-
-  if (error && mentionsMissingField(error, 'tests_weight')) {
-    const legacyResult = await supabase
-      .from('gradebook_settings')
-      .upsert({
-        classroom_id: classroomId,
-        use_weights: useWeights,
-        assignments_weight: assignmentsWeight,
-        quizzes_weight: quizzesWeight,
-      }, { onConflict: 'classroom_id' })
-      .select('use_weights, assignments_weight, quizzes_weight')
-      .single()
-    data = legacyResult.data ? { ...legacyResult.data, tests_weight: 0 } : legacyResult.data
-    error = legacyResult.error
-  }
-
-  if (error || !data) {
-    console.error('Error saving gradebook settings:', error)
-    return NextResponse.json({ error: 'Failed to save settings' }, { status: 500 })
-  }
-
-  return NextResponse.json({ settings: normalizeSettings(data as GradebookSettingsRow) })
+  return NextResponse.json({ error: 'No gradebook update provided' }, { status: 400 })
 })

--- a/src/lib/server/classroom-blueprint-source.ts
+++ b/src/lib/server/classroom-blueprint-source.ts
@@ -23,6 +23,7 @@ export type ClassroomBlueprintSource = {
     default_due_days: number
     default_due_time: string
     points_possible: number | null
+    gradebook_weight: number | null
     include_in_final: boolean
     is_draft: boolean
     position: number
@@ -33,6 +34,7 @@ export type ClassroomBlueprintSource = {
     content: QuizDraftContent
     documents: TestDocument[]
     points_possible: number | null
+    gradebook_weight: number | null
     include_in_final: boolean
     position: number
   }>
@@ -42,6 +44,7 @@ export type ClassroomBlueprintSource = {
     content: TestDraftContent
     documents: TestDocument[]
     points_possible: number | null
+    gradebook_weight: number | null
     include_in_final: boolean
     position: number
   }>
@@ -211,6 +214,7 @@ export async function loadClassroomBlueprintSource(
         default_due_days: 0,
         default_due_time: '23:59',
         points_possible: assignment.points_possible ?? null,
+        gradebook_weight: assignment.gradebook_weight ?? null,
         include_in_final: assignment.include_in_final ?? true,
         is_draft: !!assignment.is_draft,
         position: assignment.position ?? 0,
@@ -223,6 +227,7 @@ export async function loadClassroomBlueprintSource(
           content: quiz.content,
           documents: [],
           points_possible: quiz.points_possible ?? null,
+          gradebook_weight: quiz.gradebook_weight ?? null,
           include_in_final: quiz.include_in_final !== false,
           position: quiz.position ?? 0,
         })),
@@ -234,6 +239,7 @@ export async function loadClassroomBlueprintSource(
           content: test.content,
           documents: Array.isArray(test.documents) ? (test.documents as TestDocument[]) : [],
           points_possible: test.points_possible ?? null,
+          gradebook_weight: test.gradebook_weight ?? null,
           include_in_final: test.include_in_final !== false,
           position: test.position ?? 0,
         })),

--- a/src/lib/server/course-sites.ts
+++ b/src/lib/server/course-sites.ts
@@ -66,6 +66,10 @@ export type PublishedCourseSiteGradingSummary = {
   items: PublishedCourseSiteGradingItem[]
 }
 
+type WeightedPublishedCourseSiteGradingItem = PublishedCourseSiteGradingItem & {
+  assessment_weight: number
+}
+
 export type PublishedActualCourseSiteData = {
   classroom: Classroom
   resources: ClassroomResources | null
@@ -186,64 +190,9 @@ function getNumber(value: unknown, fallback: number | null = null) {
   return fallback
 }
 
-function isMissingGradebookSettingsTableError(error: any) {
-  const text = `${error?.message || ''} ${error?.details || ''} ${error?.hint || ''}`.toLowerCase()
-  return error?.code === 'PGRST205' || text.includes('gradebook_settings') || text.includes('could not find the table')
-}
-
-function mentionsMissingGradebookField(error: any, field: string) {
-  const text = `${error?.message || ''} ${error?.details || ''} ${error?.hint || ''}`.toLowerCase()
-  return text.includes(field.toLowerCase()) && (
-    error?.code === '42703' ||
-    error?.code === 'PGRST204' ||
-    text.includes('column')
-  )
-}
-
-async function loadCourseSiteGradebookSettings(classroomId: string) {
-  const supabase = getSupabase()
-  const { data, error } = await supabase
-    .from('gradebook_settings')
-    .select('use_weights, assignments_weight, quizzes_weight, tests_weight')
-    .eq('classroom_id', classroomId)
-    .maybeSingle()
-
-  if (!error) {
-    return {
-      use_weights: !!data?.use_weights,
-      assignments_weight: getNumber(data?.assignments_weight, 50) ?? 50,
-      quizzes_weight: getNumber(data?.quizzes_weight, 20) ?? 20,
-      tests_weight: getNumber(data?.tests_weight, 30) ?? 30,
-    }
-  }
-
-  if (mentionsMissingGradebookField(error, 'tests_weight')) {
-    const { data: legacyData, error: legacyError } = await supabase
-      .from('gradebook_settings')
-      .select('use_weights, assignments_weight, quizzes_weight')
-      .eq('classroom_id', classroomId)
-      .maybeSingle()
-
-    if (!legacyError) {
-      return {
-        use_weights: !!legacyData?.use_weights,
-        assignments_weight: getNumber(legacyData?.assignments_weight, 70) ?? 70,
-        quizzes_weight: getNumber(legacyData?.quizzes_weight, 30) ?? 30,
-        tests_weight: 0,
-      }
-    }
-  }
-
-  if (!isMissingGradebookSettingsTableError(error)) {
-    console.error('Error loading course site gradebook settings:', error)
-  }
-
-  return {
-    use_weights: false,
-    assignments_weight: 50,
-    quizzes_weight: 20,
-    tests_weight: 30,
-  }
+function getAssessmentWeight(value: unknown) {
+  const parsed = getNumber(value, 10) ?? 10
+  return parsed > 0 ? parsed : 10
 }
 
 function getTestPointsPossible(test: Record<string, any>) {
@@ -258,18 +207,18 @@ function getTestPointsPossible(test: Record<string, any>) {
 }
 
 function buildCourseSiteGradingSummary(
-  settings: Awaited<ReturnType<typeof loadCourseSiteGradebookSettings>>,
   assignments: Array<Record<string, any>>,
   quizzes: Array<Record<string, any>>,
   tests: Array<Record<string, any>>
 ): PublishedCourseSiteGradingSummary | null {
-  const items: PublishedCourseSiteGradingItem[] = [
+  const items: WeightedPublishedCourseSiteGradingItem[] = [
     ...assignments.map((assignment, index) => ({
       key: `assignment:${assignment.position ?? index}:${assignment.title}`,
       category: 'assignments' as const,
       category_label: 'Assignments',
       title: String(assignment.title || 'Untitled assignment'),
       points_possible: getNumber(assignment.points_possible, null),
+      assessment_weight: getAssessmentWeight(assignment.gradebook_weight),
       include_in_final: assignment.include_in_final !== false,
       course_weight_percent: null,
       category_weight_percent: null,
@@ -280,6 +229,7 @@ function buildCourseSiteGradingSummary(
       category_label: 'Quizzes',
       title: String(quiz.title || 'Untitled quiz'),
       points_possible: getNumber(quiz.points_possible, 100),
+      assessment_weight: getAssessmentWeight(quiz.gradebook_weight),
       include_in_final: quiz.include_in_final !== false,
       course_weight_percent: null,
       category_weight_percent: null,
@@ -290,6 +240,7 @@ function buildCourseSiteGradingSummary(
       category_label: 'Tests',
       title: String(test.title || 'Untitled test'),
       points_possible: getTestPointsPossible(test),
+      assessment_weight: getAssessmentWeight(test.gradebook_weight),
       include_in_final: test.include_in_final !== false,
       course_weight_percent: null,
       category_weight_percent: null,
@@ -310,13 +261,18 @@ function buildCourseSiteGradingSummary(
       .filter((item) => item.category === 'tests')
       .reduce((sum, item) => sum + Number(item.points_possible), 0),
   }
-  const totalPoints = categoryPoints.assignments + categoryPoints.quizzes + categoryPoints.tests
-
-  const configuredWeights = {
-    assignments: settings.assignments_weight,
-    quizzes: settings.quizzes_weight,
-    tests: settings.tests_weight,
+  const categoryWeights = {
+    assignments: includedItems
+      .filter((item) => item.category === 'assignments')
+      .reduce((sum, item) => sum + item.assessment_weight, 0),
+    quizzes: includedItems
+      .filter((item) => item.category === 'quizzes')
+      .reduce((sum, item) => sum + item.assessment_weight, 0),
+    tests: includedItems
+      .filter((item) => item.category === 'tests')
+      .reduce((sum, item) => sum + item.assessment_weight, 0),
   }
+  const totalWeight = categoryWeights.assignments + categoryWeights.quizzes + categoryWeights.tests
 
   const categories = ([
     ['assignments', 'Assignments'],
@@ -326,11 +282,7 @@ function buildCourseSiteGradingSummary(
     .reduce<PublishedCourseSiteGradingCategory[]>((next, [id, label]) => {
       const points = categoryPoints[id]
       if (points <= 0) return next
-      const weight = settings.use_weights
-        ? configuredWeights[id]
-        : totalPoints > 0
-          ? (points / totalPoints) * 100
-          : null
+      const weight = totalWeight > 0 ? (categoryWeights[id] / totalWeight) * 100 : null
       next.push({
         id,
         label,
@@ -342,18 +294,14 @@ function buildCourseSiteGradingSummary(
     }, [])
 
   const weightedItems = items.map((item) => {
-    if (!item.include_in_final || item.points_possible == null || item.points_possible <= 0) return item
+    const { assessment_weight, ...publicItem } = item
+    if (!item.include_in_final || item.points_possible == null || item.points_possible <= 0) return publicItem
     const points = Number(item.points_possible)
-    const pointsInCategory = categoryPoints[item.category]
-    const categoryWeight = settings.use_weights
-      ? configuredWeights[item.category]
-      : totalPoints > 0
-        ? (pointsInCategory / totalPoints) * 100
-        : 0
-    const categoryWeightPercent = pointsInCategory > 0 ? (points / pointsInCategory) * 100 : null
-    const courseWeightPercent = pointsInCategory > 0 ? categoryWeight * (points / pointsInCategory) : null
+    const weightInCategory = categoryWeights[item.category]
+    const categoryWeightPercent = weightInCategory > 0 ? (assessment_weight / weightInCategory) * 100 : null
+    const courseWeightPercent = totalWeight > 0 ? (assessment_weight / totalWeight) * 100 : null
     return {
-      ...item,
+      ...publicItem,
       points_possible: roundCourseWeight(points),
       course_weight_percent: courseWeightPercent == null ? null : roundCourseWeight(courseWeightPercent),
       category_weight_percent: categoryWeightPercent == null ? null : roundCourseWeight(categoryWeightPercent),
@@ -361,8 +309,8 @@ function buildCourseSiteGradingSummary(
   })
 
   return {
-    mode: settings.use_weights ? 'weighted' : 'points',
-    mode_label: settings.use_weights ? 'Weighted by category' : 'Points-based grading',
+    mode: 'weighted',
+    mode_label: 'Weighted by assessment',
     categories,
     items: weightedItems,
   }
@@ -415,7 +363,6 @@ export async function getPublishedActualCourseSite(
   const assignments = sourceResult.source.assignments.filter((assignment) => !assignment.is_draft)
   const quizzes = sourceResult.source.quizzes
   const tests = sourceResult.source.tests
-  const gradebookSettings = await loadCourseSiteGradebookSettings(classroom.id)
 
   return {
     ok: true,
@@ -426,7 +373,7 @@ export async function getPublishedActualCourseSite(
       assignments,
       quizzes,
       tests,
-      grading: buildCourseSiteGradingSummary(gradebookSettings, assignments, quizzes, tests),
+      grading: buildCourseSiteGradingSummary(assignments, quizzes, tests),
       lesson_plans: sourceResult.source.lesson_templates.filter((lesson) => {
         if (!maxLessonDate) return true
         const match = lesson.title.match(/\((\d{4}-\d{2}-\d{2})\)$/)

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -525,7 +525,7 @@ describe('GET /api/teacher/gradebook', () => {
     expect(body.students[0].final_percent).toBe(50)
   })
 
-  it('returns 500 when gradebook settings cannot be loaded', async () => {
+  it('does not load legacy category settings for gradebook calculations', async () => {
     ;(mockSupabaseClient.from as any) = buildMockFrom({
       settingsError: { message: 'database unavailable' },
     })
@@ -534,8 +534,14 @@ describe('GET /api/teacher/gradebook', () => {
     const response = await GET(request)
     const body = await response.json()
 
-    expect(response.status).toBe(500)
-    expect(body.error).toBe('Failed to load gradebook settings')
+    expect(response.status).toBe(200)
+    expect(body.settings).toEqual({
+      use_weights: false,
+      assignments_weight: 50,
+      quizzes_weight: 20,
+      tests_weight: 30,
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('gradebook_settings')
   })
 
   it('includes all assignments (graded/ungraded/future) in selected student details by assignment order', async () => {
@@ -842,7 +848,7 @@ describe('PATCH /api/teacher/gradebook', () => {
     vi.clearAllMocks()
   })
 
-  it('allows non-100 weights when use_weights is false', async () => {
+  it('rejects legacy category settings updates', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'classrooms') {
         return {
@@ -850,19 +856,6 @@ describe('PATCH /api/teacher/gradebook', () => {
             eq: vi.fn(() => ({
               single: vi.fn().mockResolvedValue({
                 data: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'gradebook_settings') {
-        return {
-          upsert: vi.fn(() => ({
-            select: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { use_weights: false, assignments_weight: 10, quizzes_weight: 20, tests_weight: 30 },
                 error: null,
               }),
             })),
@@ -887,13 +880,9 @@ describe('PATCH /api/teacher/gradebook', () => {
     const response = await PATCH(request)
     const body = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(body.settings).toEqual({
-      use_weights: false,
-      assignments_weight: 10,
-      quizzes_weight: 20,
-      tests_weight: 30,
-    })
+    expect(response.status).toBe(410)
+    expect(body.error).toBe('Category gradebook weights are retired; update assessment weights instead')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('gradebook_settings')
   })
 
   it('updates an individual assessment weight', async () => {

--- a/tests/lib/server/course-sites.test.ts
+++ b/tests/lib/server/course-sites.test.ts
@@ -120,6 +120,7 @@ function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
             title: 'Essay',
             instructions_markdown: 'New instructions',
             points_possible: 30,
+            gradebook_weight: 10,
             include_in_final: true,
             is_draft: false,
             position: 0,
@@ -138,6 +139,7 @@ function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
             status: 'published',
             show_results: true,
             points_possible: 10,
+            gradebook_weight: 20,
             include_in_final: true,
             position: 0,
           },
@@ -156,6 +158,7 @@ function seedActualSiteSupabase(sourceBlueprintId = 'b-1') {
             documents: [],
             show_results: false,
             points_possible: 60,
+            gradebook_weight: 70,
             include_in_final: true,
             position: 0,
           },
@@ -268,15 +271,16 @@ describe('course-sites server helpers', () => {
           tests: [expect.objectContaining({ title: 'Unit Test' })],
           grading: expect.objectContaining({
             mode: 'weighted',
+            mode_label: 'Weighted by assessment',
             categories: expect.arrayContaining([
-              expect.objectContaining({ id: 'assignments', weight_percent: 50 }),
+              expect.objectContaining({ id: 'assignments', weight_percent: 10 }),
               expect.objectContaining({ id: 'quizzes', weight_percent: 20 }),
-              expect.objectContaining({ id: 'tests', weight_percent: 30 }),
+              expect.objectContaining({ id: 'tests', weight_percent: 70 }),
             ]),
             items: expect.arrayContaining([
-              expect.objectContaining({ title: 'Essay', course_weight_percent: 50 }),
+              expect.objectContaining({ title: 'Essay', course_weight_percent: 10 }),
               expect.objectContaining({ title: 'Quiz 1', course_weight_percent: 20 }),
-              expect.objectContaining({ title: 'Unit Test', course_weight_percent: 30 }),
+              expect.objectContaining({ title: 'Unit Test', course_weight_percent: 70 }),
             ]),
           }),
           lesson_plans: [expect.objectContaining({ title: 'Lesson 1 (2026-04-16)' })],
@@ -289,6 +293,7 @@ describe('course-sites server helpers', () => {
       expect(result.site.assignments).toHaveLength(1)
       expect(result.site.lesson_plans).toHaveLength(1)
       expect(result.site.announcements).toHaveLength(1)
+      expect(mockSupabase.from).not.toHaveBeenCalledWith('gradebook_settings')
     }
   })
 


### PR DESCRIPTION
## Summary
- Stop the teacher gradebook route from loading legacy category settings for final-grade calculations
- Reject retired category-weight PATCH requests while keeping per-assessment weight updates supported
- Update published actual-course grading summaries to use the same per-assessment weights as the gradebook
- Carry `gradebook_weight` through classroom blueprint source data

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts`
- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/hooks/useGradebookData.test.ts`
- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts tests/lib/server/course-sites.test.ts tests/lib/server/classroom-blueprint-source.test.ts`
- `pnpm tsc --noEmit`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- After rebase: focused gradebook/course-site/startup tests, `pnpm lint`, `pnpm build`