### PR TITLE
[codex] Scope teacher assessment responses by enrollment

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,26 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Auth password handoff binding
-
-**Completed:**
-- Bound signup password creation and password reset confirmation to short-lived one-time handoff tokens issued only after code verification.
-- Stored only hashed handoff tokens on `verification_codes`, with expiry and consumed timestamps guarded by a filtered update.
-- Passed signup handoff tokens through `sessionStorage` instead of URL query strings and kept reset handoff tokens in page state.
-- Added migration `076_add_auth_handoff_tokens.sql` plus auth API and crypto coverage for missing, invalid/reused, and valid token paths.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/crypto.test.ts tests/api/auth/verify-signup.test.ts tests/api/auth/create-password.test.ts tests/api/auth/reset-password/verify.test.ts tests/api/auth/reset-password/confirm.test.ts`
-- `pnpm tsc --noEmit`
-- `pnpm test tests/api/auth`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test tests/unit/migration-filenames.test.ts`
-- `pnpm test`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-05-26 — Request cache invalidation races
 
 **Completed:**
@@ -355,3 +335,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=authoring'`
 - `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
 - Reviewed screenshots: `/tmp/pika-test-question-editor-teacher-fixed.png`, `/tmp/pika-test-question-editor-teacher-mobile-fixed.png`, `/tmp/pika-survey-code-editor-teacher.png`, `/tmp/pika-survey-code-editor-teacher-mobile.png`, plus teacher/student/teacher-mobile captures from the verifier.
+
+## 2026-05-27 — Teacher assessment enrollment scoping
+
+**Completed:**
+- Scoped teacher quiz result aggregates and responder hydration to current classroom enrollments.
+- Scoped teacher survey result aggregates, text/link responses, and responder hydration to current classroom enrollments.
+- Scoped teacher quiz and survey list response stats to enrolled student IDs before counting respondents.
+- Added paginated enrollment ID loading to avoid Supabase row-cap truncation.
+- Added fail-closed enrollment/response-stat query handling and regressions with stale/unenrolled response rows.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/quizzes-results.test.ts tests/api/teacher/quizzes-route.test.ts tests/api/teacher/surveys-route.test.ts tests/api/teacher/surveys-results.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm run test:coverage`
+- `pnpm build`
+- `git diff --check`

--- a/src/app/api/teacher/quizzes/[id]/results/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/results/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { aggregateResults } from '@/lib/quizzes'
 import { assertTeacherOwnsQuiz } from '@/lib/server/quizzes'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import type { QuizFocusSummary, QuizQuestion, QuizResponse } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
 
