### PR TITLE
[codex] Clarify selected Daily log history

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,43 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Critical risk fixes
-
-**Completed:**
-- Fixed `getTodayInToronto()` to format the current instant directly in `America/Toronto`, avoiding UTC-host double conversion.
-- Added archived-classroom mutation guards for assignment grading, selected grading, return, feedback return, AI grading, AI grading ticks, repo target overrides, and artifact repo analysis.
-- Preserved read-only assignment ownership checks for archived classrooms while adding a mutation-specific guard.
-- Added regression coverage for the UTC-host Toronto date edge and archived assignment mutation rejection.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/timezone.test.ts tests/unit/server-repo-review.test.ts tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts`
-- `pnpm test tests/api/teacher/assignments-id-grade.test.ts tests/api/teacher/assignments-grade-selected.test.ts tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/assignments-id.test.ts tests/api/teacher/assignments-id-students-studentId.test.ts`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
-## 2026-05-26 — Gradebook category settings retirement
-
-**Completed:**
-- Stopped the in-app gradebook route from loading legacy category settings that no longer affect final calculations.
-- Kept per-assessment weight PATCH support and now rejects retired category-weight updates with a clear response.
-- Updated published actual-course grading summaries to use the same per-assessment weights instead of `gradebook_settings`.
-- Carried `gradebook_weight` through classroom blueprint source data for actual course site grading.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/hooks/useGradebookData.test.ts`
-- `pnpm test tests/api/teacher/gradebook.test.ts tests/unit/gradebook.test.ts tests/lib/server/course-sites.test.ts tests/lib/server/classroom-blueprint-source.test.ts`
-- `pnpm tsc --noEmit`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — API route error-handler drift cleanup
 
 **Completed:**
@@ -365,3 +328,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx`
 - `pnpm test`
+
+## 2026-05-27 — Daily log history selected date clarity
+
+**Completed:**
+- Changed the teacher Daily student-log inspector to keep entries in newest-first chronological order instead of pinning the selected entry above newer logs.
+- Highlighted the selected date in place with a selected-card treatment and bold date label.
+- Added an in-order highlighted `No log for this date.` row for selected dates without a student log.
+- Added focused component coverage for chronological selected entries, empty selected dates, and removal of the old `Selected date -` label.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/StudentLogHistory.test.tsx tests/components/TeacherAttendanceTab.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm test tests/unit/ai-startup-docs.test.ts`
+- `git diff --check`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=attendance'`
+- Browser screenshots: `/tmp/pika-teacher-daily-selected-history.png`, `/tmp/pika-teacher-daily-empty-selected-history.png`

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -650,6 +650,7 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     <StudentLogHistory
       studentId={selectedRow.student_id}
       classroomId={classroom.id}
+      selectedDate={selectedDate}
       selectedEntry={selectedRow.entry}
       initialEntries={selectedRow.history_preview}
     />

--- a/src/components/StudentLogHistory.tsx
+++ b/src/components/StudentLogHistory.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { entryHasContent } from '@/lib/attendance'
 import { fetchJSONWithCache } from '@/lib/request-cache'
@@ -9,6 +9,7 @@ import type { Entry } from '@/types'
 interface Props {
   studentId: string
   classroomId: string
+  selectedDate?: string | null
   selectedEntry?: Entry | null
   initialEntries?: Entry[]
 }
