### PR TITLE
[codex] Polish required submission highlights

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Blueprint bulk sync stale-id guards
-
-**Completed:**
-- Rejected unknown blueprint assignment, assessment, and lesson template update IDs before bulk sync computes deletions.
-- Rejected assessment updates outside the selected replacement type and rejected quiz/test type drift before deleting rows.
-- Added regression coverage proving stale IDs fail with 400s and do not call the delete builder.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/lib/server/course-blueprints.test.ts tests/api/teacher/course-blueprints-route.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-27 — Assignment student table scroll preservation
 
 **Completed:**
@@ -354,3 +339,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm run test:coverage`
 - `pnpm build`
 - `git diff --check`
+
+## 2026-05-27 — Required submission highlight polish
+
+**Completed:**
+- Removed the visible `R` marker from required-submission artifact pills in the teacher assignment student table.
+- Kept required artifact pills/cards blue without the primary outline treatment, including a stronger full-pill fill in the teacher student table.
+- Renamed the student work content section from `Submitted artifacts` to `Required submissions`.
+- Removed per-card `Required submission`/`Optional submission` labels from the content area and added dashed missing cards for unmet required submissions.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=4ff75b59-3189-4240-ac5a-dd3e750467bf&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
+- Screenshots reviewed: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-content.png`, `/tmp/pika-teacher-content-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-pr671-required-pill-table.png`

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -52,17 +52,6 @@ function getArtifactIconClassName(artifact: AssignmentArtifact) {
   ].join(' ')
 }
 
