### PR TITLE
Simplify PostgREST schema-drift error shims

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-26 — Selected test delete action
-
-**Completed:**
-- Added a destructive `Delete Test` action to the selected test workspace actions menu.
-- Wired the selected-workspace delete action through the existing `onRequestDelete` callback, with the component's internal delete confirmation as fallback.
-- Updated component coverage for the selected-test action menu and delete callback path.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=grading'`
-- Browser menu screenshot: `/tmp/pika-teacher-tests-delete-action-menu.png`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-
 ## 2026-05-27 — Phase two systems and UI audit fixes
 
 **Completed:**
@@ -383,3 +366,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `rg -n '\$PIKA_WORKTREE|detached HEAD|latest 60 entries' .ai .claude .codex docs scripts tests /Users/stew/.codex/automations/pika-e2e-coverage-builder/automation.toml`
 - `git diff --check`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/trim-session-log.test.ts` could not run because this checkout is missing `node_modules` and `vitest`
+## 2026-05-30 — Simplify test schema-drift error shims
+
+**Completed:**
+- Extracted shared PostgREST error text normalization for schema-drift helpers in `src/lib/server/tests.ts`.
+- Added unit coverage for `details`/`hint` handling and case-insensitive matches.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/unit/server-access.test.ts tests/unit/test-student-access.test.ts`
+- `pnpm test`
+- `pnpm lint`
+
+**PR:**
+- https://github.com/codepetca/pika/pull/677

--- a/src/lib/server/tests.ts
+++ b/src/lib/server/tests.ts
@@ -1,6 +1,17 @@
 import { getServiceRoleClient } from '@/lib/supabase'
 import type { QuizStatus, TestStudentAvailabilityState } from '@/types'
 
+type PostgrestErrorLike = {
+  code?: string
+  message?: string
+  details?: string | null
+  hint?: string | null
+}
+
+function getPostgrestErrorText(error: PostgrestErrorLike): string {
+  return `${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`.toLowerCase()
+}
+
 export type TestAccessRecord = {
   id: string
   classroom_id: string
@@ -107,7 +118,7 @@ export function isMissingTestAttemptClosureColumnsError(error: {
   hint?: string | null
 } | null | undefined): boolean {
   if (!error) return false
-  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  const combined = getPostgrestErrorText(error)
   return (
     (error.code === 'PGRST204' || error.code === '42703') &&
     combined.includes('closed_for_grading')
@@ -121,7 +132,7 @@ export function isMissingTestStudentAvailabilityError(error: {
   hint?: string | null
 } | null | undefined): boolean {
   if (!error) return false
-  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  const combined = getPostgrestErrorText(error)
   return (
     error.code === 'PGRST205' ||
     error.code === '42P01' ||
@@ -202,7 +213,7 @@ export function isMissingTestAttemptReturnColumnsError(error: {
   hint?: string | null
 } | null | undefined): boolean {
   if (!error) return false
-  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  const combined = getPostgrestErrorText(error)
   if (!combined.includes('returned_at') && !combined.includes('returned_by')) return false
   return error.code === '42703' || error.code === 'PGRST204' || combined.includes('column')
 }
@@ -214,7 +225,7 @@ export function isMissingTestResponseAiColumnsError(error: {
   hint?: string | null
 } | null | undefined): boolean {
   if (!error) return false
-  const combined = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase()
+  const combined = getPostgrestErrorText(error)
   const mentionsAiColumn =
     combined.includes('ai_grading_basis') ||
     combined.includes('ai_reference_answers') ||

--- a/src/lib/server/tests.ts
+++ b/src/lib/server/tests.ts
@@ -9,7 +9,10 @@ type PostgrestErrorLike = {
 }
 
 function getPostgrestErrorText(error: PostgrestErrorLike): string {
-  return `${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`.toLowerCase()
+  const message = String(error.message ?? '')
+  const details = String(error.details ?? '')
+  const hint = String(error.hint ?? '')
+  return `${message} ${details} ${hint}`.toLowerCase()
 }
 
 export type TestAccessRecord = {

--- a/tests/unit/server-access.test.ts
+++ b/tests/unit/server-access.test.ts
@@ -395,6 +395,13 @@ describe('server access helpers', () => {
         })
       ).toBe(true)
 
+      expect(
+        isMissingTestResponseAiColumnsError({
+          code: 'PGRST204',
+          details: 'AI_MODEL missing from schema cache',
+        })
+      ).toBe(true)
+
       expect(isMissingTestResponseAiColumnsError({ code: '42703', message: 'column score does not exist' })).toBe(
         false
       )

--- a/tests/unit/test-student-access.test.ts
+++ b/tests/unit/test-student-access.test.ts
@@ -187,6 +187,12 @@ describe('test access migration shims', () => {
       code: 'PGRST204',
       hint: 'Test_Student_Availability missing from Schema Cache',
     })).toBe(true)
+    expect(isMissingTestStudentAvailabilityError({
+      code: 'PGRST204',
+      // Guard against future non-string error shapes (e.g. custom thrown errors).
+      message: 123 as any,
+      hint: 'test_student_availability not found in schema cache',
+    } as any)).toBe(true)
     expect(isMissingTestStudentAvailabilityError({ code: 'PGRST204', message: 'different table' })).toBe(false)
   })
 })

--- a/tests/unit/test-student-access.test.ts
+++ b/tests/unit/test-student-access.test.ts
@@ -169,6 +169,9 @@ describe('test access migration shims', () => {
     expect(isMissingTestAttemptClosureColumnsError(null)).toBe(false)
     expect(isMissingTestAttemptClosureColumnsError({ code: '42703', message: 'closed_for_grading_at' })).toBe(true)
     expect(isMissingTestAttemptClosureColumnsError({ code: 'PGRST204', details: 'closed_for_grading_by' })).toBe(true)
+    expect(isMissingTestAttemptClosureColumnsError({ code: 'PGRST204', hint: 'CLOSED_FOR_GRADING_BY missing' })).toBe(
+      true
+    )
     expect(isMissingTestAttemptClosureColumnsError({ code: '42703', message: 'returned_at' })).toBe(false)
   })
 
@@ -179,6 +182,10 @@ describe('test access migration shims', () => {
     expect(isMissingTestStudentAvailabilityError({
       code: 'PGRST204',
       message: 'test_student_availability not found in schema cache',
+    })).toBe(true)
+    expect(isMissingTestStudentAvailabilityError({
+      code: 'PGRST204',
+      hint: 'Test_Student_Availability missing from Schema Cache',
     })).toBe(true)
     expect(isMissingTestStudentAvailabilityError({ code: 'PGRST204', message: 'different table' })).toBe(false)
   })


### PR DESCRIPTION
**Hotspot**
- Fragile PostgREST/Postgres schema-drift detection helpers in `src/lib/server/tests.ts` (duplicate string-normalization logic).

**Why**
- These helpers gate runtime fallbacks in test-taking + grading flows; keeping their parsing consistent reduces drift bugs and future edits.

**Risk Profile**
- none

**Behavior**
- Preserved: refactor extracts shared error-text normalization and keeps existing detection rules unchanged.

**Tests**
- Added coverage for `details`/`hint` + case-insensitive detection.

**Commands**
- `bash scripts/verify-env.sh`
- `pnpm vitest run tests/unit/server-access.test.ts tests/unit/test-student-access.test.ts`
- `pnpm test`
- `pnpm lint`

**Follow-ups (not in scope)**
- Consider sharing similar error-text normalization across other server modules if more drift shims appear.