### PR TITLE
[codex] Harden survey list stats loading

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,23 +7,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Gradebook settings clears hidden email selection
-
-**Completed:**
-- Cleared selected gradebook students whenever settings mode opens.
-- Hid selected-student email actions while gradebook settings mode is active.
-- Added component regression coverage for selecting a student, entering settings, and returning to grades without stale selection.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook&gradebookSection=settings'`
-- Browser regression screenshot: `/tmp/pika-teacher-gradebook-settings-after-selection.png`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-26 — Selected test delete action
 
 **Completed:**
@@ -359,6 +342,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/api/teacher/quizzes-route.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`
+
+## 2026-05-28 — Survey list stats chunked pagination
+
+**Completed:**
+- Added chunked and paginated survey question and response stats loading for teacher survey lists.
+- Ordered paged survey stat reads by stable row id to prevent offset pagination skips or duplicates.
+- Preserved current-enrollment scoping for respondent counts while avoiding oversized Supabase `.in()` filters for large survey lists and rosters.
+- Returned a clear 500 when survey question stat loading fails instead of silently reporting zero questions.
+- Added regressions for missing-surveys migration fallback, base list failures, list ordering, zero-enrollment skips, stat load failures, 51x51 filter chunking, and paginated stat rows.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/surveys-route.test.ts --reporter=verbose`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `pnpm test`

