### PR TITLE
Scope assignment list stats to enrollments

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — GitHub identity API coverage
-
-**Completed:**
-- Added focused API coverage for `GET/PATCH /api/account/github-identity`.
-- Covered auth failures, null/saved identity loads, username normalization and format rejection, validation outcome persistence, missing storage 503s, and unexpected save failures.
-- Asserted the Supabase upsert payload and `onConflict: 'user_id'` contract for saved GitHub identities.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/account/github-identity.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test tests/api/account/github-identity.test.ts tests/unit/api-route-standards.test.ts`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Archived gradebook mutation guards
 
 **Completed:**
@@ -355,4 +339,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm run test:coverage`
 - `pnpm build`
+- `git diff --check`
+
+## 2026-05-28 — Assignment list stats enrollment scoping
+
+**Completed:**
+- Scoped teacher assignment list stats to currently enrolled classroom students.
+- Reused `getClassroomStudentIds()` for paginated enrollment ids and total student count.
+- Bulk-loaded assignment docs by assignment ids and enrolled student ids, chunking large `.in()` filters to avoid oversized PostgREST URLs while preserving the `teacher_cleared_at` missing-column fallback.
+- Added regressions for withdrawn-student docs, large-roster chunking, fallback scoping, zero-enrollment stats, and enrollment lookup failures.
+
+**Validation:**
+- `pnpm vitest run tests/api/teacher/assignments.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test -- --runInBand`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import {
+  assertTeacherCanMutateClassroom,
+  assertTeacherOwnsClassroom,
+  getClassroomStudentIds,
+} from '@/lib/server/classrooms'
 import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { calculateAssignmentStats } from '@/lib/assignments'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -23,6 +27,91 @@ function isMissingClassworkMaterialPositionError(error: any) {
     message.includes('classwork_materials') ||
     (message.includes('position') && message.includes('schema cache'))
   )
