### PR TITLE
[codex] Validate test response enrollment

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,20 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Action bar viewport and menu coverage
-
-**Completed:**
-- Added direct `PageActionBar` coverage for desktop action groups, mobile overflow menu containers, menu ordering, destructive grouping, disabled items, selection close, Escape close, and outside-click close.
-- Expanded teacher work-surface floating action cluster coverage for viewport max-width, fixed placement, visual chrome, floating center actions, and inline center actions.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/PageActionBar.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/TeacherWorkSurfaceShell.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-26 — Blueprint bulk sync stale-id guards
 
 **Completed:**
@@ -346,6 +332,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm run test:coverage`
+- `pnpm build`
+- `git diff --check`
+
+## 2026-05-27 — Test response enrollment validation
+
+**Completed:**
+- Validated the response student remains enrolled before teacher response grading updates.
+- Validated the response student remains enrolled before manual AI grade suggestions or reference-cache writes.
+- Bound response grade updates to the validated `student_id` as well as response and test ids.
+- Added API regressions for stale response students and enrollment validation failures in both routes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/tests-responses-grade.test.ts tests/api/teacher/tests-ai-suggest.test.ts --reporter=verbose`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm run test:coverage`

--- a/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
+++ b/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } from '@/lib/server/tests'
 import {
   getTestOpenResponseGradingModel,
   prepareTestOpenResponseGradingContext,
@@ -30,6 +30,7 @@ export const POST = withErrorHandler('AiSuggestTeacherTestGrade', async (request
       id,
       test_id,
       question_id,
+      student_id,
       response_text,
       test_questions!inner (
         id,
@@ -50,6 +51,24 @@ export const POST = withErrorHandler('AiSuggestTeacherTestGrade', async (request
 
   if (responseError || !responseRow) {
     return NextResponse.json({ error: 'Response not found' }, { status: 404 })
+  }
+
+  const responseStudentId = typeof responseRow.student_id === 'string' ? responseRow.student_id : ''
+  if (!responseStudentId) {
+    return NextResponse.json({ error: 'Response not found' }, { status: 404 })
+  }
+
+  const enrollmentValidation = await validateSelectedTestStudentEnrollment(
+    supabase,
+    access.test.classroom_id,
+    [responseStudentId]
+  )
+  if (!enrollmentValidation.ok) {
+    console.error('Error validating response student enrollment for AI suggest:', enrollmentValidation.error)
+    return NextResponse.json({ error: 'Failed to validate student enrollment' }, { status: 500 })
+  }
+  if (enrollmentValidation.missingStudentIds.length > 0) {
+    return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
   }
 
   const question = Array.isArray(responseRow.test_questions)

--- a/src/app/api/teacher/tests/[id]/responses/[responseId]/route.ts
+++ b/src/app/api/teacher/tests/[id]/responses/[responseId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { assertTeacherOwnsTest } from '@/lib/server/tests'
+import { assertTeacherOwnsTest, validateSelectedTestStudentEnrollment } from '@/lib/server/tests'
 import { withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
@@ -99,6 +99,7 @@ export const PATCH = withErrorHandler('GradeTeacherTestResponse', async (request
       id,
       test_id,
       question_id,
+      student_id,
       score,
       feedback,
       response_text,
@@ -114,6 +115,24 @@ export const PATCH = withErrorHandler('GradeTeacherTestResponse', async (request
 
   if (responseError || !responseRow) {
     return NextResponse.json({ error: 'Response not found' }, { status: 404 })
+  }
+
+  const responseStudentId = typeof responseRow.student_id === 'string' ? responseRow.student_id : ''
+  if (!responseStudentId) {
+    return NextResponse.json({ error: 'Response not found' }, { status: 404 })
+  }
+
+  const enrollmentValidation = await validateSelectedTestStudentEnrollment(
+    supabase,
+    access.test.classroom_id,
+    [responseStudentId]
+  )
+  if (!enrollmentValidation.ok) {
+    console.error('Error validating response student enrollment:', enrollmentValidation.error)
+    return NextResponse.json({ error: 'Failed to validate student enrollment' }, { status: 500 })
+  }
+  if (enrollmentValidation.missingStudentIds.length > 0) {
+    return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
   }
 
   const question = Array.isArray(responseRow.test_questions)
@@ -194,6 +213,7 @@ export const PATCH = withErrorHandler('GradeTeacherTestResponse', async (request
     .update(updatePayload)
     .eq('id', responseId)
     .eq('test_id', testId)
+    .eq('student_id', responseStudentId)
     .select('*')
     .single()
 

--- a/tests/api/teacher/tests-ai-suggest.test.ts
+++ b/tests/api/teacher/tests-ai-suggest.test.ts
@@ -2,6 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route'
 
+const {
+  mockAssertTeacherOwnsTest,
+  mockValidateSelectedTestStudentEnrollment,
+} = vi.hoisted(() => ({
+  mockAssertTeacherOwnsTest: vi.fn(),
+  mockValidateSelectedTestStudentEnrollment: vi.fn(),
+}))
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -15,15 +23,8 @@ vi.mock('@/lib/auth', () => ({
 }))
 
 vi.mock('@/lib/server/tests', () => ({
-  assertTeacherOwnsTest: vi.fn(async () => ({
-    ok: true,
-    test: {
-      id: 'test-1',
-      title: 'Unit Test',
-      classroom_id: 'classroom-1',
-      classrooms: { archived_at: null },
-    },
-  })),
+  assertTeacherOwnsTest: mockAssertTeacherOwnsTest,
+  validateSelectedTestStudentEnrollment: mockValidateSelectedTestStudentEnrollment,
 }))
 
 const getTestOpenResponseGradingModel = vi.fn(() => 'gpt-5-nano')
@@ -49,23 +50,23 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAssertTeacherOwnsTest.mockResolvedValue({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      },
+    })
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValue({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1']),
+      missingStudentIds: [],
+    })
   })
 
-  it('returns suggestion with grading metadata and uses answer_key context', async () => {
-    prepareTestOpenResponseGradingContext.mockResolvedValue({
-      model: 'gpt-5-nano',
-      grading_basis: 'teacher_key',
-      reference_answers: [],
-      reference_answers_source: 'teacher_key',
-    })
-    suggestTestOpenResponseGradeWithContext.mockResolvedValue({
-      score: 3.75,
-      feedback: 'Good foundation. Add membrane specifics.',
-      grading_basis: 'teacher_key',
-      reference_answers: [],
-      model: 'gpt-5-nano',
-    })
-
+  function setupResponseRow() {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table !== 'test_responses') {
         throw new Error(`Unexpected table: ${table}`)
@@ -78,6 +79,7 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
               id: 'response-1',
               test_id: 'test-1',
               question_id: 'question-1',
+              student_id: 'student-1',
               response_text: 'Water moves to balance concentration.',
               test_questions: {
                 id: 'question-1',
@@ -99,6 +101,24 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
         })),
       }
     })
+  }
+
+  it('returns suggestion with grading metadata and uses answer_key context', async () => {
+    prepareTestOpenResponseGradingContext.mockResolvedValue({
+      model: 'gpt-5-nano',
+      grading_basis: 'teacher_key',
+      reference_answers: [],
+      reference_answers_source: 'teacher_key',
+    })
+    suggestTestOpenResponseGradeWithContext.mockResolvedValue({
+      score: 3.75,
+      feedback: 'Good foundation. Add membrane specifics.',
+      grading_basis: 'teacher_key',
+      reference_answers: [],
+      model: 'gpt-5-nano',
+    })
+
+    setupResponseRow()
 
     const response = await POST(
       new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1/ai-suggest', {
@@ -109,6 +129,11 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(mockValidateSelectedTestStudentEnrollment).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+      ['student-1']
+    )
     expect(prepareTestOpenResponseGradingContext).toHaveBeenCalledWith(
       expect.objectContaining({
         answerKey: expect.stringContaining('semi-permeable membrane'),
@@ -124,5 +149,48 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
         model: 'gpt-5-nano',
       })
     )
+  })
+
+  it('rejects suggestions when the response student is no longer enrolled', async () => {
+    setupResponseRow()
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: true,
+      enrolledStudentIds: new Set(),
+      missingStudentIds: ['student-1'],
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1/ai-suggest', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ id: 'test-1', responseId: 'response-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Student is not enrolled in this classroom')
+    expect(prepareTestOpenResponseGradingContext).not.toHaveBeenCalled()
+    expect(suggestTestOpenResponseGradeWithContext).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when response student enrollment validation errors', async () => {
+    setupResponseRow()
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'boom' },
+    })
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1/ai-suggest', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ id: 'test-1', responseId: 'response-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to validate student enrollment')
+    expect(prepareTestOpenResponseGradingContext).not.toHaveBeenCalled()
+    expect(suggestTestOpenResponseGradeWithContext).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/teacher/tests-responses-grade.test.ts
+++ b/tests/api/teacher/tests-responses-grade.test.ts
@@ -2,6 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { PATCH } from '@/app/api/teacher/tests/[id]/responses/[responseId]/route'
 
+const {
+  mockAssertTeacherOwnsTest,
+  mockValidateSelectedTestStudentEnrollment,
+} = vi.hoisted(() => ({
+  mockAssertTeacherOwnsTest: vi.fn(),
+  mockValidateSelectedTestStudentEnrollment: vi.fn(),
+}))
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -15,15 +23,8 @@ vi.mock('@/lib/auth', () => ({
 }))
 
 vi.mock('@/lib/server/tests', () => ({
-  assertTeacherOwnsTest: vi.fn(async () => ({
-    ok: true,
-    test: {
-      id: 'test-1',
-      title: 'Unit Test',
-      classroom_id: 'classroom-1',
-      classrooms: { archived_at: null },
-    },
-  })),
+  assertTeacherOwnsTest: mockAssertTeacherOwnsTest,
+  validateSelectedTestStudentEnrollment: mockValidateSelectedTestStudentEnrollment,
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
@@ -31,6 +32,20 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAssertTeacherOwnsTest.mockResolvedValue({
+      ok: true,
+      test: {
+        id: 'test-1',
+        title: 'Unit Test',
+        classroom_id: 'classroom-1',
+        classrooms: { archived_at: null },
+      },
+    })
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValue({
+      ok: true,
+      enrolledStudentIds: new Set(['student-1']),
+      missingStudentIds: [],
+    })
   })
 
   function mockResponseRow(
@@ -41,6 +56,7 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
       id: 'response-1',
       test_id: 'test-1',
       question_id: 'question-1',
+      student_id: 'student-1',
       score: null,
       feedback: null,
       response_text: questionType === 'open_response' ? 'Water moves to balance concentration.' : null,
@@ -75,19 +91,23 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
     })
   }
 
-  it('persists AI grading metadata when saving a suggested grade', async () => {
-    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          select: vi.fn(() => ({
-            single: vi.fn().mockResolvedValue({
-              data: { id: 'response-1', ...payload },
-              error: null,
-            }),
-          })),
+  function createUpdateSpy() {
+    return vi.fn((payload: Record<string, unknown>) => {
+      const chain: any = {
+        eq: vi.fn(() => chain),
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'response-1', ...payload },
+            error: null,
+          }),
         })),
-      })),
-    }))
+      }
+      return chain
+    })
+  }
+
+  it('persists AI grading metadata when saving a suggested grade', async () => {
+    const updateSpy = createUpdateSpy()
 
     setupSupabase(updateSpy)
 
@@ -107,6 +127,11 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(mockValidateSelectedTestStudentEnrollment).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+      ['student-1']
+    )
     expect(updateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         score: 4,
@@ -116,22 +141,12 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
         ai_model: 'gpt-5-nano',
       })
     )
+    expect(updateSpy.mock.results[0]?.value.eq).toHaveBeenCalledWith('student_id', 'student-1')
     expect(data.response.ai_grading_basis).toBe('generated_reference')
   })
 
   it('allows saving a score without feedback', async () => {
-    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          select: vi.fn(() => ({
-            single: vi.fn().mockResolvedValue({
-              data: { id: 'response-1', ...payload },
-              error: null,
-            }),
-          })),
-        })),
-      })),
-    }))
+    const updateSpy = createUpdateSpy()
     setupSupabase(updateSpy)
 
     const response = await PATCH(
@@ -157,18 +172,7 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
   })
 
   it('clears score, feedback, and grading metadata', async () => {
-    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          select: vi.fn(() => ({
-            single: vi.fn().mockResolvedValue({
-              data: { id: 'response-1', ...payload },
-              error: null,
-            }),
-          })),
-        })),
-      })),
-    }))
+    const updateSpy = createUpdateSpy()
     setupSupabase(updateSpy)
 
     const response = await PATCH(
@@ -196,18 +200,7 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
   })
 
   it('allows manual score overrides for multiple-choice responses', async () => {
-    const updateSpy = vi.fn((payload: Record<string, unknown>) => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          select: vi.fn(() => ({
-            single: vi.fn().mockResolvedValue({
-              data: { id: 'response-1', ...payload },
-              error: null,
-            }),
-          })),
-        })),
-      })),
-    }))
+    const updateSpy = createUpdateSpy()
     setupSupabase(updateSpy, { questionType: 'multiple_choice', points: 2 })
 
     const response = await PATCH(
@@ -229,5 +222,54 @@ describe('PATCH /api/teacher/tests/[id]/responses/[responseId]', () => {
       })
     )
     expect(data.response.score).toBe(1.5)
+  })
+
+  it('rejects grading when the response student is no longer enrolled', async () => {
+    const updateSpy = createUpdateSpy()
+    setupSupabase(updateSpy)
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: true,
+      enrolledStudentIds: new Set(),
+      missingStudentIds: ['student-1'],
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          score: 3,
+        }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', responseId: 'response-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Student is not enrolled in this classroom')
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when response student enrollment validation errors', async () => {
+    const updateSpy = createUpdateSpy()
+    setupSupabase(updateSpy)
+    mockValidateSelectedTestStudentEnrollment.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'boom' },
+    })
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          score: 3,
+        }),
+      }),
+      { params: Promise.resolve({ id: 'test-1', responseId: 'response-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to validate student enrollment')
+    expect(updateSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Validate the response student remains enrolled before teacher response grade updates.
- Validate the response student remains enrolled before manual AI grade suggestions or reference-cache writes.
- Bind response grade updates to the validated `student_id` as well as the response and test ids.
- Add route regressions for stale response students and enrollment validation failures.

## Root cause
The response grading and AI-suggest routes authorized the teacher against the test and loaded the response by `responseId`, but did not prove that the response student was still enrolled in the test classroom before mutating grade data or running AI suggestions.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/tests-responses-grade.test.ts tests/api/teacher/tests-ai-suggest.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm run test:coverage`
- `pnpm build`
- `git diff --check`