### PR TITLE
[codex] Guard test focus telemetry by student access

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Assignment student table scroll preservation
-
-**Completed:**
-- Preserved the teacher assignment student table scroll position across lower-row student selection, refresh loading, and row updates from grading/comment actions.
-- Prevented temporary assignment-detail loading states from overwriting the saved scroll position with a clamped `0`.
-- Added component regression coverage for refresh loading clamping the class-pane scroll upward.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/hooks/useScrollPositionMemory.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a'`
-- Teacher recapture after workspace load: `/tmp/pika-teacher.png`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — GitHub identity API coverage
 
 **Completed:**
@@ -355,3 +339,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=4ff75b59-3189-4240-ac5a-dd3e750467bf&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
 - Screenshots reviewed: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-content.png`, `/tmp/pika-teacher-content-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-pr671-required-pill-table.png`
+
+## 2026-05-27 — Test focus telemetry selected access validation
+
+**Completed:**
+- Added selected-student availability validation before student test focus telemetry response reads or inserts.
+- Blocked focus telemetry when a teacher has closed access for the selected student, while preserving legacy behavior if the availability table is absent.
+- Allowed focus telemetry when a student-specific open override applies to a globally closed test.
+- Added API regressions for selected access closure/open overrides, availability lookup failures, missing availability table fallback, and successful active telemetry logging.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/student/tests-focus-events.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm run test:coverage`
+- `pnpm build`
+- `git diff --check`