+}
+
+type AssignmentStatsDocRow = {
+  assignment_id: string
+  student_id: string
+  is_submitted: boolean
+  submitted_at: string | null
+  returned_at: string | null
+  teacher_cleared_at: string | null
+}
+
+const ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE = 50
+const ASSIGNMENT_LIST_STATS_COLUMNS =
+  'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at'
+const ASSIGNMENT_LIST_STATS_FALLBACK_COLUMNS =
+  'assignment_id, student_id, is_submitted, submitted_at, returned_at'
+
+function chunkIds(ids: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+async function loadAssignmentDocsForListStats(
+  supabase: any,
+  assignmentIds: string[],
+  studentIds: string[]
+): Promise<{ docs: AssignmentStatsDocRow[]; error: any }> {
+  if (assignmentIds.length === 0 || studentIds.length === 0) {
+    return { docs: [], error: null }
+  }
+
+  const selectDocs = (columns: string, assignmentIdChunk: string[], studentIdChunk: string[]) =>
+    supabase
+      .from('assignment_docs')
+      .select(columns)
+      .in('assignment_id', assignmentIdChunk)
+      .in('student_id', studentIdChunk)
+
+  const docs: AssignmentStatsDocRow[] = []
+  let useMailboxTracking = true
+
+  for (const assignmentIdChunk of chunkIds(assignmentIds, ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      if (useMailboxTracking) {
+        const withMailboxTracking = await selectDocs(
+          ASSIGNMENT_LIST_STATS_COLUMNS,
+          assignmentIdChunk,
+          studentIdChunk
+        )
+
+        if (!withMailboxTracking.error) {
+          docs.push(...(withMailboxTracking.data || []))
+          continue
+        }
+
+        if (!isMissingAssignmentTeacherClearedAtColumnError(withMailboxTracking.error)) {
+          return { docs: [], error: withMailboxTracking.error }
+        }
+
+        useMailboxTracking = false
+      }
+
+      const fallback = await selectDocs(
+        ASSIGNMENT_LIST_STATS_FALLBACK_COLUMNS,
+        assignmentIdChunk,
+        studentIdChunk
+      )
+
+      if (fallback.error) {
+        return { docs: [], error: fallback.error }
+      }
+
+      docs.push(
+        ...(fallback.data || []).map((doc: Omit<AssignmentStatsDocRow, 'teacher_cleared_at'>) => ({
+          ...doc,
+          teacher_cleared_at: null,
+        }))
+      )
+    }
+  }
+
+  return { docs, error: null }
 }
 
 // GET /api/teacher/assignments?classroom_id=xxx - List assignments for a classroom
@@ -73,34 +162,43 @@ export const GET = withErrorHandler('GetTeacherAssignments', async (request, con
     assignments = withPosition.data
   }
 
-  const { count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('*', { count: 'exact', head: true })
-    .eq('classroom_id', classroomId)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, classroomId)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
+
+  const assignmentIds = (assignments || [])
+    .map((assignment) => assignment.id)
+    .filter((id): id is string => typeof id === 'string')
+
+  const { docs: assignmentDocs, error: assignmentDocsError } = await loadAssignmentDocsForListStats(
+    supabase,
+    assignmentIds,
+    classroomStudentsResult.studentIds
+  )
+
+  if (assignmentDocsError) {
+    console.error('Error fetching assignment doc stats:', assignmentDocsError)
+    return NextResponse.json({ error: 'Failed to fetch assignment stats' }, { status: 500 })
+  }
+
+  const docsByAssignmentId = new Map<string, AssignmentStatsDocRow[]>()
+  for (const doc of assignmentDocs) {
+    if (!classroomStudentsResult.studentIdSet.has(doc.student_id)) continue
+    if (!docsByAssignmentId.has(doc.assignment_id)) {
+      docsByAssignmentId.set(doc.assignment_id, [])
+    }
+    docsByAssignmentId.get(doc.assignment_id)!.push(doc)
+  }
 
   const assignmentsWithStats = await Promise.all(
     (assignments || []).map(async (assignment) => {
-      const withMailboxTracking = await supabase
-        .from('assignment_docs')
-        .select('is_submitted, submitted_at, returned_at, teacher_cleared_at')
-        .eq('assignment_id', assignment.id)
-
-      const docs =
-        withMailboxTracking.error && isMissingAssignmentTeacherClearedAtColumnError(withMailboxTracking.error)
-          ? (
-              (
-                await supabase
-                  .from('assignment_docs')
-                  .select('is_submitted, submitted_at, returned_at')
-                  .eq('assignment_id', assignment.id)
-              ).data || []
-            ).map((doc) => ({
-              ...doc,
-              teacher_cleared_at: null,
-            }))
-          : withMailboxTracking.data || []
-
-      const stats = calculateAssignmentStats(assignment.due_at, docs, totalStudents || 0)
+      const stats = calculateAssignmentStats(
+        assignment.due_at,
+        docsByAssignmentId.get(assignment.id) || [],
+        classroomStudentsResult.totalStudents
+      )
       const submissionRequirements = await loadAssignmentSubmissionRequirements(supabase, assignment.id)
 
       return {

--- a/tests/api/teacher/assignments.test.ts
+++ b/tests/api/teacher/assignments.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, POST } from '@/app/api/teacher/assignments/route'
 import { NextRequest } from 'next/server'
 
+const mockGetClassroomStudentIds = vi.hoisted(() => vi.fn())
+
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
 vi.mock('@/lib/server/classrooms', () => ({
@@ -17,12 +19,68 @@ vi.mock('@/lib/server/classrooms', () => ({
     ok: true,
     classroom: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
   })),
+  getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function buildEmptySubmissionRequirementsTable() {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+  }
+  return chain
+}
+
+function buildAssignmentDocsStatsTable(options: {
+  docs: Array<Record<string, any>>
+  firstError?: unknown
+  fallbackError?: unknown
+  inCalls?: Array<{ columns: string; column: string; values: string[] }>
+}) {
+  return {
+    select: vi.fn((columns: string) => {
+      let selectedAssignmentIds: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          options.inCalls?.push({ columns, column, values })
+          if (column === 'assignment_id') {
+            selectedAssignmentIds = values
+            return query
+          }
+          if (column === 'student_id') {
+            if (columns.includes('teacher_cleared_at') && options.firstError) {
+              return Promise.resolve({ data: null, error: options.firstError })
+            }
+
+            const rows = options.docs.filter(
+              (doc) => selectedAssignmentIds.includes(doc.assignment_id) && values.includes(doc.student_id)
+            )
+            return Promise.resolve({
+              data: rows,
+              error: columns.includes('teacher_cleared_at') ? null : options.fallbackError ?? null,
+            })
+          }
+          return query
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/assignments', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetClassroomStudentIds.mockResolvedValue({
+      studentIds: ['student-1', 'student-2'],
+      studentIdSet: new Set(['student-1', 'student-2']),
+      totalStudents: 2,
+      error: null,
+    })
+  })
 
   it('should return 400 when classroom_id is missing', async () => {
     const request = new NextRequest('http://localhost:3000/api/teacher/assignments')
@@ -53,12 +111,6 @@ describe('GET /api/teacher/assignments', () => {
             })),
           })),
         }
-      } else if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
-          })),
-        }
       }
     })
     ;(mockSupabaseClient.from as any) = mockFrom
