### PR TITLE
[codex] Preserve assignment student table scroll

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Split-button destructive action placement
-
-**Completed:**
-- Added a `destructive` split-button option flag and centralized menu rendering so destructive options appear last under a separator.
-- Marked assignment delete, test-work delete, and roster removal split-button actions as destructive.
-- Added focused SplitButton coverage for reordering a destructive option supplied before normal actions.
-- Stabilized the assignment refresh test by waiting for the initial detail request before clicking refresh.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Playwright menu smoke: roster, assignment, and test action dropdowns all placed Remove/Delete last under a separator.
-- Screenshots: `/tmp/pika-roster-actions-menu.png`, `/tmp/pika-assignment-actions-menu.png`, `/tmp/pika-test-actions-menu.png`
-- `pnpm test`
-- `pnpm test:coverage`
-
 ## 2026-05-26 — Critical risk fixes
 
 **Completed:**
@@ -244,6 +226,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/lib/server/course-blueprints.test.ts tests/api/teacher/course-blueprints-route.test.ts`
 - `git diff --check`
 - `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-05-27 — Assignment student table scroll preservation
+
+**Completed:**
+- Preserved the teacher assignment student table scroll position across lower-row student selection, refresh loading, and row updates from grading/comment actions.
+- Prevented temporary assignment-detail loading states from overwriting the saved scroll position with a clamped `0`.
+- Added component regression coverage for refresh loading clamping the class-pane scroll upward.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/hooks/useScrollPositionMemory.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a'`
+- Teacher recapture after workspace load: `/tmp/pika-teacher.png`
 - `pnpm test`
 - `pnpm build`
 

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -686,6 +686,7 @@ export function TeacherClassroomView({
   const [gradeSelectedTemplate, setGradeSelectedTemplate] =
     useState<TeacherAssignmentGradeTemplate | null>(null)
   const [gradeSelectedRefreshCounter, setGradeSelectedRefreshCounter] = useState(0)
+  const [classPaneRestoreCounter, setClassPaneRestoreCounter] = useState(0)
   const [refreshCounter, setRefreshCounter] = useState(0)
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const wasActiveRef = useRef(isActive)
@@ -1166,11 +1167,6 @@ export function TeacherClassroomView({
       ? selectedAssignmentData
       : null
   }, [selectedAssignmentData, selection])
-
-  const handleRefreshSelectedAssignment = useCallback(() => {
-    if (selection.mode !== 'assignment') return
-    setRefreshCounter((count) => count + 1)
-  }, [selection])
 
   const activeAssignmentAiRun = useMemo(() => {
     if (selection.mode !== 'assignment' || !assignmentAiGradingRun) return null
@@ -1813,7 +1809,7 @@ export function TeacherClassroomView({
     preserveScrollPosition: preserveClassPaneScrollPosition,
   } = useScrollPositionMemory<HTMLDivElement>({
     key: selectedAssignmentId,
-    enabled: splitPaneView !== 'content-grading',
+    enabled: splitPaneView !== 'content-grading' && !selectedAssignmentLoading,
     storageKey: selectedAssignmentId
       ? `teacher-assignment-student-scroll:${classroom.id}:${selectedAssignmentId}`
       : null,
@@ -1821,8 +1817,20 @@ export function TeacherClassroomView({
       activeSelectedStudentId ?? 'none',
       currentStudentRows.length,
       selectedAssignmentLoading ? 'loading' : 'ready',
+      classPaneRestoreCounter,
     ].join(':'),
   })
+
+  const queueClassPaneScrollRestore = useCallback(() => {
+    preserveClassPaneScrollPosition()
+    setClassPaneRestoreCounter((count) => count + 1)
+  }, [preserveClassPaneScrollPosition])
+
+  const handleRefreshSelectedAssignment = useCallback(() => {
+    if (selection.mode !== 'assignment') return
+    queueClassPaneScrollRestore()
+    setRefreshCounter((count) => count + 1)
+  }, [queueClassPaneScrollRestore, selection])
 
   const handleGoPrevStudent = useCallback(() => {
     if (selectedStudentIndex <= 0) return
@@ -1967,6 +1975,7 @@ export function TeacherClassroomView({
       const detail = customEvent.detail
       if (!detail?.assignmentId || !detail?.studentId || !detail?.doc) return
       const updatedDoc = detail.doc
+      queueClassPaneScrollRestore()
 
       setSelectedAssignmentData((prev) => {
         if (!prev || prev.assignment.id !== detail.assignmentId) return prev
@@ -1992,7 +2001,7 @@ export function TeacherClassroomView({
 
     window.addEventListener(TEACHER_GRADE_UPDATED_EVENT, onGradeUpdated)
     return () => window.removeEventListener(TEACHER_GRADE_UPDATED_EVENT, onGradeUpdated)
-  }, [])
+  }, [queueClassPaneScrollRestore])
 
   function toggleSort(column: 'first' | 'last' | 'status') {
     setSortState((prev) => toggleSortState(prev, column))
@@ -2101,7 +2110,7 @@ export function TeacherClassroomView({
       rows={currentStudentRows}
       selectedStudentId={activeSelectedStudentId}
       onSelectStudent={(studentId) => {
-        preserveClassPaneScrollPosition()
+        queueClassPaneScrollRestore()
         setIndividualHeaderMeta(null)
         setSelectedStudentAndNavigate(studentId)
       }}

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -538,6 +538,10 @@ function clearSelectionCookie() {
   document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=; Path=/; Max-Age=0; SameSite=Lax`
 }
 
+function clearAssignmentWorkspaceStudentCookie(assignmentId = 'assignment-1') {
+  document.cookie = `${encodeURIComponent(`pika_assignment_workspace_student:${classroom.id}:${assignmentId}`)}=; Path=/; Max-Age=0; SameSite=Lax`
+}
+
 function expectAssignmentSplitPaneIndicator({
   index,
   icon,
@@ -592,6 +596,7 @@ describe('TeacherClassroomView', () => {
     mockStudentSelectionState.selectedCount = 0
     window.sessionStorage.clear()
     clearSelectionCookie()
+    clearAssignmentWorkspaceStudentCookie()
     mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
       if (key === `teacher-assignments:${classroom.id}`) {
         return Promise.resolve({
@@ -617,6 +622,7 @@ describe('TeacherClassroomView', () => {
     vi.restoreAllMocks()
     window.sessionStorage.clear()
     clearSelectionCookie()
+    clearAssignmentWorkspaceStudentCookie()
   })
 
   it('does not reopen a stale assignment cookie when URL selection is on summary', async () => {
@@ -2134,6 +2140,90 @@ describe('TeacherClassroomView', () => {
     fireEvent.scroll(scrollPane)
 
     fireEvent.click(screen.getAllByText('student-25')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-25')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-student-scroll-pane')).toHaveProperty('scrollTop', 520)
+    })
+  })
+
+  it('preserves the class-pane scroll position when refreshing submissions clamps the pane upward', async () => {
+    const detailPayload = {
+      assignment: makeAssignmentDetails('assignment-1', 'Assignment One', 'student-01').assignment,
+      students: Array.from({ length: 30 }, (_, index) =>
+        makeStudentSubmissionRow(`student-${String(index + 1).padStart(2, '0')}`),
+      ),
+    }
+    const refreshResponse = createDeferred<{
+      ok: boolean
+      json: () => Promise<typeof detailPayload>
+    }>()
+    let assignmentFetchCount = 0
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        assignmentFetchCount += 1
+        if (assignmentFetchCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => detailPayload,
+          })
+        }
+        return refreshResponse.promise
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-01')
+    })
+
+    const scrollPane = screen.getByTestId('assignment-student-scroll-pane') as HTMLDivElement
+    scrollPane.scrollTop = 520
+    fireEvent.scroll(scrollPane)
+
+    fireEvent.click(screen.getAllByText('student-25')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-25')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh submissions' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assignment-student-scroll-pane')).toBeInTheDocument()
+    })
+
+    const loadingScrollPane = screen.getByTestId('assignment-student-scroll-pane') as HTMLDivElement
+    loadingScrollPane.scrollTop = 0
+    fireEvent.scroll(loadingScrollPane)
+
+    await act(async () => {
+      refreshResponse.resolve({
+        ok: true,
+        json: async () => detailPayload,
+      })
+      await refreshResponse.promise
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-25')


### PR DESCRIPTION
## Summary
- Preserve the teacher assignment student-table scroll position when selecting lower rows, refreshing submissions, or applying comment/grade updates.
- Prevent refresh/loading states from overwriting the saved table scroll with a clamped top position.
- Add regression coverage for refresh loading clamping the class-pane scroll upward.

## Root Cause
The assignment class-pane scroll memory was still active during assignment-detail refresh loading. When the table content temporarily collapsed to the loading state, the browser could clamp `scrollTop` back to `0`, and the scroll handler saved that clamped value over the teacher's real position.

## Validation
- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/hooks/useScrollPositionMemory.test.tsx`
- `pnpm lint`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a'`
- `pnpm test`
- `pnpm build`

## Review Notes
Self-review found no blocking issues. The branch was rebased onto latest `origin/main` before push; after rebase, the focused regression suite and lint were rerun successfully.