### PR TITLE
Tighten workflow guardrails for detached HEAD and weekly evidence

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -4,7 +4,8 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Rules:**
 - Append one concise entry for meaningful work at the end of a session.
-- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.
+- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 60 entries.
+- Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
 ## 2026-05-26 — Selected test delete action
@@ -367,3 +368,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-29 — Workflow guardrails for detached HEAD and weekly evidence
+
+**Completed:**
+- Raised the default session-log retention from 20 to 60 entries and updated startup/workflow docs to preserve roughly a week of evidence for weekly automations.
+- Made session-start report `detached HEAD` explicitly and updated follow-workflow plus commit/PR prompts to handle detached checkouts safely.
+- Removed the stale `$PIKA_WORKTREE` assumption from the weekly Pika e2e coverage automation prompt and aligned it with `git rev-parse --show-toplevel`.
+- Added workflow-doc tests for detached-HEAD wording and the larger session-log retention default.
+
+**Validation:**
+- `node scripts/trim-session-log.mjs --help`
+- Detached fixture run: `bash .codex/skills/pika-session-start/scripts/session_start.sh` reported `Checkout: detached HEAD at <sha>`
+- `rg -n '\$PIKA_WORKTREE|detached HEAD|latest 60 entries' .ai .claude .codex docs scripts tests /Users/stew/.codex/automations/pika-e2e-coverage-builder/automation.toml`
+- `git diff --check`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/trim-session-log.test.ts` could not run because this checkout is missing `node_modules` and `vitest`

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -41,7 +41,7 @@ All agents operate from exactly one current repo checkout/worktree.
 ## End of Session (MANDATORY)
 
 1. Append a concise session entry to `.ai/SESSION-LOG.md`.
-2. Run `node scripts/trim-session-log.mjs` to keep only the latest 20 entries.
+2. Run `node scripts/trim-session-log.mjs` to keep only the latest 60 entries so weekly automations still have about a week of evidence.
 3. Update `.ai/features.json` if anything changed:
    ```bash
    node scripts/features.mjs pass <feature-id>

--- a/.claude/commands/commit-and-pr.md
+++ b/.claude/commands/commit-and-pr.md
@@ -14,6 +14,7 @@ Steps:
    - Resolve the repo root with `git rev-parse --show-toplevel`.
    - If it equals `$HOME/Repos/pika` (hub), stop and ask me to create or open a worktree first.
    - Run: `git status -sb`, `git branch --show-current`
+   - If `git branch --show-current` is empty, stop because detached HEAD is not safe for commit/push/PR flow.
    - If on `main` or `production`, stop and ask me to create a feature branch.
    - If no changes (staged or unstaged), stop and tell me.
 

--- a/.claude/commands/follow-workflow.md
+++ b/.claude/commands/follow-workflow.md
@@ -15,5 +15,5 @@ Key rules to remember:
 
 After reading, confirm:
 1. What repo root are you in?
-2. What branch are you on?
+2. What branch are you on, or are you on detached HEAD?
 3. What task are you working on?

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -21,7 +21,7 @@ Steps:
    - Run: `git status -sb`
    - Read `.ai/CURRENT.md`.
    - Read `.ai/SESSION-LOG.md` only if recent handoff context is needed.
-   - Summarize: current branch, last few commits, uncommitted changes.
+   - Summarize: current branch or detached HEAD state, last few commits, uncommitted changes.
 
 3) Load documentation
    - Read in order:

--- a/.codex/prompts/commit-and-pr.md
+++ b/.codex/prompts/commit-and-pr.md
@@ -7,7 +7,7 @@ Use the dedicated-worktree rules from `docs/dev-workflow.md`. Task-specific safe
 - Use a conventional-commit message derived from the diff
 
 Steps:
