### PR TITLE
Improve assessment authoring accessibility

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,25 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Student test submit overwrite guard
-
-**Completed:**
-- Changed student test final submission to insert response rows instead of upserting over existing final answers.
-- Mapped unique response conflicts to the existing "already responded" response and skipped attempt finalization after the conflict.
-- Preserved the first-submit path for blank placeholder grading rows by deleting those placeholder rows by id before final insert.
-- Added API coverage for insert-only submission, placeholder cleanup, unique-conflict handling, and conditional attempt finalization.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/student/tests-respond.test.ts`
-- `pnpm tsc --noEmit`
-- `pnpm test tests/api/student/tests-respond.test.ts tests/api/student/tests-attempt.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-history.test.ts tests/api/student/tests-focus-events.test.ts tests/api/teacher/tests-results.test.ts tests/api/teacher/tests-return.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-05-26 — Auth password handoff binding
 
 **Completed:**
@@ -352,3 +333,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test`
 - `git diff --check`
+
+## 2026-05-27 — Assessment authoring accessibility audit
+
+**Completed:**
+- Added accessible names for quiz/test question prompts, options, answer keys, sample solutions, correct-answer radios, remove buttons, markdown editors, and quiz delete controls.
+- Replaced the assessment workspace mode strip with the shared tab-style `TeacherWorkSurfaceModeBar`.
+- Wired the shared mode bar tabs to labelled `tabpanel` content after PR review flagged the incomplete ARIA tab pattern.
+- Fixed a narrow mobile overlap in the test question accordion header after visual review.
+- Added focused component coverage for mode tab semantics and authoring control names.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
+- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=authoring'`
+- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
+- Reviewed screenshots: `/tmp/pika-test-question-editor-teacher-fixed.png`, `/tmp/pika-test-question-editor-teacher-mobile-fixed.png`, `/tmp/pika-survey-code-editor-teacher.png`, `/tmp/pika-survey-code-editor-teacher-mobile.png`, plus teacher/student/teacher-mobile captures from the verifier.

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -32,6 +32,7 @@ import { QuizResultsView } from '@/components/QuizResultsView'
 import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { SummaryDetailWorkspaceShell } from '@/components/SummaryDetailWorkspaceShell'
+import { TeacherWorkSurfaceModeBar, type TeacherWorkSurfaceMode } from '@/components/teacher-work-surface/TeacherWorkSurfaceModeBar'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
@@ -75,6 +76,8 @@ type AssessmentEditorDraft = {
   source_format?: 'markdown'
   source_markdown?: string
 }
