### PR TITLE
[codex] Harden gradebook bulk reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -450,6 +450,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `rg -n '\$PIKA_WORKTREE|detached HEAD|latest 60 entries' .ai .claude .codex docs scripts tests /Users/stew/.codex/automations/pika-e2e-coverage-builder/automation.toml`
 - `git diff --check`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/trim-session-log.test.ts` could not run because this checkout is missing `node_modules` and `vitest`
+
 ## 2026-05-30 — Simplify test schema-drift error shims
 
 **Completed:**
@@ -464,3 +465,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **PR:**
 - https://github.com/codepetca/pika/pull/677
+
+## 2026-05-30 — Gradebook bulk-read hardening
+
+**Completed:**
+- Added chunked and paginated loaders for teacher gradebook roster, profile, assignment doc, quiz, and test related reads.
+- Scoped assignment docs to currently enrolled students at query time so withdrawn-student docs cannot consume pages or affect current gradebook data.
+- Returned clear 500 responses for non-migration read failures that were previously swallowed into empty gradebook rows.
+- Preserved the `assignment_docs.teacher_cleared_at` missing-column fallback and optional test-table missing-table shims.
+- Added regressions for 51x51 filter chunking, >1000 related-row pagination, selected students beyond the first roster page, assignment-doc scoping, related-row failures, and migration fallbacks.
+- After rebasing onto the latest `main`, updated the assignment repo-target API test harness to match the shared chunked enrollment validator query shape.
+- Fixed PR review follow-up: legacy databases without `quiz_questions.correct_option` or `quiz_student_scores` now render the gradebook with quiz scoring/overrides empty instead of failing the route.
+
+**Validation:**
+- `pnpm vitest run tests/api/teacher/gradebook.test.ts --reporter=verbose`
+- `pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/teacher/gradebook/route.ts
+++ b/src/app/api/teacher/gradebook/route.ts
@@ -20,6 +20,8 @@ const ASSIGNMENT_POINTS_DEFAULT = 30
 const QUIZ_POINTS_DEFAULT = 100
 const ASSESSMENT_WEIGHT_DEFAULT = 10
 const ASSESSMENT_WEIGHT_MAX = 999
+const GRADEBOOK_BULK_FILTER_CHUNK_SIZE = 50
+const GRADEBOOK_BULK_PAGE_SIZE = 1000
 
 type GradebookAssessmentType = 'assignment' | 'quiz' | 'test'
 type GradebookAssessmentStatus =