-1. Confirm the current branch and stop if it is `main` or `production`.
+1. Confirm the current branch. If `git branch --show-current` is empty, stop because detached HEAD is not safe for commit/push/PR flow. Stop if the branch is `main` or `production`.
 2. Review `git diff --stat`, `git diff`, and recent commit style.
 3. Stage the intended files, generate a conventional-commit message, and commit.
 4. Push the branch, setting upstream if needed.

--- a/.codex/prompts/follow-workflow.md
+++ b/.codex/prompts/follow-workflow.md
@@ -8,5 +8,5 @@ Read these files in order:
 
 After reading, confirm:
 1. What repo root does `git rev-parse --show-toplevel` report?
-2. What branch are you on?
+2. What branch are you on, or are you on detached HEAD?
 3. What task are you working on?

--- a/.codex/skills/pika-session-start/scripts/session_start.sh
+++ b/.codex/skills/pika-session-start/scripts/session_start.sh
@@ -101,7 +101,12 @@ fi
 echo ""
 echo "── 3. Git context"
 BRANCH=$(git -C "$WORKTREE" branch --show-current)
-echo -e "${INFO} Branch: $BRANCH"
+if [[ -n "$BRANCH" ]]; then
+  CHECKOUT_STATE="branch: $BRANCH"
+else
+  CHECKOUT_STATE="detached HEAD at $(git -C "$WORKTREE" rev-parse --short HEAD)"
+fi
+echo -e "${INFO} Checkout: $CHECKOUT_STATE"
 echo ""
 git -C "$WORKTREE" log --oneline -8
 echo ""

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -13,7 +13,7 @@ Read these files at the start of every session:
 3. [`.ai/features.json`](../.ai/features.json)
 4. [`docs/ai-instructions.md`](./ai-instructions.md)
 
-Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff context.
+Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff context; the rolling log should retain enough entries for weekly automations to inspect roughly the last week.
 
 ## Load Only The Docs You Need
 
@@ -48,7 +48,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: do non-trivial work in a dedicated worktree, plan before coding, append a concise `.ai/SESSION-LOG.md` entry, and trim it with `node scripts/trim-session-log.mjs`
+- Workflow: do non-trivial work in a dedicated worktree, plan before coding, append a concise `.ai/SESSION-LOG.md` entry, and trim it with `node scripts/trim-session-log.mjs` while preserving the default weekly evidence window
 - Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map

--- a/docs/semester-plan.md
+++ b/docs/semester-plan.md
@@ -288,7 +288,7 @@ UI: Checklist-style rubric that auto-calculates total.
 | `ai-instructions.md` | 350 | 300 | Remove workflow duplication |
 | `architecture.md` | 210 | 200 | Already tight |
 | `design.md` | 715 | 400 | Move component examples to storybook/gallery |
