### PR TITLE
Fix phase four audit findings

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — API route error-handler drift cleanup
-
-**Completed:**
-- Migrated the classroom reorder route and test clear-open-grades route from manual `try/catch` blocks to `withErrorHandler`.
-- Preserved existing validation, access, and database error response behavior while centralizing auth/unknown error handling.
-- Added a unit standards test that scans every API `route.ts` export and fails on unwrapped HTTP handlers, while allowing aliases to already wrapped handlers.
-
-**Validation:**
-- `pnpm test tests/api/teacher/tests-clear-open-grades.test.ts tests/api/teacher/classrooms-reorder.test.ts tests/unit/api-route-standards.test.ts`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Gradebook assessment font weight cleanup
 
 **Completed:**
@@ -347,3 +331,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=attendance'`
 - Browser screenshots: `/tmp/pika-teacher-daily-selected-history.png`, `/tmp/pika-teacher-daily-empty-selected-history.png`
+
+## 2026-05-27 — Phase four audit fixes
+
+**Completed:**
+- Added selected-student classroom enrollment validation to the teacher test return route before availability checks, finalization, response reads, or the return RPC.
+- Scoped teacher test result aggregation and open-response stats to currently enrolled classroom students.
+- Normalized the shared feedback dialog to use `@/ui` primitives for the dialog import, category segmented control, and submit button.
+- Updated focused API and integration coverage for selected test return/results enrollment scoping.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/tests-return.test.ts tests/api/teacher/tests-results.test.ts`
+- `pnpm test tests/api/integration/test-return-visibility-flow.test.ts`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Feedback dialog screenshots: `/tmp/pika-feedback-teacher-desktop-light-idle.png`, `/tmp/pika-feedback-teacher-desktop-light-error.png`, `/tmp/pika-feedback-teacher-desktop-light-submitting.png`, `/tmp/pika-feedback-teacher-desktop-light-success.png`, `/tmp/pika-feedback-teacher-mobile-dark-idle.png`, `/tmp/pika-feedback-student-desktop-dark-idle.png`, `/tmp/pika-feedback-student-mobile-light-error.png`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -62,6 +62,10 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   }
 
   const classroomStudentIds = [...new Set((enrollments || []).map((row) => row.student_id))]
+  const classroomStudentIdSet = new Set(classroomStudentIds)
+  const enrolledResponses = (responses || []).filter((response) =>
+    classroomStudentIdSet.has(response.student_id)
+  )
   const availabilityResult = await getTestStudentAvailabilityMap(supabase, testId, classroomStudentIds)
   if (availabilityResult.error && !availabilityResult.missingTable) {
     console.error('Error fetching test student availability:', availabilityResult.error)
@@ -89,7 +93,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   const openGradedCounts = new Map<string, number>()
   const openUngradedCounts = new Map<string, number>()
 
-  for (const response of responses || []) {
+  for (const response of enrolledResponses) {
     const question = questionById.get(response.question_id)
     if (!question) continue
     if (!studentAnswers[response.student_id]) studentAnswers[response.student_id] = {}
@@ -405,7 +409,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   const multipleChoiceQuestions = (questions || []).filter(
     (question) => question.question_type !== 'open_response'
   )
-  const multipleChoiceResponses = (responses || []).flatMap((response) => {
+  const multipleChoiceResponses = enrolledResponses.flatMap((response) => {
     if (typeof response.selected_option !== 'number') return []
     return [{
       id: response.id,
@@ -430,7 +434,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
 
   let gradedOpenResponses = 0
   let ungradedOpenResponses = 0
-  for (const response of responses || []) {
+  for (const response of enrolledResponses) {
     if (!openQuestionIds.has(response.question_id)) continue
     const hasScore = typeof response.score === 'number'
     if (hasScore) {

--- a/src/app/api/teacher/tests/[id]/return/route.ts
+++ b/src/app/api/teacher/tests/[id]/return/route.ts
@@ -6,6 +6,7 @@ import {
   getEffectiveStudentTestAccess,
   getTestStudentAvailabilityMap,
   isMissingTestAttemptReturnColumnsError,
+  validateSelectedTestStudentEnrollment,
 } from '@/lib/server/tests'
 import { finalizeUnsubmittedTestAttemptsOnClose } from '@/lib/server/finalize-test-attempts'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -77,6 +78,24 @@ export const POST = withErrorHandler('ReturnTeacherTest', async (request, contex
   }
 
   const supabase = getServiceRoleClient()
+  const enrollmentValidation = await validateSelectedTestStudentEnrollment(
+    supabase,
+    access.test.classroom_id,
+    studentIds,
+  )
+
+  if (!enrollmentValidation.ok) {
+    console.error('Error validating selected students for test return:', enrollmentValidation.error)
+    return NextResponse.json({ error: 'Failed to validate selected students' }, { status: 500 })
+  }
+
+  if (enrollmentValidation.missingStudentIds.length > 0) {
+    return NextResponse.json(
+      { error: 'One or more selected students are not enrolled in this classroom' },
+      { status: 400 },
+    )
+  }
+
   const availabilityResult = await getTestStudentAvailabilityMap(supabase, testId, studentIds)
   if (availabilityResult.error && !availabilityResult.missingTable) {
     console.error('Error loading test access for return:', availabilityResult.error)

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { ContentDialog } from '@/ui/Dialog'
+import { Button, ContentDialog, SegmentedControl, type SegmentedControlOption } from '@/ui'
 
 interface FeedbackDialogProps {
   isOpen: boolean
@@ -9,6 +9,11 @@ interface FeedbackDialogProps {
 }
 
 type Category = 'bug' | 'suggestion'
+
+const categoryOptions: Array<SegmentedControlOption<Category>> = [
+  { value: 'bug', label: 'Bug report' },
+  { value: 'suggestion', label: 'Suggestion' },
+]
 
 export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
   const [category, setCategory] = useState<Category>('bug')
@@ -96,24 +101,13 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="space-y-3">
-          <fieldset aria-label="Feedback category">
-            <div className="flex gap-2">
-              {(['bug', 'suggestion'] as const).map((opt) => (
-                <button
-                  key={opt}
-                  type="button"
-                  onClick={() => setCategory(opt)}
-                  className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
-                    category === opt
-                      ? 'border-border-strong bg-surface-2 text-text-default'
-                      : 'border-border bg-surface text-text-muted hover:bg-surface-hover'
-                  }`}
-                >
-                  {opt === 'bug' ? 'Bug report' : 'Suggestion'}
-                </button>
-              ))}
-            </div>
-          </fieldset>
+          <SegmentedControl<Category>
+            ariaLabel="Feedback category"
+            value={category}
+            options={categoryOptions}
+            onChange={setCategory}
+            className="w-full [&>button]:flex-1"
+          />
 
           <textarea
             id="feedback-description"
