### PR TITLE
Bind auth password handoff tokens

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,27 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-24 — Atomic selected test-work delete
-
-**Completed:**
-- Added migration `072_atomic_test_work_bulk_delete.sql` with `delete_student_test_attempts_atomic(p_test_id, p_student_ids)`.
-- Added a bulk selected test-work delete route that validates all selected students are enrolled and calls one RPC.
-- Updated the teacher Tests selected-delete flow to POST once instead of looping per-student DELETE calls.
-- Added API, migration, and component coverage for success, validation, missing-RPC guidance, and retry-safe failure state.
-
-**Validation:**
-- `pnpm test tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/components/TeacherTestsTab.test.tsx`
-- `pnpm test tests/api/teacher/tests-student-attempt-delete.test.ts tests/api/teacher/tests-student-attempts-bulk-delete.test.ts tests/unit/test-work-bulk-delete-migration.test.ts tests/unit/migration-filenames.test.ts`
-- `pnpm lint`
-- `supabase migration list --local`
-- `supabase db lint --local --fail-on error` (passes; existing warning on `public.unsubmit_test_attempts_atomic` unused parameter)
-- `supabase migration up --local`
-- `supabase db query --local "select public.delete_student_test_attempts_atomic('00000000-0000-0000-0000-000000000001'::uuid, array['00000000-0000-0000-0000-000000000002'::uuid]) as result;"`
-- `pnpm build`
-- `pnpm test`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=tests'`
-- Focused Playwright screenshot: `/tmp/pika-test-work-bulk-delete-dialog.png`
-
 ## 2026-05-25 — Assignment submission requirements MVP
 
 **Completed:**
@@ -402,4 +381,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-05-26 — Auth password handoff binding
+
+**Completed:**
+- Bound signup password creation and password reset confirmation to short-lived one-time handoff tokens issued only after code verification.
+- Stored only hashed handoff tokens on `verification_codes`, with expiry and consumed timestamps guarded by a filtered update.
+- Passed signup handoff tokens through `sessionStorage` instead of URL query strings and kept reset handoff tokens in page state.
+- Added migration `076_add_auth_handoff_tokens.sql` plus auth API and crypto coverage for missing, invalid/reused, and valid token paths.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/crypto.test.ts tests/api/auth/verify-signup.test.ts tests/api/auth/create-password.test.ts tests/api/auth/reset-password/verify.test.ts tests/api/auth/reset-password/confirm.test.ts`
+- `pnpm tsc --noEmit`
+- `pnpm test tests/api/auth`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test tests/unit/migration-filenames.test.ts`
+- `pnpm test`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -99,9 +99,9 @@ tests/                             # Vitest unit + API suites
 - Full token reference: `src/ui/README.md` | Design rules: `docs/core/design.md`
 
 ### Authentication (Current And WorkOS-Ready)
-- **Signup**: `/api/auth/signup` stores a verification code (mock-emailed); `/verify-signup` validates; `/create-password` hashes password (bcrypt), sets session.
+- **Signup**: `/api/auth/signup` stores a verification code (mock-emailed); `/verify-signup` validates and issues a short-lived one-time handoff token; `/create-password` requires that token before hashing the password (bcrypt) and setting the session.
 - **Login**: `/api/auth/login` with email/password.
-- **Forgot/Reset**: `/api/auth/forgot-password` issues reset code; `/reset-password/verify` + `/confirm` update password.
+- **Forgot/Reset**: `/api/auth/forgot-password` issues reset code; `/reset-password/verify` issues a short-lived one-time handoff token; `/confirm` requires that token before updating the password.
 - **Session**: iron-session cookie (`pika_session`), HTTP-only, SameSite=Lax, secure in production.
 - **WorkOS migration posture**: keep `public.users.id` as Pika's internal UUID user id. Store the external WorkOS AuthKit id in `public.users.workos_user_id` and map WorkOS sessions to local users before authorization checks.
 

