### PR TITLE
[codex] Preserve assignment submit timestamps

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Nested GitHub artifact classification
-
-**Completed:**
-- Constrained inferred repo artifacts to root GitHub repository URLs only.
-- Kept nested GitHub URLs such as `/tree`, `/blob`, and `/issues` classified as normal links.
-- Preserved explicit structured `repo_link` artifacts and root GitHub repo links as repo artifacts.
-- Moved root-repo detection into the shared GitHub helper, fixed exact GitHub host matching, and blocked known GitHub product routes such as `/orgs`, `/topics`, and `/settings` from repo detection.
-
-**Validation:**
-- `pnpm test tests/lib/assignment-artifacts.test.ts tests/unit/assignment-repo-targets.test.ts tests/components/AssignmentArtifactsCell.test.tsx`
-- `pnpm test tests/lib/assignment-artifacts.test.ts tests/unit/select-and-github-repos.test.tsx tests/unit/assignment-repo-targets.test.ts tests/components/AssignmentArtifactsCell.test.tsx`
-- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/unit/repo-review.test.ts tests/unit/repo-review-validation.test.ts tests/api/assignment-docs/artifacts.test.ts`
-- `pnpm lint`
-- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx` after a full-suite timeout in that unrelated file
-- `pnpm test tests/api/auth/verify-signup.test.ts` after a second full-suite timeout in that unrelated file
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
-- Playwright artifact smoke: root `github.com/codepetca/pika` stayed `Repo`; nested `github.com/vercel/next.js/tree/canary` rendered/clicked as `Link`.
-- Screenshots: `/tmp/pika-teacher-artifact-types-loaded.png`, `/tmp/pika-artifact-link-hover.png`, `/tmp/pika-artifact-root-vs-link-hover.png`
-
 ## 2026-05-26 — Student daily log background refresh
 
 **Completed:**
@@ -362,6 +343,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — Assignment duplicate-submit timestamp guard
+
+**Completed:**
+- Preserved the original `submitted_at` value when an already-submitted assignment doc receives a duplicate submit request.
+- Kept fresh timestamps for first submissions and later resubmissions after the doc has been returned/unsubmitted.
+- Added API regression coverage proving duplicate submit writes the first timestamp back instead of replacing it.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/assignment-docs/submit.test.ts`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm test`

--- a/src/app/api/assignment-docs/[id]/submit/route.ts
+++ b/src/app/api/assignment-docs/[id]/submit/route.ts
@@ -58,7 +58,7 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
   // Check if doc exists
   const { data: existingDoc, error: docError } = await supabase
     .from('assignment_docs')
-    .select('id, student_id, content')
+    .select('id, student_id, content, is_submitted, submitted_at')
     .eq('assignment_id', assignmentId)
     .eq('student_id', user.id)
     .single()
@@ -107,12 +107,16 @@ export const POST = withErrorHandler('PostAssignmentDocSubmit', async (request, 
     )
   }
 
+  const submittedAt = existingDoc.is_submitted && existingDoc.submitted_at
+    ? existingDoc.submitted_at
+    : new Date().toISOString()
+
   // Update to submitted state
   const { data: doc, error } = await supabase
     .from('assignment_docs')
     .update({
       is_submitted: true,
-      submitted_at: new Date().toISOString()
+      submitted_at: submittedAt
     })
     .eq('id', existingDoc.id)
     .select()

--- a/tests/api/assignment-docs/submit.test.ts
+++ b/tests/api/assignment-docs/submit.test.ts
@@ -306,6 +306,93 @@ describe('POST /api/assignment-docs/[id]/submit', () => {
     expect(authenticityUpdate).toHaveBeenCalledWith('id', 'doc-1')
   })
 
+  it('preserves the first submitted_at timestamp on duplicate submit', async () => {
+    const historyInsert = vi.fn(async () => ({ error: null }))
+    const originalSubmittedAt = '2026-04-20T14:30:00.000Z'
+    const submittedContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Finished work' }] }],
+    }
+    const updateDoc = vi.fn((payload: Record<string, unknown>) => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: 'doc-1',
+              student_id: 'student-1',
+              content: submittedContent,
+              is_submitted: true,
+              submitted_at: payload.submitted_at,
+            },
+            error: null,
+          }),
+        })),
+      })),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1', is_draft: false, released_at: null },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: submittedContent,
+                    is_submitted: true,
+                    submitted_at: originalSubmittedAt,
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+          update: updateDoc,
+        }
+      }
+
+      if (table === 'assignment_doc_history') {
+        return {
+          insert: historyInsert,
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/submit', {
+      method: 'POST',
+    }), { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(updateDoc).toHaveBeenCalledWith({
+      is_submitted: true,
+      submitted_at: originalSubmittedAt,
+    })
+    expect(data.doc.submitted_at).toBe(originalSubmittedAt)
+  })
+
   it('still returns the submitted doc when history or authenticity side effects fail', async () => {
     const submittedContent = {
       type: 'doc',


### PR DESCRIPTION
## Summary
- Preserve the original `submitted_at` value when an already-submitted assignment doc receives a duplicate submit request.
- Keep first submissions and returned/unsubmitted resubmissions on the existing timestamp path, only reusing the timestamp when the doc is already submitted.
- Add API regression coverage for duplicate submits.

## Validation
- `pnpm test tests/api/assignment-docs/submit.test.ts`
- `git diff --check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`