-function RequiredSubmissionMarker() {
-  return (
-    <span
-      aria-hidden="true"
-      className="rounded-[3px] border border-primary/30 px-0.5 text-[9px] font-semibold uppercase leading-3 text-primary"
-    >
-      R
-    </span>
-  )
-}
-
 function ArtifactTypeIcon({ artifact }: { artifact: AssignmentArtifact }) {
   const className = getArtifactIconClassName(artifact)
 
@@ -172,10 +161,10 @@ export function AssignmentArtifactsCell({
               const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
               const requiredLabel = isRequiredSubmission ? 'required submission ' : ''
               const pillClassName = [
-                'inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border px-1.5 text-xs font-medium hover:bg-surface-hover',
+                'inline-flex h-6 min-w-9 items-center justify-center gap-1 rounded-full border px-1.5 text-xs font-medium',
                 isRequiredSubmission
-                  ? 'border-primary/50 bg-info-bg text-primary'
-                  : 'border-border bg-surface-2 text-text-default',
+                  ? 'border-transparent bg-info-bg-hover text-primary hover:bg-info-bg-hover'
+                  : 'border-border bg-surface-2 text-text-default hover:bg-surface-hover',
               ].join(' ')
 
               return hasMultipleArtifacts ? (
@@ -187,7 +176,6 @@ export function AssignmentArtifactsCell({
                 >
                   <ArtifactTypeIcon artifact={artifact} />
                   <span>{index + 1}</span>
-                  {isRequiredSubmission ? <RequiredSubmissionMarker /> : null}
                 </button>
               ) : (
                 <a
@@ -200,7 +188,6 @@ export function AssignmentArtifactsCell({
                 >
                   <ArtifactTypeIcon artifact={artifact} />
                   <span>{index + 1}</span>
-                  {isRequiredSubmission ? <RequiredSubmissionMarker /> : null}
                 </a>
               )
             })()}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -8,7 +8,11 @@ import { RichTextViewer } from '@/components/editor'
 import { TeacherWorkInspector } from '@/components/assignment-workspace/TeacherWorkInspector'
 import { useTeacherStudentWorkController } from '@/components/assignment-workspace/useTeacherStudentWorkController'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
-import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
+import {
+  DEFAULT_REQUIREMENT_LABELS,
+  getSubmissionRequirementCompletion,
+  submissionArtifactsToAssignmentArtifacts,
+} from '@/lib/assignment-submission-requirements'
 import { summarizeArtifactUrl, type AssignmentArtifact } from '@/lib/assignment-artifacts'
 import {
   ASSIGNMENT_GRADING_LAYOUT,
@@ -19,6 +23,7 @@ import {
 } from '@/lib/assignment-grading-layout'
 import { countCharacters, isEmpty } from '@/lib/tiptap-content'
 import type { InspectorSectionId } from '@/components/assignment-workspace/types'
+import type { AssignmentSubmissionArtifact, AssignmentSubmissionRequirement } from '@/types'
 
 interface TeacherStudentWorkPanelProps {
   classroomId: string
@@ -53,9 +58,15 @@ export interface TeacherAssignmentGradeTemplate {
   gradeMode: 'draft' | 'graded'
 }
 
-function SubmittedArtifactsList({ artifacts }: { artifacts: AssignmentArtifact[] }) {
-  if (artifacts.length === 0) return null
-
+function RequiredSubmissionsList({
+  artifacts,
+  rawArtifacts,
+  requirements,
+}: {
+  artifacts: AssignmentArtifact[]
+  rawArtifacts: AssignmentSubmissionArtifact[]
+  requirements: AssignmentSubmissionRequirement[]
+}) {
   function getArtifactFallbackLabel(artifact: AssignmentArtifact) {
     if (artifact.type === 'repo') return 'Repo link'
     if (artifact.type === 'image') return 'Image'
@@ -72,14 +83,12 @@ function SubmittedArtifactsList({ artifacts }: { artifacts: AssignmentArtifact[]
     return artifact.title?.trim() || getArtifactFallbackLabel(artifact)
   }
 
-  function isRequiredSubmissionArtifact(artifact: AssignmentArtifact) {
-    return artifact.is_required_submission === true
+  function getRequirementTitle(requirement: AssignmentSubmissionRequirement) {
+    return requirement.label?.trim() || DEFAULT_REQUIREMENT_LABELS[requirement.type]
   }
 
-  function getSubmissionArtifactStatusLabel(artifact: AssignmentArtifact) {
-    if (isRequiredSubmissionArtifact(artifact)) return 'Required submission'
-    if (artifact.requirement_id) return 'Optional submission'
-    return null
+  function isRequiredSubmissionArtifact(artifact: AssignmentArtifact) {
+    return artifact.is_required_submission === true
   }
 
   function SubmittedArtifactIcon({ artifact }: { artifact: AssignmentArtifact }) {
@@ -92,62 +101,107 @@ function SubmittedArtifactsList({ artifacts }: { artifacts: AssignmentArtifact[]
     return <Link2 className={className} aria-hidden="true" />
   }
 
+  function RequirementIcon({ requirement }: { requirement: AssignmentSubmissionRequirement }) {
+    const className = 'h-4 w-4 text-text-muted'
+    if (requirement.type === 'repo_link') return <FolderGit2 className={className} aria-hidden="true" />
+    if (requirement.type === 'image') return <ImageIcon className={className} aria-hidden="true" />
+    return <Link2 className={className} aria-hidden="true" />
+  }
+
+  const completion = getSubmissionRequirementCompletion(requirements, rawArtifacts)
+  const artifactByRequirementId = new Map(
+    artifacts
+      .filter((artifact) => artifact.requirement_id)
+      .map((artifact) => [artifact.requirement_id, artifact] as const),
+  )
+  const renderedRequirementIds = new Set<string>()
+  const cards: ReactNode[] = completion.items.flatMap((item) => {
+    const artifact = artifactByRequirementId.get(item.requirement.id)
+    if (artifact) {
+      renderedRequirementIds.add(item.requirement.id)
+      return [renderSubmittedArtifactCard(artifact, item.requirement.id)]
+    }
+    if (!item.requirement.required) return []
+
+    renderedRequirementIds.add(item.requirement.id)
+    return [
+      <div
+        key={`missing:${item.requirement.id}`}
+        className="overflow-hidden rounded-md border border-dashed border-border-strong bg-surface"
+      >
+        <div className="flex min-w-0 items-start gap-2 px-3 py-2">
+          <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-dashed border-border-strong bg-surface-2">
+            <RequirementIcon requirement={item.requirement} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium text-text-default">
+              {getRequirementTitle(item.requirement)}
+            </div>
+            <div className="truncate text-xs text-text-muted">
+              Missing
+            </div>
+          </div>
+        </div>
+      </div>,
+    ]
+  })
+
+  for (const artifact of artifacts) {
+    if (artifact.requirement_id && renderedRequirementIds.has(artifact.requirement_id)) continue
+    cards.push(renderSubmittedArtifactCard(artifact, `${artifact.url}:${cards.length}`))
+  }
+
+  if (cards.length === 0) return null
+
+  function renderSubmittedArtifactCard(artifact: AssignmentArtifact, key: string) {
+    const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
+
+    return (
+      <a
+        key={key}
+        href={artifact.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={[
+          'group overflow-hidden rounded-md border hover:bg-surface-hover',
+          isRequiredSubmission ? 'border-transparent bg-info-bg' : 'border-border bg-surface-2',
+        ].join(' ')}
+      >
+        {artifact.type === 'image' ? (
+          <div
+            className="h-28 border-b border-border bg-surface bg-contain bg-center bg-no-repeat"
+            style={{ backgroundImage: `url("${encodeURI(artifact.url)}")` }}
+          />
+        ) : null}
+        <div className="flex min-w-0 items-start gap-2 px-3 py-2">
+          <span className={[
+            'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+            isRequiredSubmission
+              ? 'border-transparent bg-surface'
+              : 'border-border bg-surface',
+          ].join(' ')}>
+            <SubmittedArtifactIcon artifact={artifact} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium text-text-default">
+              {getArtifactTitle(artifact)}
+            </div>
+            <div className="truncate text-xs text-text-muted group-hover:text-text-default">
+              {getArtifactKindLabel(artifact)} . {summarizeArtifactUrl(artifact.url)}
+            </div>
+          </div>
+        </div>
+      </a>
+    )
+  }
+
   return (
     <div className="shrink-0 border-t border-border bg-surface px-4 py-3">
       <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
-        Submitted artifacts
+        Required submissions
       </h3>
       <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-        {artifacts.map((artifact, index) => {
-          const statusLabel = getSubmissionArtifactStatusLabel(artifact)
-          const isRequiredSubmission = isRequiredSubmissionArtifact(artifact)
-
-          return (
-            <a
-              key={`${artifact.url}:${index}`}
-              href={artifact.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={[
-                'group overflow-hidden rounded-md border bg-surface-2 hover:bg-surface-hover',
-                isRequiredSubmission ? 'border-primary/50' : 'border-border',
-              ].join(' ')}
-            >
-              {artifact.type === 'image' ? (
-                <div
-                  className="h-28 border-b border-border bg-surface bg-contain bg-center bg-no-repeat"
-                  style={{ backgroundImage: `url("${encodeURI(artifact.url)}")` }}
-                />
-              ) : null}
-              <div className="flex min-w-0 items-start gap-2 px-3 py-2">
-                <span className={[
-                  'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
-                  isRequiredSubmission
-                    ? 'border-primary/50 bg-info-bg'
-                    : 'border-border bg-surface',
-                ].join(' ')}>
-                  <SubmittedArtifactIcon artifact={artifact} />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-xs font-medium text-text-default">
-                    {getArtifactTitle(artifact)}
-                  </div>
-                  <div className="truncate text-xs text-text-muted group-hover:text-text-default">
-                    {getArtifactKindLabel(artifact)} . {summarizeArtifactUrl(artifact.url)}
-                  </div>
-                  {statusLabel ? (
-                    <div className={[
-                      'mt-1 text-[11px] font-medium',
-                      isRequiredSubmission ? 'text-primary' : 'text-text-muted',
-                    ].join(' ')}>
-                      {statusLabel}
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </a>
-          )
-        })}
+        {cards}
       </div>
     </div>
   )
@@ -351,11 +405,13 @@ export function TeacherStudentWorkPanel({
   }
 
   const displayContent = previewContent || data.doc?.content
+  const submissionRequirements = data.assignment.submission_requirements || []
+  const rawSubmissionArtifacts = data.submission_artifacts || []
   const submittedArtifacts = submissionArtifactsToAssignmentArtifacts(
-    data.submission_artifacts || [],
-    data.assignment.submission_requirements || [],
+    rawSubmissionArtifacts,
+    submissionRequirements,
   )
-  const hasSubmittedArtifacts = submittedArtifacts.length > 0
+  const hasRequiredSubmissionCards = submissionRequirements.length > 0 || submittedArtifacts.length > 0
   const inspector = (
     <TeacherWorkInspector
       data={data}
@@ -417,12 +473,16 @@ export function TeacherStudentWorkPanel({
       <div className="min-h-0 flex-1 overflow-auto">
         {displayContent && !isEmpty(displayContent) ? (
           <RichTextViewer content={displayContent} fillHeight chrome="flush" />
-        ) : !hasSubmittedArtifacts ? (
+        ) : !hasRequiredSubmissionCards ? (
           <div className="flex h-32 items-center justify-center text-text-muted">
             No work submitted yet
           </div>
         ) : null}
-        <SubmittedArtifactsList artifacts={submittedArtifacts} />
+        <RequiredSubmissionsList
+          artifacts={submittedArtifacts}
+          rawArtifacts={rawSubmissionArtifacts}
+          requirements={submissionRequirements}
+        />
       </div>
     </div>
   )

--- a/tests/components/AssignmentArtifactsCell.test.tsx
+++ b/tests/components/AssignmentArtifactsCell.test.tsx
@@ -88,9 +88,12 @@ describe('AssignmentArtifactsCell', () => {
       name: /^View work items; artifact 3 is Link/i,
     })
 
-    expect(within(publishedDemoButton).getByText('R')).toBeInTheDocument()
-    expect(within(sourceRepoButton).getByText('R')).toBeInTheDocument()
+    expect(within(publishedDemoButton).queryByText('R')).not.toBeInTheDocument()
+    expect(within(sourceRepoButton).queryByText('R')).not.toBeInTheDocument()
     expect(within(freeNoteButton).queryByText('R')).not.toBeInTheDocument()
+    expect(publishedDemoButton).toHaveClass('bg-info-bg-hover')
+    expect(sourceRepoButton).toHaveClass('bg-info-bg-hover')
+    expect(freeNoteButton).not.toHaveClass('bg-info-bg-hover')
     expect(freeNoteButton).not.toHaveAccessibleName(/required submission/i)
 
     fireEvent.click(publishedDemoButton)

--- a/tests/components/TeacherStudentWorkPanel.test.tsx
+++ b/tests/components/TeacherStudentWorkPanel.test.tsx
@@ -383,7 +383,7 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    expect(await screen.findByText('Submitted artifacts')).toBeInTheDocument()
+    expect(await screen.findByText('Required submissions')).toBeInTheDocument()
     expect(screen.getByText(/Link . demo.example.com/i)).toBeInTheDocument()
     expect(screen.queryByText('No work submitted yet')).not.toBeInTheDocument()
   })
@@ -497,16 +497,57 @@ describe('TeacherStudentWorkPanel', () => {
       />,
     )
 
-    expect(await screen.findByText('Submitted artifacts')).toBeInTheDocument()
+    expect(await screen.findByText('Required submissions')).toBeInTheDocument()
     expect(screen.getByText('Published demo')).toBeInTheDocument()
     expect(screen.getByText('Source repo')).toBeInTheDocument()
     expect(screen.getByText('Process screenshot')).toBeInTheDocument()
     expect(screen.getByText(/Link . demo.example.com/i)).toBeInTheDocument()
     expect(screen.getByText(/Repo . github.com\/codepetca\/pika/i)).toBeInTheDocument()
     expect(screen.getByText(/Image . cdn.example.com\/submission-images/i)).toBeInTheDocument()
-    expect(screen.getAllByText('Required submission')).toHaveLength(2)
-    expect(screen.getByText('Optional submission')).toBeInTheDocument()
+    expect(screen.queryByText('Required submission')).not.toBeInTheDocument()
+    expect(screen.queryByText('Optional submission')).not.toBeInTheDocument()
     expect(screen.queryByText('Public link')).not.toBeInTheDocument()
+  })
+
+  it('shows dashed cards for missing required submissions in student details', async () => {
+    mockFetchByStudent({
+      'student-1': {
+        graded: false,
+        emptyContent: true,
+        submissionRequirements: [
+          {
+            id: 'req-demo',
+            assignment_id: 'assignment-1',
+            type: 'link',
+            label: 'Published demo',
+            instructions: '',
+            required: true,
+            position: 0,
+            validation_policy_json: {},
+            created_at: '2026-02-20T12:00:00Z',
+            updated_at: '2026-02-20T12:00:00Z',
+          },
+        ],
+        submissionArtifacts: [],
+      },
+    })
+
+    render(
+      <TeacherStudentWorkPanel
+        classroomId="classroom-1"
+        assignmentId="assignment-1"
+        studentId="student-1"
+        mode="details"
+        inspectorCollapsed={false}
+        inspectorWidth={40}
+        totalWidth={1200}
+      />,
+    )
+
+    expect(await screen.findByText('Required submissions')).toBeInTheDocument()
+    expect(screen.getByText('Published demo')).toBeInTheDocument()
+    expect(screen.getByText('Missing')).toBeInTheDocument()
+    expect(screen.queryByText('No work submitted yet')).not.toBeInTheDocument()
   })
 
   it('uses edit-mode checkboxes to hide inspector cards outside edit mode', async () => {


### PR DESCRIPTION
## Summary

- Removes the visible `R` marker from required-submission artifacts in the teacher assignment student table.
- Keeps required-submission artifacts visually highlighted with a blue background, without the primary outline treatment.
- Renames the teacher content-pane artifact section to `Required submissions`, removes redundant per-card required/optional labels, and shows dashed placeholder cards for missing required submissions.

## Validation

- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
- `pnpm lint`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=4ff75b59-3189-4240-ac5a-dd3e750467bf&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
- Reviewed screenshots: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-content.png`, `/tmp/pika-teacher-content-mobile.png`, `/tmp/pika-student.png`

## Notes

This PR intentionally leaves accessible names that mention required submissions in the artifact table, while removing the visible `R` marker and redundant visible labels.