### PR TITLE
[codex] Guard archived gradebook mutations

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-25 — Assignment artifact hover dropdown links
-
-**Completed:**
-- Made assignment artifact hover lists interactive so the pointer can move from an artifact pill into the dropdown.
-- Converted hover-list artifact rows into external links while preserving the existing pill-click chooser/direct-link behavior.
-- Added component coverage for clicking a hover-list artifact without opening the chooser or bubbling to parent row handlers.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
-- Playwright hover smoke: hovered artifact pill, moved into dropdown link, verified trial click to `https://github.com/vercel/next.js/tree/canary`.
-- Screenshots: `/tmp/pika-teacher-loaded.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-artifacts-hover.png`
-- `pnpm test`
-
 ## 2026-05-26 — Nested GitHub artifact classification
 
 **Completed:**
@@ -365,5 +349,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm test tests/api/account/github-identity.test.ts tests/unit/api-route-standards.test.ts`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — Archived gradebook mutation guards
+
+**Completed:**
+- Blocked gradebook assessment-weight PATCH requests when the classroom is archived while preserving read access.
+- Blocked manual quiz override writes for archived classrooms by loading `archived_at` through the joined classroom relation.
+- Added API regression coverage proving both archived paths return 403 before update/upsert work.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts`
+- `git diff --check`
+- `pnpm lint`
 - `pnpm test`
 - `pnpm build`

--- a/src/app/api/teacher/gradebook/quiz-overrides/route.ts
+++ b/src/app/api/teacher/gradebook/quiz-overrides/route.ts
@@ -30,7 +30,7 @@ export const PATCH = withErrorHandler('PatchQuizOverride', async (request) => {
 
   const { data: quiz, error: quizError } = await supabase
     .from('quizzes')
-    .select('id, classroom_id, points_possible, classrooms!inner(teacher_id)')
+    .select('id, classroom_id, points_possible, classrooms!inner(teacher_id, archived_at)')
     .eq('id', quizId)
     .single()
 
@@ -45,6 +45,9 @@ export const PATCH = withErrorHandler('PatchQuizOverride', async (request) => {
   const classroomRelation = Array.isArray(quiz.classrooms) ? quiz.classrooms[0] : quiz.classrooms
   if (!classroomRelation || classroomRelation.teacher_id !== user.id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (classroomRelation.archived_at) {
+    return NextResponse.json({ error: 'Classroom is archived' }, { status: 403 })
   }
 
   const max = Number(quiz.points_possible ?? 100)

--- a/src/app/api/teacher/gradebook/route.ts
+++ b/src/app/api/teacher/gradebook/route.ts
@@ -214,7 +214,11 @@ function getTestGradebookStatus(input: {
   return null
 }
 
-async function assertTeacherOwnsClassroom(teacherId: string, classroomId: string) {
+async function assertTeacherOwnsClassroom(
+  teacherId: string,
+  classroomId: string,
+  options?: { checkArchived?: boolean }
+) {
   const supabase = getServiceRoleClient()
   const { data, error } = await supabase
     .from('classrooms')
@@ -224,6 +228,9 @@ async function assertTeacherOwnsClassroom(teacherId: string, classroomId: string
 
   if (error || !data) return { ok: false as const, status: 404 as const, error: 'Classroom not found' }
   if (data.teacher_id !== teacherId) return { ok: false as const, status: 403 as const, error: 'Forbidden' }
+  if (options?.checkArchived && data.archived_at) {
+    return { ok: false as const, status: 403 as const, error: 'Classroom is archived' }
+  }
   return { ok: true as const, classroom: data }
 }
 
@@ -1089,7 +1096,7 @@ export const PATCH = withErrorHandler('PatchGradebook', async (request: NextRequ
     return NextResponse.json({ error: 'classroom_id is required' }, { status: 400 })
   }
 
-  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId)
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { checkArchived: true })
   if (!ownership.ok) {
     return NextResponse.json({ error: ownership.error }, { status: ownership.status })
   }

--- a/tests/api/teacher/gradebook-quiz-overrides.test.ts
+++ b/tests/api/teacher/gradebook-quiz-overrides.test.ts
@@ -70,7 +70,7 @@ describe('PATCH /api/teacher/gradebook/quiz-overrides', () => {
                   id: 'quiz-1',
                   classroom_id: 'classroom-1',
                   points_possible: 10,
-                  classrooms: { teacher_id: 'teacher-1' },
+                  classrooms: { teacher_id: 'teacher-1', archived_at: null },
                 },
                 error: null,
               }),
@@ -110,5 +110,53 @@ describe('PATCH /api/teacher/gradebook/quiz-overrides', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({ success: true })
+  })
+
+  it('rejects quiz overrides for archived classrooms before saving', async () => {
+    const upsert = vi.fn()
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  points_possible: 10,
+                  classrooms: {
+                    teacher_id: 'teacher-1',
+                    archived_at: '2026-05-01T12:00:00.000Z',
+                  },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'quiz_student_scores') {
+        return { upsert }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/gradebook/quiz-overrides', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          classroom_id: 'classroom-1',
+          quiz_id: 'quiz-1',
+          student_id: 'student-1',
+          manual_override_score: 8,
+        }),
+      })
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data).toEqual({ error: 'Classroom is archived' })
+    expect(upsert).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('classroom_enrollments')
   })
 })

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -938,4 +938,47 @@ describe('PATCH /api/teacher/gradebook', () => {
       weight: 20,
     })
   })
+
+  it('rejects assessment weight updates for archived classrooms', async () => {
+    const update = vi.fn()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'c1', teacher_id: 'teacher-1', archived_at: '2026-05-01T12:00:00.000Z' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignments') {
+        return { update }
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        classroom_id: 'c1',
+        assessment_type: 'assignment',
+        assessment_id: 'a1',
+        gradebook_weight: 20,
+      }),
+    })
+
+    const response = await PATCH(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('Classroom is archived')
+    expect(update).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('assignments')
+  })
 })


### PR DESCRIPTION
## Summary
- block gradebook assessment-weight PATCH requests when the classroom is archived while preserving gradebook read access
- block manual quiz override writes for archived classrooms by loading `archived_at` through the joined classroom relation
- add regression tests that both archived mutation paths return 403 before update/upsert work

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts
- git diff --check
- pnpm lint
- pnpm test
- pnpm build