-| `SESSION-LOG.md` | <= 20 entries | <= 20 entries | Trim with `scripts/trim-session-log.mjs` |
+| `SESSION-LOG.md` | <= 60 entries | <= 60 entries | Trim with `scripts/trim-session-log.mjs` |
 | **Total** | ~7200 | ~4000 | 44% reduction |
 
 ---

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const DEFAULT_KEEP = 20
+const DEFAULT_KEEP = 60
 const DEFAULT_SOURCE = '.ai/SESSION-LOG.md'
 const DEFAULT_OUTPUT = '.ai/SESSION-LOG.md'
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -44,7 +44,7 @@ function parseArgs(argv) {
 
 function usage() {
   return [
-    'Usage: node scripts/trim-session-log.mjs [--keep 20] [--source .ai/SESSION-LOG.md] [--output .ai/SESSION-LOG.md]',
+    'Usage: node scripts/trim-session-log.mjs [--keep 60] [--source .ai/SESSION-LOG.md] [--output .ai/SESSION-LOG.md]',
     '',
     'Keeps the latest session entries, where each entry starts with a markdown "## " heading.',
   ].join('\n')
@@ -69,7 +69,8 @@ function buildSessionLog(entries) {
     '',
     '**Rules:**',
     '- Append one concise entry for meaningful work at the end of a session.',
-    '- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 20 entries.',
+    '- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 60 entries.',
+    '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
     '- Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.',
     '',
     '',

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -78,13 +78,14 @@ describe('AI startup docs', () => {
     }
   })
 
-  it('keeps the rolling session log small', () => {
+  it('keeps the rolling session log bounded while preserving weekly evidence', () => {
     const sessionLog = readRepoFile('.ai/SESSION-LOG.md')
     const entryCount = sessionLog.match(/^## /gm)?.length ?? 0
 
     expect(sessionLog).toContain('Rolling recent session log')
+    expect(sessionLog).toContain('latest 60 entries')
     expect(entryCount).toBeGreaterThan(0)
-    expect(entryCount).toBeLessThanOrEqual(20)
+    expect(entryCount).toBeLessThanOrEqual(60)
     expect(readRepoFile('.ai/JOURNAL-ARCHIVE.md')).toContain('# Pika Project Journal')
   })
 
@@ -119,6 +120,20 @@ describe('AI startup docs', () => {
 
     for (const file of files) {
       expect(readRepoFile(file)).toContain('$HOME/Repos/.env/pika/.env.local')
+    }
+  })
+
+  it('documents detached HEAD handling in workflow prompts', () => {
+    const files = [
+      '.claude/commands/session-start.md',
+      '.claude/commands/follow-workflow.md',
+      '.claude/commands/commit-and-pr.md',
+      '.codex/prompts/follow-workflow.md',
+      '.codex/prompts/commit-and-pr.md',
+    ]
+
+    for (const file of files) {
+      expect(readRepoFile(file)).toContain('detached HEAD')
     }
   })
 
@@ -202,6 +217,28 @@ describe('AI startup docs', () => {
 
       expect(output).toContain('Created .env.local')
       expect(readlinkSync(join(repoRoot, '.env.local'))).toBe(canonicalEnv)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('reports detached HEAD state during automated session-start', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
+
+    execFileSync('git', ['checkout', '--detach'], { cwd: repoRoot })
+
+    try {
+      const output = execFileSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: repoRoot,
+        },
+        encoding: 'utf8',
+      })
+
+      expect(output).toContain('Checkout: detached HEAD at')
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
     }

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -42,6 +42,7 @@ describe('trim-session-log script', () => {
       const output = readFileSync(outputPath, 'utf8')
 
       expect(output).toContain('# Pika Session Log')
+      expect(output).toContain('latest 60 entries')
       expect(output).not.toContain('## 2026-05-01 - First')
       expect(output).toContain('## 2026-05-02 - Second')
       expect(output).toContain('## 2026-05-03 - Third')
@@ -86,5 +87,12 @@ describe('trim-session-log script', () => {
       rmSync(repoRoot, { recursive: true, force: true })
       rmSync(otherCwd, { recursive: true, force: true })
     }
+  })
+
+  it('defaults to a weekly evidence-sized retention window', () => {
+    const script = readFileSync(scriptPath, 'utf8')
+
+    expect(script).toContain('const DEFAULT_KEEP = 60')
+    expect(script).toContain('[--keep 60]')
   })
 })


### PR DESCRIPTION
## Summary
- raise the default session log retention from 20 to 60 entries so weekly automations keep enough evidence
- make session-start and workflow prompts handle detached HEAD explicitly and block commit/PR flows from detached checkouts
- add workflow doc tests for the larger retention window and detached-HEAD wording

## Testing
- `git diff --check`
- `node scripts/trim-session-log.mjs --help`
- detached fixture run of `bash .codex/skills/pika-session-start/scripts/session_start.sh` reported `Checkout: detached HEAD at <sha>`
- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/trim-session-log.test.ts` could not run in this checkout because `node_modules` is missing and `vitest` is unavailable

## Notes
- the weekly `pika-e2e-coverage-builder` automation prompt was also updated locally under `$CODEX_HOME/automations`, but that file is outside the repo and is not part of this PR
