### PR TITLE
[codex] Harden attendance export reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -526,3 +526,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-30 — Attendance export bulk-read hardening
+
+**Completed:**
+- Added a shared server attendance report loader for teacher attendance and CSV export routes.
+- Routed class-day, enrollment, profile, and entry reads through chunked, paginated loaders.
+- Scoped attendance entry reads by classroom id and currently enrolled student ids so stale withdrawn-student entries cannot consume pages or affect exports.
+- Returned explicit 500s for student profile hydration failures instead of rendering blank names after a failed read.
+- Added deterministic student ordering by email with id tie-breaks.
+- Added API regressions for >1000-student roster pagination, 51-student profile/entry chunking, dense entry pagination, stale-entry scoping, and profile failure handling.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/teacher/attendance/route.ts
+++ b/src/app/api/teacher/attendance/route.ts
@@ -4,6 +4,11 @@ import { requireRole } from '@/lib/auth'
 import { computeAttendanceRecords } from '@/lib/attendance'
 import { getTodayInToronto } from '@/lib/timezone'
 import { withErrorHandler, ApiError } from '@/lib/api-handler'
+import {
+  loadAttendanceClassDays,
+  loadAttendanceEntries,
+  loadAttendanceRoster,
+} from '@/lib/server/attendance-report'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -39,66 +44,29 @@ export const GET = withErrorHandler('GetAttendance', async (request: NextRequest
     throw new ApiError(403, 'Forbidden')
   }
 
-  // Fetch class days for this classroom
-  const { data: classDays, error: classDaysError } = await supabase
-    .from('class_days')
-    .select('*')
-    .eq('classroom_id', classroomId)
-    .order('date', { ascending: true })
+  const { rows: classDays, error: classDaysError } = await loadAttendanceClassDays(supabase, classroomId)
 
   if (classDaysError) {
     console.error('Error fetching class days:', classDaysError)
     throw new ApiError(500, 'Failed to fetch class days')
   }
 
-  // Fetch enrolled students with profiles
-  const { data: enrollments, error: enrollmentsError } = await supabase
-    .from('classroom_enrollments')
-    .select(`
-      student_id,
-      users!classroom_enrollments_student_id_fkey(
-        id,
-        email
-      )
-    `)
-    .eq('classroom_id', classroomId)
-
-  if (enrollmentsError) {
-    console.error('Error fetching enrollments:', enrollmentsError)
+  const rosterResult = await loadAttendanceRoster(supabase, classroomId)
+  if (rosterResult.enrollmentsError) {
+    console.error('Error fetching enrollments:', rosterResult.enrollmentsError)
     throw new ApiError(500, 'Failed to fetch students')
   }
 
-  // Fetch student profiles
-  const studentIds = (enrollments || []).map(e => e.student_id)
-  const { data: profiles, error: profilesError } = await supabase
-    .from('student_profiles')
-    .select('user_id, first_name, last_name')
-    .in('user_id', studentIds)
-
-  if (profilesError) {
-    console.error('Error fetching student profiles:', profilesError)
+  if (rosterResult.profilesError) {
+    console.error('Error fetching student profiles:', rosterResult.profilesError)
+    throw new ApiError(500, 'Failed to fetch student profiles')
   }
 
-  const profileMap = new Map(
-    (profiles || []).map(p => [p.user_id, p])
+  const { rows: entries, error: entriesError } = await loadAttendanceEntries(
+    supabase,
+    classroomId,
+    rosterResult.studentIds
   )
-
-  const students = (enrollments || []).map(e => {
-    const enrolledUser = e.users as unknown as { id: string; email: string }
-    const profile = profileMap.get(enrolledUser.id)
-    return {
-      id: enrolledUser.id,
-      email: enrolledUser.email,
-      first_name: profile?.first_name || '',
-      last_name: profile?.last_name || '',
-    }
-  }).sort((a, b) => a.email.localeCompare(b.email))
-
-  // Fetch all entries for this classroom
-  const { data: entries, error: entriesError } = await supabase
-    .from('entries')
-    .select('*')
-    .eq('classroom_id', classroomId)
 
   if (entriesError) {
     console.error('Error fetching entries:', entriesError)
@@ -108,14 +76,14 @@ export const GET = withErrorHandler('GetAttendance', async (request: NextRequest
   // Compute attendance records
   const today = getTodayInToronto()
   const attendanceRecords = computeAttendanceRecords(
-    students,
-    classDays || [],
-    entries || [],
+    rosterResult.students,
+    classDays,
+    entries,
     today
   )
 
   // Get sorted list of class day dates
-  const dates = (classDays || [])
+  const dates = classDays
     .filter(day => day.is_class_day)
     .map(day => day.date)
 

--- a/src/app/api/teacher/export-csv/route.ts
+++ b/src/app/api/teacher/export-csv/route.ts
@@ -4,6 +4,11 @@ import { requireRole } from '@/lib/auth'
 import { computeAttendanceRecords } from '@/lib/attendance'
 import { getTodayInToronto } from '@/lib/timezone'
 import { withErrorHandler } from '@/lib/api-handler'
+import {
+  loadAttendanceClassDays,
+  loadAttendanceEntries,
+  loadAttendanceRoster,
+} from '@/lib/server/attendance-report'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -48,12 +53,7 @@ export const GET = withErrorHandler('GetTeacherExportCsv', async (request, conte
     )
   }
 
-  // Fetch class days
-  const { data: classDays, error: classDaysError } = await supabase
-    .from('class_days')
-    .select('*')
-    .eq('classroom_id', classroomId)
-    .order('date', { ascending: true })
+  const { rows: classDays, error: classDaysError } = await loadAttendanceClassDays(supabase, classroomId)
 
   if (classDaysError) {
     console.error('Error fetching class days:', classDaysError)
@@ -63,65 +63,28 @@ export const GET = withErrorHandler('GetTeacherExportCsv', async (request, conte
     )
   }
 
-  // Fetch enrolled students
-  const { data: enrollments, error: enrollmentsError } = await supabase
-    .from('classroom_enrollments')
-    .select(`
-      student_id,
-      users!classroom_enrollments_student_id_fkey(
-        id,
-        email
-      )
-    `)
-    .eq('classroom_id', classroomId)
-
-  if (enrollmentsError) {
-    console.error('Error fetching enrollments:', enrollmentsError)
+  const rosterResult = await loadAttendanceRoster(supabase, classroomId)
+  if (rosterResult.enrollmentsError) {
+    console.error('Error fetching enrollments:', rosterResult.enrollmentsError)
     return NextResponse.json(
       { error: 'Failed to fetch students' },
       { status: 500 }
     )
   }
 
-  const studentIds = (enrollments || []).map(e => e.student_id)
-  const profileMap = new Map<string, { first_name: string; last_name: string }>()
-
-  if (studentIds.length > 0) {
-    const { data: profiles, error: profilesError } = await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', studentIds)
-
-    if (profilesError) {
-      console.error('Error fetching student profiles:', profilesError)
-    }
-
-    for (const profile of profiles || []) {
-      profileMap.set(profile.user_id, {
-        first_name: profile.first_name || '',
-        last_name: profile.last_name || '',
-      })
-    }
+  if (rosterResult.profilesError) {
+    console.error('Error fetching student profiles:', rosterResult.profilesError)
+    return NextResponse.json(
+      { error: 'Failed to fetch student profiles' },
+      { status: 500 }
+    )
   }
 
-  const students = (enrollments || [])
-    .map(e => {
-      const u = e.users as unknown as { id: string; email: string }
-      const profile = profileMap.get(u.id)
-      return {
-        id: u.id,
-        email: u.email,
-        first_name: profile?.first_name || '',
-        last_name: profile?.last_name || '',
-      }
-    })
-    .sort((a, b) => a.email.localeCompare(b.email))
-
-  // Fetch entries
-  const { data: entries, error: entriesError } = await supabase
-    .from('entries')
-    .select('*')
-    .eq('classroom_id', classroomId)
+  const { rows: entries, error: entriesError } = await loadAttendanceEntries(
+    supabase,
+    classroomId,
+    rosterResult.studentIds
+  )
 
   if (entriesError) {
     console.error('Error fetching entries:', entriesError)
@@ -134,14 +97,14 @@ export const GET = withErrorHandler('GetTeacherExportCsv', async (request, conte
   // Compute attendance
   const today = getTodayInToronto()
   const attendanceRecords = computeAttendanceRecords(
-    students || [],
-    classDays || [],
-    entries || [],
+    rosterResult.students,
+    classDays,
+    entries,
     today
   )
 
   // Get sorted dates (only class days)
-  const dates = (classDays || [])
+  const dates = classDays
     .filter(day => day.is_class_day)
     .map(day => day.date)
 

--- a/src/lib/server/attendance-report.ts
+++ b/src/lib/server/attendance-report.ts
@@ -1,0 +1,157 @@
+import type { ClassDay, Entry } from '@/types'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
+
+const ATTENDANCE_REPORT_PAGE_SIZE = 1000
+
+export type AttendanceReportStudent = {
+  id: string
+  email: string
+  first_name: string
+  last_name: string
+}
+
+type EnrollmentRow = {
+  id: string
+  student_id: string
+  users: { id: string; email: string } | Array<{ id: string; email: string }> | null
+}
+
+type StudentProfileRow = {
+  id: string
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+type AttendanceRosterResult = {
+  students: AttendanceReportStudent[]
+  studentIds: string[]
+  enrollmentsError: any
+  profilesError: any
+}
+
+function normalizeJoinedUser(users: EnrollmentRow['users']): { id: string; email: string } | null {
+  const user = Array.isArray(users) ? users[0] : users
+  if (!user || typeof user.id !== 'string') return null
+  return {
+    id: user.id,
+    email: typeof user.email === 'string' ? user.email : '',
+  }
+}
+
+export async function loadAttendanceClassDays(
+  supabase: any,
+  classroomId: string,
+): Promise<{ rows: ClassDay[]; error: any }> {
+  return loadChunkedRows<ClassDay>({
+    supabase,
+    table: 'class_days',
+    select: '*',
+    filters: [{ column: 'classroom_id', values: [classroomId] }],
+    pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
+    pageOrderColumn: 'date',
+  })
+}
+
+export async function loadAttendanceRoster(
+  supabase: any,
+  classroomId: string,
+): Promise<AttendanceRosterResult> {
+  const enrollmentsResult = await loadChunkedRows<EnrollmentRow>({
+    supabase,
+    table: 'classroom_enrollments',
+    select: `
+      id,
+      student_id,
+      users!classroom_enrollments_student_id_fkey(
+        id,
+        email
+      )
+    `,
+    filters: [{ column: 'classroom_id', values: [classroomId] }],
+    pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
+
+  if (enrollmentsResult.error) {
+    return {
+      students: [],
+      studentIds: [],
+      enrollmentsError: enrollmentsResult.error,
+      profilesError: null,
+    }
+  }
+
+  const studentIds = Array.from(new Set(
+    enrollmentsResult.rows
+      .map((enrollment) => enrollment.student_id)
+      .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0)
+  ))
+
+  const profilesResult = studentIds.length > 0
+    ? await loadChunkedRows<StudentProfileRow>({
+      supabase,
+      table: 'student_profiles',
+      select: 'id, user_id, first_name, last_name',
+      filters: [{ column: 'user_id', values: studentIds }],
+      pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
+      pageOrderColumn: 'id',
+    })
+    : { rows: [] as StudentProfileRow[], error: null }
+
+  if (profilesResult.error) {
+    return {
+      students: [],
+      studentIds,
+      enrollmentsError: null,
+      profilesError: profilesResult.error,
+    }
+  }
+
+  const profileMap = new Map(
+    profilesResult.rows.map((profile) => [profile.user_id, profile])
+  )
+
+  const students = enrollmentsResult.rows
+    .map((enrollment) => {
+      const user = normalizeJoinedUser(enrollment.users)
+      const studentId = user?.id || enrollment.student_id
+      const profile = profileMap.get(studentId)
+      return {
+        id: studentId,
+        email: user?.email || '',
+        first_name: profile?.first_name || '',
+        last_name: profile?.last_name || '',
+      }
+    })
+    .sort((a, b) => a.email.localeCompare(b.email) || a.id.localeCompare(b.id))
+
+  return {
+    students,
+    studentIds,
+    enrollmentsError: null,
+    profilesError: null,
+  }
+}
+
+export async function loadAttendanceEntries(
+  supabase: any,
+  classroomId: string,
+  studentIds: string[],
+): Promise<{ rows: Entry[]; error: any }> {
+  if (studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  return loadChunkedRows<Entry>({
+    supabase,
+    table: 'entries',
+    select: '*',
+    filters: [
+      { column: 'classroom_id', values: [classroomId] },
+      { column: 'student_id', values: studentIds },
+    ],
+    pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
+}

--- a/tests/api/teacher/attendance.test.ts
+++ b/tests/api/teacher/attendance.test.ts
@@ -32,6 +32,67 @@ vi.mock('@/lib/attendance', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values })
+          }
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => {
+              if (!(filter.column in row)) return true
+              return filter.values.includes(String(row[filter.column]))
+            })
+          )
+
+          return Promise.resolve({
+            data: filteredRows.slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/attendance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -118,53 +179,26 @@ describe('GET /api/teacher/attendance', () => {
       }
 
       if (table === 'class_days') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              order: vi.fn().mockResolvedValue({
-                data: [
-                  { date: '2026-04-20', is_class_day: true },
-                  { date: '2026-04-21', is_class_day: false },
-                  { date: '2026-04-22', is_class_day: true },
-                ],
-                error: null,
-              }),
-            })),
-          })),
-        }
+        return mockPagedTable([
+          { date: '2026-04-20', is_class_day: true },
+          { date: '2026-04-21', is_class_day: false },
+          { date: '2026-04-22', is_class_day: true },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
-                { student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          { id: 'enrollment-2', student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
+          { id: 'enrollment-1', student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+        ])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' }],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([{ id: 'profile-1', user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' }])
       }
 
       if (table === 'entries') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ data: [{ id: 'entry-1' }], error: null }),
-          })),
-        }
+        return mockPagedTable([{ id: 'entry-1' }])
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -200,5 +234,138 @@ describe('GET /api/teacher/attendance', () => {
       [{ id: 'entry-1' }],
       expect.any(String),
     )
+  })
+
+  it('paginates enrollment rows so large rosters are not truncated', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([])
+    const log = createQueryLog()
+    const enrollments = Array.from({ length: 1001 }, (_, index) => {
+      const ordinal = index + 1
+      const studentId = `student-${ordinal.toString().padStart(4, '0')}`
+      return {
+        id: `enrollment-${ordinal.toString().padStart(4, '0')}`,
+        classroom_id: 'classroom-1',
+        student_id: studentId,
+        users: { id: studentId, email: `student-${ordinal.toString().padStart(4, '0')}@example.com` },
+      }
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { teacher_id: 'teacher-1' }, error: null }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([], { table, log })
+      if (table === 'classroom_enrollments') return mockPagedTable(enrollments, { table, log })
+      if (table === 'student_profiles') return mockPagedTable([], { table, log })
+      if (table === 'entries') return mockPagedTable([], { table, log })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/attendance?classroom_id=classroom-1')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const studentsArg = (computeAttendanceRecords as any).mock.calls[0][0]
+    expect(studentsArg).toHaveLength(1001)
+    expect(studentsArg.at(-1)).toMatchObject({
+      id: 'student-1001',
+      email: 'student-1001@example.com',
+    })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 1000, to: 1999 })
+  })
+
+  it('chunks profile and entry reads and paginates dense entry chunks', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([])
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const enrollments = studentIds.map((studentId, index) => ({
+      id: `enrollment-${index + 1}`,
+      classroom_id: 'classroom-1',
+      student_id: studentId,
+      users: { id: studentId, email: `${studentId}@example.com` },
+    }))
+    const entries = studentIds.flatMap((studentId) =>
+      Array.from({ length: 21 }, (_, index) => ({
+        id: `entry-${studentId}-${index + 1}`,
+        classroom_id: 'classroom-1',
+        student_id: studentId,
+        date: `2026-04-${(index + 1).toString().padStart(2, '0')}`,
+        text: 'present',
+      }))
+    )
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { teacher_id: 'teacher-1' }, error: null }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([], { table, log })
+      if (table === 'classroom_enrollments') return mockPagedTable(enrollments, { table, log })
+      if (table === 'student_profiles') return mockPagedTable([], { table, log })
+      if (table === 'entries') return mockPagedTable(entries, { table, log })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/attendance?classroom_id=classroom-1')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const entriesArg = (computeAttendanceRecords as any).mock.calls[0][2]
+    expect(entriesArg).toHaveLength(1071)
+
+    for (const table of ['student_profiles', 'entries']) {
+      const studentChunks = log.inCalls.filter((call) =>
+        call.table === table && (call.column === 'user_id' || call.column === 'student_id')
+      )
+      expect(studentChunks.map((call) => call.values.length)).toContain(50)
+      expect(studentChunks.map((call) => call.values.length)).toContain(1)
+    }
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 1000, to: 1999 })
+  })
+
+  it('returns 500 when student profile hydration fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { teacher_id: 'teacher-1' }, error: null }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([])
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable([
+          { id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+        ])
+      }
+      if (table === 'student_profiles') {
+        return mockPagedTable([], { error: { message: 'profiles failed' } })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/attendance?classroom_id=classroom-1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch student profiles' })
   })
 })

