### PR TITLE
[codex] Harden quiz and survey result reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -486,3 +486,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-30 — Quiz and survey results bulk-read hardening
+
+**Completed:**
+- Routed teacher quiz and survey result response reads through the shared chunked, paginated Supabase loader.
+- Scoped result reads by assessment id and currently enrolled student ids at query time while preserving stale-row filtering as a defensive guard.
+- Routed responder user/profile hydration through chunked, paginated reads and returned explicit 500s on hydration failures instead of silently dropping names or emails.
+- Added stable response ordering and responder id tie-breaks.
+- Added route regressions for 51-student chunking, >1000 response-row pagination, stale unenrolled rows, and responder hydration failures.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/quizzes-results.test.ts --reporter=verbose`
+- `pnpm vitest run tests/api/teacher/surveys-results.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/teacher/quizzes/[id]/results/route.ts
+++ b/src/app/api/teacher/quizzes/[id]/results/route.ts
@@ -4,11 +4,68 @@ import { requireRole } from '@/lib/auth'
 import { aggregateResults } from '@/lib/quizzes'
 import { assertTeacherOwnsQuiz } from '@/lib/server/quizzes'
 import { getClassroomStudentIds } from '@/lib/server/classrooms'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
 import type { QuizFocusSummary, QuizQuestion, QuizResponse } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+const QUIZ_RESULTS_PAGE_SIZE = 1000