@@ -32,10 +33,23 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } = await supabase
-    .from('quiz_responses')
-    .select('*')
-    .eq('quiz_id', quizId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, quiz.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
+
+  const responseResult = classroomStudentsResult.studentIds.length > 0
+    ? await supabase
+      .from('quiz_responses')
+      .select('*')
+      .eq('quiz_id', quizId)
+      .in('student_id', classroomStudentsResult.studentIds)
+    : { data: [], error: null }
+  const { data: responseRows, error: responsesError } = responseResult
+  const responses = (responseRows || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  )
 
   if (responsesError) {
     console.error('Error fetching responses:', responsesError)
@@ -93,13 +107,8 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
 
   const aggregated = aggregateResults(
     (questions || []) as QuizQuestion[],
-    (responses || []) as QuizResponse[]
+    responses as QuizResponse[]
   )
-
-  const { count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('*', { count: 'exact', head: true })
-    .eq('classroom_id', quiz.classroom_id)
 
   return NextResponse.json({
     quiz: {
@@ -118,7 +127,7 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
     results: aggregated,
     responders,
     stats: {
-      total_students: totalStudents || 0,
+      total_students: classroomStudentsResult.totalStudents,
       responded: responderIds.length,
     },
   })

--- a/src/app/api/teacher/quizzes/route.ts
+++ b/src/app/api/teacher/quizzes/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom, getClassroomStudentIds } from '@/lib/server/classrooms'
 import {
   isMissingAssessmentDraftsError,
   validateQuizDraftContent,
@@ -47,10 +47,11 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
     return NextResponse.json({ error: 'Failed to fetch quizzes' }, { status: 500 })
   }
 
-  const { count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('*', { count: 'exact', head: true })
-    .eq('classroom_id', classroomId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, classroomId)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
 
   const quizIds = (quizzes || []).map((q) => q.id)
 
@@ -67,14 +68,21 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
   }
 
   const respondentCountMap: Record<string, number> = {}
-  if (quizIds.length > 0) {
-    const { data: responseRows } = await supabase
+  if (quizIds.length > 0 && classroomStudentsResult.studentIds.length > 0) {
+    const { data: responseRows, error: responseRowsError } = await supabase
       .from('quiz_responses')
       .select('quiz_id, student_id')
       .in('quiz_id', quizIds)
+      .in('student_id', classroomStudentsResult.studentIds)
+
+    if (responseRowsError) {
+      console.error('Error fetching quiz response stats:', responseRowsError)
+      return NextResponse.json({ error: 'Failed to fetch quiz response stats' }, { status: 500 })
+    }
 
     const seen: Record<string, Set<string>> = {}
     for (const row of responseRows || []) {
+      if (!classroomStudentsResult.studentIdSet.has(row.student_id)) continue
       if (!seen[row.quiz_id]) seen[row.quiz_id] = new Set()
       seen[row.quiz_id].add(row.student_id)
     }
@@ -112,7 +120,7 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
     show_results: draftByQuizId[quiz.id]?.show_results ?? quiz.show_results,
     assessment_type: 'quiz' as const,
     stats: {
-      total_students: totalStudents || 0,
+      total_students: classroomStudentsResult.totalStudents,
       responded: respondentCountMap[quiz.id] || 0,
       questions_count: (draftByQuizId[quiz.id]?.questions.length ?? questionCountMap[quiz.id]) || 0,
     },

--- a/src/app/api/teacher/surveys/[id]/results/route.ts
+++ b/src/app/api/teacher/surveys/[id]/results/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { aggregateSurveyResults } from '@/lib/surveys'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
 import { getServiceRoleClient } from '@/lib/supabase'
 import type { SurveyQuestion, SurveyResponse } from '@/types'
@@ -31,10 +32,23 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } = await supabase
-    .from('survey_responses')
-    .select('*')
-    .eq('survey_id', surveyId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, survey.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
+
+  const responseResult = classroomStudentsResult.studentIds.length > 0
+    ? await supabase
+      .from('survey_responses')
+      .select('*')
+      .eq('survey_id', surveyId)
+      .in('student_id', classroomStudentsResult.studentIds)
+    : { data: [], error: null }
+  const { data: responseRows, error: responsesError } = responseResult
+  const responses = (responseRows || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  )
 
   if (responsesError) {
     console.error('Error fetching survey responses:', responsesError)
@@ -72,7 +86,7 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
 
   const results = aggregateSurveyResults(
     (questions || []) as SurveyQuestion[],
-    (responses || []) as SurveyResponse[]
+    responses as SurveyResponse[]
   ).map((result) => ({
     ...result,
     responses: result.responses.map((response) => {
@@ -96,11 +110,6 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
     })
     .sort((a, b) => (a.name || a.email).localeCompare(b.name || b.email))
 
-  const { count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('*', { count: 'exact', head: true })
-    .eq('classroom_id', survey.classroom_id)
-
   return NextResponse.json({
     survey: {
       id: survey.id,
@@ -120,7 +129,7 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
     results,
     responders,
     stats: {
-      total_students: totalStudents || 0,
+      total_students: classroomStudentsResult.totalStudents,
       responded: responderIds.length,
     },
   })

--- a/src/app/api/teacher/surveys/route.ts
+++ b/src/app/api/teacher/surveys/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
-import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom, getClassroomStudentIds } from '@/lib/server/classrooms'
 import { isMissingSurveysTableError } from '@/lib/server/surveys'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { getFallbackAssessmentTitle } from '@/lib/assessment-titles'
@@ -82,10 +82,11 @@ export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
     return NextResponse.json({ error: 'Failed to fetch surveys' }, { status: 500 })
   }
 
-  const { count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('*', { count: 'exact', head: true })
-    .eq('classroom_id', classroomId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, classroomId)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
 
   const surveyIds = (surveys || []).map((survey) => survey.id)
 
@@ -102,14 +103,21 @@ export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
   }
 
   const respondentCountMap: Record<string, number> = {}
-  if (surveyIds.length > 0) {
-    const { data: responseRows } = await supabase
+  if (surveyIds.length > 0 && classroomStudentsResult.studentIds.length > 0) {
+    const { data: responseRows, error: responseRowsError } = await supabase
       .from('survey_responses')
       .select('survey_id, student_id')
       .in('survey_id', surveyIds)
+      .in('student_id', classroomStudentsResult.studentIds)
+
+    if (responseRowsError) {
+      console.error('Error fetching survey response stats:', responseRowsError)
+      return NextResponse.json({ error: 'Failed to fetch survey response stats' }, { status: 500 })
+    }
 
     const seen: Record<string, Set<string>> = {}
     for (const row of responseRows || []) {
+      if (!classroomStudentsResult.studentIdSet.has(row.student_id)) continue
       if (!seen[row.survey_id]) seen[row.survey_id] = new Set()
       seen[row.survey_id].add(row.student_id)
     }
@@ -122,7 +130,7 @@ export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
     surveys: (surveys || []).map((survey) => ({
       ...survey,
       stats: {
-        total_students: totalStudents || 0,
+        total_students: classroomStudentsResult.totalStudents,
         responded: respondentCountMap[survey.id] || 0,
         questions_count: questionCountMap[survey.id] || 0,
       },

--- a/src/lib/server/classrooms.ts
+++ b/src/lib/server/classrooms.ts
@@ -106,23 +106,53 @@ export async function assertStudentCanAccessClassroom(
 export async function getClassroomStudentIds(
   supabase: any,
   classroomId: string
-): Promise<{ studentIds: string[]; studentIdSet: Set<string>; error: unknown }> {
-  const { data, error } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id')
-    .eq('classroom_id', classroomId)
+): Promise<{ studentIds: string[]; studentIdSet: Set<string>; totalStudents: number; error: unknown }> {
+  const pageSize = 1000
+  const studentIds = new Set<string>()
+  let totalStudents: number | null = null
+  let offset = 0
 
-  if (error) {
-    return { studentIds: [], studentIdSet: new Set(), error }
+  while (true) {
+    let query = supabase
+      .from('classroom_enrollments')
+      .select('student_id', { count: 'exact' })
+      .eq('classroom_id', classroomId)
+
+    const supportsRange = typeof query.range === 'function'
+    if (typeof query.order === 'function') {
+      query = query.order('student_id', { ascending: true })
+    }
+    if (supportsRange) {
+      query = query.range(offset, offset + pageSize - 1)
+    }
+
+    const { data, error, count } = await query
+
+    if (error) {
+      return { studentIds: [], studentIdSet: new Set(), totalStudents: 0, error }
+    }
+
+    if (typeof count === 'number') {
+      totalStudents = count
+    }
+
+    for (const row of (data || []) as Array<{ student_id: unknown }>) {
+      if (typeof row.student_id === 'string' && row.student_id.length > 0) {
+        studentIds.add(row.student_id)
+      }
+    }
+
+    if (!supportsRange || (data || []).length < pageSize) break
+    if (totalStudents !== null && offset + pageSize >= totalStudents) break
+    offset += pageSize
   }
 
-  const studentIds = Array.from(
-    new Set(
-      ((data || []) as Array<{ student_id: unknown }>)
-        .map((row) => row.student_id)
-        .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0)
-    )
-  )
+  const sortedStudentIds = Array.from(studentIds)
 
-  return { studentIds, studentIdSet: new Set(studentIds), error: null }
+  return {
+    studentIds: sortedStudentIds,
+    studentIdSet: new Set(sortedStudentIds),
+    totalStudents: totalStudents ?? sortedStudentIds.length,
+    error: null,
+  }
 }

--- a/tests/api/teacher/quizzes-results.test.ts
+++ b/tests/api/teacher/quizzes-results.test.ts
@@ -60,6 +60,74 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
     expect(response.status).toBe(500)
   })
 
+  it('returns 500 when enrollment loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q1', question_text: '2 + 2?', options: ['4', '5'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, count: null, error: { message: 'boom' } }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch classroom enrollments' })
+  })
+
+  it('skips response and responder loading when no students are enrolled', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q1', question_text: '2 + 2?', options: ['4', '5'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [], count: 0, error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0].counts).toEqual([0, 0])
+    expect(data.responders).toEqual([])
+    expect(data.stats).toEqual({ total_students: 0, responded: 0 })
+  })
+
   it('returns aggregated results, responders, and stats', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'quiz_questions') {
@@ -76,12 +144,18 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
       if (table === 'quiz_responses') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 'student-1', question_id: 'q1', selected_option: 0 },
-                { student_id: 'student-2', question_id: 'q1', selected_option: 1 },
-              ],
-              error: null,
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn((column: string, studentIds: string[]) => {
+              expect(column).toBe('student_id')
+              expect(studentIds).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  { student_id: 'student-1', question_id: 'q1', selected_option: 0 },
+                  { student_id: 'student-2', question_id: 'q1', selected_option: 1 },
+                  { student_id: 'student-stale', question_id: 'q1', selected_option: 1 },
+                ],
+                error: null,
+              })
             }),
           })),
         }
@@ -115,7 +189,14 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
       if (table === 'classroom_enrollments') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ count: 3, error: null }),
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
+              ],
+              count: 2,
+              error: null,
+            }),
           })),
         }
       }
