### PR TITLE
Cover action bar menu behavior

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,26 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-25 — Supabase RLS/Auth hardening for WorkOS
-
-**Completed:**
-- Added migration `075_auth_rls_hardening.sql` with `users.workos_user_id` unique mapping while preserving local UUID user IDs.
-- Enabled RLS and explicit no-direct-access policies on announcements, announcement reads, gradebook settings, quiz score overrides, and report-card tables.
-- Revoked direct public table/sequence/function grants from `anon` and `authenticated`, preserved `service_role`, and hardened migration-owner default privileges.
-- Removed direct authenticated upload/delete storage policies for legacy public buckets while keeping public read behavior.
-- Set stable `search_path` on existing public functions surfaced by Supabase security advisors.
-- Updated architecture/AI guidance for the server-route authorization model and WorkOS posture.
-
-**Validation:**
-- `psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -v ON_ERROR_STOP=1 -1 -f supabase/migrations/075_auth_rls_hardening.sql`
-- Metadata checks for RLS, grants, policies, default privileges, and WorkOS index.
-- `supabase db lint --local --schema public,storage --fail-on none` (passes with pre-existing warnings only)
-- `supabase db advisors --local --type security --level warn --fail-on none`
-- `pnpm test tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/api/student/announcements.test.ts tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts tests/unit/auth-rls-hardening-migration.test.ts tests/unit/migration-filenames.test.ts`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `git diff --check`
-
 ## 2026-05-25 — Assignment artifact open behavior
 
 **Completed:**
@@ -372,6 +352,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading&testStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
 - Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`
 - Playwright overflow check: teacher mobile `documentScrollWidth=390`, `bodyScrollWidth=390`, viewport `390`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`
+
+## 2026-05-26 — Action bar viewport and menu coverage
+
+**Completed:**
+- Added direct `PageActionBar` coverage for desktop action groups, mobile overflow menu containers, menu ordering, destructive grouping, disabled items, selection close, Escape close, and outside-click close.
+- Expanded teacher work-surface floating action cluster coverage for viewport max-width, fixed placement, visual chrome, floating center actions, and inline center actions.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/PageActionBar.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx`
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`

