### PR TITLE
[codex] Validate assignment return enrollment

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Request cache invalidation races
-
-**Completed:**
-- Added unit coverage for `fetchJSONWithCache` TTL reuse, in-flight dedupe, direct invalidation, prefix invalidation, and stale rejection races.
-- Prevented invalidated pending requests from repopulating deleted cache entries after they resolve.
-- Prevented invalidated pending rejections from deleting newer cached values for the same key.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/request-cache.test.ts`
-- `pnpm tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-05-26 — Test grading mobile table fit
 
 **Completed:**
@@ -348,6 +331,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/api/teacher/quizzes-results.test.ts tests/api/teacher/quizzes-route.test.ts tests/api/teacher/surveys-route.test.ts tests/api/teacher/surveys-results.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm run test:coverage`
+- `pnpm build`
+- `git diff --check`
+
+## 2026-05-27 — Assignment return enrollment validation
+
+**Completed:**
+- Validated selected student enrollment before loading or mutating assignment return docs.
+- Skipped assignment doc reads/updates for selected students who are no longer enrolled.
+- Preserved unavailable-student response semantics while adding explicit not-enrolled counts and ids.
+- Added regressions for enrollment query failures, fully unenrolled selections, and stale existing assignment docs.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/assignments-id-return.test.ts --reporter=verbose`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm run test:coverage`

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -84,18 +84,37 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     teacherId: user.id,
   })
 
-  const { data: docs, error: docsError } = await supabase
-    .from('assignment_docs')
-    .select('*')
-    .eq('assignment_id', id)
+  const { data: selectedEnrollments, error: enrollmentError } = await supabase
+    .from('classroom_enrollments')
+    .select('student_id')
+    .eq('classroom_id', assignment.classroom_id)
     .in('student_id', student_ids)
 
-  if (docsError) {
-    console.error('Error loading docs for return:', docsError)
-    return NextResponse.json({ error: 'Failed to load docs for return' }, { status: 500 })
+  if (enrollmentError) {
+    console.error('Error loading enrollments for return:', enrollmentError)
+    return NextResponse.json({ error: 'Failed to load enrollments for return' }, { status: 500 })
   }
 
-  const existingDocs = docs || []
+  const enrolledStudentIds = new Set((selectedEnrollments || []).map((enrollment) => enrollment.student_id))
+  const selectedEnrolledStudentIds = student_ids.filter((studentId) => enrolledStudentIds.has(studentId))
+  const unavailableStudentIds = student_ids.filter((studentId) => !enrolledStudentIds.has(studentId))
+
+  let existingDocs: any[] = []
+  if (selectedEnrolledStudentIds.length > 0) {
+    const { data: docs, error: docsError } = await supabase
+      .from('assignment_docs')
+      .select('*')
+      .eq('assignment_id', id)
+      .in('student_id', selectedEnrolledStudentIds)
+
+    if (docsError) {
+      console.error('Error loading docs for return:', docsError)
+      return NextResponse.json({ error: 'Failed to load docs for return' }, { status: 500 })
+    }
+
+    existingDocs = (docs || []).filter((doc) => enrolledStudentIds.has(doc.student_id))
+  }
+
   const blockedDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) === 'partial')
   const nonPartialDocs = existingDocs.filter((doc) => getAssignmentRubricState(doc) !== 'partial')
   const alreadyReturnedDocs = nonPartialDocs.filter((doc) => isAssignmentAlreadyReturnedWithoutResubmission(doc))
@@ -104,12 +123,12 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
   const returnableStudentIds = returnableDocs.map((doc) => doc.student_id)
   const alreadyReturnedStudentIds = alreadyReturnedDocs.map((doc) => doc.student_id)
   const blockedStudentIds = blockedDocs.map((doc) => doc.student_id)
-  const missingStudentIds = student_ids.filter((studentId) => !existingStudentIds.has(studentId))
+  const missingStudentIds = selectedEnrolledStudentIds.filter((studentId) => !existingStudentIds.has(studentId))
 
   const now = new Date().toISOString()
   let mailboxTrackingAvailable = true
   let createdStudentIds: string[] = []
-  let uncreatedMissingStudentIds: string[] = missingStudentIds
+  const uncreatedMissingStudentIds = unavailableStudentIds
 
   if (returnableDocs.length > 0) {
     let updateError = await updateAssignmentDocsForStudents({
@@ -173,20 +192,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
   }
 
   if (missingStudentIds.length > 0) {
-    const { data: enrollments, error: enrollmentError } = await supabase
-      .from('classroom_enrollments')
-      .select('student_id')
-      .eq('classroom_id', assignment.classroom_id)
-      .in('student_id', missingStudentIds)
-
-    if (enrollmentError) {
-      console.error('Error loading enrollments for return:', enrollmentError)
-      return NextResponse.json({ error: 'Failed to load enrollments for return' }, { status: 500 })
-    }
-
-    const enrolledMissingStudentIds = new Set((enrollments || []).map((enrollment) => enrollment.student_id))
-    createdStudentIds = missingStudentIds.filter((studentId) => enrolledMissingStudentIds.has(studentId))
-    uncreatedMissingStudentIds = missingStudentIds.filter((studentId) => !enrolledMissingStudentIds.has(studentId))
+    createdStudentIds = missingStudentIds
 
     if (createdStudentIds.length > 0) {
       let insertError = await insertZeroReturnedAssignmentDocsForStudents({
@@ -236,6 +242,8 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
     already_returned_student_ids: alreadyReturnedStudentIds,
     missing_count: missingCount,
     missing_student_ids: uncreatedMissingStudentIds,
+    not_enrolled_count: unavailableStudentIds.length,
+    not_enrolled_student_ids: unavailableStudentIds,
     mailbox_tracking_available: mailboxTrackingAvailable,
   })
 })

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -32,13 +32,14 @@ function buildAssignmentDocsTable(options?: {
   selectError?: any
 }) {
   const docs = options?.docs ?? []
+  const returnUpdateIn = vi.fn().mockResolvedValue({
+    error: options?.returnUpdateError ?? null,
+  })
   const update = vi.fn((payload: Record<string, unknown>) => ({
     eq: vi.fn(() => {
       if ('returned_at' in payload) {
         return {
-          in: vi.fn().mockResolvedValue({
-            error: options?.returnUpdateError ?? null,
-          }),
+          in: returnUpdateIn,
         }
       }
       return Promise.resolve({
@@ -64,6 +65,7 @@ function buildAssignmentDocsTable(options?: {
       insert,
     },
     update,
+    returnUpdateIn,
     insert,
   }
 }
@@ -104,6 +106,177 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     expect(data.error).toBe('student_ids array is required')
   })
 
+  it('returns 500 when selected student enrollment loading fails', async () => {
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      selectError: { message: 'boom' },
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to load enrollments for return')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('assignment_docs')
+  })
+
+  it('does not load or mutate assignment docs when selected students are not enrolled', async () => {
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [],
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-stale'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(0)
+    expect(data.missing_count).toBe(1)
+    expect(data.missing_student_ids).toEqual(['student-stale'])
+    expect(data.not_enrolled_count).toBe(1)
+    expect(data.not_enrolled_student_ids).toEqual(['student-stale'])
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('assignment_docs')
+  })
+
+  it('filters stale existing docs before returning selected enrolled students', async () => {
+    const docs = [
+      {
+        id: 'doc-1',
+        student_id: 'student-1',
+        is_submitted: true,
+        submitted_at: '2026-04-10T12:00:00.000Z',
+        score_completion: 4,
+        score_thinking: 4,
+        score_workflow: 4,
+        teacher_feedback_draft: '',
+      },
+      {
+        id: 'doc-stale',
+        student_id: 'student-stale',
+        is_submitted: true,
+        submitted_at: '2026-04-10T12:00:00.000Z',
+        score_completion: 4,
+        score_thinking: 4,
+        score_workflow: 4,
+        teacher_feedback_draft: '',
+      },
+    ]
+
+    const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assignment-1',
+                  classroom_id: 'classroom-1',
+                  classrooms: { teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
+      }
+
+      if (table === 'assignment_docs') {
+        return assignmentDocsTable.table
+      }
+
+      throw new Error(`Unexpected table in test: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/return', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1', 'student-stale'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.returned_count).toBe(1)
+    expect(data.returned_student_ids).toEqual(['student-1'])
+    expect(data.missing_count).toBe(1)
+    expect(data.missing_student_ids).toEqual(['student-stale'])
+    expect(data.not_enrolled_student_ids).toEqual(['student-stale'])
+    expect(assignmentDocsTable.returnUpdateIn).toHaveBeenCalledWith('student_id', ['student-1'])
+  })
+
   it('returns existing docs, creates zero returns for enrolled missing work, and blocks partial rubrics', async () => {
     const docs = [
       {
@@ -140,7 +313,12 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
     const assignmentDocsTable = buildAssignmentDocsTable({ docs })
     const enrollmentsTable = buildClassroomEnrollmentsTable({
-      enrollments: [{ student_id: 'student-4' }],
+      enrollments: [
+        { student_id: 'student-1' },
+        { student_id: 'student-2' },
+        { student_id: 'student-3' },
+        { student_id: 'student-4' },
+      ],
     })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
@@ -295,6 +473,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     ]
 
     const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -316,6 +497,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
       if (table === 'assignment_docs') {
         return assignmentDocsTable.table
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
       }
 
       throw new Error(`Unexpected table in test: ${table}`)
@@ -369,6 +554,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     ]
 
     const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -390,6 +578,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
       if (table === 'assignment_docs') {
         return assignmentDocsTable.table
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
       }
 
       throw new Error(`Unexpected table in test: ${table}`)
@@ -432,6 +624,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
     ]
 
     const assignmentDocsTable = buildAssignmentDocsTable({ docs })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -453,6 +648,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
       if (table === 'assignment_docs') {
         return assignmentDocsTable.table
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
       }
 
       throw new Error(`Unexpected table in test: ${table}`)
@@ -505,6 +704,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
       ],
       returnUpdateError: { message: 'boom' },
     })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -526,6 +728,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
       if (table === 'assignment_docs') {
         return assignmentDocsTable.table
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
       }
 
       throw new Error(`Unexpected table in test: ${table}`)
@@ -558,6 +764,9 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
         },
       ],
     })
+    const enrollmentsTable = buildClassroomEnrollmentsTable({
+      enrollments: [{ student_id: 'student-1' }],
+    })
 
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -579,6 +788,10 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
 
       if (table === 'assignment_docs') {
         return assignmentDocsTable.table
+      }
+
+      if (table === 'classroom_enrollments') {
+        return enrollmentsTable
       }
 
       throw new Error(`Unexpected table in test: ${table}`)


### PR DESCRIPTION
## Summary
- Validate selected-student classroom enrollment before assignment return reads or mutations.
- Skip assignment doc reads/updates for students no longer enrolled, while preserving existing unavailable-student response fields.
- Add explicit not-enrolled response metadata and regressions for enrollment failures, stale docs, and fully unavailable selections.

## Root cause
Assignment return loaded selected assignment docs before checking whether every selected student was still enrolled in the assignment classroom, so stale docs could be returned for removed students.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/assignments-id-return.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm run test:coverage`
- `pnpm build`
- `git diff --check`