### PR TITLE
[codex] Clear gradebook email selection in settings

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Student daily log background refresh
-
-**Completed:**
-- Changed the student Today tab so sessionStorage history is only an instant preview, not the final source of truth.
-- Added a direct capped background `/api/student/entries?limit=12` refresh on mount to update cross-device daily logs.
-- Guarded the editor so an in-flight refresh cannot overwrite a local edit started by the student.
-- Fixed the reverted-edit edge case so a refresh can apply server content after local text returns to the saved value.
-- Updated StudentTodayTab history coverage for preview-first refresh and local-edit protection.
-
-**Validation:**
-- `pnpm test tests/components/StudentTodayTabHistory.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3003 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=today'`
-- Warm screenshots reviewed: `/tmp/pika-student-today-final.png`, `/tmp/pika-teacher-mobile-warm.png`
-
 ## 2026-05-26 — Teacher artifact table refresh
 
 **Completed:**
@@ -358,6 +341,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/api/assignment-docs/submit.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — Gradebook settings clears hidden email selection
+
+**Completed:**
+- Cleared selected gradebook students whenever settings mode opens.
+- Hid selected-student email actions while gradebook settings mode is active.
+- Added component regression coverage for selecting a student, entering settings, and returning to grades without stale selection.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook&gradebookSection=settings'`
+- Browser regression screenshot: `/tmp/pika-teacher-gradebook-settings-after-selection.png`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1379,7 +1379,7 @@ export function TeacherGradebookTab({
     [selectedStudentId, students],
   )
   const rowKeys = useMemo(() => sortedStudents.map((student) => student.student_id), [sortedStudents])
-  const { selectedIds, toggleSelect, toggleSelectAll, allSelected } = useStudentSelection(rowKeys)
+  const { selectedIds, toggleSelect, toggleSelectAll, allSelected, clearSelection } = useStudentSelection(rowKeys)
   const selectedStudents = useMemo(
     () => sortedStudents.filter((student) => selectedIds.has(student.student_id)),
     [selectedIds, sortedStudents],
@@ -1451,8 +1451,11 @@ export function TeacherGradebookTab({
 
   useEffect(() => {
     setColumnEditorOpen(section === 'settings')
-    if (section === 'settings') setSelectedStudentId(null)
-  }, [section])
+    if (section === 'settings') {
+      setSelectedStudentId(null)
+      clearSelection()
+    }
+  }, [clearSelection, section])
 
   useEffect(() => {
     if (!selectedStudentId) return
@@ -1461,7 +1464,10 @@ export function TeacherGradebookTab({
   }, [selectedStudentId, students])
 
   function handleSettingsActiveChange(active: boolean) {
-    if (active) setSelectedStudentId(null)
+    if (active) {
+      setSelectedStudentId(null)
+      clearSelection()
+    }
     setColumnEditorOpen(active)
     onSectionChange(active ? 'settings' : 'grades')
   }
@@ -1624,6 +1630,7 @@ export function TeacherGradebookTab({
   }
 
   const isSettingsActive = columnEditorOpen
+  const showSelectedStudentEmailActions = someStudentsSelected && !isSettingsActive
   const scoreDisplayOptions = [
     {
       value: 'percent',
@@ -1664,7 +1671,7 @@ export function TeacherGradebookTab({
     <TeacherWorkSurfaceActionBar
       center={
         <div className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-1.5">
-          {someStudentsSelected ? (
+          {showSelectedStudentEmailActions ? (
             <SplitButton
               label={
                 <span className="inline-flex items-center gap-2 whitespace-nowrap">

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -351,6 +351,29 @@ describe('TeacherGradebookTab', () => {
     })
   })
 
+  it('clears selected email actions when gradebook settings mode opens', async () => {
+    const onSectionChange = vi.fn()
+
+    renderGradebook('grades', onSectionChange)
+
+    expect(await screen.findByText('Ada')).toBeInTheDocument()
+    const adaSelect = screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })
+    fireEvent.click(adaSelect)
+    expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+
+    expect(onSectionChange).toHaveBeenCalledWith('settings')
+    expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+
+    expect(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeChecked()
+    expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
+  })
+
   it('renders edit controls with assessment weights only', async () => {
     renderGradebook('settings')
 


### PR DESCRIPTION
## Summary
- Clear selected gradebook students whenever settings mode opens.
- Hide selected-student email actions while gradebook settings mode is active.
- Add component regression coverage for selected email actions across settings mode.

## Validation
- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook&gradebookSection=settings'`\n- Browser regression screenshot: `/tmp/pika-teacher-gradebook-settings-after-selection.png`\n- `git diff --check`\n- `pnpm lint`\n- `pnpm test`\n- `pnpm build`