@@ -24,12 +25,14 @@ const EMPTY_ENTRIES: Entry[] = []
 export function StudentLogHistory({
   studentId,
   classroomId,
+  selectedDate = null,
   selectedEntry = null,
   initialEntries = EMPTY_ENTRIES,
 }: Props) {
   const [entries, setEntries] = useState<Entry[]>([])
   const [loading, setLoading] = useState(false)
   const [hasMore, setHasMore] = useState(false)
+  const selectedBlockRef = useRef<HTMLDivElement | null>(null)
   const previewEntries = useMemo(
     () => normalizeEntries(initialEntries),
     [initialEntries]
@@ -37,7 +40,7 @@ export function StudentLogHistory({
   const selectedDisplayEntry = selectedEntry && entryHasContent(selectedEntry)
     ? selectedEntry
     : null
-  const selectedEntryId = selectedDisplayEntry?.id ?? null
+  const selectedDateToHighlight = selectedDisplayEntry?.date ?? selectedDate ?? null
 
   useEffect(() => {
     let cancelled = false
@@ -117,10 +120,22 @@ export function StudentLogHistory({
       .finally(() => setLoading(false))
   }
 
-  const historyEntries = selectedEntryId
-    ? entries.filter(entry => entry.id !== selectedEntryId)
-    : entries
-  const isEmpty = !selectedDisplayEntry && historyEntries.length === 0 && !loading
+  const historyEntries = useMemo(() => {
+    const sourceEntries = selectedDisplayEntry
+      ? [...entries, selectedDisplayEntry]
+      : entries
+    return normalizeEntries(sourceEntries)
+  }, [entries, selectedDisplayEntry])
+  const displayItems = useMemo(
+    () => buildDisplayItems(historyEntries, selectedDateToHighlight, !selectedDisplayEntry),
+    [historyEntries, selectedDateToHighlight, selectedDisplayEntry]
+  )
+  const isEmpty = !selectedDateToHighlight && displayItems.length === 0 && !loading
+
+  useEffect(() => {
+    if (!selectedDateToHighlight) return
+    selectedBlockRef.current?.scrollIntoView?.({ block: 'nearest' })
+  }, [studentId, classroomId, selectedDateToHighlight, displayItems.length])
 
   return (
     <div className="p-4 space-y-3">
@@ -128,12 +143,15 @@ export function StudentLogHistory({
         <p className="text-sm text-text-muted">No entries.</p>
       )}
 
-      {selectedDisplayEntry && (
-        <EntryBlock entry={selectedDisplayEntry} label="Selected date" />
-      )}
-
-      {historyEntries.map(entry => (
-        <EntryBlock key={entry.id} entry={entry} />
+      {displayItems.map(item => (
+        <EntryBlock
+          key={item.kind === 'entry' ? item.entry.id : `selected-empty:${item.date}`}
+          ref={item.isSelected ? selectedBlockRef : undefined}
+          date={item.date}
+          text={item.kind === 'entry' ? item.entry.text : 'No log for this date.'}
+          isSelected={item.isSelected}
+          isEmpty={item.kind === 'empty-selected'}
+        />
       ))}
 
       {loading && (
@@ -155,18 +173,69 @@ export function StudentLogHistory({
   )
 }
 
-function EntryBlock({ entry, label }: { entry: Entry; label?: string }) {
+type DisplayItem =
+  | { kind: 'entry'; entry: Entry; date: string; isSelected: boolean }
+  | { kind: 'empty-selected'; date: string; isSelected: true }
+
+const EntryBlock = forwardRef<HTMLDivElement, {
+  date: string
+  text: string
+  isSelected: boolean
+  isEmpty: boolean
+}>(function EntryBlock({ date, text, isSelected, isEmpty }, ref) {
   return (
-    <div>
-      <p className="text-xs text-text-muted mb-1">
-        {label ? `${label} - ` : ''}
-        {formatDate(entry.date)}
+    <div
+      ref={ref}
+      aria-current={isSelected ? 'date' : undefined}
+      className={[
+        isSelected
+          ? 'rounded-md border border-primary bg-info-bg px-3 py-2'
+          : '',
+      ].join(' ')}
+    >
+      <p className={[
+        'mb-1 text-xs',
+        isSelected ? 'font-semibold text-text-default' : 'text-text-muted',
+      ].join(' ')}
+      >
+        {formatDate(date)}
       </p>
-      <p className="text-sm text-text-default whitespace-pre-wrap">
-        {entry.text}
+      <p className={[
+        'text-sm whitespace-pre-wrap',
+        isEmpty ? 'text-text-muted italic' : 'text-text-default',
+      ].join(' ')}
+      >
+        {text}
       </p>
     </div>
   )
+})
+
+function buildDisplayItems(
+  entries: Entry[],
+  selectedDate: string | null,
+  shouldShowEmptySelectedDate: boolean
+): DisplayItem[] {
+  const items: DisplayItem[] = entries.map(entry => ({
+    kind: 'entry',
+    entry,
+    date: entry.date,
+    isSelected: selectedDate === entry.date,
+  }))
+
+  if (
+    selectedDate &&
+    shouldShowEmptySelectedDate &&
+    !items.some(item => item.date === selectedDate)
+  ) {
+    items.push({
+      kind: 'empty-selected',
+      date: selectedDate,
+      isSelected: true,
+    })
+  }
+
+  return items.sort(compareDisplayItemsNewestFirst)
 }
 
 function dedupeEntries(entries: Entry[]): Entry[] {
@@ -192,6 +261,19 @@ function sortEntriesNewestFirst(entries: Entry[]): Entry[] {
     if (dateCompare !== 0) return dateCompare
     return b.updated_at.localeCompare(a.updated_at)
   })
+}
+
+function compareDisplayItemsNewestFirst(a: DisplayItem, b: DisplayItem): number {
+  const dateCompare = b.date.localeCompare(a.date)
+  if (dateCompare !== 0) return dateCompare
+
+  if (a.kind === 'entry' && b.kind === 'entry') {
+    return b.entry.updated_at.localeCompare(a.entry.updated_at)
+  }
+
+  if (a.kind === 'empty-selected' && b.kind === 'entry') return -1
+  if (a.kind === 'entry' && b.kind === 'empty-selected') return 1
+  return 0
 }
 
 function formatDate(dateStr: string): string {

--- a/tests/components/StudentLogHistory.test.tsx
+++ b/tests/components/StudentLogHistory.test.tsx
@@ -78,12 +78,104 @@ describe('StudentLogHistory', () => {
 
     expect(screen.getByText('Selected day log appears immediately.')).toBeInTheDocument()
     expect(screen.getByText('Preview history appears immediately.')).toBeInTheDocument()
+    expect(screen.queryByText(/Selected date/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Selected day log appears immediately.').closest('[aria-current="date"]')
+    ).not.toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     request.resolve(await mockJson({ entries: [exactEntry] }))
 
     await screen.findByText('Exact fetched history appears after refresh.')
     expect(screen.getByText('Selected day log appears immediately.')).toBeInTheDocument()
+  })
+
+  it('keeps the selected entry in chronological order instead of pinning it', () => {
+    const selectedEntry = entry({
+      id: 'selected-older-entry',
+      student_id: 'student-chronology',
+      classroom_id: 'classroom-chronology',
+      date: '2026-03-14',
+      text: 'Selected older day.',
+    })
+    const newerEntry = entry({
+      id: 'newer-entry',
+      student_id: 'student-chronology',
+      classroom_id: 'classroom-chronology',
+      date: '2026-03-16',
+      text: 'Newer history stays first.',
+    })
+    const olderEntry = entry({
+      id: 'older-entry',
+      student_id: 'student-chronology',
+      classroom_id: 'classroom-chronology',
+      date: '2026-03-13',
+      text: 'Older history stays after.',
+    })
+    const request = deferred<any>()
+    vi.stubGlobal('fetch', vi.fn(() => request.promise))
+
+    const { container } = render(
+      <StudentLogHistory
+        studentId="student-chronology"
+        classroomId="classroom-chronology"
+        selectedDate="2026-03-14"
+        selectedEntry={selectedEntry}
+        initialEntries={[selectedEntry, newerEntry, olderEntry]}
+      />
+    )
+
+    const text = container.textContent || ''
+    expect(text.indexOf('Newer history stays first.')).toBeLessThan(
+      text.indexOf('Selected older day.')
+    )
+    expect(text.indexOf('Selected older day.')).toBeLessThan(
+      text.indexOf('Older history stays after.')
+    )
+    expect(
+      screen.getByText('Selected older day.').closest('[aria-current="date"]')
+    ).not.toBeNull()
+    expect(screen.queryByText(/Selected date/)).not.toBeInTheDocument()
+  })
+
+  it('shows a selected no-log row at the selected date position', () => {
+    const newerEntry = entry({
+      id: 'newer-before-empty',
+      student_id: 'student-empty-date',
+      classroom_id: 'classroom-empty-date',
+      date: '2026-03-16',
+      text: 'Newer log.',
+    })
+    const olderEntry = entry({
+      id: 'older-after-empty',
+      student_id: 'student-empty-date',
+      classroom_id: 'classroom-empty-date',
+      date: '2026-03-14',
+      text: 'Older log.',
+    })
+    const request = deferred<any>()
+    vi.stubGlobal('fetch', vi.fn(() => request.promise))
+
+    const { container } = render(
+      <StudentLogHistory
+        studentId="student-empty-date"
+        classroomId="classroom-empty-date"
+        selectedDate="2026-03-15"
+        selectedEntry={null}
+        initialEntries={[newerEntry, olderEntry]}
+      />
+    )
+
+    const text = container.textContent || ''
+    expect(text.indexOf('Newer log.')).toBeLessThan(
+      text.indexOf('No log for this date.')
+    )
+    expect(text.indexOf('No log for this date.')).toBeLessThan(
+      text.indexOf('Older log.')
+    )
+    expect(
+      screen.getByText('No log for this date.').closest('[aria-current="date"]')
+    ).not.toBeNull()
   })
 
   it('filters blank selected entries and blank preview rows', async () => {


### PR DESCRIPTION
## Summary

- Keep the teacher Daily student-log inspector in newest-first chronological order instead of pinning the selected entry above newer logs.
- Highlight the selected date in place with a selected-card treatment and bold date label.
- Show an in-order highlighted `No log for this date.` row when the selected Daily date has no student log.
- Add focused component coverage for selected-date ordering, empty selected dates, and removal of the old `Selected date -` label.

## Why

The previous side panel could be confusing when a teacher chose an older Daily date: the selected entry appeared above newer current-date history, so the timeline no longer read chronologically. This keeps the history truthful while still making the chosen date obvious.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/StudentLogHistory.test.tsx tests/components/TeacherAttendanceTab.test.tsx`
- `pnpm lint`
- `pnpm test`
- `pnpm test tests/unit/ai-startup-docs.test.ts`
- `git diff --check`
- `pnpm build`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=attendance'`
- Browser screenshots: `/tmp/pika-teacher-daily-selected-history.png`, `/tmp/pika-teacher-daily-empty-selected-history.png`