### PR TITLE
Scope student assessment results by enrollment

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Gradebook action cluster consistency
-
-**Completed:**
-- Replaced the gradebook all-purpose split-button with a focused floating action cluster: contextual email split-button, persistent score-display segmented control, and icon-only settings toggle.
-- Kept email actions hidden until students are selected, matching the roster pattern and avoiding disabled placeholder actions.
-- Updated gradebook component coverage for the new score-display, email, and settings controls.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm vitest run tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm tsc --noEmit`
-- `pnpm e2e:auth`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
-- Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-gradebook-selected.png`, `/tmp/pika-teacher-mobile-gradebook-selected.png`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Student test submit overwrite guard
 
 **Completed:**
@@ -354,3 +336,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - UI screenshots reviewed from `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png` for each tab run.
 - `pnpm test`
 - `bash scripts/verify-env.sh`
+
+## 2026-05-27 — Student quiz/survey result enrollment scoping
+
+**Completed:**
+- Scoped student quiz result aggregates to current classroom enrollments before aggregating class responses.
+- Scoped student survey result aggregates and text/link response lists to current classroom enrollments.
+- Kept defensive in-memory filtering after scoped Supabase `.in('student_id', ...)` response reads.
+- Added API regressions that include stale/unenrolled response rows and assert enrolled-only result payloads.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts --reporter=verbose`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `git diff --check`

--- a/src/app/api/student/quizzes/[id]/results/route.ts
+++ b/src/app/api/student/quizzes/[id]/results/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { aggregateResults, canStudentViewResults } from '@/lib/quizzes'
 import { assertStudentCanAccessQuiz } from '@/lib/server/quizzes'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { QuizQuestion, QuizResponse } from '@/types'
 
@@ -51,21 +52,34 @@ export const GET = withErrorHandler('GetStudentQuizResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  // Fetch all responses
-  const { data: responses, error: responsesError } = await supabase
-    .from('quiz_responses')
-    .select('*')
-    .eq('quiz_id', quizId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, quiz.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments for quiz results:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } =
+    classroomStudentsResult.studentIds.length > 0
+      ? await supabase
+          .from('quiz_responses')
+          .select('*')
+          .eq('quiz_id', quizId)
+          .in('student_id', classroomStudentsResult.studentIds)
+      : { data: [], error: null }
 
   if (responsesError) {
     console.error('Error fetching responses:', responsesError)
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
+  const scopedResponses = (responses || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  )
+
   // Aggregate results
   const aggregated = aggregateResults(
     (questions || []) as QuizQuestion[],
-    (responses || []) as QuizResponse[]
+    scopedResponses as QuizResponse[]
   )
 
   // Get student's own responses

--- a/src/app/api/student/surveys/[id]/results/route.ts
+++ b/src/app/api/student/surveys/[id]/results/route.ts
@@ -4,6 +4,7 @@ import { withErrorHandler } from '@/lib/api-handler'
 import { assertStudentCanAccessSurvey } from '@/lib/server/surveys'
 import { aggregateSurveyResults, canStudentViewSurveyResults } from '@/lib/surveys'
 import { getServiceRoleClient } from '@/lib/supabase'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import type { SurveyQuestion, SurveyResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -35,19 +36,33 @@ export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, 
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } = await supabase
-    .from('survey_responses')
-    .select('*')
-    .eq('survey_id', surveyId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, survey.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments for survey results:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
+
+  const { data: responses, error: responsesError } =
+    classroomStudentsResult.studentIds.length > 0
+      ? await supabase
+          .from('survey_responses')
+          .select('*')
+          .eq('survey_id', surveyId)
+          .in('student_id', classroomStudentsResult.studentIds)
+      : { data: [], error: null }
 
   if (responsesError) {
     console.error('Error fetching survey responses:', responsesError)
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
+  const scopedResponses = (responses || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  )
+
   const results = aggregateSurveyResults(
     (questions || []) as SurveyQuestion[],
-    (responses || []) as SurveyResponse[]
+    scopedResponses as SurveyResponse[]
   ).map((result) => ({
     ...result,
     responses: result.responses.map((response) => ({

--- a/tests/api/student/quizzes-results.test.ts
+++ b/tests/api/student/quizzes-results.test.ts
@@ -118,6 +118,203 @@ describe('GET /api/student/quizzes/[id]/results', () => {
     await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch questions' })
   })
 
+  it('returns 500 when classroom enrollment loading fails before aggregation', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue({ data: [{ id: 'response-1' }], error: null }),
+          })),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
+  })
+
+  it('returns 500 when scoped response loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockResolvedValue({ data: [{ id: 'response-1' }], error: null }),
+              }
+            }
+
+            if (columns === '*') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                in: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }),
+              }
+            }
+
+            throw new Error(`Unexpected quiz_responses columns: ${columns}`)
+          }),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
+  })
+
+  it('skips aggregate response loading when the classroom enrollment list is empty', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockResolvedValue({ data: [{ id: 'response-1' }], error: null }),
+              }
+            }
+
+            if (columns === '*') {
+              throw new Error('Aggregate responses should not be loaded without enrolled students')
+            }
+
+            return {
+              eq: vi.fn().mockReturnThis(),
+              then: vi.fn((resolve: (value: unknown) => unknown) =>
+                resolve({
+                  data: [{ question_id: 'question-1', selected_option: 0 }],
+                  error: null,
+                })
+              ),
+            }
+          }),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results).toEqual([
+      {
+        question_id: 'question-1',
+        question_text: '2 + 2 = ?',
+        options: ['4', '5'],
+        counts: [0, 0],
+        total_responses: 0,
+      },
+    ])
+    expect(data.my_responses).toEqual({ 'question-1': 0 })
+  })
+
   it('returns aggregated results and the student response map', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'quiz_responses') {
@@ -132,12 +329,18 @@ describe('GET /api/student/quizzes/[id]/results', () => {
 
             if (columns === '*') {
               return {
-                eq: vi.fn().mockResolvedValue({
-                  data: [
-                    { question_id: 'question-1', selected_option: 0, student_id: 'student-1' },
-                    { question_id: 'question-1', selected_option: 1, student_id: 'student-2' },
-                  ],
-                  error: null,
+                eq: vi.fn().mockReturnThis(),
+                in: vi.fn((column: string, studentIds: string[]) => {
+                  expect(column).toBe('student_id')
+                  expect(studentIds).toEqual(['student-1', 'student-2'])
+                  return Promise.resolve({
+                    data: [
+                      { question_id: 'question-1', selected_option: 0, student_id: 'student-1' },
+                      { question_id: 'question-1', selected_option: 1, student_id: 'student-2' },
+                      { question_id: 'question-1', selected_option: 1, student_id: 'student-removed' },
+                    ],
+                    error: null,
+                  })
                 }),
               }
             }
@@ -170,6 +373,20 @@ describe('GET /api/student/quizzes/[id]/results', () => {
                   correct_option: 0,
                   position: 0,
                 },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
               ],
               error: null,
             }),

--- a/tests/api/student/surveys-route.test.ts
+++ b/tests/api/student/surveys-route.test.ts
@@ -160,9 +160,25 @@ describe('GET /api/student/surveys/[id]/results', () => {
           select: vi.fn((columns: string) => {
             if (columns !== '*') throw new Error(`Unexpected survey_responses columns: ${columns}`)
             return {
-              eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+              eq: vi.fn().mockReturnThis(),
+              in: vi.fn((column: string, studentIds: string[]) => {
+                expect(column).toBe('student_id')
+                expect(studentIds).toEqual(['student-1'])
+                return Promise.resolve({ data: [], error: null })
+              }),
             }
           }),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
         }
       }
 
@@ -212,50 +228,65 @@ describe('GET /api/student/surveys/[id]/results', () => {
 
             if (columns === '*') {
               return {
-                eq: vi.fn().mockResolvedValue({
-                  data: [
-                    {
-                      id: 'response-1',
-                      survey_id: 'survey-1',
-                      question_id: 'link-question',
-                      student_id: 'student-1',
-                      selected_option: null,
-                      response_text: 'https://example.com/game',
-                      submitted_at: '2026-01-01T00:00:00.000Z',
-                      updated_at: '2026-01-01T00:00:00.000Z',
-                    },
-                    {
-                      id: 'response-2',
-                      survey_id: 'survey-1',
-                      question_id: 'link-question',
-                      student_id: 'student-2',
-                      selected_option: null,
-                      response_text: 'https://example.com/other-game',
-                      submitted_at: '2026-01-02T00:00:00.000Z',
-                      updated_at: '2026-01-02T00:00:00.000Z',
-                    },
-                    {
-                      id: 'response-3',
-                      survey_id: 'survey-1',
-                      question_id: 'text-question',
-                      student_id: 'student-1',
-                      selected_option: null,
-                      response_text: 'Built in Godot',
-                      submitted_at: '2026-01-03T00:00:00.000Z',
-                      updated_at: '2026-01-03T00:00:00.000Z',
-                    },
-                    {
-                      id: 'response-4',
-                      survey_id: 'survey-1',
-                      question_id: 'text-question',
-                      student_id: 'student-2',
-                      selected_option: null,
-                      response_text: 'Built in Phaser',
-                      submitted_at: '2026-01-04T00:00:00.000Z',
-                      updated_at: '2026-01-04T00:00:00.000Z',
-                    },
-                  ],
-                  error: null,
+                eq: vi.fn().mockReturnThis(),
+                in: vi.fn((column: string, studentIds: string[]) => {
+                  expect(column).toBe('student_id')
+                  expect(studentIds).toEqual(['student-1', 'student-2'])
+                  return Promise.resolve({
+                    data: [
+                      {
+                        id: 'response-1',
+                        survey_id: 'survey-1',
+                        question_id: 'link-question',
+                        student_id: 'student-1',
+                        selected_option: null,
+                        response_text: 'https://example.com/game',
+                        submitted_at: '2026-01-01T00:00:00.000Z',
+                        updated_at: '2026-01-01T00:00:00.000Z',
+                      },
+                      {
+                        id: 'response-2',
+                        survey_id: 'survey-1',
+                        question_id: 'link-question',
+                        student_id: 'student-2',
+                        selected_option: null,
+                        response_text: 'https://example.com/other-game',
+                        submitted_at: '2026-01-02T00:00:00.000Z',
+                        updated_at: '2026-01-02T00:00:00.000Z',
+                      },
+                      {
+                        id: 'response-stale',
+                        survey_id: 'survey-1',
+                        question_id: 'link-question',
+                        student_id: 'student-removed',
+                        selected_option: null,
+                        response_text: 'https://example.com/removed-game',
+                        submitted_at: '2026-01-02T12:00:00.000Z',
+                        updated_at: '2026-01-02T12:00:00.000Z',
+                      },
+                      {
+                        id: 'response-3',
+                        survey_id: 'survey-1',
+                        question_id: 'text-question',
+                        student_id: 'student-1',
+                        selected_option: null,
+                        response_text: 'Built in Godot',
+                        submitted_at: '2026-01-03T00:00:00.000Z',
+                        updated_at: '2026-01-03T00:00:00.000Z',
+                      },
+                      {
+                        id: 'response-4',
+                        survey_id: 'survey-1',
+                        question_id: 'text-question',
+                        student_id: 'student-2',
+                        selected_option: null,
+                        response_text: 'Built in Phaser',
+                        submitted_at: '2026-01-04T00:00:00.000Z',
+                        updated_at: '2026-01-04T00:00:00.000Z',
+                      },
+                    ],
+                    error: null,
+                  })
                 }),
               }
             }
@@ -293,6 +324,20 @@ describe('GET /api/student/surveys/[id]/results', () => {
                   created_at: '2026-01-01T00:00:00.000Z',
                   updated_at: '2026-01-01T00:00:00.000Z',
                 },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
               ],
               error: null,
             }),


### PR DESCRIPTION
## Summary
- Scope student quiz result aggregates to current classroom enrollment ids before aggregating responses
- Scope student survey result aggregates and text/link response lists to current classroom enrollment ids
- Keep defensive in-memory filtering after the scoped Supabase response queries
- Add regressions with stale/unenrolled response rows for quiz and survey result payloads

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts --reporter=verbose
- pnpm lint
- pnpm build
- pnpm test
- git diff --check