@@ -131,7 +212,8 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
     expect(response.status).toBe(200)
     expect(data.results[0].counts).toEqual([1, 1])
     expect(data.responders).toHaveLength(2)
+    expect(data.responders.map((responder: { student_id: string }) => responder.student_id)).not.toContain('student-stale')
     expect(data.responders[0].name).toBe('Alice Brown')
-    expect(data.stats).toEqual({ total_students: 3, responded: 2 })
+    expect(data.stats).toEqual({ total_students: 2, responded: 2 })
   })
 })

--- a/tests/api/teacher/quizzes-route.test.ts
+++ b/tests/api/teacher/quizzes-route.test.ts
@@ -4,6 +4,7 @@ import { GET, POST } from '@/app/api/teacher/quizzes/route'
 import { mockAuthenticationError } from '../setup'
 
 const mockSupabaseClient = { from: vi.fn() }
+const mockGetClassroomStudentIds = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -26,11 +27,18 @@ vi.mock('@/lib/server/classrooms', () => ({
     ok: true,
     classroom: { id: 'classroom-1', teacher_id: 'teacher-1', archived_at: null },
   })),
+  getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
 
 describe('teacher quizzes collection route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetClassroomStudentIds.mockResolvedValue({
+      studentIds: ['student-1', 'student-2'],
+      studentIdSet: new Set(['student-1', 'student-2']),
+      totalStudents: 2,
+      error: null,
+    })
   })
 
   it('returns 401 when unauthenticated', async () => {
@@ -73,7 +81,14 @@ describe('teacher quizzes collection route', () => {
       if (table === 'classroom_enrollments') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ count: 2, error: null }),
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
+              ],
+              count: 2,
+              error: null,
+            }),
           })),
         }
       }