--- a/tests/api/teacher/export-csv.test.ts
+++ b/tests/api/teacher/export-csv.test.ts
@@ -13,6 +13,67 @@ vi.mock('@/lib/timezone', () => ({ getTodayInToronto: vi.fn(() => '2026-04-25') 
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values })
+          }
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => {
+              if (!(filter.column in row)) return true
+              return filter.values.includes(String(row[filter.column]))
+            })
+          )
+
+          return Promise.resolve({
+            data: filteredRows.slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 describe('GET /api/teacher/export-csv', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -78,56 +139,29 @@ describe('GET /api/teacher/export-csv', () => {
       }
 
       if (table === 'class_days') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              order: vi.fn().mockResolvedValue({
-                data: [
-                  { date: '2026-04-20', is_class_day: true },
-                  { date: '2026-04-21', is_class_day: true },
-                  { date: '2026-04-22', is_class_day: false },
-                ],
-                error: null,
-              }),
-            })),
-          })),
-        }
+        return mockPagedTable([
+          { date: '2026-04-20', is_class_day: true },
+          { date: '2026-04-21', is_class_day: true },
+          { date: '2026-04-22', is_class_day: false },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
-                { student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          { id: 'enrollment-2', student_id: 'student-2', users: { id: 'student-2', email: 'b@example.com' } },
+          { id: 'enrollment-1', student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+        ])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                { user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' },
-                { user_id: 'student-2', first_name: 'Grace', last_name: 'Hopper' },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          { id: 'profile-1', user_id: 'student-1', first_name: 'Ada', last_name: 'Lovelace' },
+          { id: 'profile-2', user_id: 'student-2', first_name: 'Grace', last_name: 'Hopper' },
+        ])
       }
 
       if (table === 'entries') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ data: [{ id: 'entry-1' }], error: null }),
