### PR TITLE
Fix test grading mobile table overflow

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,38 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-25 — Assignment artifact storage cleanup follow-up
-
-**Completed:**
-- Added best-effort teacher-side cleanup for `assignment-artifacts` image objects when image submission requirements are removed.
-- Added best-effort cleanup for image artifact objects after teacher assignment deletion succeeds.
-- Preserved storage objects when an image requirement is edited/reordered/renamed with the same requirement ID and type.
-- Added chunked Storage `remove()` calls with failure logging that does not fail successful teacher mutations.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/assignments-id.test.ts`
-- `pnpm test tests/lib/assignment-submission-artifacts.test.ts tests/api/assignment-docs/artifacts.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm build`
-- `pnpm exec vitest run tests/unit/assignment-submission-validation.test.ts`
-- `pnpm exec vitest run tests/lib/assignment-submission-artifacts.test.ts tests/unit/assignment-submission-validation.test.ts`
-- `pnpm exec vitest run tests/unit/assignment-submission-validation.test.ts tests/lib/assignment-submission-requirements.test.ts tests/lib/assignment-submission-artifacts.test.ts tests/api/assignment-docs/artifacts.test.ts`
-- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -c "begin;" -c "with target_assignment as (select id from public.assignments limit 1), replaced as (select r.* from target_assignment t cross join lateral public.replace_assignment_submission_requirements_atomic(t.id, '[{\"type\":\"link\",\"label\":\"Smoke public link\",\"required\":true,\"position\":0}]'::jsonb) r) select count(*) as replaced_count from replaced;" -c "rollback;"`
-- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -c "select has_function_privilege('anon', 'public.replace_assignment_submission_requirements_atomic(uuid, jsonb)', 'execute') as anon_execute, has_function_privilege('authenticated', 'public.replace_assignment_submission_requirements_atomic(uuid, jsonb)', 'execute') as authenticated_execute, has_function_privilege('service_role', 'public.replace_assignment_submission_requirements_atomic(uuid, jsonb)', 'execute') as service_role_execute;"`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments'`
-- Focused Playwright screenshots: `/tmp/pika-teacher-requirements-modal.png`, `/tmp/pika-student-requirements-checklist-clean.png`
-- `pnpm test tests/unit/migration-filenames.test.ts`
-- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/components/TeacherStudentWorkPanel.test.tsx tests/api/teacher/assignments-id.test.ts tests/api/assignment-docs/artifacts.test.ts tests/lib/assignment-submission-requirements.test.ts tests/lib/assignment-submission-artifacts.test.ts`
-- `git diff --check`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments'`
-- Focused Playwright screenshot: `/tmp/pika-teacher-artifact-content-pane.png`
-- `pnpm exec vitest run tests/lib/assignment-ai-grading-runs.test.ts tests/unit/ai-grading.test.ts`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-05-25 — Supabase RLS/Auth hardening for WorkOS
 
 **Completed:**
