### PR TITLE
Scope test results response query

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,19 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Gradebook assessment font weight cleanup
-
-**Completed:**
-- Reduced gradebook assessment column labels, score cells, summary score cells, and selected-student assessment detail rows to regular font weight.
-- Kept student names and final marks emphasized so the gradebook still has clear scan anchors.
-
-**Validation:**
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `git diff --check`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
-- Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-detail.png`, `/tmp/pika-teacher-dark.png`
-
 ## 2026-05-26 — Assignment unsubmit return-state guard
 
 **Completed:**
@@ -349,3 +336,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Feedback dialog screenshots: `/tmp/pika-feedback-teacher-desktop-light-idle.png`, `/tmp/pika-feedback-teacher-desktop-light-error.png`, `/tmp/pika-feedback-teacher-desktop-light-submitting.png`, `/tmp/pika-feedback-teacher-desktop-light-success.png`, `/tmp/pika-feedback-teacher-mobile-dark-idle.png`, `/tmp/pika-feedback-student-desktop-dark-idle.png`, `/tmp/pika-feedback-student-mobile-light-error.png`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-05-27 — Test results enrolled response query
+
+**Completed:**
+- Loaded classroom enrollments before teacher test response reads.
+- Scoped the service-role `test_responses` query to current classroom `student_id`s and skipped the query when no students are enrolled.
+- Kept the defensive in-memory response filter and updated route coverage to assert the scoped response query.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/tests-results.test.ts`
+- `pnpm vitest run tests/api/teacher/tests-results.test.ts tests/api/integration/test-return-visibility-flow.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -41,16 +41,6 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } = await supabase
-    .from('test_responses')
-    .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, graded_by, submitted_at')
-    .eq('test_id', testId)
-
-  if (responsesError) {
-    console.error('Error fetching test responses:', responsesError)
-    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
-  }
-
   const { data: enrollments, error: enrollmentsError } = await supabase
     .from('classroom_enrollments')
     .select('student_id')
@@ -63,6 +53,20 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
 
   const classroomStudentIds = [...new Set((enrollments || []).map((row) => row.student_id))]
   const classroomStudentIdSet = new Set(classroomStudentIds)
+  const { data: responses, error: responsesError } =
+    classroomStudentIds.length > 0
+      ? await supabase
+          .from('test_responses')
+          .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, graded_by, submitted_at')
+          .eq('test_id', testId)
+          .in('student_id', classroomStudentIds)
+      : { data: [], error: null }
+
+  if (responsesError) {
+    console.error('Error fetching test responses:', responsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
   const enrolledResponses = (responses || []).filter((response) =>
     classroomStudentIdSet.has(response.student_id)
   )

--- a/tests/api/teacher/tests-results.test.ts
+++ b/tests/api/teacher/tests-results.test.ts
@@ -52,6 +52,27 @@ vi.mock('@/lib/server/test-ai-grading-runs', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type TestResponseFixture = { student_id: string } & Record<string, unknown>
+
+function mockTestResponsesQuery(
+  rows: TestResponseFixture[],
+  onStudentIds?: (studentIds: string[]) => void
+) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn((column: string, studentIds: string[]) => {
+        expect(column).toBe('student_id')
+        onStudentIds?.(studentIds)
+        return Promise.resolve({
+          data: rows.filter((row) => studentIds.includes(row.student_id)),
+          error: null,
+        })
+      }),
+    })),
+  }
+}
+
 describe('GET /api/teacher/tests/[id]/results', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -85,28 +106,21 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'response-1',
-                  test_id: 'test-1',
-                  question_id: 'question-1',
-                  student_id: 'student-1',
-                  selected_option: 0,
-                  response_text: null,
-                  score: 1,
-                  feedback: null,
-                  graded_at: null,
-                  graded_by: null,
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockTestResponsesQuery([
+          {
+            id: 'response-1',
+            test_id: 'test-1',
+            question_id: 'question-1',
+            student_id: 'student-1',
+            selected_option: 0,
+            response_text: null,
+            score: 1,
+            feedback: null,
+            graded_at: null,
+            graded_by: null,
+            submitted_at: '2026-01-01T00:00:00.000Z',
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -199,6 +213,8 @@ describe('GET /api/teacher/tests/[id]/results', () => {
   })
 
   it('ignores unenrolled response rows in result aggregates and open-response counts', async () => {
+    let testResponseStudentIds: string[] | null = null
+
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_questions') {
         return {
@@ -236,67 +252,65 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'response-enrolled-mc',
-                  test_id: 'test-1',
-                  question_id: 'question-mc-1',
-                  student_id: 'student-1',
-                  selected_option: 0,
-                  response_text: null,
-                  score: 1,
-                  feedback: null,
-                  graded_at: null,
-                  graded_by: null,
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                },
-                {
-                  id: 'response-enrolled-open',
-                  test_id: 'test-1',
-                  question_id: 'question-open-1',
-                  student_id: 'student-1',
-                  selected_option: null,
-                  response_text: 'Partially answered',
-                  score: null,
-                  feedback: null,
-                  graded_at: null,
-                  graded_by: null,
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                },
-                {
-                  id: 'response-outside-mc',
-                  test_id: 'test-1',
-                  question_id: 'question-mc-1',
-                  student_id: 'student-outside',
-                  selected_option: 1,
-                  response_text: null,
-                  score: 0,
-                  feedback: null,
-                  graded_at: null,
-                  graded_by: null,
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                },
-                {
-                  id: 'response-outside-open',
-                  test_id: 'test-1',
-                  question_id: 'question-open-1',
-                  student_id: 'student-outside',
-                  selected_option: null,
-                  response_text: 'Outside response',
-                  score: 5,
-                  feedback: 'Good',
-                  graded_at: '2026-01-01T00:10:00.000Z',
-                  graded_by: 'teacher-1',
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockTestResponsesQuery(
+          [
+            {
+              id: 'response-enrolled-mc',
+              test_id: 'test-1',
+              question_id: 'question-mc-1',
+              student_id: 'student-1',
+              selected_option: 0,
+              response_text: null,
+              score: 1,
+              feedback: null,
+              graded_at: null,
+              graded_by: null,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'response-enrolled-open',
+              test_id: 'test-1',
+              question_id: 'question-open-1',
+              student_id: 'student-1',
+              selected_option: null,
+              response_text: 'Partially answered',
+              score: null,
+              feedback: null,
+              graded_at: null,
+              graded_by: null,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'response-outside-mc',
+              test_id: 'test-1',
+              question_id: 'question-mc-1',
+              student_id: 'student-outside',
+              selected_option: 1,
+              response_text: null,
+              score: 0,
+              feedback: null,
+              graded_at: null,
+              graded_by: null,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'response-outside-open',
+              test_id: 'test-1',
+              question_id: 'question-open-1',
+              student_id: 'student-outside',
+              selected_option: null,
+              response_text: 'Outside response',
+              score: 5,
+              feedback: 'Good',
+              graded_at: '2026-01-01T00:10:00.000Z',
+              graded_by: 'teacher-1',
+              submitted_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          (studentIds) => {
+            testResponseStudentIds = studentIds
+          }
+        )
       }
 
       if (table === 'classroom_enrollments') {
@@ -376,6 +390,7 @@ describe('GET /api/teacher/tests/[id]/results', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(testResponseStudentIds).toEqual(['student-1'])
     expect(data.students).toHaveLength(1)
     expect(data.students[0].student_id).toBe('student-1')
     expect(data.students[0].answers).not.toHaveProperty('student-outside')
@@ -420,14 +435,7 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
+        return mockTestResponsesQuery([])
       }
 
       if (table === 'classroom_enrollments') {
@@ -574,14 +582,7 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
+        return mockTestResponsesQuery([])
       }
 
       if (table === 'classroom_enrollments') {


### PR DESCRIPTION
## Summary
- load classroom enrollments before teacher test response reads
- query test_responses only for enrolled classroom student ids
- keep defensive response filtering and add route coverage for the scoped query

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/teacher/tests-results.test.ts
- pnpm vitest run tests/api/teacher/tests-results.test.ts tests/api/integration/test-return-visibility-flow.test.ts
- pnpm lint
- pnpm build
- pnpm test