### PR TITLE
[codex] Add selected test delete action

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,20 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Teacher artifact table refresh
-
-**Completed:**
-- Added a refresh control to the teacher assignment workspace action bar so teachers can re-query selected assignment details after students submit structured artifacts.
-- Kept the refresh scoped to the selected assignment detail endpoint that already merges structured submission artifacts into the student table artifact cells.
-- Added component coverage confirming the action bar refresh performs a second assignment-detail fetch.
-
-**Validation:**
-- `pnpm test tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `git diff --check`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a'`
-- Playwright screenshot after settled teacher load: `/tmp/pika-teacher-refresh-submissions.png`
-
 ## 2026-05-26 — Assignment modal title row cleanup
 
 **Completed:**
@@ -358,6 +344,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherGradebookTab.test.tsx`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook&gradebookSection=settings'`
 - Browser regression screenshot: `/tmp/pika-teacher-gradebook-settings-after-selection.png`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-26 — Selected test delete action
+
+**Completed:**
+- Added a destructive `Delete Test` action to the selected test workspace actions menu.
+- Wired the selected-workspace delete action through the existing `onRequestDelete` callback, with the component's internal delete confirmation as fallback.
+- Updated component coverage for the selected-test action menu and delete callback path.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading'`
+- Browser menu screenshot: `/tmp/pika-teacher-tests-delete-action-menu.png`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -296,6 +296,7 @@ export function TeacherTestsTab({
   onTestGradingDataRefresh,
   onTestGradingContextChange,
   onRequestTestPreview,
+  onRequestDelete,
 }: Props) {
   const apiBasePath = '/api/teacher/tests'
   const isReadOnly = !!classroom.archived_at
@@ -2331,6 +2332,26 @@ export function TeacherTestsTab({
           },
           disabled:
             batchSelectedCount === 0 ||
+            isCombinedTestActionsBusy,
+          destructive: true,
+        },
+        {
+          id: 'delete-test',
+          label: (
+            <span className="inline-flex items-center gap-2 whitespace-nowrap text-danger">
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+              <span>Delete Test</span>
+            </span>
+          ),
+          onSelect: () => {
+            if (onRequestDelete) {
+              onRequestDelete()
+              return
+            }
+            setPendingDeleteTest(selectedTestWorkspace)
+          },
+          disabled:
+            isReadOnly ||
             isCombinedTestActionsBusy,
           destructive: true,
         },

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -375,7 +375,7 @@ describe('TeacherTestsTab', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
     expect(screen.queryByRole('menuitem', { name: 'Manage Attempts' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: 'Delete Test' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Delete Test' })).toBeEnabled()
     expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
     fireEvent.click(screen.getByRole('menuitem', { name: 'Edit Test' }))
 
@@ -386,6 +386,23 @@ describe('TeacherTestsTab', () => {
       'aria-pressed',
       'false'
     )
+  })
+
+  it('requests selected test deletion from the selected test actions menu', async () => {
+    const onRequestDelete = vi.fn()
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
+    renderTab({ onRequestDelete })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete Test' }))
+
+    expect(onRequestDelete).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Delete test?')).not.toBeInTheDocument()
   })
 
   it('disables status actions while markdown edits are pending in the edit modal', async () => {
@@ -2442,7 +2459,7 @@ describe('TeacherTestsTab', () => {
 
     expect(screen.queryByRole('menuitem', { name: 'AI Prompt' })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: 'Delete Test' })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Delete Test' })).toBeEnabled()
     expect(screen.getByRole('menuitem', { name: /Delete Selected/ })).toBeDisabled()
     expect(screen.queryByRole('menuitem', { name: 'Clear Open Grades' })).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Grading strategy')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Add a destructive `Delete Test` option to the selected test workspace actions menu.
- Wire the option through the existing parent `onRequestDelete` callback, with the component delete confirmation as fallback.
- Update component coverage for the selected-test menu and delete callback path.

## Validation
- `pnpm test tests/components/TeacherTestsTab.test.tsx`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading'`\n- Browser menu screenshot: `/tmp/pika-teacher-tests-delete-action-menu.png`\n- `git diff --check`\n- `pnpm lint`\n- `pnpm test`\n- `pnpm build`