+
+type ResponderUserRow = {
+  id: string
+  email: string
+}
+
+type ResponderProfileRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+async function loadQuizResponses(
+  supabase: any,
+  quizId: string,
+  studentIds: string[]
+): Promise<{ rows: QuizResponse[]; error: any }> {
+  return loadChunkedRows<QuizResponse>({
+    supabase,
+    table: 'quiz_responses',
+    select: '*',
+    filters: [
+      { column: 'quiz_id', values: [quizId] },
+      { column: 'student_id', values: studentIds },
+    ],
+    pageSize: QUIZ_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadResponderUsers(
+  supabase: any,
+  responderIds: string[]
+): Promise<{ rows: ResponderUserRow[]; error: any }> {
+  return loadChunkedRows<ResponderUserRow>({
+    supabase,
+    table: 'users',
+    select: 'id, email',
+    filters: [{ column: 'id', values: responderIds }],
+    pageSize: QUIZ_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadResponderProfiles(
+  supabase: any,
+  responderIds: string[]
+): Promise<{ rows: ResponderProfileRow[]; error: any }> {
+  return loadChunkedRows<ResponderProfileRow>({
+    supabase,
+    table: 'student_profiles',
+    select: 'user_id, first_name, last_name',
+    filters: [{ column: 'user_id', values: responderIds }],
+    pageSize: QUIZ_RESULTS_PAGE_SIZE,
+  })
+}
 
 // GET /api/teacher/quizzes/[id]/results - Get aggregated results
 export const GET = withErrorHandler('GetTeacherQuizResults', async (request, context) => {
@@ -40,21 +97,18 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
   }
 
   const responseResult = classroomStudentsResult.studentIds.length > 0
-    ? await supabase
-      .from('quiz_responses')
-      .select('*')
-      .eq('quiz_id', quizId)
-      .in('student_id', classroomStudentsResult.studentIds)
-    : { data: [], error: null }
-  const { data: responseRows, error: responsesError } = responseResult
-  const responses = (responseRows || []).filter((response) =>
-    classroomStudentsResult.studentIdSet.has(response.student_id)
-  )
+    ? await loadQuizResponses(supabase, quizId, classroomStudentsResult.studentIds)
+    : { rows: [], error: null }
+  const { rows: responseRows, error: responsesError } = responseResult
 
   if (responsesError) {
     console.error('Error fetching responses:', responsesError)
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
+
+  const responses = (responseRows || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  ).sort((a, b) => a.id.localeCompare(b.id))
 
   const responderIds = [...new Set(responses?.map((r) => r.student_id) || [])]
 
@@ -67,20 +121,22 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
   }[] = []
 
   if (responderIds.length > 0) {
-    const { data: users } = await supabase
-      .from('users')
-      .select('id, email')
-      .in('id', responderIds)
+    const { rows: users, error: usersError } = await loadResponderUsers(supabase, responderIds)
+    if (usersError) {
+      console.error('Error fetching responder users:', usersError)
+      return NextResponse.json({ error: 'Failed to fetch responder users' }, { status: 500 })
+    }
 
-    const { data: profiles } = await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', responderIds)
+    const { rows: profiles, error: profilesError } = await loadResponderProfiles(supabase, responderIds)
+    if (profilesError) {
+      console.error('Error fetching responder profiles:', profilesError)
+      return NextResponse.json({ error: 'Failed to fetch responder profiles' }, { status: 500 })
+    }
 
     const profileMap = new Map(
       profiles?.map((p) => [
         p.user_id,
-        `${p.first_name} ${p.last_name}`.trim(),
+        `${p.first_name || ''} ${p.last_name || ''}`.trim(),
       ]) || []
     )
 
@@ -101,7 +157,7 @@ export const GET = withErrorHandler('GetTeacherQuizResults', async (request, con
     responders.sort((a, b) => {
       const nameA = a.name || a.email
       const nameB = b.name || b.email
-      return nameA.localeCompare(nameB)
+      return nameA.localeCompare(nameB) || a.student_id.localeCompare(b.student_id)
     })
   }
 

--- a/src/app/api/teacher/surveys/[id]/results/route.ts
+++ b/src/app/api/teacher/surveys/[id]/results/route.ts
@@ -3,12 +3,69 @@ import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { aggregateSurveyResults } from '@/lib/surveys'
 import { getClassroomStudentIds } from '@/lib/server/classrooms'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
 import { assertTeacherOwnsSurvey } from '@/lib/server/surveys'
 import { getServiceRoleClient } from '@/lib/supabase'
 import type { SurveyQuestion, SurveyResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+const SURVEY_RESULTS_PAGE_SIZE = 1000
+
+type ResponderUserRow = {
+  id: string
+  email: string
+}
+
+type ResponderProfileRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+async function loadSurveyResponses(
+  supabase: any,
+  surveyId: string,
+  studentIds: string[]
+): Promise<{ rows: SurveyResponse[]; error: any }> {
+  return loadChunkedRows<SurveyResponse>({
+    supabase,
+    table: 'survey_responses',
+    select: '*',
+    filters: [
+      { column: 'survey_id', values: [surveyId] },
+      { column: 'student_id', values: studentIds },
+    ],
+    pageSize: SURVEY_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadResponderUsers(
+  supabase: any,
+  responderIds: string[]
+): Promise<{ rows: ResponderUserRow[]; error: any }> {
+  return loadChunkedRows<ResponderUserRow>({
+    supabase,
+    table: 'users',
+    select: 'id, email',
+    filters: [{ column: 'id', values: responderIds }],
+    pageSize: SURVEY_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadResponderProfiles(
+  supabase: any,
+  responderIds: string[]
+): Promise<{ rows: ResponderProfileRow[]; error: any }> {
+  return loadChunkedRows<ResponderProfileRow>({
+    supabase,
+    table: 'student_profiles',
+    select: 'user_id, first_name, last_name',
+    filters: [{ column: 'user_id', values: responderIds }],
+    pageSize: SURVEY_RESULTS_PAGE_SIZE,
+  })
+}
 
 export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, context) => {
   const user = await requireRole('teacher')
@@ -39,35 +96,34 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
   }
 
   const responseResult = classroomStudentsResult.studentIds.length > 0
-    ? await supabase
-      .from('survey_responses')
-      .select('*')
-      .eq('survey_id', surveyId)
-      .in('student_id', classroomStudentsResult.studentIds)
-    : { data: [], error: null }
-  const { data: responseRows, error: responsesError } = responseResult
-  const responses = (responseRows || []).filter((response) =>
-    classroomStudentsResult.studentIdSet.has(response.student_id)
-  )
+    ? await loadSurveyResponses(supabase, surveyId, classroomStudentsResult.studentIds)
+    : { rows: [], error: null }
+  const { rows: responseRows, error: responsesError } = responseResult
 
   if (responsesError) {
     console.error('Error fetching survey responses:', responsesError)
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
+  const responses = (responseRows || []).filter((response) =>
+    classroomStudentsResult.studentIdSet.has(response.student_id)
+  ).sort((a, b) => a.id.localeCompare(b.id))
+
   const responderIds = [...new Set((responses || []).map((response) => response.student_id))]
   const usersById = new Map<string, { email: string; name: string | null }>()
 
   if (responderIds.length > 0) {
-    const { data: users } = await supabase
-      .from('users')
-      .select('id, email')
-      .in('id', responderIds)
+    const { rows: users, error: usersError } = await loadResponderUsers(supabase, responderIds)
+    if (usersError) {
+      console.error('Error fetching survey responder users:', usersError)
+      return NextResponse.json({ error: 'Failed to fetch responder users' }, { status: 500 })
+    }
 
-    const { data: profiles } = await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', responderIds)
+    const { rows: profiles, error: profilesError } = await loadResponderProfiles(supabase, responderIds)
+    if (profilesError) {
+      console.error('Error fetching survey responder profiles:', profilesError)
+      return NextResponse.json({ error: 'Failed to fetch responder profiles' }, { status: 500 })
+    }
 
     const profileMap = new Map(
       (profiles || []).map((profile) => [
@@ -108,7 +164,10 @@ export const GET = withErrorHandler('GetTeacherSurveyResults', async (_request, 
         email: userRecord?.email ?? '',
       }
     })
-    .sort((a, b) => (a.name || a.email).localeCompare(b.name || b.email))
+    .sort((a, b) =>
+      (a.name || a.email).localeCompare(b.name || b.email) ||
+      a.student_id.localeCompare(b.student_id)
+    )
 
   return NextResponse.json({
     survey: {

--- a/tests/api/teacher/quizzes-results.test.ts
+++ b/tests/api/teacher/quizzes-results.test.ts
@@ -34,6 +34,69 @@ vi.mock('@/lib/server/quizzes', () => ({
   })),
 }))
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function createPagedTable(
+  table: string,
+  rows: Array<Record<string, any>>,
+  log: QueryLog,
+  error: any = null,
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const orderColumns: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          log.inCalls.push({ table, column, values })
+          filters.push({ column, values })
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          log.orderCalls.push({ table, column })
+          orderColumns.push(column)
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          log.rangeCalls.push({ table, from, to })
+          if (error) {
+            return Promise.resolve({ data: null, count: null, error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => filter.values.includes(String(row[filter.column])))
+          )
+          const orderedRows = [...filteredRows].sort((a, b) => {
+            for (const column of orderColumns) {
+              const valueA = String(a[column] ?? '')
+              const valueB = String(b[column] ?? '')
+              const result = valueA.localeCompare(valueB)
+              if (result !== 0) return result
+            }
+            return 0
+          })
+
+          return Promise.resolve({
+            data: orderedRows.slice(from, to + 1),
+            count: orderedRows.length,
+            error: null,
+          })
+        }),
+      }
+
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/quizzes/[id]/results', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -144,18 +207,26 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
       if (table === 'quiz_responses') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn((column: string, studentIds: string[]) => {
-              expect(column).toBe('student_id')
-              expect(studentIds).toEqual(['student-1', 'student-2'])
-              return Promise.resolve({
-                data: [
-                  { student_id: 'student-1', question_id: 'q1', selected_option: 0 },
-                  { student_id: 'student-2', question_id: 'q1', selected_option: 1 },
-                  { student_id: 'student-stale', question_id: 'q1', selected_option: 1 },
-                ],
-                error: null,
-              })
+            in: vi.fn((column: string, values: string[]) => {
+              expect(column).toBe('quiz_id')
+              expect(values).toEqual(['quiz-1'])
+              return {
+                in: vi.fn((studentColumn: string, studentIds: string[]) => {
+                  expect(studentColumn).toBe('student_id')
+                  expect(studentIds).toEqual(['student-1', 'student-2'])
+                  return {
+                    order: vi.fn().mockReturnThis(),
+                    range: vi.fn().mockResolvedValue({
+                      data: [
+                        { id: 'response-1', student_id: 'student-1', question_id: 'q1', selected_option: 0 },
+                        { id: 'response-2', student_id: 'student-2', question_id: 'q1', selected_option: 1 },
+                        { id: 'response-stale', student_id: 'student-stale', question_id: 'q1', selected_option: 1 },
+                      ],
+                      error: null,
+                    }),
+                  }
+                }),
+              }
             }),
           })),
         }
@@ -163,12 +234,15 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
       if (table === 'users') {
         return {
           select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                { id: 'student-1', email: 'a@example.com' },
-                { id: 'student-2', email: 'b@example.com' },
-              ],
-              error: null,
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnThis(),
+              range: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'student-1', email: 'a@example.com' },
+                  { id: 'student-2', email: 'b@example.com' },
+                ],
+                error: null,
+              }),
             }),
           })),
         }
@@ -176,12 +250,15 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
       if (table === 'student_profiles') {
         return {
           select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
-                { user_id: 'student-2', first_name: 'Zed', last_name: 'Young' },
-              ],
-              error: null,
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnThis(),
+              range: vi.fn().mockResolvedValue({
+                data: [
+                  { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
+                  { user_id: 'student-2', first_name: 'Zed', last_name: 'Young' },
+                ],
+                error: null,
+              }),
             }),
           })),
         }
@@ -215,5 +292,259 @@ describe('GET /api/teacher/quizzes/[id]/results', () => {
     expect(data.responders.map((responder: { student_id: string }) => responder.student_id)).not.toContain('student-stale')
     expect(data.responders[0].name).toBe('Alice Brown')
     expect(data.stats).toEqual({ total_students: 2, responded: 2 })
+  })
+
+  it('chunks and paginates response and responder reads for large rosters', async () => {
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) =>
+      `student-${String(index + 1).padStart(3, '0')}`
+    )
+    const questions = Array.from({ length: 25 }, (_, index) => ({
+      id: `q-${String(index + 1).padStart(2, '0')}`,
+      quiz_id: 'quiz-1',
+      question_text: `Question ${index + 1}`,
+      options: ['A', 'B'],
+      position: index,
+    }))
+    const responseRows = studentIds.flatMap((studentId) =>
+      questions.map((question) => ({
+        id: `response-${studentId}-${question.id}`,
+        quiz_id: 'quiz-1',
+        question_id: question.id,
+        student_id: studentId,
+        selected_option: 0,
+        submitted_at: '2026-03-01T00:00:00.000Z',
+      }))
+    )
+    const userRows = studentIds.map((studentId) => ({
+      id: studentId,
+      email: `${studentId}@example.com`,
+    }))
+    const profileRows = studentIds.map((studentId) => ({
+      id: `profile-${studentId}`,
+      user_id: studentId,
+      first_name: 'Student',
+      last_name: studentId.slice('student-'.length),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: questions, error: null }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: studentIds.map((studentId) => ({ student_id: studentId })),
+              count: studentIds.length,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'quiz_responses') return createPagedTable(table, responseRows, log)
+      if (table === 'users') return createPagedTable(table, userRows, log)
+      if (table === 'student_profiles') return createPagedTable(table, profileRows, log)
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results).toHaveLength(25)
+    expect(data.results[0].total_responses).toBe(51)
+    expect(data.stats).toEqual({ total_students: 51, responded: 51 })
+
+    const responseStudentChunks = log.inCalls.filter(
+      (call) => call.table === 'quiz_responses' && call.column === 'student_id'
+    )
+    expect(responseStudentChunks.map((call) => call.values.length)).toContain(50)
+    expect(responseStudentChunks.map((call) => call.values.length)).toContain(1)
+    expect(responseStudentChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(log.rangeCalls).toContainEqual({ table: 'quiz_responses', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'quiz_responses', from: 1000, to: 1999 })
+
+    const userChunks = log.inCalls.filter((call) => call.table === 'users' && call.column === 'id')
+    const profileChunks = log.inCalls.filter(
+      (call) => call.table === 'student_profiles' && call.column === 'user_id'
+    )
+    expect(userChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(profileChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(log.orderCalls).toContainEqual({ table: 'quiz_responses', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'users', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'student_profiles', column: 'id' })
+  })
+
+  it('returns 500 when response loading fails', async () => {
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q1', question_text: '2 + 2?', options: ['4', '5'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              count: 1,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'quiz_responses') {
+        return createPagedTable(table, [], log, { message: 'responses failed' })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch responses' })
+  })
+
+  it('returns 500 when responder user loading fails', async () => {
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q1', question_text: '2 + 2?', options: ['4', '5'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              count: 1,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'quiz_responses') {
+        return createPagedTable(
+          table,
+          [
+            {
+              id: 'response-1',
+              quiz_id: 'quiz-1',
+              question_id: 'q1',
+              student_id: 'student-1',
+              selected_option: 0,
+              submitted_at: '2026-03-01T00:00:00.000Z',
+            },
+          ],
+          log,
+        )
+      }
+      if (table === 'users') {
+        return createPagedTable(table, [], log, { message: 'users failed' })
+      }
+      if (table === 'student_profiles') {
+        throw new Error('profiles should not be loaded after user failure')
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch responder users' })
+  })
+
+  it('returns 500 when responder profile loading fails', async () => {
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'q1', question_text: '2 + 2?', options: ['4', '5'], position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              count: 1,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'quiz_responses') {
+        return createPagedTable(
+          table,
+          [
+            {
+              id: 'response-1',
+              quiz_id: 'quiz-1',
+              question_id: 'q1',
+              student_id: 'student-1',
+              selected_option: 0,
+              submitted_at: '2026-03-01T00:00:00.000Z',
+            },
+          ],
+          log,
+        )
+      }
+      if (table === 'users') {
+        return createPagedTable(table, [{ id: 'student-1', email: 'student@example.com' }], log)
+      }
+      if (table === 'student_profiles') {
+        return createPagedTable(table, [], log, { message: 'profiles failed' })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch responder profiles' })
   })
 })

--- a/tests/api/teacher/surveys-results.test.ts
+++ b/tests/api/teacher/surveys-results.test.ts
@@ -35,6 +35,69 @@ vi.mock('@/lib/server/surveys', () => ({
   })),
 }))
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function createPagedTable(
+  table: string,
+  rows: Array<Record<string, any>>,
+  log: QueryLog,
+  error: any = null,
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const orderColumns: string[] = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          log.inCalls.push({ table, column, values })
+          filters.push({ column, values })
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          log.orderCalls.push({ table, column })
+          orderColumns.push(column)
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          log.rangeCalls.push({ table, from, to })
+          if (error) {
+            return Promise.resolve({ data: null, count: null, error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => filter.values.includes(String(row[filter.column])))
+          )
+          const orderedRows = [...filteredRows].sort((a, b) => {
+            for (const column of orderColumns) {
+              const valueA = String(a[column] ?? '')
+              const valueB = String(b[column] ?? '')
+              const result = valueA.localeCompare(valueB)
+              if (result !== 0) return result
+            }
+            return 0
+          })
+
+          return Promise.resolve({
+            data: orderedRows.slice(from, to + 1),
+            count: orderedRows.length,
+            error: null,
+          })
+        }),
+      }
+
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/surveys/[id]/results', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -163,65 +226,73 @@ describe('GET /api/teacher/surveys/[id]/results', () => {
       if (table === 'survey_responses') {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn((column: string, studentIds: string[]) => {
-              expect(column).toBe('student_id')
-              expect(studentIds).toEqual(['student-1', 'student-2'])
-              return Promise.resolve({
-                data: [
-                  {
-                    id: 'response-1',
-                    survey_id: 'survey-1',
-                    question_id: 'q-mc',
-                    student_id: 'student-1',
-                    selected_option: 0,
-                    response_text: null,
-                    submitted_at: '2026-05-01T00:00:00.000Z',
-                    updated_at: '2026-05-01T00:00:00.000Z',
-                  },
-                  {
-                    id: 'response-2',
-                    survey_id: 'survey-1',
-                    question_id: 'q-mc',
-                    student_id: 'student-2',
-                    selected_option: 1,
-                    response_text: null,
-                    submitted_at: '2026-05-01T00:00:00.000Z',
-                    updated_at: '2026-05-01T00:00:00.000Z',
-                  },
-                  {
-                    id: 'response-stale-mc',
-                    survey_id: 'survey-1',
-                    question_id: 'q-mc',
-                    student_id: 'student-stale',
-                    selected_option: 1,
-                    response_text: null,
-                    submitted_at: '2026-05-02T00:00:00.000Z',
-                    updated_at: '2026-05-02T00:00:00.000Z',
-                  },
-                  {
-                    id: 'response-3',
-                    survey_id: 'survey-1',
-                    question_id: 'q-text',
-                    student_id: 'student-1',
-                    selected_option: null,
-                    response_text: 'Enrolled answer',
-                    submitted_at: '2026-05-03T00:00:00.000Z',
-                    updated_at: '2026-05-03T00:00:00.000Z',
-                  },
-                  {
-                    id: 'response-stale-text',
-                    survey_id: 'survey-1',
-                    question_id: 'q-text',
-                    student_id: 'student-stale',
-                    selected_option: null,
-                    response_text: 'Stale answer',
-                    submitted_at: '2026-05-04T00:00:00.000Z',
-                    updated_at: '2026-05-04T00:00:00.000Z',
-                  },
-                ],
-                error: null,
-              })
+            in: vi.fn((column: string, values: string[]) => {
+              expect(column).toBe('survey_id')
+              expect(values).toEqual(['survey-1'])
+              return {
+                in: vi.fn((studentColumn: string, studentIds: string[]) => {
+                  expect(studentColumn).toBe('student_id')
+                  expect(studentIds).toEqual(['student-1', 'student-2'])
+                  return {
+                    order: vi.fn().mockReturnThis(),
+                    range: vi.fn().mockResolvedValue({
+                      data: [
+                        {
+                          id: 'response-1',
+                          survey_id: 'survey-1',
+                          question_id: 'q-mc',
+                          student_id: 'student-1',
+                          selected_option: 0,
+                          response_text: null,
+                          submitted_at: '2026-05-01T00:00:00.000Z',
+                          updated_at: '2026-05-01T00:00:00.000Z',
+                        },
+                        {
+                          id: 'response-2',
+                          survey_id: 'survey-1',
+                          question_id: 'q-mc',
+                          student_id: 'student-2',
+                          selected_option: 1,
+                          response_text: null,
+                          submitted_at: '2026-05-01T00:00:00.000Z',
+                          updated_at: '2026-05-01T00:00:00.000Z',
+                        },
+                        {
+                          id: 'response-stale-mc',
+                          survey_id: 'survey-1',
+                          question_id: 'q-mc',
+                          student_id: 'student-stale',
+                          selected_option: 1,
+                          response_text: null,
+                          submitted_at: '2026-05-02T00:00:00.000Z',
+                          updated_at: '2026-05-02T00:00:00.000Z',
+                        },
+                        {
+                          id: 'response-3',
+                          survey_id: 'survey-1',
+                          question_id: 'q-text',
+                          student_id: 'student-1',
+                          selected_option: null,
+                          response_text: 'Enrolled answer',
+                          submitted_at: '2026-05-03T00:00:00.000Z',
+                          updated_at: '2026-05-03T00:00:00.000Z',
+                        },
+                        {
+                          id: 'response-stale-text',
+                          survey_id: 'survey-1',
+                          question_id: 'q-text',
+                          student_id: 'student-stale',
+                          selected_option: null,
+                          response_text: 'Stale answer',
+                          submitted_at: '2026-05-04T00:00:00.000Z',
+                          updated_at: '2026-05-04T00:00:00.000Z',
+                        },
+                      ],
+                      error: null,
+                    }),
+                  }
+                }),
+              }
             }),
           })),
         }