+
+type AssessmentViewMode = 'questions' | 'documents' | 'markdown' | 'preview' | 'results'
 
 const TEST_SUMMARY_DETAIL_LAYOUT = {
   defaultMarkdownWidth: 50,
@@ -150,9 +153,7 @@ export function QuizDetailPanel({
   )
   const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
   const [loading, setLoading] = useState(true)
-  const [viewMode, setViewMode] = useState<'questions' | 'documents' | 'markdown' | 'preview' | 'results'>(
-    () => 'questions'
-  )
+  const [viewMode, setViewMode] = useState<AssessmentViewMode>(() => 'questions')
   const [isDocumentsCardExpanded, setIsDocumentsCardExpanded] = useState(true)
   const [externalDocumentAddRequest, setExternalDocumentAddRequest] = useState<{
     id: number
@@ -506,6 +507,43 @@ export function QuizDetailPanel({
   const areAllEditorSectionsExpanded =
     (questions.length === 0 || areAllQuestionsExpanded) &&
     (!hasInlineDocumentsCard || isDocumentsCardExpanded)
+  const assessmentModeTabs = useMemo<readonly TeacherWorkSurfaceMode<AssessmentViewMode>[]>(() => {
+    const modes: TeacherWorkSurfaceMode<AssessmentViewMode>[] = [
+      {
+        id: 'questions',
+        label: `Questions (${questions.length})`,
+      },
+    ]
+
+    if (isTestsView) {
+      modes.push({
+        id: 'documents',
+        label: documents.length > 0 ? `Documents (${documents.length})` : 'Documents',
+      })
+    }
+
+    if (showMarkdown) {
+      modes.push({ id: 'markdown', label: 'Markdown' })
+    }
+
+    if (!isTestsView) {
+      modes.push({ id: 'preview', label: 'Preview' })
+    }
+
+    if (resolvedShowResultsTab) {
+      modes.push({ id: 'results', label: `Results (${quiz.stats.responded})` })
+    }
+
+    return modes
+  }, [documents.length, isTestsView, questions.length, quiz.stats.responded, resolvedShowResultsTab, showMarkdown])
+  const assessmentModeTabId = useCallback(
+    (mode: AssessmentViewMode) => `assessment-${quiz.id}-${mode}-tab`,
+    [quiz.id],
+  )
+  const assessmentModePanelId = useCallback(
+    (mode: AssessmentViewMode) => `assessment-${quiz.id}-${mode}-panel`,
+    [quiz.id],
+  )
 
   useEffect(() => {
     if (markdownDirty) return
@@ -1568,6 +1606,7 @@ export function QuizDetailPanel({
       )}
       <textarea
         data-testid={isTestsView ? 'test-markdown-editor' : 'quiz-markdown-editor'}
+        aria-label={isTestsView ? 'Test markdown editor' : 'Quiz markdown editor'}
         value={markdownContent}
         readOnly={!isMarkdownEditable}
         onChange={(event) => handleMarkdownChange(event.target.value)}
@@ -1898,103 +1937,70 @@ export function QuizDetailPanel({
       {titlePortal}
       {/* Tabs */}
       {!usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions && (
-        <div className="flex border-b border-border shrink-0">
-        <button
-          type="button"
-          onClick={() => setViewMode('questions')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-            viewMode === 'questions'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-text-muted hover:text-text-default'
-          }`}
-          >
-            {`Questions (${questions.length})`}
-          </button>
-        {isTestsView && (
-          <button
-            type="button"
-            onClick={() => setViewMode('documents')}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              viewMode === 'documents'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:text-text-default'
-            }`}
-          >
-            {documents.length > 0 ? `Documents (${documents.length})` : 'Documents'}
-          </button>
-        )}
-        {showMarkdown && (
-          <button
-            type="button"
-            onClick={() => setViewMode('markdown')}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              viewMode === 'markdown'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:text-text-default'
-            }`}
-          >
-            Markdown
-          </button>
-        )}
-        {!isTestsView && (
-          <button
-            type="button"
-            onClick={() => setViewMode('preview')}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              viewMode === 'preview'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:text-text-default'
-            }`}
-          >
-            Preview
-          </button>
-        )}
-        {resolvedShowResultsTab && (
-          <button
-            type="button"
-            onClick={() => setViewMode('results')}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              viewMode === 'results'
-                ? 'border-primary text-primary'
-                : 'border-transparent text-text-muted hover:text-text-default'
-            }`}
-          >
-            Results ({quiz.stats.responded})
-          </button>
-        )}
-        {isTestsView && showPreviewButton && (
-          <div className="ml-2 flex items-center">
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                void handleOpenTestPreview()
-              }}
-              disabled={openingTestPreview || hasPendingMarkdownImport}
-              className="h-8 gap-1.5 px-3 font-semibold"
-            >
-              <ExternalLink className="h-4 w-4" />
-              {openingTestPreview ? 'Opening Preview...' : 'Preview'}
-            </Button>
-          </div>
-        )}
-        {isTestsView && onRequestDelete && showInlineDeleteAction ? (
-          <Button
-            type="button"
-            variant="danger"
-            size="sm"
-            onClick={onRequestDelete}
-            className="ml-auto mr-3 h-8 px-3 font-semibold"
-          >
-            Delete Test
-          </Button>
-        ) : null}
-      </div>
+        <div className="shrink-0 border-b border-border bg-surface px-3 pt-2">
+          <TeacherWorkSurfaceModeBar
+            modes={assessmentModeTabs}
+            activeMode={viewMode}
+            onModeChange={setViewMode}
+            getTabId={assessmentModeTabId}
+            getPanelId={assessmentModePanelId}
+            ariaLabel={`${titleLabel} workspace modes`}
+            trailing={
+              <>
+                {isTestsView && showPreviewButton ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => {
+                      void handleOpenTestPreview()
+                    }}
+                    disabled={openingTestPreview || hasPendingMarkdownImport}
+                    className="h-8 gap-1.5 px-3 font-semibold"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {openingTestPreview ? 'Opening Preview...' : 'Preview'}
+                  </Button>
+                ) : null}
+                {isTestsView && onRequestDelete && showInlineDeleteAction ? (
+                  <Button
+                    type="button"
+                    variant="danger"
+                    size="sm"
+                    onClick={onRequestDelete}
+                    className="h-8 px-3 font-semibold"
+                  >
+                    Delete Test
+                  </Button>
+                ) : null}
+              </>
+            }
+          />
+        </div>
       )}
 
       {/* Content */}
       <div
+        id={
+          !usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions
+            ? assessmentModePanelId(viewMode)
+            : undefined
+        }
+        role={
+          !usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions
+            ? 'tabpanel'
+            : undefined
+        }
+        aria-labelledby={
+          !usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions
+            ? assessmentModeTabId(viewMode)
+            : undefined
+        }
+        tabIndex={
+          !usesSummaryDetailQuestions && !usesEditorOnlyQuestions && !usesMarkdownOnlyQuestions
+            ? 0
+            : undefined
+        }
         className={[
           'flex-1',
           usesSummaryDetailQuestions || usesEditorOnlyQuestions || usesMarkdownOnlyQuestions

--- a/src/components/QuizQuestionEditor.tsx
+++ b/src/components/QuizQuestionEditor.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Plus, Trash2, GripVertical } from 'lucide-react'
-import { Input } from '@/ui'
+import { Button, Input } from '@/ui'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { MAX_QUIZ_OPTIONS, validateQuizOptions } from '@/lib/quizzes'
 import type { QuizQuestion } from '@/types'
@@ -42,6 +42,7 @@ export function QuizQuestionEditor({
   const [options, setOptions] = useState<string[]>(question.options)
   const [focusedField, setFocusedField] = useState<'text' | number | null>(null)
   const [error, setError] = useState('')
+  const questionLabel = `Question ${questionNumber} prompt`
 
   const newOptionRef = useRef<HTMLInputElement>(null)
   const justAddedOption = useRef(false)
@@ -149,17 +150,20 @@ export function QuizQuestionEditor({
               value={text}
               onChange={(e) => setText(e.target.value)}
               onBlur={handleTextBlur}
+              aria-label={questionLabel}
               placeholder="Enter question"
               className="text-sm"
               autoFocus
             />
           ) : isEditable ? (
-            <p
-              className="text-sm text-text-default cursor-text hover:bg-surface-2 rounded px-1 -mx-1"
+            <button
+              type="button"
+              className="block w-full rounded px-1 -mx-1 text-left text-sm text-text-default hover:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-primary"
               onClick={() => setFocusedField('text')}
+              aria-label={`Edit ${questionLabel.toLowerCase()}`}
             >
               {text}
-            </p>
+            </button>
           ) : (
             <QuestionMarkdown content={text} />
           )}
@@ -177,15 +181,22 @@ export function QuizQuestionEditor({
                     value={option}
                     onChange={(e) => handleOptionChange(index, e.target.value)}
                     onBlur={() => handleOptionBlur(index)}
+                    aria-label={`Question ${questionNumber} option ${String.fromCharCode(65 + index)}`}
                     placeholder={`Option ${String.fromCharCode(65 + index)}`}
                     className="flex-1 text-sm"
                     autoFocus
                   />
-                ) : (
-                  <span
-                    className={`text-sm text-text-muted flex-1 ${isEditable ? 'cursor-text hover:bg-surface-2 rounded px-1 -mx-1' : ''}`}
-                    onClick={isEditable ? () => setFocusedField(index) : undefined}
+                ) : isEditable ? (
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 rounded px-1 -mx-1 text-left text-sm text-text-muted hover:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-primary"
+                    onClick={() => setFocusedField(index)}
+                    aria-label={`Edit question ${questionNumber} option ${String.fromCharCode(65 + index)}`}
                   >
+                    {option || <span className="italic text-text-muted">Empty option</span>}
+                  </button>
+                ) : (
+                  <span className="min-w-0 flex-1 text-sm text-text-muted">
                     {option || <span className="italic text-text-muted">Empty option</span>}
                   </span>
                 )}
@@ -206,13 +217,16 @@ export function QuizQuestionEditor({
         </div>
 
         {isEditable && (
-          <button
+          <Button
             type="button"
             onClick={() => onDelete(question.id)}
-            className="p-1 text-text-muted hover:text-danger"
+            variant="ghost"
+            size="sm"
+            aria-label={`Delete question ${questionNumber}`}
+            className="h-8 w-8 shrink-0 p-0 text-text-muted hover:text-danger"
           >
             <Trash2 className="h-4 w-4" />
-          </button>
+          </Button>
         )}
       </div>
 

--- a/src/components/TestQuestionEditor.tsx
+++ b/src/components/TestQuestionEditor.tsx
@@ -94,8 +94,12 @@ export function TestQuestionEditor({
   const [error, setError] = useState('')
   const [isAnswerSectionOpen, setIsAnswerSectionOpen] = useState(variant !== 'card')
   const codeToggleId = `question-${question.id}-code-toggle`
+  const defaultPointsId = `question-${question.id}-points`
   const toggleLabel = `${isExpanded ? 'Collapse' : 'Expand'} question ${questionNumber}`
   const questionPlaceholder = `Question ${questionNumber}`
+  const questionPromptLabel = `Question ${questionNumber} prompt`
+  const answerKeyLabel = `Question ${questionNumber} answer key`
+  const sampleSolutionLabel = `Question ${questionNumber} sample solution`
   const pointsLabel = `${Number.parseInt(state.points, 10) || question.points || defaultPointsForQuestionType(state.question_type)} pts`
   const collapsedSummary = summarizeHeaderLine(state.question_text)
 
@@ -211,49 +215,56 @@ export function TestQuestionEditor({
       }
     >
       <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Answer Options</p>
-      {state.options.map((option, index) => (
-        <div key={index} className="flex items-center gap-2">
-          <input
-            type="radio"
-            name={`correct-option-${question.id}`}
-            checked={state.correct_option === index}
-            disabled={!isEditable}
-            onChange={() => {
-              updateState({ correct_option: index })
-              setTimeout(() => handleSave(), 0)
-            }}
-            className="h-4 w-4"
-          />
-          {isEditable ? (
-            <Input
-              type="text"
-              value={option}
-              onChange={(event) => updateOption(index, event.target.value)}
-              onBlur={() => handleSave()}
-              placeholder={`Option ${String.fromCharCode(65 + index)}`}
-              className="flex-1"
-            />
-          ) : (
-            <div className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default">
-              {option}
-            </div>
-          )}
-          {isEditable && state.options.length > 2 ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                removeOption(index)
+      {state.options.map((option, index) => {
+        const optionLetter = String.fromCharCode(65 + index)
+
+        return (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              type="radio"
+              name={`correct-option-${question.id}`}
+              checked={state.correct_option === index}
+              disabled={!isEditable}
+              aria-label={`Question ${questionNumber} option ${optionLetter} correct answer`}
+              onChange={() => {
+                updateState({ correct_option: index })
                 setTimeout(() => handleSave(), 0)
               }}
-              className="p-1 text-text-muted hover:text-danger"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          ) : null}
-        </div>
-      ))}
+              className="h-4 w-4"
+            />
+            {isEditable ? (
+              <Input
+                type="text"
+                value={option}
+                onChange={(event) => updateOption(index, event.target.value)}
+                onBlur={() => handleSave()}
+                aria-label={`Question ${questionNumber} option ${optionLetter}`}
+                placeholder={`Option ${optionLetter}`}
+                className="flex-1"
+              />
+            ) : (
+              <div className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default">
+                {option}
+              </div>
+            )}
+            {isEditable && state.options.length > 2 ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Remove question ${questionNumber} option ${optionLetter}`}
+                onClick={() => {
+                  removeOption(index)
+                  setTimeout(() => handleSave(), 0)
+                }}
+                className="p-1 text-text-muted hover:text-danger"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            ) : null}
+          </div>
+        )
+      })}
       {isEditable && state.options.length < MAX_QUIZ_OPTIONS ? (
         <Button type="button" variant="secondary" size="sm" onClick={addOption} className="gap-1.5">
           <Plus className="h-4 w-4" />
@@ -308,6 +319,7 @@ export function TestQuestionEditor({
                       value={state.answer_key}
                       onChange={(event) => updateState({ answer_key: event.target.value })}
                       onBlur={() => handleSave()}
+                      aria-label={answerKeyLabel}
                       placeholder="Enter an optional answer key for AI-assisted grading..."
                       rows={4}
                       className="w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -326,6 +338,7 @@ export function TestQuestionEditor({
                     value={state.answer_key}
                     onChange={(event) => updateState({ answer_key: event.target.value })}
                     onBlur={() => handleSave()}
+                    aria-label={answerKeyLabel}
                     placeholder="Enter an optional answer key for AI-assisted grading..."
                     rows={4}
                     className="w-full min-h-[96px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -334,6 +347,7 @@ export function TestQuestionEditor({
                     value={state.sample_solution}
                     onChange={(event) => updateState({ sample_solution: event.target.value })}
                     onBlur={() => handleSave()}
+                    aria-label={sampleSolutionLabel}
                     placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
                     rows={6}
                     className="w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -347,6 +361,7 @@ export function TestQuestionEditor({
                       value={state.sample_solution}
                       onChange={(event) => updateState({ sample_solution: event.target.value })}
                       onBlur={() => handleSave()}
+                      aria-label={sampleSolutionLabel}
                       placeholder="Optional sample solution. Coding sample solutions will be shown to students when the returned test is released."
                       rows={6}
                       className="w-full min-h-[128px] resize-y rounded-md border border-border bg-surface px-3 py-2 font-mono text-sm leading-6 text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -379,6 +394,7 @@ export function TestQuestionEditor({
           value={state.question_text}
           onChange={(event) => updateState({ question_text: event.target.value })}
           onBlur={() => handleSave()}
+          aria-label={questionPromptLabel}
           placeholder={questionPlaceholder}
           rows={5}
           className="w-full min-h-[144px] resize-y rounded-md border border-border bg-surface px-4 py-3 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -444,7 +460,7 @@ export function TestQuestionEditor({
             ) : null}
           </button>
 
-          <div className="ml-auto flex flex-wrap items-center justify-end gap-3">
+          <div className="flex basis-full flex-wrap items-center justify-end gap-3 pl-6 sm:ml-auto sm:basis-auto sm:pl-0">
             {isEditable ? (
               <>
                 <label
@@ -535,6 +551,7 @@ export function TestQuestionEditor({
                     value={state.question_text}
                     onChange={(event) => updateState({ question_text: event.target.value })}
                     onBlur={() => handleSave()}
+                    aria-label={questionPromptLabel}
                     placeholder={questionPlaceholder}
                     rows={4}
                     className="block w-full min-h-[112px] resize-y border-0 bg-surface px-4 py-4 text-sm text-text-default placeholder:text-text-muted focus:outline-none focus:ring-0"
@@ -594,6 +611,7 @@ export function TestQuestionEditor({
                 value={state.question_text}
                 onChange={(event) => updateState({ question_text: event.target.value })}
                 onBlur={() => handleSave()}
+                aria-label={questionPromptLabel}
                 placeholder={questionPlaceholder}
                 rows={3}
                 className="w-full min-h-[88px] resize-y rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-default focus:outline-none focus:ring-2 focus:ring-primary"
@@ -623,15 +641,17 @@ export function TestQuestionEditor({
         {isEditable ? (
           <div className="w-full min-w-0 space-y-2 rounded-md border border-border bg-surface-2 p-2.5 md:self-start">
             <div className="grid min-w-0 grid-cols-[1fr_52px] items-center gap-2">
-              <label className="text-[11px] font-medium uppercase leading-none tracking-wide text-text-muted">
+              <label htmlFor={defaultPointsId} className="text-[11px] font-medium uppercase leading-none tracking-wide text-text-muted">
                 Points
               </label>
               <Input
+                id={defaultPointsId}
                 type="text"
                 inputMode="decimal"
                 value={state.points}
                 onChange={(event) => updateState({ points: event.target.value })}
                 onBlur={() => handleSave()}
+                aria-label={`Question ${questionNumber} points`}
                 className="h-8 min-w-0 w-full px-2 text-sm"
               />
             </div>

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -905,6 +905,7 @@ export function TeacherSurveyWorkspace({
 
             <textarea
               data-testid="survey-markdown-editor"
+              aria-label="Survey markdown editor"
               value={surveyMarkdown}
               onChange={(event) => handleSurveyMarkdownChange(event.target.value)}
               onKeyDown={(event) => {

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceModeBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceModeBar.tsx
@@ -13,6 +13,8 @@ interface TeacherWorkSurfaceModeBarProps<TMode extends string = string> {
   modes: readonly TeacherWorkSurfaceMode<TMode>[]
   activeMode: TMode
   onModeChange: (mode: TMode) => void
+  getTabId?: (mode: TMode) => string
+  getPanelId?: (mode: TMode) => string
   center?: ReactNode
   trailing?: ReactNode
   status?: ReactNode
@@ -23,6 +25,8 @@ export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
   modes,
   activeMode,
   onModeChange,
+  getTabId,
+  getPanelId,
   center,
   trailing,
   status,
@@ -30,7 +34,7 @@ export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
 }: TeacherWorkSurfaceModeBarProps<TMode>) {
   const tabListId = useId()
 
-  const getTabId = (modeId: TMode) => `${tabListId}-${modeId}`
+  const resolveTabId = (modeId: TMode) => getTabId?.(modeId) ?? `${tabListId}-${modeId}`
 
   const selectMode = (mode: TeacherWorkSurfaceMode<TMode>) => {
     if (mode.disabled) return
@@ -40,7 +44,7 @@ export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
   const moveToMode = (mode: TeacherWorkSurfaceMode<TMode>) => {
     if (mode.disabled) return
 
-    document.getElementById(getTabId(mode.id))?.focus()
+    document.getElementById(resolveTabId(mode.id))?.focus()
     onModeChange(mode.id)
   }
 
@@ -93,7 +97,7 @@ export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
           return (
             <button
               key={mode.id}
-              id={getTabId(mode.id)}
+              id={resolveTabId(mode.id)}
               type="button"
               role="tab"
               className={[
@@ -106,6 +110,7 @@ export function TeacherWorkSurfaceModeBar<TMode extends string = string>({
               onClick={() => selectMode(mode)}
               onKeyDown={(event) => handleTabKeyDown(event, index)}
               aria-selected={isActive}
+              aria-controls={getPanelId?.(mode.id)}
               aria-disabled={mode.disabled || undefined}
               tabIndex={isActive && !mode.disabled ? 0 : -1}
               disabled={mode.disabled}

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -223,7 +223,7 @@ describe('QuizDetailPanel', () => {
         title: 'Docs Tab Order Test',
       })
 
-      const { container } = render(
+      render(
         <QuizDetailPanel
           quiz={testQuiz}
           classroomId="classroom-1"
@@ -237,13 +237,109 @@ describe('QuizDetailPanel', () => {
         expect(screen.getByText('Documents (1)')).toBeInTheDocument()
       })
 
-      const tabStrip = container.querySelector('.flex.border-b.border-border.shrink-0')
-      expect(tabStrip).toBeTruthy()
-      const tabLabels = Array.from(tabStrip!.children)
-        .filter((element) => element.tagName === 'BUTTON')
-        .map((element) => element.textContent?.trim() || '')
+      const tabList = screen.getByRole('tablist', { name: 'Test workspace modes' })
+      const tabLabels = within(tabList).getAllByRole('tab').map((tab) => tab.textContent?.trim() || '')
       expect(tabLabels).toEqual(['Questions (2)', 'Documents (1)', 'Markdown'])
+      const questionsTab = within(tabList).getByRole('tab', { name: 'Questions (2)' })
+      expect(questionsTab).toHaveAttribute('aria-selected', 'true')
+      expect(questionsTab).toHaveAttribute('aria-controls')
+      expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', questionsTab.id)
       expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
+    })
+
+    it('moves across workspace mode tabs with keyboard navigation', async () => {
+      mockFetchForQuiz(sampleQuestions, sampleResults)
+      const quiz = makeQuizWithStats({ stats: { total_students: 25, responded: 20, questions_count: 2 } })
+
+      render(<QuizDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+
+      const tabList = await screen.findByRole('tablist', { name: 'Quiz workspace modes' })
+      const questionsTab = within(tabList).getByRole('tab', { name: 'Questions (2)' })
+      const nextTab = within(tabList).getAllByRole('tab')[1]
+
+      questionsTab.focus()
+      fireEvent.keyDown(questionsTab, { key: 'ArrowRight' })
+
+      await waitFor(() => {
+        expect(nextTab).toHaveAttribute('aria-selected', 'true')
+        expect(nextTab).toHaveFocus()
+      })
+    })
+
+    it('exposes quiz question inline editing controls with accessible names', async () => {
+      mockFetchForQuiz(sampleQuestions)
+      const quiz = makeQuizWithStats()
+
+      render(<QuizDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+
+      const editPromptButton = await screen.findByRole('button', { name: 'Edit question 1 prompt' })
+      expect(screen.getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
+
+      fireEvent.click(editPromptButton)
+      const promptInput = screen.getByLabelText('Question 1 prompt') as HTMLInputElement
+      expect(promptInput).toHaveValue('Favorite color?')
+      fireEvent.blur(promptInput)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit question 1 option A' }))
+      expect(screen.getByLabelText('Question 1 option A')).toHaveValue('Red')
+    })
+
+    it('exposes test question card controls with accessible names', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Accessible Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }),
+      })
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          quiz: { documents: [] },
+          questions: summaryDetailQuestions,
+        }),
+      })
+
+      const testQuiz = makeQuizWithStats({
+        assessment_type: 'test',
+        title: 'Accessible Test',
+        stats: { total_students: 25, responded: 0, questions_count: 2 },
+      })
+
+      render(
+        <QuizDetailPanel
+          quiz={testQuiz}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(await screen.findByLabelText('Question 1 prompt')).toHaveValue(
+        'Explain the runtime complexity of your solution.'
+      )
+      expect(screen.getByLabelText('Question 1 points')).toHaveValue('6')
+      fireEvent.click(screen.getByRole('button', { name: 'Grading Notes Added' }))
+      expect(screen.getByLabelText('Question 1 answer key')).toHaveValue(
+        'Look for linear-time reasoning and mention of hash-map tradeoffs.'
+      )
+      expect(screen.getByLabelText('Question 1 sample solution')).toHaveValue(
+        'A good answer explains O(n) time and O(n) space.'
+      )
+      expect(screen.getByLabelText('Question 2 option A correct answer')).not.toBeChecked()
+      expect(screen.getByLabelText('Question 2 option B correct answer')).toBeChecked()
+      expect(screen.getByLabelText('Question 2 option A')).toHaveValue('Inorder')
+      expect(screen.getByRole('button', { name: 'Remove question 2 option A' })).toBeInTheDocument()
     })
 
     it('renders tests in summary-detail mode with accordion editors on the left and markdown on the right', async () => {
@@ -305,10 +401,11 @@ describe('QuizDetailPanel', () => {
 
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('2 questions')
       expect(within(editorPane).getByTestId('test-question-editor-header-summary')).toHaveTextContent('9 pts')
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Expand all sections' }))
       await waitFor(() => {
-        expect(within(editorPane).getByRole('button', { name: 'Expand all sections' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Collapse all sections' })).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: 'Collapse question 1' })).toBeInTheDocument()
-        expect(within(editorPane).getByRole('button', { name: 'Expand question 2' })).toBeInTheDocument()
+        expect(within(editorPane).getByRole('button', { name: 'Collapse question 2' })).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: 'Duplicate question 1' })).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: 'Delete question 1' })).toBeInTheDocument()
       })
@@ -317,16 +414,25 @@ describe('QuizDetailPanel', () => {
       expect(within(editorPane).getByLabelText('Question 1 points')).toHaveValue(6)
       expect(within(editorPane).getByLabelText('Question 1 code response')).toBeChecked()
       expect(within(editorPane).getByTestId('question-sq1-answer-section')).toHaveClass('bg-surface', 'p-px')
-      expect(within(editorPane).getByTestId('question-sq2-collapsed-summary')).toHaveTextContent(
-        'Which traversal visits the root node first?'
+      expect(within(editorPane).getByLabelText('Question 1 prompt')).toHaveValue('Explain the runtime complexity of your solution.')
+      expect(within(editorPane).getByLabelText('Question 1 answer key')).toHaveValue(
+        'Look for linear-time reasoning and mention of hash-map tradeoffs.'
+      )
+      expect(within(editorPane).getByLabelText('Question 1 sample solution')).toHaveValue(
+        'A good answer explains O(n) time and O(n) space.'
       )
       expect(within(editorPane).getByDisplayValue('Explain the runtime complexity of your solution.')).toBeInTheDocument()
       expect(
         within(editorPane).getByDisplayValue('Look for linear-time reasoning and mention of hash-map tradeoffs.')
       ).toBeInTheDocument()
-      expect(within(editorPane).queryByDisplayValue('Which traversal visits the root node first?')).not.toBeInTheDocument()
+      expect(within(editorPane).getByDisplayValue('Which traversal visits the root node first?')).toBeInTheDocument()
+      expect(within(editorPane).getByLabelText('Question 2 prompt')).toHaveValue('Which traversal visits the root node first?')
+      expect(within(editorPane).getByLabelText('Question 2 option A correct answer')).not.toBeChecked()
+      expect(within(editorPane).getByLabelText('Question 2 option B correct answer')).toBeChecked()
+      expect(within(editorPane).getByLabelText('Question 2 option A')).toHaveValue('Inorder')
+      expect(within(editorPane).getByRole('button', { name: 'Remove question 2 option A' })).toBeInTheDocument()
 
-      const markdownEditor = within(markdownPane).getByTestId('test-markdown-editor')
+      const markdownEditor = within(markdownPane).getByLabelText('Test markdown editor')
       expect((markdownEditor as HTMLTextAreaElement).value).toContain('Explain the runtime complexity of your solution.')
       expect((markdownEditor as HTMLTextAreaElement).value).toContain('Which traversal visits the root node first?')
       expect(markdownEditor).toHaveProperty('readOnly', true)
@@ -350,6 +456,12 @@ describe('QuizDetailPanel', () => {
       await waitFor(() => {
         expect(within(editorPane).getByRole('button', { name: 'Collapse documents' })).toBeInTheDocument()
         expect(within(editorPane).getByRole('button', { name: 'Add Document' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(editorPane).getByRole('button', { name: 'Collapse all sections' }))
+
+      await waitFor(() => {
+        expect(within(editorPane).getByRole('button', { name: 'Expand all sections' })).toBeInTheDocument()
       })
 
       fireEvent.click(within(editorPane).getByRole('button', { name: 'Expand all sections' }))
@@ -2499,10 +2611,10 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: /Documents/ })).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: /Documents/ }))
+      fireEvent.click(screen.getByRole('tab', { name: /Documents/ }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
       expect(screen.getByRole('heading', { name: 'Add Document' })).toBeInTheDocument()
       fireEvent.change(screen.getByPlaceholderText('Title'), {
@@ -2620,10 +2732,10 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: /Documents/ })).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: /Documents/ }))
+      fireEvent.click(screen.getByRole('tab', { name: /Documents/ }))
 
       await waitFor(() => {
         expect(screen.getByText('4m')).toBeInTheDocument()
@@ -2725,7 +2837,7 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Documents/ })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: /Documents/ })).toBeInTheDocument()
       })
 
       await waitFor(() => {
@@ -2818,10 +2930,10 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Documents' })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: 'Documents' })).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: 'Documents' }))
+      fireEvent.click(screen.getByRole('tab', { name: 'Documents' }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
       fireEvent.click(screen.getByRole('tab', { name: 'Text' }))
       fireEvent.change(screen.getByPlaceholderText('Title'), {
@@ -2890,10 +3002,10 @@ Prompt:
       )
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Documents' })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: 'Documents' })).toBeInTheDocument()
       })
 
-      fireEvent.click(screen.getByRole('button', { name: 'Documents' }))
+      fireEvent.click(screen.getByRole('tab', { name: 'Documents' }))
       fireEvent.click(screen.getByRole('button', { name: 'Add Document' }))
       fireEvent.click(screen.getByRole('tab', { name: 'PDF' }))
 

--- a/tests/components/TeacherSurveyWorkspace.test.tsx
+++ b/tests/components/TeacherSurveyWorkspace.test.tsx
@@ -67,7 +67,7 @@ describe('TeacherSurveyWorkspace', () => {
       />
     )
 
-    const editor = await screen.findByTestId('survey-markdown-editor')
+    const editor = await screen.findByLabelText('Survey markdown editor')
     const editorValue = (editor as HTMLTextAreaElement).value
 
     expect(editorValue).toContain('# Survey')

--- a/tests/components/TeacherWorkSurfaceModeBar.test.tsx
+++ b/tests/components/TeacherWorkSurfaceModeBar.test.tsx
@@ -12,6 +12,8 @@ describe('TeacherWorkSurfaceModeBar', () => {
         ]}
         activeMode="overview"
         onModeChange={vi.fn()}
+        getTabId={(mode) => `mode-${mode}-tab`}
+        getPanelId={(mode) => `mode-${mode}-panel`}
         center={<button type="button">AI Grade</button>}
         status={<span>Updating</span>}
         trailing={<button type="button">Edit assignment</button>}
@@ -20,7 +22,10 @@ describe('TeacherWorkSurfaceModeBar', () => {
 
     expect(screen.getByRole('tablist', { name: 'Workspace modes' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('id', 'mode-overview-tab')
+    expect(screen.getByRole('tab', { name: 'Class' })).toHaveAttribute('aria-controls', 'mode-overview-panel')
     expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('tab', { name: 'Individual' })).toHaveAttribute('aria-controls', 'mode-details-panel')
     expect(screen.getByRole('button', { name: 'AI Grade' })).toBeInTheDocument()
     expect(screen.getByText('Updating')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Edit assignment' })).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- add accessible names to quiz/test authoring controls and markdown editors
- replace the assessment workspace mode strip with the shared tab-style mode bar
- fix the narrow mobile test-question header overlap caught during visual verification

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx --reporter=verbose
- pnpm lint
- pnpm build
- pnpm test
- git diff --check
- E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'
- E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=authoring'
- E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'
- reviewed supplemental authoring screenshots in /tmp for test question and survey code editors