### PR TITLE
[codex] Harden teacher test result reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -506,3 +506,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-30 — Test results bulk-read hardening
+
+**Completed:**
+- Routed teacher test result reads through chunked, paginated loaders for roster, responses, student availability, attempts, users, profiles, and focus events.
+- Scoped test result reads by test id and currently enrolled student ids at query time while retaining defensive enrollment filtering.
+- Preserved legacy `test_attempts` return-column and closure-column fallbacks, including databases that are missing both sets of columns.
+- Returned explicit 500 responses for availability, user, profile, and focus-event load failures instead of silently rendering partial result data.
+- Preserved exact roster totals from the paginated enrollment helper and added deterministic student tie-break ordering.
+- Added route regressions for roster pagination beyond 1000 students, 51-student filter chunking, >1000 response-row pagination, availability migration fallback, attempt schema fallbacks, and hydration/focus failures.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/tests-results.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -5,17 +5,279 @@ import { aggregateResults, summarizeQuizFocusEvents } from '@/lib/quizzes'
 import {
   assertTeacherOwnsTest,
   getEffectiveStudentTestAccess,
-  getTestStudentAvailabilityMap,
   isMissingTestAttemptClosureColumnsError,
   isMissingTestAttemptReturnColumnsError,
+  isMissingTestStudentAvailabilityError,
 } from '@/lib/server/tests'
+import { getClassroomStudentIds } from '@/lib/server/classrooms'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
 import { getActiveTestAiGradingRunSummary } from '@/lib/server/test-ai-grading-runs'
 import { normalizeTestResponses } from '@/lib/test-attempts'
