### PR TITLE
Guard student test response submission

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,27 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-23 — Roster delete action in FAB menu
-
-**Completed:**
-- Moved roster removal from the details pane into the floating roster actions dropdown.
-- Added an atomic roster removal RPC plus a bulk-delete action route so selected multi-row removal is one server-side operation.
-- Updated the existing single-row DELETE route to use the same atomic roster removal path.
-- Added component coverage for opening the roster FAB dropdown, choosing Remove student/students, and confirming deletion.
-- Updated retry behavior so failed bulk deletion keeps the full selected set pending instead of retrying partial client-side deletes.
-
-**Validation:**
-- `pnpm test tests/components/TeacherRosterTab.test.tsx`
-- `pnpm lint`
-- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts`
-- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/api/teacher/roster-rosterId.test.ts tests/api/teacher/roster-bulk-delete.test.ts tests/unit/roster-removal-migration.test.ts tests/unit/migration-filenames.test.ts`
-- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -f supabase/migrations/071_atomic_roster_bulk_removal.sql`
-- `select public.remove_classroom_roster_entries_atomic('00000000-0000-0000-0000-000000000000'::uuid, array[]::uuid[])`
-- `git diff --check`
-- Targeted Playwright screenshot: `/tmp/pika-roster-multi-delete-dropdown.png`
-- `E2E_BASE_URL=http://127.0.0.1:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=roster'`
-- Playwright screenshots: `/tmp/pika-roster-dropdown.png`, `/tmp/pika-roster-remove-confirm.png`, `/tmp/pika-roster-dropdown-dark.png`
-
 ## 2026-05-24 — Atomic selected test-work delete
 
 **Completed:**
@@ -405,3 +384,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-05-26 — Student test submit overwrite guard
+
+**Completed:**
+- Changed student test final submission to insert response rows instead of upserting over existing final answers.
+- Mapped unique response conflicts to the existing "already responded" response and skipped attempt finalization after the conflict.
+- Preserved the first-submit path for blank placeholder grading rows by deleting those placeholder rows by id before final insert.
+- Added API coverage for insert-only submission, placeholder cleanup, unique-conflict handling, and conditional attempt finalization.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/student/tests-respond.test.ts`
+- `pnpm tsc --noEmit`
+- `pnpm test tests/api/student/tests-respond.test.ts tests/api/student/tests-attempt.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-history.test.ts tests/api/student/tests-focus-events.test.ts tests/api/teacher/tests-results.test.ts tests/api/teacher/tests-return.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/app/api/student/tests/[id]/respond/route.ts
+++ b/src/app/api/student/tests/[id]/respond/route.ts
@@ -12,7 +12,7 @@ import {
   validateTestResponsesAgainstQuestions,
   type TestResponses,
 } from '@/lib/test-attempts'