--- a/src/app/api/auth/create-password/route.ts
+++ b/src/app/api/auth/create-password/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { hashPassword } from '@/lib/crypto'
+import { hashHandoffToken, hashPassword } from '@/lib/crypto'
 import { createSession } from '@/lib/auth'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
 import { createPasswordSchema } from '@/lib/validations/auth'
 
 export const POST = withErrorHandler('CreatePassword', async (request: NextRequest) => {
-  const { email: normalizedEmail, password } = createPasswordSchema.parse(await request.json())
+  const { email: normalizedEmail, password, handoffToken } = createPasswordSchema.parse(await request.json())
 
   const supabase = getServiceRoleClient()
 
@@ -29,6 +29,27 @@ export const POST = withErrorHandler('CreatePassword', async (request: NextReque
   // Check if email is verified
   if (!user.email_verified_at) {
     throw new ApiError(400, 'Email must be verified before creating a password')
+  }
+
+  const now = new Date().toISOString()
+  const { data: consumedHandoff, error: handoffError } = await supabase
+    .from('verification_codes')
+    .update({ handoff_consumed_at: now })
+    .eq('user_id', user.id)
+    .eq('purpose', 'signup')
+    .eq('handoff_token_hash', hashHandoffToken(handoffToken))
+    .is('handoff_consumed_at', null)
+    .gt('handoff_expires_at', now)
+    .select('id')
+    .maybeSingle()
+
+  if (handoffError) {
+    console.error('Error consuming password handoff token:', handoffError)
+    throw new ApiError(500, 'Failed to create password')
+  }
+
+  if (!consumedHandoff) {
+    throw new ApiError(401, 'Verification session expired. Please verify your email again.')
   }
 
   // Hash password

--- a/src/app/api/auth/reset-password/confirm/route.ts
+++ b/src/app/api/auth/reset-password/confirm/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { hashPassword } from '@/lib/crypto'
+import { hashHandoffToken, hashPassword } from '@/lib/crypto'
 import { createSession } from '@/lib/auth'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
 import { resetPasswordConfirmSchema } from '@/lib/validations/auth'
 
 export const POST = withErrorHandler('ResetPasswordConfirm', async (request: NextRequest) => {
-  const { email: normalizedEmail, password } = resetPasswordConfirmSchema.parse(await request.json())
+  const { email: normalizedEmail, password, handoffToken } = resetPasswordConfirmSchema.parse(await request.json())
 
   const supabase = getServiceRoleClient()
 
@@ -21,21 +21,24 @@ export const POST = withErrorHandler('ResetPasswordConfirm', async (request: Nex
     throw new ApiError(404, 'User not found')
   }
 
-  // Verify that user has a recent used reset code
-  const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000)
-
-  const { data: recentCode } = await supabase
+  const now = new Date().toISOString()
+  const { data: consumedHandoff, error: handoffError } = await supabase
     .from('verification_codes')
-    .select('id, used_at')
+    .update({ handoff_consumed_at: now })
     .eq('user_id', user.id)
     .eq('purpose', 'reset_password')
-    .not('used_at', 'is', null)
-    .gte('used_at', fiveMinutesAgo.toISOString())
-    .order('used_at', { ascending: false })
-    .limit(1)
-    .single()
+    .eq('handoff_token_hash', hashHandoffToken(handoffToken))
+    .is('handoff_consumed_at', null)
+    .gt('handoff_expires_at', now)
+    .select('id')
+    .maybeSingle()
 
-  if (!recentCode) {
+  if (handoffError) {
+    console.error('Error consuming reset handoff token:', handoffError)
+    throw new ApiError(500, 'Failed to reset password')
+  }
+
+  if (!consumedHandoff) {
     throw new ApiError(401, 'Password reset session expired. Please request a new code.')
   }
 

--- a/src/app/api/auth/reset-password/verify/route.ts
+++ b/src/app/api/auth/reset-password/verify/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { verifyCode } from '@/lib/crypto'
+import { generateHandoffToken, hashHandoffToken, verifyCode } from '@/lib/crypto'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
 import { resetPasswordVerifySchema } from '@/lib/validations/auth'
 
 const MAX_VERIFICATION_ATTEMPTS = 5
+const HANDOFF_TOKEN_TTL_MS = 10 * 60 * 1000
 
 export const POST = withErrorHandler('ResetPasswordVerify', async (request: NextRequest) => {
   const { email: normalizedEmail, code: normalizedCode } = resetPasswordVerifySchema.parse(await request.json())
@@ -69,15 +70,34 @@ export const POST = withErrorHandler('ResetPasswordVerify', async (request: Next
     throw new ApiError(401, 'Invalid code')
   }
 
-  // Mark code as used (will be fully validated when password is set)
-  await supabase
+  const usedAt = new Date()
+  const handoffToken = generateHandoffToken()
+  const { data: markedCode, error: markCodeError } = await supabase
     .from('verification_codes')
-    .update({ used_at: new Date().toISOString() })
+    .update({
+      used_at: usedAt.toISOString(),
+      handoff_token_hash: hashHandoffToken(handoffToken),
+      handoff_expires_at: new Date(usedAt.getTime() + HANDOFF_TOKEN_TTL_MS).toISOString(),
+      handoff_consumed_at: null,
+    })
     .eq('id', validCode.id)
+    .is('used_at', null)
+    .select('id')
+    .maybeSingle()
+
+  if (markCodeError) {
+    console.error('Error marking reset code as used:', markCodeError)
+    throw new ApiError(500, 'Internal server error')
+  }
+
+  if (!markedCode) {
+    throw new ApiError(401, 'Invalid or expired code')
+  }
 
   return NextResponse.json({
     success: true,
     message: 'Code verified successfully',
     userId: user.id,
+    handoffToken,
   })
 })

--- a/src/app/api/auth/verify-signup/route.ts
+++ b/src/app/api/auth/verify-signup/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { verifyCode } from '@/lib/crypto'
+import { generateHandoffToken, hashHandoffToken, verifyCode } from '@/lib/crypto'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
 import { verifySignupSchema } from '@/lib/validations/auth'
 
 const MAX_VERIFICATION_ATTEMPTS = 5
+const HANDOFF_TOKEN_TTL_MS = 10 * 60 * 1000
 
 export const POST = withErrorHandler('VerifySignup', async (request: NextRequest) => {
   const { email: normalizedEmail, code: normalizedCode } = verifySignupSchema.parse(await request.json())
@@ -74,20 +75,44 @@ export const POST = withErrorHandler('VerifySignup', async (request: NextRequest
     throw new ApiError(401, 'Invalid code')
   }
 
-  // Mark code as used and verify email
-  await supabase
+  const usedAt = new Date()
+  const handoffToken = generateHandoffToken()
+  const { data: markedCode, error: markCodeError } = await supabase
     .from('verification_codes')
-    .update({ used_at: new Date().toISOString() })
+    .update({
+      used_at: usedAt.toISOString(),
+      handoff_token_hash: hashHandoffToken(handoffToken),
+      handoff_expires_at: new Date(usedAt.getTime() + HANDOFF_TOKEN_TTL_MS).toISOString(),
+      handoff_consumed_at: null,
+    })
     .eq('id', validCode.id)
+    .is('used_at', null)
+    .select('id')
+    .maybeSingle()
 
-  await supabase
+  if (markCodeError) {
+    console.error('Error marking verification code as used:', markCodeError)
+    throw new ApiError(500, 'Internal server error')
+  }
+
+  if (!markedCode) {
+    throw new ApiError(401, 'Invalid or expired code')
+  }
+
+  const { error: verifyEmailError } = await supabase
     .from('users')
-    .update({ email_verified_at: new Date().toISOString() })
+    .update({ email_verified_at: usedAt.toISOString() })
     .eq('id', user.id)
+
+  if (verifyEmailError) {
+    console.error('Error marking email as verified:', verifyEmailError)
+    throw new ApiError(500, 'Internal server error')
+  }
 
   return NextResponse.json({
     success: true,
     message: 'Email verified successfully',
     userId: user.id,
+    handoffToken,
   })
 })

--- a/src/app/create-password/page.tsx
+++ b/src/app/create-password/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState, FormEvent, Suspense } from 'react'
+import { useEffect, useState, FormEvent, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { AppMessageFallback, Input, Button, FormField } from '@/ui'
+
+const SIGNUP_HANDOFF_TOKEN_STORAGE_KEY = 'pika.signupHandoffToken'
 
 function CreatePasswordForm() {
   const router = useRouter()
@@ -10,10 +12,25 @@ function CreatePasswordForm() {
   const emailFromUrl = searchParams.get('email') || ''
 
   const [email] = useState(emailFromUrl)
+  const [handoffToken, setHandoffToken] = useState('')
   const [password, setPassword] = useState('')
   const [passwordConfirmation, setPasswordConfirmation] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    try {
+      const stored = window.sessionStorage.getItem(SIGNUP_HANDOFF_TOKEN_STORAGE_KEY)
+      if (!stored) return
+
+      const parsed = JSON.parse(stored) as { email?: string; token?: string }
+      if (parsed.email === email && parsed.token) {
+        setHandoffToken(parsed.token)
+      }
+    } catch {
+      window.sessionStorage.removeItem(SIGNUP_HANDOFF_TOKEN_STORAGE_KEY)
+    }
+  }, [email])
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -24,7 +41,7 @@ function CreatePasswordForm() {
       const response = await fetch('/api/auth/create-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password, passwordConfirmation }),
+        body: JSON.stringify({ email, password, passwordConfirmation, handoffToken }),
       })
 
       const data = await response.json()
@@ -33,7 +50,7 @@ function CreatePasswordForm() {
         throw new Error(data.error || 'Failed to create password')
       }
 
-      // Redirect based on user role
+      window.sessionStorage.removeItem(SIGNUP_HANDOFF_TOKEN_STORAGE_KEY)
       router.push(data.redirectUrl)
     } catch (err: any) {
       setError(err.message || 'An error occurred')

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -13,6 +13,7 @@ function ResetPasswordForm() {
   const [step, setStep] = useState<'verify' | 'reset'>('verify')
   const [email, setEmail] = useState(emailFromUrl)
   const [code, setCode] = useState('')
+  const [handoffToken, setHandoffToken] = useState('')
   const [password, setPassword] = useState('')
   const [passwordConfirmation, setPasswordConfirmation] = useState('')
   const [loading, setLoading] = useState(false)
@@ -38,7 +39,7 @@ function ResetPasswordForm() {
         throw new Error(data.error || 'Invalid code')
       }
 
-      // Move to password reset step
+      setHandoffToken(data.handoffToken)
       setStep('reset')
       setLoading(false)
     } catch (err: any) {
@@ -56,7 +57,7 @@ function ResetPasswordForm() {
       const response = await fetch('/api/auth/reset-password/confirm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password, passwordConfirmation }),
+        body: JSON.stringify({ email, password, passwordConfirmation, handoffToken }),
       })
 
       const data = await response.json()
@@ -75,6 +76,7 @@ function ResetPasswordForm() {
 
   async function handleResendCode() {
     try {
+      setHandoffToken('')
       await fetch('/api/auth/forgot-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/app/verify-signup/page.tsx
+++ b/src/app/verify-signup/page.tsx
@@ -4,6 +4,8 @@ import { useState, FormEvent, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { AppMessageFallback, Input, Button, FormField, useAppMessage } from '@/ui'
 
+const SIGNUP_HANDOFF_TOKEN_STORAGE_KEY = 'pika.signupHandoffToken'
+
 function VerifySignupForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -33,7 +35,11 @@ function VerifySignupForm() {
         throw new Error(data.error || 'Invalid code')
       }
 
-      // Redirect to create password page
+      window.sessionStorage.setItem(
+        SIGNUP_HANDOFF_TOKEN_STORAGE_KEY,
+        JSON.stringify({ email, token: data.handoffToken }),
+      )
+
       router.push(`/create-password?email=${encodeURIComponent(email)}`)
     } catch (err: any) {
       setError(err.message || 'An error occurred')

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,6 +1,8 @@
 import bcrypt from 'bcryptjs'
+import { createHash, randomBytes } from 'crypto'
 
 const VERIFICATION_CODE_LENGTH = 5 // For email verification (signup/reset)
+const HANDOFF_TOKEN_BYTES = 32
 const SALT_ROUNDS = 10
 
 /**
@@ -33,6 +35,20 @@ export async function hashCode(code: string): Promise<string> {
  */
 export async function verifyCode(plainCode: string, hashedCode: string): Promise<boolean> {
   return bcrypt.compare(plainCode, hashedCode)
+}
+
+/**
+ * Generates an opaque one-time token for the verified-code to password handoff.
+ */
+export function generateHandoffToken(): string {
+  return randomBytes(HANDOFF_TOKEN_BYTES).toString('base64url')
+}
+
+/**
+ * Hashes one-time handoff tokens before storage.
+ */
+export function hashHandoffToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex')
 }
 
 /**

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -4,6 +4,10 @@ import { z } from 'zod'
  * Shared email validation: required string, email format, lowercased and trimmed.
  */
 const emailField = z.string().email('Invalid email format').transform(v => v.toLowerCase().trim())
+const handoffTokenField = z.preprocess(
+  value => (typeof value === 'string' ? value.trim() : ''),
+  z.string().min(32, 'Verification session is required'),
+)
 
 /**
  * POST /api/auth/signup
@@ -27,6 +31,7 @@ export const createPasswordSchema = z.object({
   email: emailField,
   password: z.string().min(8, 'Password must be at least 8 characters'),
   passwordConfirmation: z.string().min(1, 'Password confirmation is required'),
+  handoffToken: handoffTokenField,
 }).refine(data => data.password === data.passwordConfirmation, {
   message: 'Passwords do not match',
   path: ['passwordConfirmation'],
@@ -62,6 +67,7 @@ export const resetPasswordConfirmSchema = z.object({
   email: emailField,
   password: z.string().min(8, 'Password must be at least 8 characters'),
   passwordConfirmation: z.string().min(1, 'Password confirmation is required'),
+  handoffToken: handoffTokenField,
 }).refine(data => data.password === data.passwordConfirmation, {
   message: 'Passwords do not match',
   path: ['passwordConfirmation'],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,9 @@ export interface VerificationCode {
   expires_at: string
   attempts: number
   used_at: string | null
+  handoff_token_hash: string | null
+  handoff_expires_at: string | null
+  handoff_consumed_at: string | null
   created_at: string
 }
 

--- a/supabase/migrations/076_add_auth_handoff_tokens.sql
+++ b/supabase/migrations/076_add_auth_handoff_tokens.sql
@@ -1,0 +1,13 @@
+alter table public.verification_codes
+  add column if not exists handoff_token_hash text,
+  add column if not exists handoff_expires_at timestamptz,
+  add column if not exists handoff_consumed_at timestamptz;
+
+create index if not exists idx_verification_codes_handoff_token_hash
+  on public.verification_codes (handoff_token_hash)
+  where handoff_token_hash is not null;
+
+create index if not exists idx_verification_codes_handoff_active
+  on public.verification_codes (user_id, purpose, handoff_expires_at)
+  where handoff_token_hash is not null
+    and handoff_consumed_at is null;

--- a/tests/api/auth/create-password.test.ts
+++ b/tests/api/auth/create-password.test.ts
@@ -6,12 +6,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '@/app/api/auth/create-password/route'
 import { NextRequest } from 'next/server'
 
+const VALID_HANDOFF_TOKEN = 'handoff-token-abcdefghijklmnopqrstuvwxyz1234567890'
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
 
 vi.mock('@/lib/crypto', () => ({
   hashPassword: vi.fn(async (pwd: string) => `hashed_${pwd}`),
+  hashHandoffToken: vi.fn((token: string) => `hashed_${token}`),
   validatePassword: vi.fn(() => null),
 }))
 
@@ -21,23 +24,57 @@ vi.mock('@/lib/auth', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function createRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost:3000/api/auth/create-password', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    email: 'test@example.com',
+    password: 'Password123',
+    passwordConfirmation: 'Password123',
+    handoffToken: VALID_HANDOFF_TOKEN,
+    ...overrides,
+  }
+}
+
+function chainableUpdate(result: { data?: unknown; error: unknown }) {
+  const builder: any = {
+    eq: vi.fn(() => builder),
+    is: vi.fn(() => builder),
+    gt: vi.fn(() => builder),
+    select: vi.fn(() => builder),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+  return builder
+}
+
 describe('POST /api/auth/create-password', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('should return 400 when passwords do not match', async () => {
-    const request = new NextRequest('http://localhost:3000/api/auth/create-password', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'Password123',
-        passwordConfirmation: 'DifferentPassword',
-      }),
-    })
+    const response = await POST(createRequest(validBody({
+      passwordConfirmation: 'DifferentPassword',
+    })))
 
-    const response = await POST(request)
     expect(response.status).toBe(400)
+  })
+
+  it('should return 400 when handoff token is missing', async () => {
+    const response = await POST(createRequest({
+      email: 'test@example.com',
+      password: 'Password123',
+      passwordConfirmation: 'Password123',
+    }))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('Verification session is required')
   })
 
   it('should return 400 when user already has password', async () => {
@@ -58,16 +95,8 @@ describe('POST /api/auth/create-password', () => {
     }))
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/auth/create-password', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'Password123',
-        passwordConfirmation: 'Password123',
-      }),
-    })
+    const response = await POST(createRequest(validBody()))
 
-    const response = await POST(request)
     expect(response.status).toBe(400)
   })
 
@@ -89,55 +118,100 @@ describe('POST /api/auth/create-password', () => {
     }))
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/auth/create-password', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'Password123',
-        passwordConfirmation: 'Password123',
-      }),
-    })
+    const response = await POST(createRequest(validBody()))
 
-    const response = await POST(request)
     expect(response.status).toBe(400)
   })
 
-  it('should create password for verified user', async () => {
-    const mockFrom = vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({
-            data: {
-              id: 'user-1',
-              email: 'test@example.com',
-              role: 'student',
-              password_hash: null,
-              email_verified_at: new Date().toISOString(),
-            },
-            error: null,
-          }),
-        })),
-      })),
-      update: vi.fn(() => ({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      })),
+  it('should reject an invalid, expired, or reused handoff token', async () => {
+    const userUpdate = vi.fn(() => ({
+      eq: vi.fn().mockResolvedValue({ error: null }),
     }))
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'user-1',
+                  email: 'test@example.com',
+                  role: 'student',
+                  password_hash: null,
+                  email_verified_at: new Date().toISOString(),
+                },
+                error: null,
+              }),
+            })),
+          })),
+          update: userUpdate,
+        }
+      }
+
+      if (table === 'verification_codes') {
+        return {
+          update: vi.fn(() => chainableUpdate({ data: null, error: null })),
+        }
+      }
+    })
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/auth/create-password', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'Password123',
-        passwordConfirmation: 'Password123',
-      }),
+    const response = await POST(createRequest(validBody()))
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toBe('Verification session expired. Please verify your email again.')
+    expect(userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('should create password for verified user with valid handoff token', async () => {
+    const userUpdate = vi.fn(() => ({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }))
+
+    const consumeBuilder = chainableUpdate({
+      data: { id: 'code-1' },
+      error: null,
     })
 
-    const response = await POST(request)
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'user-1',
+                  email: 'test@example.com',
+                  role: 'student',
+                  password_hash: null,
+                  email_verified_at: new Date().toISOString(),
+                },
+                error: null,
+              }),
+            })),
+          })),
+          update: userUpdate,
+        }
+      }
+
+      if (table === 'verification_codes') {
+        return {
+          update: vi.fn(() => consumeBuilder),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const response = await POST(createRequest(validBody()))
     const data = await response.json()
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
     expect(data.redirectUrl).toBe('/classrooms')
+    expect(consumeBuilder.eq).toHaveBeenCalledWith('purpose', 'signup')
+    expect(consumeBuilder.eq).toHaveBeenCalledWith('handoff_token_hash', `hashed_${VALID_HANDOFF_TOKEN}`)
+    expect(userUpdate).toHaveBeenCalledWith({ password_hash: 'hashed_Password123' })
   })
 })

--- a/tests/api/auth/reset-password/confirm.test.ts
+++ b/tests/api/auth/reset-password/confirm.test.ts
@@ -6,12 +6,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '@/app/api/auth/reset-password/confirm/route'
 import { NextRequest } from 'next/server'
 
+const VALID_HANDOFF_TOKEN = 'reset-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890'
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
 
 vi.mock('@/lib/crypto', () => ({
   hashPassword: vi.fn(async (pwd: string) => `hashed_${pwd}`),
+  hashHandoffToken: vi.fn((token: string) => `hashed_${token}`),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -26,18 +29,41 @@ vi.mock('@/lib/auth', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function createRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost:3000/api/auth/reset-password/confirm', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    email: 'test@example.com',
+    password: 'NewPassword123',
+    passwordConfirmation: 'NewPassword123',
+    handoffToken: VALID_HANDOFF_TOKEN,
+    ...overrides,
+  }
+}
+
+function chainableUpdate(result: { data?: unknown; error: unknown }) {
+  const builder: any = {
+    eq: vi.fn(() => builder),
+    is: vi.fn(() => builder),
+    gt: vi.fn(() => builder),
+    select: vi.fn(() => builder),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+  return builder
+}
+
 describe('POST /api/auth/reset-password/confirm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('should return 400 for missing required fields', async () => {
-    const request = new NextRequest('http://localhost:3000/api/auth/reset-password/confirm', {
-      method: 'POST',
-      body: JSON.stringify({ email: 'test@example.com' }),
-    })
-
-    const response = await POST(request)
+    const response = await POST(createRequest({ email: 'test@example.com' }))
     const data = await response.json()
 
     expect(response.status).toBe(400)
@@ -45,66 +71,29 @@ describe('POST /api/auth/reset-password/confirm', () => {
   })
 
   it('should return 400 when passwords do not match', async () => {
-    const request = new NextRequest('http://localhost:3000/api/auth/reset-password/confirm', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'NewPassword123',
-        passwordConfirmation: 'DifferentPassword',
-      }),
-    })
-
-    const response = await POST(request)
+    const response = await POST(createRequest(validBody({
+      passwordConfirmation: 'DifferentPassword',
+    })))
     const data = await response.json()
 
     expect(response.status).toBe(400)
     expect(data.error).toContain('Passwords do not match')
   })
 
-  it('should return 401 when no recent reset code exists', async () => {
-    const mockFrom = vi.fn((table: string) => {
-      if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'user-1', email: 'test@example.com', role: 'student' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      } else if (table === 'verification_codes') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            not: vi.fn().mockReturnThis(),
-            gte: vi.fn().mockReturnThis(),
-            order: vi.fn().mockReturnThis(),
-            limit: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({ data: null, error: null }),
-            })),
-          })),
-        }
-      }
-    })
-    ;(mockSupabaseClient.from as any) = mockFrom
+  it('should return 400 when handoff token is missing', async () => {
+    const response = await POST(createRequest({
+      email: 'test@example.com',
+      password: 'NewPassword123',
+      passwordConfirmation: 'NewPassword123',
+    }))
+    const data = await response.json()
 
-    const request = new NextRequest('http://localhost:3000/api/auth/reset-password/confirm', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'NewPassword123',
-        passwordConfirmation: 'NewPassword123',
-      }),
-    })
-
-    const response = await POST(request)
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(400)
+    expect(data.error).toContain('Verification session is required')
   })
 
-  it('should reset password with valid code session', async () => {
-    const mockUpdate = vi.fn(() => ({
+  it('should return 401 when no valid reset handoff token exists', async () => {
+    const userUpdate = vi.fn(() => ({
       eq: vi.fn().mockResolvedValue({ error: null }),
     }))
 
@@ -119,40 +108,64 @@ describe('POST /api/auth/reset-password/confirm', () => {
               }),
             })),
           })),
-          update: mockUpdate,
+          update: userUpdate,
         }
-      } else if (table === 'verification_codes') {
+      }
+
+      if (table === 'verification_codes') {
         return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            not: vi.fn().mockReturnThis(),
-            gte: vi.fn().mockReturnThis(),
-            order: vi.fn().mockReturnThis(),
-            limit: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { id: 'code-1', used_at: new Date().toISOString() },
-                error: null,
-              }),
-            })),
-          })),
+          update: vi.fn(() => chainableUpdate({ data: null, error: null })),
         }
       }
     })
     ;(mockSupabaseClient.from as any) = mockFrom
 
-    const request = new NextRequest('http://localhost:3000/api/auth/reset-password/confirm', {
-      method: 'POST',
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'NewPassword123',
-        passwordConfirmation: 'NewPassword123',
-      }),
+    const response = await POST(createRequest(validBody()))
+
+    expect(response.status).toBe(401)
+    expect(userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('should reset password with valid handoff token', async () => {
+    const userUpdate = vi.fn(() => ({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }))
+
+    const consumeBuilder = chainableUpdate({
+      data: { id: 'code-1' },
+      error: null,
     })
 
-    const response = await POST(request)
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'user-1', email: 'test@example.com', role: 'student' },
+                error: null,
+              }),
+            })),
+          })),
+          update: userUpdate,
+        }
+      }
+
+      if (table === 'verification_codes') {
+        return {
+          update: vi.fn(() => consumeBuilder),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const response = await POST(createRequest(validBody()))
     const data = await response.json()
 
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
+    expect(consumeBuilder.eq).toHaveBeenCalledWith('purpose', 'reset_password')
+    expect(consumeBuilder.eq).toHaveBeenCalledWith('handoff_token_hash', `hashed_${VALID_HANDOFF_TOKEN}`)
+    expect(userUpdate).toHaveBeenCalledWith({ password_hash: 'hashed_NewPassword123' })
   })
 })

--- a/tests/api/auth/reset-password/verify.test.ts
+++ b/tests/api/auth/reset-password/verify.test.ts
@@ -12,6 +12,8 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/crypto', () => ({
   verifyCode: vi.fn(async (code: string, hash: string) => code === 'ABC12' && hash === 'hashed_ABC12'),
+  generateHandoffToken: vi.fn(() => 'reset-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890'),
+  hashHandoffToken: vi.fn((token: string) => `hashed_${token}`),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -78,10 +80,14 @@ describe('POST /api/auth/reset-password/verify', () => {
     expect(response.status).toBe(401)
   })
 
-  it('should verify code and mark as used', async () => {
-    const mockUpdate = vi.fn(() => ({
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    }))
+  it('should verify code and issue a reset handoff token', async () => {
+    const codeUpdateBuilder: any = {
+      eq: vi.fn(() => codeUpdateBuilder),
+      is: vi.fn(() => codeUpdateBuilder),
+      select: vi.fn(() => codeUpdateBuilder),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'code-1' }, error: null }),
+    }
+    const codeUpdate = vi.fn(() => codeUpdateBuilder)
 
     const mockFrom = vi.fn((table: string) => {
       if (table === 'users') {
@@ -110,7 +116,7 @@ describe('POST /api/auth/reset-password/verify', () => {
               error: null,
             }),
           })),
-          update: mockUpdate,
+          update: codeUpdate,
         }
       }
     })
@@ -127,5 +133,12 @@ describe('POST /api/auth/reset-password/verify', () => {
     expect(response.status).toBe(200)
     expect(data.success).toBe(true)
     expect(data.userId).toBe('user-1')
+    expect(data.handoffToken).toBe('reset-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890')
+    expect(codeUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      used_at: expect.any(String),
+      handoff_token_hash: 'hashed_reset-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890',
+      handoff_expires_at: expect.any(String),
+      handoff_consumed_at: null,
+    }))
   })
 })

--- a/tests/api/auth/verify-signup.test.ts
+++ b/tests/api/auth/verify-signup.test.ts
@@ -14,6 +14,8 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/crypto', () => ({
   verifyCode: vi.fn(async (code: string, hash: string) => code === 'ABC12' && hash === 'hashed_ABC12'),
+  generateHandoffToken: vi.fn(() => 'signup-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890'),
+  hashHandoffToken: vi.fn((token: string) => `hashed_${token}`),
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -145,10 +147,17 @@ describe('POST /api/auth/verify-signup', () => {
       expect(data.error).toBe('Invalid or expired code')
     })
 
-    it('should verify code and mark email as verified', async () => {
-      const mockUpdate = vi.fn(() => ({
+    it('should verify code and issue a password handoff token', async () => {
+      const userUpdate = vi.fn(() => ({
         eq: vi.fn().mockResolvedValue({ error: null }),
       }))
+      const codeUpdateBuilder: any = {
+        eq: vi.fn(() => codeUpdateBuilder),
+        is: vi.fn(() => codeUpdateBuilder),
+        select: vi.fn(() => codeUpdateBuilder),
+        maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'code-1' }, error: null }),
+      }
+      const codeUpdate = vi.fn(() => codeUpdateBuilder)
 
       const mockFrom = vi.fn((table: string) => {
         if (table === 'users') {
@@ -161,7 +170,7 @@ describe('POST /api/auth/verify-signup', () => {
                 }),
               })),
             })),
-            update: mockUpdate,
+            update: userUpdate,
           }
         } else if (table === 'verification_codes') {
           return {
@@ -180,7 +189,7 @@ describe('POST /api/auth/verify-signup', () => {
                 error: null,
               }),
             })),
-            update: mockUpdate,
+            update: codeUpdate,
           }
         }
       })
@@ -199,7 +208,15 @@ describe('POST /api/auth/verify-signup', () => {
         success: true,
         message: 'Email verified successfully',
         userId: 'user-1',
+        handoffToken: 'signup-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890',
       })
+      expect(codeUpdate).toHaveBeenCalledWith(expect.objectContaining({
+        used_at: expect.any(String),
+        handoff_token_hash: 'hashed_signup-handoff-token-abcdefghijklmnopqrstuvwxyz1234567890',
+        handoff_expires_at: expect.any(String),
+        handoff_consumed_at: null,
+      }))
+      expect(userUpdate).toHaveBeenCalledWith({ email_verified_at: expect.any(String) })
     })
   })
 })

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -3,6 +3,8 @@ import {
   generateVerificationCode,
   hashCode,
   verifyCode,
+  generateHandoffToken,
+  hashHandoffToken,
   hashPassword,
   verifyPassword,
   validatePassword,
@@ -53,6 +55,25 @@ describe('crypto utilities', () => {
     it('should use Math.random to choose characters', () => {
       vi.spyOn(Math, 'random').mockReturnValue(0)
       expect(generateVerificationCode()).toBe('AAAAA')
+    })
+  })
+
+  describe('handoff tokens', () => {
+    it('should generate a high-entropy URL-safe token', () => {
+      const token = generateHandoffToken()
+
+      expect(token.length).toBeGreaterThanOrEqual(32)
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+
+    it('should hash handoff tokens deterministically without storing the token itself', () => {
+      const token = 'handoff-token-abcdefghijklmnopqrstuvwxyz1234567890'
+      const hash = hashHandoffToken(token)
+
+      expect(hash).not.toBe(token)
+      expect(hash).toHaveLength(64)
+      expect(hash).toBe(hashHandoffToken(token))
+      expect(hash).not.toBe(hashHandoffToken(`${token}-different`))
     })
   })
 


### PR DESCRIPTION
## Summary
- issue short-lived one-time handoff tokens after signup/reset code verification
- require and consume hashed handoff tokens before create-password/reset-confirm writes
- pass signup tokens via sessionStorage and reset tokens through page state; add migration 076

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/crypto.test.ts tests/api/auth/verify-signup.test.ts tests/api/auth/create-password.test.ts tests/api/auth/reset-password/verify.test.ts tests/api/auth/reset-password/confirm.test.ts
- pnpm tsc --noEmit
- pnpm test tests/api/auth
- git diff --check
- pnpm lint
- pnpm build
- pnpm test tests/unit/migration-filenames.test.ts
- pnpm test
- bash .codex/skills/pika-audit/scripts/audit.sh