### PR TITLE
Harden teacher logs bulk reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -546,3 +546,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-30 — Teacher logs bulk-read hardening
+
+**Completed:**
+- Extracted the paginated classroom roster/profile loader into a neutral server helper shared by attendance/export and teacher logs.
+- Routed teacher logs roster, profile, and selected-date entry reads through chunked, paginated Supabase loaders.
+- Scoped selected-date log entries by currently enrolled student ids at query time so stale withdrawn-student entries cannot consume pages or appear in teacher logs.
+- Returned an explicit 500 for student profile hydration failures instead of silently rendering blank names after a failed read.
+- Chunked history-preview RPC calls and bounded the missing-RPC fallback to per-student batches.
+- Added API regressions for >1000-student roster pagination, 51-student profile/entry chunking, dense selected-date entry pagination, stale-entry scoping, profile failure handling, and history-preview RPC fallback.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/teacher/logs.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/teacher/logs/route.ts
+++ b/src/app/api/teacher/logs/route.ts
@@ -2,12 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
+import { loadClassroomRoster } from '@/lib/server/classroom-roster'
+import { chunkValues, loadChunkedRows } from '@/lib/server/query-chunks'
 import type { Entry } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 const HISTORY_PREVIEW_LIMIT = 5
+const HISTORY_PREVIEW_STUDENT_CHUNK_SIZE = 50
+const TEACHER_LOG_PAGE_SIZE = 1000
 const ENTRY_SELECT = [
   'id',
   'student_id',
@@ -71,71 +75,37 @@ export const GET = withErrorHandler('GetTeacherLogs', async (request: NextReques
     )
   }
 
-  const { data: enrollments, error: enrollmentsError } = await supabase
-    .from('classroom_enrollments')
-    .select(`
-      student_id,
-      users!classroom_enrollments_student_id_fkey(
-        id,
-        email
-      )
-    `)
-    .eq('classroom_id', classroomId)
+  const rosterResult = await loadClassroomRoster(supabase, classroomId)
 
-  if (enrollmentsError) {
-    console.error('Error fetching enrollments:', enrollmentsError)
+  if (rosterResult.enrollmentsError) {
+    console.error('Error fetching enrollments:', rosterResult.enrollmentsError)
     return NextResponse.json(
       { error: 'Failed to fetch students' },
       { status: 500 }
     )
   }
 
-  const studentIds = (enrollments || []).map(e => e.student_id)
-  const { data: profiles, error: profilesError } = studentIds.length > 0
-    ? await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', studentIds)
-    : { data: [], error: null }
-
-  if (profilesError) {
-    console.error('Error fetching student profiles:', profilesError)
+  if (rosterResult.profilesError) {
+    console.error('Error fetching student profiles:', rosterResult.profilesError)
+    return NextResponse.json(
+      { error: 'Failed to fetch student profiles' },
+      { status: 500 }
+    )
   }
 
-  const profileMap = new Map(
-    (profiles || []).map(p => [p.user_id, p])
-  )
+  const studentIds = rosterResult.studentIds
+  const students = rosterResult.students
+  const entriesResult = await loadTeacherLogEntriesForDate(supabase, classroomId, studentIds, date)
 
-  const students = (enrollments || [])
-    .map(e => {
-      const u = e.users as unknown as { id: string; email: string }
-      const profile = profileMap.get(u.id)
-      return {
-        id: u.id,
-        email: u.email,
-        first_name: profile?.first_name || '',
-        last_name: profile?.last_name || '',
-      }
-    })
-    .sort((a, b) => a.email.localeCompare(b.email))
-
-  const { data: entries, error: entriesError } = date
-    ? await supabase
-      .from('entries')
-      .select(ENTRY_SELECT)
-      .eq('classroom_id', classroomId)
-      .eq('date', date)
-    : { data: [], error: null }
-
-  if (entriesError) {
-    console.error('Error fetching entries:', entriesError)
+  if (entriesResult.error) {
+    console.error('Error fetching entries:', entriesResult.error)
     return NextResponse.json(
       { error: 'Failed to fetch entries' },
       { status: 500 }
     )
   }
 
-  const selectedEntries = (entries || []) as unknown as Entry[]
+  const selectedEntries = entriesResult.rows
   const entryByStudentId = new Map(
     selectedEntries.map(entry => [entry.student_id, entry])
   )
@@ -178,6 +148,30 @@ export const GET = withErrorHandler('GetTeacherLogs', async (request: NextReques
   })
 })
 
+async function loadTeacherLogEntriesForDate(
+  supabase: SupabaseClient,
+  classroomId: string,
+  studentIds: string[],
+  date: string | null,
+): Promise<{ rows: Entry[]; error: any }> {
+  if (!date || studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  return loadChunkedRows<Entry>({
+    supabase,
+    table: 'entries',
+    select: ENTRY_SELECT,
+    filters: [
+      { column: 'classroom_id', values: [classroomId] },
+      { column: 'date', values: [date] },
+      { column: 'student_id', values: studentIds },
+    ],
+    pageSize: TEACHER_LOG_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
+}
+
 async function fetchHistoryPreviewEntries(
   supabase: SupabaseClient,
   classroomId: string,
@@ -187,41 +181,61 @@ async function fetchHistoryPreviewEntries(
     return { entries: [], error: null }
   }
 
-  const { data, error } = await supabase.rpc('get_teacher_log_history_preview', {
-    p_classroom_id: classroomId,
-    p_student_ids: studentIds,
-    p_limit: HISTORY_PREVIEW_LIMIT,
-  })
+  const entries: Entry[] = []
+  for (const studentChunk of chunkValues(studentIds, HISTORY_PREVIEW_STUDENT_CHUNK_SIZE)) {
+    const { data, error } = await supabase.rpc('get_teacher_log_history_preview', {
+      p_classroom_id: classroomId,
+      p_student_ids: studentChunk,
+      p_limit: HISTORY_PREVIEW_LIMIT,
+    })
 
-  if (!error) {
-    return { entries: (data || []) as unknown as Entry[], error: null }
-  }
+    if (!error) {
+      entries.push(...((data || []) as unknown as Entry[]))
+      continue
+    }
 
-  if (!isMissingRpcError(error)) {
+    if (isMissingRpcError(error)) {
+      return fetchHistoryPreviewEntriesFallback(supabase, classroomId, studentIds)
+    }
+
     return { entries: [], error }
   }
 
-  console.warn('History preview RPC is unavailable; falling back to per-student preview queries')
-  const results = await Promise.all(
-    studentIds.map((studentId) =>
-      supabase
-        .from('entries')
-        .select(ENTRY_SELECT)
-        .eq('classroom_id', classroomId)
-        .eq('student_id', studentId)
-        .order('date', { ascending: false })
-        .order('updated_at', { ascending: false })
-        .limit(HISTORY_PREVIEW_LIMIT)
-    )
-  )
+  return { entries, error: null }
+}
 
-  const failed = results.find(result => result.error)
-  if (failed?.error) {
-    return { entries: [], error: failed.error }
+async function fetchHistoryPreviewEntriesFallback(
+  supabase: SupabaseClient,
+  classroomId: string,
+  studentIds: string[],
+): Promise<{ entries: Entry[]; error: unknown | null }> {
+  console.warn('History preview RPC is unavailable; falling back to per-student preview queries')
+  const entries: Entry[] = []
+
+  for (const studentChunk of chunkValues(studentIds, HISTORY_PREVIEW_STUDENT_CHUNK_SIZE)) {
+    const results = await Promise.all(
+      studentChunk.map((studentId) =>
+        supabase
+          .from('entries')
+          .select(ENTRY_SELECT)
+          .eq('classroom_id', classroomId)
+          .eq('student_id', studentId)
+          .order('date', { ascending: false })
+          .order('updated_at', { ascending: false })
+          .limit(HISTORY_PREVIEW_LIMIT)
+      )
+    )
+
+    const failed = results.find(result => result.error)
+    if (failed?.error) {
+      return { entries: [], error: failed.error }
+    }
+
+    entries.push(...results.flatMap(result => (result.data || []) as unknown as Entry[]))
   }
 
   return {
-    entries: results.flatMap(result => (result.data || []) as unknown as Entry[]),
+    entries,
     error: null,
   }
 }

--- a/src/lib/server/attendance-report.ts
+++ b/src/lib/server/attendance-report.ts
@@ -1,42 +1,19 @@
 import type { ClassDay, Entry } from '@/types'
 import { loadChunkedRows } from '@/lib/server/query-chunks'
+import {
+  loadClassroomRoster,
+  type ClassroomRosterStudent,
+} from '@/lib/server/classroom-roster'
 
 const ATTENDANCE_REPORT_PAGE_SIZE = 1000
 
-export type AttendanceReportStudent = {
-  id: string
-  email: string
-  first_name: string
-  last_name: string
-}
-
-type EnrollmentRow = {
-  id: string
-  student_id: string
-  users: { id: string; email: string } | Array<{ id: string; email: string }> | null
-}
-
-type StudentProfileRow = {
-  id: string
-  user_id: string
-  first_name: string | null
-  last_name: string | null
-}
+export type AttendanceReportStudent = ClassroomRosterStudent
 
 type AttendanceRosterResult = {
   students: AttendanceReportStudent[]
   studentIds: string[]
   enrollmentsError: any
   profilesError: any
-}
-
-function normalizeJoinedUser(users: EnrollmentRow['users']): { id: string; email: string } | null {
-  const user = Array.isArray(users) ? users[0] : users
-  if (!user || typeof user.id !== 'string') return null
-  return {
-    id: user.id,
-    email: typeof user.email === 'string' ? user.email : '',
-  }
 }
 
 export async function loadAttendanceClassDays(
@@ -57,81 +34,7 @@ export async function loadAttendanceRoster(
   supabase: any,
   classroomId: string,
 ): Promise<AttendanceRosterResult> {
-  const enrollmentsResult = await loadChunkedRows<EnrollmentRow>({
-    supabase,
-    table: 'classroom_enrollments',
-    select: `
-      id,
-      student_id,
-      users!classroom_enrollments_student_id_fkey(
-        id,
-        email
-      )
-    `,
-    filters: [{ column: 'classroom_id', values: [classroomId] }],
-    pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
-    pageOrderColumn: 'id',
-  })
-
-  if (enrollmentsResult.error) {
-    return {
-      students: [],
-      studentIds: [],
-      enrollmentsError: enrollmentsResult.error,
-      profilesError: null,
-    }
-  }
-
-  const studentIds = Array.from(new Set(
-    enrollmentsResult.rows
-      .map((enrollment) => enrollment.student_id)
-      .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0)
-  ))
-
-  const profilesResult = studentIds.length > 0
-    ? await loadChunkedRows<StudentProfileRow>({
-      supabase,
-      table: 'student_profiles',
-      select: 'id, user_id, first_name, last_name',
-      filters: [{ column: 'user_id', values: studentIds }],
-      pageSize: ATTENDANCE_REPORT_PAGE_SIZE,
-      pageOrderColumn: 'id',
-    })
-    : { rows: [] as StudentProfileRow[], error: null }
-
-  if (profilesResult.error) {
-    return {
-      students: [],
-      studentIds,
-      enrollmentsError: null,
-      profilesError: profilesResult.error,
-    }
-  }
-
-  const profileMap = new Map(
-    profilesResult.rows.map((profile) => [profile.user_id, profile])
-  )
-
-  const students = enrollmentsResult.rows
-    .map((enrollment) => {
-      const user = normalizeJoinedUser(enrollment.users)
-      const studentId = user?.id || enrollment.student_id
-      const profile = profileMap.get(studentId)
-      return {
-        id: studentId,
-        email: user?.email || '',
-        first_name: profile?.first_name || '',
-        last_name: profile?.last_name || '',
-      }
-    })
-    .sort((a, b) => a.email.localeCompare(b.email) || a.id.localeCompare(b.id))
-
-  return {
-    students,
-    studentIds,
-    enrollmentsError: null,
-    profilesError: null,
-  }
+  return loadClassroomRoster(supabase, classroomId)
 }
 
 export async function loadAttendanceEntries(

--- a/src/lib/server/classroom-roster.ts
+++ b/src/lib/server/classroom-roster.ts
@@ -1,0 +1,120 @@
+import { loadChunkedRows } from '@/lib/server/query-chunks'
+
+const CLASSROOM_ROSTER_PAGE_SIZE = 1000
+
+export type ClassroomRosterStudent = {
+  id: string
+  email: string
+  first_name: string
+  last_name: string
+}
+
+type EnrollmentRow = {
+  id: string
+  student_id: string
+  users: { id: string; email: string } | Array<{ id: string; email: string }> | null
+}
+
+type StudentProfileRow = {
+  id: string
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+export type ClassroomRosterResult = {
+  students: ClassroomRosterStudent[]
+  studentIds: string[]
+  enrollmentsError: any
+  profilesError: any
+}
+
+function normalizeJoinedUser(users: EnrollmentRow['users']): { id: string; email: string } | null {
+  const user = Array.isArray(users) ? users[0] : users
+  if (!user || typeof user.id !== 'string') return null
+  return {
+    id: user.id,
+    email: typeof user.email === 'string' ? user.email : '',
+  }
+}
+
+export async function loadClassroomRoster(
+  supabase: any,
+  classroomId: string,
+): Promise<ClassroomRosterResult> {
+  const enrollmentsResult = await loadChunkedRows<EnrollmentRow>({
+    supabase,
+    table: 'classroom_enrollments',
+    select: `
+      id,
+      student_id,
+      users!classroom_enrollments_student_id_fkey(
+        id,
+        email
+      )
+    `,
+    filters: [{ column: 'classroom_id', values: [classroomId] }],
+    pageSize: CLASSROOM_ROSTER_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
+
+  if (enrollmentsResult.error) {
+    return {
+      students: [],
+      studentIds: [],
+      enrollmentsError: enrollmentsResult.error,
+      profilesError: null,
+    }
+  }
+
+  const studentIds = Array.from(new Set(
+    enrollmentsResult.rows
+      .map((enrollment) => enrollment.student_id)
+      .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0)
+  ))
+
+  const profilesResult = studentIds.length > 0
+    ? await loadChunkedRows<StudentProfileRow>({
+      supabase,
+      table: 'student_profiles',
+      select: 'id, user_id, first_name, last_name',
+      filters: [{ column: 'user_id', values: studentIds }],
+      pageSize: CLASSROOM_ROSTER_PAGE_SIZE,
+      pageOrderColumn: 'id',
+    })
+    : { rows: [] as StudentProfileRow[], error: null }
+
+  if (profilesResult.error) {
+    return {
+      students: [],
+      studentIds,
+      enrollmentsError: null,
+      profilesError: profilesResult.error,
+    }
+  }
+
+  const profileMap = new Map(
+    profilesResult.rows.map((profile) => [profile.user_id, profile])
+  )
+
+  const students = enrollmentsResult.rows
+    .map((enrollment) => {
+      const user = normalizeJoinedUser(enrollment.users)
+      const studentId = user?.id || enrollment.student_id
+      const profile = profileMap.get(studentId)
+      return {
+        id: studentId,
+        email: user?.email || '',
+        first_name: profile?.first_name || '',
+        last_name: profile?.last_name || '',
+      }
+    })
+    .sort((a, b) => a.email.localeCompare(b.email) || a.id.localeCompare(b.id))
+
+  return {
+    students,
+    studentIds,
+    enrollmentsError: null,
+    profilesError: null,
+  }
+}

--- a/tests/api/teacher/logs.test.ts
+++ b/tests/api/teacher/logs.test.ts
@@ -22,9 +22,121 @@ vi.mock('@/lib/auth', () => ({
 
 const mockSupabaseClient = { from: vi.fn(), rpc: vi.fn() }
 
+type QueryLog = {
+  eqCalls: Array<{ table: string; column: string; value: string }>
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+  limitCalls: Array<{ table: string; count: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { eqCalls: [], inCalls: [], orderCalls: [], rangeCalls: [], limitCalls: [] }
+}
+
+function mockClassroomQuery(teacherId: string | null, error: any = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: teacherId ? { teacher_id: teacherId } : null,
+          error,
+        }),
+      })),
+    })),
+  }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return true
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const resolveRows = (from: number, to: number) => {
+        if (options.error) {
+          return Promise.resolve({ data: null, error: options.error })
+        }
+        return Promise.resolve({
+          data: filteredRows().slice(from, to + 1),
+          error: null,
+        })
+      }
+      const query: any = {
+        eq: vi.fn((column: string, value: string) => {
+          filters.push({ column, values: [String(value)] })
+          if (options.table) {
+            options.log?.eqCalls.push({ table: options.table, column, value: String(value) })
+          }
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          return resolveRows(from, to)
+        }),
+        limit: vi.fn((count: number) => {
+          if (options.table) {
+            options.log?.limitCalls.push({ table: options.table, count })
+          }
+          return resolveRows(0, count - 1)
+        }),
+      }
+      return query
+    }),
+  }
+}
+
+function mockOwnedTeacherTables(
+  tables: Record<string, Array<Record<string, any>>>,
+  options: {
+    log?: QueryLog
+    errors?: Record<string, any>
+  } = {},
+) {
+  return vi.fn((table: string) => {
+    if (table === 'classrooms') return mockClassroomQuery('teacher-1')
+    if (table in tables) {
+      return mockPagedTable(tables[table], {
+        table,
+        log: options.log,
+        error: options.errors?.[table],
+      })
+    }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
 describe('GET /api/teacher/logs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSupabaseClient.from = vi.fn()
+    mockSupabaseClient.rpc = vi.fn()
   })
 
   afterEach(() => {
@@ -54,22 +166,10 @@ describe('GET /api/teacher/logs', () => {
   })
 
   it('should return 403 when teacher does not own classroom', async () => {
-    const mockFrom = vi.fn((table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { teacher_id: 'other-teacher' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classrooms') return mockClassroomQuery('other-teacher')
       return {}
     })
-    ;(mockSupabaseClient.from as any) = mockFrom
 
     const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1')
     const response = await GET(request)
@@ -77,59 +177,16 @@ describe('GET /api/teacher/logs', () => {
   })
 
   it('should return 200 with roster and entry (when present)', async () => {
-    const mockFrom = vi.fn((table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { teacher_id: 'teacher-1' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-      if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
-                { student_id: 's2', users: { id: 's2', email: 'b@student.com' } },
-              ],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'entries') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn().mockResolvedValue({
-                data: [
-                  { id: 'e1', student_id: 's2', classroom_id: 'classroom-1', date: '2025-01-02', text: 'hello', minutes_reported: null, mood: null, created_at: '', updated_at: '', on_time: true },
-                ],
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-      return {}
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: [
+        { id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
+        { id: 'enrollment-2', classroom_id: 'classroom-1', student_id: 's2', users: { id: 's2', email: 'b@student.com' } },
+      ],
+      student_profiles: [],
+      entries: [
+        { id: 'e1', student_id: 's2', classroom_id: 'classroom-1', date: '2025-01-02', text: 'hello', minutes_reported: null, mood: null, created_at: '', updated_at: '', on_time: true },
+      ],
     })
-    ;(mockSupabaseClient.from as any) = mockFrom
     ;(mockSupabaseClient.rpc as any).mockResolvedValue({
       data: [
         { id: 'h1', student_id: 's1', classroom_id: 'classroom-1', date: '2025-01-03', text: 'preview 1', minutes_reported: null, mood: null, created_at: '', updated_at: '2025-01-03T12:00:00Z', on_time: true },
@@ -161,56 +218,13 @@ describe('GET /api/teacher/logs', () => {
   })
 
   it('caps batched history previews to five entries per student', async () => {
-    const mockFrom = vi.fn((table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { teacher_id: 'teacher-1' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-      if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
-              ],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'entries') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn().mockResolvedValue({
-                data: [],
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-      return {}
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: [
+        { id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
+      ],
+      student_profiles: [],
+      entries: [],
     })
-    ;(mockSupabaseClient.from as any) = mockFrom
     const historyRows = Array.from({ length: 7 }, (_, index) => ({
       id: `h${index + 1}`,
       student_id: 's1',
@@ -242,78 +256,17 @@ describe('GET /api/teacher/logs', () => {
   })
 
   it('falls back to per-student capped previews when the preview RPC is unavailable', async () => {
-    let entriesQueryIndex = 0
-    const historyQuery = (rows: any[]) => {
-      const query: any = {
-        select: vi.fn(() => query),
-        eq: vi.fn(() => query),
-        order: vi.fn(() => query),
-        limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
-      }
-      return query
-    }
-    const mockFrom = vi.fn((table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn().mockResolvedValue({
-                data: { teacher_id: 'teacher-1' },
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-      if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
-                { student_id: 's2', users: { id: 's2', email: 'b@student.com' } },
-              ],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          })),
-        }
-      }
-      if (table === 'entries') {
-        entriesQueryIndex += 1
-        if (entriesQueryIndex === 1) {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                eq: vi.fn().mockResolvedValue({
-                  data: [],
-                  error: null,
-                }),
-              })),
-            })),
-          }
-        }
-        if (entriesQueryIndex === 2) {
-          return historyQuery([
-            { id: 'fallback-h1', student_id: 's1', classroom_id: 'classroom-1', date: '2025-01-03', text: 'fallback 1', minutes_reported: null, mood: null, created_at: '', updated_at: '2025-01-03T12:00:00Z', on_time: true },
-          ])
-        }
-        return historyQuery([
-          { id: 'fallback-h2', student_id: 's2', classroom_id: 'classroom-1', date: '2025-01-02', text: 'fallback 2', minutes_reported: null, mood: null, created_at: '', updated_at: '2025-01-02T12:00:00Z', on_time: true },
-        ])
-      }
-      return {}
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: [
+        { id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 's1', users: { id: 's1', email: 'a@student.com' } },
+        { id: 'enrollment-2', classroom_id: 'classroom-1', student_id: 's2', users: { id: 's2', email: 'b@student.com' } },
+      ],
+      student_profiles: [],
+      entries: [
+        { id: 'fallback-h1', student_id: 's1', classroom_id: 'classroom-1', date: '2025-01-03', text: 'fallback 1', minutes_reported: null, mood: null, created_at: '', updated_at: '2025-01-03T12:00:00Z', on_time: true },
+        { id: 'fallback-h2', student_id: 's2', classroom_id: 'classroom-1', date: '2025-01-04', text: 'fallback 2', minutes_reported: null, mood: null, created_at: '', updated_at: '2025-01-04T12:00:00Z', on_time: true },
+      ],
     })
-    ;(mockSupabaseClient.from as any) = mockFrom
     ;(mockSupabaseClient.rpc as any).mockResolvedValue({
       data: null,
       error: { code: 'PGRST202', message: 'missing function' },
@@ -334,5 +287,133 @@ describe('GET /api/teacher/logs', () => {
       'History preview RPC is unavailable; falling back to per-student preview queries'
     )
     warnSpy.mockRestore()
+  })
+
+  it('paginates roster rows and chunks history preview RPC calls for large rosters', async () => {
+    const log = createQueryLog()
+    const enrollments = Array.from({ length: 1001 }, (_, index) => {
+      const ordinal = index + 1
+      const padded = ordinal.toString().padStart(4, '0')
+      const studentId = `student-${padded}`
+      return {
+        id: `enrollment-${padded}`,
+        classroom_id: 'classroom-1',
+        student_id: studentId,
+        users: { id: studentId, email: `${studentId}@example.com` },
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: enrollments,
+      student_profiles: [],
+      entries: [],
+    }, { log })
+    ;(mockSupabaseClient.rpc as any).mockResolvedValue({ data: [], error: null })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.logs).toHaveLength(1001)
+    expect(body.logs.at(-1)).toMatchObject({
+      student_id: 'student-1001',
+      student_email: 'student-1001@example.com',
+    })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'classroom_enrollments', from: 1000, to: 1999 })
+    const rpcChunks = (mockSupabaseClient.rpc as any).mock.calls.map((call: any[]) => call[1].p_student_ids)
+    expect(rpcChunks).toHaveLength(21)
+    expect(rpcChunks.every((chunk: string[]) => chunk.length <= 50)).toBe(true)
+    expect(rpcChunks.at(-1)).toEqual(['student-1001'])
+  })
+
+  it('chunks profile and selected-day entry reads and excludes stale entries', async () => {
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const enrollments = studentIds.map((studentId, index) => ({
+      id: `enrollment-${index + 1}`,
+      classroom_id: 'classroom-1',
+      student_id: studentId,
+      users: { id: studentId, email: `${studentId}@example.com` },
+    }))
+    const entries = [
+      ...studentIds.flatMap((studentId) =>
+        Array.from({ length: 21 }, (_, index) => ({
+          id: `entry-${studentId}-${index + 1}`,
+          classroom_id: 'classroom-1',
+          student_id: studentId,
+          date: '2025-01-02',
+          text: 'present',
+        }))
+      ),
+      {
+        id: 'stale-entry',
+        classroom_id: 'classroom-1',
+        student_id: 'withdrawn-student',
+        date: '2025-01-02',
+        text: 'stale',
+      },
+    ]
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: enrollments,
+      student_profiles: [],
+      entries,
+    }, { log })
+    ;(mockSupabaseClient.rpc as any).mockResolvedValue({ data: [], error: null })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1&date=2025-01-02')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.logs).toHaveLength(51)
+    expect(body.logs.some((row: any) => row.entry?.id === 'stale-entry')).toBe(false)
+
+    for (const table of ['student_profiles', 'entries']) {
+      const studentChunks = log.inCalls.filter((call) =>
+        call.table === table && (call.column === 'user_id' || call.column === 'student_id')
+      )
+      expect(studentChunks.map((call) => call.values.length)).toContain(50)
+      expect(studentChunks.map((call) => call.values.length)).toContain(1)
+      expect(studentChunks.every((call) => call.values.length <= 50)).toBe(true)
+    }
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 1000, to: 1999 })
+  })
+
+  it('returns 500 when enrollment rows fail to load', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: [],
+      student_profiles: [],
+      entries: [],
+    }, { errors: { classroom_enrollments: { message: 'enrollments failed' } } })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1&date=2025-01-02')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({ error: 'Failed to fetch students' })
+    errorSpy.mockRestore()
+  })
+
+  it('returns 500 when student profile hydration fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(mockSupabaseClient.from as any) = mockOwnedTeacherTables({
+      classroom_enrollments: [
+        { id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 'student-1', users: { id: 'student-1', email: 'a@example.com' } },
+      ],
+      student_profiles: [],
+      entries: [],
+    }, { errors: { student_profiles: { message: 'profiles failed' } } })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/logs?classroom_id=classroom-1&date=2025-01-02')
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({ error: 'Failed to fetch student profiles' })
+    errorSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- extract the classroom roster/profile loader into a neutral shared server helper
- route teacher logs roster, profile, selected-date entries, and history previews through chunked/paged read paths
- fail closed on enrollment/profile/entry/history read errors and add large-roster/stale-row regressions

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/teacher/logs.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check