### PR TITLE
Fix next systems and UI audit findings

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Mobile navigation drawer labels
-
-**Completed:**
-- Made the classroom mobile navigation drawer show tab labels beside icons even when the persisted desktop left rail is collapsed.
-- Kept desktop collapsed-rail behavior icon-only with screen-reader labels and tooltips.
-- Closed mobile drawer state when the viewport crosses to the desktop breakpoint so stale mobile state cannot affect the desktop rail.
-- Added NavItems regression coverage for mobile-open labels and desktop-collapsed hidden labels.
-
-**Validation:**
-- `pnpm test tests/components/NavItems.test.tsx`
-- `pnpm test tests/components/NavItems.test.tsx tests/components/ThreePanelProvider.test.tsx`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861"`
-- Playwright mobile drawer assertions for teacher and student labels.
-- Screenshots: `/tmp/pika-teacher-mobile-menu.png`, `/tmp/pika-student-mobile-menu.png`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-05-26 — Gradebook action cluster consistency
 
 **Completed:**
@@ -350,3 +333,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
 - Browser screenshots: `/tmp/pika-teacher-details-artifacts.png`, `/tmp/pika-student-loaded.png`, `/tmp/pika-teacher-mobile.png`
+
+## 2026-05-27 — Next systems/UI audit slice
+
+**Completed:**
+- Hardened student test document snapshot access to respect draft status, selected-student availability, submitted work, grading lock state, and returned work.
+- Scoped student test result aggregates to currently enrolled students whose attempts have been returned.
+- Kept returned assignment grade/feedback fields visible while stripping teacher-only draft feedback and AI suggestion fields.
+- Added accessible names for student survey link/text responses, student open-response test answers, and teacher announcement body textareas.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/student/tests-documents-snapshot.test.ts tests/api/student/tests-results.test.ts tests/unit/assignments.test.ts tests/api/student/assignments.test.ts tests/components/StudentSurveyPanel.test.tsx tests/components/StudentQuizForm.test.tsx tests/components/AnnouncementsMarkdown.test.tsx`
+- `pnpm vitest run tests/api/integration/test-return-visibility-flow.test.ts --reporter=verbose`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=announcements'`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
+- UI screenshots reviewed from `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png` for each tab run.
+- `pnpm test`
+- `bash scripts/verify-env.sh`

--- a/src/app/api/student/tests/[id]/documents/[docId]/snapshot/route.ts
+++ b/src/app/api/student/tests/[id]/documents/[docId]/snapshot/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
-import { assertStudentCanAccessTest } from '@/lib/server/tests'
+import { getServiceRoleClient } from '@/lib/supabase'
+import {
+  assertStudentCanAccessTest,
+  getEffectiveStudentTestAccess,
+  getTestStudentAvailabilityState,
+  isMissingTestAttemptClosureColumnsError,
+  isMissingTestAttemptReturnColumnsError,
+} from '@/lib/server/tests'
 import { buildSnapshotResponse, findTestDocument } from '@/lib/server/test-document-snapshots'