--- a/src/app/api/student/tests/[id]/focus-events/route.ts
+++ b/src/app/api/student/tests/[id]/focus-events/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { summarizeQuizFocusEvents } from '@/lib/quizzes'
-import { assertStudentCanAccessTest } from '@/lib/server/tests'
+import {
+  assertStudentCanAccessTest,
+  getEffectiveStudentTestAccess,
+  getTestStudentAvailabilityState,
+} from '@/lib/server/tests'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -51,13 +55,6 @@ export const POST = withErrorHandler('PostStudentTestFocusEvent', async (request
 
   const supabase = getServiceRoleClient()
 
-  if (test.status !== 'active') {
-    return NextResponse.json(
-      { error: 'Focus telemetry is only available while the test is active' },
-      { status: 400 }
-    )
-  }
-
   const { data: existingAttempt, error: existingAttemptError } = await supabase
     .from('test_attempts')
     .select('id, is_submitted')
@@ -74,6 +71,31 @@ export const POST = withErrorHandler('PostStudentTestFocusEvent', async (request
     return NextResponse.json(
       { error: 'Focus telemetry is only available before submitting the test' },
       { status: 400 }
+    )
+  }
+
+  const availabilityResult = await getTestStudentAvailabilityState(supabase, testId, user.id)
+  if (availabilityResult.error && !availabilityResult.missingTable) {
+    console.error('Error fetching student test access for focus event:', availabilityResult.error)
+    return NextResponse.json({ error: 'Failed to save focus event' }, { status: 500 })
+  }
+  const accessState = getEffectiveStudentTestAccess({
+    testStatus: test.status,
+    accessState: availabilityResult.state,
+    hasSubmitted: existingAttempt?.is_submitted === true,
+  })
+
+  if (!accessState.can_start_or_continue) {
+    if (accessState.access_source !== 'student') {
+      return NextResponse.json(
+        { error: 'Focus telemetry is only available while the test is active' },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json(
+      { error: 'Focus telemetry is only available while the test is open for you' },
+      { status: 403 }
     )
   }
 

--- a/tests/api/student/tests-focus-events.test.ts
+++ b/tests/api/student/tests-focus-events.test.ts
@@ -3,6 +3,11 @@ import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/student/tests/[id]/focus-events/route'
 import { mockAuthenticationError } from '../setup'
 
+const serverTestsMocks = vi.hoisted(() => ({
+  assertStudentCanAccessTest: vi.fn(),
+  getTestStudentAvailabilityState: vi.fn(),
+}))
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -15,29 +20,32 @@ vi.mock('@/lib/auth', () => ({
   })),
 }))
 
-vi.mock('@/lib/server/tests', () => ({
-  assertStudentCanAccessTest: vi.fn(async () => ({
-    ok: true,
-    test: {
-      id: 'test-1',
-      classroom_id: 'classroom-1',
-      status: 'active',
-      title: 'Unit Test',
-      show_results: false,
-      position: 0,
-      created_by: 'teacher-1',
-      created_at: '2026-01-01T00:00:00.000Z',
-      updated_at: '2026-01-01T00:00:00.000Z',
-      classrooms: {
-        id: 'classroom-1',
-        teacher_id: 'teacher-1',
-        archived_at: null,
-      },
-    },
-  })),
-}))
+vi.mock('@/lib/server/tests', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/server/tests')>('@/lib/server/tests')
+  return {
+    ...actual,
+    assertStudentCanAccessTest: serverTestsMocks.assertStudentCanAccessTest,
+    getTestStudentAvailabilityState: serverTestsMocks.getTestStudentAvailabilityState,
+  }
+})
 
 const mockSupabaseClient = { from: vi.fn() }
+const activeTest = {
+  id: 'test-1',
+  classroom_id: 'classroom-1',
+  status: 'active',
+  title: 'Unit Test',
+  show_results: false,
+  position: 0,
+  created_by: 'teacher-1',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  classrooms: {
+    id: 'classroom-1',
+    teacher_id: 'teacher-1',
+    archived_at: null,
+  },
+}
 
 function buildRequest(body: unknown) {
   return new NextRequest('http://localhost:3000/api/student/tests/test-1/focus-events', {
@@ -49,6 +57,15 @@ function buildRequest(body: unknown) {
 describe('POST /api/student/tests/[id]/focus-events', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    serverTestsMocks.assertStudentCanAccessTest.mockResolvedValue({
+      ok: true,
+      test: activeTest,
+    })
+    serverTestsMocks.getTestStudentAvailabilityState.mockResolvedValue({
+      state: null,
+      missingTable: false,
+      error: null,
+    })
   })
 
   it('returns 401 when unauthenticated', async () => {
@@ -66,6 +83,7 @@ describe('POST /api/student/tests/[id]/focus-events', () => {
 
   it('rejects logging when test is not active', async () => {
     const { assertStudentCanAccessTest } = await import('@/lib/server/tests')
+    const tables: string[] = []
     ;(assertStudentCanAccessTest as any).mockResolvedValueOnce({
       ok: true,
       test: {
@@ -75,6 +93,21 @@ describe('POST /api/student/tests/[id]/focus-events', () => {
         classrooms: { id: 'classroom-1', teacher_id: 'teacher-1', archived_at: null },
       },
     })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      tables.push(table)
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false },
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
 
     const response = await POST(buildRequest({ event_type: 'away_start', session_id: 's1' }), {
       params: Promise.resolve({ id: 'test-1' }),
@@ -83,6 +116,65 @@ describe('POST /api/student/tests/[id]/focus-events', () => {
 
     expect(response.status).toBe(400)
     expect(data.error).toContain('only available while the test is active')
+    expect(tables).toEqual(['test_attempts'])
+  })
+
+  it('logs event when selected-student access is open on a closed test', async () => {
+    const { assertStudentCanAccessTest } = await import('@/lib/server/tests')
+    ;(assertStudentCanAccessTest as any).mockResolvedValueOnce({
+      ok: true,
+      test: {
+        ...activeTest,
+        status: 'closed',
+      },
+    })
+    serverTestsMocks.getTestStudentAvailabilityState.mockResolvedValueOnce({
+      state: 'open',
+      missingTable: false,
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+      if (table === 'test_focus_events') {
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ event_type: 'away_start', occurred_at: '2026-02-24T12:00:00.000Z' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(buildRequest({ event_type: 'away_start', session_id: 's1' }), {
+      params: Promise.resolve({ id: 'test-1' }),
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
   })
 
   it('rejects logging after the student has already submitted', async () => {
@@ -108,6 +200,127 @@ describe('POST /api/student/tests/[id]/focus-events', () => {
 
     expect(response.status).toBe(400)
     expect(data.error).toContain('before submitting')
+  })
+
+  it('rejects logging when selected-student access is closed', async () => {
+    const tables: string[] = []
+    serverTestsMocks.getTestStudentAvailabilityState.mockResolvedValueOnce({
+      state: 'closed',
+      missingTable: false,
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      tables.push(table)
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false },
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(buildRequest({ event_type: 'away_start', session_id: 's1' }), {
+      params: Promise.resolve({ id: 'test-1' }),
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toContain('open for you')
+    expect(serverTestsMocks.getTestStudentAvailabilityState).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'test-1',
+      'student-1'
+    )
+    expect(tables).toEqual(['test_attempts'])
+  })
+
+  it('returns 500 when selected-student access validation fails', async () => {
+    const tables: string[] = []
+    serverTestsMocks.getTestStudentAvailabilityState.mockResolvedValueOnce({
+      state: null,
+      missingTable: false,
+      error: { message: 'availability lookup failed' },
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      tables.push(table)
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false },
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(buildRequest({ event_type: 'away_start', session_id: 's1' }), {
+      params: Promise.resolve({ id: 'test-1' }),
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to save focus event')
+    expect(tables).toEqual(['test_attempts'])
+  })
+
+  it('continues logging when the selected-student access table is missing', async () => {
+    serverTestsMocks.getTestStudentAvailabilityState.mockResolvedValueOnce({
+      state: null,
+      missingTable: true,
+      error: { code: 'PGRST205' },
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'attempt-1', is_submitted: false },
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+      if (table === 'test_focus_events') {
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ event_type: 'away_start', occurred_at: '2026-02-24T12:00:00.000Z' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await POST(buildRequest({ event_type: 'away_start', session_id: 's1' }), {
+      params: Promise.resolve({ id: 'test-1' }),
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
   })
 
   it('logs event successfully for active, unanswered test', async () => {


### PR DESCRIPTION
## Summary
- Validate selected-student test availability before student focus telemetry reads responses or writes focus events.
- Return a forbidden response when a teacher has closed test access for that student.
- Preserve legacy telemetry behavior when the selected-student availability table is missing during rollout.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/student/tests-focus-events.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm run test:coverage`
- `pnpm build`
- `git diff --check`