@@ -390,3 +358,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-05-26 — Test grading mobile table fit
+
+**Completed:**
+- Constrained the teacher test grading student table on mobile/tablet by keeping actionable columns visible and moving telemetry columns to desktop widths.
+- Added truncation for long student names and tightened mobile header spacing to avoid wrapped labels.
+- Added component coverage for the responsive table constraints.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading&testStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
+- Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`
+- Playwright overflow check: teacher mobile `documentScrollWidth=390`, `bodyScrollWidth=390`, viewport `390`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -1968,10 +1968,10 @@ export function TeacherTestsTab({
           data-testid="test-grading-student-scroll-pane"
           onScroll={preserveGradingStudentTableScrollPosition}
         >
-          <DataTable density="tight" className="text-sm">
+          <DataTable density="tight" className="table-fixed text-sm lg:table-auto">
             <DataTableHead>
               <DataTableRow>
-                <DataTableHeaderCell className="w-10 px-3 py-2">
+                <DataTableHeaderCell className="w-9 px-2 py-2 sm:w-10 sm:px-3">
                   <input
                     type="checkbox"
                     checked={batchAllSelected}
@@ -1980,34 +1980,34 @@ export function TeacherTestsTab({
                     aria-label="Select all students"
                   />
                 </DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">
+                <DataTableHeaderCell className="min-w-0 px-2 py-2 sm:px-3">
                   <button
                     type="button"
                     onClick={() => {
                       setGradingSortColumn((prev) => (prev === 'last_name' ? 'first_name' : 'last_name'))
                     }}
-                    className="inline-flex items-center gap-2 text-left text-text-muted hover:text-text-default"
+                    className="inline-flex w-full min-w-0 items-center gap-1 text-left text-text-muted hover:text-text-default sm:gap-2"
                     aria-label={
                       gradingSortColumn === 'last_name'
                         ? 'Sort students by first name'
                         : 'Sort students by last name'
                     }
                   >
-                    <span>Student</span>
-                    <span className="text-xs font-medium text-text-muted">
+                    <span className="truncate">Student</span>
+                    <span className="hidden text-xs font-medium text-text-muted sm:inline">
                       {gradingSortColumn === 'last_name' ? 'Last' : 'First'}
                     </span>
                   </button>
                 </DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">Status</DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">Access</DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">Score</DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">
+                <DataTableHeaderCell className="w-14 whitespace-nowrap px-1.5 py-2 text-xs sm:w-20 sm:px-3 sm:text-sm">Status</DataTableHeaderCell>
+                <DataTableHeaderCell className="w-14 whitespace-nowrap px-1.5 py-2 text-xs sm:w-20 sm:px-3 sm:text-sm">Access</DataTableHeaderCell>
+                <DataTableHeaderCell className="w-16 whitespace-nowrap px-1.5 py-2 text-xs sm:w-20 sm:px-3 sm:text-sm">Score</DataTableHeaderCell>
+                <DataTableHeaderCell className="hidden px-3 py-2 lg:table-cell">
                   <Tooltip content="Most recent recorded in-test activity time (Toronto).">
                     <span className="cursor-help">Last</span>
                   </Tooltip>
                 </DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">
+                <DataTableHeaderCell className="hidden px-3 py-2 lg:table-cell">
                   <Tooltip
                     content={
                       <div className="space-y-0.5">
@@ -2023,7 +2023,7 @@ export function TeacherTestsTab({
                     </span>
                   </Tooltip>
                 </DataTableHeaderCell>
-                <DataTableHeaderCell className="px-3 py-2">
+                <DataTableHeaderCell className="hidden px-3 py-2 lg:table-cell">
                   <Tooltip content="Total time this student was away from the test route.">
                     <span className="inline-flex cursor-help items-center" aria-label="Away column">
                       <ClockAlert className="h-4 w-4" />
@@ -2109,7 +2109,7 @@ export function TeacherTestsTab({
                     }
                     onClick={() => handleGradingStudentSelect(student.student_id)}
                   >
-                    <DataTableCell className="px-3 py-2">
+                    <DataTableCell className="px-2 py-2 sm:px-3">
                       <input
                         type="checkbox"
                         checked={batchSelectedIds.has(student.student_id)}
@@ -2119,10 +2119,10 @@ export function TeacherTestsTab({
                         aria-label={`Select ${student.name || 'student'}`}
                       />
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2">
-                      <div className="font-medium text-text-default">{student.name || 'Student'}</div>
+                    <DataTableCell className="min-w-0 max-w-0 px-2 py-2 sm:px-3 lg:max-w-none">
+                      <div className="truncate font-medium text-text-default">{student.name || 'Student'}</div>
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2">
+                    <DataTableCell className="px-2 py-2 sm:px-3">
                       {student.status === 'submitted' ? (
                         <Tooltip content={canUnsubmitStudent ? `${statusMeta.label}. Click to mark ${studentLabel} unsubmitted.` : statusMeta.label}>
                           <button
@@ -2150,7 +2150,7 @@ export function TeacherTestsTab({
                         </Tooltip>
                       )}
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2">
+                    <DataTableCell className="px-2 py-2 sm:px-3">
                       <Tooltip content={`${accessTooltip}. ${accessActionTooltip}`}>
                         <button
                           type="button"
@@ -2166,10 +2166,10 @@ export function TeacherTestsTab({
                         </button>
                       </Tooltip>
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2 text-text-default">{scoreLabel}</DataTableCell>
+                    <DataTableCell className="px-2 py-2 text-text-default sm:px-3">{scoreLabel}</DataTableCell>
                     <DataTableCell
                       className={[
-                        'px-3 py-2 tabular-nums',
+                        'hidden px-3 py-2 tabular-nums lg:table-cell',
                         formattedLastActivity.isPm ? 'font-semibold text-text-default' : 'text-text-muted',
                       ].join(' ')}
                     >
@@ -2184,7 +2184,7 @@ export function TeacherTestsTab({
                         </span>
                       </Tooltip>
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2 text-xs tabular-nums">
+                    <DataTableCell className="hidden px-3 py-2 text-xs tabular-nums lg:table-cell">
                       <Tooltip
                         content={
                           <div className="space-y-0.5">
@@ -2203,7 +2203,7 @@ export function TeacherTestsTab({
                         </span>
                       </Tooltip>
                     </DataTableCell>
-                    <DataTableCell className="px-3 py-2 text-xs text-text-muted tabular-nums">
+                    <DataTableCell className="hidden px-3 py-2 text-xs text-text-muted tabular-nums lg:table-cell">
                       <Tooltip content={`Away from test route for ${awayLabel} total.`}>
                         <span
                           className="cursor-help"

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1051,6 +1051,33 @@ describe('TeacherTestsTab', () => {
     expect(within(inspectorScrollPane).getByTestId('mock-test-grading-panel')).toBeInTheDocument()
   })
 
+  it('keeps the grading student table constrained on mobile widths', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    const studentScrollPane = await screen.findByTestId('test-grading-student-scroll-pane')
+    const table = within(studentScrollPane).getByRole('table')
+    expect(table).toHaveClass('table-fixed')
+    expect(table).toHaveClass('lg:table-auto')
+
+    const row = screen.getByTestId('test-grading-student-row-student-1')
+    expect(within(row).getByText('Alice Zephyr').closest('td')).toHaveClass('max-w-0')
+    expect(within(row).getByLabelText(/Exits \d+\./).closest('td')).toHaveClass('hidden')
+    expect(within(row).getByLabelText(/Away time/).closest('td')).toHaveClass('hidden')
+
+    expect(screen.getByText('Last', { selector: 'span.cursor-help' }).closest('th')).toHaveClass('hidden')
+    expect(screen.getByLabelText('Exits column').closest('th')).toHaveClass('lg:table-cell')
+    expect(screen.getByLabelText('Away column').closest('th')).toHaveClass('lg:table-cell')
+  })
+
   it('clears the selected grading row with Escape', async () => {
     fetchMock
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- constrain teacher test grading table columns on mobile/tablet
- keep telemetry columns desktop-only while preserving actionable columns
- add component coverage for responsive table constraints

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/TeacherTestsTab.test.tsx
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading&testStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'
- Playwright overflow check: teacher mobile document/body scrollWidth 390 at viewport 390
- pnpm lint
- pnpm test
- pnpm build