### PR TITLE
Harden teacher assignment detail reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -586,3 +586,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
+
+## 2026-05-31 — Teacher assignment detail bulk-read hardening
+
+**Completed:**
+- Routed teacher assignment detail enrollment reads through pagination.
+- Chunked and paged student profile, assignment doc, doc-history, and structured submission artifact reads.
+- Scoped assignment docs to currently enrolled student ids so withdrawn-student docs cannot consume pages or drive artifact/history hydration.
+- Returned explicit 500s for profile, doc, history, and artifact read failures instead of rendering partial detail data.
+- Added regressions for >1000-student detail pagination, 51-student chunking, stale withdrawn-student doc exclusion, dense history pagination, read-failure handling, and artifact helper chunking/pagination.
+- Addressed subagent review follow-up by tightening paged-table mocks so missing filtered columns no longer pass rows through.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/assignments-id.test.ts tests/lib/assignment-submission-artifacts.test.ts tests/unit/query-chunks.test.ts -- --runInBand`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm test:coverage`
+- `git diff --check`

--- a/src/app/api/teacher/assignments/[id]/route.ts
+++ b/src/app/api/teacher/assignments/[id]/route.ts
@@ -10,6 +10,7 @@ import { extractAssignmentArtifacts, type AssignmentArtifact } from '@/lib/assig
 import { buildAssignmentInstructionFields, getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { withErrorHandler } from '@/lib/api-handler'
 import { getActiveAssignmentAiGradingRunSummary } from '@/lib/server/assignment-ai-grading-runs'
+import { chunkValues, loadChunkedRows, loadPagedRows } from '@/lib/server/query-chunks'
 import {
   ASSIGNMENT_SCHEDULE_DUE_DATE_ERROR,
   getFutureScheduledReleaseDueDateError,
@@ -26,9 +27,110 @@ import {
   removeAssignmentArtifactStorageObjects,
   replaceAssignmentSubmissionRequirements,
 } from '@/lib/server/assignment-submission-artifacts'
+import type { AssignmentDoc, AssignmentSubmissionArtifact } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+const ASSIGNMENT_DETAIL_PAGE_SIZE = 1000
+
+type AssignmentEnrollmentRow = {
+  id?: string
+  student_id: string
+  users: {
+    id: string
+    email: string
+  } | null
+}
+
+type AssignmentStudentProfileRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+
+type AssignmentDocHistoryRow = {
+  assignment_doc_id: string
+  created_at: string
+}
+
+async function loadAssignmentEnrollments(
+  supabase: any,
+  classroomId: string
+): Promise<{ rows: AssignmentEnrollmentRow[]; error: any }> {
+  return loadPagedRows<AssignmentEnrollmentRow>(() =>
+    supabase
+      .from('classroom_enrollments')
+      .select(`
+        id,
+        student_id,
+        users!inner (
+          id,
+          email
+        )
+      `)
+      .eq('classroom_id', classroomId),
+    ASSIGNMENT_DETAIL_PAGE_SIZE,
+    'id'
+  )
+}
+
+async function loadAssignmentStudentProfiles(
+  supabase: any,
+  studentIds: string[]
+): Promise<{ rows: AssignmentStudentProfileRow[]; error: any }> {
+  return loadChunkedRows<AssignmentStudentProfileRow>({
+    supabase,
+    table: 'student_profiles',
+    select: 'user_id, first_name, last_name',
+    filters: [{ column: 'user_id', values: studentIds }],
+    pageSize: ASSIGNMENT_DETAIL_PAGE_SIZE,
+    pageOrderColumn: 'user_id',
+  })
+}
+
+async function loadAssignmentDocsForStudents(
+  supabase: any,
+  assignmentId: string,
+  studentIds: string[]
+): Promise<{ rows: AssignmentDoc[]; error: any }> {
+  if (studentIds.length === 0) {
+    return { rows: [], error: null }
+  }
+
+  const rows: AssignmentDoc[] = []
+  for (const studentIdChunk of chunkValues(studentIds)) {
+    const result = await loadPagedRows<AssignmentDoc>(() =>
+      supabase
+        .from('assignment_docs')
+        .select('*')
+        .eq('assignment_id', assignmentId)
+        .in('student_id', studentIdChunk),
+      ASSIGNMENT_DETAIL_PAGE_SIZE,
+      'id'
+    )
+
+    if (result.error) {
+      return result
+    }
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadAssignmentDocHistoryRows(
+  supabase: any,
+  assignmentDocIds: string[]
+): Promise<{ rows: AssignmentDocHistoryRow[]; error: any }> {
+  return loadChunkedRows<AssignmentDocHistoryRow>({
+    supabase,
+    table: 'assignment_doc_history',
+    select: 'assignment_doc_id, created_at',
+    filters: [{ column: 'assignment_doc_id', values: assignmentDocIds }],
+    pageSize: ASSIGNMENT_DETAIL_PAGE_SIZE,
+  })
+}
 
 function mergeAssignmentArtifacts(
   structuredArtifacts: AssignmentArtifact[],
@@ -81,16 +183,10 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
     )
   }
 
-  const { data: enrollments, error: enrollmentError } = await supabase
-    .from('classroom_enrollments')
-    .select(`
-      student_id,
-      users!inner (
-        id,
-        email
-      )
-    `)
-    .eq('classroom_id', assignment.classroom_id)
+  const { rows: enrollments, error: enrollmentError } = await loadAssignmentEnrollments(
+    supabase,
+    assignment.classroom_id
+  )
 
   if (enrollmentError) {
     console.error('Error fetching enrollments:', enrollmentError)
@@ -101,10 +197,15 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
   }
 
   const studentIds = enrollments?.map((enrollment) => enrollment.student_id) || []
-  const { data: profiles } = await supabase
-    .from('student_profiles')
-    .select('user_id, first_name, last_name')
-    .in('user_id', studentIds)
+  const { rows: profiles, error: profilesError } = await loadAssignmentStudentProfiles(supabase, studentIds)
+
+  if (profilesError) {
+    console.error('Error fetching student profiles:', profilesError)
+    return NextResponse.json(
+      { error: 'Failed to fetch student profiles' },
+      { status: 500 }
+    )
+  }
 
   const profileMap = new Map(
     profiles?.map((profile) => [
@@ -117,15 +218,29 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
     ]) || []
   )
 
-  const { data: docs } = await supabase
-    .from('assignment_docs')
-    .select('*')
-    .eq('assignment_id', id)
+  const { rows: docs, error: docsError } = await loadAssignmentDocsForStudents(supabase, id, studentIds)
+
+  if (docsError) {
+    console.error('Error fetching assignment docs:', docsError)
+    return NextResponse.json(
+      { error: 'Failed to fetch assignment docs' },
+      { status: 500 }
+    )
+  }
 
   const docMap = new Map(docs?.map((doc) => [doc.student_id, doc]) || [])
   const docIds = (docs || []).map((doc) => doc.id)
   const submissionRequirements = await loadAssignmentSubmissionRequirements(supabase, id)
-  const structuredArtifacts = await loadAssignmentSubmissionArtifactsForDocs(supabase, docIds)
+  let structuredArtifacts: AssignmentSubmissionArtifact[]
+  try {
+    structuredArtifacts = await loadAssignmentSubmissionArtifactsForDocs(supabase, docIds)
+  } catch (error) {
+    console.error('Error fetching assignment submission artifacts:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch assignment submission artifacts' },
+      { status: 500 }
+    )
+  }
   const structuredArtifactsByDocId = new Map<string, typeof structuredArtifacts>()
   for (const artifact of structuredArtifacts) {
     const current = structuredArtifactsByDocId.get(artifact.assignment_doc_id) || []
@@ -135,10 +250,15 @@ export const GET = withErrorHandler('GetTeacherAssignment', async (request, cont
 
   const studentUpdatedAtByDocId = new Map<string, string>()
   if (docIds.length > 0) {
-    const { data: historyRows } = await supabase
-      .from('assignment_doc_history')
-      .select('assignment_doc_id, created_at')
-      .in('assignment_doc_id', docIds)
+    const { rows: historyRows, error: historyError } = await loadAssignmentDocHistoryRows(supabase, docIds)
+
+    if (historyError) {
+      console.error('Error fetching assignment doc history:', historyError)
+      return NextResponse.json(
+        { error: 'Failed to fetch assignment doc history' },
+        { status: 500 }
+      )
+    }
 
     for (const row of historyRows || []) {
       const existing = studentUpdatedAtByDocId.get(row.assignment_doc_id)

--- a/src/lib/server/assignment-submission-artifacts.ts
+++ b/src/lib/server/assignment-submission-artifacts.ts
@@ -6,6 +6,7 @@ import type {
   AssignmentSubmissionArtifact,
   AssignmentSubmissionRequirement,
 } from '@/types'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
 
 const ASSIGNMENT_ARTIFACTS_BUCKET = 'assignment-artifacts'
 const SIGNED_IMAGE_URL_EXPIRES_SECONDS = 60 * 60
@@ -112,18 +113,21 @@ export async function loadAssignmentSubmissionArtifactsForDocs(
   if (assignmentDocIds.length === 0) return []
 
   try {
-    const query = supabase.from('assignment_submission_artifacts')
-    if (!query) return []
-    const { data, error } = await query
-      .select('*')
-      .in('assignment_doc_id', assignmentDocIds)
+    if (typeof supabase.from !== 'function') return []
+    const { rows, error } = await loadChunkedRows<AssignmentSubmissionArtifact>({
+      supabase,
+      table: 'assignment_submission_artifacts',
+      select: '*',
+      filters: [{ column: 'assignment_doc_id', values: assignmentDocIds }],
+      pageSize: 1000,
+    })
 
     if (error) {
       if (isMissingAssignmentSubmissionSchemaError(error)) return []
       throw new Error('Failed to load assignment submission artifacts')
     }
 
-    return signArtifactImageUrls(supabase, (data || []) as AssignmentSubmissionArtifact[])
+    return signArtifactImageUrls(supabase, rows)
   } catch (error) {
     if (isMissingAssignmentSubmissionSchemaError(error)) return []
     throw error

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -91,6 +91,151 @@ function makeImageArtifactsTable(paths: string[]) {
   }
 }
 
+type QueryLog = {
+  eqCalls: Array<{ table: string; column: string; value: string }>
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { eqCalls: [], inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const query: any = {
+        eq: vi.fn((column: string, value: string) => {
+          filters.push({ column, values: [String(value)] })
+          if (options.table) {
+            options.log?.eqCalls.push({ table: options.table, column, value: String(value) })
+          }
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+          return Promise.resolve({
+            data: filteredRows().slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
+
+function makeAssignmentDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'doc-1',
+    assignment_id: 'a-1',
+    student_id: 'student-1',
+    content: { type: 'doc', content: [] },
+    is_submitted: false,
+    submitted_at: null,
+    updated_at: '2026-03-10T09:30:00.000Z',
+    score_completion: null,
+    score_thinking: null,
+    score_workflow: null,
+    graded_at: null,
+    returned_at: null,
+    ...overrides,
+  }
+}
+
+function mockAssignmentDetailTables(options: {
+  assignment?: Record<string, any>
+  enrollments?: Array<Record<string, any>>
+  profiles?: Array<Record<string, any>>
+  docs?: Array<Record<string, any>>
+  requirements?: unknown[]
+  artifacts?: Array<Record<string, any>>
+  historyRows?: Array<Record<string, any>>
+  errors?: Record<string, any>
+  log?: QueryLog
+} = {}) {
+  const assignment = options.assignment ?? makeAssignment({
+    classroom_id: 'classroom-1',
+    classrooms: {
+      id: 'classroom-1',
+      teacher_id: 'teacher-1',
+      title: 'Test Classroom',
+      archived_at: null,
+    },
+  })
+  const enrollments = options.enrollments ?? [
+    {
+      id: 'enrollment-1',
+      classroom_id: 'classroom-1',
+      student_id: 'student-1',
+      users: { id: 'student-1', email: 'student1@example.com' },
+    },
+  ]
+  const profiles = options.profiles ?? [
+    { user_id: 'student-1', first_name: 'Alex', last_name: 'Lee' },
+  ]
+  const docs = options.docs ?? [makeAssignmentDoc()]
+  const requirements = options.requirements ?? []
+  const artifacts = options.artifacts ?? []
+  const historyRows = options.historyRows ?? []
+
+  return vi.fn((table: string) => {
+    if (table === 'assignments') return makeAssignmentSelectTable(assignment)
+    if (table === 'classroom_enrollments') {
+      return mockPagedTable(enrollments, { table, log: options.log, error: options.errors?.[table] })
+    }
+    if (table === 'student_profiles') {
+      return mockPagedTable(profiles, { table, log: options.log, error: options.errors?.[table] })
+    }
+    if (table === 'assignment_docs') {
+      return mockPagedTable(docs, { table, log: options.log, error: options.errors?.[table] })
+    }
+    if (table === 'assignment_submission_requirements') {
+      return makeRequirementsTable(requirements)
+    }
+    if (table === 'assignment_submission_artifacts') {
+      return mockPagedTable(artifacts, { table, log: options.log, error: options.errors?.[table] })
+    }
+    if (table === 'assignment_doc_history') {
+      return mockPagedTable(historyRows, { table, log: options.log, error: options.errors?.[table] })
+    }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
 describe('GET /api/teacher/assignments/[id]', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
@@ -150,91 +295,65 @@ describe('GET /api/teacher/assignments/[id]', () => {
       }
 
       if (table === 'classroom_enrollments') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  student_id: 'student-1',
-                  users: { id: 'student-1', email: 'student1@example.com' },
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'enrollment-1',
+            classroom_id: 'classroom-1',
+            student_id: 'student-1',
+            users: { id: 'student-1', email: 'student1@example.com' },
+          },
+        ])
       }
 
       if (table === 'student_profiles') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  user_id: 'student-1',
-                  first_name: 'Alex',
-                  last_name: 'Lee',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            user_id: 'student-1',
+            first_name: 'Alex',
+            last_name: 'Lee',
+          },
+        ])
       }
 
       if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({
-              data: [
+        return mockPagedTable([
+          {
+            id: 'doc-1',
+            assignment_id: 'a-1',
+            student_id: 'student-1',
+            content: {
+              type: 'doc',
+              content: [
                 {
-                  id: 'doc-1',
-                  assignment_id: 'a-1',
-                  student_id: 'student-1',
-                  content: {
-                    type: 'doc',
-                    content: [
-                      {
-                        type: 'paragraph',
-                        content: [
-                          {
-                            type: 'text',
-                            text: 'Source https://example.com/resource',
-                            marks: [{ type: 'link', attrs: { href: 'mailto:nope@example.com' } }],
-                          },
-                        ],
-                      },
-                      {
-                        type: 'image',
-                        attrs: { src: 'https://cdn.example.com/submission-images/shot.png' },
-                      },
-                    ],
-                  },
-                  is_submitted: true,
-                  submitted_at: submittedAt,
-                  updated_at: updatedAt,
-                  score_completion: 9,
-                  score_thinking: 8,
-                  score_workflow: 7,
-                  graded_at: '2026-03-10T12:00:00.000Z',
-                  returned_at: null,
+                  type: 'paragraph',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Source https://example.com/resource',
+                      marks: [{ type: 'link', attrs: { href: 'mailto:nope@example.com' } }],
+                    },
+                  ],
+                },
+                {
+                  type: 'image',
+                  attrs: { src: 'https://cdn.example.com/submission-images/shot.png' },
                 },
               ],
-              error: null,
-            }),
-          })),
-        }
+            },
+            is_submitted: true,
+            submitted_at: submittedAt,
+            updated_at: updatedAt,
+            score_completion: 9,
+            score_thinking: 8,
+            score_workflow: 7,
+            graded_at: '2026-03-10T12:00:00.000Z',
+            returned_at: null,
+          },
+        ])
       }
 
       if (table === 'assignment_doc_history') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ assignment_doc_id: 'doc-1', created_at: historyCreatedAt }],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([{ assignment_doc_id: 'doc-1', created_at: historyCreatedAt }])
       }
 
       if (table === 'assignment_submission_requirements') {
@@ -272,64 +391,57 @@ describe('GET /api/teacher/assignments/[id]', () => {
       }
 
       if (table === 'assignment_submission_artifacts') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'artifact-1',
-                  assignment_doc_id: 'doc-1',
-                  requirement_id: 'req-1',
-                  student_id: 'student-1',
-                  type: 'link',
-                  url: 'https://example.com/resource',
-                  storage_path: null,
-                  metadata_json: {},
-                  validation_status: 'valid',
-                  validation_message: null,
-                  validated_at: '2026-03-10T09:35:00.000Z',
-                  created_at: '2026-03-10T09:35:00.000Z',
-                  updated_at: '2026-03-10T09:35:00.000Z',
-                },
-                {
-                  id: 'artifact-2',
-                  assignment_doc_id: 'doc-1',
-                  requirement_id: 'req-2',
-                  student_id: 'student-1',
-                  type: 'link',
-                  url: 'https://example.com/resource',
-                  storage_path: null,
-                  metadata_json: {},
-                  validation_status: 'valid',
-                  validation_message: null,
-                  validated_at: '2026-03-10T09:35:00.000Z',
-                  created_at: '2026-03-10T09:35:00.000Z',
-                  updated_at: '2026-03-10T09:35:00.000Z',
-                },
-                {
-                  id: 'artifact-3',
-                  assignment_doc_id: 'doc-1',
-                  requirement_id: 'req-3',
-                  student_id: 'student-1',
-                  type: 'repo_link',
-                  url: 'https://github.com/codepetca/pika',
-                  storage_path: null,
-                  metadata_json: {
-                    repo_owner: 'codepetca',
-                    repo_name: 'pika',
-                    normalized_url: 'https://github.com/codepetca/pika',
-                  },
-                  validation_status: 'valid',
-                  validation_message: null,
-                  validated_at: '2026-03-10T09:35:00.000Z',
-                  created_at: '2026-03-10T09:35:00.000Z',
-                  updated_at: '2026-03-10T09:35:00.000Z',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'artifact-1',
+            assignment_doc_id: 'doc-1',
+            requirement_id: 'req-1',
+            student_id: 'student-1',
+            type: 'link',
+            url: 'https://example.com/resource',
+            storage_path: null,
+            metadata_json: {},
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-03-10T09:35:00.000Z',
+            created_at: '2026-03-10T09:35:00.000Z',
+            updated_at: '2026-03-10T09:35:00.000Z',
+          },
+          {
+            id: 'artifact-2',
+            assignment_doc_id: 'doc-1',
+            requirement_id: 'req-2',
+            student_id: 'student-1',
+            type: 'link',
+            url: 'https://example.com/resource',
+            storage_path: null,
+            metadata_json: {},
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-03-10T09:35:00.000Z',
+            created_at: '2026-03-10T09:35:00.000Z',
+            updated_at: '2026-03-10T09:35:00.000Z',
+          },
+          {
+            id: 'artifact-3',
+            assignment_doc_id: 'doc-1',
+            requirement_id: 'req-3',
+            student_id: 'student-1',
+            type: 'repo_link',
+            url: 'https://github.com/codepetca/pika',
+            storage_path: null,
+            metadata_json: {
+              repo_owner: 'codepetca',
+              repo_name: 'pika',
+              normalized_url: 'https://github.com/codepetca/pika',
+            },
+            validation_status: 'valid',
+            validation_message: null,
+            validated_at: '2026-03-10T09:35:00.000Z',
+            created_at: '2026-03-10T09:35:00.000Z',
+            updated_at: '2026-03-10T09:35:00.000Z',
+          },
+        ])
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -390,6 +502,97 @@ describe('GET /api/teacher/assignments/[id]', () => {
     })
     expect(data.students[0].doc).not.toHaveProperty('content')
     expect(data.active_ai_grading_run).toBeNull()
