### PR TITLE
[codex] Harden blueprint bulk sync stale ids

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-25 — Assignment artifact open behavior
-
-**Completed:**
-- Changed assignment artifact pills so a single artifact opens directly as an external link.
-- Replaced the multi-artifact preview carousel with a narrow chooser dialog listing each artifact as a direct external link.
-- Added component coverage for direct-link mode and the multi-artifact chooser.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test -- tests/components/AssignmentArtifactsCell.test.tsx` (ran full suite; pass)
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e285be41-5add-4baf-8ac7-d476ec365cad?tab=assignments&assignmentId=f2bc083c-cec5-4b36-8659-603f84e11ff6'`
-- Playwright interaction smoke: multi-artifact chooser opens; single-artifact row opens `https://github.com/codepetca/pika`
-- Screenshot: `/tmp/pika-teacher-artifact-chooser.png`
-
 ## 2026-05-25 — Assignment student table artifact UX
 
 **Completed:**
@@ -370,3 +355,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `pnpm build`
 - `git diff --check`
+
+## 2026-05-26 — Blueprint bulk sync stale-id guards
+
+**Completed:**
+- Rejected unknown blueprint assignment, assessment, and lesson template update IDs before bulk sync computes deletions.
+- Rejected assessment updates outside the selected replacement type and rejected quiz/test type drift before deleting rows.
+- Added regression coverage proving stale IDs fail with 400s and do not call the delete builder.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/lib/server/course-blueprints.test.ts tests/api/teacher/course-blueprints-route.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -362,6 +362,12 @@ export async function syncCourseBlueprintAssignments(
 
   const creates = assignments.filter((assignment) => !assignment.id)
   const updates = assignments.filter((assignment) => assignment.id)
+  const existingIds = new Set((existingAssignments || []).map((assignment) => assignment.id as string))
+  const unknownUpdate = updates.find((assignment) => !existingIds.has(assignment.id!))
+  if (unknownUpdate) {
+    return { ok: false as const, status: 400, error: 'Cannot update unknown blueprint assignment' }
+  }
+
   const incomingIds = new Set(updates.map((assignment) => assignment.id!))
   const deleteIds = (existingAssignments || [])
     .map((assignment) => assignment.id as string)
@@ -450,8 +456,36 @@ export async function syncCourseBlueprintAssessments(
 
   const creates = assessments.filter((assessment) => !assessment.id)
   const updates = assessments.filter((assessment) => assessment.id)
+  const existingAssessmentTypesById = new Map(
+    (existingAssessments || []).map((assessment) => [
+      assessment.id as string,
+      assessment.assessment_type as 'quiz' | 'test',
+    ])
+  )
+  const unknownUpdate = updates.find((assessment) => !existingAssessmentTypesById.has(assessment.id!))
+  if (unknownUpdate) {
+    return { ok: false as const, status: 400, error: 'Cannot update unknown blueprint assessment' }
+  }
+
   const incomingIds = new Set(updates.map((assessment) => assessment.id!))
   const replaceTypes = options?.replaceTypes ? new Set(options.replaceTypes) : null
+  const outOfScopeUpdate = replaceTypes
+    ? updates.find((assessment) => !replaceTypes.has(existingAssessmentTypesById.get(assessment.id!)!))
+    : undefined
+  if (outOfScopeUpdate) {
+    return {
+      ok: false as const,
+      status: 400,
+      error: 'Cannot update a blueprint assessment outside the selected assessment type',
+    }
+  }
+  const typeChange = updates.find(
+    (assessment) => existingAssessmentTypesById.get(assessment.id!) !== assessment.assessment_type
+  )
+  if (typeChange) {
+    return { ok: false as const, status: 400, error: 'Cannot change blueprint assessment type during bulk sync' }
+  }
+
   const deleteIds = (existingAssessments || [])
     .filter((assessment) => {
       const assessmentType = assessment.assessment_type as 'quiz' | 'test'
@@ -526,6 +560,12 @@ export async function syncCourseBlueprintLessonTemplates(
 
   const creates = lessonTemplates.filter((lesson) => !lesson.id)
   const updates = lessonTemplates.filter((lesson) => lesson.id)
+  const existingIds = new Set((existingLessons || []).map((lesson) => lesson.id as string))
+  const unknownUpdate = updates.find((lesson) => !existingIds.has(lesson.id!))
+  if (unknownUpdate) {
+    return { ok: false as const, status: 400, error: 'Cannot update unknown lesson template' }
+  }
+
   const incomingIds = new Set(updates.map((lesson) => lesson.id!))
   const deleteIds = (existingLessons || [])
     .map((lesson) => lesson.id as string)

--- a/tests/lib/server/course-blueprints.test.ts
+++ b/tests/lib/server/course-blueprints.test.ts
@@ -9,7 +9,9 @@ import {
   getNextTeacherCourseBlueprintPosition,
   hydrateCourseBlueprint,
   importCourseBlueprintBundle,
+  syncCourseBlueprintAssignments,
   syncCourseBlueprintAssessments,
+  syncCourseBlueprintLessonTemplates,
   updateCourseBlueprint,
 } from '@/lib/server/course-blueprints'
 import {
@@ -223,6 +225,185 @@ describe('course-blueprints server helpers', () => {
 
     expect(deleteBuilder.in).toHaveBeenCalledWith('id', ['q-2'])
     expect(updateBuilder.eq).toHaveBeenCalledWith('id', 'q-1')
+  })
+
+  it('rejects unknown assignment update IDs before deleting existing blueprint assignments', async () => {
+    const deleteBuilder = makeQueryBuilder({ data: null, error: null })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({ data: { id: 'b-1', teacher_id: 'teacher-1' }, error: null }),
+      ],
+      course_blueprint_assignments: [
+        makeQueryBuilder({
+          data: [{ id: 'a-1' }, { id: 'a-2' }],
+          error: null,
+        }),
+        deleteBuilder,
+      ],
+    })
+
+    await expect(syncCourseBlueprintAssignments('teacher-1', 'b-1', [{
+      id: 'stale-assignment-id',
+      title: 'Updated Essay',
+      instructions_markdown: 'Updated instructions',
+      default_due_days: 1,
+      default_due_time: '23:59',
+      points_possible: 10,
+      include_in_final: true,
+      is_draft: false,
+      position: 0,
+    }])).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot update unknown blueprint assignment',
+    })
+
+    expect(deleteBuilder.delete).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown assessment update IDs before deleting existing blueprint assessments', async () => {
+    const deleteBuilder = makeQueryBuilder({ data: null, error: null })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({ data: { id: 'b-1', teacher_id: 'teacher-1' }, error: null }),
+      ],
+      course_blueprint_assessments: [
+        makeQueryBuilder({
+          data: [
+            { id: 'q-1', assessment_type: 'quiz' },
+            { id: 'q-2', assessment_type: 'quiz' },
+          ],
+          error: null,
+        }),
+        deleteBuilder,
+      ],
+    })
+
+    await expect(syncCourseBlueprintAssessments(
+      'teacher-1',
+      'b-1',
+      [{
+        id: 'stale-assessment-id',
+        assessment_type: 'quiz',
+        title: 'Updated Quiz',
+        content: { title: 'Updated Quiz', show_results: true, questions: [] } as any,
+        documents: [],
+        position: 0,
+      }],
+      { replaceTypes: ['quiz'] },
+    )).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot update unknown blueprint assessment',
+    })
+
+    expect(deleteBuilder.delete).not.toHaveBeenCalled()
+  })
+
+  it('rejects assessment type drift before deleting existing blueprint assessments', async () => {
+    const deleteBuilder = makeQueryBuilder({ data: null, error: null })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({ data: { id: 'b-1', teacher_id: 'teacher-1' }, error: null }),
+      ],
+      course_blueprint_assessments: [
+        makeQueryBuilder({
+          data: [
+            { id: 'q-1', assessment_type: 'quiz' },
+            { id: 'q-2', assessment_type: 'quiz' },
+          ],
+          error: null,
+        }),
+        deleteBuilder,
+      ],
+    })
+
+    await expect(syncCourseBlueprintAssessments(
+      'teacher-1',
+      'b-1',
+      [{
+        id: 'q-1',
+        assessment_type: 'test',
+        title: 'Updated Test',
+        content: { title: 'Updated Test', questions: [] } as any,
+        documents: [],
+        position: 0,
+      }],
+    )).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot change blueprint assessment type during bulk sync',
+    })
+
+    expect(deleteBuilder.delete).not.toHaveBeenCalled()
+  })
+
+  it('rejects assessment updates outside the selected replacement type before deleting rows', async () => {
+    const deleteBuilder = makeQueryBuilder({ data: null, error: null })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({ data: { id: 'b-1', teacher_id: 'teacher-1' }, error: null }),
+      ],
+      course_blueprint_assessments: [
+        makeQueryBuilder({
+          data: [
+            { id: 'q-1', assessment_type: 'quiz' },
+            { id: 't-1', assessment_type: 'test' },
+          ],
+          error: null,
+        }),
+        deleteBuilder,
+      ],
+    })
+
+    await expect(syncCourseBlueprintAssessments(
+      'teacher-1',
+      'b-1',
+      [{
+        id: 't-1',
+        assessment_type: 'test',
+        title: 'Updated Test',
+        content: { title: 'Updated Test', questions: [] } as any,
+        documents: [],
+        position: 0,
+      }],
+      { replaceTypes: ['quiz'] },
+    )).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot update a blueprint assessment outside the selected assessment type',
+    })
+
+    expect(deleteBuilder.delete).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown lesson template update IDs before deleting existing lesson templates', async () => {
+    const deleteBuilder = makeQueryBuilder({ data: null, error: null })
+    mockSupabase = makeSupabaseFromQueues({
+      course_blueprints: [
+        makeQueryBuilder({ data: { id: 'b-1', teacher_id: 'teacher-1' }, error: null }),
+      ],
+      course_blueprint_lesson_templates: [
+        makeQueryBuilder({
+          data: [{ id: 'l-1' }, { id: 'l-2' }],
+          error: null,
+        }),
+        deleteBuilder,
+      ],
+    })
+
+    await expect(syncCourseBlueprintLessonTemplates('teacher-1', 'b-1', [{
+      id: 'stale-lesson-id',
+      title: 'Updated Lesson',
+      content_markdown: 'Updated markdown',
+      position: 0,
+    }])).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Cannot update unknown lesson template',
+    })
+
+    expect(deleteBuilder.delete).not.toHaveBeenCalled()
   })
 
   it('loads detail hydration and deletes owned blueprints', async () => {


### PR DESCRIPTION
## Summary
- reject unknown assignment, assessment, and lesson template update IDs before bulk sync deletes removed rows
- reject assessment updates that target a type outside the selected replacement scope
- reject quiz/test type drift for existing blueprint assessments
- add regression coverage that stale IDs return 400 and never call the delete builder

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/lib/server/course-blueprints.test.ts tests/api/teacher/course-blueprints-route.test.ts
- git diff --check
- pnpm lint
- pnpm test
- pnpm build