@@ -233,13 +304,16 @@ describe('GET /api/teacher/surveys/[id]/results', () => {
             in: vi.fn((column: string, studentIds: string[]) => {
               expect(column).toBe('id')
               expect(studentIds).toEqual(['student-1', 'student-2'])
-              return Promise.resolve({
-                data: [
-                  { id: 'student-1', email: 'alice@example.com' },
-                  { id: 'student-2', email: 'zed@example.com' },
-                ],
-                error: null,
-              })
+              return {
+                order: vi.fn().mockReturnThis(),
+                range: vi.fn().mockResolvedValue({
+                  data: [
+                    { id: 'student-1', email: 'alice@example.com' },
+                    { id: 'student-2', email: 'zed@example.com' },
+                  ],
+                  error: null,
+                }),
+              }
             }),
           })),
         }
@@ -251,13 +325,16 @@ describe('GET /api/teacher/surveys/[id]/results', () => {
             in: vi.fn((column: string, studentIds: string[]) => {
               expect(column).toBe('user_id')
               expect(studentIds).toEqual(['student-1', 'student-2'])
-              return Promise.resolve({
-                data: [
-                  { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
-                  { user_id: 'student-2', first_name: 'Zed', last_name: 'Young' },
-                ],
-                error: null,
-              })
+              return {
+                order: vi.fn().mockReturnThis(),
+                range: vi.fn().mockResolvedValue({
+                  data: [
+                    { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
+                    { user_id: 'student-2', first_name: 'Zed', last_name: 'Young' },
+                  ],
+                  error: null,
+                }),
+              }
             }),
           })),
         }
