### PR TITLE
[codex] Add exam mode window exit e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -767,3 +767,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `pnpm build`
 - `git diff --check`
+
+## 2026-05-31 — Student exam-mode e2e telemetry coverage
+
+**Completed:**
+- Extended the existing student exam-mode Playwright flow for sustained window loss.
+- Asserted that a sustained resize records a window/full-screen exit and does not increment route-exit telemetry.
+- Preserved existing checks for content locking, restoration, and open-response draft survival.
+
+**Validation:**
+- `VITEST_MAX_WORKERS=4 bash scripts/verify-env.sh`
+- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"`
+- `pnpm lint`

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -27,6 +27,7 @@ interface StudentTestDetailRecord {
     away_count?: number
     away_total_seconds?: number
     route_exit_attempts?: number
+    window_unmaximize_attempts?: number
   } | null
 }
 
@@ -223,6 +224,20 @@ test.describe('student exam mode', () => {
       await expect(obscurer).toHaveCount(0)
       await expect(responseBox).toBeVisible()
       await expect(responseBox).toHaveValue('Draft survives exam-mode lock and reload.')
+
+      await expect.poll(async () => {
+        if (!testId) return 0
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return detail.focus_summary?.window_unmaximize_attempts ?? 0
+      }).toBeGreaterThanOrEqual(1)
+      await expect.poll(async () => {
+        if (!testId) return -1
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return detail.focus_summary?.route_exit_attempts ?? 0
+      }).toBe(0)
+      await expect(
+        page.locator('[data-testid="student-test-documents-pane"]').getByLabel(/window\/full-screen exits 1/)
+      ).toBeVisible()
 
       await page.reload({ waitUntil: 'domcontentloaded' })
       await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()


### PR DESCRIPTION
## Selected Flow

Student exam mode sustained window-loss flow. This was chosen because the coverage policy prioritizes student exam mode first, and the existing flow already exercised content lock/restoration and open-response draft preservation but did not assert telemetry classification for the same sustained window loss.

## Risk Profile

exam-mode

## Tests Added Or Updated

- Updated `e2e/student-exam-mode.spec.ts` to assert that sustained viewport/window loss increments `window_unmaximize_attempts` and does not increment `route_exit_attempts`.
- Kept the existing assertions for transient restoration, content hiding, restored content visibility, reload, and open-response draft preservation.

## Commands Run

- `pnpm install`
- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (failed before dependency install because `node_modules` was missing)
- `bash scripts/verify-env.sh` (initial full Vitest run hit fork worker startup timeouts after reporting all test files passed)
- `VITEST_MAX_WORKERS=4 bash scripts/verify-env.sh`
- `pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"` (stopped because port 3000 belonged to another local project)
- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"`
- `pnpm lint`
- `git diff --check`

## Seeded-Data Assumptions

Uses existing e2e auth setup (`teacher@example.com`, `student1@example.com`, `test1234`) and requires those users to share at least one seeded classroom. The test creates and deletes its own active open-response test through existing app API routes.

## Residual Coverage Gaps

- Teacher-facing exam telemetry e2e coverage remains separate.
- This run does not add assignment flow coverage.
- The flow verifies one sustained window-loss path; browser-native fullscreen exit variants remain covered primarily below e2e level.