### PR TITLE
[codex] Fix phase three audit findings

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Split-button destructive action placement
-
-**Completed:**
-- Added a `destructive` split-button option flag and centralized menu rendering so destructive options appear last under a separator.
-- Marked assignment delete, test-work delete, and roster removal split-button actions as destructive.
-- Added focused SplitButton coverage for reordering a destructive option supplied before normal actions.
-- Stabilized the assignment refresh test by waiting for the initial detail request before clicking refresh.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Playwright menu smoke: roster, assignment, and test action dropdowns all placed Remove/Delete last under a separator.
-- Screenshots: `/tmp/pika-roster-actions-menu.png`, `/tmp/pika-assignment-actions-menu.png`, `/tmp/pika-test-actions-menu.png`
-- `pnpm test`
-- `pnpm test:coverage`
-
 ## 2026-05-26 — Critical risk fixes
 
 **Completed:**
@@ -348,3 +330,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=roster'`
 - Browser selected-row screenshots: `/tmp/pika-roster-selected-desktop.png`, `/tmp/pika-roster-selected-mobile.png`, `/tmp/pika-roster-selected-email-menu-desktop.png`, `/tmp/pika-roster-selected-email-menu-mobile.png`
+
+## 2026-05-27 — Phase three audit fixes
+
+**Completed:**
+- Added shared selected-student enrollment validation for teacher test mutation routes.
+- Blocked test AI auto-grade run creation and open-response grade clearing when any selected student is outside the test classroom.
+- Normalized teacher settings controls toward `@/ui` primitives: shared segmented section switcher, cards, `FormField`, `Input`, `Select`, and a FormField-compatible textarea.
+- Fixed the syllabus lesson-plan visibility select's accessible label and added settings switcher coverage.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=settings&section=general'`
+- Browser screenshots: `/tmp/pika-settings-general-full-desktop.png`, `/tmp/pika-settings-general-full-mobile.png`, `/tmp/pika-settings-class-days-desktop.png`, `/tmp/pika-settings-class-days-mobile.png`, `/tmp/pika-settings-general-dark-desktop.png`
+- `pnpm test tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts`
+- `pnpm build`
+- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm test`