@@ -69,32 +121,56 @@ describe('GET /api/teacher/assignments', () => {
   })
 
   it('counts only submissions that still need to be returned', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: ['student-1', 'student-2', 'student-3', 'student-4'],
+      studentIdSet: new Set(['student-1', 'student-2', 'student-3', 'student-4']),
+      totalStudents: 4,
+      error: null,
+    })
+
     const docs = [
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
         is_submitted: true,
         submitted_at: '2026-03-13T10:00:00.000Z',
         returned_at: null,
         teacher_cleared_at: null,
       },
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-2',
         is_submitted: true,
         submitted_at: '2026-03-13T11:00:00.000Z',
         returned_at: null,
         teacher_cleared_at: '2026-03-13T12:00:00.000Z',
       },
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-3',
         is_submitted: true,
         submitted_at: '2026-03-15T10:00:00.000Z',
         returned_at: null,
         teacher_cleared_at: '2026-03-14T08:00:00.000Z',
       },
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-4',
         is_submitted: false,
         submitted_at: '2026-03-16T10:00:00.000Z',
         returned_at: '2026-03-17T08:00:00.000Z',
         teacher_cleared_at: '2026-03-17T08:00:00.000Z',
       },
+      {
+        assignment_id: 'assignment-1',
+        student_id: 'withdrawn-student',
+        is_submitted: true,
+        submitted_at: '2026-03-16T12:00:00.000Z',
+        returned_at: null,
+        teacher_cleared_at: null,
+      },
     ]
+    const assignmentDocInCalls: Array<{ columns: string; column: string; values: string[] }> = []
 
     const mockFrom = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -124,20 +200,12 @@ describe('GET /api/teacher/assignments', () => {
         }
       }
 
