### PR TITLE
[codex] Validate assignment repo target enrollment

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,24 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Test grading mobile table fit
-
-**Completed:**
-- Constrained the teacher test grading student table on mobile/tablet by keeping actionable columns visible and moving telemetry columns to desktop widths.
-- Added truncation for long student names and tightened mobile header spacing to avoid wrapped labels.
-- Added component coverage for the responsive table constraints.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading&testStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
-- Screenshots reviewed: `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`
-- Playwright overflow check: teacher mobile `documentScrollWidth=390`, `bodyScrollWidth=390`, viewport `390`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-26 — Action bar viewport and menu coverage
 
 **Completed:**
@@ -348,6 +330,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/api/teacher/assignments-id-return.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm run test:coverage`
+- `pnpm build`
+- `git diff --check`
+
+## 2026-05-27 — Assignment repo target enrollment validation
+
+**Completed:**
+- Validated current classroom enrollment before teacher repo-target override reads, deletes, or saves.
+- Failed closed on enrollment query errors and returned the existing not-enrolled bad request for stale students.
+- Added API coverage for unenrolled overrides, enrollment query failures, enrolled override saves, and override resets.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts --reporter=verbose`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm run test:coverage`

--- a/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route.ts
@@ -16,7 +16,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: assignmentId, studentId } = await context.params
-  await assertTeacherCanMutateAssignment(user.id, assignmentId)
+  const assignment = await assertTeacherCanMutateAssignment(user.id, assignmentId)
 
   const body = await request.json()
   const selectionMode = body.selection_mode === 'teacher_override' ? 'teacher_override'
@@ -27,6 +27,20 @@ export const PUT = withErrorHandler('PutTeacherAssignmentRepoTarget', async (req
     : ''
 
   const supabase = getServiceRoleClient()
+
+  const { data: enrollment, error: enrollmentError } = await supabase
+    .from('classroom_enrollments')
+    .select('id')
+    .eq('classroom_id', assignment.classroom_id)
+    .eq('student_id', studentId)
+    .maybeSingle()
+
+  if (enrollmentError) {
+    throw new Error('Failed to validate student enrollment')
+  }
+  if (!enrollment) {
+    throw apiErrors.badRequest('Student is not enrolled in this classroom')
+  }
 
   const { data: existingDoc } = await supabase
     .from('assignment_docs')

--- a/tests/api/teacher/assignments-repo-targets-studentId.test.ts
+++ b/tests/api/teacher/assignments-repo-targets-studentId.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const {
+  mockAssertTeacherCanMutateAssignment,
+  mockExtractRepoArtifactsFromContent,
+  mockLoadAssignmentRepoTarget,
+  mockLoadAssignmentSubmissionArtifactsForDoc,
+  mockResolveAssignmentRepoTarget,
+  mockSaveAssignmentRepoTarget,
+  mockSubmissionArtifactsToAssignmentArtifacts,
+  mockSupabaseClient,
+  mockValidatePublicGitHubRepo,
+} = vi.hoisted(() => ({
+  mockAssertTeacherCanMutateAssignment: vi.fn(),
+  mockExtractRepoArtifactsFromContent: vi.fn(),
+  mockLoadAssignmentRepoTarget: vi.fn(),
+  mockLoadAssignmentSubmissionArtifactsForDoc: vi.fn(),
+  mockResolveAssignmentRepoTarget: vi.fn(),
+  mockSaveAssignmentRepoTarget: vi.fn(),
+  mockSubmissionArtifactsToAssignmentArtifacts: vi.fn(),
+  mockSupabaseClient: { from: vi.fn() },
+  mockValidatePublicGitHubRepo: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(async () => ({ id: 'teacher-1', role: 'teacher' })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/server/repo-review', () => ({
+  assertTeacherCanMutateAssignment: mockAssertTeacherCanMutateAssignment,
+}))
+
+vi.mock('@/lib/server/assignment-submission-artifacts', () => ({
+  loadAssignmentSubmissionArtifactsForDoc: mockLoadAssignmentSubmissionArtifactsForDoc,
+}))
+
+vi.mock('@/lib/assignment-submission-requirements', () => ({
+  submissionArtifactsToAssignmentArtifacts: mockSubmissionArtifactsToAssignmentArtifacts,
+}))
+
+vi.mock('@/lib/server/assignment-repo-targets', () => ({
+  extractRepoArtifactsFromContent: mockExtractRepoArtifactsFromContent,
+  loadAssignmentRepoTarget: mockLoadAssignmentRepoTarget,
+  resolveAssignmentRepoTarget: mockResolveAssignmentRepoTarget,
+  saveAssignmentRepoTarget: mockSaveAssignmentRepoTarget,
+  validatePublicGitHubRepo: mockValidatePublicGitHubRepo,
+}))
+
+import { PUT } from '@/app/api/teacher/assignments/[id]/repo-targets/[studentId]/route'
+
+function createRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/teacher/assignments/assignment-1/repo-targets/student-1', {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  })
+}
+
+function createContext(studentId = 'student-1') {
+  return {
+    params: Promise.resolve({
+      id: 'assignment-1',
+      studentId,
+    }),
+  }
+}
+
+function installRepoTargetTables(opts: {
+  enrollment?: { id: string } | null
+  enrollmentError?: unknown
+  existingDoc?: Record<string, unknown> | null
+}) {
+  const deleteEq = vi.fn(async () => ({ error: null }))
+  const deleteTarget = vi.fn(() => ({ eq: deleteEq }))
+
+  const from = vi.fn((table: string) => {
+    if (table === 'classroom_enrollments') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({
+                data: opts.enrollment === undefined ? { id: 'enrollment-1' } : opts.enrollment,
+                error: opts.enrollmentError ?? null,
+              })),
+            })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_docs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({
+                data: opts.existingDoc ?? {
+                  id: 'doc-1',
+                  content: { type: 'doc', content: [] },
+                  repo_url: 'https://github.com/submitted/repo',
+                  github_username: 'student-login',
+                },
+                error: null,
+              })),
+            })),
+          })),
+        })),
+      }
+    }
+
+    if (table === 'assignment_repo_targets') {
+      return {
+        delete: deleteTarget,
+      }
+    }
+
+    throw new Error(`Unexpected table in test: ${table}`)
+  })
+
+  mockSupabaseClient.from = from
+  return { deleteEq, deleteTarget, from }
+}
+
+describe('PUT /api/teacher/assignments/[id]/repo-targets/[studentId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupabaseClient.from.mockReset?.()
+    mockAssertTeacherCanMutateAssignment.mockResolvedValue({
+      id: 'assignment-1',
+      classroom_id: 'classroom-1',
+    })
+    mockExtractRepoArtifactsFromContent.mockReturnValue([])
+    mockLoadAssignmentRepoTarget.mockResolvedValue(null)
+    mockLoadAssignmentSubmissionArtifactsForDoc.mockResolvedValue([])
+    mockResolveAssignmentRepoTarget.mockReturnValue({
+      submittedRepoUrl: 'https://github.com/submitted/repo',
+      submittedGitHubUsername: 'student-login',
+    })
+    mockSaveAssignmentRepoTarget.mockResolvedValue({
+      id: 'target-1',
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      selected_repo_url: 'https://github.com/codepetca/pika',
+      override_github_username: 'student-login',
+      selection_mode: 'teacher_override',
+      validation_status: 'valid',
+      validation_message: null,
+    })
+    mockSubmissionArtifactsToAssignmentArtifacts.mockReturnValue([])
+    mockValidatePublicGitHubRepo.mockResolvedValue({
+      repoUrl: 'https://github.com/codepetca/pika',
+      repoOwner: 'codepetca',
+      repoName: 'pika',
+      defaultBranch: 'main',
+      validationStatus: 'valid',
+      validationMessage: null,
+    })
+  })
+
+  it('rejects repo target changes for students who are not enrolled before reading docs', async () => {
+    const { from } = installRepoTargetTables({ enrollment: null })
+
+    const response = await PUT(createRequest({
+      selection_mode: 'teacher_override',
+      selected_repo_url: 'https://github.com/codepetca/pika',
+      override_github_username: 'student-login',
+    }), createContext('student-stale'))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Student is not enrolled in this classroom')
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(from).toHaveBeenCalledWith('classroom_enrollments')
+    expect(mockLoadAssignmentRepoTarget).not.toHaveBeenCalled()
+    expect(mockSaveAssignmentRepoTarget).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when enrollment validation errors before reading docs', async () => {
+    const { from } = installRepoTargetTables({ enrollmentError: { message: 'boom' } })
+
+    const response = await PUT(createRequest({
+      selection_mode: 'teacher_override',
+      selected_repo_url: 'https://github.com/codepetca/pika',
+    }), createContext())
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Internal server error')
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(from).toHaveBeenCalledWith('classroom_enrollments')
+    expect(mockValidatePublicGitHubRepo).not.toHaveBeenCalled()
+    expect(mockSaveAssignmentRepoTarget).not.toHaveBeenCalled()
+  })
+
+  it('saves an override only after validating current enrollment', async () => {
+    installRepoTargetTables({})
+
+    const response = await PUT(createRequest({
+      selection_mode: 'teacher_override',
+      selected_repo_url: 'https://github.com/codepetca/pika',
+      override_github_username: 'student-login',
+    }), createContext())
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.repo_target).toEqual(expect.objectContaining({
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      selection_mode: 'teacher_override',
+    }))
+    expect(mockLoadAssignmentRepoTarget).toHaveBeenCalledWith('assignment-1', 'student-1')
+    expect(mockValidatePublicGitHubRepo).toHaveBeenCalledWith('https://github.com/codepetca/pika')
+    expect(mockSaveAssignmentRepoTarget).toHaveBeenCalledWith(expect.objectContaining({
+      assignmentId: 'assignment-1',
+      studentId: 'student-1',
+      repoUrl: 'https://github.com/codepetca/pika',
+      overrideGitHubUsername: 'student-login',
+      selectionMode: 'teacher_override',
+      validationStatus: 'valid',
+    }))
+  })
+
+  it('resets an existing override only after validating current enrollment', async () => {
+    const { deleteEq, deleteTarget } = installRepoTargetTables({})
+    mockLoadAssignmentRepoTarget.mockResolvedValue({
+      id: 'target-1',
+      assignment_id: 'assignment-1',
+      student_id: 'student-1',
+      selection_mode: 'teacher_override',
+    })
+
+    const response = await PUT(createRequest({
+      selection_mode: 'auto',
+    }), createContext())
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.repo_target).toBeNull()
+    expect(deleteTarget).toHaveBeenCalled()
+    expect(deleteEq).toHaveBeenCalledWith('id', 'target-1')
+    expect(mockSaveAssignmentRepoTarget).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Validate the selected student is currently enrolled before teacher repo-target override reads, deletes, or saves.
- Fail closed on enrollment lookup errors and preserve the existing bad-request response for stale/unenrolled students.
- Add route coverage for unenrolled overrides, enrollment query failures, enrolled override saves, and override resets.

## Root cause
The repo-target override endpoint proved teacher ownership of the assignment, then used the route `studentId` to read assignment docs and mutate `assignment_repo_targets` without first proving that student still belongs to the assignment classroom.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm run test:coverage`
- `pnpm build`
- `git diff --check`