### PR TITLE
[codex] Harden quiz list stats loading

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,21 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Assignment duplicate-submit timestamp guard
-
-**Completed:**
-- Preserved the original `submitted_at` value when an already-submitted assignment doc receives a duplicate submit request.
-- Kept fresh timestamps for first submissions and later resubmissions after the doc has been returned/unsubmitted.
-- Added API regression coverage proving duplicate submit writes the first timestamp back instead of replacing it.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/assignment-docs/submit.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Gradebook settings clears hidden email selection
 
 **Completed:**
@@ -354,6 +339,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm vitest run tests/api/teacher/tests-route.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`
+
+## 2026-05-28 — Quiz list stats chunked pagination
+
+**Completed:**
+- Added chunked and paginated quiz question and response stats loading for teacher quiz lists.
+- Ordered paged quiz stat reads by stable row id to prevent offset pagination skips or duplicates.
+- Preserved enrolled-student scoping while preventing large quiz lists or rosters from exceeding Supabase `.in()` and default row-limit behavior.
+- Chunked assessment draft overlay reads and pinned the existing active-quiz overlay behavior to match quiz detail parity.
+- Returned a clear 500 when quiz question stat loading fails instead of silently reporting zero questions.
+- Added regressions for stat load failures, 51x51 filter chunking, paginated stat rows, and active-list draft overlays.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/quizzes-route.test.ts --reporter=verbose`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm test`

--- a/src/app/api/teacher/quizzes/route.ts
+++ b/src/app/api/teacher/quizzes/route.ts
@@ -12,6 +12,113 @@ import { withErrorHandler } from '@/lib/api-handler'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+type QuizQuestionStatsRow = {
+  quiz_id: string
+}
+
+type QuizResponseStatsRow = {
+  quiz_id: string
+  student_id: string
+}
+
+const QUIZ_LIST_STATS_FILTER_CHUNK_SIZE = 50
+const QUIZ_LIST_STATS_PAGE_SIZE = 1000
+
+function chunkIds(ids: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+async function loadPagedRows<T>(buildQuery: () => any): Promise<{ rows: T[]; error: any }> {
+  const rows: T[] = []
+  let offset = 0
+
+  while (true) {
+    let query = buildQuery()
+    const supportsRange = typeof query.range === 'function'
+    if (supportsRange && typeof query.order === 'function') {
+      query = query.order('id', { ascending: true })
+    }
+    if (supportsRange) {
+      query = query.range(offset, offset + QUIZ_LIST_STATS_PAGE_SIZE - 1)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      return { rows: [], error }
+    }
+
+    const pageRows = (data || []) as T[]
+    rows.push(...pageRows)
+
+    if (!supportsRange || pageRows.length < QUIZ_LIST_STATS_PAGE_SIZE) break
+    offset += QUIZ_LIST_STATS_PAGE_SIZE
+  }
+
+  return { rows, error: null }
+}
+
+async function loadQuizQuestionRows(
+  supabase: any,
+  quizIds: string[]
+): Promise<{ rows: QuizQuestionStatsRow[]; error: any }> {
+  if (quizIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: QuizQuestionStatsRow[] = []
+  for (const quizIdChunk of chunkIds(quizIds, QUIZ_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    const result = await loadPagedRows<QuizQuestionStatsRow>(() =>
+      supabase
+        .from('quiz_questions')
+        .select('quiz_id')
+        .in('quiz_id', quizIdChunk)
+    )
+
+    if (result.error) {
+      return { rows: [], error: result.error }
+    }
+
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadQuizResponseRows(
+  supabase: any,
+  quizIds: string[],
+  studentIds: string[]
+): Promise<{ rows: QuizResponseStatsRow[]; error: any }> {
+  if (quizIds.length === 0 || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: QuizResponseStatsRow[] = []
+  for (const quizIdChunk of chunkIds(quizIds, QUIZ_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, QUIZ_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      const result = await loadPagedRows<QuizResponseStatsRow>(() =>
+        supabase
+          .from('quiz_responses')
+          .select('quiz_id, student_id')
+          .in('quiz_id', quizIdChunk)
+          .in('student_id', studentIdChunk)
+      )
+
+      if (result.error) {
+        return { rows: [], error: result.error }
+      }
+
+      rows.push(...result.rows)
+    }
+  }
+
+  return { rows, error: null }
+}
+
 // GET /api/teacher/quizzes?classroom_id=xxx - List quizzes for a classroom
 export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
   const user = await requireRole('teacher')
@@ -57,10 +164,12 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
 
   const questionCountMap: Record<string, number> = {}
   if (quizIds.length > 0) {
-    const { data: questionRows } = await supabase
-      .from('quiz_questions')
-      .select('quiz_id')
-      .in('quiz_id', quizIds)
+    const { rows: questionRows, error: questionRowsError } = await loadQuizQuestionRows(supabase, quizIds)
+
+    if (questionRowsError) {
+      console.error('Error fetching quiz question stats:', questionRowsError)
+      return NextResponse.json({ error: 'Failed to fetch quiz question stats' }, { status: 500 })
+    }
 
     for (const row of questionRows || []) {
       questionCountMap[row.quiz_id] = (questionCountMap[row.quiz_id] || 0) + 1
@@ -69,11 +178,10 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
 
   const respondentCountMap: Record<string, number> = {}
   if (quizIds.length > 0 && classroomStudentsResult.studentIds.length > 0) {
-    const { data: responseRows, error: responseRowsError } = await supabase
-      .from('quiz_responses')
-      .select('quiz_id, student_id')
-      .in('quiz_id', quizIds)
-      .in('student_id', classroomStudentsResult.studentIds)
+    const {
+      rows: responseRows,
+      error: responseRowsError,
+    } = await loadQuizResponseRows(supabase, quizIds, classroomStudentsResult.studentIds)
 
     if (responseRowsError) {
       console.error('Error fetching quiz response stats:', responseRowsError)
@@ -93,24 +201,26 @@ export const GET = withErrorHandler('GetTeacherQuizzes', async (request) => {
 
   const draftByQuizId: Record<string, QuizDraftContent> = {}
   if (quizIds.length > 0) {
-    try {
-      const { data: draftRows, error: draftError } = await supabase
-        .from('assessment_drafts')
-        .select('assessment_id, content')
-        .eq('assessment_type', 'quiz')
-        .in('assessment_id', quizIds)
+    for (const quizIdChunk of chunkIds(quizIds, QUIZ_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      try {
+        const { data: draftRows, error: draftError } = await supabase
+          .from('assessment_drafts')
+          .select('assessment_id, content')
+          .eq('assessment_type', 'quiz')
+          .in('assessment_id', quizIdChunk)
 
-      if (draftError && !isMissingAssessmentDraftsError(draftError)) {
-        console.error('Error fetching quiz draft overlays:', draftError)
-      }
+        if (draftError && !isMissingAssessmentDraftsError(draftError)) {
+          console.error('Error fetching quiz draft overlays:', draftError)
+        }
 
-      for (const row of draftRows || []) {
-        const parsed = validateQuizDraftContent(row.content)
-        if (!parsed.valid) continue
-        draftByQuizId[row.assessment_id] = parsed.value
+        for (const row of draftRows || []) {
+          const parsed = validateQuizDraftContent(row.content)
+          if (!parsed.valid) continue
+          draftByQuizId[row.assessment_id] = parsed.value
+        }
+      } catch {
+        // Older test mocks may not implement this table query yet.
       }
-    } catch {
-      // Older test mocks may not implement this table query yet.
     }
   }
 

--- a/tests/api/teacher/quizzes-route.test.ts
+++ b/tests/api/teacher/quizzes-route.test.ts
@@ -30,6 +30,126 @@ vi.mock('@/lib/server/classrooms', () => ({
   getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
 
+function buildQuizIdStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  filterColumn?: string
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  orderCalls?: Array<{ table: string; column: string; ascending?: boolean }>
+  pageable?: boolean
+  rangeCalls?: Array<{ table: string; from: number; to: number }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => ({
+      in: vi.fn((column: string, values: string[]) => {
+        options.inCalls?.push({ table: options.table, column, values })
+        if (options.error) {
+          return Promise.resolve({ data: null, error: options.error })
+        }
+        const filterColumn = options.filterColumn ?? column
+        const rows = options.rows.filter((row) => values.includes(row[filterColumn]))
+        if (options.pageable) {
+          const query: any = {
+            order: vi.fn((orderColumn: string, orderOptions?: { ascending?: boolean }) => {
+              options.orderCalls?.push({
+                table: options.table,
+                column: orderColumn,
+                ascending: orderOptions?.ascending,
+              })
+              return query
+            }),
+            range: vi.fn((from: number, to: number) => {
+              options.rangeCalls?.push({ table: options.table, from, to })
+              return Promise.resolve({
+                data: rows.slice(from, to + 1),
+                error: null,
+              })
+            }),
+          }
+          return query
+        }
+        return Promise.resolve({ data: rows, error: null })
+      }),
+    })),
+  }
+}
+
+function buildStudentScopedQuizStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  orderCalls?: Array<{ table: string; column: string; ascending?: boolean }>
+  pageable?: boolean
+  rangeCalls?: Array<{ table: string; from: number; to: number }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => {
+      let selectedQuizIds: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          options.inCalls?.push({ table: options.table, column, values })
+          if (column === 'quiz_id') {
+            selectedQuizIds = values
+            return query
+          }
+          if (column === 'student_id') {
+            if (options.error) {
+              return Promise.resolve({ data: null, error: options.error })
+            }
+            const rows = options.rows.filter(
+              (row) => selectedQuizIds.includes(row.quiz_id) && values.includes(row.student_id)
+            )
+            if (options.pageable) {
+              const pageQuery: any = {
+                order: vi.fn((orderColumn: string, orderOptions?: { ascending?: boolean }) => {
+                  options.orderCalls?.push({
+                    table: options.table,
+                    column: orderColumn,
+                    ascending: orderOptions?.ascending,
+                  })
+                  return pageQuery
+                }),
+                range: vi.fn((from: number, to: number) => {
+                  options.rangeCalls?.push({ table: options.table, from, to })
+                  return Promise.resolve({
+                    data: rows.slice(from, to + 1),
+                    error: null,
+                  })
+                }),
+              }
+              return pageQuery
+            }
+            return Promise.resolve({ data: rows, error: null })
+          }
+          return query
+        }),
+      }
+      return query
+    }),
+  }
+}
+
+function buildAssessmentDraftRows(
+  rows: Array<{ assessment_id: string; content: Record<string, unknown> }>,
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn((column: string, values: string[]) => {
+          inCalls?.push({ table: 'assessment_drafts', column, values })
+          return Promise.resolve({
+            data: rows.filter((row) => values.includes(row.assessment_id)),
+            error: null,
+          })
+        }),
+      })),
+    })),
+  }
+}
+
 describe('teacher quizzes collection route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -318,6 +438,331 @@ describe('teacher quizzes collection route', () => {
 
     expect(response.status).toBe(500)
     expect(data).toEqual({ error: 'Failed to fetch quiz response stats' })
+  })
+
+  it('returns 500 when quiz question stat loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Quiz One',
+                  status: 'draft',
+                  show_results: false,
+                  position: 0,
+                  created_at: '2026-03-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'quiz_questions') {
+        return buildQuizIdStatsTable({
+          table,
+          rows: [],
+          error: { message: 'question stats failed' },
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch quiz question stats' })
+  })
+
+  it('chunks quiz stats filters for large rosters and quiz lists', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const quizRows = Array.from({ length: 51 }, (_, index) => ({
+      id: `quiz-${index + 1}`,
+      classroom_id: 'classroom-1',
+      title: `Quiz ${index + 1}`,
+      status: 'draft',
+      show_results: false,
+      position: index,
+      created_at: '2026-03-01T00:00:00.000Z',
+    }))
+    const questionRows = quizRows.map((quiz) => ({ quiz_id: quiz.id }))
+    const statsInCalls: Array<{ table: string; column: string; values: string[] }> = []
+
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds,
+      studentIdSet: new Set(studentIds),
+      totalStudents: studentIds.length,
+      error: null,
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: quizRows,
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+
+      if (table === 'quiz_questions') {
+        return buildQuizIdStatsTable({
+          table,
+          rows: questionRows,
+          filterColumn: 'quiz_id',
+          inCalls: statsInCalls,
+        })
+      }
+
+      if (table === 'quiz_responses') {
+        return buildStudentScopedQuizStatsTable({
+          table,
+          inCalls: statsInCalls,
+          rows: [
+            { quiz_id: 'quiz-1', student_id: 'student-1' },
+            { quiz_id: 'quiz-1', student_id: 'student-2' },
+          ],
+        })
+      }
+
+      if (table === 'assessment_drafts') {
+        return buildAssessmentDraftRows(
+          [
+            {
+              assessment_id: 'quiz-51',
+              content: {
+                title: 'Draft Quiz 51',
+                show_results: true,
+                questions: [],
+              },
+            },
+          ],
+          statsInCalls
+        )
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes).toHaveLength(51)
+    expect(data.quizzes[0].stats).toEqual({
+      total_students: 51,
+      responded: 2,
+      questions_count: 1,
+    })
+    expect(data.quizzes[50].title).toBe('Draft Quiz 51')
+    expect(statsInCalls.every((call) => call.values.length <= 50)).toBe(true)
+    expect(statsInCalls).toContainEqual({
+      table: 'quiz_questions',
+      column: 'quiz_id',
+      values: quizRows.slice(0, 50).map((quiz) => quiz.id),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'quiz_questions',
+      column: 'quiz_id',
+      values: ['quiz-51'],
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'quiz_responses',
+      column: 'student_id',
+      values: studentIds.slice(0, 50),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'quiz_responses',
+      column: 'student_id',
+      values: ['student-51'],
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'assessment_drafts',
+      column: 'assessment_id',
+      values: ['quiz-51'],
+    })
+  })
+
+  it('paginates quiz stat rows inside each filter chunk', async () => {
+    const questionRows = Array.from({ length: 1001 }, () => ({ quiz_id: 'quiz-1' }))
+    const responseRows = [
+      ...Array.from({ length: 1000 }, () => ({ quiz_id: 'quiz-1', student_id: 'student-1' })),
+      { quiz_id: 'quiz-1', student_id: 'student-2' },
+    ]
+    const orderCalls: Array<{ table: string; column: string; ascending?: boolean }> = []
+    const rangeCalls: Array<{ table: string; from: number; to: number }> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Quiz One',
+                  status: 'draft',
+                  show_results: false,
+                  position: 0,
+                  created_at: '2026-03-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+
+      if (table === 'quiz_questions') {
+        return buildQuizIdStatsTable({
+          table,
+          rows: questionRows,
+          filterColumn: 'quiz_id',
+          orderCalls,
+          pageable: true,
+          rangeCalls,
+        })
+      }
+
+      if (table === 'quiz_responses') {
+        return buildStudentScopedQuizStatsTable({
+          table,
+          rows: responseRows,
+          orderCalls,
+          pageable: true,
+          rangeCalls,
+        })
+      }
+
+      if (table === 'assessment_drafts') {
+        return buildAssessmentDraftRows([])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes[0].stats).toEqual({
+      total_students: 2,
+      responded: 2,
+      questions_count: 1001,
+    })
+    expect(orderCalls).toEqual([
+      { table: 'quiz_questions', column: 'id', ascending: true },
+      { table: 'quiz_questions', column: 'id', ascending: true },
+      { table: 'quiz_responses', column: 'id', ascending: true },
+      { table: 'quiz_responses', column: 'id', ascending: true },
+    ])
+    expect(rangeCalls).toContainEqual({ table: 'quiz_questions', from: 0, to: 999 })
+    expect(rangeCalls).toContainEqual({ table: 'quiz_questions', from: 1000, to: 1999 })
+    expect(rangeCalls).toContainEqual({ table: 'quiz_responses', from: 0, to: 999 })
+    expect(rangeCalls).toContainEqual({ table: 'quiz_responses', from: 1000, to: 1999 })
+  })
+
+  it('keeps quiz draft overlays visible for active list rows', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quizzes') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'quiz-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Canonical active title',
+                  status: 'active',
+                  show_results: false,
+                  position: 0,
+                  created_at: '2026-03-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+
+      if (table === 'quiz_questions') {
+        return buildQuizIdStatsTable({
+          table,
+          rows: [{ quiz_id: 'quiz-1' }],
+          filterColumn: 'quiz_id',
+        })
+      }
+
+      if (table === 'quiz_responses') {
+        return buildStudentScopedQuizStatsTable({ table, rows: [] })
+      }
+
+      if (table === 'assessment_drafts') {
+        return buildAssessmentDraftRows([
+          {
+            assessment_id: 'quiz-1',
+            content: {
+              title: 'Draft active title',
+              show_results: true,
+              questions: [
+                {
+                  id: '11111111-1111-4111-8111-111111111111',
+                  question_text: 'Draft question',
+                  options: ['A', 'B'],
+                },
+                {
+                  id: '22222222-2222-4222-8222-222222222222',
+                  question_text: 'Second draft question',
+                  options: ['C', 'D'],
+                },
+              ],
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.quizzes[0].title).toBe('Draft active title')
+    expect(data.quizzes[0].show_results).toBe(true)
+    expect(data.quizzes[0].stats.questions_count).toBe(2)
   })
 
   it('creates a new quiz at the next position', async () => {


### PR DESCRIPTION
## Summary
- Chunk and paginate teacher quiz list question/response stat reads so large quiz lists and rosters do not exceed Supabase filter or default row-limit behavior.
- Preserve current enrolled-student scoping for respondent counts while failing closed on quiz question stat load errors.
- Chunk assessment draft overlay reads and pin the existing active-quiz overlay behavior for parity with quiz detail.

## Risk Profile
- workspace-state: touches teacher quiz list aggregate stats and draft overlay reads.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/quizzes-route.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
- `git diff --check`