### PR TITLE
Harden nightly log summary reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -566,3 +566,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-30 — Nightly log summary bulk-read hardening
+
+**Completed:**
+- Routed nightly log-summary active-classroom discovery through paginated entry reads.
+- Chunked class-day filtering for discovered classroom ids.
+- Loaded per-classroom enrollments before summary entries and scoped summary entry reads to currently enrolled students.
+- Paged enrollment, roster-name, and selected entry reads, and chunked student profile hydration.
+- Returned skip/failure for required profile reads instead of generating summaries with incomplete redaction context.
+- Added cron regressions for active-entry pagination, 51-classroom class-day chunking, scoped dense entry pagination, stale withdrawn-student exclusion, profile chunking, and profile-read failures.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts --reporter=verbose`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
+- `git diff --check`

--- a/src/app/api/cron/nightly-log-summaries/route.ts
+++ b/src/app/api/cron/nightly-log-summaries/route.ts
@@ -16,14 +16,38 @@ import {
 } from '@/lib/developer-log-feedback'
 import type { TiptapContent } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
+import {
+  chunkValues,
+  loadChunkedRows,
+  loadPagedRows,
+} from '@/lib/server/query-chunks'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 const TIMEZONE = 'America/Toronto'
 const CONCURRENCY_LIMIT = 5
+const CRON_READ_PAGE_SIZE = 1000
+const CRON_FILTER_CHUNK_SIZE = 50
 
 type SupabaseClient = ReturnType<typeof getServiceRoleClient>
+type ActiveClassroomEntryRow = { classroom_id: string }
+type ClassDayClassroomRow = { classroom_id: string }
+type SummaryEntryRow = {
+  id: string
+  classroom_id: string
+  student_id: string
+  text: string | null
+  rich_content: unknown
+  updated_at: string | null
+}
+type EnrollmentStudentRow = { student_id: string }
+type ClassroomRosterNameRow = { first_name: string | null; last_name: string | null }
+type StudentProfileRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
 
 function getCronAuthHeader(request: NextRequest): string | null {
   return request.headers.get('authorization') ?? request.headers.get('Authorization')
@@ -95,16 +119,20 @@ async function getEligibleClassroomIds(
   supabase: SupabaseClient,
   date: string
 ): Promise<{ classroomIds: string[]; error: NextResponse | null }> {
-  const { data: activeEntries, error: entriesError } = await supabase
-    .from('entries')
-    .select('classroom_id, classrooms!inner(archived_at,start_date,end_date)')
-    .eq('date', date)
-    .is('classrooms.archived_at', null)
-    .lte('classrooms.start_date', date)
-    .gte('classrooms.end_date', date)
+  const activeEntriesResult = await loadPagedRows<ActiveClassroomEntryRow>(() =>
+    supabase
+      .from('entries')
+      .select('classroom_id, classrooms!inner(archived_at,start_date,end_date)')
+      .eq('date', date)
+      .is('classrooms.archived_at', null)
+      .lte('classrooms.start_date', date)
+      .gte('classrooms.end_date', date),
+    CRON_READ_PAGE_SIZE,
+    'id',
+  )
 
-  if (entriesError) {
-    console.error('Error fetching active classrooms:', entriesError)
+  if (activeEntriesResult.error) {
+    console.error('Error fetching active classrooms:', activeEntriesResult.error)
     return {
       classroomIds: [],
       error: NextResponse.json(
@@ -114,20 +142,15 @@ async function getEligibleClassroomIds(
     }
   }
 
-  const classroomIds = [...new Set((activeEntries || []).map((e: { classroom_id: string }) => e.classroom_id))]
+  const classroomIds = [...new Set(activeEntriesResult.rows.map((e) => e.classroom_id))]
   if (classroomIds.length === 0) {
     return { classroomIds: [], error: null }
   }
 
-  const { data: classDays, error: classDaysError } = await supabase
-    .from('class_days')
-    .select('classroom_id')
-    .in('classroom_id', classroomIds)
-    .eq('date', date)
-    .eq('is_class_day', true)
+  const classDaysResult = await loadClassDayRowsForClassrooms(supabase, classroomIds, date)
 
-  if (classDaysError) {
-    console.error('Error fetching class days:', classDaysError)
+  if (classDaysResult.error) {
+    console.error('Error fetching class days:', classDaysResult.error)
     return {
       classroomIds: [],
       error: NextResponse.json(
@@ -137,7 +160,7 @@ async function getEligibleClassroomIds(
     }
   }
 
-  const classDayIds = new Set((classDays || []).map((day: { classroom_id: string }) => day.classroom_id))
+  const classDayIds = new Set(classDaysResult.rows.map((day) => day.classroom_id))
   return {
     classroomIds: classroomIds.filter((classroomId) => classDayIds.has(classroomId)),
     error: null,
@@ -154,59 +177,48 @@ async function generateSummaryForClassroom(
     return false
   }
 
-  // Fetch entries for this active classroom and date
-  const { data: entries, error: entriesError } = await supabase
-    .from('entries')
-    .select('*, classrooms!inner(archived_at,start_date,end_date)')
-    .eq('classroom_id', classroomId)
-    .eq('date', date)
-    .is('classrooms.archived_at', null)
-    .lte('classrooms.start_date', date)
-    .gte('classrooms.end_date', date)
+  const enrollmentsResult = await loadEnrollmentStudentRows(supabase, classroomId)
 
-  if (entriesError) {
-    console.error(`Error fetching entries for classroom ${classroomId}:`, entriesError)
+  if (enrollmentsResult.error) {
+    console.error(`Error fetching roster for classroom ${classroomId}:`, enrollmentsResult.error)
     return false
   }
 
-  if (!entries || entries.length === 0) {
+  const rosterStudentIds = [...new Set(enrollmentsResult.rows.map((row) => row.student_id))]
+  if (rosterStudentIds.length === 0) {
+    return false
+  }
+
+  const entriesResult = await loadSummaryEntriesForClassroom(supabase, classroomId, rosterStudentIds, date)
+
+  if (entriesResult.error) {
+    console.error(`Error fetching entries for classroom ${classroomId}:`, entriesResult.error)
+    return false
+  }
+
+  const entries = entriesResult.rows
+  if (entries.length === 0) {
     return false
   }
 
   const entryStudentIds = [...new Set(entries.map((e) => e.student_id))]
-
-  const { data: enrollments, error: enrollmentsError } = await supabase
-    .from('classroom_enrollments')
-    .select('student_id')
-    .eq('classroom_id', classroomId)
-
-  if (enrollmentsError) {
-    console.error(`Error fetching roster for classroom ${classroomId}:`, enrollmentsError)
-    return false
-  }
-
-  const rosterStudentIds = [...new Set((enrollments || []).map((row) => row.student_id))]
   const studentIdsForRedaction = [...new Set([...entryStudentIds, ...rosterStudentIds])]
 
-  const { data: rosterRows, error: rosterError } = await supabase
-    .from('classroom_roster')
-    .select('first_name, last_name')
-    .eq('classroom_id', classroomId)
+  const rosterRowsResult = await loadRosterNameRows(supabase, classroomId)
 
-  if (rosterError) {
-    console.error(`Error fetching roster names for classroom ${classroomId}:`, rosterError)
+  if (rosterRowsResult.error) {
+    console.error(`Error fetching roster names for classroom ${classroomId}:`, rosterRowsResult.error)
     return false
   }
 
-  const profilesResult = studentIdsForRedaction.length > 0
-    ? await supabase
-      .from('student_profiles')
-      .select('user_id, first_name, last_name')
-      .in('user_id', studentIdsForRedaction)
-    : { data: [] }
+  const profilesResult = await loadStudentProfileRows(supabase, studentIdsForRedaction)
+  if (profilesResult.error) {
+    console.error(`Error fetching student profiles for classroom ${classroomId}:`, profilesResult.error)
+    return false
+  }
 
   const profileMap = new Map(
-    (profilesResult.data || []).map((p) => [p.user_id, p])
+    profilesResult.rows.map((p) => [p.user_id, p])
   )
 
   const studentsByName = new Map<string, { firstName: string; lastName: string }>()
@@ -225,7 +237,7 @@ async function generateSummaryForClassroom(
     addStudentForRedaction(profile?.first_name, profile?.last_name)
   }
 
-  for (const row of rosterRows || []) {
+  for (const row of rosterRowsResult.rows) {
     addStudentForRedaction(row.first_name, row.last_name)
   }
 
@@ -276,9 +288,10 @@ async function generateSummaryForClassroom(
   const model = getSummaryModel()
 
   // Get max updated_at from entries for staleness tracking
-  const maxUpdatedAt = entries.reduce((max, e) => {
+  const maxUpdatedAt = entries.reduce<string | null>((max, e) => {
+    if (!e.updated_at) return max
     return !max || e.updated_at > max ? e.updated_at : max
-  }, '' as string) || null
+  }, null)
 
   const { error: upsertError } = await supabase.from('log_summaries').upsert(
     {
@@ -316,6 +329,121 @@ async function generateSummaryForClassroom(
   }
 
   return true
+}
+
+async function loadClassDayRowsForClassrooms(
+  supabase: SupabaseClient,
+  classroomIds: string[],
+  date: string,
+): Promise<{ rows: ClassDayClassroomRow[]; error: any }> {
+  if (classroomIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: ClassDayClassroomRow[] = []
+  for (const classroomIdChunk of chunkValues(classroomIds, CRON_FILTER_CHUNK_SIZE)) {
+    const result = await loadPagedRows<ClassDayClassroomRow>(() =>
+      supabase
+        .from('class_days')
+        .select('classroom_id')
+        .in('classroom_id', classroomIdChunk)
+        .eq('date', date)
+        .eq('is_class_day', true),
+      CRON_READ_PAGE_SIZE,
+      'classroom_id',
+    )
+
+    if (result.error) {
+      return { rows: [], error: result.error }
+    }
+
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadSummaryEntriesForClassroom(
+  supabase: SupabaseClient,
+  classroomId: string,
+  studentIds: string[],
+  date: string,
+): Promise<{ rows: SummaryEntryRow[]; error: any }> {
+  if (studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: SummaryEntryRow[] = []
+  for (const studentIdChunk of chunkValues(studentIds, CRON_FILTER_CHUNK_SIZE)) {
+    const result = await loadPagedRows<SummaryEntryRow>(() =>
+      supabase
+        .from('entries')
+        .select('*, classrooms!inner(archived_at,start_date,end_date)')
+        .eq('classroom_id', classroomId)
+        .eq('date', date)
+        .in('student_id', studentIdChunk)
+        .is('classrooms.archived_at', null)
+        .lte('classrooms.start_date', date)
+        .gte('classrooms.end_date', date),
+      CRON_READ_PAGE_SIZE,
+      'id',
+    )
+
+    if (result.error) {
+      return { rows: [], error: result.error }
+    }
+
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadEnrollmentStudentRows(
+  supabase: SupabaseClient,
+  classroomId: string,
+): Promise<{ rows: EnrollmentStudentRow[]; error: any }> {
+  return loadPagedRows<EnrollmentStudentRow>(() =>
+    supabase
+      .from('classroom_enrollments')
+      .select('student_id')
+      .eq('classroom_id', classroomId),
+    CRON_READ_PAGE_SIZE,
+    'id',
+  )
+}
+
+async function loadRosterNameRows(
+  supabase: SupabaseClient,
+  classroomId: string,
+): Promise<{ rows: ClassroomRosterNameRow[]; error: any }> {
+  return loadPagedRows<ClassroomRosterNameRow>(() =>
+    supabase
+      .from('classroom_roster')
+      .select('first_name, last_name')
+      .eq('classroom_id', classroomId),
+    CRON_READ_PAGE_SIZE,
+    'id',
+  )
+}
+
+async function loadStudentProfileRows(
+  supabase: SupabaseClient,
+  studentIds: string[],
+): Promise<{ rows: StudentProfileRow[]; error: any }> {
+  if (studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  return loadChunkedRows<StudentProfileRow>({
+    supabase,
+    table: 'student_profiles',
+    select: 'user_id, first_name, last_name',
+    filters: [{ column: 'user_id', values: studentIds }],
+    chunkSize: CRON_FILTER_CHUNK_SIZE,
+    pageSize: CRON_READ_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
 }
 
 async function isClassroomEligibleForSummary(

--- a/src/lib/server/query-chunks.ts
+++ b/src/lib/server/query-chunks.ts
@@ -23,7 +23,7 @@ export function chunkValues<T>(values: T[], chunkSize = DEFAULT_FILTER_CHUNK_SIZ
   return chunks
 }
 
-async function loadPagedRows<T>(buildQuery: () => any, pageSize?: number, pageOrderColumn = 'id') {
+export async function loadPagedRows<T>(buildQuery: () => any, pageSize?: number, pageOrderColumn = 'id') {
   const rows: T[] = []
   let offset = 0
 

--- a/tests/api/cron/nightly-log-summaries.test.ts
+++ b/tests/api/cron/nightly-log-summaries.test.ts
@@ -6,6 +6,76 @@ import { extractAndStoreDeveloperFeedbackCandidates } from '@/lib/developer-log-
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return true
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const query: any = {
+        eq: vi.fn((column: string, value: string | boolean) => {
+          filters.push({ column, values: [String(value)] })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        is: vi.fn(() => query),
+        lte: vi.fn(() => query),
+        gte: vi.fn(() => query),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+          return Promise.resolve({
+            data: filteredRows().slice(from, to + 1),
+            error: null,
+          })
+        }),
+        single: vi.fn(() => {
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+          const [row] = filteredRows()
+          return Promise.resolve({
+            data: row || null,
+            error: row ? null : { code: 'PGRST116' },
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -251,6 +321,40 @@ describe('cron nightly-log-summaries route', () => {
     expect(callOpenAIForSummary).not.toHaveBeenCalled()
   })
 
+  it('paginates active classroom discovery and chunks class-day lookups', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const log = createQueryLog()
+    const classroomIds = Array.from({ length: 51 }, (_, index) => `classroom-${index + 1}`)
+    const activeEntries = Array.from({ length: 1001 }, (_, index) => ({
+      id: `entry-${index + 1}`,
+      classroom_id: classroomIds[index % classroomIds.length],
+    }))
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'entries') return mockPagedTable(activeEntries, { table, log })
+      if (table === 'class_days') return mockPagedTable([], { table, log })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/cron/nightly-log-summaries', {
+        headers: { Authorization: 'Bearer secret' },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', generated: 0, skipped: 0 })
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 0, to: 999 })
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 1000, to: 1999 })
+    const classDayChunks = log.inCalls
+      .filter((call) => call.table === 'class_days' && call.column === 'classroom_id')
+      .map((call) => call.values.length)
+    expect(classDayChunks).toContain(50)
+    expect(classDayChunks).toContain(1)
+    expect(classDayChunks.every((length) => length <= 50)).toBe(true)
+    expect(callOpenAIForSummary).not.toHaveBeenCalled()
+  })
+
   it('skips a classroom when the eligibility recheck no longer finds it active and in range', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
@@ -410,6 +514,7 @@ describe('cron nightly-log-summaries route', () => {
 
             const entryQuery: any = {
               eq: vi.fn(() => entryQuery),
+              in: vi.fn(() => entryQuery),
               is: vi.fn(() => entryQuery),
               lte: vi.fn(() => entryQuery),
               gte: vi.fn().mockResolvedValue({
@@ -532,6 +637,143 @@ describe('cron nightly-log-summaries route', () => {
     )
   })
 
+  it('chunks profile and scoped entry reads and excludes withdrawn-student entries', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const log = createQueryLog()
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
+    const activeEntries = [{ id: 'active-entry', classroom_id: 'classroom-1' }]
+    const classDays = [{ id: 'class-day-1', classroom_id: 'classroom-1', is_class_day: true }]
+    const entries = [
+      ...studentIds.flatMap((studentId) =>
+        Array.from({ length: 21 }, (_, index) => ({
+          id: `entry-${studentId}-${index + 1}`,
+          classroom_id: 'classroom-1',
+          student_id: studentId,
+          text: `${studentId} reflected on progress`,
+          rich_content: null,
+          updated_at: `2026-03-15T12:${String(index).padStart(2, '0')}:00.000Z`,
+        }))
+      ),
+      {
+        id: 'stale-entry',
+        classroom_id: 'classroom-1',
+        student_id: 'withdrawn-student',
+        text: 'Withdrawn Student should not be summarized',
+        rich_content: null,
+        updated_at: '2026-03-15T12:59:00.000Z',
+      },
+    ]
+    const enrollments = studentIds.map((studentId, index) => ({
+      id: `enrollment-${index + 1}`,
+      classroom_id: 'classroom-1',
+      student_id: studentId,
+    }))
+    const profiles = studentIds.map((studentId, index) => ({
+      id: `profile-${index + 1}`,
+      user_id: studentId,
+      first_name: `First${index + 1}`,
+      last_name: `Last${index + 1}`,
+    }))
+
+    const activeEntriesTable = mockPagedTable(activeEntries, { table: 'entries', log })
+    const detailEntriesTable = mockPagedTable(entries, { table: 'entries', log })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'entries') {
+        return {
+          select: vi.fn((columns: string) =>
+            columns === 'classroom_id, classrooms!inner(archived_at,start_date,end_date)'
+              ? activeEntriesTable.select(columns)
+              : detailEntriesTable.select(columns)
+          ),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable(classDays, { table, log })
+      if (table === 'classrooms') return mockPagedTable([{ id: 'classroom-1' }], { table, log })
+      if (table === 'classroom_enrollments') return mockPagedTable(enrollments, { table, log })
+      if (table === 'classroom_roster') return mockPagedTable([], { table, log })
+      if (table === 'student_profiles') return mockPagedTable(profiles, { table, log })
+      if (table === 'log_summaries') return { upsert: vi.fn().mockResolvedValue({ error: null }) }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/cron/nightly-log-summaries', {
+        headers: { Authorization: 'Bearer secret' },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', generated: 1, skipped: 0 })
+    expect(extractAndStoreDeveloperFeedbackCandidates).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        classroomId: 'classroom-1',
+        sourceEntryCount: 1071,
+      })
+    )
+    const entryStudentChunks = log.inCalls
+      .filter((call) => call.table === 'entries' && call.column === 'student_id')
+      .map((call) => call.values.length)
+    expect(entryStudentChunks).toContain(50)
+    expect(entryStudentChunks).toContain(1)
+    expect(entryStudentChunks.every((length) => length <= 50)).toBe(true)
+    const profileChunks = log.inCalls
+      .filter((call) => call.table === 'student_profiles' && call.column === 'user_id')
+      .map((call) => call.values.length)
+    expect(profileChunks).toContain(50)
+    expect(profileChunks).toContain(1)
+    expect(profileChunks.every((length) => length <= 50)).toBe(true)
+    expect(log.rangeCalls).toContainEqual({ table: 'entries', from: 1000, to: 1999 })
+  })
+
+  it('skips a classroom when student profile hydration fails', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const activeEntries = [{ id: 'active-entry', classroom_id: 'classroom-1' }]
+    const classDays = [{ id: 'class-day-1', classroom_id: 'classroom-1', is_class_day: true }]
+    const detailEntries = [{
+      id: 'entry-1',
+      classroom_id: 'classroom-1',
+      student_id: 'student-1',
+      text: 'Reflected on progress',
+      rich_content: null,
+      updated_at: '2026-03-15T12:00:00.000Z',
+    }]
+    const activeEntriesTable = mockPagedTable(activeEntries)
+    const detailEntriesTable = mockPagedTable(detailEntries)
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'entries') {
+        return {
+          select: vi.fn((columns: string) =>
+            columns === 'classroom_id, classrooms!inner(archived_at,start_date,end_date)'
+              ? activeEntriesTable.select(columns)
+              : detailEntriesTable.select(columns)
+          ),
+        }
+      }
+      if (table === 'class_days') return mockPagedTable(classDays)
+      if (table === 'classrooms') return mockPagedTable([{ id: 'classroom-1' }])
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable([{ id: 'enrollment-1', classroom_id: 'classroom-1', student_id: 'student-1' }])
+      }
+      if (table === 'classroom_roster') return mockPagedTable([])
+      if (table === 'student_profiles') return mockPagedTable([], { error: { message: 'profiles failed' } })
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/cron/nightly-log-summaries', {
+        headers: { Authorization: 'Bearer secret' },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', generated: 0, skipped: 1 })
+    expect(callOpenAIForSummary).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
   it('redacts full-roster names and direct identifiers before sending logs to OpenAI', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
@@ -553,6 +795,7 @@ describe('cron nightly-log-summaries route', () => {
 
             const entryQuery: any = {
               eq: vi.fn(() => entryQuery),
+              in: vi.fn(() => entryQuery),
               is: vi.fn(() => entryQuery),
               lte: vi.fn(() => entryQuery),
               gte: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- page nightly log-summary active-classroom discovery and per-classroom source reads
- chunk class-day and profile filters, and scope summary entries to currently enrolled students
- skip summary generation on required profile read failures so redaction context is not silently incomplete

## Risk profile
- runtime-platform: cron/background route only; no schedule or deployment config changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts --reporter=verbose
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build
- pnpm vitest run --coverage --no-file-parallelism --reporter=dot
- git diff --check