@@ -85,12 +100,28 @@ describe('teacher quizzes collection route', () => {
         }
       }
       if (table === 'quiz_responses') {
+        const responseFilter: any = {
+          in: vi.fn((column: string, values: string[]) => {
+            if (column === 'quiz_id') {
+              expect(values).toEqual(['quiz-1'])
+              return responseFilter
+            }
+            if (column === 'student_id') {
+              expect(values).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  { quiz_id: 'quiz-1', student_id: 'student-1' },
+                  { quiz_id: 'quiz-1', student_id: 'student-stale' },
+                ],
+                error: null,
+              })
+            }
+            throw new Error(`Unexpected quiz_responses in column: ${column}`)
+          }),
+        }
         return {
           select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ quiz_id: 'quiz-1', student_id: 'student-1' }],
-              error: null,
-            }),
+            in: responseFilter.in,
           })),
         }
       }
@@ -135,6 +166,158 @@ describe('teacher quizzes collection route', () => {
       responded: 1,
       questions_count: 1,
     })
+  })
+
+  it('returns 500 when enrollment loading fails', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: { message: 'boom' },
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+        }
+        return chain
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch classroom enrollments' })
+  })
+
+  it('skips response stat loading when no students are enrolled', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Quiz One',
+                  status: 'draft',
+                  show_results: false,
+                  position: 0,
+                  created_at: '2026-03-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [{ quiz_id: 'quiz-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'assessment_drafts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes[0].stats).toEqual({
+      total_students: 0,
+      responded: 0,
+      questions_count: 1,
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('quiz_responses')
+  })
+
+  it('returns 500 when scoped quiz response stat loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Quiz One',
+                  status: 'draft',
+                  show_results: false,
+                  position: 0,
+                  created_at: '2026-03-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [{ quiz_id: 'quiz-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'quiz_responses') {
+        const responseFilter: any = {
+          in: vi.fn((column: string) => {
+            if (column === 'quiz_id') return responseFilter
+            if (column === 'student_id') return Promise.resolve({ data: null, error: { message: 'boom' } })
+            throw new Error(`Unexpected quiz_responses in column: ${column}`)
+          }),
+        }
+        return {
+          select: vi.fn(() => ({
+            in: responseFilter.in,
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch quiz response stats' })
   })
 
   it('creates a new quiz at the next position', async () => {

--- a/tests/api/teacher/surveys-results.test.ts
+++ b/tests/api/teacher/surveys-results.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/teacher/surveys/[id]/results/route'
+
+const mockSupabaseClient = { from: vi.fn() }
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({
+    id: 'teacher-1',
+    email: 'teacher@example.com',
+    role: 'teacher',
+  })),
+}))
+
+vi.mock('@/lib/server/surveys', () => ({
+  assertTeacherOwnsSurvey: vi.fn(async () => ({
+    ok: true,
+    survey: {
+      id: 'survey-1',
+      classroom_id: 'classroom-1',
+      title: 'Survey One',
+      status: 'active',
+      show_results: true,
+      dynamic_responses: false,
+      position: 0,
+      created_by: 'teacher-1',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+      classrooms: { id: 'classroom-1', teacher_id: 'teacher-1', archived_at: null },
+    },
+  })),
+}))
+
+describe('GET /api/teacher/surveys/[id]/results', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 500 when enrollment loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q-mc', question_type: 'multiple_choice', question_text: 'Choose one', options: ['A'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, count: null, error: { message: 'boom' } }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch classroom enrollments' })
+  })
+
+  it('skips response and responder loading when no students are enrolled', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q-mc', question_type: 'multiple_choice', question_text: 'Choose one', options: ['A', 'B'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [], count: 0, error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0].counts).toEqual([0, 0])
+    expect(data.responders).toEqual([])
+    expect(data.stats).toEqual({ total_students: 0, responded: 0 })
+  })
+
+  it('aggregates and hydrates only current enrolled student responses', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'q-mc',
+                  survey_id: 'survey-1',
+                  question_type: 'multiple_choice',
+                  question_text: 'Choose one',
+                  options: ['A', 'B'],
+                  response_max_chars: 500,
+                  position: 0,
+                },
+                {
+                  id: 'q-text',
+                  survey_id: 'survey-1',
+                  question_type: 'short_text',
+                  question_text: 'Explain',
+                  options: [],
+                  response_max_chars: 500,
+                  position: 1,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
+              ],
+              count: 2,
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'survey_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            in: vi.fn((column: string, studentIds: string[]) => {
+              expect(column).toBe('student_id')
+              expect(studentIds).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  {
+                    id: 'response-1',
+                    survey_id: 'survey-1',
+                    question_id: 'q-mc',
+                    student_id: 'student-1',
+                    selected_option: 0,
+                    response_text: null,
+                    submitted_at: '2026-05-01T00:00:00.000Z',
+                    updated_at: '2026-05-01T00:00:00.000Z',
+                  },
+                  {
+                    id: 'response-2',
+                    survey_id: 'survey-1',
+                    question_id: 'q-mc',
+                    student_id: 'student-2',
+                    selected_option: 1,
+                    response_text: null,
+                    submitted_at: '2026-05-01T00:00:00.000Z',
+                    updated_at: '2026-05-01T00:00:00.000Z',
+                  },
+                  {
+                    id: 'response-stale-mc',
+                    survey_id: 'survey-1',
+                    question_id: 'q-mc',
+                    student_id: 'student-stale',
+                    selected_option: 1,
+                    response_text: null,
+                    submitted_at: '2026-05-02T00:00:00.000Z',
+                    updated_at: '2026-05-02T00:00:00.000Z',
+                  },
+                  {
+                    id: 'response-3',
+                    survey_id: 'survey-1',
+                    question_id: 'q-text',
+                    student_id: 'student-1',
+                    selected_option: null,
+                    response_text: 'Enrolled answer',
+                    submitted_at: '2026-05-03T00:00:00.000Z',
+                    updated_at: '2026-05-03T00:00:00.000Z',
+                  },
+                  {
+                    id: 'response-stale-text',
+                    survey_id: 'survey-1',
+                    question_id: 'q-text',
+                    student_id: 'student-stale',
+                    selected_option: null,
+                    response_text: 'Stale answer',
+                    submitted_at: '2026-05-04T00:00:00.000Z',
+                    updated_at: '2026-05-04T00:00:00.000Z',
+                  },
+                ],
+                error: null,
+              })
+            }),
+          })),
+        }
+      }
+
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn((column: string, studentIds: string[]) => {
+              expect(column).toBe('id')
+              expect(studentIds).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  { id: 'student-1', email: 'alice@example.com' },
+                  { id: 'student-2', email: 'zed@example.com' },
+                ],
+                error: null,
+              })
+            }),
+          })),
+        }
+      }
+
+      if (table === 'student_profiles') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn((column: string, studentIds: string[]) => {
+              expect(column).toBe('user_id')
+              expect(studentIds).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
+                  { user_id: 'student-2', first_name: 'Zed', last_name: 'Young' },
+                ],
+                error: null,
+              })
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0].counts).toEqual([1, 1])
+    expect(data.results[1].responses).toEqual([
+      {
+        response_id: 'response-3',
+        student_id: 'student-1',
+        name: 'Alice Brown',
+        email: 'alice@example.com',
+        response_text: 'Enrolled answer',
+        submitted_at: '2026-05-03T00:00:00.000Z',
+        updated_at: '2026-05-03T00:00:00.000Z',
+      },
+    ])
+    expect(data.responders.map((responder: { student_id: string }) => responder.student_id)).toEqual([
+      'student-1',
+      'student-2',
+    ])
+    expect(data.stats).toEqual({ total_students: 2, responded: 2 })
+  })
+})

