### PR TITLE
[codex] Harden student assessment result reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -606,3 +606,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test:coverage`
 - `git diff --check`
+
+## 2026-05-31 — Student assessment results bulk-read hardening
+
+**Completed:**
+- Routed student quiz, survey, and test result question reads through paginated loaders.
+- Chunked and paged classroom-scoped quiz/survey response aggregation by currently enrolled student ids.
+- Chunked and paged returned-student test attempt discovery and returned test response aggregation.
+- Paged current-student quiz/test response reads used for visibility, response maps, and returned test detail summaries.
+- Preserved defense-in-depth filtering so stale or unenrolled student responses cannot affect aggregate result payloads.
+- Returned explicit 500s for current-student response read failures instead of treating failed reads as empty work.
+- Updated route and integration tests for paged Supabase mocks, dense result pagination, 51-student chunking, stale-response exclusion, and read-failure handling.
+
+**Validation:**
+- `pnpm test tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts tests/api/student/tests-results.test.ts -- --runInBand`
+- `pnpm test tests/api/integration/test-return-visibility-flow.test.ts -- --runInBand`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`

--- a/src/app/api/student/quizzes/[id]/results/route.ts
+++ b/src/app/api/student/quizzes/[id]/results/route.ts
@@ -4,11 +4,73 @@ import { requireRole } from '@/lib/auth'
 import { aggregateResults, canStudentViewResults } from '@/lib/quizzes'
 import { assertStudentCanAccessQuiz } from '@/lib/server/quizzes'
 import { getClassroomStudentIds } from '@/lib/server/classrooms'
+import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { QuizQuestion, QuizResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+const STUDENT_QUIZ_RESULTS_PAGE_SIZE = 1000
+
+type QuizOwnResponseRow = {
+  id: string
+  question_id: string
+  selected_option: number
+}
+
+async function loadQuizQuestions(
+  supabase: any,
+  quizId: string
+): Promise<{ rows: QuizQuestion[]; error: any }> {
+  return loadPagedRows<QuizQuestion>(() =>
+    supabase
+      .from('quiz_questions')
+      .select('*')
+      .eq('quiz_id', quizId),
+    STUDENT_QUIZ_RESULTS_PAGE_SIZE,
+    'position'
+  )
+}
+
+async function loadQuizResponsesForStudents(
+  supabase: any,
+  quizId: string,
+  studentIds: string[]
+): Promise<{ rows: QuizResponse[]; error: any }> {
+  if (studentIds.length === 0) return { rows: [], error: null }
+
+  const rows: QuizResponse[] = []
+  for (const studentIdChunk of chunkValues(studentIds)) {
+    const result = await loadPagedRows<QuizResponse>(() =>
+      supabase
+        .from('quiz_responses')
+        .select('*')
+        .eq('quiz_id', quizId)
+        .in('student_id', studentIdChunk),
+      STUDENT_QUIZ_RESULTS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadQuizOwnResponses(
+  supabase: any,
+  quizId: string,
+  studentId: string
+): Promise<{ rows: QuizOwnResponseRow[]; error: any }> {
+  return loadPagedRows<QuizOwnResponseRow>(() =>
+    supabase
+      .from('quiz_responses')
+      .select('id, question_id, selected_option')
+      .eq('quiz_id', quizId)
+      .eq('student_id', studentId),
+    STUDENT_QUIZ_RESULTS_PAGE_SIZE
+  )
+}
 
 // GET /api/student/quizzes/[id]/results - Get aggregated results (if allowed)
 export const GET = withErrorHandler('GetStudentQuizResults', async (request, context) => {
@@ -23,12 +85,17 @@ export const GET = withErrorHandler('GetStudentQuizResults', async (request, con
   const supabase = getServiceRoleClient()
 
   // Check if student has responded
-  const { data: studentResponses } = await supabase
+  const { data: studentResponses, error: studentResponsesError } = await supabase
     .from('quiz_responses')
     .select('id')
     .eq('quiz_id', quizId)
     .eq('student_id', user.id)
     .limit(1)
+
+  if (studentResponsesError) {
+    console.error('Error checking quiz response:', studentResponsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
 
   const hasResponded = (studentResponses?.length || 0) > 0
 
@@ -40,12 +107,7 @@ export const GET = withErrorHandler('GetStudentQuizResults', async (request, con
     )
   }
 
-  // Fetch questions
-  const { data: questions, error: questionsError } = await supabase
-    .from('quiz_questions')
-    .select('*')
-    .eq('quiz_id', quizId)
-    .order('position', { ascending: true })
+  const { rows: questions, error: questionsError } = await loadQuizQuestions(supabase, quizId)
 
   if (questionsError) {
     console.error('Error fetching questions:', questionsError)
@@ -58,14 +120,11 @@ export const GET = withErrorHandler('GetStudentQuizResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } =
-    classroomStudentsResult.studentIds.length > 0
-      ? await supabase
-          .from('quiz_responses')
-          .select('*')
-          .eq('quiz_id', quizId)
-          .in('student_id', classroomStudentsResult.studentIds)
-      : { data: [], error: null }
+  const { rows: responses, error: responsesError } = await loadQuizResponsesForStudents(
+    supabase,
+    quizId,
+    classroomStudentsResult.studentIds
+  )
 
   if (responsesError) {
     console.error('Error fetching responses:', responsesError)
@@ -84,11 +143,16 @@ export const GET = withErrorHandler('GetStudentQuizResults', async (request, con
 
   // Get student's own responses
   const myResponses: Record<string, number> = {}
-  const { data: myResponsesData } = await supabase
-    .from('quiz_responses')
-    .select('question_id, selected_option')
-    .eq('quiz_id', quizId)
-    .eq('student_id', user.id)
+  const { rows: myResponsesData, error: myResponsesError } = await loadQuizOwnResponses(
+    supabase,
+    quizId,
+    user.id
+  )
+
+  if (myResponsesError) {
+    console.error('Error fetching student quiz responses:', myResponsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
 
   for (const r of myResponsesData || []) {
     myResponses[r.question_id] = r.selected_option

--- a/src/app/api/student/surveys/[id]/results/route.ts
+++ b/src/app/api/student/surveys/[id]/results/route.ts
@@ -5,10 +5,51 @@ import { assertStudentCanAccessSurvey } from '@/lib/server/surveys'
 import { aggregateSurveyResults, canStudentViewSurveyResults } from '@/lib/surveys'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { getClassroomStudentIds } from '@/lib/server/classrooms'
+import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import type { SurveyQuestion, SurveyResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+const STUDENT_SURVEY_RESULTS_PAGE_SIZE = 1000
+
+async function loadSurveyQuestions(
+  supabase: any,
+  surveyId: string
+): Promise<{ rows: SurveyQuestion[]; error: any }> {
+  return loadPagedRows<SurveyQuestion>(() =>
+    supabase
+      .from('survey_questions')
+      .select('*')
+      .eq('survey_id', surveyId),
+    STUDENT_SURVEY_RESULTS_PAGE_SIZE,
+    'position'
+  )
+}
+
+async function loadSurveyResponsesForStudents(
+  supabase: any,
+  surveyId: string,
+  studentIds: string[]
+): Promise<{ rows: SurveyResponse[]; error: any }> {
+  if (studentIds.length === 0) return { rows: [], error: null }
+
+  const rows: SurveyResponse[] = []
+  for (const studentIdChunk of chunkValues(studentIds)) {
+    const result = await loadPagedRows<SurveyResponse>(() =>
+      supabase
+        .from('survey_responses')
+        .select('*')
+        .eq('survey_id', surveyId)
+        .in('student_id', studentIdChunk),
+      STUDENT_SURVEY_RESULTS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
 
 export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, context) => {
   const user = await requireRole('student')
@@ -25,11 +66,7 @@ export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, 
   }
 
   const supabase = getServiceRoleClient()
-  const { data: questions, error: questionsError } = await supabase
-    .from('survey_questions')
-    .select('*')
-    .eq('survey_id', surveyId)
-    .order('position', { ascending: true })
+  const { rows: questions, error: questionsError } = await loadSurveyQuestions(supabase, surveyId)
 
   if (questionsError) {
     console.error('Error fetching survey questions:', questionsError)
@@ -42,14 +79,11 @@ export const GET = withErrorHandler('GetStudentSurveyResults', async (_request, 
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
-  const { data: responses, error: responsesError } =
-    classroomStudentsResult.studentIds.length > 0
-      ? await supabase
-          .from('survey_responses')
-          .select('*')
-          .eq('survey_id', surveyId)
-          .in('student_id', classroomStudentsResult.studentIds)
-      : { data: [], error: null }
+  const { rows: responses, error: responsesError } = await loadSurveyResponsesForStudents(
+    supabase,
+    surveyId,
+    classroomStudentsResult.studentIds
+  )
 
   if (responsesError) {
     console.error('Error fetching survey responses:', responsesError)

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -11,11 +11,155 @@ import {
 } from '@/lib/server/tests'
 import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
+import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import { withErrorHandler } from '@/lib/api-handler'
 import type { QuizQuestion, QuizResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+const STUDENT_TEST_RESULTS_PAGE_SIZE = 1000
+
+type TestResultQuestionRow = {
+  id: string
+  question_type: string
+  question_text: string
+  options: string[]
+  correct_option: number | null
+  points: number | null
+  response_max_chars: number | null
+  response_monospace: boolean | null
+  sample_solution: string | null
+  position: number
+}
+
+type ReturnedAttemptRow = {
+  student_id: string
+  returned_at: string | null
+}
+
+type StudentTestResponseSummaryRow = {
+  id: string
+  selected_option: number | null
+  response_text: string | null
+}
+
+type StudentTestResponseDetailRow = {
+  id: string
+  question_id: string
+  selected_option: number | null
+  response_text: string | null
+  score: number | null
+  feedback: string | null
+  graded_at: string | null
+}
+
+type TestResponseResultRow = {
+  id: string
+  test_id: string
+  question_id: string
+  student_id: string
+  selected_option: number | null
+  response_text: string | null
+  score: number | null
+  feedback: string | null
+  graded_at: string | null
+  submitted_at: string
+}
+
+async function loadStudentTestResponseSummaries(
+  supabase: any,
+  testId: string,
+  studentId: string
+): Promise<{ rows: StudentTestResponseSummaryRow[]; error: any }> {
+  return loadPagedRows<StudentTestResponseSummaryRow>(() =>
+    supabase
+      .from('test_responses')
+      .select('id, selected_option, response_text')
+      .eq('test_id', testId)
+      .eq('student_id', studentId),
+    STUDENT_TEST_RESULTS_PAGE_SIZE
+  )
+}
+
+async function loadTestResultQuestions(
+  supabase: any,
+  testId: string
+): Promise<{ rows: TestResultQuestionRow[]; error: any }> {
+  return loadPagedRows<TestResultQuestionRow>(() =>
+    supabase
+      .from('test_questions')
+      .select('id, question_type, question_text, options, correct_option, points, response_max_chars, response_monospace, sample_solution, position')
+      .eq('test_id', testId),
+    STUDENT_TEST_RESULTS_PAGE_SIZE,
+    'position'
+  )
+}
+
+async function loadReturnedTestAttemptsForStudents(
+  supabase: any,
+  testId: string,
+  studentIds: string[]
+): Promise<{ rows: ReturnedAttemptRow[]; error: any }> {
+  if (studentIds.length === 0) return { rows: [], error: null }
+
+  const rows: ReturnedAttemptRow[] = []
+  for (const studentIdChunk of chunkValues(studentIds)) {
+    const result = await loadPagedRows<ReturnedAttemptRow>(() =>
+      supabase
+        .from('test_attempts')
+        .select('student_id, returned_at')
+        .eq('test_id', testId)
+        .in('student_id', studentIdChunk),
+      STUDENT_TEST_RESULTS_PAGE_SIZE,
+      'student_id'
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadStudentTestResponseDetails(
+  supabase: any,
+  testId: string,
+  studentId: string
+): Promise<{ rows: StudentTestResponseDetailRow[]; error: any }> {
+  return loadPagedRows<StudentTestResponseDetailRow>(() =>
+    supabase
+      .from('test_responses')
+      .select('id, question_id, selected_option, response_text, score, feedback, graded_at')
+      .eq('test_id', testId)
+      .eq('student_id', studentId),
+    STUDENT_TEST_RESULTS_PAGE_SIZE
+  )
+}
+
+async function loadReturnedTestResponsesForStudents(
+  supabase: any,
+  testId: string,
+  studentIds: string[]
+): Promise<{ rows: TestResponseResultRow[]; error: any }> {
+  if (studentIds.length === 0) return { rows: [], error: null }
+
+  const rows: TestResponseResultRow[] = []
+  for (const studentIdChunk of chunkValues(studentIds)) {
+    const result = await loadPagedRows<TestResponseResultRow>(() =>
+      supabase
+        .from('test_responses')
+        .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, submitted_at')
+        .eq('test_id', testId)
+        .in('student_id', studentIdChunk),
+      STUDENT_TEST_RESULTS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
 
 // GET /api/student/tests/[id]/results - Get aggregated results (if allowed)
 export const GET = withErrorHandler('GetStudentTestResults', async (request, context) => {
@@ -77,11 +221,15 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
     return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
   }
 
-  const { data: studentResponses } = await supabase
-    .from('test_responses')
-    .select('selected_option, response_text')
-    .eq('test_id', testId)
-    .eq('student_id', user.id)
+  const {
+    rows: studentResponses,
+    error: studentResponsesError,
+  } = await loadStudentTestResponseSummaries(supabase, testId, user.id)
+
+  if (studentResponsesError) {
+    console.error('Error checking student test responses:', studentResponsesError)
+    return NextResponse.json({ error: 'Failed to fetch responses' }, { status: 500 })
+  }
 
   const isLockedForGrading = Boolean(attempt?.closed_for_grading_at)
   const hasResponded = Boolean(attempt?.is_submitted) || (!isLockedForGrading && hasAnyMeaningfulTestResponse(studentResponses))
@@ -107,11 +255,7 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
     )
   }
 
-  const { data: questions, error: questionsError } = await supabase
-    .from('test_questions')
-    .select('id, question_type, question_text, options, correct_option, points, response_max_chars, response_monospace, sample_solution, position')
-    .eq('test_id', testId)
-    .order('position', { ascending: true })
+  const { rows: questions, error: questionsError } = await loadTestResultQuestions(supabase, testId)
 
   if (questionsError) {
     console.error('Error fetching test questions:', questionsError)
@@ -126,11 +270,14 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
 
   let returnedStudentIds: string[] = []
   if (classroomStudentsResult.studentIds.length > 0) {
-    const { data: returnedAttempts, error: returnedAttemptsError } = await supabase
-      .from('test_attempts')
-      .select('student_id, returned_at')
-      .eq('test_id', testId)
-      .in('student_id', classroomStudentsResult.studentIds)
+    const {
+      rows: returnedAttempts,
+      error: returnedAttemptsError,
+    } = await loadReturnedTestAttemptsForStudents(
+      supabase,
+      testId,
+      classroomStudentsResult.studentIds
+    )
 
     if (returnedAttemptsError) {
       console.error('Error fetching returned test attempts:', returnedAttemptsError)
@@ -142,19 +289,19 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
         (returnedAttempts || [])
           .filter((attempt) => attempt.returned_at)
           .map((attempt) => attempt.student_id)
-          .filter((studentId): studentId is string => typeof studentId === 'string')
+          .filter((studentId): studentId is string =>
+            typeof studentId === 'string' &&
+            classroomStudentsResult.studentIdSet.has(studentId)
+          )
       )
     )
   }
 
-  const { data: responses, error: responsesError } =
-    returnedStudentIds.length > 0
-      ? await supabase
-          .from('test_responses')
-          .select('id, test_id, question_id, student_id, selected_option, response_text, score, feedback, graded_at, submitted_at')
-          .eq('test_id', testId)
-          .in('student_id', returnedStudentIds)
-      : { data: [], error: null }
+  const { rows: responses, error: responsesError } = await loadReturnedTestResponsesForStudents(
+    supabase,
+    testId,
+    returnedStudentIds
+  )
 
   if (responsesError) {
     console.error('Error fetching test responses:', responsesError)
@@ -187,11 +334,11 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
   )
 
   const myResponses: Record<string, number> = {}
-  const { data: myResponsesData, error: myResponsesError } = await supabase
-    .from('test_responses')
-    .select('id, question_id, selected_option, response_text, score, feedback, graded_at')
-    .eq('test_id', testId)
-    .eq('student_id', user.id)
+  const { rows: myResponsesData, error: myResponsesError } = await loadStudentTestResponseDetails(
+    supabase,
+    testId,
+    user.id
+  )
 
   if (myResponsesError) {
     console.error('Error fetching student test responses:', myResponsesError)

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -234,6 +234,10 @@ function setupSupabaseMock() {
       return {
         select: vi.fn((_columns: string) => {
           let testId: string | null = null
+          const questionRows = () =>
+            state.testQuestions
+              .filter((q) => (testId ? q.test_id === testId : true))
+              .sort((a, b) => a.position - b.position)
           const chain: any = {
             eq: vi.fn((column: string, value: string) => {
               if (column === 'test_id') {
@@ -251,12 +255,17 @@ function setupSupabaseMock() {
               }
               return chain
             }),
-            order: vi.fn(async () => ({
-              data: state.testQuestions
-                .filter((q) => (testId ? q.test_id === testId : true))
-                .sort((a, b) => a.position - b.position),
+            order: vi.fn(() => chain),
+            range: vi.fn(async (from: number, to: number) => ({
+              data: questionRows().slice(from, to + 1),
               error: null,
             })),
+            then: vi.fn((resolve: any, reject: any) =>
+              Promise.resolve({
+                data: questionRows(),
+                error: null,
+              }).then(resolve, reject)
+            ),
           }
           return chain
         }),

--- a/tests/api/student/quizzes-results.test.ts
+++ b/tests/api/student/quizzes-results.test.ts
@@ -5,6 +5,61 @@ import { mockAuthenticationError } from '../setup'
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const resolveRows = (from: number, to: number) => {
+        if (options.error) return Promise.resolve({ data: null, error: options.error })
+        return Promise.resolve({ data: filteredRows().slice(from, to + 1), error: null })
+      }
+      const query: any = {
+        eq: vi.fn((column: string, value: string) => {
+          filters.push({ column, values: [String(value)] })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) options.log?.rangeCalls.push({ table: options.table, from, to })
+          return resolveRows(from, to)
+        }),
+        limit: vi.fn((count: number) => resolveRows(0, count - 1)),
+        then: vi.fn((resolve: any, reject: any) => resolveRows(0, rows.length - 1).then(resolve, reject)),
+      }
+      return query
+    }),
+  }
+}
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -86,6 +141,29 @@ describe('GET /api/student/quizzes/[id]/results', () => {
     })
   })
 
+  it('returns 500 when response visibility check fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
+  })
+
   it('returns 500 when question loading fails', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'quiz_responses') {
@@ -98,12 +176,7 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       }
 
       if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }),
-          })),
-        }
+        return mockPagedTable([], { error: { message: 'boom' } })
       }
 
       throw new Error(`Unexpected table: ${table}`)
@@ -130,23 +203,16 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       }
 
       if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'question-1',
-                  question_text: '2 + 2 = ?',
-                  options: ['4', '5'],
-                  correct_option: 0,
-                  position: 0,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -182,10 +248,7 @@ describe('GET /api/student/quizzes/[id]/results', () => {
             }
 
             if (columns === '*') {
-              return {
-                eq: vi.fn().mockReturnThis(),
-                in: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }),
-              }
+              return mockPagedTable([], { error: { message: 'boom' } }).select(columns)
             }
 
             throw new Error(`Unexpected quiz_responses columns: ${columns}`)
@@ -194,23 +257,16 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       }
 
       if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'question-1',
-                  question_text: '2 + 2 = ?',
-                  options: ['4', '5'],
-                  correct_option: 0,
-                  position: 0,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -266,23 +322,16 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       }
 
       if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'question-1',
-                  question_text: '2 + 2 = ?',
-                  options: ['4', '5'],
-                  correct_option: 0,
-                  position: 0,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -313,6 +362,64 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       },
     ])
     expect(data.my_responses).toEqual({ 'question-1': 0 })
+  })
+
+  it('returns 500 when student response loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockResolvedValue({ data: [{ id: 'response-1' }], error: null }),
+              }
+            }
+
+            if (columns === '*') {
+              throw new Error('Aggregate responses should not be loaded without enrolled students')
+            }
+
+            if (columns === 'id, question_id, selected_option') {
+              return mockPagedTable([], { error: { message: 'boom' } }).select(columns)
+            }
+
+            throw new Error(`Unexpected quiz_responses columns: ${columns}`)
+          }),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
   })
 
   it('returns aggregated results and the student response map', async () => {
@@ -361,23 +468,16 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       }
 
       if (table === 'quiz_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'question-1',
-                  question_text: '2 + 2 = ?',
-                  options: ['4', '5'],
-                  correct_option: 0,
-                  position: 0,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -419,5 +519,99 @@ describe('GET /api/student/quizzes/[id]/results', () => {
       },
     ])
     expect(data.my_responses).toEqual({ 'question-1': 0 })
+  })
+
+  it('chunks enrolled student response filters and pages dense result rows', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index}`)
+    const enrollments = studentIds.map((student_id) => ({ classroom_id: 'classroom-1', student_id }))
+    const responses = [
+      ...Array.from({ length: 1001 }, (_, index) => ({
+        id: `response-page-${index}`,
+        quiz_id: 'quiz-1',
+        question_id: 'question-1',
+        student_id: 'student-0',
+        selected_option: 0,
+      })),
+      {
+        id: 'response-last-chunk',
+        quiz_id: 'quiz-1',
+        question_id: 'question-1',
+        student_id: 'student-50',
+        selected_option: 1,
+      },
+      {
+        id: 'response-stale',
+        quiz_id: 'quiz-1',
+        question_id: 'question-1',
+        student_id: 'student-removed',
+        selected_option: 1,
+      },
+    ]
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'quiz_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                limit: vi.fn().mockResolvedValue({ data: [{ id: 'own-response' }], error: null }),
+              }
+            }
+            if (columns === '*') return mockPagedTable(responses, { table, log }).select(columns)
+            return {
+              eq: vi.fn().mockReturnThis(),
+              then: vi.fn((resolve: (value: unknown) => unknown) =>
+                resolve({
+                  data: [{ question_id: 'question-1', selected_option: 0 }],
+                  error: null,
+                })
+              ),
+            }
+          }),
+        }
+      }
+
+      if (table === 'quiz_questions') {
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            quiz_id: 'quiz-1',
+            question_text: '2 + 2 = ?',
+            options: ['4', '5'],
+            correct_option: 0,
+            position: 0,
+          },
+        ])
+      }
+
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable(enrollments, { table, log })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/quizzes/quiz-1/results'),
+      { params: Promise.resolve({ id: 'quiz-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0]).toEqual(
+      expect.objectContaining({
+        counts: [1001, 1],
+        total_responses: 1002,
+      })
+    )
+    expect(log.inCalls.filter((call) => call.table === 'quiz_responses').map((call) => call.values.length))
+      .toEqual([50, 50, 1])
+    expect(log.rangeCalls.filter((call) => call.table === 'quiz_responses')).toEqual([
+      { table: 'quiz_responses', from: 0, to: 999 },
+      { table: 'quiz_responses', from: 1000, to: 1999 },
+      { table: 'quiz_responses', from: 0, to: 999 },
+    ])
   })
 })

--- a/tests/api/student/surveys-route.test.ts
+++ b/tests/api/student/surveys-route.test.ts
@@ -25,6 +25,60 @@ const mockSurveyState = vi.hoisted(() => ({
   },
 }))
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const resolveRows = (from: number, to: number) => {
+        if (options.error) return Promise.resolve({ data: null, error: options.error })
+        return Promise.resolve({ data: filteredRows().slice(from, to + 1), error: null })
+      }
+      const query: any = {
+        eq: vi.fn((column: string, value: string) => {
+          filters.push({ column, values: [String(value)] })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) options.log?.rangeCalls.push({ table: options.table, from, to })
+          return resolveRows(from, to)
+        }),
+        then: vi.fn((resolve: any, reject: any) => resolveRows(0, rows.length - 1).then(resolve, reject)),
+      }
+      return query
+    }),
+  }
+}
+
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
@@ -147,12 +201,7 @@ describe('GET /api/student/surveys/[id]/results', () => {
   it('allows students to view class results before submitting when results are visible', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'survey_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        }
+        return mockPagedTable([])
       }
 
       if (table === 'survey_responses') {
@@ -297,38 +346,30 @@ describe('GET /api/student/surveys/[id]/results', () => {
       }
 
       if (table === 'survey_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'link-question',
-                  survey_id: 'survey-1',
-                  question_type: 'link',
-                  question_text: 'Share your game',
-                  options: [],
-                  response_max_chars: 2048,
-                  position: 0,
-                  created_at: '2026-01-01T00:00:00.000Z',
-                  updated_at: '2026-01-01T00:00:00.000Z',
-                },
-                {
-                  id: 'text-question',
-                  survey_id: 'survey-1',
-                  question_type: 'short_text',
-                  question_text: 'What did you build?',
-                  options: [],
-                  response_max_chars: 500,
-                  position: 1,
-                  created_at: '2026-01-01T00:00:00.000Z',
-                  updated_at: '2026-01-01T00:00:00.000Z',
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'link-question',
+            survey_id: 'survey-1',
+            question_type: 'link',
+            question_text: 'Share your game',
+            options: [],
+            response_max_chars: 2048,
+            position: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'text-question',
+            survey_id: 'survey-1',
+            question_type: 'short_text',
+            question_text: 'What did you build?',
+            options: [],
+            response_max_chars: 500,
+            position: 1,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        ])
       }
 
       if (table === 'classroom_enrollments') {
@@ -382,6 +423,138 @@ describe('GET /api/student/surveys/[id]/results', () => {
         submitted_at: '2026-01-04T00:00:00.000Z',
         updated_at: '2026-01-04T00:00:00.000Z',
       },
+    ])
+  })
+
+  it('returns 500 when scoped survey response loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return mockPagedTable([
+          {
+            id: 'choice-question',
+            survey_id: 'survey-1',
+            question_type: 'multiple_choice',
+            question_text: 'Pick one',
+            options: ['A', 'B'],
+            response_max_chars: 500,
+            position: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        ])
+      }
+
+      if (table === 'survey_responses') {
+        return mockPagedTable([], { error: { message: 'boom' } })
+      }
+
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ student_id: 'student-1' }],
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET_SURVEY_RESULTS(
+      new NextRequest('http://localhost:3000/api/student/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
+  })
+
+  it('chunks enrolled student response filters and pages dense survey result rows', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index}`)
+    const enrollments = studentIds.map((student_id) => ({ classroom_id: 'classroom-1', student_id }))
+    const responses = [
+      ...Array.from({ length: 1001 }, (_, index) => ({
+        id: `response-page-${index}`,
+        survey_id: 'survey-1',
+        question_id: 'choice-question',
+        student_id: 'student-0',
+        selected_option: 0,
+        response_text: null,
+        submitted_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      })),
+      {
+        id: 'response-last-chunk',
+        survey_id: 'survey-1',
+        question_id: 'choice-question',
+        student_id: 'student-50',
+        selected_option: 1,
+        response_text: null,
+        submitted_at: '2026-01-02T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+      },
+      {
+        id: 'response-stale',
+        survey_id: 'survey-1',
+        question_id: 'choice-question',
+        student_id: 'student-removed',
+        selected_option: 1,
+        response_text: null,
+        submitted_at: '2026-01-03T00:00:00.000Z',
+        updated_at: '2026-01-03T00:00:00.000Z',
+      },
+    ]
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'survey_questions') {
+        return mockPagedTable([
+          {
+            id: 'choice-question',
+            survey_id: 'survey-1',
+            question_type: 'multiple_choice',
+            question_text: 'Pick one',
+            options: ['A', 'B'],
+            response_max_chars: 500,
+            position: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        ])
+      }
+
+      if (table === 'survey_responses') {
+        return mockPagedTable(responses, { table, log })
+      }
+
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable(enrollments, { table, log })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET_SURVEY_RESULTS(
+      new NextRequest('http://localhost:3000/api/student/surveys/survey-1/results'),
+      { params: Promise.resolve({ id: 'survey-1' }) },
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0]).toEqual(
+      expect.objectContaining({
+        counts: [1001, 1],
+        total_responses: 1002,
+      })
+    )
+    expect(log.inCalls.filter((call) => call.table === 'survey_responses').map((call) => call.values.length))
+      .toEqual([50, 50, 1])
+    expect(log.rangeCalls.filter((call) => call.table === 'survey_responses')).toEqual([
+      { table: 'survey_responses', from: 0, to: 999 },
+      { table: 'survey_responses', from: 1000, to: 1999 },
+      { table: 'survey_responses', from: 0, to: 999 },
     ])
   })
 })

--- a/tests/api/student/tests-results.test.ts
+++ b/tests/api/student/tests-results.test.ts
@@ -44,6 +44,60 @@ vi.mock('@/lib/server/tests', async () => {
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const resolveRows = (from: number, to: number) => {
+        if (options.error) return Promise.resolve({ data: null, error: options.error })
+        return Promise.resolve({ data: filteredRows().slice(from, to + 1), error: null })
+      }
+      const query: any = {
+        eq: vi.fn((column: string, value: string) => {
+          filters.push({ column, values: [String(value)] })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) options.log?.rangeCalls.push({ table: options.table, from, to })
+          return resolveRows(from, to)
+        }),
+        then: vi.fn((resolve: any, reject: any) => resolveRows(0, rows.length - 1).then(resolve, reject)),
+      }
+      return query
+    }),
+  }
+}
+
 describe('GET /api/student/tests/[id]/results', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -144,6 +198,48 @@ describe('GET /api/student/tests/[id]/results', () => {
     expect(data.error).toBe('Results are available after your teacher returns this test')
   })
 
+  it('returns 500 when student response summary loading fails', async () => {
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                is_submitted: false,
+                returned_at: null,
+                closed_for_grading_at: null,
+              },
+              error: null,
+            }),
+          })),
+        }
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id, selected_option, response_text') {
+              return mockPagedTable([], { error: { message: 'boom' } }).select(columns)
+            }
+
+            throw new Error(`Unexpected test_responses columns: ${columns}`)
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Failed to fetch responses' })
+  })
+
   it('returns results when test work has been returned', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_attempts') {
@@ -178,40 +274,34 @@ describe('GET /api/student/tests/[id]/results', () => {
       }
 
       if (table === 'test_questions') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({
-              data: [
-                {
-                  id: 'question-1',
-                  question_type: 'open_response',
-                  question_text: 'Write a loop.',
-                  options: [],
-                  correct_option: null,
-                  points: 5,
-                  response_max_chars: 5000,
-                  response_monospace: true,
-                  sample_solution: 'for (int i = 0; i < 5; i++) {\n  println(i);\n}',
-                  position: 0,
-                },
-                {
-                  id: 'question-2',
-                  question_type: 'multiple_choice',
-                  question_text: 'Which loop keyword is valid?',
-                  options: ['for', 'repeatUntilDone'],
-                  correct_option: 0,
-                  points: 1,
-                  response_max_chars: 5000,
-                  response_monospace: false,
-                  sample_solution: null,
-                  position: 1,
-                },
-              ],
-              error: null,
-            }),
-          })),
-        }
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            test_id: 'test-1',
+            question_type: 'open_response',
+            question_text: 'Write a loop.',
+            options: [],
+            correct_option: null,
+            points: 5,
+            response_max_chars: 5000,
+            response_monospace: true,
+            sample_solution: 'for (int i = 0; i < 5; i++) {\n  println(i);\n}',
+            position: 0,
+          },
+          {
+            id: 'question-2',
+            test_id: 'test-1',
+            question_type: 'multiple_choice',
+            question_text: 'Which loop keyword is valid?',
+            options: ['for', 'repeatUntilDone'],
+            correct_option: 0,
+            points: 1,
+            response_max_chars: 5000,
+            response_monospace: false,
+            sample_solution: null,
+            position: 1,
+          },
+        ])
       }
 
       if (table === 'test_responses') {
@@ -355,5 +445,172 @@ describe('GET /api/student/tests/[id]/results', () => {
         total_responses: 1,
       })
     )
+  })
+
+  it('chunks returned attempt and response filters and pages dense returned result rows', async () => {
+    const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index}`)
+    const enrollments = studentIds.map((student_id) => ({ classroom_id: 'classroom-1', student_id }))
+    const returnedAttempts = studentIds.map((student_id) => ({
+      test_id: 'test-1',
+      student_id,
+      returned_at: '2026-03-05T11:00:00.000Z',
+    }))
+    const returnedResponses = [
+      ...Array.from({ length: 1001 }, (_, index) => ({
+        id: `response-page-${index}`,
+        test_id: 'test-1',
+        question_id: 'question-1',
+        student_id: 'student-0',
+        selected_option: 0,
+        response_text: null,
+        score: null,
+        feedback: null,
+        graded_at: null,
+        submitted_at: '2026-01-01T00:00:00.000Z',
+      })),
+      {
+        id: 'response-last-chunk',
+        test_id: 'test-1',
+        question_id: 'question-1',
+        student_id: 'student-50',
+        selected_option: 1,
+        response_text: null,
+        score: null,
+        feedback: null,
+        graded_at: null,
+        submitted_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'response-stale',
+        test_id: 'test-1',
+        question_id: 'question-1',
+        student_id: 'student-removed',
+        selected_option: 1,
+        response_text: null,
+        score: null,
+        feedback: null,
+        graded_at: null,
+        submitted_at: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+    const log = createQueryLog()
+
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns.includes('is_submitted')) {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: {
+                    is_submitted: true,
+                    returned_at: '2026-03-05T11:00:00.000Z',
+                    closed_for_grading_at: null,
+                  },
+                  error: null,
+                }),
+              }
+            }
+
+            if (columns === 'student_id, returned_at') {
+              return mockPagedTable(returnedAttempts, { table, log }).select(columns)
+            }
+
+            throw new Error(`Unexpected test_attempts columns: ${columns}`)
+          }),
+        }
+      }
+
+      if (table === 'test_questions') {
+        return mockPagedTable([
+          {
+            id: 'question-1',
+            test_id: 'test-1',
+            question_type: 'multiple_choice',
+            question_text: 'Which answer?',
+            options: ['A', 'B'],
+            correct_option: 0,
+            points: 1,
+            response_max_chars: 5000,
+            response_monospace: false,
+            sample_solution: null,
+            position: 0,
+          },
+        ])
+      }
+
+      if (table === 'test_responses') {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === 'id, selected_option, response_text') {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                then: vi.fn((resolve: (value: unknown) => unknown) =>
+                  resolve({ data: [{ selected_option: 0, response_text: null }], error: null })
+                ),
+              }
+            }
+
+            if (columns.includes('submitted_at')) {
+              return mockPagedTable(returnedResponses, { table, log }).select(columns)
+            }
+
+            if (columns.includes('question_id')) {
+              return {
+                eq: vi.fn().mockReturnThis(),
+                then: vi.fn((resolve: (value: unknown) => unknown) =>
+                  resolve({
+                    data: [
+                      {
+                        id: 'own-response',
+                        question_id: 'question-1',
+                        selected_option: 0,
+                        response_text: null,
+                        score: 1,
+                        feedback: null,
+                        graded_at: '2026-03-06T12:00:00.000Z',
+                      },
+                    ],
+                    error: null,
+                  })
+                ),
+              }
+            }
+
+            throw new Error(`Unexpected test_responses columns: ${columns}`)
+          }),
+        }
+      }
+
+      if (table === 'classroom_enrollments') {
+        return mockPagedTable(enrollments, { table, log })
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.results[0]).toEqual(
+      expect.objectContaining({
+        counts: [1001, 1],
+        total_responses: 1002,
+      })
+    )
+    expect(log.inCalls.filter((call) => call.table === 'test_attempts').map((call) => call.values.length))
+      .toEqual([50, 1])
+    expect(log.inCalls.filter((call) => call.table === 'test_responses').map((call) => call.values.length))
+      .toEqual([50, 50, 1])
+    expect(log.rangeCalls.filter((call) => call.table === 'test_responses')).toEqual([
+      { table: 'test_responses', from: 0, to: 999 },
+      { table: 'test_responses', from: 1000, to: 1999 },
+      { table: 'test_responses', from: 0, to: 999 },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- page quiz, survey, and test result question reads for student-visible results
- chunk and page classroom-scoped response aggregation by enrolled student ids
- page current-student quiz/test response reads and return explicit 500s on read failures
- add route and integration regressions for chunking, dense pagination, stale response filtering, and error paths

## Validation
- pnpm test tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts tests/api/student/tests-results.test.ts -- --runInBand
- pnpm test tests/api/integration/test-return-visibility-flow.test.ts -- --runInBand
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test
- pnpm build
- git diff --check

## Review
- Read-only subagent review found no blocking findings. Residual low-risk gaps: no explicit >1000-question pagination test and no explicit >1000-own-response pagination test; both paths use the same paged helper covered by dense response tests.