+import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -14,6 +22,88 @@ export const GET = withErrorHandler('GetStudentTestDocumentSnapshot', async (_re
   const access = await assertStudentCanAccessTest(user.id, testId)
   if (!access.ok) {
     return NextResponse.json({ error: access.error }, { status: access.status })
+  }
+
+  if (access.test.status === 'draft') {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+  }
+
+  const supabase = getServiceRoleClient()
+  type AttemptRow = {
+    is_submitted: boolean
+    returned_at: string | null
+    closed_for_grading_at: string | null
+  }
+  let attempt: AttemptRow | null = null
+  let attemptError: { code?: string; message?: string; details?: string; hint?: string } | null = null
+
+  {
+    const attemptResult = await supabase
+      .from('test_attempts')
+      .select('is_submitted, returned_at, closed_for_grading_at')
+      .eq('test_id', testId)
+      .eq('student_id', user.id)
+      .maybeSingle()
+
+    attempt = (attemptResult.data as AttemptRow | null) || null
+    attemptError = attemptResult.error
+  }
+
+  if (
+    attemptError &&
+    (isMissingTestAttemptReturnColumnsError(attemptError) ||
+      isMissingTestAttemptClosureColumnsError(attemptError))
+  ) {
+    const legacyAttemptResult = await supabase
+      .from('test_attempts')
+      .select('is_submitted')
+      .eq('test_id', testId)
+      .eq('student_id', user.id)
+      .maybeSingle()
+
+    attempt = legacyAttemptResult.data
+      ? {
+          ...(legacyAttemptResult.data as { is_submitted: boolean }),
+          returned_at: null,
+          closed_for_grading_at: null,
+        }
+      : null
+    attemptError = legacyAttemptResult.error
+  }
+
+  if (attemptError && attemptError.code !== 'PGRST205') {
+    console.error('Error checking student test snapshot access:', attemptError)
+    return NextResponse.json({ error: 'Failed to fetch test access' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } = await supabase
+    .from('test_responses')
+    .select('selected_option, response_text')
+    .eq('test_id', testId)
+    .eq('student_id', user.id)
+
+  if (responsesError) {
+    console.error('Error checking student test snapshot responses:', responsesError)
+    return NextResponse.json({ error: 'Failed to fetch test access' }, { status: 500 })
+  }
+
+  const isLockedForGrading = Boolean(attempt?.closed_for_grading_at)
+  const hasSubmitted = Boolean(attempt?.is_submitted) || (!isLockedForGrading && hasAnyMeaningfulTestResponse(responses))
+  const availabilityResult = await getTestStudentAvailabilityState(supabase, testId, user.id)
+  if (availabilityResult.error && !availabilityResult.missingTable) {
+    console.error('Error checking student test snapshot availability:', availabilityResult.error)
+    return NextResponse.json({ error: 'Failed to fetch test access' }, { status: 500 })
+  }
+
+  const accessState = getEffectiveStudentTestAccess({
+    testStatus: access.test.status,
+    accessState: availabilityResult.state,
+    hasSubmitted,
+    returnedAt: attempt?.returned_at || null,
+    isLockedForGrading,
+  })
+  if (!accessState.can_start_or_continue && !accessState.can_view_submitted) {
+    return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
   }
 
   const doc = findTestDocument(access.test, docId)

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -9,6 +9,7 @@ import {
   isMissingTestAttemptClosureColumnsError,
   isMissingTestAttemptReturnColumnsError,
 } from '@/lib/server/tests'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { QuizQuestion, QuizResponse } from '@/types'
@@ -117,20 +118,58 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } = await supabase
-    .from('test_responses')
-    .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, submitted_at')
-    .eq('test_id', testId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, test.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments for test results:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
+  let returnedStudentIds: string[] = []
+  if (classroomStudentsResult.studentIds.length > 0) {
+    const { data: returnedAttempts, error: returnedAttemptsError } = await supabase
+      .from('test_attempts')
+      .select('student_id, returned_at')
+      .eq('test_id', testId)
+      .in('student_id', classroomStudentsResult.studentIds)
+
+    if (returnedAttemptsError) {
+      console.error('Error fetching returned test attempts:', returnedAttemptsError)
+      return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+    }
+
+    returnedStudentIds = Array.from(
+      new Set(
+        (returnedAttempts || [])
+          .filter((attempt) => attempt.returned_at)
+          .map((attempt) => attempt.student_id)
+          .filter((studentId): studentId is string => typeof studentId === 'string')
+      )
+    )
+  }
+
+  const { data: responses, error: responsesError } =
+    returnedStudentIds.length > 0
+      ? await supabase
+          .from('test_responses')
+          .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, submitted_at')
+          .eq('test_id', testId)
+          .in('student_id', returnedStudentIds)
+      : { data: [], error: null }
 
   if (responsesError) {
     console.error('Error fetching test responses:', responsesError)
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
+  const returnedStudentIdSet = new Set(returnedStudentIds)
+  const returnedResponses = (responses || []).filter((response) =>
+    returnedStudentIdSet.has(response.student_id)
+  )
+
   const multipleChoiceQuestions = (questions || []).filter(
     (question) => question.question_type !== 'open_response'
   )
-  const multipleChoiceResponses = (responses || []).flatMap((response) => {
+  const multipleChoiceResponses = returnedResponses.flatMap((response) => {
     if (typeof response.selected_option !== 'number') return []
     return [{
       id: response.id,

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -435,6 +435,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
           </FormField>
           <textarea
             ref={newTextareaRef}
+            aria-label="Announcement body"
             value={newContent}
             onChange={(e) => setNewContent(e.target.value)}
             onKeyDown={handleNewKeyDown}
@@ -575,6 +576,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
                     </FormField>
                     <textarea
                       ref={editTextareaRef}
+                      aria-label="Edit announcement body"
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
                       onKeyDown={handleEditKeyDown}

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -496,6 +496,7 @@ export function StudentQuizForm({
                     {question.question_type === 'open_response' ? (
                       <div className="space-y-2">
                         <textarea
+                          aria-label={`Response for question ${index + 1}`}
                           value={openResponseText}
                           disabled={isInteractionLocked}
                           onChange={(event) =>

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -324,6 +324,7 @@ export function StudentSurveyPanel({
                   ) : question.question_type === 'link' ? (
                     <Input
                       type="url"
+                      aria-label={`${question.question_text} response`}
                       value={textValue}
                       onChange={(event) =>
                         setResponses((current) => ({
@@ -339,6 +340,7 @@ export function StudentSurveyPanel({
                     />
                   ) : (
                     <textarea
+                      aria-label={`${question.question_text} response`}
                       value={textValue}
                       onChange={(event) =>
                         setResponses((current) => ({

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -426,13 +426,16 @@ const DRAFT_ONLY_FIELDS = [
  */
 export function sanitizeDocForStudent<T extends Record<string, any>>(doc: T): T {
   if (!doc) return doc
-  if (doc.returned_at) return doc // Student can see grades after return
 
   const sanitized = { ...doc }
-  for (const field of GRADE_FIELDS) {
+  for (const field of DRAFT_ONLY_FIELDS) {
     ;(sanitized as any)[field] = null
   }
-  for (const field of DRAFT_ONLY_FIELDS) {
+  if (doc.returned_at) {
+    return sanitized
+  }
+
+  for (const field of GRADE_FIELDS) {
     ;(sanitized as any)[field] = null
   }
   if (!doc.feedback_returned_at) {

--- a/src/lib/server/classrooms.ts
+++ b/src/lib/server/classrooms.ts
@@ -102,3 +102,27 @@ export async function assertStudentCanAccessClassroom(
 
   return { ok: true, classroom }
 }
+
+export async function getClassroomStudentIds(
+  supabase: any,
+  classroomId: string
+): Promise<{ studentIds: string[]; studentIdSet: Set<string>; error: unknown }> {
+  const { data, error } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', classroomId)
+
+  if (error) {
+    return { studentIds: [], studentIdSet: new Set(), error }
+  }
+
+  const studentIds = Array.from(
+    new Set(
+      ((data || []) as Array<{ student_id: unknown }>)
+        .map((row) => row.student_id)
+        .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0)
+    )
+  )
+
+  return { studentIds, studentIdSet: new Set(studentIds), error: null }
+}

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -102,12 +102,16 @@ vi.mock('@/lib/auth', () => ({
   }),
 }))
 
-vi.mock('@/lib/server/classrooms', () => ({
-  assertStudentCanAccessClassroom: vi.fn(async () => ({
-    ok: true,
-    classroom: { id: 'classroom-1', archived_at: null },
-  })),
-}))
+vi.mock('@/lib/server/classrooms', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/server/classrooms')>('@/lib/server/classrooms')
+  return {
+    ...actual,
+    assertStudentCanAccessClassroom: vi.fn(async () => ({
+      ok: true,
+      classroom: { id: 'classroom-1', archived_at: null },
+    })),
+  }
+})
 
 vi.mock('@/lib/server/tests', async () => {
   const actual = await vi.importActual<typeof import('@/lib/server/tests')>('@/lib/server/tests')

--- a/tests/api/student/assignments.test.ts
+++ b/tests/api/student/assignments.test.ts
@@ -27,18 +27,21 @@ vi.mock('@/lib/server/classrooms', () => ({
   })),
 }))
 
-vi.mock('@/lib/assignments', () => ({
-  calculateAssignmentStatus: vi.fn((assignment, doc) => {
-    if (doc?.is_submitted) return 'submitted'
-    if (doc) return 'in-progress'
-    return 'not-started'
-  }),
-  isAssignmentVisibleToStudents: vi.fn((assignment) => (
-    !assignment.is_draft &&
-    (!assignment.released_at || new Date(assignment.released_at).getTime() <= Date.now())
-  )),
-  sanitizeDocForStudent: vi.fn((doc) => doc),
-}))
+vi.mock('@/lib/assignments', async () => {
+  const actual = await vi.importActual<any>('@/lib/assignments')
+  return {
+    ...actual,
+    calculateAssignmentStatus: vi.fn((assignment, doc) => {
+      if (doc?.is_submitted) return 'submitted'
+      if (doc) return 'in-progress'
+      return 'not-started'
+    }),
+    isAssignmentVisibleToStudents: vi.fn((assignment) => (
+      !assignment.is_draft &&
+      (!assignment.released_at || new Date(assignment.released_at).getTime() <= Date.now())
+    )),
+  }
+})
 
 const mockSupabaseClient = { from: vi.fn() }
 
@@ -411,6 +414,86 @@ describe('GET /api/student/assignments', () => {
 
       expect(data.assignments[0].doc).not.toBeNull()
       expect(data.assignments[0].doc.id).toBe('doc-1')
+    })
+
+    it('should sanitize returned docs before sending them to students', async () => {
+      const mockFrom = vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'enrollment-1' },
+                error: null,
+              }),
+            })),
+          }
+        } else if (table === 'assignments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  order: vi.fn().mockResolvedValue({
+                    data: [{ id: 'assignment-1', title: 'Test' }],
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          }
+        } else if (table === 'assignment_docs') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                in: vi.fn().mockResolvedValue({
+                  data: [
+                    {
+                      id: 'doc-1',
+                      assignment_id: 'assignment-1',
+                      student_id: 'student-1',
+                      is_submitted: true,
+                      submitted_at: '2024-10-20T12:00:00Z',
+                      returned_at: '2024-10-21T12:00:00Z',
+                      score_completion: 8,
+                      score_thinking: 7,
+                      score_workflow: 9,
+                      feedback: 'Released feedback',
+                      teacher_feedback_draft: 'Teacher-only draft',
+                      teacher_feedback_draft_updated_at: '2024-10-21T11:00:00Z',
+                      ai_feedback_suggestion: 'AI suggestion',
+                      ai_feedback_suggested_at: '2024-10-21T11:30:00Z',
+                      ai_feedback_model: 'gpt-5-nano',
+                    },
+                  ],
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+      })
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/student/assignments?classroom_id=classroom-1')
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.assignments[0].doc).toEqual(
+        expect.objectContaining({
+          score_completion: 8,
+          score_thinking: 7,
+          score_workflow: 9,
+          feedback: 'Released feedback',
+          returned_at: '2024-10-21T12:00:00Z',
+          teacher_feedback_draft: null,
+          teacher_feedback_draft_updated_at: null,
+          ai_feedback_suggestion: null,
+          ai_feedback_suggested_at: null,
+          ai_feedback_model: null,
+        })
+      )
     })
 
     it('should include null doc when none exists', async () => {

--- a/tests/api/student/tests-documents-snapshot.test.ts
+++ b/tests/api/student/tests-documents-snapshot.test.ts
@@ -10,32 +10,43 @@ vi.mock('@/lib/auth', () => ({
   })),
 }))
 
-vi.mock('@/lib/server/tests', () => ({
-  assertStudentCanAccessTest: vi.fn(async () => ({
-    ok: true,
-    test: {
-      id: 'test-1',
-      documents: [
-        {
-          id: 'doc-1',
-          title: 'Node.js API',
-          source: 'link',
-          url: 'https://nodejs.org/api/fs.html',
-          snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
-          snapshot_content_type: 'text/html',
-          synced_at: '2026-04-02T12:00:00.000Z',
-        },
-      ],
-    },
-  })),
+const { defaultTest } = vi.hoisted(() => ({
+  defaultTest: {
+    id: 'test-1',
+    status: 'active',
+    documents: [
+      {
+        id: 'doc-1',
+        title: 'Node.js API',
+        source: 'link',
+        url: 'https://nodejs.org/api/fs.html',
+        snapshot_path: 'link-docs/teacher-1/test-1/doc-1/snapshot',
+        snapshot_content_type: 'text/html',
+        synced_at: '2026-04-02T12:00:00.000Z',
+      },
+    ],
+  },
 }))
+
+vi.mock('@/lib/server/tests', async () => {
+  const actual = await vi.importActual<any>('@/lib/server/tests')
+  return {
+    ...actual,
+    assertStudentCanAccessTest: vi.fn(async () => ({
+      ok: true,
+      test: defaultTest,
+    })),
+  }
+})
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabase),
 }))
 
 const mockDownload = vi.fn()
+const mockFrom = vi.fn()
 const mockSupabase = {
+  from: mockFrom,
   storage: {
     from: vi.fn(() => ({
       download: mockDownload,
@@ -66,6 +77,47 @@ async function readResponseText(response: Response) {
 describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: [],
+                error: null,
+              })
+            ),
+          })),
+        }
+      }
+
+      if (table === 'test_student_availability') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
     mockDownload.mockResolvedValue({
       data: createMockDownloadBody('<html><body>Snapshot</body></html>', 'text/html'),
       error: null,
@@ -89,6 +141,7 @@ describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
     vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
       ok: true,
       test: {
+        ...defaultTest,
         id: 'test-1',
         documents: [
           {
@@ -109,5 +162,96 @@ describe('GET /api/student/tests/[id]/documents/[docId]/snapshot', () => {
 
     expect(response.status).toBe(404)
     expect(data.error).toBe('Snapshot not found')
+  })
+
+  it('does not stream snapshots for draft tests', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        ...defaultTest,
+        status: 'draft',
+      } as any,
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Snapshot not found')
+    expect(mockDownload).not.toHaveBeenCalled()
+  })
+
+  it('does not stream snapshots for closed tests before the student has submitted', async () => {
+    const serverTests = await import('@/lib/server/tests')
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        ...defaultTest,
+        status: 'closed',
+      } as any,
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Snapshot not found')
+    expect(mockDownload).not.toHaveBeenCalled()
+  })
+
+  it('does not stream snapshots when selected-student test access is closed', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+
+      if (table === 'test_student_availability') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1', state: 'closed' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/documents/doc-1/snapshot'),
+      { params: Promise.resolve({ id: 'test-1', docId: 'doc-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Snapshot not found')
+    expect(mockDownload).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/student/tests-results.test.ts
+++ b/tests/api/student/tests-results.test.ts
@@ -148,13 +148,32 @@ describe('GET /api/student/tests/[id]/results', () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_attempts') {
         return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            maybeSingle: vi.fn().mockResolvedValue({
-              data: { is_submitted: true, returned_at: '2026-03-05T11:00:00.000Z' },
-              error: null,
-            }),
-          })),
+          select: vi.fn((columns: string) => {
+            if (columns.includes('student_id')) {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                in: vi.fn().mockResolvedValue({
+                  data: [
+                    { student_id: 'student-1', returned_at: '2026-03-05T11:00:00.000Z' },
+                    { student_id: 'student-2', returned_at: null },
+                  ],
+                  error: null,
+                }),
+              }
+            }
+
+            return {
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  is_submitted: true,
+                  returned_at: '2026-03-05T11:00:00.000Z',
+                  closed_for_grading_at: null,
+                },
+                error: null,
+              }),
+            }
+          }),
         }
       }
 
@@ -176,6 +195,18 @@ describe('GET /api/student/tests/[id]/results', () => {
                   sample_solution: 'for (int i = 0; i < 5; i++) {\n  println(i);\n}',
                   position: 0,
                 },
+                {
+                  id: 'question-2',
+                  question_type: 'multiple_choice',
+                  question_text: 'Which loop keyword is valid?',
+                  options: ['for', 'repeatUntilDone'],
+                  correct_option: 0,
+                  points: 1,
+                  response_max_chars: 5000,
+                  response_monospace: false,
+                  sample_solution: null,
+                  position: 1,
+                },
               ],
               error: null,
             }),
@@ -187,9 +218,10 @@ describe('GET /api/student/tests/[id]/results', () => {
         return {
           select: vi.fn((columns: string) => ({
             eq: vi.fn().mockReturnThis(),
-            then: vi.fn((resolve: any) => {
+            in: vi.fn((column: string, studentIds: string[]) => {
+              expect(column).toBe('student_id')
               if (columns.includes('submitted_at')) {
-                resolve({
+                return Promise.resolve({
                   data: [
                     {
                       id: 'response-1',
@@ -203,12 +235,50 @@ describe('GET /api/student/tests/[id]/results', () => {
                       graded_at: '2026-03-06T12:00:00.000Z',
                       submitted_at: '2026-01-01T00:00:00.000Z',
                     },
+                    {
+                      id: 'response-2',
+                      test_id: 'test-1',
+                      question_id: 'question-2',
+                      student_id: 'student-1',
+                      selected_option: 0,
+                      response_text: null,
+                      score: null,
+                      feedback: null,
+                      graded_at: null,
+                      submitted_at: '2026-01-01T00:00:00.000Z',
+                    },
+                    {
+                      id: 'response-unreturned',
+                      test_id: 'test-1',
+                      question_id: 'question-2',
+                      student_id: 'student-2',
+                      selected_option: 1,
+                      response_text: null,
+                      score: 1,
+                      feedback: null,
+                      graded_at: null,
+                      submitted_at: '2026-01-01T00:00:00.000Z',
+                    },
+                    {
+                      id: 'response-outside',
+                      test_id: 'test-1',
+                      question_id: 'question-2',
+                      student_id: 'student-outside',
+                      selected_option: 1,
+                      response_text: null,
+                      score: 5,
+                      feedback: null,
+                      graded_at: null,
+                      submitted_at: '2026-01-01T00:00:00.000Z',
+                    },
                   ],
                   error: null,
                 })
-                return
               }
 
+              throw new Error(`Unexpected in() for test_responses columns: ${columns}`)
+            }),
+            then: vi.fn((resolve: any) => {
               if (columns.includes('question_id')) {
                 resolve({
                   data: [
@@ -220,6 +290,15 @@ describe('GET /api/student/tests/[id]/results', () => {
                       score: 4,
                       feedback: 'Good start',
                       graded_at: '2026-03-06T12:00:00.000Z',
+                    },
+                    {
+                      id: 'response-2',
+                      question_id: 'question-2',
+                      selected_option: 0,
+                      response_text: null,
+                      score: null,
+                      feedback: null,
+                      graded_at: null,
                     },
                   ],
                   error: null,
@@ -241,6 +320,20 @@ describe('GET /api/student/tests/[id]/results', () => {
         }
       }
 
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
       throw new Error(`Unexpected table: ${table}`)
     })
 
@@ -255,5 +348,12 @@ describe('GET /api/student/tests/[id]/results', () => {
     expect(data.quiz.returned_at).toBe('2026-03-05T11:00:00.000Z')
     expect(data.summary.earned_points).toBe(4)
     expect(data.question_results[0].sample_solution).toContain('println')
+    expect(data.results[0]).toEqual(
+      expect.objectContaining({
+        question_id: 'question-2',
+        counts: [1, 0],
+        total_responses: 1,
+      })
+    )
   })
 })

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -103,7 +103,7 @@ describe('announcement markdown rendering', () => {
     expect(screen.queryByPlaceholderText('Optional title')).not.toBeInTheDocument()
     expect(titleInput.compareDocumentPosition(screen.getByText('Unit update')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    const textarea = screen.getByPlaceholderText('Write an announcement...')
+    const textarea = screen.getByRole('textbox', { name: 'Announcement body' })
     expect(textarea).toHaveAttribute('rows', '6')
     expect(textarea).toHaveClass('min-h-[10rem]')
     expect(textarea).toHaveClass('resize-y')
@@ -111,6 +111,17 @@ describe('announcement markdown rendering', () => {
     fireEvent.change(textarea, { target: { value: 'Announcement draft' } })
     fireEvent.click(screen.getByRole('button', { name: 'Choose announcement action' }))
     expect(screen.getByRole('menuitem', { name: 'Schedule...' })).toBeInTheDocument()
+  })
+
+  it('labels the edit announcement textarea', async () => {
+    render(<TeacherAnnouncementsSection classroom={classroom} />)
+
+    await screen.findByRole('link', { name: 'course outline' })
+    fireEvent.click(screen.getByText('bring notes'))
+
+    expect(screen.getByRole('textbox', { name: 'Edit announcement body' })).toHaveValue(
+      markdownAnnouncement.content,
+    )
   })
 
   it('shows the newest teacher announcements first', async () => {

--- a/tests/components/StudentQuizForm.test.tsx
+++ b/tests/components/StudentQuizForm.test.tsx
@@ -48,6 +48,27 @@ describe('StudentQuizForm preview mode', () => {
     expect(onSubmitted).not.toHaveBeenCalled()
   })
 
+  it('labels open-response textboxes for assistive technology', () => {
+    render(
+      <StudentQuizForm
+        quizId="test-open-response-label-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Explain your reasoning.',
+            options: [],
+            question_type: 'open_response',
+            position: 0,
+          }),
+        ]}
+        assessmentType="test"
+        previewMode
+      />
+    )
+
+    expect(screen.getByRole('textbox', { name: 'Response for question 1' })).toBeInTheDocument()
+  })
+
   it('flags and unfags a question', async () => {
     const onSubmitted = vi.fn()
 

--- a/tests/components/StudentSurveyPanel.test.tsx
+++ b/tests/components/StudentSurveyPanel.test.tsx
@@ -53,6 +53,28 @@ describe('StudentSurveyPanel', () => {
               created_at: '2026-01-01T00:00:00.000Z',
               updated_at: '2026-01-01T00:00:00.000Z',
             },
+            {
+              id: 'question-link',
+              survey_id: 'survey-1',
+              question_type: 'link',
+              question_text: 'Share your project link',
+              options: [],
+              response_max_chars: 2048,
+              position: 1,
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              id: 'question-text',
+              survey_id: 'survey-1',
+              question_type: 'short_text',
+              question_text: 'What did you build?',
+              options: [],
+              response_max_chars: 500,
+              position: 2,
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
           ],
           student_status: 'can_view_results',
           has_submitted: false,
@@ -83,5 +105,7 @@ describe('StudentSurveyPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Respond' }))
     expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'View results' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Share your project link response' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'What did you build? response' })).toBeInTheDocument()
   })
 })

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -1223,12 +1223,17 @@ describe('assignment utilities', () => {
   // ==========================================================================
 
   describe('sanitizeDocForStudent', () => {
-    it('should return doc unchanged when returned_at is set', () => {
+    it('should preserve returned grade fields while stripping draft-only fields', () => {
       const doc = createMockAssignmentDoc({
         score_completion: 8,
         score_thinking: 7,
         score_workflow: 9,
         feedback: 'Good work',
+        teacher_feedback_draft: 'Do not show this draft',
+        teacher_feedback_draft_updated_at: '2024-10-21T11:00:00Z',
+        ai_feedback_suggestion: 'Suggested feedback',
+        ai_feedback_suggested_at: '2024-10-21T11:30:00Z',
+        ai_feedback_model: 'gpt-5-nano',
         graded_at: '2024-10-21T10:00:00Z',
         graded_by: 'teacher',
         returned_at: '2024-10-21T14:00:00Z',
@@ -1243,6 +1248,11 @@ describe('assignment utilities', () => {
       expect(result.graded_at).toBe('2024-10-21T10:00:00Z')
       expect(result.graded_by).toBe('teacher')
       expect(result.returned_at).toBe('2024-10-21T14:00:00Z')
+      expect(result.teacher_feedback_draft).toBeNull()
+      expect(result.teacher_feedback_draft_updated_at).toBeNull()
+      expect(result.ai_feedback_suggestion).toBeNull()
+      expect(result.ai_feedback_suggested_at).toBeNull()
+      expect(result.ai_feedback_model).toBeNull()
     })
 
     it('should strip all grade fields when returned_at is null', () => {


### PR DESCRIPTION
## Summary
- Harden student test document snapshot access around draft status, selected-student availability, submitted/locked state, and returned work
- Scope student test result aggregates to currently enrolled students whose attempts have been returned
- Strip returned assignment docs of teacher-only draft/AI feedback fields while preserving returned grade/feedback fields
- Add accessible names to student survey/test response controls and teacher announcement textareas

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/student/tests-documents-snapshot.test.ts tests/api/student/tests-results.test.ts tests/unit/assignments.test.ts tests/api/student/assignments.test.ts tests/components/StudentSurveyPanel.test.tsx tests/components/StudentQuizForm.test.tsx tests/components/AnnouncementsMarkdown.test.tsx
- pnpm vitest run tests/api/integration/test-return-visibility-flow.test.ts --reporter=verbose
- pnpm lint
- pnpm build
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=announcements'
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'
- pnpm test
- bash scripts/verify-env.sh