--- a/tests/components/PageActionBar.test.tsx
+++ b/tests/components/PageActionBar.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { PageActionBar, type ActionBarItem } from '@/components/PageLayout'
+
+function renderActionBar(actions: ActionBarItem[], actionsAlign: 'start' | 'end' = 'end') {
+  return render(
+    <PageActionBar
+      primary={<div>Primary content</div>}
+      actions={actions}
+      actionsAlign={actionsAlign}
+      trailing={<button type="button">Trailing action</button>}
+    />,
+  )
+}
+
+describe('PageActionBar', () => {
+  it('renders desktop actions and mobile overflow menu containers with responsive classes', () => {
+    renderActionBar([
+      { id: 'archive', label: 'Archive', onSelect: vi.fn() },
+      { id: 'delete', label: 'Delete', destructive: true, onSelect: vi.fn() },
+    ])
+
+    const desktopActions = screen.getByRole('button', { name: 'Archive' }).parentElement
+    expect(desktopActions).toHaveClass('hidden', 'sm:flex', 'justify-end')
+
+    const menuButton = screen.getByRole('button', { name: 'Open actions menu' })
+    expect(menuButton).toHaveAttribute('aria-haspopup', 'menu')
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+    expect(menuButton.parentElement?.parentElement).toHaveClass('sm:hidden')
+  })
+
+  it('opens mobile actions, groups destructive items last, and closes after selection', () => {
+    const onArchive = vi.fn()
+    const onDelete = vi.fn()
+
+    renderActionBar([
+      { id: 'delete', label: 'Delete', destructive: true, onSelect: onDelete },
+      { id: 'archive', label: 'Archive', onSelect: onArchive },
+    ])
+
+    const menuButton = screen.getByRole('button', { name: 'Open actions menu' })
+    fireEvent.click(menuButton)
+
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true')
+    const menu = screen.getByRole('menu')
+    expect(menu).toHaveClass('absolute', 'right-0', 'z-20', 'mt-2', 'w-56')
+
+    const menuItems = within(menu).getAllByRole('menuitem')
+    expect(menuItems.map((item) => item.textContent)).toEqual(['Archive', 'Delete'])
+    expect(menuItems[1].parentElement).toHaveClass('border-t', 'border-border')
+
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Archive' }))
+
+    expect(onArchive).toHaveBeenCalledOnce()
+    expect(onDelete).not.toHaveBeenCalled()
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('closes the mobile actions menu on escape and outside click', () => {
+    renderActionBar([
+      { id: 'archive', label: 'Archive', onSelect: vi.fn() },
+    ])
+
+    const menuButton = screen.getByRole('button', { name: 'Open actions menu' })
+
+    fireEvent.click(menuButton)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+    fireEvent.click(menuButton)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('preserves disabled mobile actions without firing their handlers', () => {
+    const onArchive = vi.fn()
+
+    renderActionBar([
+      { id: 'archive', label: 'Archive', disabled: true, onSelect: onArchive },
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open actions menu' }))
+    const item = screen.getByRole('menuitem', { name: 'Archive' })
+
+    expect(item).toBeDisabled()
+    fireEvent.click(item)
+    expect(onArchive).not.toHaveBeenCalled()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('supports start-aligned desktop action groups while retaining the mobile menu', () => {
+    renderActionBar(
+      [
+        { id: 'archive', label: 'Archive', onSelect: vi.fn() },
+      ],
+      'start',
+    )
+
+    const desktopActions = screen.getByRole('button', { name: 'Archive' }).parentElement
+    expect(desktopActions).toHaveClass('hidden', 'sm:flex', 'justify-start')
+    expect(screen.getByRole('button', { name: 'Open actions menu' }).parentElement?.parentElement).toHaveClass(
+      'sm:hidden',
+    )
+  })
+})

--- a/tests/components/TeacherWorkSurfaceActionBar.test.tsx
+++ b/tests/components/TeacherWorkSurfaceActionBar.test.tsx
@@ -31,6 +31,9 @@ describe('TeacherWorkSurfaceFloatingActionCluster', () => {
     )
 
     const cluster = screen.getByRole('button', { name: 'Jump to today' }).parentElement
+    expect(cluster).toHaveClass('fixed', 'top-[3.25rem]', 'z-40', 'w-max')
+    expect(cluster?.className).toContain('max-w-[calc(100vw-1rem)]')
+    expect(cluster).toHaveClass('rounded-lg', 'bg-surface/95', 'shadow-elevated', 'backdrop-blur')
     expect(cluster).toHaveClass('left-1/2')
     expect(cluster?.className).toContain('lg:left-[var(--main-content-center-x,50%)]')
     expect(cluster?.className).toContain('lg:transition-[left]')
@@ -50,5 +53,24 @@ describe('TeacherWorkSurfaceFloatingActionCluster', () => {
     const label = screen.getByText('May 2026')
     expect(label).toBeInTheDocument()
     expect(label).toHaveClass('justify-self-start', 'font-semibold', 'text-text-default')
+
+    const floatingCluster = screen.getByRole('button', { name: 'Tue May 5' }).parentElement
+    expect(floatingCluster).toHaveClass('fixed')
+    expect(floatingCluster?.className).toContain('max-w-[calc(100vw-1rem)]')
+  })
+
+  it('keeps inline center actions in the normal grid flow', () => {
+    render(
+      <TeacherWorkSurfaceActionBar
+        label="Assignments"
+        center={<button type="button">New Assignment</button>}
+        trailing={<button type="button">Settings</button>}
+      />,
+    )
+
+    const center = screen.getByRole('button', { name: 'New Assignment' }).parentElement
+    expect(center).toHaveClass('justify-self-center')
+    expect(center).not.toHaveClass('fixed')
+    expect(screen.getByRole('button', { name: 'Settings' }).parentElement).toHaveClass('justify-self-end')
   })
 })


### PR DESCRIPTION
## Summary
- add direct PageActionBar coverage for desktop action groups and mobile overflow menu behavior
- cover menu ordering, destructive grouping, disabled items, selection close, Escape close, and outside-click close
- expand teacher floating action-cluster viewport and placement assertions

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/PageActionBar.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx
- pnpm lint
- pnpm test
- pnpm build