### PR TITLE
[codex] Scope test list stats to enrollments

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Archived gradebook mutation guards
-
-**Completed:**
-- Blocked gradebook assessment-weight PATCH requests when the classroom is archived while preserving read access.
-- Blocked manual quiz override writes for archived classrooms by loading `archived_at` through the joined classroom relation.
-- Added API regression coverage proving both archived paths return 403 before update/upsert work.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/gradebook.test.ts tests/api/teacher/gradebook-quiz-overrides.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Assignment duplicate-submit timestamp guard
 
 **Completed:**
@@ -354,6 +339,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm test -- --runInBand`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`
+
+## 2026-05-28 — Test list stats enrollment scoping
+
+**Completed:**
+- Scoped teacher test list respondent, submission, and availability stats to paginated current classroom enrollments.
+- Added chunked stats loaders for test questions, attempts, responses, availability overrides, and draft overlays to avoid oversized Supabase `.in()` filters on large test lists or rosters.
+- Returned a clear 500 when classroom enrollment loading fails instead of reporting empty stats.
+- Applied assessment draft overlays only to draft tests so active/closed list rows match canonical test metadata.
+- Added regressions for enrollment failures, current-enrollment scoping, 51x51 chunking, and stale draft overlays.
+
+**Validation:**
+- `pnpm vitest run tests/api/teacher/tests-route.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { assertTeacherCanMutateClassroom, assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
+import {
+  assertTeacherCanMutateClassroom,
+  assertTeacherOwnsClassroom,
+  getClassroomStudentIds,
+} from '@/lib/server/classrooms'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import {
@@ -21,6 +25,131 @@ import type { TestStudentAvailabilityState } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+type TestAttemptStatsRow = {
+  test_id: string
+  student_id: string
+  is_submitted: boolean
+}
+
+type TestQuestionStatsRow = {
+  test_id: string
+}
+
+type TestResponseStatsRow = {
+  test_id: string
+  student_id: string
+  selected_option: unknown
+  response_text: unknown
+}
+
+type TestAvailabilityStatsRow = {
+  test_id: string
+  student_id: string
+  state: unknown
+}
+
+const TEST_LIST_STATS_FILTER_CHUNK_SIZE = 50
+
+function chunkIds(ids: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+async function loadStudentScopedTestRows<T>(
+  supabase: any,
+  options: {
+    table: string
+    columns: string
+    testIds: string[]
+    studentIds: string[]
+  }
+): Promise<{ rows: T[]; error: any }> {
+  const { table, columns, testIds, studentIds } = options
+  if (testIds.length === 0 || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: T[] = []
+  for (const testIdChunk of chunkIds(testIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      const { data, error } = await supabase
+        .from(table)
+        .select(columns)
+        .in('test_id', testIdChunk)
+        .in('student_id', studentIdChunk)
+
+      if (error) {
+        return { rows: [], error }
+      }
+
+      rows.push(...((data || []) as T[]))
+    }
+  }
+
+  return { rows, error: null }
+}
+
+async function loadTestQuestionRows(
+  supabase: any,
+  testIds: string[]
+): Promise<{ rows: TestQuestionStatsRow[]; error: any }> {
+  if (testIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: TestQuestionStatsRow[] = []
+  for (const testIdChunk of chunkIds(testIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    const { data, error } = await supabase
+      .from('test_questions')
+      .select('test_id')
+      .in('test_id', testIdChunk)
+
+    if (error) {
+      return { rows: [], error }
+    }
+
+    rows.push(...((data || []) as TestQuestionStatsRow[]))
+  }
+
+  return { rows, error: null }
+}
+
+async function loadTestAvailabilityRows(
+  supabase: any,
+  testIds: string[],
+  studentIds: string[]
+): Promise<{ rows: TestAvailabilityStatsRow[]; error: any }> {
+  if (testIds.length === 0 || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: TestAvailabilityStatsRow[] = []
+  for (const testIdChunk of chunkIds(testIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      try {
+        const result = await supabase
+          .from('test_student_availability')
+          .select('test_id, student_id, state')
+          .in('test_id', testIdChunk)
+          .in('student_id', studentIdChunk)
+
+        if (result.error) {
+          return { rows: [], error: result.error }
+        }
+
+        rows.push(...((result.data || []) as TestAvailabilityStatsRow[]))
+      } catch (error) {
+        return { rows: [], error }
+      }
+    }
+  }
+
+  return { rows, error: null }
+}
 
 // GET /api/teacher/tests?classroom_id=xxx - List tests for a classroom
 export const GET = withErrorHandler('GetTeacherTests', async (request) => {
@@ -60,20 +189,23 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
   }
 
-  const { data: enrollmentRows, count: totalStudents } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id', { count: 'exact' })
-    .eq('classroom_id', classroomId)
-  const enrolledStudentIds = new Set((enrollmentRows || []).map((row) => row.student_id))
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, classroomId)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
+    return NextResponse.json({ error: 'Failed to fetch classroom enrollments' }, { status: 500 })
+  }
 
   const testIds = (tests || []).map((t) => t.id)
+  const enrolledStudentIdList = classroomStudentsResult.studentIds
 
   const questionCountMap: Record<string, number> = {}
   if (testIds.length > 0) {
-    const { data: questionRows } = await supabase
-      .from('test_questions')
-      .select('test_id')
-      .in('test_id', testIds)
+    const { rows: questionRows, error: questionRowsError } = await loadTestQuestionRows(supabase, testIds)
+
+    if (questionRowsError) {
+      console.error('Error fetching test question stats:', questionRowsError)
+      return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
+    }
 
     for (const row of questionRows || []) {
       questionCountMap[row.test_id] = (questionCountMap[row.test_id] || 0) + 1
@@ -82,14 +214,19 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
   const respondentCountMap: Record<string, number> = {}
   const submittedCountMap: Record<string, number> = {}
-  if (testIds.length > 0) {
+  if (testIds.length > 0 && enrolledStudentIdList.length > 0) {
     const seen: Record<string, Set<string>> = {}
     const submittedSeen: Record<string, Set<string>> = {}
 
-    const { data: attemptRows, error: attemptRowsError } = await supabase
-      .from('test_attempts')
-      .select('test_id, student_id, is_submitted')
-      .in('test_id', testIds)
+    const {
+      rows: attemptRows,
+      error: attemptRowsError,
+    } = await loadStudentScopedTestRows<TestAttemptStatsRow>(supabase, {
+      table: 'test_attempts',
+      columns: 'test_id, student_id, is_submitted',
+      testIds,
+      studentIds: enrolledStudentIdList,
+    })
 
     if (attemptRowsError && attemptRowsError.code !== 'PGRST205') {
       console.error('Error fetching test attempts:', attemptRowsError)
@@ -98,17 +235,22 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
     for (const row of attemptRows || []) {
       if (!row.is_submitted) continue
-      if (!enrolledStudentIds.has(row.student_id)) continue
+      if (!classroomStudentsResult.studentIdSet.has(row.student_id)) continue
       if (!seen[row.test_id]) seen[row.test_id] = new Set()
       seen[row.test_id].add(row.student_id)
       if (!submittedSeen[row.test_id]) submittedSeen[row.test_id] = new Set()
       submittedSeen[row.test_id].add(row.student_id)
     }
 
-    const { data: responseRows, error: responseRowsError } = await supabase
-      .from('test_responses')
-      .select('test_id, student_id, selected_option, response_text')
-      .in('test_id', testIds)
+    const {
+      rows: responseRows,
+      error: responseRowsError,
+    } = await loadStudentScopedTestRows<TestResponseStatsRow>(supabase, {
+      table: 'test_responses',
+      columns: 'test_id, student_id, selected_option, response_text',
+      testIds,
+      studentIds: enrolledStudentIdList,
+    })
 
     if (responseRowsError) {
       console.error('Error fetching test responses:', responseRowsError)
@@ -117,7 +259,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
     for (const row of responseRows || []) {
       if (!hasMeaningfulTestResponse(row)) continue
-      if (!enrolledStudentIds.has(row.student_id)) continue
+      if (!classroomStudentsResult.studentIdSet.has(row.student_id)) continue
       if (!seen[row.test_id]) seen[row.test_id] = new Set()
       seen[row.test_id].add(row.student_id)
     }
@@ -130,22 +272,11 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
   }
 
   const availabilityByTestId = new Map<string, Map<string, TestStudentAvailabilityState>>()
-  const enrolledStudentIdList = Array.from(enrolledStudentIds)
   if (testIds.length > 0 && enrolledStudentIdList.length > 0) {
-    let availabilityRows: Array<{ test_id: string; student_id: string; state: unknown }> | null = null
-    let availabilityError: any = null
-
-    try {
-      const result = await supabase
-        .from('test_student_availability')
-        .select('test_id, student_id, state')
-        .in('test_id', testIds)
-        .in('student_id', enrolledStudentIdList)
-      availabilityRows = result.data
-      availabilityError = result.error
-    } catch (error) {
-      availabilityError = error
-    }
+    const {
+      rows: availabilityRows,
+      error: availabilityError,
+    } = await loadTestAvailabilityRows(supabase, testIds, enrolledStudentIdList)
 
     const isMissingAvailabilityTable =
       isMissingTestStudentAvailabilityError(availabilityError) ||
@@ -166,31 +297,34 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
   const draftByTestId: Record<string, TestDraftContent> = {}
   if (testIds.length > 0) {
-    try {
-      const { data: draftRows, error: draftError } = await supabase
-        .from('assessment_drafts')
-        .select('assessment_id, content')
-        .eq('assessment_type', 'test')
-        .in('assessment_id', testIds)
+    for (const testIdChunk of chunkIds(testIds, TEST_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      try {
+        const { data: draftRows, error: draftError } = await supabase
+          .from('assessment_drafts')
+          .select('assessment_id, content')
+          .eq('assessment_type', 'test')
+          .in('assessment_id', testIdChunk)
 
-      if (draftError && !isMissingAssessmentDraftsError(draftError)) {
-        console.error('Error fetching test draft overlays:', draftError)
-      }
+        if (draftError && !isMissingAssessmentDraftsError(draftError)) {
+          console.error('Error fetching test draft overlays:', draftError)
+        }
 
-      for (const row of draftRows || []) {
-        const parsed = validateTestDraftContent(row.content, {
-          allowEmptyQuestionText: true,
-        })
-        if (!parsed.valid) continue
-        draftByTestId[row.assessment_id] = parsed.value
+        for (const row of draftRows || []) {
+          const parsed = validateTestDraftContent(row.content, {
+            allowEmptyQuestionText: true,
+          })
+          if (!parsed.valid) continue
+          draftByTestId[row.assessment_id] = parsed.value
+        }
+      } catch {
+        // Older test mocks may not implement this table query yet.
       }
-    } catch {
-      // Older test mocks may not implement this table query yet.
     }
   }
 
   const testsWithStats = (tests || []).map((test) => {
-    const totalStudentCount = totalStudents || 0
+    const totalStudentCount = classroomStudentsResult.totalStudents
+    const draft = test.status === 'draft' ? draftByTestId[test.id] : undefined
     let openAccessCount = 0
     let closedAccessCount = 0
 
@@ -214,8 +348,8 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
     return {
       ...test,
-      title: draftByTestId[test.id]?.title ?? test.title,
-      show_results: draftByTestId[test.id]?.show_results ?? test.show_results,
+      title: draft?.title ?? test.title,
+      show_results: draft?.show_results ?? test.show_results,
       assessment_type: 'test' as const,
       documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
       stats: {
@@ -224,7 +358,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
         submitted: submittedCountMap[test.id] || 0,
         open_access: openAccessCount,
         closed_access: closedAccessCount,
-        questions_count: (draftByTestId[test.id]?.questions.length ?? questionCountMap[test.id]) || 0,
+        questions_count: (draft?.questions.length ?? questionCountMap[test.id]) || 0,
       },
     }
   })

--- a/tests/api/teacher/tests-route.test.ts
+++ b/tests/api/teacher/tests-route.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { GET, POST } from '@/app/api/teacher/tests/route'
 
+const mockGetClassroomStudentIds = vi.hoisted(() => vi.fn())
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -23,13 +25,94 @@ vi.mock('@/lib/server/classrooms', () => ({
     ok: true,
     classroom: { id: 'classroom-1', teacher_id: 'teacher-1' },
   })),
+  getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
 
+function buildStudentScopedStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => {
+      let selectedTestIds: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          options.inCalls?.push({ table: options.table, column, values })
+          if (column === 'test_id') {
+            selectedTestIds = values
+            return query
+          }
+          if (column === 'student_id') {
+            if (options.error) {
+              return Promise.resolve({ data: null, error: options.error })
+            }
+            return Promise.resolve({
+              data: options.rows.filter(
+                (row) => selectedTestIds.includes(row.test_id) && values.includes(row.student_id)
+              ),
+              error: null,
+            })
+          }
+          return query
+        }),
+      }
+      return query
+    }),
+  }
+}
+
+function buildTestIdStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  filterColumn?: string
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => ({
+      in: vi.fn((column: string, values: string[]) => {
+        options.inCalls?.push({ table: options.table, column, values })
+        if (options.error) {
+          return Promise.resolve({ data: null, error: options.error })
+        }
+        const filterColumn = options.filterColumn ?? column
+        return Promise.resolve({
+          data: options.rows.filter((row) => values.includes(row[filterColumn])),
+          error: null,
+        })
+      }),
+    })),
+  }
+}
+
+function buildAssessmentDraftRows(rows: Array<{ assessment_id: string; content: Record<string, unknown> }>) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn((_column: string, values: string[]) =>
+          Promise.resolve({
+            data: rows.filter((row) => values.includes(row.assessment_id)),
+            error: null,
+          })
+        ),
+      })),
+    })),
+  }
+}
+
 describe('GET /api/teacher/tests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetClassroomStudentIds.mockResolvedValue({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: null,
+    })
   })
 
   it('requests tests in descending position order with a descending created_at tie-breaker', async () => {
@@ -106,6 +189,13 @@ describe('GET /api/teacher/tests', () => {
   })
 
   it('returns 500 when reading test responses fails', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: ['student-1'],
+      studentIdSet: new Set(['student-1']),
+      totalStudents: 10,
+      error: null,
+    })
+
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'tests') {
         return {
@@ -139,25 +229,18 @@ describe('GET /api/teacher/tests', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ test_id: 'test-1', student_id: 'student-1', is_submitted: true }],
-              error: null,
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({
+          table,
+          rows: [{ test_id: 'test-1', student_id: 'student-1', is_submitted: true }],
+        })
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: null,
-              error: { message: 'Database error' },
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({
+          table,
+          rows: [],
+          error: { message: 'Database error' },
+        })
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -172,7 +255,50 @@ describe('GET /api/teacher/tests', () => {
     expect(data.error).toBe('Failed to fetch tests')
   })
 
+  it('returns 500 when reading classroom enrollments fails', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: { message: 'enrollment read failed' },
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: [{ id: 'test-1', classroom_id: 'classroom-1', title: 'T1', position: 0 }],
+                error: null,
+              })
+            ),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Failed to fetch classroom enrollments')
+  })
+
   it('does not count placeholder graded rows as respondents', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: ['student-1'],
+      studentIdSet: new Set(['student-1']),
+      totalStudents: 10,
+      error: null,
+    })
+
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'tests') {
         return {
@@ -206,32 +332,21 @@ describe('GET /api/teacher/tests', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({ table, rows: [] })
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  test_id: 'test-1',
-                  student_id: 'student-1',
-                  selected_option: null,
-                  response_text: '   ',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({
+          table,
+          rows: [
+            {
+              test_id: 'test-1',
+              student_id: 'student-1',
+              selected_option: null,
+              response_text: '   ',
+            },
+          ],
+        })
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -248,6 +363,14 @@ describe('GET /api/teacher/tests', () => {
   })
 
   it('counts only currently enrolled students as respondents', async () => {
+    const scopedInCalls: Array<{ table: string; column: string; values: string[] }> = []
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: ['student-1', 'student-2'],
+      studentIdSet: new Set(['student-1', 'student-2']),
+      totalStudents: 2,
+      error: null,
+    })
+
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'tests') {
         return {
@@ -285,41 +408,35 @@ describe('GET /api/teacher/tests', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                { test_id: 'test-1', student_id: 'student-1', is_submitted: true },
-                { test_id: 'test-1', student_id: 'student-3', is_submitted: true },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({
+          table,
+          inCalls: scopedInCalls,
+          rows: [
+            { test_id: 'test-1', student_id: 'student-1', is_submitted: true },
+            { test_id: 'test-1', student_id: 'student-3', is_submitted: true },
+          ],
+        })
       }
 
       if (table === 'test_responses') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  test_id: 'test-1',
-                  student_id: 'student-2',
-                  selected_option: 0,
-                  response_text: null,
-                },
-                {
-                  test_id: 'test-1',
-                  student_id: 'student-4',
-                  selected_option: 1,
-                  response_text: null,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return buildStudentScopedStatsTable({
+          table,
+          inCalls: scopedInCalls,
+          rows: [
+            {
+              test_id: 'test-1',
+              student_id: 'student-2',
+              selected_option: 0,
+              response_text: null,
+            },
+            {
+              test_id: 'test-1',
+              student_id: 'student-4',
+              selected_option: 1,
+              response_text: null,
+            },
+          ],
+        })
       }
 
       if (table === 'test_student_availability') {
@@ -350,6 +467,218 @@ describe('GET /api/teacher/tests', () => {
     expect(data.quizzes[0].stats.submitted).toBe(1)
     expect(data.quizzes[0].stats.open_access).toBe(1)
     expect(data.quizzes[0].stats.closed_access).toBe(1)
+    expect(scopedInCalls).toContainEqual({
+      table: 'test_attempts',
+      column: 'student_id',
+      values: ['student-1', 'student-2'],
+    })
+    expect(scopedInCalls).toContainEqual({
+      table: 'test_responses',
+      column: 'student_id',
+      values: ['student-1', 'student-2'],
+    })
+  })
+
+  it('chunks test stats filters for large rosters and test lists', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const testRows = Array.from({ length: 51 }, (_, index) => ({
+      id: `test-${index + 1}`,
+      classroom_id: 'classroom-1',
+      title: `Test ${index + 1}`,
+      status: 'active',
+      position: index,
+    }))
+    const questionRows = testRows.map((test) => ({ test_id: test.id }))
+    const statsInCalls: Array<{ table: string; column: string; values: string[] }> = []
+
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds,
+      studentIdSet: new Set(studentIds),
+      totalStudents: studentIds.length,
+      error: null,
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: testRows,
+                error: null,
+              })
+            ),
+          })),
+        }
+      }
+
+      if (table === 'test_questions') {
+        return buildTestIdStatsTable({
+          table,
+          rows: questionRows,
+          filterColumn: 'test_id',
+          inCalls: statsInCalls,
+        })
+      }
+
+      if (table === 'test_attempts') {
+        return buildStudentScopedStatsTable({
+          table,
+          inCalls: statsInCalls,
+          rows: [{ test_id: 'test-1', student_id: 'student-1', is_submitted: true }],
+        })
+      }
+
+      if (table === 'test_responses') {
+        return buildStudentScopedStatsTable({
+          table,
+          inCalls: statsInCalls,
+          rows: [
+            {
+              test_id: 'test-1',
+              student_id: 'student-2',
+              selected_option: 0,
+              response_text: null,
+            },
+          ],
+        })
+      }
+
+      if (table === 'test_student_availability') {
+        return buildStudentScopedStatsTable({
+          table,
+          inCalls: statsInCalls,
+          rows: [{ test_id: 'test-1', student_id: 'student-1', state: 'closed' }],
+        })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes).toHaveLength(51)
+    expect(data.quizzes[0].stats).toEqual({
+      total_students: 51,
+      responded: 2,
+      submitted: 1,
+      open_access: 50,
+      closed_access: 1,
+      questions_count: 1,
+    })
+    expect(statsInCalls.every((call) => call.values.length <= 50)).toBe(true)
+    expect(statsInCalls).toContainEqual({
+      table: 'test_questions',
+      column: 'test_id',
+      values: testRows.slice(0, 50).map((test) => test.id),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'test_questions',
+      column: 'test_id',
+      values: ['test-51'],
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'test_attempts',
+      column: 'student_id',
+      values: studentIds.slice(0, 50),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'test_attempts',
+      column: 'student_id',
+      values: ['student-51'],
+    })
+  })
+
+  it('applies draft overlays only to draft tests in the list', async () => {
+    const testRows = [
+      {
+        id: 'test-draft',
+        classroom_id: 'classroom-1',
+        title: 'Canonical Draft Title',
+        status: 'draft',
+        show_results: false,
+        position: 1,
+      },
+      {
+        id: 'test-closed',
+        classroom_id: 'classroom-1',
+        title: 'Closed Test',
+        status: 'closed',
+        show_results: false,
+        position: 0,
+      },
+    ]
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'tests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) =>
+              resolve({
+                data: testRows,
+                error: null,
+              })
+            ),
+          })),
+        }
+      }
+
+      if (table === 'test_questions') {
+        return buildTestIdStatsTable({
+          table,
+          rows: [
+            { test_id: 'test-draft' },
+            { test_id: 'test-closed' },
+            { test_id: 'test-closed' },
+          ],
+          filterColumn: 'test_id',
+        })
+      }
+
+      if (table === 'assessment_drafts') {
+        return buildAssessmentDraftRows([
+          {
+            assessment_id: 'test-draft',
+            content: {
+              title: 'Draft Overlay Title',
+              show_results: true,
+              questions: [],
+            },
+          },
+          {
+            assessment_id: 'test-closed',
+            content: {
+              title: 'Stale Draft Title',
+              show_results: true,
+              questions: [],
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes[0].title).toBe('Draft Overlay Title')
+    expect(data.quizzes[0].show_results).toBe(true)
+    expect(data.quizzes[0].stats.questions_count).toBe(0)
+    expect(data.quizzes[1].title).toBe('Closed Test')
+    expect(data.quizzes[1].show_results).toBe(false)
+    expect(data.quizzes[1].stats.questions_count).toBe(2)
   })
 })
 


### PR DESCRIPTION
## Summary
- reuse paginated classroom enrollment loading for teacher test-list stats
- chunk test questions, attempts, responses, availability, and draft overlay filters for large test lists/rosters
- fail closed on enrollment load errors and keep active/closed tests on canonical metadata when stale drafts exist

## Risk
- workspace-state: teacher test list stats and access counts guide review/grading work. No UI layout changes.

## Validation
- pnpm vitest run tests/api/teacher/tests-route.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check