-import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
+import { hasAnyMeaningfulTestResponse, hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { insertVersionedBaselineHistory } from '@/lib/server/versioned-history'
 import { withErrorHandler } from '@/lib/api-handler'
 
@@ -73,11 +73,16 @@ export const POST = withErrorHandler('PostStudentTestRespond', async (request, c
     return NextResponse.json({ error: 'This test is closed for grading' }, { status: 400 })
   }
 
-  const { data: existingResponses } = await supabase
+  const { data: existingResponses, error: existingResponsesError } = await supabase
     .from('test_responses')
-    .select('selected_option, response_text')
+    .select('id, selected_option, response_text')
     .eq('test_id', testId)
     .eq('student_id', user.id)
+
+  if (existingResponsesError) {
+    console.error('Error fetching existing test responses:', existingResponsesError)
+    return NextResponse.json({ error: 'Failed to submit responses' }, { status: 500 })
+  }
 
   if (hasAnyMeaningfulTestResponse(existingResponses)) {
     return NextResponse.json({ error: 'You have already responded to this test' }, { status: 400 })
@@ -140,11 +145,31 @@ export const POST = withErrorHandler('PostStudentTestRespond', async (request, c
     }
   })
 
+  const placeholderResponseIds = (existingResponses || [])
+    .filter((response) => !hasMeaningfulTestResponse(response))
+    .map((response) => response.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+
+  if (placeholderResponseIds.length > 0) {
+    const { error: deletePlaceholderError } = await supabase
+      .from('test_responses')
+      .delete()
+      .in('id', placeholderResponseIds)
+
+    if (deletePlaceholderError) {
+      console.error('Error clearing placeholder test responses:', deletePlaceholderError)
+      return NextResponse.json({ error: 'Failed to submit responses' }, { status: 500 })
+    }
+  }
+
   const { error: insertError } = await supabase
     .from('test_responses')
-    .upsert(responsesToInsert, { onConflict: 'question_id,student_id' })
+    .insert(responsesToInsert)
 
   if (insertError) {
+    if (insertError.code === '23505') {
+      return NextResponse.json({ error: 'You have already responded to this test' }, { status: 400 })
+    }
     console.error('Error inserting test responses:', insertError)
     return NextResponse.json({ error: 'Failed to submit responses' }, { status: 500 })
   }
@@ -164,6 +189,7 @@ export const POST = withErrorHandler('PostStudentTestRespond', async (request, c
         .from('test_attempts')
         .update(attemptUpdatePayload)
         .eq('id', testAttemptId)
+        .eq('is_submitted', false)
 
       if (updateAttemptError) {
         console.error('Error updating submitted test attempt:', updateAttemptError)

--- a/tests/api/student/tests-respond.test.ts
+++ b/tests/api/student/tests-respond.test.ts
@@ -100,10 +100,11 @@ describe('POST /api/student/tests/[id]/respond', () => {
   })
 
   it('submits responses and updates an existing test attempt', async () => {
-    const responsesUpsert = vi.fn().mockResolvedValue({ error: null })
-    const attemptsUpdate = vi.fn(() => ({
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    }))
+    const responsesInsert = vi.fn().mockResolvedValue({ error: null })
+    const attemptsUpdateQuery = {
+      eq: vi.fn(() => attemptsUpdateQuery),
+    }
+    const attemptsUpdate = vi.fn(() => attemptsUpdateQuery)
     const historyInsert = vi.fn(() => ({
       select: vi.fn(() => ({
         single: vi.fn().mockResolvedValue({
@@ -133,7 +134,7 @@ describe('POST /api/student/tests/[id]/respond', () => {
         }
         return {
           select: vi.fn(() => query),
-          upsert: responsesUpsert,
+          insert: responsesInsert,
         }
       }
       if (table === 'test_questions') {
@@ -165,16 +166,23 @@ describe('POST /api/student/tests/[id]/respond', () => {
 
     expect(response.status).toBe(201)
     expect(data.success).toBe(true)
-    expect(responsesUpsert).toHaveBeenCalledOnce()
-    expect(responsesUpsert).toHaveBeenCalledWith(expect.any(Array), {
-      onConflict: 'question_id,student_id',
-    })
+    expect(responsesInsert).toHaveBeenCalledOnce()
+    expect(responsesInsert).toHaveBeenCalledWith(expect.any(Array))
     expect(attemptsUpdate).toHaveBeenCalledOnce()
+    expect(attemptsUpdateQuery.eq).toHaveBeenCalledWith('id', 'attempt-1')
+    expect(attemptsUpdateQuery.eq).toHaveBeenCalledWith('is_submitted', false)
     expect(historyInsert).toHaveBeenCalledOnce()
   })
 
   it('allows submit when only placeholder graded rows exist', async () => {
-    const responsesUpsert = vi.fn().mockResolvedValue({ error: null })
+    const responsesInsert = vi.fn().mockResolvedValue({ error: null })
+    const placeholderDeleteIn = vi.fn().mockResolvedValue({ error: null })
+    const placeholderDelete = vi.fn(() => ({
+      in: placeholderDeleteIn,
+    }))
+    const attemptsUpdateQuery = {
+      eq: vi.fn(() => attemptsUpdateQuery),
+    }
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_attempts') {
@@ -186,9 +194,7 @@ describe('POST /api/student/tests/[id]/respond', () => {
               error: null,
             }),
           })),
-          update: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ error: null }),
-          })),
+          update: vi.fn(() => attemptsUpdateQuery),
         }
       }
       if (table === 'test_responses') {
@@ -197,12 +203,13 @@ describe('POST /api/student/tests/[id]/respond', () => {
             eq: vi.fn().mockReturnThis(),
             then: vi.fn((resolve: any) =>
               resolve({
-                data: [{ selected_option: null, response_text: '   ' }],
+                data: [{ id: 'placeholder-response-1', selected_option: null, response_text: '   ' }],
                 error: null,
               })
             ),
           })),
-          upsert: responsesUpsert,
+          delete: placeholderDelete,
+          insert: responsesInsert,
         }
       }
       if (table === 'test_questions') {
@@ -240,6 +247,70 @@ describe('POST /api/student/tests/[id]/respond', () => {
 
     expect(response.status).toBe(201)
     expect(data.success).toBe(true)
-    expect(responsesUpsert).toHaveBeenCalledOnce()
+    expect(placeholderDeleteIn).toHaveBeenCalledWith('id', ['placeholder-response-1'])
+    expect(responsesInsert).toHaveBeenCalledOnce()
+  })
+
+  it('returns already responded when final response insert hits a unique constraint', async () => {
+    const responsesInsert = vi.fn().mockResolvedValue({
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint',
+      },
+    })
+    const attemptsUpdate = vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false, responses: {} },
+              error: null,
+            }),
+          })),
+          update: attemptsUpdate,
+        }
+      }
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: [],
+                error: null,
+              })
+            ),
+          })),
+          insert: responsesInsert,
+        }
+      }
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ id: 'q-1', options: ['A', 'B'] }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(
+      buildRequest({ responses: { 'q-1': 1 } }),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('already responded')
+    expect(responsesInsert).toHaveBeenCalledOnce()
+    expect(attemptsUpdate).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- switches student test final response writes from upsert to insert so final answers cannot be overwritten after first submit
- clears blank placeholder response rows by id before insert so legitimate first submissions still work
- maps unique response conflicts to the existing already-responded error and keeps attempt finalization conditional

## Risk profile
- exam-mode

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/student/tests-respond.test.ts
- pnpm tsc --noEmit
- pnpm test tests/api/student/tests-respond.test.ts tests/api/student/tests-attempt.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-history.test.ts tests/api/student/tests-focus-events.test.ts tests/api/teacher/tests-results.test.ts tests/api/teacher/tests-return.test.ts
- git diff --check
- pnpm lint
- pnpm test
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh