### PR TITLE
[codex] Harden student notification counts

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -626,3 +626,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `pnpm build`
 - `git diff --check`
+
+## 2026-05-31 — Student notification count hardening
+
+**Completed:**
+- Routed student notification assignment, assignment-doc, test, response, attempt, selected-access, announcement, and announcement-read queries through paginated or chunked Supabase reads.
+- Scoped dense notification child reads by current student/user ids so stale same-id rows for other users cannot affect counts.
+- Counted returned assignment feedback as unread when return timestamps are newer than the student's last view, and refreshed `viewed_at` when the returned work is opened.
+- Counted closed tests reopened for the selected student by loading active and closed test candidates and passing the real status into effective-access checks.
+- Changed student test submission notifications to decrement one active-test notification instead of clearing all active-test notifications.
+- Added regressions for dense pagination/chunking, wrong-user scoping, returned-feedback notifications, reopened closed tests, child-read failures, and client decrement semantics.
+- Addressed subagent review follow-up by making the reopened-closed-test regression use the filter-aware paged mock and assert the `status in (active, closed)` query.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/student/notifications.test.ts tests/api/assignment-docs/assignment-docs-id.test.ts tests/components/StudentNotificationsProvider.test.tsx -- --runInBand`
+- `pnpm test tests/components/StudentQuizzesTab.test.tsx -- --runInBand`
+- `pnpm test tests/api/student/notifications.test.ts -- --runInBand`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm test:coverage`
+- `git diff --check`

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -38,6 +38,28 @@ function buildHistoryMetrics(
   }
 }
 