--- a/src/app/api/teacher/tests/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/tests/[id]/auto-grade/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } from '@/lib/server/tests'
+import { getServiceRoleClient } from '@/lib/supabase'
 import {
   createOrResumeTestAiGradingRun,
   type TestAiGradingNoopSummary,
@@ -56,6 +57,25 @@ export const POST = withErrorHandler('PostTeacherTestAutoGrade', async (request,
   const access = await assertTeacherOwnsTest(user.id, testId, { checkArchived: true })
   if (!access.ok) {
     return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  const supabase = getServiceRoleClient()
+  const enrollmentValidation = await validateSelectedTestStudentEnrollment(
+    supabase,
+    access.test.classroom_id,
+    studentIds,
+  )
+
+  if (!enrollmentValidation.ok) {
+    console.error('Error validating selected students for test auto-grade:', enrollmentValidation.error)
+    return NextResponse.json({ error: 'Failed to validate selected students' }, { status: 500 })
+  }
+
+  if (enrollmentValidation.missingStudentIds.length > 0) {
+    return NextResponse.json(
+      { error: 'One or more selected students are not enrolled in this classroom' },
+      { status: 400 },
+    )
   }
 
   const runResult = await createOrResumeTestAiGradingRun({

--- a/src/app/api/teacher/tests/[id]/clear-open-grades/route.ts
+++ b/src/app/api/teacher/tests/[id]/clear-open-grades/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withErrorHandler } from '@/lib/api-handler'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } from '@/lib/server/tests'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -41,6 +41,24 @@ export const POST = withErrorHandler('ClearTestOpenResponseGrades', async (reque
   }
 
   const supabase = getServiceRoleClient()
+  const enrollmentValidation = await validateSelectedTestStudentEnrollment(
+    supabase,
+    access.test.classroom_id,
+    studentIds,
+  )
+
+  if (!enrollmentValidation.ok) {
+    console.error('Error validating selected students for clearing open-response grades:', enrollmentValidation.error)
+    return NextResponse.json({ error: 'Failed to validate selected students' }, { status: 500 })
+  }
+
+  if (enrollmentValidation.missingStudentIds.length > 0) {
+    return NextResponse.json(
+      { error: 'One or more selected students are not enrolled in this classroom' },
+      { status: 400 },
+    )
+  }
+
   const { data: openQuestionRows, error: openQuestionError } = await supabase
     .from('test_questions')
     .select('id')

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -1,9 +1,21 @@
 'use client'
 
-import { useMemo, useState, useId } from 'react'
+import { forwardRef, useMemo, useState, useId, type ReactNode, type TextareaHTMLAttributes } from 'react'
 import { useRouter } from 'next/navigation'
 import { Info } from 'lucide-react'
-import { Button, ConfirmDialog, DialogPanel, FormField, Input, Tooltip, useAppMessage } from '@/ui'
+import {
+  Button,
+  Card,
+  ConfirmDialog,
+  DialogPanel,
+  FormField,
+  Input,
+  SegmentedControl,
+  Select,
+  Tooltip,
+  cn,
+  useAppMessage,
+} from '@/ui'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_ACTUAL_COURSE_SITE_CONFIG, slugifyCourseSiteValue } from '@/lib/course-site-publishing'
@@ -20,6 +32,23 @@ function generateJoinCode() {
 
 type SettingsSection = 'general' | 'class-days'
 
+const SETTINGS_SECTION_OPTIONS: Array<{ value: SettingsSection; label: string }> = [
+  { value: 'general', label: 'General' },
+  { value: 'class-days', label: 'Class Days' },
+]
+
+const LESSON_PLAN_VISIBILITY_OPTIONS = [
+  { value: 'current_week', label: 'Current week (and all previous)' },
+  { value: 'one_week_ahead', label: '1 week ahead' },
+  { value: 'all', label: 'All (no restrictions)' },
+]
+
+const SYLLABUS_LESSON_PLAN_SCOPE_OPTIONS = [
+  { value: 'current_week', label: 'Current week (and earlier)' },
+  { value: 'one_week_ahead', label: 'One week ahead' },
+  { value: 'all', label: 'All lesson plans' },
+]
+
 function visibleActualSiteConfig(config: ActualCourseSiteConfig | null | undefined): ActualCourseSiteConfig {
   return {
     ...(config || DEFAULT_ACTUAL_COURSE_SITE_CONFIG),
@@ -33,6 +62,50 @@ interface Props {
   onSectionChange?: (section: SettingsSection) => void
 }
 
+function SettingsPanel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <Card padding="md" className={cn('space-y-3 shadow-none', className)}>
+      {children}
+    </Card>
+  )
+}
+
+function SettingsHeading({ title, tooltip }: { title: string; tooltip?: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="text-sm font-semibold text-text-default">{title}</div>
+      {tooltip ? (
+        <Tooltip content={tooltip} side="right">
+          <span className="text-text-muted cursor-help">
+            <Info size={14} />
+          </span>
+        </Tooltip>
+      ) : null}
+    </div>
+  )
+}
+
+interface SettingsTextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  hasError?: boolean
+}
+
+const SettingsTextarea = forwardRef<HTMLTextAreaElement, SettingsTextareaProps>(function SettingsTextarea(
+  { hasError, className, ...props },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        'w-full rounded-control border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary disabled:bg-surface-2 disabled:cursor-not-allowed',
+        hasError ? 'border-danger' : 'border-border',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+
 export function TeacherSettingsTab({
   classroom,
   sectionParam,
@@ -45,6 +118,7 @@ export function TeacherSettingsTab({
   const actualSiteSlugId = useId()
   const actualOverviewId = useId()
   const actualOutlineId = useId()
+  const actualLessonPlanScopeId = useId()
   const showMarkdownId = useId()
   const isReadOnly = !!classroom.archived_at
   const { showMarkdown, mounted: markdownMounted, setShowMarkdown } = useMarkdownPreference()
@@ -269,48 +343,23 @@ export function TeacherSettingsTab({
 
   return (
     <PageLayout>
-      {/* Sub-tab navigation */}
-      <div className="mb-2 flex border-b border-border">
-        <button
-          type="button"
-          onClick={() => onSectionChange('general')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            section === 'general'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-text-muted hover:text-text-default hover:border-border'
-          }`}
-        >
-          General
-        </button>
-        <button
-          type="button"
-          onClick={() => onSectionChange('class-days')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            section === 'class-days'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-text-muted hover:text-text-default hover:border-border'
-          }`}
-        >
-          Class Days
-        </button>
+      <div className="mb-2">
+        <SegmentedControl
+          ariaLabel="Settings section"
+          value={section}
+          options={SETTINGS_SECTION_OPTIONS}
+          onChange={onSectionChange}
+          className="[&_button]:min-h-11"
+        />
       </div>
 
       {section === 'general' ? (
         <PageContent className="space-y-4 pt-0">
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <label htmlFor={titleId} className="text-sm font-semibold text-text-default">
-                  Course Name
-                </label>
-                <Tooltip content="Name shown to students and in reports" side="right">
-                  <span className="text-text-muted cursor-help">
-                    <Info size={14} />
-                  </span>
-                </Tooltip>
-              </div>
-              <div className="flex flex-col sm:flex-row sm:items-stretch gap-3">
-                <input
-                  id={titleId}
+          <SettingsPanel>
+            <SettingsHeading title="Course Name" tooltip="Name shown to students and in reports" />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+              <FormField label="Course Name" htmlFor={titleId} hideLabel error={titleError} className="flex-1">
+                <Input
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
@@ -322,295 +371,248 @@ export function TeacherSettingsTab({
                     }
                   }}
                   disabled={titleSaving || isReadOnly}
-                  className="flex-1 rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                   placeholder="Enter course name"
                 />
-                {titleSaving && <span className="text-sm text-text-muted self-center">Saving...</span>}
-              </div>
-              {titleError && <div className="text-sm text-danger">{titleError}</div>}
+              </FormField>
+              {titleSaving && <span className="text-sm text-text-muted sm:pt-2">Saving...</span>}
+            </div>
+          </SettingsPanel>
+
+          <SettingsPanel>
+            <SettingsHeading title="Join Code" tooltip="Students must be on the roster to join" />
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => copyWithNotice('Join code', joinCode)}
+                aria-label="Copy join code"
+                className="w-full justify-start font-mono text-base font-semibold sm:w-auto"
+              >
+                {joinCode}
+              </Button>
+
+              <Button
+                variant="secondary"
+                onClick={() => setShowRegenerateConfirm(true)}
+                disabled={isRegenerating || isReadOnly}
+                className="w-full sm:w-auto"
+              >
+                {isRegenerating ? 'Generating...' : 'New code'}
+              </Button>
+
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => copyWithNotice('Join link', joinLink)}
+                aria-label="Copy join link"
+                title={joinLink}
+                className="w-full min-w-0 justify-start font-mono text-xs sm:flex-1"
+              >
+                <span className="min-w-0 truncate">{joinLink}</span>
+              </Button>
             </div>
 
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <div className="text-sm font-semibold text-text-default">Join Code</div>
-                <Tooltip content="Students must be on the roster to join" side="right">
-                  <span className="text-text-muted cursor-help">
-                    <Info size={14} />
-                  </span>
-                </Tooltip>
-              </div>
-
-              <div className="flex flex-col sm:flex-row sm:items-stretch gap-3">
-                <button
-                  type="button"
-                  className="w-full sm:w-auto rounded-md border border-border bg-surface-2 px-3 py-2 text-left font-mono text-base font-semibold text-text-default hover:bg-surface-hover"
-                  onClick={() => copyWithNotice('Join code', joinCode)}
-                  aria-label="Copy join code"
-                >
-                  {joinCode}
-                </button>
-
-                <Button
-                  variant="secondary"
-                  onClick={() => setShowRegenerateConfirm(true)}
-                  disabled={isRegenerating || isReadOnly}
-                  className="w-full sm:w-auto"
-                >
-                  {isRegenerating ? 'Generating…' : 'New code'}
-                </Button>
-
-                <button
-                  type="button"
-                  className="w-full flex-1 rounded-md border border-border bg-surface-2 px-3 py-2 text-left font-mono text-xs text-text-default hover:bg-surface-hover truncate"
-                  onClick={() => copyWithNotice('Join link', joinLink)}
-                  aria-label="Copy join link"
-                  title={joinLink}
-                >
-                  {joinLink}
-                </button>
-              </div>
-
-              <div className="flex items-center gap-3 pt-2 border-t border-border">
-                <input
-                  id={allowEnrollmentId}
-                  type="checkbox"
-                  checked={allowEnrollment}
-                  onChange={(e) => saveAllowEnrollment(e.target.checked)}
-                  disabled={saving || isReadOnly}
-                  className="h-4 w-4"
-                />
-                <label htmlFor={allowEnrollmentId} className="text-sm text-text-default">
-                  Allow joining
-                </label>
-                {saving && <span className="text-sm text-text-muted">Saving...</span>}
-              </div>
-
-              {joinCodeError && <div className="text-sm text-danger">{joinCodeError}</div>}
-              {enrollmentError && <div className="text-sm text-danger">{enrollmentError}</div>}
+            <div className="flex items-center gap-3 border-t border-border pt-2">
+              <input
+                id={allowEnrollmentId}
+                type="checkbox"
+                checked={allowEnrollment}
+                onChange={(e) => saveAllowEnrollment(e.target.checked)}
+                disabled={saving || isReadOnly}
+                className="h-4 w-4"
+              />
+              <label htmlFor={allowEnrollmentId} className="text-sm text-text-default">
+                Allow joining
+              </label>
+              {saving && <span className="text-sm text-text-muted">Saving...</span>}
             </div>
 
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <div className="text-sm font-semibold text-text-default">Calendar Visibility</div>
-                <Tooltip content="Control how far ahead students can see lesson plans" side="right">
-                  <span className="text-text-muted cursor-help">
-                    <Info size={14} />
-                  </span>
-                </Tooltip>
-              </div>
+            {joinCodeError && <div className="text-sm text-danger">{joinCodeError}</div>}
+            {enrollmentError && <div className="text-sm text-danger">{enrollmentError}</div>}
+          </SettingsPanel>
 
-              <div className="flex flex-col sm:flex-row sm:items-center gap-3">
-                <label htmlFor={visibilityId} className="sr-only">
-                  Calendar visibility
-                </label>
-                <select
-                  id={visibilityId}
+          <SettingsPanel>
+            <SettingsHeading title="Calendar Visibility" tooltip="Control how far ahead students can see lesson plans" />
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+              <FormField label="Calendar visibility" htmlFor={visibilityId} hideLabel error={visibilityError} className="sm:max-w-md">
+                <Select
+                  options={LESSON_PLAN_VISIBILITY_OPTIONS}
                   value={lessonPlanVisibility}
                   onChange={(e) => saveLessonPlanVisibility(e.target.value as LessonPlanVisibility)}
                   disabled={visibilitySaving || isReadOnly}
-                  className="rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="current_week">Current week (and all previous)</option>
-                  <option value="one_week_ahead">1 week ahead</option>
-                  <option value="all">All (no restrictions)</option>
-                </select>
-                {visibilitySaving && <span className="text-sm text-text-muted">Saving...</span>}
-              </div>
-
-              {visibilityError && <div className="text-sm text-danger">{visibilityError}</div>}
-            </div>
-
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
-              <div className="text-sm font-semibold text-text-default">Display</div>
-
-              <label htmlFor={showMarkdownId} className="flex items-center gap-3 text-sm text-text-default">
-                <input
-                  id={showMarkdownId}
-                  type="checkbox"
-                  checked={markdownMounted ? showMarkdown : true}
-                  onChange={(event) => setShowMarkdown(event.target.checked)}
-                  className="h-4 w-4"
                 />
-                Show markdown
-              </label>
+              </FormField>
+              {visibilitySaving && <span className="text-sm text-text-muted sm:pt-2">Saving...</span>}
             </div>
+          </SettingsPanel>
 
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-4">
-              <div className="flex items-center gap-2">
-                <div className="text-sm font-semibold text-text-default">Public Syllabus</div>
-                <Tooltip content="Publish the public syllabus page for this classroom" side="right">
-                  <span className="text-text-muted cursor-help">
-                    <Info size={14} />
-                  </span>
-                </Tooltip>
-              </div>
+          <SettingsPanel>
+            <div className="text-sm font-semibold text-text-default">Display</div>
 
-              <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),auto]">
-                <div>
-                  <label htmlFor={actualSiteSlugId} className="mb-2 block text-sm text-text-muted">
-                    Syllabus slug
-                  </label>
-                  <Input
-                    id={actualSiteSlugId}
-                    value={actualSiteSlug}
-                    onChange={(e) => setActualSiteSlug(slugifyCourseSiteValue(e.target.value))}
-                    disabled={siteSaving || isReadOnly}
-                    placeholder="career-studies-period-1"
-                  />
-                </div>
-                <div className="flex items-end">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={siteSaving || isReadOnly}
-                    onClick={() => setActualSiteSlug(slugifyCourseSiteValue(title || classroom.title))}
-                  >
-                    Generate
-                  </Button>
-                </div>
-              </div>
+            <label htmlFor={showMarkdownId} className="flex items-center gap-3 text-sm text-text-default">
+              <input
+                id={showMarkdownId}
+                type="checkbox"
+                checked={markdownMounted ? showMarkdown : true}
+                onChange={(event) => setShowMarkdown(event.target.checked)}
+                className="h-4 w-4"
+              />
+              Show markdown
+            </label>
+          </SettingsPanel>
 
-              <label className="flex items-center gap-3 text-sm text-text-default">
-                <input
-                  type="checkbox"
-                  checked={actualSitePublished}
-                  onChange={(e) => setActualSitePublished(e.target.checked)}
+          <SettingsPanel className="space-y-4">
+            <SettingsHeading title="Public Syllabus" tooltip="Publish the public syllabus page for this classroom" />
+
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr),auto]">
+              <FormField label="Syllabus slug" htmlFor={actualSiteSlugId}>
+                <Input
+                  value={actualSiteSlug}
+                  onChange={(e) => setActualSiteSlug(slugifyCourseSiteValue(e.target.value))}
                   disabled={siteSaving || isReadOnly}
-                  className="h-4 w-4"
+                  placeholder="career-studies-period-1"
                 />
-                Publish this classroom syllabus
-              </label>
-
-              <div className="grid gap-3 md:grid-cols-2">
-                {(
-                  [
-                    ['overview', 'Overview'],
-                    ['outline', 'Outline'],
-                    ['assignments', 'Assignments'],
-                    ['tests', 'Tests'],
-                    ['lesson_plans', 'Lesson plans'],
-                    ['announcements', 'Announcements'],
-                  ] as Array<[keyof ActualCourseSiteConfig, string]>
-                ).map(([key, label]) => (
-                  <label key={key} className="flex items-center gap-3 text-sm text-text-default">
-                    <input
-                      type="checkbox"
-                      checked={typeof actualSiteConfig[key] === 'boolean' ? (actualSiteConfig[key] as boolean) : false}
-                      onChange={(e) =>
-                        setActualSiteConfig((current) => ({
-                          ...current,
-                          [key]: e.target.checked,
-                        }))
-                      }
-                      disabled={siteSaving || isReadOnly}
-                      className="h-4 w-4"
-                    />
-                    {label}
-                  </label>
-                ))}
-              </div>
-
-              <div>
-                <label className="mb-2 block text-sm text-text-muted">Lesson plan visibility on syllabus</label>
-                <select
-                  value={actualSiteConfig.lesson_plan_scope}
-                  onChange={(e) =>
-                    setActualSiteConfig((current) => ({
-                      ...current,
-                      lesson_plan_scope: e.target.value as ActualCourseSiteConfig['lesson_plan_scope'],
-                    }))
-                  }
-                  disabled={siteSaving || isReadOnly}
-                  className="rounded-md border border-border-strong bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="current_week">Current week (and earlier)</option>
-                  <option value="one_week_ahead">One week ahead</option>
-                  <option value="all">All lesson plans</option>
-                </select>
-              </div>
-
-              {showMarkdown ? (
-                <>
-                  <div>
-                    <label htmlFor={actualOverviewId} className="mb-2 block text-sm text-text-muted">
-                      Course overview
-                    </label>
-                    <textarea
-                      id={actualOverviewId}
-                      value={courseOverviewMarkdown}
-                      onChange={(e) => setCourseOverviewMarkdown(e.target.value)}
-                      disabled={siteSaving || isReadOnly}
-                      className="min-h-[140px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                  </div>
-
-                  <div>
-                    <label htmlFor={actualOutlineId} className="mb-2 block text-sm text-text-muted">
-                      Course outline
-                    </label>
-                    <textarea
-                      id={actualOutlineId}
-                      value={courseOutlineMarkdown}
-                      onChange={(e) => setCourseOutlineMarkdown(e.target.value)}
-                      disabled={siteSaving || isReadOnly}
-                      className="min-h-[160px] w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                  </div>
-                </>
-              ) : (
-                <div className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-muted">
-                  Course overview and outline editing is hidden by your display setting.
-                </div>
-              )}
-
-              {actualSitePublished && actualSiteSlug ? (
-                <div className="text-sm text-text-muted">
-                  Syllabus URL:{' '}
-                  <a
-                    href={`/actual/${actualSiteSlug}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-primary underline"
-                  >
-                    {`/actual/${actualSiteSlug}`}
-                  </a>
-                </div>
-              ) : null}
-
-              <div className="flex flex-wrap gap-3">
-                <Button type="button" onClick={saveActualSiteSettings} disabled={siteSaving || isReadOnly}>
-                  {siteSaving ? 'Saving…' : 'Save Syllabus'}
-                </Button>
-              </div>
-
-              {siteError && <div className="text-sm text-danger">{siteError}</div>}
-            </div>
-
-            <div className="bg-surface rounded-lg border border-border p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <div className="text-sm font-semibold text-text-default">Course Blueprint</div>
-                <Tooltip content="Save this classroom's teacher-authored course content as a reusable course blueprint" side="right">
-                  <span className="text-text-muted cursor-help">
-                    <Info size={14} />
-                  </span>
-                </Tooltip>
-              </div>
-
-              <p className="text-sm text-text-muted">
-                Save the classroom overview, outline, resources, assignments, tests, and lesson plans as a reusable course blueprint. Students, submissions, grades, and attendance stay out of the blueprint.
-              </p>
-
-              <div className="flex flex-wrap gap-3">
+              </FormField>
+              <div className="flex items-end">
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={openCreateBlueprintDialog}
-                  disabled={blueprintBusy || isReadOnly}
+                  disabled={siteSaving || isReadOnly}
+                  onClick={() => setActualSiteSlug(slugifyCourseSiteValue(title || classroom.title))}
                 >
-                  {blueprintBusy ? 'Working...' : 'Save as Course Blueprint'}
+                  Generate
                 </Button>
               </div>
             </div>
+
+            <label className="flex items-center gap-3 text-sm text-text-default">
+              <input
+                type="checkbox"
+                checked={actualSitePublished}
+                onChange={(e) => setActualSitePublished(e.target.checked)}
+                disabled={siteSaving || isReadOnly}
+                className="h-4 w-4"
+              />
+              Publish this classroom syllabus
+            </label>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              {(
+                [
+                  ['overview', 'Overview'],
+                  ['outline', 'Outline'],
+                  ['assignments', 'Assignments'],
+                  ['tests', 'Tests'],
+                  ['lesson_plans', 'Lesson plans'],
+                  ['announcements', 'Announcements'],
+                ] as Array<[keyof ActualCourseSiteConfig, string]>
+              ).map(([key, label]) => (
+                <label key={key} className="flex items-center gap-3 text-sm text-text-default">
+                  <input
+                    type="checkbox"
+                    checked={typeof actualSiteConfig[key] === 'boolean' ? (actualSiteConfig[key] as boolean) : false}
+                    onChange={(e) =>
+                      setActualSiteConfig((current) => ({
+                        ...current,
+                        [key]: e.target.checked,
+                      }))
+                    }
+                    disabled={siteSaving || isReadOnly}
+                    className="h-4 w-4"
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+
+            <FormField label="Lesson plan visibility on syllabus" htmlFor={actualLessonPlanScopeId}>
+              <Select
+                options={SYLLABUS_LESSON_PLAN_SCOPE_OPTIONS}
+                value={actualSiteConfig.lesson_plan_scope}
+                onChange={(e) =>
+                  setActualSiteConfig((current) => ({
+                    ...current,
+                    lesson_plan_scope: e.target.value as ActualCourseSiteConfig['lesson_plan_scope'],
+                  }))
+                }
+                disabled={siteSaving || isReadOnly}
+              />
+            </FormField>
+
+            {showMarkdown ? (
+              <>
+                <FormField label="Course overview" htmlFor={actualOverviewId}>
+                  <SettingsTextarea
+                    value={courseOverviewMarkdown}
+                    onChange={(e) => setCourseOverviewMarkdown(e.target.value)}
+                    disabled={siteSaving || isReadOnly}
+                    className="min-h-[140px] font-mono"
+                  />
+                </FormField>
+
+                <FormField label="Course outline" htmlFor={actualOutlineId}>
+                  <SettingsTextarea
+                    value={courseOutlineMarkdown}
+                    onChange={(e) => setCourseOutlineMarkdown(e.target.value)}
+                    disabled={siteSaving || isReadOnly}
+                    className="min-h-[160px] font-mono"
+                  />
+                </FormField>
+              </>
+            ) : (
+              <div className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-muted">
+                Course overview and outline editing is hidden by your display setting.
+              </div>
+            )}
+
+            {actualSitePublished && actualSiteSlug ? (
+              <div className="text-sm text-text-muted">
+                Syllabus URL:{' '}
+                <a
+                  href={`/actual/${actualSiteSlug}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline"
+                >
+                  {`/actual/${actualSiteSlug}`}
+                </a>
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-3">
+              <Button type="button" onClick={saveActualSiteSettings} disabled={siteSaving || isReadOnly}>
+                {siteSaving ? 'Saving...' : 'Save Syllabus'}
+              </Button>
+            </div>
+
+            {siteError && <div className="text-sm text-danger">{siteError}</div>}
+          </SettingsPanel>
+
+          <SettingsPanel>
+            <SettingsHeading
+              title="Course Blueprint"
+              tooltip="Save this classroom's teacher-authored course content as a reusable course blueprint"
+            />
+
+            <p className="text-sm text-text-muted">
+              Save the classroom overview, outline, resources, assignments, tests, and lesson plans as a reusable course blueprint. Students, submissions, grades, and attendance stay out of the blueprint.
+            </p>
+
+            <div className="flex flex-wrap gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={openCreateBlueprintDialog}
+                disabled={blueprintBusy || isReadOnly}
+              >
+                {blueprintBusy ? 'Working...' : 'Save as Course Blueprint'}
+              </Button>
+            </div>
+          </SettingsPanel>
 
             <ConfirmDialog
               isOpen={showRegenerateConfirm}

--- a/src/lib/server/tests.ts
+++ b/src/lib/server/tests.ts
@@ -25,6 +25,36 @@ type AccessResult<T> =
   | { ok: true; test: T }
   | { ok: false; status: number; error: string }
 
+export async function validateSelectedTestStudentEnrollment(
+  supabase: any,
+  classroomId: string,
+  studentIds: string[],
+): Promise<
+  | { ok: true; enrolledStudentIds: Set<string>; missingStudentIds: string[] }
+  | { ok: false; error: unknown }
+> {
+  const { data: enrollmentRows, error } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', classroomId)
+    .in('student_id', studentIds)
+
+  if (error) {
+    return { ok: false, error }
+  }
+
+  const enrolledStudentIds = new Set<string>(
+    ((enrollmentRows || []) as Array<{ student_id: unknown }>)
+      .map((row) => row.student_id)
+      .filter((studentId): studentId is string => typeof studentId === 'string'),
+  )
+  return {
+    ok: true,
+    enrolledStudentIds,
+    missingStudentIds: studentIds.filter((studentId) => !enrolledStudentIds.has(studentId)),
+  }
+}
+
 export type EffectiveStudentTestAccess = {
   access_state: TestStudentAvailabilityState | null
   effective_access: TestStudentAvailabilityState

--- a/tests/api/teacher/tests-auto-grade.test.ts
+++ b/tests/api/teacher/tests-auto-grade.test.ts
@@ -9,6 +9,15 @@ const { assertTeacherOwnsTest } = vi.hoisted(() => ({
   assertTeacherOwnsTest: vi.fn(),
 }))
 
+const { mockSupabaseClient, validateSelectedTestStudentEnrollment } = vi.hoisted(() => ({
+  mockSupabaseClient: {},
+  validateSelectedTestStudentEnrollment: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
 vi.mock('@/lib/auth', () => ({
   requireRole: vi.fn(async () => ({
     id: 'teacher-1',
@@ -19,6 +28,7 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/server/tests', () => ({
   assertTeacherOwnsTest,
+  validateSelectedTestStudentEnrollment,
 }))
 
 vi.mock('@/lib/server/test-ai-grading-runs', () => ({
@@ -62,6 +72,11 @@ describe('POST /api/teacher/tests/[id]/auto-grade', () => {
         completed_at: null,
         created_at: '2026-04-20T12:00:00.000Z',
       },
+    })
+    validateSelectedTestStudentEnrollment.mockResolvedValue({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1', 'student-2']),
+      missingStudentIds: [],
     })
   })
 
@@ -121,6 +136,54 @@ describe('POST /api/teacher/tests/[id]/auto-grade', () => {
       studentIds: ['student-1', 'student-2'],
       promptGuidelineOverride: 'Use one strength and one next step.',
     })
+    expect(validateSelectedTestStudentEnrollment).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+      ['student-1', 'student-2'],
+    )
+  })
+
+  it('rejects selected students outside the test classroom before creating a run', async () => {
+    validateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1']),
+      missingStudentIds: ['student-2'],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1', 'student-2'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('One or more selected students are not enrolled in this classroom')
+    expect(createOrResumeTestAiGradingRun).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when selected student enrollment validation fails', async () => {
+    validateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'enrollment lookup failed' },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to validate selected students')
+    expect(createOrResumeTestAiGradingRun).not.toHaveBeenCalled()
   })
 
   it('returns the active run when another selection is already in progress', async () => {

--- a/tests/api/teacher/tests-clear-open-grades.test.ts
+++ b/tests/api/teacher/tests-clear-open-grades.test.ts
@@ -2,6 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/tests/[id]/clear-open-grades/route'
 
+const { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } = vi.hoisted(() => ({
+  assertTeacherOwnsTest: vi.fn(async () => ({
+    ok: true,
+    test: {
+      id: 'test-1',
+      title: 'Unit Test',
+      classroom_id: 'classroom-1',
+      classrooms: { archived_at: null },
+    },
+  })),
+  validateSelectedTestStudentEnrollment: vi.fn(),
+}))
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -15,15 +28,8 @@ vi.mock('@/lib/auth', () => ({
 }))
 
 vi.mock('@/lib/server/tests', () => ({
-  assertTeacherOwnsTest: vi.fn(async () => ({
-    ok: true,
-    test: {
-      id: 'test-1',
-      title: 'Unit Test',
-      classroom_id: 'classroom-1',
-      classrooms: { archived_at: null },
-    },
-  })),
+  assertTeacherOwnsTest,
+  validateSelectedTestStudentEnrollment,
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -31,6 +37,20 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('POST /api/teacher/tests/[id]/clear-open-grades', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    assertTeacherOwnsTest.mockResolvedValue({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      },
+    })
+    validateSelectedTestStudentEnrollment.mockResolvedValue({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1', 'student-2', 'student-3']),
+      missingStudentIds: [],
+    })
   })
 
   it('returns 400 when student_ids is missing', async () => {
@@ -114,6 +134,54 @@ describe('POST /api/teacher/tests/[id]/clear-open-grades', () => {
       skipped_students: 1,
       cleared_responses: 3,
     })
+    expect(validateSelectedTestStudentEnrollment).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+      ['student-1', 'student-2', 'student-3'],
+    )
+  })
+
+  it('rejects selected students outside the test classroom before clearing anything', async () => {
+    validateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1']),
+      missingStudentIds: ['student-2'],
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn(() => {
+      throw new Error('No Supabase table queries should run after validation rejection')
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/clear-open-grades', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1', 'student-2'] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('One or more selected students are not enrolled in this classroom')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when selected student enrollment validation fails', async () => {
+    validateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'enrollment lookup failed' },
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn(() => {
+      throw new Error('No Supabase table queries should run after validation failure')
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/clear-open-grades', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1'] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to validate selected students')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
   })
 
   it('returns skipped counts when there are no open-response questions', async () => {

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -89,6 +89,31 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     expect(screen.getByText('Course overview and outline editing is hidden by your display setting.')).toBeInTheDocument()
   })
 
+  it('exposes the syllabus lesson-plan visibility select with an accessible label', () => {
+    render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+    expect(screen.getByLabelText('Lesson plan visibility on syllabus')).toHaveValue('current_week')
+  })
+
+  it('uses the shared section switcher for general and class-days settings', () => {
+    const onSectionChange = vi.fn()
+    render(
+      <TeacherSettingsTab
+        classroom={mockClassroom}
+        sectionParam="general"
+        onSectionChange={onSectionChange}
+      />,
+      { wrapper: Wrapper }
+    )
+
+    const sectionSwitcher = screen.getByRole('group', { name: 'Settings section' })
+    expect(within(sectionSwitcher).getByRole('button', { name: 'General' })).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(within(sectionSwitcher).getByRole('button', { name: 'Class Days' }))
+
+    expect(onSectionChange).toHaveBeenCalledWith('class-days')
+  })
+
   it('saves on blur when value has changed', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({

--- a/tests/unit/test-student-access.test.ts
+++ b/tests/unit/test-student-access.test.ts
@@ -7,6 +7,7 @@ import {
   getTestStudentAvailabilityState,
   isMissingTestAttemptClosureColumnsError,
   isMissingTestStudentAvailabilityError,
+  validateSelectedTestStudentEnrollment,
 } from '@/lib/server/tests'
 
 const mockSupabaseClient = vi.hoisted(() => ({ from: vi.fn() }))
@@ -59,6 +60,24 @@ function mockAvailabilityClient(result: {
         error: result.error ?? null,
       }
     }),
+  }
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => query),
+    })),
+  }
+}
+
+function mockEnrollmentClient(result: {
+  data?: Array<{ student_id: string }> | null
+  error?: unknown
+}) {
+  const query: any = {
+    eq: vi.fn(() => query),
+    in: vi.fn(async () => ({
+      data: result.data ?? null,
+      error: result.error ?? null,
+    })),
   }
   return {
     from: vi.fn(() => ({
@@ -231,6 +250,43 @@ describe('student availability helpers', () => {
       state: 'closed',
       missingTable: false,
       error: null,
+    })
+  })
+})
+
+describe('validateSelectedTestStudentEnrollment', () => {
+  it('returns enrolled and missing selected student ids', async () => {
+    const supabase = mockEnrollmentClient({
+      data: [{ student_id: 'student-1' }, { student_id: 'student-3' }],
+    })
+
+    const result = await validateSelectedTestStudentEnrollment(supabase, 'classroom-1', [
+      'student-1',
+      'student-2',
+      'student-3',
+    ])
+
+    expect(supabase.from).toHaveBeenCalledWith('classroom_enrollments')
+    expect(result).toMatchObject({
+      ok: true,
+      missingStudentIds: ['student-2'],
+    })
+    if (result.ok) {
+      expect(result.enrolledStudentIds.has('student-1')).toBe(true)
+      expect(result.enrolledStudentIds.has('student-3')).toBe(true)
+    }
+  })
+
+  it('returns validation errors without hiding them', async () => {
+    const supabase = mockEnrollmentClient({
+      error: { message: 'lookup failed' },
+    })
+
+    await expect(
+      validateSelectedTestStudentEnrollment(supabase, 'classroom-1', ['student-1']),
+    ).resolves.toEqual({
+      ok: false,
+      error: { message: 'lookup failed' },
     })
   })
 })


### PR DESCRIPTION
## Summary
- validates selected students against the test classroom before test AI auto-grade runs or clear-open-grades mutations
- normalizes TeacherSettingsTab controls onto shared UI primitives and fixes the syllabus visibility select label
- adds API/unit/component coverage for the enrollment guardrails and settings switcher/accessibility behavior

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts
- pnpm lint
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=settings&section=general"
- browser screenshots: /tmp/pika-settings-general-full-desktop.png, /tmp/pika-settings-general-full-mobile.png, /tmp/pika-settings-class-days-desktop.png, /tmp/pika-settings-class-days-mobile.png, /tmp/pika-settings-general-dark-desktop.png
- pnpm test tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts
- pnpm build
- pnpm test tests/components/TeacherStudentWorkPanel.test.tsx
- pnpm test