-      if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ count: 31, error: null }),
-          })),
-        }
+      if (table === 'assignment_docs') {
+        return buildAssignmentDocsStatsTable({ docs, inCalls: assignmentDocInCalls })
       }
 
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ data: docs, error: null }),
-          })),
-        }
+      if (table === 'assignment_submission_requirements') {
+        return buildEmptySubmissionRequirementsTable()
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -151,26 +219,149 @@ describe('GET /api/teacher/assignments', () => {
     expect(response.status).toBe(200)
     expect(data.assignments).toHaveLength(1)
     expect(data.assignments[0].stats).toEqual({
-      total_students: 31,
+      total_students: 4,
       submitted: 2,
       late: 2,
     })
+    expect(assignmentDocInCalls).toContainEqual({
+      columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+      column: 'assignment_id',
+      values: ['assignment-1'],
+    })
+    expect(assignmentDocInCalls).toContainEqual({
+      columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+      column: 'student_id',
+      values: ['student-1', 'student-2', 'student-3', 'student-4'],
+    })
+  })
+
+  it('chunks assignment doc stats filters for large rosters and assignment lists', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const assignmentRows = Array.from({ length: 51 }, (_, index) => ({
+      id: `assignment-${index + 1}`,
+      classroom_id: 'c1',
+      title: `Essay Draft ${index + 1}`,
+      description: '',
+      instructions_markdown: null,
+      rich_instructions: null,
+      due_at: '2026-03-14T23:59:59.000Z',
+    }))
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds,
+      studentIdSet: new Set(studentIds),
+      totalStudents: studentIds.length,
+      error: null,
+    })
+
+    const docs = [
+      {
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
+        is_submitted: true,
+        submitted_at: '2026-03-13T10:00:00.000Z',
+        returned_at: null,
+        teacher_cleared_at: null,
+      },
+      {
+        assignment_id: 'assignment-51',
+        student_id: 'student-51',
+        is_submitted: true,
+        submitted_at: '2026-03-13T11:00:00.000Z',
+        returned_at: null,
+        teacher_cleared_at: null,
+      },
+    ]
+    const assignmentDocInCalls: Array<{ columns: string; column: string; values: string[] }> = []
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        const builder: any = {}
+        builder.order = vi
+          .fn()
+          .mockImplementationOnce(() => builder)
+          .mockResolvedValue({ data: assignmentRows, error: null })
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: builder.order,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return buildAssignmentDocsStatsTable({ docs, inCalls: assignmentDocInCalls })
+      }
+
+      if (table === 'assignment_submission_requirements') {
+        return buildEmptySubmissionRequirementsTable()
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments?classroom_id=c1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    const statsByAssignmentId = new Map(
+      data.assignments.map((assignment: { id: string; stats: unknown }) => [assignment.id, assignment.stats])
+    )
+    expect(statsByAssignmentId.get('assignment-1')).toEqual({
+      total_students: 51,
+      submitted: 1,
+      late: 0,
+    })
+    expect(statsByAssignmentId.get('assignment-2')).toEqual({
+      total_students: 51,
+      submitted: 0,
+      late: 0,
+    })
+    expect(statsByAssignmentId.get('assignment-51')).toEqual({
+      total_students: 51,
+      submitted: 1,
+      late: 0,
+    })
+
+    const assignmentFilterCalls = assignmentDocInCalls.filter((call) => call.column === 'assignment_id')
+    const studentFilterCalls = assignmentDocInCalls.filter((call) => call.column === 'student_id')
+    expect(assignmentFilterCalls.map((call) => call.values.length)).toEqual([50, 50, 1, 1])
+    expect(studentFilterCalls.map((call) => call.values.length)).toEqual([50, 1, 50, 1])
+    expect(new Set(assignmentFilterCalls.flatMap((call) => call.values))).toEqual(
+      new Set(assignmentRows.map((assignment) => assignment.id))
+    )
+    expect(new Set(studentFilterCalls.flatMap((call) => call.values))).toEqual(new Set(studentIds))
   })
 
   it('falls back only to returned_at when teacher_cleared_at is missing', async () => {
     const docs = [
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-1',
         is_submitted: true,
         submitted_at: '2026-03-23T16:27:46.54+00:00',
         returned_at: '2026-03-25T16:27:46.54+00:00',
       },
       {
+        assignment_id: 'assignment-1',
+        student_id: 'student-2',
         is_submitted: true,
         submitted_at: '2026-03-25T16:27:46.54+00:00',
         returned_at: null,
         feedback_returned_at: '2026-03-26T16:27:46.54+00:00',
       },
+      {
+        assignment_id: 'assignment-1',
+        student_id: 'withdrawn-student',
+        is_submitted: true,
+        submitted_at: '2026-03-26T16:27:46.54+00:00',
+        returned_at: null,
+      },
     ]
+    const assignmentDocInCalls: Array<{ columns: string; column: string; values: string[] }> = []
 
     const mockFrom = vi.fn((table: string) => {
       if (table === 'assignments') {
@@ -200,24 +391,16 @@ describe('GET /api/teacher/assignments', () => {
         }
       }
 
-      if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ count: 2, error: null }),
-          })),
-        }
+      if (table === 'assignment_docs') {
+        return buildAssignmentDocsStatsTable({
+          docs,
+          firstError: { code: '42703', message: "column assignment_docs.teacher_cleared_at does not exist" },
+          inCalls: assignmentDocInCalls,
+        })
       }
 
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn((columns: string) => ({
-            eq: vi.fn().mockResolvedValue(
-              columns.includes('teacher_cleared_at')
-                ? { data: null, error: { code: '42703', message: "column assignment_docs.teacher_cleared_at does not exist" } }
-                : { data: docs, error: null }
-            ),
-          })),
-        }
+      if (table === 'assignment_submission_requirements') {
+        return buildEmptySubmissionRequirementsTable()
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -234,6 +417,107 @@ describe('GET /api/teacher/assignments', () => {
       submitted: 1,
       late: 1,
     })
+    expect(assignmentDocInCalls.filter((call) => call.column === 'student_id')).toHaveLength(2)
+    expect(assignmentDocInCalls).toContainEqual({
+      columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at',
+      column: 'student_id',
+      values: ['student-1', 'student-2'],
+    })
+  })
+
+  it('returns zero stats without reading assignment docs when no students are enrolled', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: null,
+    })
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        const assignmentRows = [
+          {
+            id: 'assignment-1',
+            classroom_id: 'c1',
+            title: 'Essay Draft',
+            description: '',
+            instructions_markdown: null,
+            rich_instructions: null,
+            due_at: '2026-03-24T23:59:59.000Z',
+          },
+        ]
+        const builder: any = {}
+        builder.order = vi
+          .fn()
+          .mockImplementationOnce(() => builder)
+          .mockResolvedValue({ data: assignmentRows, error: null })
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: builder.order,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_submission_requirements') {
+        return buildEmptySubmissionRequirementsTable()
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments?classroom_id=c1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.assignments[0].stats).toEqual({
+      total_students: 0,
+      submitted: 0,
+      late: 0,
+    })
+    expect(mockFrom).not.toHaveBeenCalledWith('assignment_docs')
+  })
+
+  it('returns 500 when classroom enrollment stats fail', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: { message: 'database unavailable' },
+    })
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        const builder: any = {}
+        builder.order = vi
+          .fn()
+          .mockImplementationOnce(() => builder)
+          .mockResolvedValue({ data: [], error: null })
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: builder.order,
+            })),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments?classroom_id=c1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to fetch classroom enrollments')
+    expect(mockFrom).not.toHaveBeenCalledWith('assignment_docs')
   })
 })
 


### PR DESCRIPTION
## Summary
- Scope teacher assignment list stats to current classroom enrollments using getClassroomStudentIds
- Bulk-load assignment docs for all listed assignments and enrolled students instead of reading docs per assignment
- Preserve the teacher_cleared_at missing-column fallback and add regressions for stale docs, zero enrollment, and enrollment failures

## Validation
- pnpm vitest run tests/api/teacher/assignments.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test -- --runInBand
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check