@@ -130,13 +124,13 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
             <p className="text-sm text-danger">{errorMsg}</p>
           )}
 
-          <button
+          <Button
             type="submit"
-            disabled={state === 'submitting'}
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            fullWidth
+            loading={state === 'submitting'}
           >
-            {state === 'submitting' ? 'Sending…' : 'Send Feedback'}
-          </button>
+            {state === 'submitting' ? 'Sending' : 'Send Feedback'}
+          </Button>
         </form>
       )}
     </ContentDialog>

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -68,6 +68,12 @@ const state = {
       returned_by: null as string | null,
     },
   ],
+  classroomEnrollments: [
+    {
+      classroom_id: 'classroom-1',
+      student_id: 'student-1',
+    },
+  ],
   testStudentAvailability: [] as Array<{
     test_id: string
     student_id: string
@@ -334,6 +340,40 @@ function setupSupabaseMock() {
         insert: vi.fn(async (rows: Array<Record<string, unknown>>) => {
           state.testAttempts.push(...(rows as any))
           return { error: null }
+        }),
+      }
+    }
+
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => {
+          const eqFilters: Record<string, string> = {}
+          const chain: any = {
+            eq: vi.fn((column: string, value: string) => {
+              eqFilters[column] = value
+              return chain
+            }),
+            in: vi.fn(async (column: string, values: string[]) => ({
+              data: state.classroomEnrollments
+                .filter((row) =>
+                  Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                )
+                .filter((row) => values.includes(String((row as any)[column])))
+                .map((row) => ({ student_id: row.student_id })),
+              error: null,
+            })),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: state.classroomEnrollments
+                  .filter((row) =>
+                    Object.entries(eqFilters).every(([key, val]) => String((row as any)[key]) === val)
+                  )
+                  .map((row) => ({ student_id: row.student_id })),
+                error: null,
+              })
+            ),
+          }
+          return chain
         }),
       }
     }

--- a/tests/api/teacher/tests-results.test.ts
+++ b/tests/api/teacher/tests-results.test.ts
@@ -198,6 +198,201 @@ describe('GET /api/teacher/tests/[id]/results', () => {
     expect(data.active_ai_grading_run).toBeNull()
   })
 