-          })),
-        }
+        return mockPagedTable([{ id: 'entry-1' }])
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -159,5 +193,156 @@ describe('GET /api/teacher/export-csv', () => {
       [{ id: 'entry-1' }],
       '2026-04-25',
     )
+  })
+
+  it('paginates large rosters before computing the CSV export', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([])
+    const log = createQueryLog()
+    const enrollments = Array.from({ length: 1001 }, (_, index) => {
+      const ordinal = index + 1
+      const padded = ordinal.toString().padStart(4, '0')
+      const studentId = `student-${padded}`
+      return {
+        id: `enrollment-${padded}`,
+        classroom_id: 'c1',
+        student_id: studentId,
+        users: { id: studentId, email: `${studentId}@example.com` },
+      }
+    })
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1', title: 'Period 1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([], { table, log })
+      if (table === 'classroom_enrollments') return mockPagedTable(enrollments, { table, log })
+      if (table === 'student_profiles') return mockPagedTable([], { table, log })
+      if (table === 'entries') return mockPagedTable([], { table, log })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/export-csv?classroom_id=c1')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const studentsArg = (computeAttendanceRecords as any).mock.calls[0][0]
+    expect(studentsArg).toHaveLength(1001)
+    expect(studentsArg.at(-1)).toMatchObject({
+      id: 'student-1001',
+      email: 'student-1001@example.com',
+    })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 1000, to: 1999 })
+  })
+
+  it('scopes and paginates dense entry reads for enrolled students', async () => {
+    const { computeAttendanceRecords } = await import('@/lib/attendance')
+    ;(computeAttendanceRecords as any).mockReturnValueOnce([])
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const enrollments = studentIds.map((studentId, index) => ({
+      id: `enrollment-${index + 1}`,
+      classroom_id: 'c1',
+      student_id: studentId,
+      users: { id: studentId, email: `${studentId}@example.com` },
+    }))
+    const entries = [
+      ...studentIds.flatMap((studentId) =>
+        Array.from({ length: 21 }, (_, index) => ({
+          id: `entry-${studentId}-${index + 1}`,
+          classroom_id: 'c1',
+          student_id: studentId,
+          date: `2026-04-${(index + 1).toString().padStart(2, '0')}`,
+          text: 'present',
+        }))
+      ),
+      {
+        id: 'stale-entry',
+        classroom_id: 'c1',
+        student_id: 'withdrawn-student',
+        date: '2026-04-01',
+        text: 'stale',
+      },
+    ]
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1', title: 'Period 1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([], { table, log })
+      if (table === 'classroom_enrollments') return mockPagedTable(enrollments, { table, log })
+      if (table === 'student_profiles') return mockPagedTable([], { table, log })
+      if (table === 'entries') return mockPagedTable(entries, { table, log })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/export-csv?classroom_id=c1')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const entriesArg = (computeAttendanceRecords as any).mock.calls[0][2]
+    expect(entriesArg).toHaveLength(1071)
+    expect(entriesArg.some((entry: any) => entry.id === 'stale-entry')).toBe(false)
+    const entryStudentChunks = log.inCalls
+      .filter((call) => call.table === 'entries' && call.column === 'student_id')
+      .map((call) => call.values.length)
+    expect(entryStudentChunks).toContain(50)
+    expect(entryStudentChunks).toContain(1)
+    expect(entryStudentChunks.every((length) => length <= 50)).toBe(true)
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 1000, to: 1999 })
+  })
+
+  it('returns 500 when student profile hydration fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { teacher_id: 'teacher-1', title: 'Period 1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable([])
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable([
+          { id: 'enrollment-1', classroom_id: 'c1', student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+        ])
+      }
+      if (table === 'student_profiles') {
+        return mockPagedTable([], { error: { message: 'profiles failed' } })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/export-csv?classroom_id=c1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Failed to fetch student profiles' })
   })
 })


### PR DESCRIPTION
## Summary
- add a shared attendance report loader for teacher attendance and CSV export routes
- page class-day, roster, profile, and entry reads while scoping entries to enrolled students
- fail closed on profile hydration errors and keep student ordering deterministic by email plus id

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check