@@ -40,6 +42,124 @@ type GradebookAssessmentCell = {
   is_graded: boolean
   is_manual_override?: boolean
   status?: GradebookAssessmentStatus | null
+}
+
+type QueryOrder = {
+  column: string
+  ascending?: boolean
+}
+
+function chunkIds(ids: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += chunkSize) {
+    chunks.push(ids.slice(index, index + chunkSize))
+  }
+  return chunks
+}
+
+function applyOrders(query: any, orderBy: QueryOrder[]): any {
+  return orderBy.reduce((currentQuery, order) => {
+    if (typeof currentQuery.order !== 'function') return currentQuery
+    return currentQuery.order(order.column, { ascending: order.ascending ?? true })
+  }, query)
+}
+
+async function loadPagedRows<T>(
+  buildQuery: () => any,
+  orderBy: QueryOrder[] = [{ column: 'id', ascending: true }]
+): Promise<{ rows: T[]; error: any }> {
+  const rows: T[] = []
+  let offset = 0
+
+  while (true) {
+    let query = buildQuery()
+    const supportsRange = typeof query.range === 'function'
+    if (supportsRange) {
+      query = applyOrders(query, orderBy)
+      query = query.range(offset, offset + GRADEBOOK_BULK_PAGE_SIZE - 1)
+    }
+
+    const { data, error } = await query
+    if (error) {
+      return { rows: [], error }
+    }
+
+    const pageRows = (data || []) as T[]
+    rows.push(...pageRows)
+
+    if (!supportsRange || pageRows.length < GRADEBOOK_BULK_PAGE_SIZE) break
+    offset += GRADEBOOK_BULK_PAGE_SIZE
+  }
+
+  return { rows, error: null }
+}
+
+async function loadSingleFilterRows<T>(
+  supabase: any,
+  table: string,
+  selection: string,
+  filterColumn: string,
+  ids: string[],
+  orderBy: QueryOrder[] = [{ column: 'id', ascending: true }]
+): Promise<{ rows: T[]; error: any }> {
+  if (ids.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: T[] = []
+  for (const idChunk of chunkIds(ids, GRADEBOOK_BULK_FILTER_CHUNK_SIZE)) {
+    const result = await loadPagedRows<T>(() =>
+      supabase
+        .from(table)
+        .select(selection)
+        .in(filterColumn, idChunk),
+      orderBy
+    )
+
+    if (result.error) {
+      return { rows: [], error: result.error }
+    }
+
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadStudentScopedRows<T>(
+  supabase: any,
+  table: string,
+  selection: string,
+  assessmentColumn: string,
+  assessmentIds: string[],
+  studentIds: string[],
+  orderBy: QueryOrder[] = [{ column: 'id', ascending: true }]
+): Promise<{ rows: T[]; error: any }> {
+  if (assessmentIds.length === 0 || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: T[] = []
+  for (const assessmentIdChunk of chunkIds(assessmentIds, GRADEBOOK_BULK_FILTER_CHUNK_SIZE)) {
+    for (const studentIdChunk of chunkIds(studentIds, GRADEBOOK_BULK_FILTER_CHUNK_SIZE)) {
+      const result = await loadPagedRows<T>(() =>
+        supabase
+          .from(table)
+          .select(selection)
+          .in(assessmentColumn, assessmentIdChunk)
+          .in('student_id', studentIdChunk),
+        orderBy
+      )
+
+      if (result.error) {
+        return { rows: [], error: result.error }
+      }
+
+      rows.push(...result.rows)
+    }
+  }
+
+  return { rows, error: null }
 }
 
 function mentionsMissingField(
@@ -250,10 +370,15 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
 
   const supabase = getServiceRoleClient()
 
-  const { data: enrollments, error: enrollmentError } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id, users!inner(email)')
-    .eq('classroom_id', classroomId)
+  const {
+    rows: enrollments,
+    error: enrollmentError,
+  } = await loadPagedRows<Array<{ student_id: string; users: { email: string } }>[number]>(() =>
+    supabase
+      .from('classroom_enrollments')
+      .select('student_id, users!inner(email)')
+      .eq('classroom_id', classroomId)
+  )
 
   if (enrollmentError) {
     console.error('Error loading enrollments:', enrollmentError)
@@ -266,12 +391,26 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 404 })
   }
 
-  const { data: profiles } = studentIds.length
-    ? await supabase
-        .from('student_profiles')
-        .select('user_id, student_number, first_name, last_name')
-        .in('user_id', studentIds)
-    : { data: [] as Array<{ user_id: string; student_number: string | null; first_name: string | null; last_name: string | null }> }
+  const {
+    rows: profiles,
+    error: profilesError,
+  } = await loadSingleFilterRows<{
+    user_id: string
+    student_number: string | null
+    first_name: string | null
+    last_name: string | null
+  }>(
+    supabase,
+    'student_profiles',
+    'user_id, student_number, first_name, last_name',
+    'user_id',
+    studentIds
+  )
+
+  if (profilesError) {
+    console.error('Error loading student profiles for gradebook:', profilesError)
+    return NextResponse.json({ error: 'Failed to load student profiles for gradebook' }, { status: 500 })
+  }
 
   const profileMap = new Map((profiles || []).map((p) => [p.user_id, p]))
 
@@ -286,11 +425,16 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     gradebook_weight: number
   }> = []
 
-  const { data: assignmentsWithMeta, error: assignmentsWithMetaError } = await supabase
-    .from('assignments')
-    .select('id, title, due_at, position, points_possible, include_in_final, is_draft, gradebook_weight')
-    .eq('classroom_id', classroomId)
-    .order('position', { ascending: true })
+  const {
+    rows: assignmentsWithMeta,
+    error: assignmentsWithMetaError,
+  } = await loadPagedRows<any>(() =>
+    supabase
+      .from('assignments')
+      .select('id, title, due_at, position, points_possible, include_in_final, is_draft, gradebook_weight')
+      .eq('classroom_id', classroomId)
+      .order('position', { ascending: true })
+  )
 
   if (!assignmentsWithMetaError) {
     assignments = (assignmentsWithMeta || []).map((assignment) => ({
@@ -309,11 +453,16 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       : 'id, title, due_at, position, is_draft'
 
     // Backward-compatible fallback for databases that have not applied gradebook metadata columns yet.
-    const { data: assignmentsLegacy, error: assignmentsLegacyError } = await supabase
-      .from('assignments')
-      .select(assignmentSelection)
-      .eq('classroom_id', classroomId)
-      .order('position', { ascending: true })
+    const {
+      rows: assignmentsLegacy,
+      error: assignmentsLegacyError,
+    } = await loadPagedRows<any>(() =>
+      supabase
+        .from('assignments')
+        .select(assignmentSelection)
+        .eq('classroom_id', classroomId)
+        .order('position', { ascending: true })
+    )
 
     if (assignmentsLegacyError) {
       console.error('Error loading assignments for gradebook:', assignmentsWithMetaError, assignmentsLegacyError)
@@ -334,12 +483,40 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
   assignments.sort(comparePositionThenTitle)
 
   const assignmentIds = assignments.map((a) => a.id)
-  const { data: docs } = assignmentIds.length
-    ? await supabase
-        .from('assignment_docs')
-        .select('assignment_id, student_id, score_completion, score_thinking, score_workflow, is_submitted, submitted_at, returned_at, teacher_cleared_at, graded_at')
-        .in('assignment_id', assignmentIds)
-    : { data: [] as Array<any> }
+  let docs: Array<any> = []
+  if (assignmentIds.length && studentIds.length) {
+    const assignmentDocSelection = 'assignment_id, student_id, score_completion, score_thinking, score_workflow, is_submitted, submitted_at, returned_at, teacher_cleared_at, graded_at'
+    const assignmentDocLegacySelection = 'assignment_id, student_id, score_completion, score_thinking, score_workflow, is_submitted, submitted_at, returned_at, graded_at'
+    let docsResult = await loadStudentScopedRows<any>(
+      supabase,
+      'assignment_docs',
+      assignmentDocSelection,
+      'assignment_id',
+      assignmentIds,
+      studentIds
+    )
+
+    if (docsResult.error && mentionsMissingField(docsResult.error, 'teacher_cleared_at')) {
+      docsResult = await loadStudentScopedRows<any>(
+        supabase,
+        'assignment_docs',
+        assignmentDocLegacySelection,
+        'assignment_id',
+        assignmentIds,
+        studentIds
+      )
+      if (!docsResult.error) {
+        docs = docsResult.rows.map((doc) => ({ ...doc, teacher_cleared_at: null }))
+      }
+    } else if (!docsResult.error) {
+      docs = docsResult.rows
+    }
+
+    if (docsResult.error) {
+      console.error('Error loading assignment docs for gradebook:', docsResult.error)
+      return NextResponse.json({ error: 'Failed to load assignment docs for gradebook' }, { status: 500 })
+    }
+  }
 
   type GradebookAssignmentDoc = {
     student_id: string
@@ -404,10 +581,15 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     gradebook_weight: number
   }> = []
 
-  const { data: quizzesWithMeta, error: quizzesWithMetaError } = await supabase
-    .from('quizzes')
-    .select('id, title, status, position, points_possible, include_in_final, gradebook_weight')
-    .eq('classroom_id', classroomId)
+  const {
+    rows: quizzesWithMeta,
+    error: quizzesWithMetaError,
+  } = await loadPagedRows<any>(() =>
+    supabase
+      .from('quizzes')
+      .select('id, title, status, position, points_possible, include_in_final, gradebook_weight')
+      .eq('classroom_id', classroomId)
+  )
 
   if (!quizzesWithMetaError) {
     quizzes = (quizzesWithMeta || []).map((quiz) => ({
@@ -425,10 +607,15 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       : 'id, title, status, position'
 
     // Backward-compatible fallback for databases that have not applied gradebook metadata columns yet.
-    const { data: quizzesLegacy, error: quizzesLegacyError } = await supabase
-      .from('quizzes')
-      .select(quizSelection)
-      .eq('classroom_id', classroomId)
+    const {
+      rows: quizzesLegacy,
+      error: quizzesLegacyError,
+    } = await loadPagedRows<any>(() =>
+      supabase
+        .from('quizzes')
+        .select(quizSelection)
+        .eq('classroom_id', classroomId)
+    )
 
     if (quizzesLegacyError) {
       console.error('Error loading quizzes for gradebook:', quizzesWithMetaError, quizzesLegacyError)
@@ -449,28 +636,75 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
 
   const quizIds = quizzes.map((q) => q.id)
 
-  const { data: quizQuestions } = quizIds.length
-    ? await supabase
-        .from('quiz_questions')
-        .select('id, quiz_id, correct_option')
-        .in('quiz_id', quizIds)
-    : { data: [] as Array<any> }
+  let quizQuestions: Array<any> = []
+  let quizQuestionsResult = await loadSingleFilterRows<any>(
+    supabase,
+    'quiz_questions',
+    'id, quiz_id, correct_option',
+    'quiz_id',
+    quizIds
+  )
 
-  const { data: quizResponses } = quizIds.length && studentIds.length
-    ? await supabase
-        .from('quiz_responses')
-        .select('quiz_id, question_id, student_id, selected_option')
-        .in('quiz_id', quizIds)
-        .in('student_id', studentIds)
-    : { data: [] as Array<any> }
+  if (quizQuestionsResult.error && mentionsMissingField(quizQuestionsResult.error, 'correct_option')) {
+    quizQuestionsResult = await loadSingleFilterRows<any>(
+      supabase,
+      'quiz_questions',
+      'id, quiz_id',
+      'quiz_id',
+      quizIds
+    )
+    if (!quizQuestionsResult.error) {
+      quizQuestions = quizQuestionsResult.rows.map((question) => ({ ...question, correct_option: null }))
+    }
+  } else if (!quizQuestionsResult.error) {
+    quizQuestions = quizQuestionsResult.rows
+  }
 
-  const { data: overrides } = quizIds.length && studentIds.length
-    ? await supabase
-        .from('quiz_student_scores')
-        .select('quiz_id, student_id, manual_override_score')
-        .in('quiz_id', quizIds)
-        .in('student_id', studentIds)
-    : { data: [] as Array<any> }
+  if (quizQuestionsResult.error) {
+    console.error('Error loading quiz questions for gradebook:', quizQuestionsResult.error)
+    return NextResponse.json({ error: 'Failed to load quiz questions for gradebook' }, { status: 500 })
+  }
+
+  const {
+    rows: quizResponses,
+    error: quizResponsesError,
+  } = await loadStudentScopedRows<any>(
+    supabase,
+    'quiz_responses',
+    'quiz_id, question_id, student_id, selected_option',
+    'quiz_id',
+    quizIds,
+    studentIds
+  )
+
+  if (quizResponsesError) {
+    console.error('Error loading quiz responses for gradebook:', quizResponsesError)
+    return NextResponse.json({ error: 'Failed to load quiz responses for gradebook' }, { status: 500 })
+  }
+
+  const {
+    rows: overrideRows,
+    error: overridesError,
+  } = await loadStudentScopedRows<any>(
+    supabase,
+    'quiz_student_scores',
+    'quiz_id, student_id, manual_override_score',
+    'quiz_id',
+    quizIds,
+    studentIds
+  )
+
+  let overrides = overrideRows
+
+  if (overridesError && (
+    isMissingTableError(overridesError) ||
+    mentionsMissingField(overridesError, 'manual_override_score')
+  )) {
+    overrides = []
+  } else if (overridesError) {
+    console.error('Error loading quiz override scores for gradebook:', overridesError)
+    return NextResponse.json({ error: 'Failed to load quiz override scores for gradebook' }, { status: 500 })
+  }
 
   const quizMap = new Map(quizzes.map((q) => [q.id, q]))
 
@@ -597,10 +831,15 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
     gradebook_weight: number
   }> = []
 
-  const { data: testsWithMeta, error: testsWithMetaError } = await supabase
-    .from('tests')
-    .select('id, title, status, position, include_in_final, gradebook_weight')
-    .eq('classroom_id', classroomId)
+  const {
+    rows: testsWithMeta,
+    error: testsWithMetaError,
+  } = await loadPagedRows<any>(() =>
+    supabase
+      .from('tests')
+      .select('id, title, status, position, include_in_final, gradebook_weight')
+      .eq('classroom_id', classroomId)
+  )
 
   if (!testsWithMetaError) {
     tests = (testsWithMeta || []).map((test) => ({
@@ -619,10 +858,15 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
       ? 'id, title, status, position, include_in_final'
       : 'id, title, status, position'
 
-    const { data: testsLegacy, error: testsLegacyError } = await supabase
-      .from('tests')
-      .select(testSelection)
-      .eq('classroom_id', classroomId)
+    const {
+      rows: testsLegacy,
+      error: testsLegacyError,
+    } = await loadPagedRows<any>(() =>
+      supabase
+        .from('tests')
+        .select(testSelection)
+        .eq('classroom_id', classroomId)
+    )
 
     if (!testsLegacyError) {
       tests = ((testsLegacy || []) as Array<any>).map((test) => ({
@@ -644,38 +888,50 @@ export const GET = withErrorHandler('GetGradebook', async (request: NextRequest)
   tests.sort(comparePositionThenTitle)
 
   const testIds = tests.map((test) => test.id)
-  const { data: testQuestions, error: testQuestionsError } = testIds.length
-    ? await supabase
-        .from('test_questions')
-        .select('id, test_id, points')
-        .in('test_id', testIds)
-    : { data: [] as Array<any>, error: null }
+  const {
+    rows: testQuestions,
+    error: testQuestionsError,
+  } = await loadSingleFilterRows<any>(
+    supabase,
+    'test_questions',
+    'id, test_id, points',
+    'test_id',
+    testIds
+  )
 
   if (testQuestionsError && !isMissingTableError(testQuestionsError)) {
     console.error('Error loading test questions for gradebook:', testQuestionsError)
     return NextResponse.json({ error: 'Failed to load test questions for gradebook' }, { status: 500 })
   }
 
-  const { data: testResponses, error: testResponsesError } = testIds.length && studentIds.length
-    ? await supabase
-        .from('test_responses')
-        .select('test_id, question_id, student_id, score')
-        .in('test_id', testIds)
-        .in('student_id', studentIds)
-    : { data: [] as Array<any>, error: null }
+  const {
+    rows: testResponses,
+    error: testResponsesError,
+  } = await loadStudentScopedRows<any>(
+    supabase,
+    'test_responses',
+    'test_id, question_id, student_id, score',
+    'test_id',
+    testIds,
+    studentIds
+  )
 
   if (testResponsesError && !isMissingTableError(testResponsesError)) {
     console.error('Error loading test responses for gradebook:', testResponsesError)
     return NextResponse.json({ error: 'Failed to load test responses for gradebook' }, { status: 500 })
   }
 
-  const { data: testAttempts, error: testAttemptsError } = testIds.length && studentIds.length
-    ? await supabase
-        .from('test_attempts')
-        .select('test_id, student_id, is_submitted, submitted_at')
-        .in('test_id', testIds)
-        .in('student_id', studentIds)
-    : { data: [] as Array<any>, error: null }
+  const {
+    rows: testAttempts,
+    error: testAttemptsError,
+  } = await loadStudentScopedRows<any>(
+    supabase,
+    'test_attempts',
+    'test_id, student_id, is_submitted, submitted_at',
+    'test_id',
+    testIds,
+    studentIds
+  )
 
   if (testAttemptsError && !isMissingTableError(testAttemptsError)) {
     console.error('Error loading test attempts for gradebook:', testAttemptsError)

--- a/tests/api/teacher/assignments-repo-targets-studentId.test.ts
+++ b/tests/api/teacher/assignments-repo-targets-studentId.test.ts
@@ -70,7 +70,7 @@ function createContext(studentId = 'student-1') {
 }
 
 function installRepoTargetTables(opts: {
-  enrollment?: { id: string } | null
+  enrollment?: { id?: string; student_id?: string } | null
   enrollmentError?: unknown
   existingDoc?: Record<string, unknown> | null
 }) {
@@ -82,12 +82,15 @@ function installRepoTargetTables(opts: {
       return {
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: vi.fn(async () => ({
-                data: opts.enrollment === undefined ? { id: 'enrollment-1' } : opts.enrollment,
+            in: vi.fn(async (_column: string, studentIds: string[]) => {
+              const enrollment = opts.enrollment === undefined
+                ? { id: 'enrollment-1', student_id: studentIds[0] }
+                : opts.enrollment
+              return {
+                data: enrollment ? [enrollment] : [],
                 error: opts.enrollmentError ?? null,
-              })),
-            })),
+              }
+            }),
           })),
         })),
       }

--- a/tests/api/teacher/gradebook.test.ts
+++ b/tests/api/teacher/gradebook.test.ts
@@ -7,21 +7,33 @@ vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1'
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type SupabaseReadError = { code?: string; message?: string; details?: string; hint?: string }
+
 type GradebookFixture = {
   enrollments?: Array<{ student_id: string; users: { email: string } }>
   profiles?: Array<{ user_id: string; student_number?: string | null; first_name: string | null; last_name: string | null }>
+  profilesError?: SupabaseReadError | null
   assignments?: Array<any>
   docs?: Array<any>
+  docsError?: SupabaseReadError | null
+  docsTeacherClearedAtError?: SupabaseReadError | null
   quizzes?: Array<any>
   quizQuestions?: Array<any>
+  quizQuestionsCorrectOptionError?: SupabaseReadError | null
+  quizQuestionsError?: SupabaseReadError | null
   quizResponses?: Array<any>
+  quizResponsesError?: SupabaseReadError | null
   quizOverrides?: Array<any>
+  quizOverridesError?: SupabaseReadError | null
   tests?: Array<any>
   testQuestions?: Array<any>
+  testQuestionsError?: SupabaseReadError | null
   testResponses?: Array<any>
+  testResponsesError?: SupabaseReadError | null
   testAttempts?: Array<any>
+  testAttemptsError?: SupabaseReadError | null
   settings?: { use_weights: boolean; assignments_weight: number; quizzes_weight: number; tests_weight?: number } | null
-  settingsError?: { code?: string; message?: string; details?: string; hint?: string } | null
+  settingsError?: SupabaseReadError | null
 }
 
 function buildMockFrom(fixture: GradebookFixture) {
@@ -73,11 +85,12 @@ function buildMockFrom(fixture: GradebookFixture) {
       return {
         select: vi.fn(() => ({
           in: vi.fn().mockResolvedValue({
-            data:
-              fixture.profiles ?? [
-                { user_id: 'student-1', student_number: '1001', first_name: 'Student', last_name: 'One' },
-              ],
-            error: null,
+            data: fixture.profilesError
+              ? null
+              : fixture.profiles ?? [
+                  { user_id: 'student-1', student_number: '1001', first_name: 'Student', last_name: 'One' },
+                ],
+            error: fixture.profilesError ?? null,
           }),
         })),
       }
@@ -102,12 +115,19 @@ function buildMockFrom(fixture: GradebookFixture) {
 
     if (table === 'assignment_docs') {
       return {
-        select: vi.fn(() => ({
-          in: vi.fn().mockResolvedValue({
-            data: fixture.docs ?? [],
-            error: null,
-          }),
-        })),
+        select: vi.fn((selection: string) => {
+          const selectionError = fixture.docsError ?? (
+            selection.includes('teacher_cleared_at') ? fixture.docsTeacherClearedAtError ?? null : null
+          )
+          return {
+            in: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: selectionError ? null : fixture.docs ?? [],
+                error: selectionError,
+              }),
+            })),
+          }
+        }),
       }
     }
 
@@ -124,12 +144,17 @@ function buildMockFrom(fixture: GradebookFixture) {
 
     if (table === 'quiz_questions') {
       return {
-        select: vi.fn(() => ({
-          in: vi.fn().mockResolvedValue({
-            data: fixture.quizQuestions ?? [],
-            error: null,
-          }),
-        })),
+        select: vi.fn((selection: string) => {
+          const selectionError = fixture.quizQuestionsError ?? (
+            selection.includes('correct_option') ? fixture.quizQuestionsCorrectOptionError ?? null : null
+          )
+          return {
+            in: vi.fn().mockResolvedValue({
+              data: selectionError ? null : fixture.quizQuestions ?? [],
+              error: selectionError,
+            }),
+          }
+        }),
       }
     }
 
@@ -138,8 +163,8 @@ function buildMockFrom(fixture: GradebookFixture) {
         select: vi.fn(() => ({
           in: vi.fn(() => ({
             in: vi.fn().mockResolvedValue({
-              data: fixture.quizResponses ?? [],
-              error: null,
+              data: fixture.quizResponsesError ? null : fixture.quizResponses ?? [],
+              error: fixture.quizResponsesError ?? null,
             }),
           })),
         })),
@@ -151,8 +176,8 @@ function buildMockFrom(fixture: GradebookFixture) {
         select: vi.fn(() => ({
           in: vi.fn(() => ({
             in: vi.fn().mockResolvedValue({
-              data: fixture.quizOverrides ?? [],
-              error: null,
+              data: fixture.quizOverridesError ? null : fixture.quizOverrides ?? [],
+              error: fixture.quizOverridesError ?? null,
             }),
           })),
         })),
@@ -174,8 +199,8 @@ function buildMockFrom(fixture: GradebookFixture) {
       return {
         select: vi.fn(() => ({
           in: vi.fn().mockResolvedValue({
-            data: fixture.testQuestions ?? [],
-            error: null,
+            data: fixture.testQuestionsError ? null : fixture.testQuestions ?? [],
+            error: fixture.testQuestionsError ?? null,
           }),
         })),
       }
@@ -186,8 +211,8 @@ function buildMockFrom(fixture: GradebookFixture) {
         select: vi.fn(() => ({
           in: vi.fn(() => ({
             in: vi.fn().mockResolvedValue({
-              data: fixture.testResponses ?? [],
-              error: null,
+              data: fixture.testResponsesError ? null : fixture.testResponses ?? [],
+              error: fixture.testResponsesError ?? null,
             }),
           })),
         })),
@@ -199,8 +224,8 @@ function buildMockFrom(fixture: GradebookFixture) {
         select: vi.fn(() => ({
           in: vi.fn(() => ({
             in: vi.fn().mockResolvedValue({
-              data: fixture.testAttempts ?? [],
-              error: null,
+              data: fixture.testAttemptsError ? null : fixture.testAttempts ?? [],
+              error: fixture.testAttemptsError ?? null,
             }),
           })),
         })),
@@ -208,6 +233,95 @@ function buildMockFrom(fixture: GradebookFixture) {
     }
 
     throw new Error(`Unexpected table in test: ${table}`)
+  })
+}
+
+type QueryTrace = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string; ascending?: boolean }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createTrace(): QueryTrace {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function buildPagedMockFrom(
+  rowsByTable: Record<string, Array<Record<string, any>>>,
+  trace: QueryTrace,
+  errors: Partial<Record<string, SupabaseReadError>> = {}
+) {
+  return vi.fn((table: string) => {
+    if (table === 'classrooms') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'c1', teacher_id: 'teacher-1', archived_at: null },
+              error: null,
+            }),
+          })),
+        })),
+      }
+    }
+
+    const createQuery = () => {
+      const filters: Array<{ column: string; values: any[] }> = []
+      const orders: Array<{ column: string; ascending: boolean }> = []
+
+      const resolveRows = (from?: number, to?: number) => {
+        const error = errors[table]
+        if (error) {
+          return { data: null, error }
+        }
+
+        let rows = [...(rowsByTable[table] || [])]
+        for (const filter of filters) {
+          rows = rows.filter((row) => filter.values.includes(row[filter.column]))
+        }
+
+        for (let index = orders.length - 1; index >= 0; index -= 1) {
+          const order = orders[index]
+          rows.sort((a, b) => {
+            const aValue = a[order.column]
+            const bValue = b[order.column]
+            const comparison = String(aValue ?? '').localeCompare(String(bValue ?? ''), undefined, { numeric: true })
+            return order.ascending ? comparison : -comparison
+          })
+        }
+
+        const data = from == null || to == null ? rows : rows.slice(from, to + 1)
+        return { data, error: null }
+      }
+
+      const query: any = {
+        eq: vi.fn((column: string, value: any) => {
+          filters.push({ column, values: [value] })
+          return query
+        }),
+        in: vi.fn((column: string, values: any[]) => {
+          trace.inCalls.push({ table, column, values: [...values] })
+          filters.push({ column, values: [...values] })
+          return query
+        }),
+        order: vi.fn((column: string, options?: { ascending?: boolean }) => {
+          trace.orderCalls.push({ table, column, ascending: options?.ascending })
+          orders.push({ column, ascending: options?.ascending ?? true })
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          trace.rangeCalls.push({ table, from, to })
+          return Promise.resolve(resolveRows(from, to))
+        }),
+        then: (resolve: any, reject: any) => Promise.resolve(resolveRows()).then(resolve, reject),
+      }
+
+      return query
+    }
+
+    return {
+      select: vi.fn(() => createQuery()),
+    }
   })
 }
 
@@ -673,6 +787,359 @@ describe('GET /api/teacher/gradebook', () => {
     })
   })
 
+  it('chunks large gradebook filters and scopes assignment docs to enrolled students', async () => {
+    const trace = createTrace()
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${String(index + 1).padStart(2, '0')}`)
+    const assignments = Array.from({ length: 51 }, (_, index) => ({
+      id: `assignment-${String(index + 1).padStart(2, '0')}`,
+      classroom_id: 'c1',
+      title: `Assignment ${index + 1}`,
+      due_at: '2025-01-01T12:00:00.000Z',
+      position: index + 1,
+      is_draft: false,
+      points_possible: 30,
+      include_in_final: true,
+      gradebook_weight: 10,
+    }))
+    const quizzes = Array.from({ length: 51 }, (_, index) => ({
+      id: `quiz-${String(index + 1).padStart(2, '0')}`,
+      classroom_id: 'c1',
+      title: `Quiz ${index + 1}`,
+      status: 'closed',
+      position: index + 1,
+      points_possible: 10,
+      include_in_final: true,
+      gradebook_weight: 10,
+    }))
+    const tests = Array.from({ length: 51 }, (_, index) => ({
+      id: `test-${String(index + 1).padStart(2, '0')}`,
+      classroom_id: 'c1',
+      title: `Test ${index + 1}`,
+      status: 'closed',
+      position: index + 1,
+      include_in_final: true,
+      gradebook_weight: 10,
+    }))
+
+    ;(mockSupabaseClient.from as any) = buildPagedMockFrom({
+      classroom_enrollments: studentIds.map((studentId, index) => ({
+        id: `enrollment-${String(index + 1).padStart(2, '0')}`,
+        classroom_id: 'c1',
+        student_id: studentId,
+        users: { email: `${studentId}@example.com` },
+      })),
+      student_profiles: studentIds.map((studentId, index) => ({
+        id: `profile-${String(index + 1).padStart(2, '0')}`,
+        user_id: studentId,
+        student_number: String(1000 + index),
+        first_name: 'Student',
+        last_name: String(index + 1),
+      })),
+      assignments,
+      assignment_docs: [
+        {
+          id: 'doc-first',
+          assignment_id: assignments[0].id,
+          student_id: studentIds[0],
+          score_completion: 3,
+          score_thinking: 3,
+          score_workflow: 3,
+        },
+        {
+          id: 'doc-last',
+          assignment_id: assignments[50].id,
+          student_id: studentIds[50],
+          score_completion: 6,
+          score_thinking: 6,
+          score_workflow: 6,
+        },
+        {
+          id: 'doc-withdrawn',
+          assignment_id: assignments[0].id,
+          student_id: 'withdrawn-student',
+          score_completion: 10,
+          score_thinking: 10,
+          score_workflow: 10,
+        },
+      ],
+      quizzes,
+      quiz_questions: [
+        { id: 'quiz-question-first', quiz_id: quizzes[0].id, correct_option: 1 },
+        { id: 'quiz-question-last', quiz_id: quizzes[50].id, correct_option: 1 },
+      ],
+      quiz_responses: [
+        { id: 'quiz-response-first', quiz_id: quizzes[0].id, question_id: 'quiz-question-first', student_id: studentIds[0], selected_option: 1 },
+        { id: 'quiz-response-last', quiz_id: quizzes[50].id, question_id: 'quiz-question-last', student_id: studentIds[50], selected_option: 1 },
+      ],
+      quiz_student_scores: [
+        { id: 'quiz-override-last', quiz_id: quizzes[50].id, student_id: studentIds[50], manual_override_score: 9 },
+      ],
+      tests,
+      test_questions: [
+        { id: 'test-question-first', test_id: tests[0].id, points: 5 },
+        { id: 'test-question-last', test_id: tests[50].id, points: 5 },
+      ],
+      test_responses: [
+        { id: 'test-response-first', test_id: tests[0].id, question_id: 'test-question-first', student_id: studentIds[0], score: 5 },
+        { id: 'test-response-last', test_id: tests[50].id, question_id: 'test-question-last', student_id: studentIds[50], score: 4 },
+      ],
+      test_attempts: [
+        { id: 'test-attempt-first', test_id: tests[0].id, student_id: studentIds[0], is_submitted: true },
+        { id: 'test-attempt-last', test_id: tests[50].id, student_id: studentIds[50], is_submitted: true },
+      ],
+    }, trace)
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(trace.inCalls.every((call) => call.values.length <= 50)).toBe(true)
+
+    const assignmentStudentFilters = trace.inCalls.filter((call) =>
+      call.table === 'assignment_docs' && call.column === 'student_id'
+    )
+    expect(assignmentStudentFilters.length).toBeGreaterThan(0)
+    expect(assignmentStudentFilters.some((call) => call.values.includes(studentIds[0]))).toBe(true)
+    expect(assignmentStudentFilters.some((call) => call.values.includes(studentIds[50]))).toBe(true)
+    expect(assignmentStudentFilters.every((call) => !call.values.includes('withdrawn-student'))).toBe(true)
+    expect(body.class_summary.assignments[0]).toMatchObject({
+      assignment_id: assignments[0].id,
+      graded_count: 1,
+      average_percent: 30,
+    })
+  })
+
+  it('paginates large gradebook related rows with stable ordering', async () => {
+    const trace = createTrace()
+    const studentIds = Array.from({ length: 50 }, (_, index) => `student-${String(index + 1).padStart(2, '0')}`)
+    const assignments = Array.from({ length: 50 }, (_, index) => ({
+      id: `assignment-${String(index + 1).padStart(2, '0')}`,
+      classroom_id: 'c1',
+      title: `Assignment ${index + 1}`,
+      due_at: '2025-01-01T12:00:00.000Z',
+      position: index + 1,
+      is_draft: false,
+      points_possible: 30,
+      include_in_final: true,
+      gradebook_weight: 10,
+    }))
+    const docs = assignments.flatMap((assignment, assignmentIndex) =>
+      studentIds.map((studentId, studentIndex) => ({
+        id: `doc-${String(assignmentIndex + 1).padStart(2, '0')}-${String(studentIndex + 1).padStart(2, '0')}`,
+        assignment_id: assignment.id,
+        student_id: studentId,
+        score_completion: 10,
+        score_thinking: 10,
+        score_workflow: 10,
+      }))
+    )
+
+    ;(mockSupabaseClient.from as any) = buildPagedMockFrom({
+      classroom_enrollments: studentIds.map((studentId, index) => ({
+        id: `enrollment-${String(index + 1).padStart(2, '0')}`,
+        classroom_id: 'c1',
+        student_id: studentId,
+        users: { email: `${studentId}@example.com` },
+      })),
+      student_profiles: [],
+      assignments,
+      assignment_docs: docs,
+      quizzes: [],
+      quiz_questions: [],
+      quiz_responses: [],
+      quiz_student_scores: [],
+      tests: [],
+      test_questions: [],
+      test_responses: [],
+      test_attempts: [],
+    }, trace)
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.class_summary.assignments[0].graded_count).toBe(50)
+    expect(body.class_summary.assignments[49].graded_count).toBe(50)
+    expect(trace.orderCalls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ table: 'assignment_docs', column: 'id' }),
+    ]))
+    expect(trace.rangeCalls).toEqual(expect.arrayContaining([
+      { table: 'assignment_docs', from: 0, to: 999 },
+      { table: 'assignment_docs', from: 1000, to: 1999 },
+      { table: 'assignment_docs', from: 2000, to: 2999 },
+    ]))
+  })
+
+  it('finds a selected enrolled student beyond the first roster page', async () => {
+    const trace = createTrace()
+    const studentIds = Array.from({ length: 1001 }, (_, index) => `student-${String(index + 1).padStart(4, '0')}`)
+    const selectedStudentId = studentIds[1000]
+
+    ;(mockSupabaseClient.from as any) = buildPagedMockFrom({
+      classroom_enrollments: studentIds.map((studentId, index) => ({
+        id: `enrollment-${String(index + 1).padStart(4, '0')}`,
+        classroom_id: 'c1',
+        student_id: studentId,
+        users: { email: `${studentId}@example.com` },
+      })),
+      student_profiles: [],
+      assignments: [],
+      assignment_docs: [],
+      quizzes: [],
+      quiz_questions: [],
+      quiz_responses: [],
+      quiz_student_scores: [],
+      tests: [],
+      test_questions: [],
+      test_responses: [],
+      test_attempts: [],
+    }, trace)
+
+    const request = new NextRequest(`http://localhost:3000/api/teacher/gradebook?classroom_id=c1&student_id=${selectedStudentId}`)
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.class_summary.total_students).toBe(1001)
+    expect(body.selected_student.student_id).toBe(selectedStudentId)
+    expect(trace.rangeCalls).toEqual(expect.arrayContaining([
+      { table: 'classroom_enrollments', from: 0, to: 999 },
+      { table: 'classroom_enrollments', from: 1000, to: 1999 },
+    ]))
+  })
+
+  it('returns 500 when gradebook related rows fail to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      assignments: [
+        { id: 'a1', title: 'Essay', due_at: '2025-01-01T12:00:00.000Z', position: 1, is_draft: false, points_possible: 30, include_in_final: true },
+      ],
+      docsError: { message: 'database unavailable' },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe('Failed to load assignment docs for gradebook')
+    consoleError.mockRestore()
+  })
+
+  it('falls back when assignment doc teacher_cleared_at is not migrated yet', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      assignments: [
+        { id: 'a1', title: 'Essay', due_at: '2025-01-01T12:00:00.000Z', position: 1, is_draft: false, points_possible: 30, include_in_final: true },
+      ],
+      docs: [
+        { assignment_id: 'a1', student_id: 'student-1', score_completion: 9, score_thinking: 8, score_workflow: 7 },
+      ],
+      docsTeacherClearedAtError: {
+        code: '42703',
+        message: 'column assignment_docs.teacher_cleared_at does not exist',
+      },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students[0].assignments_percent).toBe(80)
+    expect(body.students[0].final_percent).toBe(80)
+  })
+
+  it('falls back when quiz question correct_option is not migrated yet', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      quizzes: [{ id: 'q1', title: 'Quiz 1', status: 'closed', points_possible: 10, include_in_final: true }],
+      quizQuestions: [{ id: 'qq1', quiz_id: 'q1' }],
+      quizQuestionsCorrectOptionError: {
+        code: '42703',
+        message: 'column quiz_questions.correct_option does not exist',
+      },
+      quizResponses: [{ quiz_id: 'q1', question_id: 'qq1', student_id: 'student-1', selected_option: 0 }],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students[0].quizzes_percent).toBeNull()
+    expect(body.students[0].assessment_scores[0]).toEqual({
+      assessment_id: 'q1',
+      assessment_type: 'quiz',
+      earned: null,
+      possible: 10,
+      percent: null,
+      is_graded: false,
+      is_manual_override: false,
+      status: 'started',
+    })
+    expect(body.class_summary.quizzes[0]).toMatchObject({
+      quiz_id: 'q1',
+      scored_count: 0,
+      average_percent: null,
+    })
+  })
+
+  it('falls back when quiz override storage is not migrated yet', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      quizzes: [{ id: 'q1', title: 'Quiz 1', status: 'closed', points_possible: 10, include_in_final: true }],
+      quizQuestions: [{ id: 'qq1', quiz_id: 'q1', correct_option: 0 }],
+      quizResponses: [{ quiz_id: 'q1', question_id: 'qq1', student_id: 'student-1', selected_option: 0 }],
+      quizOverridesError: {
+        code: 'PGRST205',
+        message: 'Could not find the table public.quiz_student_scores',
+      },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.students[0].assessment_scores[0]).toEqual({
+      assessment_id: 'q1',
+      assessment_type: 'quiz',
+      earned: 10,
+      possible: 10,
+      percent: 100,
+      is_graded: true,
+      is_manual_override: false,
+    })
+    expect(body.students[0].final_percent).toBe(100)
+  })
+
+  it('keeps missing optional test tables as an empty test breakdown', async () => {
+    ;(mockSupabaseClient.from as any) = buildMockFrom({
+      tests: [{ id: 't1', title: 'Unit Test', status: 'closed', include_in_final: true }],
+      testQuestionsError: { code: 'PGRST205', message: 'Could not find the table public.test_questions' },
+      testResponsesError: { code: 'PGRST205', message: 'Could not find the table public.test_responses' },
+      testAttemptsError: { code: 'PGRST205', message: 'Could not find the table public.test_attempts' },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/gradebook?classroom_id=c1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.totals.tests).toBe(1)
+    expect(body.students[0].tests_percent).toBeNull()
+    expect(body.class_summary.tests).toEqual([
+      {
+        test_id: 't1',
+        title: 'Unit Test',
+        status: 'closed',
+        possible: 0,
+        scored_count: 0,
+        average_percent: null,
+      },
+    ])
+  })
+
   it('falls back to legacy assignment/quiz columns when gradebook metadata columns are unavailable', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'classrooms') {
@@ -745,9 +1212,13 @@ describe('GET /api/teacher/gradebook', () => {
       if (table === 'assignment_docs') {
         return {
           select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ assignment_id: 'a1', student_id: 'student-1', score_completion: 9, score_thinking: 8, score_workflow: 7 }],
-              error: null,
+            in: vi.fn(() => {
+              return {
+                in: vi.fn().mockResolvedValue({
+                  data: [{ assignment_id: 'a1', student_id: 'student-1', score_completion: 9, score_thinking: 8, score_workflow: 7 }],
+                  error: null,
+                }),
+              }
             }),
           })),
         }


### PR DESCRIPTION
## Summary
- Add chunked, paginated gradebook loaders for roster, profiles, assignment docs, quiz rows, overrides, and test rows.
- Scope assignment docs by currently enrolled student ids at query time so withdrawn-student docs cannot consume pages or affect current rows.
- Return clear 500s for non-migration read failures while preserving teacher_cleared_at, quiz correct_option, quiz override storage, and optional test-table migration fallbacks.
- Update the rebased assignment repo-target test harness to match the shared chunked enrollment validator query shape from latest main.

## Review follow-up
- Fixed the blocking review finding: legacy databases without quiz answer-key or override-score storage now render gradebooks with quiz scoring/overrides empty instead of returning 500.

## Validation
- pnpm vitest run tests/api/teacher/gradebook.test.ts --reporter=verbose
- pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check