+  it('ignores unenrolled response rows in result aggregates and open-response counts', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-mc-1',
+                  test_id: 'test-1',
+                  question_type: 'multiple_choice',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  points: 1,
+                  response_max_chars: 5000,
+                  position: 0,
+                },
+                {
+                  id: 'question-open-1',
+                  test_id: 'test-1',
+                  question_type: 'open_response',
+                  question_text: 'Explain your process',
+                  options: [],
+                  correct_option: null,
+                  points: 5,
+                  response_max_chars: 5000,
+                  position: 1,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'response-enrolled-mc',
+                  test_id: 'test-1',
+                  question_id: 'question-mc-1',
+                  student_id: 'student-1',
+                  selected_option: 0,
+                  response_text: null,
+                  score: 1,
+                  feedback: null,
+                  graded_at: null,
+                  graded_by: null,
+                  submitted_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  id: 'response-enrolled-open',
+                  test_id: 'test-1',
+                  question_id: 'question-open-1',
+                  student_id: 'student-1',
+                  selected_option: null,
+                  response_text: 'Partially answered',
+                  score: null,
+                  feedback: null,
+                  graded_at: null,
+                  graded_by: null,
+                  submitted_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  id: 'response-outside-mc',
+                  test_id: 'test-1',
+                  question_id: 'question-mc-1',
+                  student_id: 'student-outside',
+                  selected_option: 1,
+                  response_text: null,
+                  score: 0,
+                  feedback: null,
+                  graded_at: null,
+                  graded_by: null,
+                  submitted_at: '2026-01-01T00:00:00.000Z',
+                },
+                {
+                  id: 'response-outside-open',
+                  test_id: 'test-1',
+                  question_id: 'question-open-1',
+                  student_id: 'student-outside',
+                  selected_option: null,
+                  response_text: 'Outside response',
+                  score: 5,
+                  feedback: 'Good',
+                  graded_at: '2026-01-01T00:10:00.000Z',
+                  graded_by: 'teacher-1',
+                  submitted_at: '2026-01-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  student_id: 'student-1',
+                  is_submitted: true,
+                  submitted_at: '2026-01-01T00:00:00.000Z',
+                  returned_at: null,
+                  returned_by: null,
+                  closed_for_grading_at: null,
+                  closed_for_grading_by: null,
+                  updated_at: '2026-01-01T00:00:00.000Z',
+                  responses: null,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ id: 'student-1', email: 'student1@example.com' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({
+              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_focus_events') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students).toHaveLength(1)
+    expect(data.students[0].student_id).toBe('student-1')
+    expect(data.students[0].answers).not.toHaveProperty('student-outside')
+    expect(data.students[0].graded_open_responses).toBe(0)
+    expect(data.students[0].ungraded_open_responses).toBe(1)
+    expect(data.results).toEqual([
+      expect.objectContaining({
+        question_id: 'question-mc-1',
+        counts: [1, 0],
+        total_responses: 1,
+      }),
+    ])
+    expect(data.stats.graded_open_responses).toBe(0)
+    expect(data.stats.ungraded_open_responses).toBe(1)
+    expect(data.stats.total_students).toBe(1)
+  })
+
   it('includes in-progress draft answers from test_attempts for teacher monitoring', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_questions') {

--- a/tests/api/teacher/tests-return.test.ts
+++ b/tests/api/teacher/tests-return.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/tests/[id]/return/route'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } from '@/lib/server/tests'
 import { finalizeUnsubmittedTestAttemptsOnClose } from '@/lib/server/finalize-test-attempts'
 
 vi.mock('@/lib/supabase', () => ({
@@ -35,6 +35,11 @@ vi.mock('@/lib/server/tests', async () => {
       const message = `${error.message || ''}`.toLowerCase()
       return (error.code === 'PGRST204' || error.code === '42703') && message.includes('returned_at')
     }),
+    validateSelectedTestStudentEnrollment: vi.fn(async (_supabase: unknown, _classroomId: string, studentIds: string[]) => ({
+      ok: true,
+      enrolledStudentIds: new Set(studentIds),
+      missingStudentIds: [],
+    })),
   }
 })
 
@@ -67,6 +72,34 @@ describe('POST /api/teacher/tests/[id]/return', () => {
 
     expect(response.status).toBe(400)
     expect(data.error).toBe('student_ids array is required')
+  })
+
+  it('rejects selected students who are not enrolled before finalizing or returning work', async () => {
+    vi.mocked(validateSelectedTestStudentEnrollment).mockResolvedValueOnce({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1']),
+      missingStudentIds: ['student-outside'],
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/tests/test-1/return', {
+      method: 'POST',
+      body: JSON.stringify({ student_ids: ['student-1', 'student-outside'] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'test-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('One or more selected students are not enrolled in this classroom')
+    expect(validateSelectedTestStudentEnrollment).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+      ['student-1', 'student-outside'],
+    )
+    expect(finalizeUnsubmittedTestAttemptsOnClose).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled()
   })
 
   it('returns only students whose open responses are fully graded', async () => {


### PR DESCRIPTION
## Summary
- validate selected students against test classroom enrollment before returning teacher test work
- scope teacher test result aggregates/open-response stats to currently enrolled classroom students
- normalize the feedback dialog to shared `@/ui` primitives for category selection and submit state

## Why
Phase-four audit found two high-confidence drift points: the test return/results routes could use historical or outside-classroom response rows, and the shared feedback dialog had one-off controls/styles instead of the UI canon primitives.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/api/teacher/tests-return.test.ts tests/api/teacher/tests-results.test.ts`
- `pnpm test tests/api/integration/test-return-visibility-flow.test.ts`
- `pnpm lint`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Feedback dialog screenshots reviewed for teacher/student, desktop/mobile, light/dark, validation/loading/success states
- `pnpm test`
- `pnpm build`