-import type { QuizFocusSummary, QuizQuestion, QuizResponse } from '@/types'
+import type { QuizFocusSummary, QuizQuestion, QuizResponse, TestStudentAvailabilityState } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+const TEST_RESULTS_PAGE_SIZE = 1000
+
+type TestResponseResultRow = {
+  id: string
+  test_id: string
+  question_id: string
+  student_id: string
+  selected_option: number | null
+  response_text: string | null
+  score: number | null
+  feedback: string | null
+  graded_at: string | null
+  graded_by: string | null
+  submitted_at: string
+}
+
+type TestAttemptResultRow = {
+  student_id: string
+  is_submitted: boolean
+  submitted_at: string | null
+  returned_at: string | null
+  returned_by: string | null
+  closed_for_grading_at: string | null
+  closed_for_grading_by: string | null
+  updated_at: string
+  responses: unknown
+}
+
+type UserResultRow = {
+  id: string
+  email: string
+}
+
+type StudentProfileResultRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+type FocusEventResultRow = {
+  student_id: string
+  event_type: any
+  occurred_at: string
+}
+
+type AvailabilityResultRow = {
+  student_id: string
+  state: unknown
+}
+
+function isMissingAvailabilityTableError(error: any): boolean {
+  return (
+    isMissingTestStudentAvailabilityError(error) ||
+    `${error?.message || error || ''}`.includes('Unexpected table: test_student_availability')
+  )
+}
+
+async function loadStudentScopedRows<T>(
+  supabase: any,
+  table: string,
+  select: string,
+  testId: string,
+  studentIds: string[],
+): Promise<{ rows: T[]; error: any }> {
+  return loadChunkedRows<T>({
+    supabase,
+    table,
+    select,
+    filters: [
+      { column: 'test_id', values: [testId] },
+      { column: 'student_id', values: studentIds },
+    ],
+    pageSize: TEST_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadTestResponses(
+  supabase: any,
+  testId: string,
+  studentIds: string[],
+): Promise<{ rows: TestResponseResultRow[]; error: any }> {
+  return loadStudentScopedRows<TestResponseResultRow>(
+    supabase,
+    'test_responses',
+    'id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, graded_by, submitted_at',
+    testId,
+    studentIds,
+  )
+}
+
+async function loadTestAttempts(
+  supabase: any,
+  testId: string,
+  studentIds: string[],
+): Promise<{ rows: TestAttemptResultRow[]; error: any }> {
+  async function loadAttemptsWithoutReturnOrClosure() {
+    const legacyResult = await loadStudentScopedRows<{
+      student_id: string
+      is_submitted: boolean
+      submitted_at: string | null
+      updated_at: string
+      responses: unknown
+    }>(
+      supabase,
+      'test_attempts',
+      'id, student_id, is_submitted, submitted_at, updated_at, responses',
+      testId,
+      studentIds,
+    )
+
+    return {
+      rows: legacyResult.rows.map((attempt) => ({
+        ...attempt,
+        returned_at: null,
+        returned_by: null,
+        closed_for_grading_at: null,
+        closed_for_grading_by: null,
+      })),
+      error: legacyResult.error,
+    }
+  }
+
+  const primaryResult = await loadStudentScopedRows<TestAttemptResultRow>(
+    supabase,
+    'test_attempts',
+    'id, student_id, is_submitted, submitted_at, returned_at, returned_by, closed_for_grading_at, closed_for_grading_by, updated_at, responses',
+    testId,
+    studentIds,
+  )
+  let attempts = primaryResult.rows
+  let attemptsError = primaryResult.error
+
+  if (attemptsError && isMissingTestAttemptReturnColumnsError(attemptsError)) {
+    const legacyResult = await loadAttemptsWithoutReturnOrClosure()
+    attempts = legacyResult.rows
+    attemptsError = legacyResult.error
+  }
+
+  if (attemptsError && isMissingTestAttemptClosureColumnsError(attemptsError)) {
+    const legacyResult = await loadStudentScopedRows<{
+      student_id: string
+      is_submitted: boolean
+      submitted_at: string | null
+      returned_at: string | null
+      returned_by: string | null
+      updated_at: string
+      responses: unknown
+    }>(
+      supabase,
+      'test_attempts',
+      'id, student_id, is_submitted, submitted_at, returned_at, returned_by, updated_at, responses',
+      testId,
+      studentIds,
+    )
+
+    attempts = legacyResult.rows.map((attempt) => ({
+      ...attempt,
+      closed_for_grading_at: null,
+      closed_for_grading_by: null,
+    }))
+    attemptsError = legacyResult.error
+
+    if (attemptsError && isMissingTestAttemptReturnColumnsError(attemptsError)) {
+      const baseLegacyResult = await loadAttemptsWithoutReturnOrClosure()
+      attempts = baseLegacyResult.rows
+      attemptsError = baseLegacyResult.error
+    }
+  }
+
+  return { rows: attempts || [], error: attemptsError }
+}
+
+async function loadUsers(
+  supabase: any,
+  studentIds: string[],
+): Promise<{ rows: UserResultRow[]; error: any }> {
+  return loadChunkedRows<UserResultRow>({
+    supabase,
+    table: 'users',
+    select: 'id, email',
+    filters: [{ column: 'id', values: studentIds }],
+    pageSize: TEST_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadStudentProfiles(
+  supabase: any,
+  studentIds: string[],
+): Promise<{ rows: StudentProfileResultRow[]; error: any }> {
+  return loadChunkedRows<StudentProfileResultRow>({
+    supabase,
+    table: 'student_profiles',
+    select: 'id, user_id, first_name, last_name',
+    filters: [{ column: 'user_id', values: studentIds }],
+    pageSize: TEST_RESULTS_PAGE_SIZE,
+  })
+}
+
+async function loadFocusEvents(
+  supabase: any,
+  testId: string,
+  studentIds: string[],
+): Promise<{ rows: FocusEventResultRow[]; error: any }> {
+  return loadStudentScopedRows<FocusEventResultRow>(
+    supabase,
+    'test_focus_events',
+    'id, student_id, event_type, occurred_at',
+    testId,
+    studentIds,
+  )
+}
+
+async function loadStudentAvailabilityMap(
+  supabase: any,
+  testId: string,
+  studentIds: string[],
+): Promise<{
+  stateByStudentId: Map<string, TestStudentAvailabilityState>
+  missingTable: boolean
+  error: any
+}> {
+  const stateByStudentId = new Map<string, TestStudentAvailabilityState>()
+  if (studentIds.length === 0) {
+    return { stateByStudentId, missingTable: false, error: null }
+  }
+
+  let result: { rows: AvailabilityResultRow[]; error: any }
+  try {
+    result = await loadStudentScopedRows<AvailabilityResultRow>(
+      supabase,
+      'test_student_availability',
+      'id, student_id, state',
+      testId,
+      studentIds,
+    )
+  } catch (error) {
+    return {
+      stateByStudentId,
+      missingTable: isMissingAvailabilityTableError(error),
+      error,
+    }
+  }
+
+  if (result.error) {
+    return {
+      stateByStudentId,
+      missingTable: isMissingAvailabilityTableError(result.error),
+      error: result.error,
+    }
+  }
+
+  for (const row of result.rows || []) {
+    if (row.state === 'open' || row.state === 'closed') {
+      stateByStudentId.set(row.student_id, row.state)
+    }
+  }
+
+  return { stateByStudentId, missingTable: false, error: null }
+}
 
 // GET /api/teacher/tests/[id]/results - Get aggregated results
 export const GET = withErrorHandler('GetTeacherTestResults', async (request, context) => {
@@ -41,26 +303,18 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 })
   }
 
-  const { data: enrollments, error: enrollmentsError } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id')
-    .eq('classroom_id', test.classroom_id)
-
-  if (enrollmentsError) {
-    console.error('Error fetching classroom enrollments:', enrollmentsError)
+  const classroomStudentsResult = await getClassroomStudentIds(supabase, test.classroom_id)
+  if (classroomStudentsResult.error) {
+    console.error('Error fetching classroom enrollments:', classroomStudentsResult.error)
     return NextResponse.json({ error: 'Failed to fetch enrollments' }, { status: 500 })
   }
 
-  const classroomStudentIds = [...new Set((enrollments || []).map((row) => row.student_id))]
-  const classroomStudentIdSet = new Set(classroomStudentIds)
-  const { data: responses, error: responsesError } =
+  const classroomStudentIds = classroomStudentsResult.studentIds
+  const classroomStudentIdSet = classroomStudentsResult.studentIdSet
+  const { rows: responses, error: responsesError } =
     classroomStudentIds.length > 0
-      ? await supabase
-          .from('test_responses')
-          .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, graded_by, submitted_at')
-          .eq('test_id', testId)
-          .in('student_id', classroomStudentIds)
-      : { data: [], error: null }
+      ? await loadTestResponses(supabase, testId, classroomStudentIds)
+      : { rows: [], error: null }
 
   if (responsesError) {
     console.error('Error fetching test responses:', responsesError)
@@ -69,8 +323,8 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
 
   const enrolledResponses = (responses || []).filter((response) =>
     classroomStudentIdSet.has(response.student_id)
-  )
-  const availabilityResult = await getTestStudentAvailabilityMap(supabase, testId, classroomStudentIds)
+  ).sort((a, b) => a.id.localeCompare(b.id))
+  const availabilityResult = await loadStudentAvailabilityMap(supabase, testId, classroomStudentIds)
   if (availabilityResult.error && !availabilityResult.missingTable) {
     console.error('Error fetching test student availability:', availabilityResult.error)
     return NextResponse.json({ error: 'Failed to fetch student access' }, { status: 500 })
@@ -146,79 +400,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     }
   >()
   if (classroomStudentIds.length > 0) {
-    let attempts:
-      | Array<{
-          student_id: string
-          is_submitted: boolean
-          submitted_at: string | null
-          returned_at: string | null
-          returned_by: string | null
-          closed_for_grading_at: string | null
-          closed_for_grading_by: string | null
-          updated_at: string
-          responses: unknown
-        }>
-      | null = null
-    let attemptsError: { code?: string; message?: string; details?: string; hint?: string } | null = null
-
-    {
-      const attemptsWithReturnResult = await supabase
-        .from('test_attempts')
-        .select('student_id, is_submitted, submitted_at, returned_at, returned_by, closed_for_grading_at, closed_for_grading_by, updated_at, responses')
-        .eq('test_id', testId)
-        .in('student_id', classroomStudentIds)
-
-      attempts = (attemptsWithReturnResult.data as typeof attempts) || null
-      attemptsError = attemptsWithReturnResult.error
-    }
-
-    if (attemptsError && isMissingTestAttemptReturnColumnsError(attemptsError)) {
-      const legacyAttemptsResult = await supabase
-        .from('test_attempts')
-        .select('student_id, is_submitted, submitted_at, updated_at, responses')
-        .eq('test_id', testId)
-        .in('student_id', classroomStudentIds)
-
-      attempts =
-        ((legacyAttemptsResult.data as Array<{
-          student_id: string
-          is_submitted: boolean
-          submitted_at: string | null
-          updated_at: string
-          responses: unknown
-        }> | null) || []).map((attempt) => ({
-          ...attempt,
-          returned_at: null,
-          returned_by: null,
-          closed_for_grading_at: null,
-          closed_for_grading_by: null,
-        }))
-      attemptsError = legacyAttemptsResult.error
-    }
-
-    if (attemptsError && isMissingTestAttemptClosureColumnsError(attemptsError)) {
-      const legacyAttemptsResult = await supabase
-        .from('test_attempts')
-        .select('student_id, is_submitted, submitted_at, returned_at, returned_by, updated_at, responses')
-        .eq('test_id', testId)
-        .in('student_id', classroomStudentIds)
-
-      attempts =
-        ((legacyAttemptsResult.data as Array<{
-          student_id: string
-          is_submitted: boolean
-          submitted_at: string | null
-          returned_at: string | null
-          returned_by: string | null
-          updated_at: string
-          responses: unknown
-        }> | null) || []).map((attempt) => ({
-          ...attempt,
-          closed_for_grading_at: null,
-          closed_for_grading_by: null,
-        }))
-      attemptsError = legacyAttemptsResult.error
-    }
+    const { rows: attempts, error: attemptsError } = await loadTestAttempts(supabase, testId, classroomStudentIds)
 
     if (attemptsError && attemptsError.code !== 'PGRST205') {
       console.error('Error fetching test attempts:', attemptsError)
@@ -244,14 +426,18 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     { email: string; first_name: string | null; last_name: string | null; name: string | null }
   >()
   if (classroomStudentIds.length > 0) {
-    const { data: users } = await supabase
-      .from('users')
-      .select('id, email')
-      .in('id', classroomStudentIds)
-    const { data: profiles } = await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', classroomStudentIds)
+    const { rows: users, error: usersError } = await loadUsers(supabase, classroomStudentIds)
+    if (usersError) {
+      console.error('Error fetching test result users:', usersError)
+      return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 })
+    }
+
+    const { rows: profiles, error: profilesError } = await loadStudentProfiles(supabase, classroomStudentIds)
+    if (profilesError) {
+      console.error('Error fetching test result student profiles:', profilesError)
+      return NextResponse.json({ error: 'Failed to fetch student profiles' }, { status: 500 })
+    }
+
     const profileMap = new Map(
       (profiles || []).map((profile) => [profile.user_id, profile])
     )
@@ -270,12 +456,11 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
 
   const focusSummaryByStudent = new Map<string, QuizFocusSummary>()
   if (classroomStudentIds.length > 0) {
-    const { data: focusEvents } = await supabase
-      .from('test_focus_events')
-      .select('student_id, event_type, occurred_at')
-      .eq('test_id', testId)
-      .in('student_id', classroomStudentIds)
-      .order('occurred_at', { ascending: true })
+    const { rows: focusEvents, error: focusEventsError } = await loadFocusEvents(supabase, testId, classroomStudentIds)
+    if (focusEventsError) {
+      console.error('Error fetching test focus events:', focusEventsError)
+      return NextResponse.json({ error: 'Failed to fetch focus events' }, { status: 500 })
+    }
 
     const grouped = new Map<string, Array<{ event_type: any; occurred_at: string }>>()
     for (const row of focusEvents || []) {
@@ -397,7 +582,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   students.sort((a, b) => {
     const left = a.name || a.email
     const right = b.name || b.email
-    return left.localeCompare(right)
+    return left.localeCompare(right) || a.student_id.localeCompare(b.student_id)
   })
 
   const responders = students
@@ -471,7 +656,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     students,
     responders,
     stats: {
-      total_students: classroomStudentIds.length,
+      total_students: classroomStudentsResult.totalStudents,
       responded: responders.length,
       open_questions_count: openQuestionIds.size,
       graded_open_responses: gradedOpenResponses,

--- a/tests/api/teacher/tests-results.test.ts
+++ b/tests/api/teacher/tests-results.test.ts
@@ -54,22 +54,113 @@ const mockSupabaseClient = { from: vi.fn() }
 
 type TestResponseFixture = { student_id: string } & Record<string, unknown>
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+type ChunkedTableOptions = {
+  table?: string
+  log?: QueryLog
+  errorForSelect?: (columns: string) => any
+  onIn?: (column: string, values: string[]) => void
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function mockChunkedTable(
+  rows: Array<Record<string, any>>,
+  options: ChunkedTableOptions = {},
+) {
+  return {
+    select: vi.fn((columns: string) => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values })
+          }
+          options.onIn?.(column, values)
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          const error = options.errorForSelect?.(columns)
+          if (error) {
+            return Promise.resolve({ data: null, error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => filter.values.includes(String(row[filter.column])))
+          )
+
+          return Promise.resolve({
+            data: filteredRows.slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 function mockTestResponsesQuery(
   rows: TestResponseFixture[],
   onStudentIds?: (studentIds: string[]) => void
 ) {
+  return mockChunkedTable(rows, {
+    table: 'test_responses',
+    onIn: (column, values) => {
+      if (column === 'student_id') onStudentIds?.(values)
+    },
+  })
+}
+
+function mockUsersQuery(rows: Array<Record<string, any>>, log?: QueryLog) {
+  return mockChunkedTable(rows, { table: 'users', log })
+}
+
+function mockProfilesQuery(rows: Array<Record<string, any>>, log?: QueryLog) {
+  return mockChunkedTable(rows, { table: 'student_profiles', log })
+}
+
+function mockFocusEventsQuery(rows: Array<Record<string, any>> = [], log?: QueryLog) {
+  return mockChunkedTable(rows, { table: 'test_focus_events', log })
+}
+
+function mockEnrollmentQuery(studentIds: string[], log?: QueryLog) {
   return {
-    select: vi.fn(() => ({
-      eq: vi.fn().mockReturnThis(),
-      in: vi.fn((column: string, studentIds: string[]) => {
-        expect(column).toBe('student_id')
-        onStudentIds?.(studentIds)
-        return Promise.resolve({
-          data: rows.filter((row) => studentIds.includes(row.student_id)),
-          error: null,
-        })
-      }),
-    })),
+    select: vi.fn(() => {
+      const query: any = {
+        eq: vi.fn(() => query),
+        order: vi.fn((column: string) => {
+          log?.orderCalls.push({ table: 'classroom_enrollments', column })
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          log?.rangeCalls.push({ table: 'classroom_enrollments', from, to })
+          return Promise.resolve({
+            data: studentIds.slice(from, to + 1).map((student_id) => ({ student_id })),
+            count: studentIds.length,
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
   }
 }
 
@@ -135,64 +226,38 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn((columns: string) => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockResolvedValue(
+        return mockChunkedTable(
+          [
+            {
+              test_id: 'test-1',
+              student_id: 'student-1',
+              is_submitted: true,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          {
+            errorForSelect: (columns) =>
               columns.includes('returned_at')
                 ? {
-                    data: null,
-                    error: {
-                      code: 'PGRST204',
-                      message: "Could not find column 'returned_at'",
-                    },
+                    code: 'PGRST204',
+                    message: "Could not find column 'returned_at'",
                   }
-                : {
-                    data: [
-                      {
-                        student_id: 'student-1',
-                        is_submitted: true,
-                        submitted_at: '2026-01-01T00:00:00.000Z',
-                        updated_at: '2026-01-01T00:00:00.000Z',
-                      },
-                    ],
-                    error: null,
-                  }
-            ),
-          })),
-        }
+                : null,
+          },
+        )
       }
 
       if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ id: 'student-1', email: 'student1@example.com' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
       }
 
       if (table === 'test_focus_events') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
+        return mockFocusEventsQuery()
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -325,59 +390,32 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  student_id: 'student-1',
-                  is_submitted: true,
-                  submitted_at: '2026-01-01T00:00:00.000Z',
-                  returned_at: null,
-                  returned_by: null,
-                  closed_for_grading_at: null,
-                  closed_for_grading_by: null,
-                  updated_at: '2026-01-01T00:00:00.000Z',
-                  responses: null,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockChunkedTable([
+          {
+            test_id: 'test-1',
+            student_id: 'student-1',
+            is_submitted: true,
+            submitted_at: '2026-01-01T00:00:00.000Z',
+            returned_at: null,
+            returned_by: null,
+            closed_for_grading_at: null,
+            closed_for_grading_by: null,
+            updated_at: '2026-01-01T00:00:00.000Z',
+            responses: null,
+          },
+        ])
       }
 
       if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ id: 'student-1', email: 'student1@example.com' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
       }
 
       if (table === 'test_focus_events') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
+        return mockFocusEventsQuery()
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -406,6 +444,553 @@ describe('GET /api/teacher/tests/[id]/results', () => {
     expect(data.stats.graded_open_responses).toBe(0)
     expect(data.stats.ungraded_open_responses).toBe(1)
     expect(data.stats.total_students).toBe(1)
+  })
+
+  it('paginates classroom enrollments so students beyond the first page are included', async () => {
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 1001 }, (_, index) =>
+      `student-${String(index + 1).padStart(4, '0')}`
+    )
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  test_id: 'test-1',
+                  question_type: 'multiple_choice',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  points: 1,
+                  response_max_chars: 5000,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') return mockEnrollmentQuery(studentIds, log)
+      if (table === 'test_responses') return mockChunkedTable([], { table, log })
+      if (table === 'test_attempts') return mockChunkedTable([], { table, log })
+      if (table === 'users') return mockUsersQuery([], log)
+      if (table === 'student_profiles') return mockProfilesQuery([], log)
+      if (table === 'test_focus_events') return mockFocusEventsQuery([], log)
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.stats.total_students).toBe(1001)
+    expect(data.students).toHaveLength(1001)
+    expect(data.students.some((student: { student_id: string }) => student.student_id === 'student-1001')).toBe(true)
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 1000, to: 1999 })
+  })
+
+  it('chunks and paginates test result reads for large rosters', async () => {
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) =>
+      `student-${String(index + 1).padStart(3, '0')}`
+    )
+    const questions = Array.from({ length: 25 }, (_, index) => ({
+      id: `question-${String(index + 1).padStart(2, '0')}`,
+      test_id: 'test-1',
+      question_type: 'multiple_choice',
+      question_text: `Question ${index + 1}`,
+      options: ['A', 'B'],
+      correct_option: 0,
+      points: 1,
+      response_max_chars: 5000,
+      position: index,
+    }))
+    const responseRows = studentIds.flatMap((studentId) =>
+      questions.map((question) => ({
+        id: `response-${studentId}-${question.id}`,
+        test_id: 'test-1',
+        question_id: question.id,
+        student_id: studentId,
+        selected_option: 0,
+        response_text: null,
+        score: 1,
+        feedback: null,
+        graded_at: null,
+        graded_by: null,
+        submitted_at: '2026-01-01T00:00:00.000Z',
+      }))
+    )
+    const attemptRows = studentIds.map((studentId) => ({
+      id: `attempt-${studentId}`,
+      test_id: 'test-1',
+      student_id: studentId,
+      is_submitted: true,
+      submitted_at: '2026-01-01T00:00:00.000Z',
+      returned_at: null,
+      returned_by: null,
+      closed_for_grading_at: null,
+      closed_for_grading_by: null,
+      updated_at: '2026-01-01T00:00:00.000Z',
+      responses: null,
+    }))
+    const userRows = studentIds.map((studentId) => ({
+      id: studentId,
+      email: `${studentId}@example.com`,
+    }))
+    const profileRows = studentIds.map((studentId) => ({
+      id: `profile-${studentId}`,
+      user_id: studentId,
+      first_name: 'Student',
+      last_name: studentId.slice('student-'.length),
+    }))
+    const focusRows = studentIds.map((studentId) => ({
+      id: `focus-${studentId}`,
+      test_id: 'test-1',
+      student_id: studentId,
+      event_type: 'route_exit_attempt',
+      occurred_at: '2026-01-01T00:05:00.000Z',
+    }))
+    const availabilityRows = studentIds.map((studentId) => ({
+      id: `availability-${studentId}`,
+      test_id: 'test-1',
+      student_id: studentId,
+      state: 'closed',
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: questions, error: null }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') return mockEnrollmentQuery(studentIds, log)
+      if (table === 'test_responses') return mockChunkedTable(responseRows, { table, log })
+      if (table === 'test_student_availability') return mockChunkedTable(availabilityRows, { table, log })
+      if (table === 'test_attempts') return mockChunkedTable(attemptRows, { table, log })
+      if (table === 'users') return mockUsersQuery(userRows, log)
+      if (table === 'student_profiles') return mockProfilesQuery(profileRows, log)
+      if (table === 'test_focus_events') return mockFocusEventsQuery(focusRows, log)
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results).toHaveLength(25)
+    expect(data.results[0].total_responses).toBe(51)
+    expect(data.stats).toEqual(
+      expect.objectContaining({
+        total_students: 51,
+        responded: 51,
+      }),
+    )
+
+    for (const table of [
+      'test_responses',
+      'test_student_availability',
+      'test_attempts',
+      'users',
+      'student_profiles',
+      'test_focus_events',
+    ]) {
+      const studentChunks = log.inCalls.filter((call) =>
+        call.table === table &&
+        (call.column === 'student_id' || call.column === 'id' || call.column === 'user_id')
+      )
+      expect(studentChunks.map((call) => call.values.length)).toContain(50)
+      expect(studentChunks.map((call) => call.values.length)).toContain(1)
+      expect(studentChunks.every((call) => call.values.length <= 50)).toBe(true)
+    }
+
+    expect(log.rangeCalls).toContainEqual({ table: 'test_responses', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'test_responses', from: 1000, to: 1999 })
+    expect(log.orderCalls).toContainEqual({ table: 'test_responses', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'test_attempts', column: 'id' })
+    expect(log.orderCalls).toContainEqual({ table: 'test_focus_events', column: 'id' })
+  })
+
+  it('falls back when only test_attempts closure columns are missing', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  test_id: 'test-1',
+                  question_type: 'multiple_choice',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  points: 1,
+                  response_max_chars: 5000,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_attempts') {
+        return mockChunkedTable(
+          [
+            {
+              test_id: 'test-1',
+              student_id: 'student-1',
+              is_submitted: true,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+              returned_at: '2026-01-02T00:00:00.000Z',
+              returned_by: 'teacher-1',
+              updated_at: '2026-01-02T00:00:00.000Z',
+              responses: null,
+            },
+          ],
+          {
+            errorForSelect: (columns) =>
+              columns.includes('closed_for_grading_at')
+                ? {
+                    code: 'PGRST204',
+                    message: "Could not find column 'closed_for_grading_at'",
+                  }
+                : null,
+          },
+        )
+      }
+      if (table === 'users') return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
+      if (table === 'student_profiles') {
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
+      }
+      if (table === 'test_focus_events') return mockFocusEventsQuery()
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students[0].status).toBe('returned')
+    expect(data.students[0].returned_at).toBe('2026-01-02T00:00:00.000Z')
+    expect(data.students[0].closed_for_grading_at).toBeNull()
+    expect(data.stats.returned_count).toBe(1)
+  })
+
+  it('falls back to the base legacy attempt shape when closure fallback also lacks return columns', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'question-1',
+                  test_id: 'test-1',
+                  question_type: 'multiple_choice',
+                  question_text: '2 + 2 = ?',
+                  options: ['4', '5'],
+                  correct_option: 0,
+                  points: 1,
+                  response_max_chars: 5000,
+                  position: 0,
+                },
+              ],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_attempts') {
+        return mockChunkedTable(
+          [
+            {
+              test_id: 'test-1',
+              student_id: 'student-1',
+              is_submitted: true,
+              submitted_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+              responses: null,
+            },
+          ],
+          {
+            errorForSelect: (columns) => {
+              if (columns.includes('closed_for_grading_at')) {
+                return {
+                  code: 'PGRST204',
+                  message: "Could not find column 'closed_for_grading_at'",
+                }
+              }
+              if (columns.includes('returned_at')) {
+                return {
+                  code: 'PGRST204',
+                  message: "Could not find column 'returned_at'",
+                }
+              }
+              return null
+            },
+          },
+        )
+      }
+      if (table === 'users') return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
+      if (table === 'student_profiles') {
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
+      }
+      if (table === 'test_focus_events') return mockFocusEventsQuery()
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students[0].status).toBe('submitted')
+    expect(data.students[0].returned_at).toBeNull()
+    expect(data.students[0].closed_for_grading_at).toBeNull()
+  })
+
+  it('continues when test student availability has not been migrated yet', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'question-1', question_type: 'multiple_choice', question_text: 'Q', options: ['A'], points: 1, position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ student_id: 'student-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_student_availability') {
+        return mockChunkedTable([], { errorForSelect: () => ({ code: 'PGRST205', message: 'missing table' }) })
+      }
+      if (table === 'test_attempts') return mockChunkedTable([])
+      if (table === 'users') return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
+      if (table === 'student_profiles') {
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
+      }
+      if (table === 'test_focus_events') return mockFocusEventsQuery()
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students[0].access_state).toBeNull()
+    expect(data.students[0].effective_access).toBe('open')
+  })
+
+  it('returns 500 when availability loading fails for a non-migration reason', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'question-1', question_type: 'multiple_choice', question_text: 'Q', options: ['A'], points: 1, position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ student_id: 'student-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_student_availability') {
+        return mockChunkedTable([], { errorForSelect: () => ({ code: '500', message: 'availability failed' }) })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch student access' })
+  })
+
+  it('returns 500 when user hydration fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'question-1', question_type: 'multiple_choice', question_text: 'Q', options: ['A'], points: 1, position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ student_id: 'student-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_attempts') return mockChunkedTable([])
+      if (table === 'users') return mockChunkedTable([], { errorForSelect: () => ({ message: 'users failed' }) })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch users' })
+  })
+
+  it('returns 500 when profile hydration fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'question-1', question_type: 'multiple_choice', question_text: 'Q', options: ['A'], points: 1, position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ student_id: 'student-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_attempts') return mockChunkedTable([])
+      if (table === 'users') return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
+      if (table === 'student_profiles') {
+        return mockChunkedTable([], { errorForSelect: () => ({ message: 'profiles failed' }) })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch student profiles' })
+  })
+
+  it('returns 500 when focus event loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_questions') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [{ id: 'question-1', question_type: 'multiple_choice', question_text: 'Q', options: ['A'], points: 1, position: 0 }],
+              error: null,
+            }),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [{ student_id: 'student-1' }], error: null }),
+          })),
+        }
+      }
+      if (table === 'test_responses') return mockTestResponsesQuery([])
+      if (table === 'test_attempts') return mockChunkedTable([])
+      if (table === 'users') return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
+      if (table === 'student_profiles') {
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
+      }
+      if (table === 'test_focus_events') {
+        return mockChunkedTable([], { errorForSelect: () => ({ message: 'focus failed' }) })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch focus events' })
   })
 
   it('includes in-progress draft answers from test_attempts for teacher monitoring', async () => {
@@ -450,62 +1035,37 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  student_id: 'student-1',
-                  is_submitted: false,
-                  submitted_at: null,
-                  returned_at: null,
-                  returned_by: null,
-                  updated_at: '2026-01-02T12:00:00.000Z',
-                  responses: {
-                    'question-open-1': {
-                      question_type: 'open_response',
-                      response_text: 'Draft answer in progress',
-                    },
-                  },
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockChunkedTable([
+          {
+            test_id: 'test-1',
+            student_id: 'student-1',
+            is_submitted: false,
+            submitted_at: null,
+            returned_at: null,
+            returned_by: null,
+            closed_for_grading_at: null,
+            closed_for_grading_by: null,
+            updated_at: '2026-01-02T12:00:00.000Z',
+            responses: {
+              'question-open-1': {
+                question_type: 'open_response',
+                response_text: 'Draft answer in progress',
+              },
+            },
+          },
+        ])
       }
 
       if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ id: 'student-1', email: 'student1@example.com' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
       }
 
       if (table === 'test_focus_events') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
+        return mockFocusEventsQuery()
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -597,47 +1157,19 @@ describe('GET /api/teacher/tests/[id]/results', () => {
       }
 
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
+        return mockChunkedTable([])
       }
 
       if (table === 'users') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ id: 'student-1', email: 'student1@example.com' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockUsersQuery([{ id: 'student-1', email: 'student1@example.com' }])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ user_id: 'student-1', first_name: 'Student', last_name: 'One' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockProfilesQuery([{ id: 'profile-1', user_id: 'student-1', first_name: 'Student', last_name: 'One' }])
       }
 
       if (table === 'test_focus_events') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            in: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
+        return mockFocusEventsQuery()
       }
 
       throw new Error(`Unexpected table: ${table}`)


### PR DESCRIPTION
## Summary
- route teacher test result reads through chunked, paginated loaders for roster, responses, availability, attempts, users, profiles, and focus events
- preserve legacy test_attempts return/closure-column fallbacks, including databases missing both column groups
- return explicit 500s for availability/user/profile/focus load failures and preserve exact roster totals from paginated enrollment reads

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/teacher/tests-results.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check