--- a/src/app/api/teacher/surveys/route.ts
+++ b/src/app/api/teacher/surveys/route.ts
@@ -9,6 +9,113 @@ import { getFallbackAssessmentTitle } from '@/lib/assessment-titles'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+type SurveyQuestionStatsRow = {
+  survey_id: string
+}
+
+type SurveyResponseStatsRow = {
+  survey_id: string
+  student_id: string
+}
+
+const SURVEY_LIST_STATS_FILTER_CHUNK_SIZE = 50
+const SURVEY_LIST_STATS_PAGE_SIZE = 1000
+
+function chunkIds(ids: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+async function loadPagedRows<T>(buildQuery: () => any): Promise<{ rows: T[]; error: any }> {
+  const rows: T[] = []
+  let offset = 0
+
+  while (true) {
+    let query = buildQuery()
+    const supportsRange = typeof query.range === 'function'
+    if (supportsRange && typeof query.order === 'function') {
+      query = query.order('id', { ascending: true })
+    }
+    if (supportsRange) {
+      query = query.range(offset, offset + SURVEY_LIST_STATS_PAGE_SIZE - 1)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      return { rows: [], error }
+    }
+
+    const pageRows = (data || []) as T[]
+    rows.push(...pageRows)
+
+    if (!supportsRange || pageRows.length < SURVEY_LIST_STATS_PAGE_SIZE) break
+    offset += SURVEY_LIST_STATS_PAGE_SIZE
+  }
+
+  return { rows, error: null }
+}
+
+async function loadSurveyQuestionRows(
+  supabase: any,
+  surveyIds: string[]
+): Promise<{ rows: SurveyQuestionStatsRow[]; error: any }> {
+  if (surveyIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: SurveyQuestionStatsRow[] = []
+  for (const surveyIdChunk of chunkIds(surveyIds, SURVEY_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    const result = await loadPagedRows<SurveyQuestionStatsRow>(() =>
+      supabase
+        .from('survey_questions')
+        .select('survey_id')
+        .in('survey_id', surveyIdChunk)
+    )
+
+    if (result.error) {
+      return { rows: [], error: result.error }
+    }
+
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadSurveyResponseRows(
+  supabase: any,
+  surveyIds: string[],
+  studentIds: string[]
+): Promise<{ rows: SurveyResponseStatsRow[]; error: any }> {
+  if (surveyIds.length === 0 || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: SurveyResponseStatsRow[] = []
+  for (const surveyIdChunk of chunkIds(surveyIds, SURVEY_LIST_STATS_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, SURVEY_LIST_STATS_FILTER_CHUNK_SIZE)) {
+      const result = await loadPagedRows<SurveyResponseStatsRow>(() =>
+        supabase
+          .from('survey_responses')
+          .select('survey_id, student_id')
+          .in('survey_id', surveyIdChunk)
+          .in('student_id', studentIdChunk)
+      )
+
+      if (result.error) {
+        return { rows: [], error: result.error }
+      }
+
+      rows.push(...result.rows)
+    }
+  }
+
+  return { rows, error: null }
+}
+
 async function getNextClassworkPosition(classroomId: string) {
   const supabase = getServiceRoleClient()
   const [lastAssignmentResult, lastMaterialResult, lastSurveyResult] = await Promise.all([
@@ -92,10 +199,12 @@ export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
 
   const questionCountMap: Record<string, number> = {}
   if (surveyIds.length > 0) {
-    const { data: questionRows } = await supabase
-      .from('survey_questions')
-      .select('survey_id')
-      .in('survey_id', surveyIds)
+    const { rows: questionRows, error: questionRowsError } = await loadSurveyQuestionRows(supabase, surveyIds)
+
+    if (questionRowsError) {
+      console.error('Error fetching survey question stats:', questionRowsError)
+      return NextResponse.json({ error: 'Failed to fetch survey question stats' }, { status: 500 })
+    }
 
     for (const row of questionRows || []) {
       questionCountMap[row.survey_id] = (questionCountMap[row.survey_id] || 0) + 1
@@ -104,11 +213,10 @@ export const GET = withErrorHandler('GetTeacherSurveys', async (request) => {
 
   const respondentCountMap: Record<string, number> = {}
   if (surveyIds.length > 0 && classroomStudentsResult.studentIds.length > 0) {
-    const { data: responseRows, error: responseRowsError } = await supabase
-      .from('survey_responses')
-      .select('survey_id, student_id')
-      .in('survey_id', surveyIds)
-      .in('student_id', classroomStudentsResult.studentIds)
+    const {
+      rows: responseRows,
+      error: responseRowsError,
+    } = await loadSurveyResponseRows(supabase, surveyIds, classroomStudentsResult.studentIds)
 
     if (responseRowsError) {
       console.error('Error fetching survey response stats:', responseRowsError)

--- a/tests/api/teacher/surveys-route.test.ts
+++ b/tests/api/teacher/surveys-route.test.ts
@@ -23,6 +23,107 @@ vi.mock('@/lib/server/classrooms', () => ({
   getClassroomStudentIds: mockGetClassroomStudentIds,
 }))
 
+function buildSurveyIdStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  filterColumn?: string
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  orderCalls?: Array<{ table: string; column: string; ascending?: boolean }>
+  pageable?: boolean
+  rangeCalls?: Array<{ table: string; from: number; to: number }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => ({
+      in: vi.fn((column: string, values: string[]) => {
+        options.inCalls?.push({ table: options.table, column, values })
+        if (options.error) {
+          return Promise.resolve({ data: null, error: options.error })
+        }
+        const filterColumn = options.filterColumn ?? column
+        const rows = options.rows.filter((row) => values.includes(row[filterColumn]))
+        if (options.pageable) {
+          const query: any = {
+            order: vi.fn((orderColumn: string, orderOptions?: { ascending?: boolean }) => {
+              options.orderCalls?.push({
+                table: options.table,
+                column: orderColumn,
+                ascending: orderOptions?.ascending,
+              })
+              return query
+            }),
+            range: vi.fn((from: number, to: number) => {
+              options.rangeCalls?.push({ table: options.table, from, to })
+              return Promise.resolve({
+                data: rows.slice(from, to + 1),
+                error: null,
+              })
+            }),
+          }
+          return query
+        }
+        return Promise.resolve({ data: rows, error: null })
+      }),
+    })),
+  }
+}
+
+function buildStudentScopedSurveyStatsTable(options: {
+  rows: Array<Record<string, any>>
+  error?: unknown
+  inCalls?: Array<{ table: string; column: string; values: string[] }>
+  orderCalls?: Array<{ table: string; column: string; ascending?: boolean }>
+  pageable?: boolean
+  rangeCalls?: Array<{ table: string; from: number; to: number }>
+  table: string
+}) {
+  return {
+    select: vi.fn(() => {
+      let selectedSurveyIds: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          options.inCalls?.push({ table: options.table, column, values })
+          if (column === 'survey_id') {
+            selectedSurveyIds = values
+            return query
+          }
+          if (column === 'student_id') {
+            if (options.error) {
+              return Promise.resolve({ data: null, error: options.error })
+            }
+            const rows = options.rows.filter(
+              (row) => selectedSurveyIds.includes(row.survey_id) && values.includes(row.student_id)
+            )
+            if (options.pageable) {
+              const pageQuery: any = {
+                order: vi.fn((orderColumn: string, orderOptions?: { ascending?: boolean }) => {
+                  options.orderCalls?.push({
+                    table: options.table,
+                    column: orderColumn,
+                    ascending: orderOptions?.ascending,
+                  })
+                  return pageQuery
+                }),
+                range: vi.fn((from: number, to: number) => {
+                  options.rangeCalls?.push({ table: options.table, from, to })
+                  return Promise.resolve({
+                    data: rows.slice(from, to + 1),
+                    error: null,
+                  })
+                }),
+              }
+              return pageQuery
+            }
+            return Promise.resolve({ data: rows, error: null })
+          }
+          return query
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/surveys', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -32,6 +133,134 @@ describe('GET /api/teacher/surveys', () => {
       totalStudents: 2,
       error: null,
     })
+  })
+
+  it('returns migration-required when the surveys table is missing', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: null,
+              error: { code: 'PGRST205', message: 'Could not find the table public.surveys' },
+            })
+          ),
+        }
+        return chain
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ surveys: [], migration_required: true })
+    expect(mockGetClassroomStudentIds).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('survey_questions')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('survey_responses')
+  })
+
+  it('returns 500 when the surveys list query fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: null,
+              error: { code: 'DATABASE_DOWN', message: 'database offline' },
+            })
+          ),
+        }
+        return chain
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch surveys' })
+    expect(mockGetClassroomStudentIds).not.toHaveBeenCalled()
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('survey_questions')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('survey_responses')
+  })
+
+  it('orders surveys by classwork position and creation time', async () => {
+    const orderCalls: Array<{ column: string; ascending?: boolean }> = []
+    const surveyRows = [
+      {
+        id: 'survey-1',
+        classroom_id: 'classroom-1',
+        title: 'Survey One',
+        status: 'active',
+        show_results: true,
+        dynamic_responses: false,
+        position: 0,
+        created_at: '2026-05-01T00:00:00.000Z',
+      },
+      {
+        id: 'survey-2',
+        classroom_id: 'classroom-1',
+        title: 'Survey Two',
+        status: 'active',
+        show_results: true,
+        dynamic_responses: false,
+        position: 1,
+        created_at: '2026-05-02T00:00:00.000Z',
+      },
+    ]
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn((column: string, options?: { ascending?: boolean }) => {
+            orderCalls.push({ column, ascending: options?.ascending })
+            return chain
+          }),
+          then: vi.fn((resolve: any) => resolve({ data: surveyRows, error: null })),
+        }
+        return chain
+      }
+      if (table === 'survey_questions') {
+        return buildSurveyIdStatsTable({
+          table,
+          rows: [],
+          filterColumn: 'survey_id',
+        })
+      }
+      if (table === 'survey_responses') {
+        return buildStudentScopedSurveyStatsTable({
+          table,
+          rows: [],
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(orderCalls).toEqual([
+      { column: 'position', ascending: true },
+      { column: 'created_at', ascending: true },
+    ])
+    expect(data.surveys.map((survey: { id: string }) => survey.id)).toEqual(['survey-1', 'survey-2'])
   })
 
   it('counts only currently enrolled responders in survey stats', async () => {
@@ -153,6 +382,109 @@ describe('GET /api/teacher/surveys', () => {
     expect(data).toEqual({ error: 'Failed to fetch classroom enrollments' })
   })
 
+  it('skips response stat loading when no students are enrolled', async () => {
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds: [],
+      studentIdSet: new Set(),
+      totalStudents: 0,
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'survey-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Survey One',
+                  status: 'active',
+                  show_results: true,
+                  dynamic_responses: false,
+                  position: 0,
+                  created_at: '2026-05-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'survey_questions') {
+        return buildSurveyIdStatsTable({
+          table,
+          rows: [{ survey_id: 'survey-1' }],
+          filterColumn: 'survey_id',
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.surveys[0].stats).toEqual({
+      total_students: 0,
+      responded: 0,
+      questions_count: 1,
+    })
+    expect(mockSupabaseClient.from).not.toHaveBeenCalledWith('survey_responses')
+  })
+
+  it('returns 500 when survey question stat loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'survey-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Survey One',
+                  status: 'active',
+                  show_results: true,
+                  dynamic_responses: false,
+                  position: 0,
+                  created_at: '2026-05-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+      if (table === 'survey_questions') {
+        return buildSurveyIdStatsTable({
+          table,
+          rows: [],
+          error: { message: 'question stats failed' },
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch survey question stats' })
+  })
+
   it('returns 500 when scoped survey response stat loading fails', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'surveys') {
@@ -211,6 +543,201 @@ describe('GET /api/teacher/surveys', () => {
 
     expect(response.status).toBe(500)
     expect(data).toEqual({ error: 'Failed to fetch survey response stats' })
+  })
+
+  it('chunks survey stats filters for large rosters and survey lists', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const surveyRows = Array.from({ length: 51 }, (_, index) => ({
+      id: `survey-${index + 1}`,
+      classroom_id: 'classroom-1',
+      title: `Survey ${index + 1}`,
+      status: 'active',
+      show_results: true,
+      dynamic_responses: false,
+      position: index,
+      created_at: '2026-05-01T00:00:00.000Z',
+    }))
+    const questionRows = surveyRows.map((survey) => ({ survey_id: survey.id }))
+    const statsInCalls: Array<{ table: string; column: string; values: string[] }> = []
+
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds,
+      studentIdSet: new Set(studentIds),
+      totalStudents: studentIds.length,
+      error: null,
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: surveyRows,
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+
+      if (table === 'survey_questions') {
+        return buildSurveyIdStatsTable({
+          table,
+          rows: questionRows,
+          filterColumn: 'survey_id',
+          inCalls: statsInCalls,
+        })
+      }
+
+      if (table === 'survey_responses') {
+        return buildStudentScopedSurveyStatsTable({
+          table,
+          inCalls: statsInCalls,
+          rows: [
+            { survey_id: 'survey-1', student_id: 'student-1' },
+            { survey_id: 'survey-1', student_id: 'student-2' },
+            { survey_id: 'survey-51', student_id: 'student-51' },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.surveys).toHaveLength(51)
+    expect(data.surveys[0].stats).toEqual({
+      total_students: 51,
+      responded: 2,
+      questions_count: 1,
+    })
+    expect(data.surveys[50].stats).toEqual({
+      total_students: 51,
+      responded: 1,
+      questions_count: 1,
+    })
+    expect(statsInCalls.every((call) => call.values.length <= 50)).toBe(true)
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_questions',
+      column: 'survey_id',
+      values: surveyRows.slice(0, 50).map((survey) => survey.id),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_questions',
+      column: 'survey_id',
+      values: ['survey-51'],
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_responses',
+      column: 'survey_id',
+      values: surveyRows.slice(0, 50).map((survey) => survey.id),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_responses',
+      column: 'survey_id',
+      values: ['survey-51'],
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_responses',
+      column: 'student_id',
+      values: studentIds.slice(0, 50),
+    })
+    expect(statsInCalls).toContainEqual({
+      table: 'survey_responses',
+      column: 'student_id',
+      values: ['student-51'],
+    })
+  })
+
+  it('paginates survey stat rows inside each filter chunk', async () => {
+    const questionRows = Array.from({ length: 1001 }, () => ({ survey_id: 'survey-1' }))
+    const responseRows = [
+      ...Array.from({ length: 1000 }, () => ({ survey_id: 'survey-1', student_id: 'student-1' })),
+      { survey_id: 'survey-1', student_id: 'student-2' },
+    ]
+    const orderCalls: Array<{ table: string; column: string; ascending?: boolean }> = []
+    const rangeCalls: Array<{ table: string; from: number; to: number }> = []
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'surveys') {
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          then: vi.fn((resolve: any) =>
+            resolve({
+              data: [
+                {
+                  id: 'survey-1',
+                  classroom_id: 'classroom-1',
+                  title: 'Survey One',
+                  status: 'active',
+                  show_results: true,
+                  dynamic_responses: false,
+                  position: 0,
+                  created_at: '2026-05-01T00:00:00.000Z',
+                },
+              ],
+              error: null,
+            })
+          ),
+        }
+        return chain
+      }
+
+      if (table === 'survey_questions') {
+        return buildSurveyIdStatsTable({
+          table,
+          rows: questionRows,
+          filterColumn: 'survey_id',
+          orderCalls,
+          pageable: true,
+          rangeCalls,
+        })
+      }
+
+      if (table === 'survey_responses') {
+        return buildStudentScopedSurveyStatsTable({
+          table,
+          rows: responseRows,
+          orderCalls,
+          pageable: true,
+          rangeCalls,
+        })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys?classroom_id=classroom-1')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.surveys[0].stats).toEqual({
+      total_students: 2,
+      responded: 2,
+      questions_count: 1001,
+    })
+    expect(orderCalls).toEqual([
+      { table: 'survey_questions', column: 'id', ascending: true },
+      { table: 'survey_questions', column: 'id', ascending: true },
+      { table: 'survey_responses', column: 'id', ascending: true },
+      { table: 'survey_responses', column: 'id', ascending: true },
+    ])
+    expect(rangeCalls).toContainEqual({ table: 'survey_questions', from: 0, to: 999 })
+    expect(rangeCalls).toContainEqual({ table: 'survey_questions', from: 1000, to: 1999 })
+    expect(rangeCalls).toContainEqual({ table: 'survey_responses', from: 0, to: 999 })
+    expect(rangeCalls).toContainEqual({ table: 'survey_responses', from: 1000, to: 1999 })
   })
 })
 


### PR DESCRIPTION
## Summary
- Chunk and paginate teacher survey list question/response stat reads so large survey lists and rosters do not exceed Supabase filter or default row-limit behavior.
- Preserve current enrolled-student scoping for respondent counts while failing closed on survey question stat load errors.
- Lock base survey-list migration/error semantics and classwork ordering in route coverage.

## Risk Profile
- workspace-state: touches teacher survey list aggregate stats shown in the classroom work surface.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/surveys-route.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
- `git diff --check`