@@ -290,5 +367,175 @@ describe('GET /api/teacher/surveys/[id]/results', () => {
       'student-2',
     ])
     expect(data.stats).toEqual({ total_students: 2, responded: 2 })
+  })
+
+  it('chunks and paginates response and responder reads for large rosters', async () => {
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) =>
+      `student-${String(index + 1).padStart(3, '0')}`
+    )
+    const questions = Array.from({ length: 25 }, (_, index) => ({
+      id: `q-${String(index + 1).padStart(2, '0')}`,
+      survey_id: 'survey-1',
+      question_type: 'multiple_choice',
+      question_text: `Question ${index + 1}`,
+      options: ['A', 'B'],
+      response_max_chars: 500,
+      position: index,
+    }))
+    const responseRows = studentIds.flatMap((studentId) =>
+      questions.map((question) => ({
+        id: `response-${studentId}-${question.id}`,
+        survey_id: 'survey-1',
+        question_id: question.id,
+        student_id: studentId,
+        selected_option: 0,
+        response_text: null,
+        submitted_at: '2026-05-01T00:00:00.000Z',
+        updated_at: '2026-05-01T00:00:00.000Z',
+      }))
+    )
+    const userRows = studentIds.map((studentId) => ({
+      id: studentId,
+      email: `${studentId}@example.com`,
+    }))
+    const profileRows = studentIds.map((studentId) => ({
+      id: `profile-${studentId}`,
+      user_id: studentId,
+      first_name: 'Student',
+      last_name: studentId.slice('student-'.length),
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: questions, error: null }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: studentIds.map((studentId) => ({ student_id: studentId })),
+              count: studentIds.length,
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'survey_responses') return createPagedTable(table, responseRows, log)
+      if (table === 'users') return createPagedTable(table, userRows, log)
+      if (table === 'student_profiles') return createPagedTable(table, profileRows, log)
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results).toHaveLength(25)
+    expect(data.results[0].total_responses).toBe(51)
+    expect(data.stats).toEqual({ total_students: 51, responded: 51 })
+
+    const responseStudentChunks = log.inCalls.filter(
+      (call) => call.table === 'survey_responses' && call.column === 'student_id'
+    )
+    expect(responseStudentChunks.map((call) => call.values.length)).toContain(50)
+    expect(responseStudentChunks.map((call) => call.values.length)).toContain(1)
+    expect(responseStudentChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(log.rangeCalls).toContainEqual({ table: 'survey_responses', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'survey_responses', from: 1000, to: 1999 })
+
+    const userChunks = log.inCalls.filter((call) => call.table === 'users' && call.column === 'id')
+    const profileChunks = log.inCalls.filter(
+      (call) => call.table === 'student_profiles' && call.column === 'user_id'
+    )
+    expect(userChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(profileChunks.every((call) => call.values.length <= 50)).toBe(true)
+    expect(log.orderCalls).toContainEqual({ table: 'survey_responses', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'users', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'student_profiles', column: 'id' })
+  })
+
+  it('returns 500 when responder profile loading fails', async () => {
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'q-mc',
+                  survey_id: 'survey-1',
+                  question_type: 'multiple_choice',
+                  question_text: 'Choose one',
+                  options: ['A', 'B'],
+                  response_max_chars: 500,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              count: 1,
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'survey_responses') {
+        return createPagedTable(
+          table,
+          [
+            {
+              id: 'response-1',
+              survey_id: 'survey-1',
+              question_id: 'q-mc',
+              student_id: 'student-1',
+              selected_option: 0,
+              response_text: null,
+              submitted_at: '2026-05-01T00:00:00.000Z',
+              updated_at: '2026-05-01T00:00:00.000Z',
+            },
+          ],
+          log,
+        )
+      }
+      if (table === 'users') {
+        return createPagedTable(table, [{ id: 'student-1', email: 'student@example.com' }], log)
+      }
+      if (table === 'student_profiles') {
+        return createPagedTable(table, [], log, { message: 'profiles failed' })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch responder profiles' })
   })
 })


### PR DESCRIPTION
## Summary
- Route teacher quiz and survey result response reads through the shared chunked, paginated Supabase loader.
- Scope response reads by assessment id plus enrolled student ids at query time, while keeping stale-row filtering as a defensive guard.
- Make responder user/profile hydration chunked, paginated, stable, and explicit about Supabase failures.
- Add regressions for 51-student chunking, >1000 response-row pagination, stale unenrolled rows, and hydration failures.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/teacher/quizzes-results.test.ts --reporter=verbose`
- `pnpm vitest run tests/api/teacher/surveys-results.test.ts --reporter=verbose`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
- `git diff --check`