--- a/tests/api/teacher/surveys-route.test.ts
+++ b/tests/api/teacher/surveys-route.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
-import { POST } from '@/app/api/teacher/surveys/route'
+import { GET, POST } from '@/app/api/teacher/surveys/route'
 
 const mockSupabaseClient = { from: vi.fn() }
+const mockGetClassroomStudentIds = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -19,7 +20,199 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@/lib/server/classrooms', () => ({
   assertTeacherCanMutateClassroom: vi.fn(async () => ({ ok: true })),
   assertTeacherOwnsClassroom: vi.fn(async () => ({ ok: true })),
+  getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
+
+describe('GET /api/teacher/surveys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetClassroomStudentIds.mockResolvedValue({
+      studentIds: ['student-1', 'student-2'],
+      studentIdSet: new Set(['student-1', 'student-2']),
+      totalStudents: 2,
+      error: null,
+    })
+  })
+
+  it('counts only currently enrolled responders in survey stats', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'survey-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Survey One',
+                  status: 'active',
+                  show_results: true,
+                  dynamic_responses: false,
+                  position: 0,
+                  created_at: '2026-05-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { student_id: 'student-1' },
+                { student_id: 'student-2' },
+              ],
+              count: 2,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [{ survey_id: 'survey-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'survey_responses') {
+        const responseFilter: any = {
+          in: vi.fn((column: string, values: string[]) => {
+            if (column === 'survey_id') {
+              expect(values).toEqual(['survey-1'])
+              return responseFilter
+            }
+            if (column === 'student_id') {
+              expect(values).toEqual(['student-1', 'student-2'])
+              return Promise.resolve({
+                data: [
+                  { survey_id: 'survey-1', student_id: 'student-1' },
+                  { survey_id: 'survey-1', student_id: 'student-stale' },
+                ],
+                error: null,
+              })
+            }
+            throw new Error(`Unexpected survey_responses in column: ${column}`)
+          }),
+        }
+        return {
+          select: vi.fn(() => ({
+            in: responseFilter.in,
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.surveys[0].stats).toEqual({
+      total_students: 2,
+      responded: 1,
+      questions_count: 1,
+    })
+  })
+
+  it('returns 500 when enrollment loading fails', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: { message: 'boom' },
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+        }
+        return chain
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch classroom enrollments' })
+  })
+
+  it('returns 500 when scoped survey response stat loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'survey-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Survey One',
+                  status: 'active',
+                  show_results: true,
+                  dynamic_responses: false,
+                  position: 0,
+                  created_at: '2026-05-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            in: vi.fn().mockResolvedValue({ data: [{ survey_id: 'survey-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'survey_responses') {
+        const responseFilter: any = {
+          in: vi.fn((column: string) => {
+            if (column === 'survey_id') return responseFilter
+            if (column === 'student_id') return Promise.resolve({ data: null, error: { message: 'boom' } })
+            throw new Error(`Unexpected survey_responses in column: ${column}`)
+          }),
+        }
+        return {
+          select: vi.fn(() => ({
+            in: responseFilter.in,
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch survey response stats' })
+  })
+})
 
 describe('POST /api/teacher/surveys', () => {
   beforeEach(() => {

--- a/tests/unit/server-access.test.ts
+++ b/tests/unit/server-access.test.ts
@@ -3,6 +3,7 @@ import {
   assertStudentCanAccessClassroom,
   assertTeacherCanMutateClassroom,
   assertTeacherOwnsClassroom,
+  getClassroomStudentIds,
 } from '@/lib/server/classrooms'
 import {
   assertStudentCanAccessQuiz,
@@ -125,6 +126,46 @@ describe('server access helpers', () => {
         ok: true,
         classroom: { id: 'classroom-1', archived_at: null },
       })
+    })
+
+    it('paginates classroom student ids beyond the Supabase default row cap', async () => {
+      const rangeCalls: Array<[number, number]> = []
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        expect(table).toBe('classroom_enrollments')
+        return {
+          select: vi.fn((_columns: string, options: { count: string }) => {
+            expect(options).toEqual({ count: 'exact' })
+            const chain: any = {
+              eq: vi.fn((column: string, classroomId: string) => {
+                expect(column).toBe('classroom_id')
+                expect(classroomId).toBe('classroom-1')
+                return chain
+              }),
+              order: vi.fn((column: string, options: { ascending: boolean }) => {
+                expect(column).toBe('student_id')
+                expect(options).toEqual({ ascending: true })
+                return chain
+              }),
+              range: vi.fn((from: number, to: number) => {
+                rangeCalls.push([from, to])
+                const page = rangeCalls.length === 1
+                  ? Array.from({ length: 1000 }, (_, index) => ({ student_id: `student-${index}` }))
+                  : [{ student_id: 'student-1000' }]
+                return Promise.resolve({ data: page, count: 1001, error: null })
+              }),
+            }
+            return chain
+          }),
+        }
+      })
+
+      const result = await getClassroomStudentIds(mockSupabaseClient, 'classroom-1')
+
+      expect(rangeCalls).toEqual([[0, 999], [1000, 1999]])
+      expect(result.error).toBeNull()
+      expect(result.totalStudents).toBe(1001)
+      expect(result.studentIds).toHaveLength(1001)
+      expect(result.studentIdSet.has('student-1000')).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- Scope teacher quiz and survey result endpoints to current classroom enrollments before aggregating or hydrating responders.
- Scope teacher quiz and survey list response stats to enrolled student IDs before counting respondents.
- Fail closed when enrollment lookup fails and add stale-response regressions for quiz/survey routes.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/teacher/quizzes-results.test.ts tests/api/teacher/quizzes-route.test.ts tests/api/teacher/surveys-route.test.ts tests/api/teacher/surveys-results.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm build
- pnpm test
- git diff --check