### PR TITLE
[codex] Fix required submission artifact display

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Assignment unsubmit return-state guard
-
-**Completed:**
-- Added a shared assignment rule that only allows student unsubmit before the first teacher return.
-- Blocked `/api/assignment-docs/[id]/unsubmit` from clearing submitted state after returned work, preserving teacher return queues for returned/resubmitted cycles.
-- Updated student assignment action bars to hide `Unsubmit` when the returned submission state is no longer mutable.
-- Moved repeated student assignment reads through `fetchJSONWithCache` with zero TTL so the audit pattern is satisfied without caching the first-view side effect.
-
-**Validation:**
-- `pnpm test tests/api/assignment-docs/unsubmit.test.ts tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm test tests/api/assignment-docs tests/api/student/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx tests/unit/assignments.test.ts`
-- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a'`
-- Visual follow-up screenshots: `/tmp/pika-student-assignment-returned.png`, `/tmp/pika-teacher-assignment-loaded.png`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Mobile navigation drawer labels
 
 **Completed:**
@@ -351,3 +333,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-05-27 — Required submission artifact display
+
+**Completed:**
+- Preserved structured required-submission artifacts as first-class teacher table items before adding free-floating content artifacts.
+- Added requirement title/metadata to teacher artifact display objects so student detail cards show labels like `Published demo` instead of generic `Public link`.
+- Highlighted required-submission artifact pills/cards and kept ordinary content-extracted artifacts visually regular.
+- Added regression coverage for multi-artifact teacher rows, required-submission labels, and student detail artifact titles.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/lib/assignment-submission-requirements.test.ts tests/api/teacher/assignments-id.test.ts tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx -- --testTimeout=10000`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx -- --testTimeout=10000`
+- `pnpm lint`
+- `pnpm test`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
+- Browser screenshots: `/tmp/pika-teacher-details-artifacts.png`, `/tmp/pika-student-loaded.png`, `/tmp/pika-teacher-mobile.png`

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -34,14 +34,17 @@ function mergeAssignmentArtifacts(
   structuredArtifacts: AssignmentArtifact[],
   contentArtifacts: AssignmentArtifact[]
 ): AssignmentArtifact[] {
-  const byUrl = new Map<string, AssignmentArtifact>()
+  const merged = [...structuredArtifacts]
+  const structuredUrls = new Set(structuredArtifacts.map((artifact) => artifact.url).filter(Boolean))
+  const contentUrls = new Set<string>()
 
-  for (const artifact of [...structuredArtifacts, ...contentArtifacts]) {
-    if (!artifact.url || byUrl.has(artifact.url)) continue
-    byUrl.set(artifact.url, artifact)
+  for (const artifact of contentArtifacts) {
+    if (!artifact.url || structuredUrls.has(artifact.url) || contentUrls.has(artifact.url)) continue
+    contentUrls.add(artifact.url)
+    merged.push(artifact)
   }
 
-  return Array.from(byUrl.values())
+  return merged
 }
 
 // GET /api/teacher/assignments/[id] - Get assignment details with all student submissions
@@ -152,7 +155,7 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
     const profile = profileMap.get(enrollment.student_id) || null
     const studentStructuredArtifacts = doc ? (structuredArtifactsByDocId.get(doc.id) || []) : []
     const artifacts = mergeAssignmentArtifacts(
-      submissionArtifactsToAssignmentArtifacts(studentStructuredArtifacts),
+      submissionArtifactsToAssignmentArtifacts(studentStructuredArtifacts, submissionRequirements),
       doc ? extractAssignmentArtifacts(doc.content) : []
     )
     const completion = getSubmissionRequirementCompletion(submissionRequirements, studentStructuredArtifacts)

--- a/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/students/[studentId]/route.ts
@@ -8,7 +8,10 @@ import {
   resolveAssignmentRepoTarget,
 } from '@/lib/server/assignment-repo-targets'
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
-import { loadAssignmentSubmissionArtifactsForDoc } from '@/lib/server/assignment-submission-artifacts'
+import {
+  loadAssignmentSubmissionArtifactsForDoc,
+  loadAssignmentSubmissionRequirements,
+} from '@/lib/server/assignment-submission-artifacts'
 import { loadAssignmentFeedbackEntries } from '@/lib/server/assignment-feedback'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { parseContentField } from '@/lib/tiptap-content'
@@ -93,7 +96,11 @@ export const GET = withErrorHandler('GetTeacherAssignmentStudent', async (reques
   const structuredArtifacts = doc?.id
     ? await loadAssignmentSubmissionArtifactsForDoc(supabase, doc.id)
     : []
-  const structuredCandidateRepos = submissionArtifactsToAssignmentArtifacts(structuredArtifacts)
+  const submissionRequirements = await loadAssignmentSubmissionRequirements(supabase, assignmentId)
+  const structuredCandidateRepos = submissionArtifactsToAssignmentArtifacts(
+    structuredArtifacts,
+    submissionRequirements,
+  )
     .filter((artifact) => artifact.type === 'repo')
 
   const status = calculateAssignmentStatus(assignment, doc)
@@ -124,6 +131,7 @@ export const GET = withErrorHandler('GetTeacherAssignmentStudent', async (reques
       instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
       due_at: assignment.due_at,
       position: assignment.position ?? 0,
+      submission_requirements: submissionRequirements,
       created_by: assignment.created_by,
       created_at: assignment.created_at,
       updated_at: assignment.updated_at,

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -14,7 +14,7 @@ interface AssignmentArtifactsCellProps {
 }
 
 function getArtifactLabel(artifact: AssignmentArtifact): string {
-  const prefix = artifact.type === 'image' ? 'Image' : artifact.type === 'repo' ? 'Repo' : 'Link'
+  const prefix = artifact.title?.trim() || (artifact.type === 'image' ? 'Image' : artifact.type === 'repo' ? 'Repo' : 'Link')
   return `${prefix} . ${summarizeArtifactUrl(artifact.url)}`
 }
 
@@ -23,19 +23,56 @@ function getArtifactSummary(artifact: AssignmentArtifact): string {
 }
 
 function getArtifactTypeLabel(artifact: AssignmentArtifact): string {
+  if (artifact.title?.trim()) return artifact.title.trim()
   if (artifact.type === 'image') return 'Image'
   if (artifact.type === 'repo') return 'Repo'
   return 'Link'
 }
 
+function getArtifactKindLabel(artifact: AssignmentArtifact): string {
+  if (artifact.type === 'image') return 'Image'
+  if (artifact.type === 'repo') return 'Repo'
+  return 'Link'
+}
+
+function isRequiredSubmissionArtifact(artifact: AssignmentArtifact): boolean {
+  return artifact.is_required_submission === true
+}
+
+function getSubmissionArtifactStatusLabel(artifact: AssignmentArtifact): string | null {
+  if (isRequiredSubmissionArtifact(artifact)) return 'Required submission'
+  if (artifact.requirement_id) return 'Optional submission'
+  return null
+}
+
+function getArtifactIconClassName(artifact: AssignmentArtifact) {
+  return [
+    'h-3.5 w-3.5 shrink-0',
+    isRequiredSubmissionArtifact(artifact) ? 'text-primary' : 'text-text-muted',
+  ].join(' ')
+}
+
+function RequiredSubmissionMarker() {
+  return (
+    <span
+      aria-hidden="true"
+      className="rounded-[3px] border border-primary/30 px-0.5 text-[9px] font-semibold uppercase leading-3 text-primary"
+    >
+      R
+    </span>
+  )
+}
+
 function ArtifactTypeIcon({ artifact }: { artifact: AssignmentArtifact }) {
+  const className = getArtifactIconClassName(artifact)
+
   if (artifact.type === 'image') {
-    return <ImageIcon className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+    return <ImageIcon className={className} aria-hidden="true" />
   }
   if (artifact.type === 'repo') {
-    return <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+    return <FolderGit2 className={className} aria-hidden="true" />
   }
-  return <Link2 className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+  return <Link2 className={className} aria-hidden="true" />
 }
 
 function ArtifactsTooltipList({
@@ -55,36 +92,46 @@ function ArtifactsTooltipList({
         {artifacts.length} artifact{artifacts.length === 1 ? '' : 's'}
       </div>
       <div className="space-y-1">
-        {artifacts.map((artifact, index) => (
-          <a
-            key={`${artifact.url}:${index}`}
-            href={artifact.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={handleArtifactClick}
-            aria-label={`Open artifact ${index + 1}: ${getArtifactTypeLabel(artifact)} . ${getArtifactSummary(artifact)}`}
-            className={[
-              'flex min-w-0 items-start gap-2 rounded-md border px-2 py-1.5',
-              index === activeIndex
-                ? 'border-primary/40 bg-surface-selected'
-                : 'border-border bg-surface-2',
-              'hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface',
-            ].join(' ')}
-          >
-            <span className="mt-0.5 inline-flex h-5 min-w-8 shrink-0 items-center justify-center gap-1 rounded-full border border-border bg-surface text-[11px] font-medium text-text-default">
-              <ArtifactTypeIcon artifact={artifact} />
-              {index + 1}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-[11px] font-medium text-text-default">
-                {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+        {artifacts.map((artifact, index) => {
+          const statusLabel = getSubmissionArtifactStatusLabel(artifact)
+          const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
+          const borderClass = isRequiredSubmission
+            ? 'border-primary/50'
+            : index === activeIndex
+              ? 'border-primary/40'
+              : 'border-border'
+          const surfaceClass = index === activeIndex ? 'bg-surface-selected' : 'bg-surface-2'
+
+          return (
+            <a
+              key={`${artifact.url}:${index}`}
+              href={artifact.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleArtifactClick}
+              aria-label={`Open ${statusLabel ? `${statusLabel.toLowerCase()} ` : ''}artifact ${index + 1}: ${getArtifactTypeLabel(artifact)} . ${getArtifactSummary(artifact)}`}
+              className={[
+                'flex min-w-0 items-start gap-2 rounded-md border px-2 py-1.5',
+                borderClass,
+                surfaceClass,
+                'hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface',
+              ].join(' ')}
+            >
+              <span className="mt-0.5 inline-flex h-5 min-w-8 shrink-0 items-center justify-center gap-1 rounded-full border border-border bg-surface text-[11px] font-medium text-text-default">
+                <ArtifactTypeIcon artifact={artifact} />
+                {index + 1}
               </span>
-              <span className="block truncate text-[11px] text-text-muted">
-                {artifact.url}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[11px] font-medium text-text-default">
+                  {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+                </span>
+                <span className="block truncate text-[11px] text-text-muted">
+                  {statusLabel ?? getArtifactKindLabel(artifact)} . {artifact.url}
+                </span>
               </span>
-            </span>
-          </a>
-        ))}
+            </a>
+          )
+        })}
       </div>
     </div>
   )
@@ -121,29 +168,42 @@ export function AssignmentArtifactsCell({
             side="bottom"
             align="start"
           >
-            {hasMultipleArtifacts ? (
-              <button
-                type="button"
-                onClick={handleOpenChooser}
-                className="inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border border-border bg-surface-2 px-1.5 text-xs font-medium text-text-default hover:bg-surface-hover"
-                aria-label={`View work items; artifact ${index + 1} is ${getArtifactLabel(artifact)}`}
-              >
-                <ArtifactTypeIcon artifact={artifact} />
-                <span>{index + 1}</span>
-              </button>
-            ) : (
-              <a
-                href={artifact.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={handleOpenSingle}
-                className="inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border border-border bg-surface-2 px-1.5 text-xs font-medium text-text-default hover:bg-surface-hover"
-                aria-label={`Open artifact ${index + 1}: ${getArtifactLabel(artifact)}`}
-              >
-                <ArtifactTypeIcon artifact={artifact} />
-                <span>{index + 1}</span>
-              </a>
-            )}
+            {(() => {
+              const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
+              const requiredLabel = isRequiredSubmission ? 'required submission ' : ''
+              const pillClassName = [
+                'inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border px-1.5 text-xs font-medium hover:bg-surface-hover',
+                isRequiredSubmission
+                  ? 'border-primary/50 bg-info-bg text-primary'
+                  : 'border-border bg-surface-2 text-text-default',
+              ].join(' ')
+
+              return hasMultipleArtifacts ? (
+                <button
+                  type="button"
+                  onClick={handleOpenChooser}
+                  className={pillClassName}
+                  aria-label={`View work items; ${requiredLabel}artifact ${index + 1} is ${getArtifactLabel(artifact)}`}
+                >
+                  <ArtifactTypeIcon artifact={artifact} />
+                  <span>{index + 1}</span>
+                  {isRequiredSubmission ? <RequiredSubmissionMarker /> : null}
+                </button>
+              ) : (
+                <a
+                  href={artifact.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={handleOpenSingle}
+                  className={pillClassName}
+                  aria-label={`Open ${requiredLabel}artifact ${index + 1}: ${getArtifactLabel(artifact)}`}
+                >
+                  <ArtifactTypeIcon artifact={artifact} />
+                  <span>{index + 1}</span>
+                  {isRequiredSubmission ? <RequiredSubmissionMarker /> : null}
+                </a>
+              )
+            })()}
           </Tooltip>
         ))}
       </div>
@@ -157,29 +217,39 @@ export function AssignmentArtifactsCell({
         showFooterClose={false}
       >
         <div className="space-y-2">
-          {artifacts.map((artifact, index) => (
-            <a
-              key={`${artifact.url}:${index}`}
-              href={artifact.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setIsChooserOpen(false)}
-              className="flex min-w-0 items-center gap-3 rounded-md border border-border bg-surface p-2.5 text-left hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
-            >
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-surface-2">
-                <ArtifactTypeIcon artifact={artifact} />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-medium text-text-default">
-                  {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+          {artifacts.map((artifact, index) => {
+            const statusLabel = getSubmissionArtifactStatusLabel(artifact)
+            const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
+
+            return (
+              <a
+                key={`${artifact.url}:${index}`}
+                href={artifact.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setIsChooserOpen(false)}
+                className="flex min-w-0 items-center gap-3 rounded-md border border-border bg-surface p-2.5 text-left hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
+              >
+                <span className={[
+                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md border',
+                  isRequiredSubmission
+                    ? 'border-primary/50 bg-info-bg'
+                    : 'border-border bg-surface-2',
+                ].join(' ')}>
+                  <ArtifactTypeIcon artifact={artifact} />
                 </span>
-                <span className="mt-0.5 block truncate text-xs text-text-muted">
-                  {artifact.url}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-text-default">
+                    {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
+                  </span>
+                  <span className="mt-0.5 block truncate text-xs text-text-muted">
+                    {statusLabel ?? getArtifactKindLabel(artifact)} . {artifact.url}
+                  </span>
                 </span>
-              </span>
-              <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
-            </a>
-          ))}
+                <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+              </a>
+            )
+          })}
         </div>
       </ContentDialog>
     </>

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { formatInTimeZone } from 'date-fns-tz'
+import { FolderGit2, Image as ImageIcon, Link2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
@@ -55,36 +56,98 @@ export interface TeacherAssignmentGradeTemplate {
 function SubmittedArtifactsList({ artifacts }: { artifacts: AssignmentArtifact[] }) {
   if (artifacts.length === 0) return null
 
+  function getArtifactFallbackLabel(artifact: AssignmentArtifact) {
+    if (artifact.type === 'repo') return 'Repo link'
+    if (artifact.type === 'image') return 'Image'
+    return 'Public link'
+  }
+
+  function getArtifactKindLabel(artifact: AssignmentArtifact) {
+    if (artifact.type === 'repo') return 'Repo'
+    if (artifact.type === 'image') return 'Image'
+    return 'Link'
+  }
+
+  function getArtifactTitle(artifact: AssignmentArtifact) {
+    return artifact.title?.trim() || getArtifactFallbackLabel(artifact)
+  }
+
+  function isRequiredSubmissionArtifact(artifact: AssignmentArtifact) {
+    return artifact.is_required_submission === true
+  }
+
+  function getSubmissionArtifactStatusLabel(artifact: AssignmentArtifact) {
+    if (isRequiredSubmissionArtifact(artifact)) return 'Required submission'
+    if (artifact.requirement_id) return 'Optional submission'
+    return null
+  }
+
+  function SubmittedArtifactIcon({ artifact }: { artifact: AssignmentArtifact }) {
+    const className = [
+      'h-4 w-4',
+      isRequiredSubmissionArtifact(artifact) ? 'text-primary' : 'text-text-muted',
+    ].join(' ')
+    if (artifact.type === 'repo') return <FolderGit2 className={className} aria-hidden="true" />
+    if (artifact.type === 'image') return <ImageIcon className={className} aria-hidden="true" />
+    return <Link2 className={className} aria-hidden="true" />
+  }
+
   return (
     <div className="shrink-0 border-t border-border bg-surface px-4 py-3">
       <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
         Submitted artifacts
       </h3>
       <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-        {artifacts.map((artifact, index) => (
-          <a
-            key={`${artifact.url}:${index}`}
-            href={artifact.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group overflow-hidden rounded-md border border-border bg-surface-2 hover:bg-surface-hover"
-          >
-            {artifact.type === 'image' ? (
-              <div
-                className="h-28 border-b border-border bg-surface bg-contain bg-center bg-no-repeat"
-                style={{ backgroundImage: `url("${encodeURI(artifact.url)}")` }}
-              />
-            ) : null}
-            <div className="min-w-0 px-3 py-2">
-              <div className="text-xs font-medium text-text-default">
-                {artifact.type === 'repo' ? 'Repo link' : artifact.type === 'image' ? 'Image' : 'Public link'}
+        {artifacts.map((artifact, index) => {
+          const statusLabel = getSubmissionArtifactStatusLabel(artifact)
+          const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
+
+          return (
+            <a
+              key={`${artifact.url}:${index}`}
+              href={artifact.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={[
+                'group overflow-hidden rounded-md border bg-surface-2 hover:bg-surface-hover',
+                isRequiredSubmission ? 'border-primary/50' : 'border-border',
+              ].join(' ')}
+            >
+              {artifact.type === 'image' ? (
+                <div
+                  className="h-28 border-b border-border bg-surface bg-contain bg-center bg-no-repeat"
+                  style={{ backgroundImage: `url("${encodeURI(artifact.url)}")` }}
+                />
+              ) : null}
+              <div className="flex min-w-0 items-start gap-2 px-3 py-2">
+                <span className={[
+                  'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+                  isRequiredSubmission
+                    ? 'border-primary/50 bg-info-bg'
+                    : 'border-border bg-surface',
+                ].join(' ')}>
+                  <SubmittedArtifactIcon artifact={artifact} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-xs font-medium text-text-default">
+                    {getArtifactTitle(artifact)}
+                  </div>
+                  <div className="truncate text-xs text-text-muted group-hover:text-text-default">
+                    {getArtifactKindLabel(artifact)} . {summarizeArtifactUrl(artifact.url)}
+                  </div>
+                  {statusLabel ? (
+                    <div className={[
+                      'mt-1 text-[11px] font-medium',
+                      isRequiredSubmission ? 'text-primary' : 'text-text-muted',
+                    ].join(' ')}>
+                      {statusLabel}
+                    </div>
+                  ) : null}
+                </div>
               </div>
-              <div className="truncate text-xs text-text-muted group-hover:text-text-default">
-                {summarizeArtifactUrl(artifact.url)}
-              </div>
-            </div>
-          </a>
-        ))}
+            </a>
+          )
+        })}
       </div>
     </div>
   )
@@ -288,7 +351,10 @@ export function TeacherStudentWorkPanel({
   }
 
   const displayContent = previewContent || data.doc?.content
-  const submittedArtifacts = submissionArtifactsToAssignmentArtifacts(data.submission_artifacts || [])
+  const submittedArtifacts = submissionArtifactsToAssignmentArtifacts(
+    data.submission_artifacts || [],
+    data.assignment.submission_requirements || [],
+  )
   const hasSubmittedArtifacts = submittedArtifacts.length > 0
   const inspector = (
     <TeacherWorkInspector

--- a/src/lib/assignment-artifacts.ts
+++ b/src/lib/assignment-artifacts.ts
@@ -6,6 +6,10 @@ export type AssignmentArtifactType = 'image' | 'link' | 'repo'
 export interface AssignmentArtifact {
   type: AssignmentArtifactType
   url: string
+  title?: string
+  is_required_submission?: boolean
+  requirement_id?: string
+  requirement_required?: boolean
   repo_owner?: string
   repo_name?: string
   normalized_url?: string

--- a/src/lib/assignment-submission-requirements.ts
+++ b/src/lib/assignment-submission-requirements.ts
@@ -164,14 +164,28 @@ export function getSubmissionRequirementCompletion(
   }
 }
 
+function getRequirementArtifactFields(
+  artifact: AssignmentSubmissionArtifact,
+  requirement?: AssignmentSubmissionRequirement | null
+) {
+  return {
+    title: requirement?.label?.trim() || DEFAULT_REQUIREMENT_LABELS[artifact.type],
+    is_required_submission: requirement?.required ?? true,
+    requirement_id: artifact.requirement_id,
+    requirement_required: requirement?.required ?? true,
+  }
+}
+
 export function submissionArtifactToAssignmentArtifact(
-  artifact: AssignmentSubmissionArtifact
+  artifact: AssignmentSubmissionArtifact,
+  requirement?: AssignmentSubmissionRequirement | null
 ): AssignmentArtifact | null {
   const url = artifact.url?.trim()
   if (!url) return null
+  const requirementFields = getRequirementArtifactFields(artifact, requirement)
 
   if (artifact.type === 'image') {
-    return { type: 'image', url }
+    return { type: 'image', url, ...requirementFields }
   }
 
   if (artifact.type === 'repo_link') {
@@ -191,6 +205,7 @@ export function submissionArtifactToAssignmentArtifact(
     return {
       type: 'repo',
       url,
+      ...requirementFields,
       repo_owner: repoOwner,
       repo_name: repoName,
       normalized_url: normalizedUrl,
@@ -198,13 +213,19 @@ export function submissionArtifactToAssignmentArtifact(
     }
   }
 
-  return { type: 'link', url }
+  return { type: 'link', url, ...requirementFields }
 }
 
 export function submissionArtifactsToAssignmentArtifacts(
-  artifacts: AssignmentSubmissionArtifact[]
+  artifacts: AssignmentSubmissionArtifact[],
+  requirements: AssignmentSubmissionRequirement[] = []
 ): AssignmentArtifact[] {
+  const requirementsById = new Map(requirements.map((requirement) => [requirement.id, requirement]))
+
   return artifacts
-    .map(submissionArtifactToAssignmentArtifact)
+    .map((artifact) => submissionArtifactToAssignmentArtifact(
+      artifact,
+      requirementsById.get(artifact.requirement_id) ?? null
+    ))
     .filter((artifact): artifact is AssignmentArtifact => artifact !== null)
 }

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -243,7 +243,26 @@ describe('GET /api/teacher/assignments/[id]', () => {
             eq: vi.fn(() => ({
               order: vi.fn(() => ({
                 order: vi.fn().mockResolvedValue({
-                  data: [],
+                  data: [
+                    makeRequirement({
+                      id: 'req-1',
+                      type: 'link',
+                      label: 'Project page',
+                      position: 0,
+                    }),
+                    makeRequirement({
+                      id: 'req-2',
+                      type: 'link',
+                      label: 'Backup page',
+                      position: 1,
+                    }),
+                    makeRequirement({
+                      id: 'req-3',
+                      type: 'repo_link',
+                      label: 'Source repo',
+                      position: 2,
+                    }),
+                  ],
                   error: null,
                 }),
               })),
@@ -263,9 +282,43 @@ describe('GET /api/teacher/assignments/[id]', () => {
                   requirement_id: 'req-1',
                   student_id: 'student-1',
                   type: 'link',
-                  url: 'https://demo.example.com',
+                  url: 'https://example.com/resource',
                   storage_path: null,
                   metadata_json: {},
+                  validation_status: 'valid',
+                  validation_message: null,
+                  validated_at: '2026-03-10T09:35:00.000Z',
+                  created_at: '2026-03-10T09:35:00.000Z',
+                  updated_at: '2026-03-10T09:35:00.000Z',
+                },
+                {
+                  id: 'artifact-2',
+                  assignment_doc_id: 'doc-1',
+                  requirement_id: 'req-2',
+                  student_id: 'student-1',
+                  type: 'link',
+                  url: 'https://example.com/resource',
+                  storage_path: null,
+                  metadata_json: {},
+                  validation_status: 'valid',
+                  validation_message: null,
+                  validated_at: '2026-03-10T09:35:00.000Z',
+                  created_at: '2026-03-10T09:35:00.000Z',
+                  updated_at: '2026-03-10T09:35:00.000Z',
+                },
+                {
+                  id: 'artifact-3',
+                  assignment_doc_id: 'doc-1',
+                  requirement_id: 'req-3',
+                  student_id: 'student-1',
+                  type: 'repo_link',
+                  url: 'https://github.com/codepetca/pika',
+                  storage_path: null,
+                  metadata_json: {
+                    repo_owner: 'codepetca',
+                    repo_name: 'pika',
+                    normalized_url: 'https://github.com/codepetca/pika',
+                  },
                   validation_status: 'valid',
                   validation_message: null,
                   validated_at: '2026-03-10T09:35:00.000Z',
@@ -290,10 +343,41 @@ describe('GET /api/teacher/assignments/[id]', () => {
     expect(data.students).toHaveLength(1)
     expect(data.students[0].student_updated_at).toBe(historyCreatedAt)
     expect(data.students[0].artifacts).toEqual([
-      { type: 'link', url: 'https://demo.example.com' },
-      { type: 'link', url: 'https://example.com/resource' },
+      {
+        type: 'link',
+        url: 'https://example.com/resource',
+        title: 'Project page',
+        is_required_submission: true,
+        requirement_id: 'req-1',
+        requirement_required: true,
+      },
+      {
+        type: 'link',
+        url: 'https://example.com/resource',
+        title: 'Backup page',
+        is_required_submission: true,
+        requirement_id: 'req-2',
+        requirement_required: true,
+      },
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        title: 'Source repo',
+        is_required_submission: true,
+        requirement_id: 'req-3',
+        requirement_required: true,
+        repo_owner: 'codepetca',
+        repo_name: 'pika',
+        normalized_url: 'https://github.com/codepetca/pika',
+      },
       { type: 'image', url: 'https://cdn.example.com/submission-images/shot.png' },
     ])
+    expect(data.students[0].submission_completion).toEqual({
+      required_count: 3,
+      completed_required_count: 3,
+      can_submit: true,
+      blocking_count: 0,
+    })
     expect(data.students[0].doc).toEqual({
       is_submitted: true,
       submitted_at: submittedAt,

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -53,6 +53,77 @@ describe('AssignmentArtifactsCell', () => {
     expect(artifactLink).toHaveTextContent('1')
     fireEvent.click(artifactLink)
     expect(screen.queryByText('Open artifact')).not.toBeInTheDocument()
+  })
+
+  it('labels required submission artifacts with requirement titles', () => {
+    const artifacts: AssignmentArtifact[] = [
+      {
+        type: 'link',
+        url: 'https://demo.example.com',
+        title: 'Published demo',
+        is_required_submission: true,
+        requirement_id: 'req-demo',
+        requirement_required: true,
+      },
+      {
+        type: 'repo',
+        url: 'https://github.com/codepetca/pika',
+        title: 'Source repo',
+        is_required_submission: true,
+        requirement_id: 'req-repo',
+        requirement_required: true,
+      },
+      { type: 'link', url: 'https://example.com/free-note' },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
+
+    const publishedDemoButton = screen.getByRole('button', {
+      name: /required submission artifact 1 is published demo/i,
+    })
+    const sourceRepoButton = screen.getByRole('button', {
+      name: /required submission artifact 2 is source repo/i,
+    })
+    const freeNoteButton = screen.getByRole('button', {
+      name: /^View work items; artifact 3 is Link/i,
+    })
+
+    expect(within(publishedDemoButton).getByText('R')).toBeInTheDocument()
+    expect(within(sourceRepoButton).getByText('R')).toBeInTheDocument()
+    expect(within(freeNoteButton).queryByText('R')).not.toBeInTheDocument()
+    expect(freeNoteButton).not.toHaveAccessibleName(/required submission/i)
+
+    fireEvent.click(publishedDemoButton)
+
+    expect(screen.getByText(/Published demo . demo.example.com/i)).toBeInTheDocument()
+    expect(screen.getByText(/Source repo . github.com\/codepetca\/pika/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/^Required submission \./)).toHaveLength(2)
+  })
+
+  it('includes required submission status in hover list link labels', async () => {
+    const user = userEvent.setup()
+    const artifacts: AssignmentArtifact[] = [
+      {
+        type: 'link',
+        url: 'https://demo.example.com',
+        title: 'Published demo',
+        is_required_submission: true,
+        requirement_id: 'req-demo',
+        requirement_required: true,
+      },
+      { type: 'link', url: 'https://example.com/free-note' },
+    ]
+
+    renderWithTooltipProvider(<AssignmentArtifactsCell artifacts={artifacts} isCompact />)
+    await user.hover(screen.getByRole('button', {
+      name: /required submission artifact 1 is published demo/i,
+    }))
+
+    const tooltipLinks = await screen.findAllByRole('link', {
+      name: /open required submission artifact 1: published demo/i,
+    })
+    expect(tooltipLinks.length).toBeGreaterThan(0)
+    expect(tooltipLinks[0]).toHaveAttribute('href', 'https://demo.example.com')
   })
 
   it('opens a narrow chooser dialog for multiple artifacts', () => {

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -68,6 +68,7 @@ function makeStudentWork(
     authenticityScore?: number | null
     emptyContent?: boolean
     submissionArtifacts?: Array<Record<string, any>>
+    submissionRequirements?: Array<Record<string, any>>
   },
 ) {
   const doc = {
@@ -131,6 +132,7 @@ function makeStudentWork(
       is_draft: false,
       released_at: '2026-02-18T12:00:00Z',
       track_authenticity: true,
+      submission_requirements: opts.submissionRequirements || [],
       created_by: 'teacher-1',
       created_at: '2026-02-20T12:00:00Z',
       updated_at: '2026-02-20T12:00:00Z',
@@ -181,6 +183,7 @@ function mockFetchByStudent(
       authenticityScore?: number | null
       emptyContent?: boolean
       submissionArtifacts?: Array<Record<string, any>>
+      submissionRequirements?: Array<Record<string, any>>
       historyEntries?: Array<Record<string, any>>
     }
   >,
@@ -381,8 +384,129 @@ describe('TeacherStudentWorkPanel', () => {
     )
 
     expect(await screen.findByText('Submitted artifacts')).toBeInTheDocument()
-    expect(screen.getByText('demo.example.com')).toBeInTheDocument()
+    expect(screen.getByText(/Link . demo.example.com/i)).toBeInTheDocument()
     expect(screen.queryByText('No work submitted yet')).not.toBeInTheDocument()
+  })
+
+  it('renders submission artifact titles, kinds, and required status in student details', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        emptyContent: true,
+        submissionRequirements: [
+          {
+            id: 'req-demo',
+            assignment_id: 'assignment-1',
+            type: 'link',
+            label: 'Published demo',
+            instructions: '',
+            required: true,
+            position: 0,
+            validation_policy_json: {},
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+          {
+            id: 'req-repo',
+            assignment_id: 'assignment-1',
+            type: 'repo_link',
+            label: 'Source repo',
+            instructions: '',
+            required: true,
+            position: 1,
+            validation_policy_json: {},
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+          {
+            id: 'req-screenshot',
+            assignment_id: 'assignment-1',
+            type: 'image',
+            label: 'Process screenshot',
+            instructions: '',
+            required: false,
+            position: 2,
+            validation_policy_json: {},
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+        ],
+        submissionArtifacts: [
+          {
+            id: 'artifact-1',
+            assignment_doc_id: 'doc-student-1',
+            requirement_id: 'req-demo',
+            student_id: 'student-1',
+            type: 'link',
+            url: 'https://demo.example.com',
+            storage_path: null,
+            metadata_json: {},
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-02-20T12:00:00Z',
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+          {
+            id: 'artifact-2',
+            assignment_doc_id: 'doc-student-1',
+            requirement_id: 'req-repo',
+            student_id: 'student-1',
+            type: 'repo_link',
+            url: 'https://github.com/codepetca/pika',
+            storage_path: null,
+            metadata_json: {
+              repo_owner: 'codepetca',
+              repo_name: 'pika',
+              normalized_url: 'https://github.com/codepetca/pika',
+            },
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-02-20T12:00:00Z',
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+          {
+            id: 'artifact-3',
+            assignment_doc_id: 'doc-student-1',
+            requirement_id: 'req-screenshot',
+            student_id: 'student-1',
+            type: 'image',
+            url: 'https://cdn.example.com/submission-images/process.png',
+            storage_path: 'student-1/assignment-1/process.png',
+            metadata_json: {},
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-02-20T12:00:00Z',
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+        ],
+      },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByText('Submitted artifacts')).toBeInTheDocument()
+    expect(screen.getByText('Published demo')).toBeInTheDocument()
+    expect(screen.getByText('Source repo')).toBeInTheDocument()
+    expect(screen.getByText('Process screenshot')).toBeInTheDocument()
+    expect(screen.getByText(/Link . demo.example.com/i)).toBeInTheDocument()
+    expect(screen.getByText(/Repo . github.com\/codepetca\/pika/i)).toBeInTheDocument()
+    expect(screen.getByText(/Image . cdn.example.com\/submission-images/i)).toBeInTheDocument()
+    expect(screen.getAllByText('Required submission')).toHaveLength(2)
+    expect(screen.getByText('Optional submission')).toBeInTheDocument()
+    expect(screen.queryByText('Public link')).not.toBeInTheDocument()
   })
 
   it('uses edit-mode checkboxes to hide inspector cards outside edit mode', async () => {

--- a/tests/lib/assignment-submission-requirements.test.ts
+++ b/tests/lib/assignment-submission-requirements.test.ts
@@ -133,6 +133,10 @@ describe('submissionArtifactsToAssignmentArtifacts', () => {
       {
         type: 'repo',
         url: 'https://github.com/codepetca/pika',
+        title: 'Repo link',
+        is_required_submission: true,
+        requirement_id: 'req-1',
+        requirement_required: true,
         repo_owner: 'codepetca',
         repo_name: 'pika',
         normalized_url: 'https://github.com/codepetca/pika',
@@ -140,6 +144,36 @@ describe('submissionArtifactsToAssignmentArtifacts', () => {
       {
         type: 'image',
         url: 'https://signed.example.com/image.png',
+        title: 'Screenshot',
+        is_required_submission: true,
+        requirement_id: 'req-2',
+        requirement_required: true,
+      },
+    ])
+  })
+
+  it('uses requirement labels for teacher artifact display metadata', () => {
+    expect(submissionArtifactsToAssignmentArtifacts([
+      artifact({
+        requirement_id: 'req-demo',
+        type: 'link',
+        url: 'https://demo.example.com',
+      }),
+    ], [
+      requirement({
+        id: 'req-demo',
+        type: 'link',
+        label: 'Published demo',
+        required: false,
+      }),
+    ])).toEqual([
+      {
+        type: 'link',
+        url: 'https://demo.example.com',
+        title: 'Published demo',
+        is_required_submission: false,
+        requirement_id: 'req-demo',
+        requirement_required: false,
       },
     ])
   })


### PR DESCRIPTION
## Summary
- Preserve structured required-submission artifacts as first-class teacher table artifacts before adding regular content-extracted artifacts.
- Carry requirement titles and metadata through teacher assignment APIs so student detail cards show labels like `Published demo` and the correct artifact icon.
- Add a non-color `R` marker and accessible required-submission labels for required artifact pills while keeping free-floating artifacts visually regular.

## Root Cause
Structured submission artifacts were flattened into generic link/image/repo artifacts and then de-duped by URL with content-extracted artifacts, so multiple required submissions could collapse into fewer display pills and detail cards lost requirement titles.

## Subagent Review
- API/data review: no blockers; noted requirement-position ordering would be separate product scope.
- UI/accessibility review: fixed tooltip aria labels, non-color required markers, and optional requirement labeling.
- Test coverage review: added duplicate-URL required-submission coverage and stricter table/detail assertions.

## Validation
- `pnpm lint`
- `pnpm test` (291 files / 2425 tests)
- `pnpm build`
- `git diff --check`
- Visual verification on local fixture: `/tmp/pika-teacher-final.png`, `/tmp/pika-teacher-mobile-final.png`, `/tmp/pika-teacher-content-artifacts-final.png`, `/tmp/pika-student.png`