+function parseTimestamp(value: unknown) {
+  if (typeof value !== 'string' || value.length === 0) return null
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : null
+}
+
+function shouldRefreshViewedAt(doc: {
+  viewed_at?: unknown
+  returned_at?: unknown
+  feedback_returned_at?: unknown
+}) {
+  const viewedTime = parseTimestamp(doc.viewed_at)
+  if (viewedTime === null) return true
+
+  const latestReturnTime = Math.max(
+    parseTimestamp(doc.returned_at) ?? 0,
+    parseTimestamp(doc.feedback_returned_at) ?? 0
+  )
+
+  return latestReturnTime > viewedTime
+}
+
 async function loadStudentSubmissionContext(
   supabase: ReturnType<typeof getServiceRoleClient>,
   assignmentId: string,
@@ -101,7 +123,7 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
     .eq('student_id', user.id)
     .single()
 
-  // Track whether this is the first time viewing (for notification decrement)
+  // Track whether this request cleared an assignment notification.
   let wasFirstView = false
 
   if (docError) {
@@ -181,18 +203,19 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
     existingDoc.content = parseContentField(existingDoc.content)
   }
 
-  // Mark as viewed if not already (for notification tracking)
-  if (existingDoc && existingDoc.viewed_at === null) {
+  // Mark as viewed if this request clears a first-view or returned-feedback notification.
+  if (existingDoc && shouldRefreshViewedAt(existingDoc)) {
+    const viewedAt = new Date().toISOString()
     const { error: viewedError } = await supabase
       .from('assignment_docs')
-      .update({ viewed_at: new Date().toISOString() })
+      .update({ viewed_at: viewedAt })
       .eq('id', existingDoc.id)
 
     if (viewedError) {
-      console.error('Error updating viewed_at:', viewedError)
-      // Non-fatal: continue with response, but don't mark as first view
+      console.error('Error updating assignment viewed_at:', viewedError)
+      // Non-fatal: continue with response, but don't clear local notification count.
     } else {
-      existingDoc.viewed_at = new Date().toISOString()
+      existingDoc.viewed_at = viewedAt
       wasFirstView = true
     }
   }

--- a/src/app/api/student/notifications/route.ts
+++ b/src/app/api/student/notifications/route.ts
@@ -6,6 +6,7 @@ import { assertStudentCanAccessClassroom } from '@/lib/server/classrooms'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { isAssignmentVisibleToStudents } from '@/lib/server/assignments'
 import { withErrorHandler } from '@/lib/api-handler'
+import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import {
   getEffectiveStudentTestAccess,
   isMissingTestAttemptClosureColumnsError,
@@ -14,6 +15,281 @@ import {
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+const STUDENT_NOTIFICATIONS_PAGE_SIZE = 1000
+
+type AssignmentNotificationRow = {
+  id: string
+  released_at: string | null
+}
+
+type AssignmentDocNotificationRow = {
+  assignment_id: string
+  viewed_at: string | null
+  returned_at: string | null
+  feedback_returned_at: string | null
+}
+
+type TestNotificationRow = {
+  id: string
+  status: string
+}
+
+type TestResponseNotificationRow = {
+  test_id: string
+  selected_option: unknown
+  response_text: unknown
+}
+
+type TestAttemptNotificationRow = {
+  test_id: string
+  is_submitted: boolean
+  closed_for_grading_at: string | null
+}
+
+type LegacyTestAttemptNotificationRow = {
+  test_id: string
+  is_submitted: boolean
+}
+
+type TestAvailabilityNotificationRow = {
+  test_id: string
+  state: unknown
+}
+
+type AnnouncementNotificationRow = {
+  id: string
+}
+
+type AnnouncementReadNotificationRow = {
+  announcement_id: string
+}
+
+function parseTimestamp(value: string | null | undefined) {
+  if (!value) return null
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : null
+}
+
+function hasUnreadAssignmentDocNotification(doc: AssignmentDocNotificationRow | undefined) {
+  if (!doc) return true
+  const viewedTime = parseTimestamp(doc.viewed_at)
+  if (viewedTime === null) return true
+
+  const latestReturnTime = Math.max(
+    parseTimestamp(doc.returned_at) ?? 0,
+    parseTimestamp(doc.feedback_returned_at) ?? 0
+  )
+
+  return latestReturnTime > viewedTime
+}
+
+async function loadVisibleAssignmentIds(
+  supabase: any,
+  classroomId: string
+): Promise<{ ids: string[]; error: any }> {
+  const { rows, error } = await loadPagedRows<AssignmentNotificationRow>(() =>
+    supabase
+      .from('assignments')
+      .select('id,released_at')
+      .eq('classroom_id', classroomId)
+      .eq('is_draft', false),
+    STUDENT_NOTIFICATIONS_PAGE_SIZE
+  )
+
+  if (error) return { ids: [], error }
+
+  const ids = rows
+    .filter((assignment) =>
+      isAssignmentVisibleToStudents({ is_draft: false, released_at: assignment.released_at ?? null })
+    )
+    .map((assignment) => assignment.id)
+
+  return { ids, error: null }
+}
+
+async function loadAssignmentDocsForAssignments(
+  supabase: any,
+  studentId: string,
+  assignmentIds: string[]
+): Promise<{ rows: AssignmentDocNotificationRow[]; error: any }> {
+  if (assignmentIds.length === 0) return { rows: [], error: null }
+
+  const rows: AssignmentDocNotificationRow[] = []
+  for (const assignmentIdChunk of chunkValues(assignmentIds)) {
+    const result = await loadPagedRows<AssignmentDocNotificationRow>(() =>
+      supabase
+        .from('assignment_docs')
+        .select('assignment_id, viewed_at, returned_at, feedback_returned_at')
+        .eq('student_id', studentId)
+        .in('assignment_id', assignmentIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadTestNotificationCandidates(
+  supabase: any,
+  classroomId: string
+): Promise<{ rows: TestNotificationRow[]; error: any }> {
+  return loadPagedRows<TestNotificationRow>(() =>
+    supabase
+      .from('tests')
+      .select('id, status')
+      .eq('classroom_id', classroomId)
+      .in('status', ['active', 'closed']),
+    STUDENT_NOTIFICATIONS_PAGE_SIZE
+  )
+}
+
+async function loadTestResponsesForTests(
+  supabase: any,
+  studentId: string,
+  testIds: string[]
+): Promise<{ rows: TestResponseNotificationRow[]; error: any }> {
+  if (testIds.length === 0) return { rows: [], error: null }
+
+  const rows: TestResponseNotificationRow[] = []
+  for (const testIdChunk of chunkValues(testIds)) {
+    const result = await loadPagedRows<TestResponseNotificationRow>(() =>
+      supabase
+        .from('test_responses')
+        .select('test_id, selected_option, response_text')
+        .eq('student_id', studentId)
+        .in('test_id', testIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadTestAttemptsForTests(
+  supabase: any,
+  studentId: string,
+  testIds: string[]
+): Promise<{ rows: TestAttemptNotificationRow[]; error: any }> {
+  if (testIds.length === 0) return { rows: [], error: null }
+
+  const rows: TestAttemptNotificationRow[] = []
+  for (const testIdChunk of chunkValues(testIds)) {
+    const result = await loadPagedRows<TestAttemptNotificationRow>(() =>
+      supabase
+        .from('test_attempts')
+        .select('test_id, is_submitted, closed_for_grading_at')
+        .eq('student_id', studentId)
+        .in('test_id', testIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadLegacyTestAttemptsForTests(
+  supabase: any,
+  studentId: string,
+  testIds: string[]
+): Promise<{ rows: TestAttemptNotificationRow[]; error: any }> {
+  if (testIds.length === 0) return { rows: [], error: null }
+
+  const rows: TestAttemptNotificationRow[] = []
+  for (const testIdChunk of chunkValues(testIds)) {
+    const result = await loadPagedRows<LegacyTestAttemptNotificationRow>(() =>
+      supabase
+        .from('test_attempts')
+        .select('test_id, is_submitted')
+        .eq('student_id', studentId)
+        .in('test_id', testIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return { rows: [], error: result.error }
+    rows.push(...result.rows.map((attempt) => ({
+      ...attempt,
+      closed_for_grading_at: null,
+    })))
+  }
+
+  return { rows, error: null }
+}
+
+async function loadTestAvailabilityForTests(
+  supabase: any,
+  studentId: string,
+  testIds: string[]
+): Promise<{ rows: TestAvailabilityNotificationRow[]; error: any }> {
+  if (testIds.length === 0) return { rows: [], error: null }
+
+  const rows: TestAvailabilityNotificationRow[] = []
+  for (const testIdChunk of chunkValues(testIds)) {
+    const result = await loadPagedRows<TestAvailabilityNotificationRow>(() =>
+      supabase
+        .from('test_student_availability')
+        .select('test_id, state')
+        .eq('student_id', studentId)
+        .in('test_id', testIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
+
+async function loadAnnouncementIds(
+  supabase: any,
+  classroomId: string
+): Promise<{ ids: string[]; error: any }> {
+  const { rows, error } = await loadPagedRows<AnnouncementNotificationRow>(() =>
+    supabase
+      .from('announcements')
+      .select('id')
+      .eq('classroom_id', classroomId)
+      .or('scheduled_for.is.null,scheduled_for.lte.now()'),
+    STUDENT_NOTIFICATIONS_PAGE_SIZE
+  )
+
+  if (error) return { ids: [], error }
+  return { ids: rows.map((announcement) => announcement.id), error: null }
+}
+
+async function loadAnnouncementReadsForAnnouncements(
+  supabase: any,
+  userId: string,
+  announcementIds: string[]
+): Promise<{ rows: AnnouncementReadNotificationRow[]; error: any }> {
+  if (announcementIds.length === 0) return { rows: [], error: null }
+
+  const rows: AnnouncementReadNotificationRow[] = []
+  for (const announcementIdChunk of chunkValues(announcementIds)) {
+    const result = await loadPagedRows<AnnouncementReadNotificationRow>(() =>
+      supabase
+        .from('announcement_reads')
+        .select('announcement_id')
+        .eq('user_id', userId)
+        .in('announcement_id', announcementIdChunk),
+      STUDENT_NOTIFICATIONS_PAGE_SIZE
+    )
+
+    if (result.error) return result
+    rows.push(...result.rows)
+  }
+
+  return { rows, error: null }
+}
 
 /**
  * GET /api/student/notifications?classroom_id=xxx
@@ -32,10 +308,11 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
       { status: 400 }
     )
   }
+  const scopedClassroomId = classroomId
 
   const supabase = getServiceRoleClient()
 
-  const access = await assertStudentCanAccessClassroom(user.id, classroomId)
+  const access = await assertStudentCanAccessClassroom(user.id, scopedClassroomId)
   if (!access.ok) {
     return NextResponse.json(
       { error: access.error },
@@ -49,7 +326,7 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
   const { data: classDay, error: classDayError } = await supabase
     .from('class_days')
     .select('is_class_day')
-    .eq('classroom_id', classroomId)
+    .eq('classroom_id', scopedClassroomId)
     .eq('date', today)
     .maybeSingle()
 
@@ -71,7 +348,7 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
       .from('entries')
       .select('id')
       .eq('student_id', user.id)
-      .eq('classroom_id', classroomId)
+      .eq('classroom_id', scopedClassroomId)
       .eq('date', today)
       .maybeSingle()
 
@@ -86,12 +363,10 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     hasTodayEntry = todayEntry !== null
   }
 
-  // Get all assignments for this classroom
-  const { data: assignments, error: assignmentsError } = await supabase
-    .from('assignments')
-    .select('id,released_at')
-    .eq('classroom_id', classroomId)
-    .eq('is_draft', false)
+  const { ids: assignmentIds, error: assignmentsError } = await loadVisibleAssignmentIds(
+    supabase,
+    scopedClassroomId
+  )
 
   if (assignmentsError) {
     console.error('Error fetching assignments:', assignmentsError)
@@ -103,19 +378,13 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
 
   // Count unviewed assignments
   let unviewedCount = 0
-  const assignmentIds = (assignments || [])
-    .filter((a: { is_draft?: boolean; released_at?: string | null }) =>
-      isAssignmentVisibleToStudents({ is_draft: false, released_at: a.released_at ?? null })
-    )
-    .map((a: { id: string }) => a.id)
 
   if (assignmentIds.length > 0) {
-    // Get this student's docs for these assignments
-    const { data: docs, error: docsError } = await supabase
-      .from('assignment_docs')
-      .select('assignment_id, viewed_at')
-      .eq('student_id', user.id)
-      .in('assignment_id', assignmentIds)
+    const { rows: docs, error: docsError } = await loadAssignmentDocsForAssignments(
+      supabase,
+      user.id,
+      assignmentIds
+    )
 
     if (docsError) {
       console.error('Error fetching assignment docs:', docsError)
@@ -131,7 +400,7 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     // Count: no doc exists OR doc.viewed_at is null
     for (const assignmentId of assignmentIds) {
       const doc = docMap.get(assignmentId)
-      if (!doc || doc.viewed_at === null) {
+      if (hasUnreadAssignmentDocNotification(doc)) {
         unviewedCount++
       }
     }
@@ -142,35 +411,29 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
   ): Promise<{ count: number; error: boolean }> {
     const tolerateMissingTable = opts?.tolerateMissingTable === true
 
-    const { data: activeRows, error: activeError } = await supabase
-      .from('tests')
-      .select('id, status')
-      .eq('classroom_id', classroomId)
-      .eq('status', 'active')
+    const { rows: testRows, error: testRowsError } = await loadTestNotificationCandidates(
+      supabase,
+      scopedClassroomId
+    )
 
-    if (activeError) {
-      if (tolerateMissingTable && activeError.code === 'PGRST205') {
+    if (testRowsError) {
+      if (tolerateMissingTable && testRowsError.code === 'PGRST205') {
         return { count: 0, error: false }
       }
-      console.error('Error fetching tests:', activeError)
+      console.error('Error fetching tests:', testRowsError)
       return { count: 0, error: true }
     }
 
-    const activeIds = (activeRows || []).map((row) => row.id)
+    const testIds = (testRows || []).map((row) => row.id)
 
-    if (activeIds.length === 0) {
+    if (testIds.length === 0) {
       return { count: 0, error: false }
     }
 
-    const testResponsesResult = await supabase
-      .from('test_responses')
-      .select('test_id, selected_option, response_text')
-      .eq('student_id', user.id)
-      .in('test_id', activeIds)
-
-    const responses =
-      (testResponsesResult.data as Array<{ test_id: string; selected_option: unknown; response_text: unknown }> | null) || []
-    const responsesError = testResponsesResult.error
+    const {
+      rows: responses,
+      error: responsesError,
+    } = await loadTestResponsesForTests(supabase, user.id, testIds)
 
     if (responsesError) {
       if (tolerateMissingTable && responsesError.code === 'PGRST205') {
@@ -195,28 +458,14 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     let attemptsError: { code?: string; message?: string; details?: string | null; hint?: string | null } | null = null
 
     {
-      const latestAttemptsResult = await supabase
-        .from('test_attempts')
-        .select('test_id, is_submitted, closed_for_grading_at')
-        .eq('student_id', user.id)
-        .in('test_id', activeIds)
-
-      submittedAttempts = (latestAttemptsResult.data as AttemptRow[] | null) || null
+      const latestAttemptsResult = await loadTestAttemptsForTests(supabase, user.id, testIds)
+      submittedAttempts = latestAttemptsResult.rows
       attemptsError = latestAttemptsResult.error
     }
 
     if (attemptsError && isMissingTestAttemptClosureColumnsError(attemptsError)) {
-      const legacyAttemptsResult = await supabase
-        .from('test_attempts')
-        .select('test_id, is_submitted')
-        .eq('student_id', user.id)
-        .in('test_id', activeIds)
-
-      submittedAttempts = ((legacyAttemptsResult.data as Array<{ test_id: string; is_submitted: boolean }> | null) || [])
-        .map((attempt) => ({
-          ...attempt,
-          closed_for_grading_at: null,
-        }))
+      const legacyAttemptsResult = await loadLegacyTestAttemptsForTests(supabase, user.id, testIds)
+      submittedAttempts = legacyAttemptsResult.rows
       attemptsError = legacyAttemptsResult.error
     }
 
@@ -239,12 +488,8 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     let availabilityRows: Array<{ test_id: string; state: unknown }> | null = null
     let availabilityError: any = null
     try {
-      const availabilityResult = await supabase
-        .from('test_student_availability')
-        .select('test_id, state')
-        .eq('student_id', user.id)
-        .in('test_id', activeIds)
-      availabilityRows = availabilityResult.data
+      const availabilityResult = await loadTestAvailabilityForTests(supabase, user.id, testIds)
+      availabilityRows = availabilityResult.rows
       availabilityError = availabilityResult.error
     } catch (error) {
       availabilityError = error
@@ -264,9 +509,9 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     }
 
     return {
-      count: (activeRows || []).filter((test) => {
+      count: (testRows || []).filter((test) => {
         const access = getEffectiveStudentTestAccess({
-          testStatus: 'active',
+          testStatus: test.status === 'closed' ? 'closed' : 'active',
           accessState: availabilityByTestId.get(test.id) ?? null,
           hasSubmitted: respondedIds.has(test.id),
           returnedAt: null,
@@ -291,11 +536,10 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
   // Count unread announcements for this classroom (only published ones)
   let unreadAnnouncementsCount = 0
 
-  const { data: announcements, error: announcementsError } = await supabase
-    .from('announcements')
-    .select('id')
-    .eq('classroom_id', classroomId)
-    .or('scheduled_for.is.null,scheduled_for.lte.now()')
+  const { ids: announcementIds, error: announcementsError } = await loadAnnouncementIds(
+    supabase,
+    scopedClassroomId
+  )
 
   if (announcementsError) {
     console.error('Error fetching announcements:', announcementsError)
@@ -305,14 +549,12 @@ export const GET = withErrorHandler('GetStudentNotifications', async (request, c
     )
   }
 
-  const announcementIds = announcements?.map((a) => a.id) || []
-
   if (announcementIds.length > 0) {
-    const { data: reads, error: readsError } = await supabase
-      .from('announcement_reads')
-      .select('announcement_id')
-      .eq('user_id', user.id)
-      .in('announcement_id', announcementIds)
+    const { rows: reads, error: readsError } = await loadAnnouncementReadsForAnnouncements(
+      supabase,
+      user.id,
+      announcementIds
+    )
 
     if (readsError) {
       console.error('Error fetching announcement reads:', readsError)

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -800,7 +800,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   function handleQuizSubmitted() {
     setRemoteClosureNotice(null)
     if (isTestsView) {
-      notifications?.clearActiveTestsCount()
+      notifications?.decrementActiveTestsCount()
     }
     void loadQuizzes()
 

--- a/src/components/StudentNotificationsProvider.tsx
+++ b/src/components/StudentNotificationsProvider.tsx
@@ -20,7 +20,7 @@ type NotificationState = {
   refresh: () => Promise<void>
   markTodayComplete: () => void
   decrementUnviewedCount: () => void
-  clearActiveTestsCount: () => void
+  decrementActiveTestsCount: () => void
   markAnnouncementsRead: () => void
 }
 
@@ -88,8 +88,8 @@ export function StudentNotificationsProvider({
     setUnviewedAssignmentsCount((prev) => Math.max(0, prev - 1))
   }, [])
 
-  const clearActiveTestsCount = useCallback(() => {
-    setActiveTestsCount(0)
+  const decrementActiveTestsCount = useCallback(() => {
+    setActiveTestsCount((prev) => Math.max(0, prev - 1))
   }, [])
 
   const markAnnouncementsRead = useCallback(() => {
@@ -106,7 +106,7 @@ export function StudentNotificationsProvider({
       refresh,
       markTodayComplete,
       decrementUnviewedCount,
-      clearActiveTestsCount,
+      decrementActiveTestsCount,
       markAnnouncementsRead,
     }),
     [
@@ -118,7 +118,7 @@ export function StudentNotificationsProvider({
       refresh,
       markTodayComplete,
       decrementUnviewedCount,
-      clearActiveTestsCount,
+      decrementActiveTestsCount,
       markAnnouncementsRead,
     ]
   )

--- a/tests/api/assignment-docs/assignment-docs-id.test.ts
+++ b/tests/api/assignment-docs/assignment-docs-id.test.ts
@@ -100,6 +100,64 @@ describe('GET /api/assignment-docs/[id]', () => {
     expect(response.status).toBe(200)
     expect(data.doc.id).toBe('doc-new')
   })
+
+  it('refreshes viewed_at when returned feedback is newer than the last view', async () => {
+    const viewedUpdate = vi.fn(() => ({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }))
+    const existingDoc = {
+      id: 'doc-1',
+      assignment_id: 'assign-1',
+      student_id: 'student-1',
+      content: { type: 'doc', content: [] },
+      viewed_at: '2026-01-01T00:00:00.000Z',
+      returned_at: null,
+      feedback_returned_at: '2026-01-02T00:00:00.000Z',
+    }
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assign-1', classroom_id: 'class-1' },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'assignment_docs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: existingDoc, error: null }),
+          })),
+          update: viewedUpdate,
+        }
+      }
+      if (table === 'assignment_feedback_entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1')
+    const response = await GET(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.wasFirstView).toBe(true)
+    expect(viewedUpdate).toHaveBeenCalledWith({
+      viewed_at: expect.stringMatching(/^20/),
+    })
+  })
 })
 
 describe('PATCH /api/assignment-docs/[id]', () => {

--- a/tests/api/student/notifications.test.ts
+++ b/tests/api/student/notifications.test.ts
@@ -35,6 +35,61 @@ vi.mock('@/lib/server/classrooms', () => ({
 
 const mockSupabaseClient = { from: vi.fn() }
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [] }
+}
+
+function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: QueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const filteredRows = () => rows.filter((row) =>
+        filters.every((filter) => {
+          if (!(filter.column in row)) return false
+          return filter.values.includes(String(row[filter.column]))
+        })
+      )
+      const resolveRows = (from: number, to: number) => {
+        if (options.error) return Promise.resolve({ data: null, error: options.error })
+        return Promise.resolve({ data: filteredRows().slice(from, to + 1), error: null })
+      }
+      const query: any = {
+        eq: vi.fn((column: string, value: string | boolean) => {
+          filters.push({ column, values: [String(value)] })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values: values.map(String) })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values: values.map(String) })
+          }
+          return query
+        }),
+        or: vi.fn(() => query),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) options.log?.rangeCalls.push({ table: options.table, from, to })
+          return resolveRows(from, to)
+        }),
+        then: vi.fn((resolve: any, reject: any) => resolveRows(0, rows.length - 1).then(resolve, reject)),
+      }
+      return query
+    }),
+  }
+}
+
 // Helper to create a mock that handles multiple tables
 function createTableMock(config: {
   class_days?: { data: any; error: any }
@@ -114,6 +169,7 @@ function createTableMock(config: {
       return {
         select: vi.fn(() => ({
           eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockReturnThis(),
           then: vi.fn((resolve: any) => resolve(testsConfig)),
         })),
       }
@@ -366,6 +422,42 @@ describe('GET /api/student/notifications', () => {
       expect(data.unviewedAssignmentsCount).toBe(0)
     })
 
+    it('should count viewed assignments when returned feedback is newer than the last view', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [{ id: 'assignment-1' }, { id: 'assignment-2' }], error: null },
+        assignment_docs: {
+          data: [
+            {
+              assignment_id: 'assignment-1',
+              viewed_at: '2026-01-01T00:00:00.000Z',
+              returned_at: null,
+              feedback_returned_at: '2026-01-02T00:00:00.000Z',
+            },
+            {
+              assignment_id: 'assignment-2',
+              viewed_at: '2026-01-03T00:00:00.000Z',
+              returned_at: '2026-01-02T00:00:00.000Z',
+              feedback_returned_at: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+          error: null,
+        },
+        quizzes: { data: [], error: null },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.unviewedAssignmentsCount).toBe(1)
+    })
+
     it('should handle empty assignments list', async () => {
       ;(mockSupabaseClient.from as any) = createTableMock({
         class_days: { data: { is_class_day: true }, error: null },
@@ -384,6 +476,81 @@ describe('GET /api/student/notifications', () => {
       expect(response.status).toBe(200)
       expect(data.hasTodayEntry).toBe(false)
       expect(data.unviewedAssignmentsCount).toBe(0)
+    })
+
+    it('should page visible assignments and chunk assignment document reads', async () => {
+      const assignments = Array.from({ length: 1001 }, (_, index) => ({
+        id: `assignment-${index}`,
+        classroom_id: 'classroom-1',
+        is_draft: false,
+        released_at: null,
+      }))
+      const docs = [
+        {
+          assignment_id: 'assignment-0',
+          student_id: 'student-1',
+          viewed_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          assignment_id: 'assignment-1',
+          student_id: 'student-1',
+          viewed_at: null,
+        },
+        {
+          assignment_id: 'assignment-stale',
+          student_id: 'student-1',
+          viewed_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          assignment_id: 'assignment-2',
+          student_id: 'student-2',
+          viewed_at: '2026-01-01T00:00:00.000Z',
+        },
+      ]
+      const log = createQueryLog()
+
+      ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+        if (table === 'class_days') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { is_class_day: true }, error: null }),
+            })),
+          }
+        }
+        if (table === 'entries') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'entry-1' }, error: null }),
+            })),
+          }
+        }
+        if (table === 'assignments') return mockPagedTable(assignments, { table, log })
+        if (table === 'assignment_docs') return mockPagedTable(docs, { table, log })
+        if (table === 'tests') return mockPagedTable([], { table, log })
+        if (table === 'announcements') return mockPagedTable([], { table, log })
+
+        throw new Error(`Unexpected table: ${table}`)
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.unviewedAssignmentsCount).toBe(1000)
+      expect(log.rangeCalls.filter((call) => call.table === 'assignments')).toEqual([
+        { table: 'assignments', from: 0, to: 999 },
+        { table: 'assignments', from: 1000, to: 1999 },
+      ])
+      const assignmentDocChunks = log.inCalls.filter((call) => call.table === 'assignment_docs')
+      expect(assignmentDocChunks).toHaveLength(21)
+      expect(assignmentDocChunks[0].values).toHaveLength(50)
+      expect(assignmentDocChunks[20].values).toHaveLength(1)
     })
   })
 
@@ -466,6 +633,110 @@ describe('GET /api/student/notifications', () => {
         assignments: { data: [], error: null },
         quizzes: { data: [], error: null },
         tests: { data: null, error: { code: 'XX000', message: 'Database error' } },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('Failed to check notifications')
+    })
+
+    it('should return 500 when test response loading fails', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        tests: { data: [{ id: 'test-1', status: 'active' }], error: null },
+        test_responses: { data: null, error: { code: 'XX000', message: 'Database error' } },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('Failed to check notifications')
+    })
+
+    it('should return 500 when test attempt loading fails', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        tests: { data: [{ id: 'test-1', status: 'active' }], error: null },
+        test_responses: { data: [], error: null },
+        test_attempts: { data: null, error: { code: 'XX000', message: 'Database error' } },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('Failed to check notifications')
+    })
+
+    it('should return 500 when selected test access loading fails', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        tests: { data: [{ id: 'test-1', status: 'active' }], error: null },
+        test_responses: { data: [], error: null },
+        test_attempts: { data: [], error: null },
+        test_student_availability: { data: null, error: { code: 'XX000', message: 'Database error' } },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('Failed to check notifications')
+    })
+
+    it('should return 500 when announcements query fails', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        tests: { data: [], error: null },
+        announcements: { data: null, error: { message: 'Database error' } },
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('Failed to check notifications')
+    })
+
+    it('should return 500 when announcement read loading fails', async () => {
+      ;(mockSupabaseClient.from as any) = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        tests: { data: [], error: null },
+        announcements: { data: [{ id: 'announcement-1' }], error: null },
+        announcement_reads: { data: null, error: { message: 'Database error' } },
       })
 
       const request = new NextRequest(
@@ -573,6 +844,49 @@ describe('GET /api/student/notifications', () => {
       expect(data.activeTestsCount).toBe(1)
     })
 
+    it('should count closed tests reopened for this student', async () => {
+      const log = createQueryLog()
+      const baseFrom = createTableMock({
+        class_days: { data: { is_class_day: true }, error: null },
+        entries: { data: { id: 'entry-1' }, error: null },
+        assignments: { data: [], error: null },
+        quizzes: { data: [], error: null },
+      })
+
+      ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+        if (table === 'tests') {
+          return mockPagedTable(
+            [{ id: 'test-1', classroom_id: 'classroom-1', status: 'closed' }],
+            { table, log }
+          )
+        }
+        if (table === 'test_responses') return mockPagedTable([], { table, log })
+        if (table === 'test_attempts') return mockPagedTable([], { table, log })
+        if (table === 'test_student_availability') {
+          return mockPagedTable(
+            [{ test_id: 'test-1', student_id: 'student-1', state: 'open' }],
+            { table, log }
+          )
+        }
+        return baseFrom(table)
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.activeTestsCount).toBe(1)
+      expect(log.inCalls).toContainEqual({
+        table: 'tests',
+        column: 'status',
+        values: ['active', 'closed'],
+      })
+    })
+
     it('should exclude active tests closed for grading', async () => {
       ;(mockSupabaseClient.from as any) = createTableMock({
         class_days: { data: { is_class_day: true }, error: null },
@@ -624,6 +938,177 @@ describe('GET /api/student/notifications', () => {
 
       expect(response.status).toBe(200)
       expect(data.activeTestsCount).toBe(2)
+    })
+
+    it('should page active tests and chunk response, attempt, and availability reads', async () => {
+      const tests = Array.from({ length: 1001 }, (_, index) => ({
+        id: `test-${index}`,
+        classroom_id: 'classroom-1',
+        status: 'active',
+      }))
+      const testResponses = [
+        {
+          test_id: 'test-0',
+          student_id: 'student-1',
+          selected_option: 0,
+          response_text: null,
+        },
+        {
+          test_id: 'test-stale',
+          student_id: 'student-1',
+          selected_option: 0,
+          response_text: null,
+        },
+        {
+          test_id: 'test-3',
+          student_id: 'student-2',
+          selected_option: 0,
+          response_text: null,
+        },
+      ]
+      const testAttempts = [
+        {
+          test_id: 'test-1',
+          student_id: 'student-1',
+          is_submitted: true,
+          closed_for_grading_at: null,
+        },
+        {
+          test_id: 'test-4',
+          student_id: 'student-2',
+          is_submitted: true,
+          closed_for_grading_at: null,
+        },
+      ]
+      const availabilityRows = [
+        {
+          test_id: 'test-2',
+          student_id: 'student-1',
+          state: 'closed',
+        },
+        {
+          test_id: 'test-5',
+          student_id: 'student-2',
+          state: 'closed',
+        },
+      ]
+      const log = createQueryLog()
+
+      ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+        if (table === 'class_days') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { is_class_day: true }, error: null }),
+            })),
+          }
+        }
+        if (table === 'entries') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'entry-1' }, error: null }),
+            })),
+          }
+        }
+        if (table === 'assignments') return mockPagedTable([], { table, log })
+        if (table === 'tests') return mockPagedTable(tests, { table, log })
+        if (table === 'test_responses') return mockPagedTable(testResponses, { table, log })
+        if (table === 'test_attempts') return mockPagedTable(testAttempts, { table, log })
+        if (table === 'test_student_availability') {
+          return mockPagedTable(availabilityRows, { table, log })
+        }
+        if (table === 'announcements') return mockPagedTable([], { table, log })
+
+        throw new Error(`Unexpected table: ${table}`)
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.activeTestsCount).toBe(998)
+      expect(log.rangeCalls.filter((call) => call.table === 'tests')).toEqual([
+        { table: 'tests', from: 0, to: 999 },
+        { table: 'tests', from: 1000, to: 1999 },
+      ])
+      for (const table of ['test_responses', 'test_attempts', 'test_student_availability']) {
+        const chunks = log.inCalls.filter((call) => call.table === table)
+        expect(chunks).toHaveLength(21)
+        expect(chunks[0].values).toHaveLength(50)
+        expect(chunks[20].values).toHaveLength(1)
+      }
+    })
+  })
+
+  describe('announcement counts', () => {
+    it('should page announcements and chunk announcement read filters', async () => {
+      const announcements = Array.from({ length: 1001 }, (_, index) => ({
+        id: `announcement-${index}`,
+        classroom_id: 'classroom-1',
+      }))
+      const reads = [
+        {
+          announcement_id: 'announcement-0',
+          user_id: 'student-1',
+        },
+        {
+          announcement_id: 'announcement-stale',
+          user_id: 'student-1',
+        },
+        {
+          announcement_id: 'announcement-1',
+          user_id: 'student-2',
+        },
+      ]
+      const log = createQueryLog()
+
+      ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+        if (table === 'class_days') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { is_class_day: true }, error: null }),
+            })),
+          }
+        }
+        if (table === 'entries') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'entry-1' }, error: null }),
+            })),
+          }
+        }
+        if (table === 'assignments') return mockPagedTable([], { table, log })
+        if (table === 'tests') return mockPagedTable([], { table, log })
+        if (table === 'announcements') return mockPagedTable(announcements, { table, log })
+        if (table === 'announcement_reads') return mockPagedTable(reads, { table, log })
+
+        throw new Error(`Unexpected table: ${table}`)
+      })
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/student/notifications?classroom_id=classroom-1'
+      )
+
+      const response = await GET(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.unreadAnnouncementsCount).toBe(1000)
+      expect(log.rangeCalls.filter((call) => call.table === 'announcements')).toEqual([
+        { table: 'announcements', from: 0, to: 999 },
+        { table: 'announcements', from: 1000, to: 1999 },
+      ])
+      const readChunks = log.inCalls.filter((call) => call.table === 'announcement_reads')
+      expect(readChunks).toHaveLength(21)
+      expect(readChunks[0].values).toHaveLength(50)
+      expect(readChunks[20].values).toHaveLength(1)
     })
   })
 })

--- a/tests/components/StudentNotificationsProvider.test.tsx
+++ b/tests/components/StudentNotificationsProvider.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, waitFor, act } from '@testing-library/react'
-import { StudentNotificationsProvider } from '@/components/StudentNotificationsProvider'
+import {
+  StudentNotificationsProvider,
+  useStudentNotifications,
+} from '@/components/StudentNotificationsProvider'
 
 function notificationFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   return fetchMock.mock.calls.filter(
@@ -21,6 +24,18 @@ describe('StudentNotificationsProvider', () => {
         unreadAnnouncementsCount: 0,
       }),
     })
+  }
+
+  function NotificationProbe() {
+    const notifications = useStudentNotifications()
+    return (
+      <button
+        type="button"
+        onClick={() => notifications?.decrementActiveTestsCount()}
+      >
+        tests:{notifications?.activeTestsCount ?? 0}
+      </button>
+    )
   }
 
   beforeEach(() => {
@@ -98,5 +113,35 @@ describe('StudentNotificationsProvider', () => {
 
     await new Promise((r) => setTimeout(r, 50))
     expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('decrements one active test notification after a submission', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hasTodayEntry: true,
+        unviewedAssignmentsCount: 0,
+        activeTestsCount: 2,
+        unreadAnnouncementsCount: 0,
+      }),
+    })
+
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <NotificationProbe />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('tests:2')
+    })
+
+    act(() => {
+      document.querySelector('button')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+    })
+
+    expect(document.body).toHaveTextContent('tests:1')
   })
 })


### PR DESCRIPTION
## Summary
- Page and chunk the student notification API reads for assignments, docs, tests, attempts, selected access, announcements, and announcement reads.
- Count returned assignment feedback as unread when return timestamps are newer than the last student view, and refresh viewed_at when the returned doc is opened.
- Count closed tests reopened for the selected student, and decrement one active-test notification after a student submission instead of clearing all active-test notifications.
- Add regressions for dense pagination/chunking, wrong-user scoping, child-read failures, returned feedback notifications, reopened closed tests, and client decrement behavior.

## Review Notes
- Hume reviewed the uncommitted diff and found no blocking implementation issues.
- Follow-up test gap was fixed by moving the reopened-closed-test regression to the filter-aware paged mock and asserting the tests.status filter includes active and closed.
- No visual layout/styling changes were made.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/student/notifications.test.ts tests/api/assignment-docs/assignment-docs-id.test.ts tests/components/StudentNotificationsProvider.test.tsx -- --runInBand
- pnpm test tests/components/StudentQuizzesTab.test.tsx -- --runInBand
- pnpm test tests/api/student/notifications.test.ts -- --runInBand
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:coverage
- git diff --check