+  })
+
+  it('pages and chunks detail reads while ignoring unenrolled assignment docs', async () => {
+    const studentIds = Array.from({ length: 1001 }, (_, index) => `student-${index}`)
+    const enrollments = studentIds.map((studentId, index) => ({
+      id: `enrollment-${index.toString().padStart(4, '0')}`,
+      classroom_id: 'classroom-1',
+      student_id: studentId,
+      users: { id: studentId, email: `${studentId}@example.com` },
+    }))
+    const profiles = studentIds.map((studentId, index) => ({
+      user_id: studentId,
+      first_name: 'Student',
+      last_name: index.toString().padStart(4, '0'),
+    }))
+    const docs = [
+      ...studentIds.map((studentId, index) =>
+        makeAssignmentDoc({
+          id: `doc-${index}`,
+          student_id: studentId,
+          updated_at: `2026-03-10T09:${String(index % 60).padStart(2, '0')}:00.000Z`,
+        })
+      ),
+      makeAssignmentDoc({
+        id: 'removed-doc',
+        student_id: 'removed-student',
+        updated_at: '2026-03-10T10:00:00.000Z',
+      }),
+    ]
+    const historyRows = Array.from({ length: 1001 }, (_, index) => ({
+      assignment_doc_id: 'doc-0',
+      created_at: `2026-03-10T10:${String(index % 60).padStart(2, '0')}:00.000Z`,
+    }))
+    const log = createQueryLog()
+    ;(mockSupabaseClient.from as any) = mockAssignmentDetailTables({
+      enrollments,
+      profiles,
+      docs,
+      historyRows,
+      log,
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1')
+    const response = await GET(request, { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.students).toHaveLength(1001)
+    expect(data.students.some((student: any) => student.student_id === 'removed-student')).toBe(false)
+    expect(data.students.find((student: any) => student.student_id === 'student-1000')?.doc?.updated_at)
+      .toBe('2026-03-10T09:40:00.000Z')
+
+    expect(log.rangeCalls.filter((call) => call.table === 'classroom_enrollments')).toEqual([
+      { table: 'classroom_enrollments', from: 0, to: 999 },
+      { table: 'classroom_enrollments', from: 1000, to: 1999 },
+    ])
+
+    const profileInCalls = log.inCalls.filter((call) => call.table === 'student_profiles')
+    expect(profileInCalls).toHaveLength(21)
+    expect(profileInCalls[0].values).toHaveLength(50)
+    expect(profileInCalls[20].values).toHaveLength(1)
+
+    const docStudentIds = log.inCalls
+      .filter((call) => call.table === 'assignment_docs')
+      .flatMap((call) => call.values)
+    expect(docStudentIds).toContain('student-1000')
+    expect(docStudentIds).not.toContain('removed-student')
+
+    expect(log.rangeCalls.filter((call) => call.table === 'assignment_doc_history').slice(0, 2)).toEqual([
+      { table: 'assignment_doc_history', from: 0, to: 999 },
+      { table: 'assignment_doc_history', from: 1000, to: 1999 },
+    ])
+  })
+
+  it.each([
+    ['student_profiles', 'Failed to fetch student profiles'],
+    ['assignment_docs', 'Failed to fetch assignment docs'],
+    ['assignment_doc_history', 'Failed to fetch assignment doc history'],
+  ])('returns 500 when %s cannot be read', async (failingTable, expectedError) => {
+    ;(mockSupabaseClient.from as any) = mockAssignmentDetailTables({
+      errors: {
+        [failingTable]: { message: `${failingTable} failed` },
+      },
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/a-1')
+    const response = await GET(request, { params: { id: 'a-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe(expectedError)
   })
 })
 

--- a/tests/lib/assignment-submission-artifacts.test.ts
+++ b/tests/lib/assignment-submission-artifacts.test.ts
@@ -1,6 +1,62 @@
 import { describe, expect, it, vi } from 'vitest'
-import { replaceAssignmentSubmissionRequirements } from '@/lib/server/assignment-submission-artifacts'
-import type { AssignmentSubmissionRequirement } from '@/types'
+import {
+  loadAssignmentSubmissionArtifactsForDocs,
+  replaceAssignmentSubmissionRequirements,
+} from '@/lib/server/assignment-submission-artifacts'
+import type { AssignmentSubmissionArtifact, AssignmentSubmissionRequirement } from '@/types'
+
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+          return Promise.resolve({
+            data: filteredRows().slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}
 
 function makeRequirement(
   overrides: Partial<AssignmentSubmissionRequirement>
@@ -14,6 +70,26 @@ function makeRequirement(
     required: overrides.required ?? true,
     position: overrides.position ?? 0,
     validation_policy_json: overrides.validation_policy_json ?? {},
+    created_at: overrides.created_at ?? '2026-05-01T00:00:00.000Z',
+    updated_at: overrides.updated_at ?? '2026-05-01T00:00:00.000Z',
+  }
+}
+
+function makeArtifact(
+  overrides: Partial<AssignmentSubmissionArtifact>
+): AssignmentSubmissionArtifact {
+  return {
+    id: overrides.id ?? 'artifact-1',
+    assignment_doc_id: overrides.assignment_doc_id ?? 'doc-1',
+    requirement_id: overrides.requirement_id ?? 'req-1',
+    student_id: overrides.student_id ?? 'student-1',
+    type: overrides.type ?? 'link',
+    url: overrides.url ?? 'https://example.com/work',
+    storage_path: overrides.storage_path ?? null,
+    metadata_json: overrides.metadata_json ?? {},
+    validation_status: overrides.validation_status ?? 'valid',
+    validation_message: overrides.validation_message ?? null,
+    validated_at: overrides.validated_at ?? '2026-05-01T00:00:00.000Z',
     created_at: overrides.created_at ?? '2026-05-01T00:00:00.000Z',
     updated_at: overrides.updated_at ?? '2026-05-01T00:00:00.000Z',
   }
@@ -59,5 +135,48 @@ describe('replaceAssignmentSubmissionRequirements', () => {
       ],
     })
     expect(result.map((requirement) => requirement.id)).toEqual(['new-1', 'req-repo'])
+  })
+})
+
+describe('loadAssignmentSubmissionArtifactsForDocs', () => {
+  it('chunks doc filters and pages large artifact result sets', async () => {
+    const docIds = Array.from({ length: 51 }, (_, index) => `doc-${index}`)
+    const rows = [
+      ...Array.from({ length: 1001 }, (_, index) =>
+        makeArtifact({
+          id: `artifact-doc-0-${index}`,
+          assignment_doc_id: 'doc-0',
+          student_id: 'student-0',
+          url: `https://example.com/work-${index}`,
+        })
+      ),
+      makeArtifact({
+        id: 'artifact-doc-50',
+        assignment_doc_id: 'doc-50',
+        student_id: 'student-50',
+        url: 'https://example.com/work-50',
+      }),
+    ]
+    const log = createQueryLog()
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'assignment_submission_artifacts') {
+          return mockPagedTable(rows, { table, log })
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+      storage: { from: vi.fn() },
+    }
+
+    const result = await loadAssignmentSubmissionArtifactsForDocs(supabase, docIds)
+
+    expect(result).toHaveLength(1002)
+    expect(result.map((artifact) => artifact.id)).toContain('artifact-doc-50')
+    expect(log.inCalls.map((call) => call.values.length)).toEqual([50, 50, 1])
+    expect(log.rangeCalls).toEqual([
+      { table: 'assignment_submission_artifacts', from: 0, to: 999 },
+      { table: 'assignment_submission_artifacts', from: 1000, to: 1999 },
+      { table: 'assignment_submission_artifacts', from: 0, to: 999 },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- page teacher assignment detail enrollment reads and chunk/paginate profile, doc, history, and structured artifact reads
- scope assignment docs to currently enrolled students so withdrawn-student docs cannot consume pages or hydrate stale artifacts/history
- return explicit 500s for dependent read failures instead of rendering partial detail data

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/teacher/assignments-id.test.ts tests/lib/assignment-submission-artifacts.test.ts tests/unit/query-chunks.test.ts -- --runInBand
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:coverage
- git diff --check

## Review
- Subagent Curie identified the slice risks before implementation.
- Subagent Ohm reviewed the patch: no blocking findings; P3 stricter mock follow-up fixed before commit.