### PR TITLE
[codex] Harden history cleanup cron

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -649,3 +649,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test:coverage`
 - `git diff --check`
+
+## 2026-05-31 — History cleanup cron hardening
+
+**Completed:**
+- Scheduled `/api/cron/cleanup-history` as a daily repo-managed Vercel cron and documented both current cron schedules.
+- Routed expired-classroom, assignment, assignment-doc, test, and test-attempt discovery through paged/chunked Supabase reads.
+- Kept history cleanup scoped through classrooms whose `end_date` is older than the 30-day Toronto cutoff.
+- Added cleanup for `test_attempt_history` alongside existing assignment doc history cleanup.
+- Preserved chunked deletes for history tables and returned explicit 500s for each read/delete failure path.
+- Rebuilt cleanup cron tests with filter-aware paged mocks and regressions for dense parent chunking, child result pagination, assignmentless test cleanup, retention boundary behavior, and all read/delete errors.
+- Addressed subagent review follow-ups by aligning cron configuration docs and proving child-table pagination for >1000 docs/attempts under a single parent.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/cron/cleanup-history.test.ts -- --runInBand`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm test:coverage`
+- `git diff --check`

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -86,7 +86,7 @@ pnpm run lint
 - `DEV_TEACHER_EMAILS` (comma-separated)
 - `ENABLE_MOCK_EMAIL` (`true` to log verification/reset codes)
 - `NEXT_PUBLIC_APP_URL`
-- `CRON_SECRET` (required for protected cron endpoints; Vercel sends `Authorization: Bearer <CRON_SECRET>`; cron schedules are configured in the Vercel dashboard; on the Hobby plan, schedules must run at most once per day)
+- `CRON_SECRET` (required for protected cron endpoints; Vercel sends `Authorization: Bearer <CRON_SECRET>`; cron schedules are configured in `vercel.json` or the Vercel dashboard; on the Hobby plan, schedules must run at most once per day)
 - `OPENAI_API_KEY` (optional; required for AI grading, nightly log summaries, and developer feedback extraction)
 - `OPENAI_SUMMARY_MODEL` / `OPENAI_DEVELOPER_FEEDBACK_MODEL` (optional model overrides)
 
@@ -112,7 +112,7 @@ Legacy anon/service keys are supported but publishable/secret are preferred.
 
 - Host on Vercel; configure env vars in dashboard; set `ENABLE_MOCK_EMAIL=false` and add real email provider before production.
 - Supabase Cloud for DB; enable connection pooling; treat migrations as a separate human-controlled deploy step.
-- If using cron, configure schedules in the Vercel dashboard (production recommended). On the Hobby plan, Vercel cron is limited to at most one run per day, so do not add sub-daily schedules. Current recommended schedule: `0 6 * * *` (06:00 UTC).
+- If using cron, configure schedules in `vercel.json` or the Vercel dashboard for production. On the Hobby plan, Vercel cron jobs must run at most once per day, so do not add sub-daily schedules. Current repo-managed schedules: nightly log summaries at `0 6 * * *` (06:00 UTC) and history cleanup at `0 7 * * *` (07:00 UTC).
 
 ---
 

--- a/src/app/api/cron/cleanup-history/route.ts
+++ b/src/app/api/cron/cleanup-history/route.ts
@@ -3,15 +3,77 @@ import { formatInTimeZone } from 'date-fns-tz'
 import { subDays } from 'date-fns'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { withErrorHandler } from '@/lib/api-handler'
+import { chunkValues, loadChunkedRows, loadPagedRows } from '@/lib/server/query-chunks'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 const TIMEZONE = 'America/Toronto'
-const DEFAULT_CHUNK_SIZE = 200
+const DELETE_CHUNK_SIZE = 200
+const CLEANUP_PAGE_SIZE = 1000
+
+type IdRow = { id: string }
 
 function getCronAuthHeader(request: NextRequest): string | null {
   return request.headers.get('authorization') ?? request.headers.get('Authorization')
+}
+
+async function loadExpiredClassroomIds(
+  supabase: any,
+  cutoffDate: string
+): Promise<{ ids: string[]; error: any }> {
+  const { rows, error } = await loadPagedRows<IdRow>(() =>
+    supabase
+      .from('classrooms')
+      .select('id')
+      .not('end_date', 'is', null)
+      .lt('end_date', cutoffDate),
+    CLEANUP_PAGE_SIZE
+  )
+
+  if (error) return { ids: [], error }
+  return { ids: rows.map((row) => row.id), error: null }
+}
+
+async function loadIdsByParentIds(
+  supabase: any,
+  table: string,
+  parentColumn: string,
+  parentIds: string[]
+): Promise<{ ids: string[]; error: any }> {
+  if (parentIds.length === 0) return { ids: [], error: null }
+
+  const { rows, error } = await loadChunkedRows<IdRow>({
+    supabase,
+    table,
+    select: 'id',
+    filters: [{ column: parentColumn, values: parentIds }],
+    pageSize: CLEANUP_PAGE_SIZE,
+  })
+
+  if (error) return { ids: [], error }
+  return { ids: rows.map((row) => row.id), error: null }
+}
+
+async function deleteHistoryByParentIds(
+  supabase: any,
+  table: string,
+  parentColumn: string,
+  parentIds: string[]
+): Promise<{ deleted: number; error: any }> {
+  let deleted = 0
+
+  for (const parentIdChunk of chunkValues(parentIds, DELETE_CHUNK_SIZE)) {
+    const { count, error } = await supabase
+      .from(table)
+      .delete({ count: 'exact' })
+      .in(parentColumn, parentIdChunk)
+
+    if (error) return { deleted, error }
+    deleted += count ?? 0
+  }
+
+  return { deleted, error: null }
 }
 
 async function handle(request: NextRequest) {
@@ -37,11 +99,10 @@ async function handle(request: NextRequest) {
 
   const supabase = getServiceRoleClient()
 
-  const { data: classrooms, error: classroomsError } = await supabase
-    .from('classrooms')
-    .select('id')
-    .not('end_date', 'is', null)
-    .lt('end_date', cutoffDate)
+  const { ids: classroomIds, error: classroomsError } = await loadExpiredClassroomIds(
+    supabase,
+    cutoffDate
+  )
 
   if (classroomsError) {
     console.error('Error fetching classrooms for cleanup:', classroomsError)
@@ -51,15 +112,18 @@ async function handle(request: NextRequest) {
     )
   }
 
-  const classroomIds = (classrooms || []).map((c: { id: string }) => c.id)
   if (classroomIds.length === 0) {
     return NextResponse.json({ status: 'ok', deleted: 0 })
   }
 
-  const { data: assignments, error: assignmentsError } = await supabase
-    .from('assignments')
-    .select('id')
-    .in('classroom_id', classroomIds)
+  let deleted = 0
+
+  const { ids: assignmentIds, error: assignmentsError } = await loadIdsByParentIds(
+    supabase,
+    'assignments',
+    'classroom_id',
+    classroomIds
+  )
 
   if (assignmentsError) {
     console.error('Error fetching assignments for cleanup:', assignmentsError)
@@ -69,15 +133,12 @@ async function handle(request: NextRequest) {
     )
   }
 
-  const assignmentIds = (assignments || []).map((a: { id: string }) => a.id)
-  if (assignmentIds.length === 0) {
-    return NextResponse.json({ status: 'ok', deleted: 0 })
-  }
-
-  const { data: docs, error: docsError } = await supabase
-    .from('assignment_docs')
-    .select('id')
-    .in('assignment_id', assignmentIds)
+  const { ids: assignmentDocIds, error: docsError } = await loadIdsByParentIds(
+    supabase,
+    'assignment_docs',
+    'assignment_id',
+    assignmentIds
+  )
 
   if (docsError) {
     console.error('Error fetching assignment docs for cleanup:', docsError)
@@ -87,29 +148,69 @@ async function handle(request: NextRequest) {
     )
   }
 
-  const docIds = (docs || []).map((d: { id: string }) => d.id)
-  if (docIds.length === 0) {
-    return NextResponse.json({ status: 'ok', deleted: 0 })
+  const { deleted: assignmentHistoryDeleted, error: assignmentHistoryError } =
+    await deleteHistoryByParentIds(
+      supabase,
+      'assignment_doc_history',
+      'assignment_doc_id',
+      assignmentDocIds
+    )
+
+  if (assignmentHistoryError) {
+    console.error('Error deleting assignment doc history:', assignmentHistoryError)
+    return NextResponse.json(
+      { error: 'Failed to delete history' },
+      { status: 500 }
+    )
+  }
+  deleted += assignmentHistoryDeleted
+
+  const { ids: testIds, error: testsError } = await loadIdsByParentIds(
+    supabase,
+    'tests',
+    'classroom_id',
+    classroomIds
+  )
+
+  if (testsError) {
+    console.error('Error fetching tests for cleanup:', testsError)
+    return NextResponse.json(
+      { error: 'Failed to fetch tests' },
+      { status: 500 }
+    )
   }
 
-  let deleted = 0
-  for (let i = 0; i < docIds.length; i += DEFAULT_CHUNK_SIZE) {
-    const chunk = docIds.slice(i, i + DEFAULT_CHUNK_SIZE)
-    const { count, error: deleteError } = await supabase
-      .from('assignment_doc_history')
-      .delete({ count: 'exact' })
-      .in('assignment_doc_id', chunk)
+  const { ids: testAttemptIds, error: attemptsError } = await loadIdsByParentIds(
+    supabase,
+    'test_attempts',
+    'test_id',
+    testIds
+  )
 
-    if (deleteError) {
-      console.error('Error deleting assignment doc history:', deleteError)
-      return NextResponse.json(
-        { error: 'Failed to delete history' },
-        { status: 500 }
-      )
-    }
-
-    deleted += count ?? 0
+  if (attemptsError) {
+    console.error('Error fetching test attempts for cleanup:', attemptsError)
+    return NextResponse.json(
+      { error: 'Failed to fetch test attempts' },
+      { status: 500 }
+    )
   }
+
+  const { deleted: testHistoryDeleted, error: testHistoryError } =
+    await deleteHistoryByParentIds(
+      supabase,
+      'test_attempt_history',
+      'test_attempt_id',
+      testAttemptIds
+    )
+
+  if (testHistoryError) {
+    console.error('Error deleting test attempt history:', testHistoryError)
+    return NextResponse.json(
+      { error: 'Failed to delete history' },
+      { status: 500 }
+    )
+  }
+  deleted += testHistoryDeleted
 
   return NextResponse.json({ status: 'ok', deleted })
 }

--- a/tests/api/cron/cleanup-history.test.ts
+++ b/tests/api/cron/cleanup-history.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { GET, POST } from '@/app/api/cron/cleanup-history/route'
 
@@ -8,10 +8,186 @@ vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
 }))
 
+type QueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+  deleteCalls: Array<{ table: string; column: string; values: string[] }>
+}
+
+function createQueryLog(): QueryLog {
+  return { inCalls: [], rangeCalls: [], deleteCalls: [] }
+}
+
+function createSelectTable(
+  table: string,
+  rows: Array<Record<string, unknown>>,
+  log: QueryLog,
+  error: unknown = null
+) {
+  return {
+    select: vi.fn(() => {
+      const eqFilters: Array<{ column: string; values: string[] }> = []
+      const notNullColumns: string[] = []
+      const ltFilters: Array<{ column: string; value: string }> = []
+      const filteredRows = () => rows.filter((row) => {
+        for (const column of notNullColumns) {
+          if (row[column] === null || row[column] === undefined) return false
+        }
+        for (const filter of ltFilters) {
+          const value = row[filter.column]
+          if (typeof value !== 'string' || value >= filter.value) return false
+        }
+        for (const filter of eqFilters) {
+          if (!filter.values.includes(String(row[filter.column]))) return false
+        }
+        return true
+      })
+      const resolveRows = (from: number, to: number) => {
+        if (error) return Promise.resolve({ data: null, error })
+        return Promise.resolve({ data: filteredRows().slice(from, to + 1), error: null })
+      }
+      const query: any = {
+        not: vi.fn((column: string) => {
+          notNullColumns.push(column)
+          return query
+        }),
+        lt: vi.fn((column: string, value: string) => {
+          ltFilters.push({ column, value })
+          return query
+        }),
+        in: vi.fn((column: string, values: string[]) => {
+          const stringValues = values.map(String)
+          eqFilters.push({ column, values: stringValues })
+          log.inCalls.push({ table, column, values: stringValues })
+          return query
+        }),
+        order: vi.fn(() => query),
+        range: vi.fn((from: number, to: number) => {
+          log.rangeCalls.push({ table, from, to })
+          return resolveRows(from, to)
+        }),
+        then: vi.fn((resolve: any, reject: any) =>
+          resolveRows(0, rows.length - 1).then(resolve, reject)
+        ),
+      }
+      return query
+    }),
+  }
+}
+
+function createDeleteTable(
+  table: string,
+  parentColumn: string,
+  rows: Array<Record<string, unknown>>,
+  log: QueryLog,
+  error: unknown = null
+) {
+  return {
+    delete: vi.fn(() => ({
+      in: vi.fn(async (column: string, values: string[]) => {
+        const stringValues = values.map(String)
+        log.deleteCalls.push({ table, column, values: stringValues })
+        if (error) return { count: null, error }
+        const count = rows.filter((row) =>
+          column === parentColumn && stringValues.includes(String(row[parentColumn]))
+        ).length
+        return { count, error: null }
+      }),
+    })),
+  }
+}
+
+function createCleanupMock(opts: {
+  classrooms?: Array<Record<string, unknown>>
+  assignments?: Array<Record<string, unknown>>
+  assignmentDocs?: Array<Record<string, unknown>>
+  assignmentHistory?: Array<Record<string, unknown>>
+  tests?: Array<Record<string, unknown>>
+  testAttempts?: Array<Record<string, unknown>>
+  testAttemptHistory?: Array<Record<string, unknown>>
+  errors?: Record<string, unknown>
+  log?: QueryLog
+} = {}) {
+  const log = opts.log ?? createQueryLog()
+  const classrooms = opts.classrooms ?? [
+    { id: 'classroom-1', end_date: '2026-01-01' },
+  ]
+  const assignments = opts.assignments ?? [
+    { id: 'assignment-1', classroom_id: 'classroom-1' },
+  ]
+  const assignmentDocs = opts.assignmentDocs ?? [
+    { id: 'doc-1', assignment_id: 'assignment-1' },
+  ]
+  const assignmentHistory = opts.assignmentHistory ?? [
+    { id: 'history-1', assignment_doc_id: 'doc-1' },
+  ]
+  const tests = opts.tests ?? [
+    { id: 'test-1', classroom_id: 'classroom-1' },
+  ]
+  const testAttempts = opts.testAttempts ?? [
+    { id: 'attempt-1', test_id: 'test-1' },
+  ]
+  const testAttemptHistory = opts.testAttemptHistory ?? [
+    { id: 'test-history-1', test_attempt_id: 'attempt-1' },
+  ]
+  const errors = opts.errors ?? {}
+
+  return {
+    log,
+    from: vi.fn((table: string) => {
+      if (table === 'classrooms') {
+        return createSelectTable(table, classrooms, log, errors.classrooms)
+      }
+      if (table === 'assignments') {
+        return createSelectTable(table, assignments, log, errors.assignments)
+      }
+      if (table === 'assignment_docs') {
+        return createSelectTable(table, assignmentDocs, log, errors.assignment_docs)
+      }
+      if (table === 'assignment_doc_history') {
+        return createDeleteTable(
+          table,
+          'assignment_doc_id',
+          assignmentHistory,
+          log,
+          errors.assignment_doc_history
+        )
+      }
+      if (table === 'tests') {
+        return createSelectTable(table, tests, log, errors.tests)
+      }
+      if (table === 'test_attempts') {
+        return createSelectTable(table, testAttempts, log, errors.test_attempts)
+      }
+      if (table === 'test_attempt_history') {
+        return createDeleteTable(
+          table,
+          'test_attempt_id',
+          testAttemptHistory,
+          log,
+          errors.test_attempt_history
+        )
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+  }
+}
+
+function cronRequest(method: 'GET' | 'POST' = 'GET') {
+  return new NextRequest('http://localhost:3000/api/cron/cleanup-history', {
+    method,
+    headers: { authorization: 'Bearer secret' },
+  })
+}
+
 describe('cron cleanup-history route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('returns 500 when CRON_SECRET is missing', async () => {
@@ -36,91 +212,243 @@ describe('cron cleanup-history route', () => {
 
   it('returns deleted=0 when no expired classrooms are found', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
-    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
-      expect(table).toBe('classrooms')
-      return {
-        select: vi.fn(() => ({
-          not: vi.fn(() => ({
-            lt: vi.fn().mockResolvedValue({ data: [], error: null }),
-          })),
-        })),
-      }
-    })
+    const log = createQueryLog()
+    const mock = createCleanupMock({ classrooms: [], log })
+    ;(mockSupabaseClient.from as any) = mock.from
 
-    const response = await POST(
-      new NextRequest('http://localhost:3000/api/cron/cleanup-history', {
-        method: 'POST',
-        headers: { authorization: 'Bearer secret' },
-      })
-    )
+    const response = await POST(cronRequest('POST'))
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 0 })
+    expect(mock.from).toHaveBeenCalledTimes(1)
+    expect(log.rangeCalls).toEqual([{ table: 'classrooms', from: 0, to: 999 }])
   })
 
-  it('deletes assignment doc history in chunks and sums deleted counts', async () => {
+  it('pages and chunks expired classroom assignment and test history cleanup', async () => {
     vi.stubEnv('CRON_SECRET', 'secret')
-    const deleteChunks: number[] = []
-    const docIds = Array.from({ length: 205 }, (_, index) => ({ id: `doc-${index + 1}` }))
+    const log = createQueryLog()
+    const classrooms = Array.from({ length: 1001 }, (_, index) => ({
+      id: `classroom-${index + 1}`,
+      end_date: '2026-01-01',
+    }))
+    const assignments = classrooms.map((classroom, index) => ({
+      id: `assignment-${index + 1}`,
+      classroom_id: classroom.id,
+    }))
+    const assignmentDocs = assignments.map((assignment, index) => ({
+      id: `doc-${index + 1}`,
+      assignment_id: assignment.id,
+    }))
+    const assignmentHistory = assignmentDocs.map((doc, index) => ({
+      id: `history-${index + 1}`,
+      assignment_doc_id: doc.id,
+    }))
+    const tests = classrooms.map((classroom, index) => ({
+      id: `test-${index + 1}`,
+      classroom_id: classroom.id,
+    }))
+    const testAttempts = tests.map((test, index) => ({
+      id: `attempt-${index + 1}`,
+      test_id: test.id,
+    }))
+    const testAttemptHistory = testAttempts.map((attempt, index) => ({
+      id: `test-history-${index + 1}`,
+      test_attempt_id: attempt.id,
+    }))
 
-    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
-      if (table === 'classrooms') {
-        return {
-          select: vi.fn(() => ({
-            not: vi.fn(() => ({
-              lt: vi.fn().mockResolvedValue({
-                data: [{ id: 'classroom-1' }],
-                error: null,
-              }),
-            })),
-          })),
-        }
-      }
-
-      if (table === 'assignments') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: [{ id: 'assignment-1' }],
-              error: null,
-            }),
-          })),
-        }
-      }
-
-      if (table === 'assignment_docs') {
-        return {
-          select: vi.fn(() => ({
-            in: vi.fn().mockResolvedValue({
-              data: docIds,
-              error: null,
-            }),
-          })),
-        }
-      }
-
-      if (table === 'assignment_doc_history') {
-        return {
-          delete: vi.fn(() => ({
-            in: vi.fn(async (_column: string, ids: string[]) => {
-              deleteChunks.push(ids.length)
-              return { count: ids.length, error: null }
-            }),
-          })),
-        }
-      }
-
-      throw new Error(`Unexpected table: ${table}`)
+    const mock = createCleanupMock({
+      classrooms,
+      assignments,
+      assignmentDocs,
+      assignmentHistory,
+      tests,
+      testAttempts,
+      testAttemptHistory,
+      log,
     })
+    ;(mockSupabaseClient.from as any) = mock.from
 
-    const response = await GET(
-      new NextRequest('http://localhost:3000/api/cron/cleanup-history', {
-        headers: { Authorization: 'Bearer secret' },
-      })
-    )
+    const response = await GET(cronRequest())
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 205 })
-    expect(deleteChunks).toEqual([200, 5])
+    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 2002 })
+    expect(log.rangeCalls.filter((call) => call.table === 'classrooms')).toEqual([
+      { table: 'classrooms', from: 0, to: 999 },
+      { table: 'classrooms', from: 1000, to: 1999 },
+    ])
+    expect(log.inCalls.filter((call) => call.table === 'assignments')).toHaveLength(21)
+    expect(log.inCalls.filter((call) => call.table === 'assignment_docs')).toHaveLength(21)
+    expect(log.inCalls.filter((call) => call.table === 'tests')).toHaveLength(21)
+    expect(log.inCalls.filter((call) => call.table === 'test_attempts')).toHaveLength(21)
+    expect(log.inCalls.find((call) => call.table === 'assignments')?.values).toHaveLength(50)
+    expect(log.deleteCalls.filter((call) => call.table === 'assignment_doc_history').map((call) => call.values.length)).toEqual([
+      200,
+      200,
+      200,
+      200,
+      200,
+      1,
+    ])
+    expect(log.deleteCalls.filter((call) => call.table === 'test_attempt_history').map((call) => call.values.length)).toEqual([
+      200,
+      200,
+      200,
+      200,
+      200,
+      1,
+    ])
+  })
+
+  it('still deletes test attempt history when expired classrooms have no assignments', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const log = createQueryLog()
+    const mock = createCleanupMock({
+      assignments: [],
+      assignmentDocs: [],
+      assignmentHistory: [],
+      log,
+    })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 1 })
+    expect(log.inCalls.some((call) => call.table === 'assignment_docs')).toBe(false)
+    expect(log.deleteCalls.filter((call) => call.table === 'test_attempt_history')).toHaveLength(1)
+  })
+
+  it('pages assignment docs and test attempts when one parent has more than one result page', async () => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const log = createQueryLog()
+    const assignmentDocs = Array.from({ length: 1001 }, (_, index) => ({
+      id: `doc-${index + 1}`,
+      assignment_id: 'assignment-1',
+    }))
+    const assignmentHistory = assignmentDocs.map((doc, index) => ({
+      id: `history-${index + 1}`,
+      assignment_doc_id: doc.id,
+    }))
+    const testAttempts = Array.from({ length: 1001 }, (_, index) => ({
+      id: `attempt-${index + 1}`,
+      test_id: 'test-1',
+    }))
+    const testAttemptHistory = testAttempts.map((attempt, index) => ({
+      id: `test-history-${index + 1}`,
+      test_attempt_id: attempt.id,
+    }))
+    const mock = createCleanupMock({
+      assignmentDocs,
+      assignmentHistory,
+      testAttempts,
+      testAttemptHistory,
+      log,
+    })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 2002 })
+    expect(log.rangeCalls.filter((call) => call.table === 'assignment_docs')).toEqual([
+      { table: 'assignment_docs', from: 0, to: 999 },
+      { table: 'assignment_docs', from: 1000, to: 1999 },
+    ])
+    expect(log.rangeCalls.filter((call) => call.table === 'test_attempts')).toEqual([
+      { table: 'test_attempts', from: 0, to: 999 },
+      { table: 'test_attempts', from: 1000, to: 1999 },
+    ])
+  })
+
+  it('retains classrooms ending exactly 30 Toronto days ago and cleans older classrooms only', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-31T16:00:00.000Z'))
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const log = createQueryLog()
+    const mock = createCleanupMock({
+      classrooms: [
+        { id: 'old-classroom', end_date: '2026-04-30' },
+        { id: 'boundary-classroom', end_date: '2026-05-01' },
+        { id: 'active-classroom', end_date: null },
+      ],
+      assignments: [
+        { id: 'old-assignment', classroom_id: 'old-classroom' },
+        { id: 'boundary-assignment', classroom_id: 'boundary-classroom' },
+        { id: 'active-assignment', classroom_id: 'active-classroom' },
+      ],
+      assignmentDocs: [
+        { id: 'old-doc', assignment_id: 'old-assignment' },
+        { id: 'boundary-doc', assignment_id: 'boundary-assignment' },
+        { id: 'active-doc', assignment_id: 'active-assignment' },
+      ],
+      assignmentHistory: [
+        { id: 'old-history', assignment_doc_id: 'old-doc' },
+        { id: 'boundary-history', assignment_doc_id: 'boundary-doc' },
+        { id: 'active-history', assignment_doc_id: 'active-doc' },
+      ],
+      tests: [
+        { id: 'old-test', classroom_id: 'old-classroom' },
+        { id: 'boundary-test', classroom_id: 'boundary-classroom' },
+        { id: 'active-test', classroom_id: 'active-classroom' },
+      ],
+      testAttempts: [
+        { id: 'old-attempt', test_id: 'old-test' },
+        { id: 'boundary-attempt', test_id: 'boundary-test' },
+        { id: 'active-attempt', test_id: 'active-test' },
+      ],
+      testAttemptHistory: [
+        { id: 'old-test-history', test_attempt_id: 'old-attempt' },
+        { id: 'boundary-test-history', test_attempt_id: 'boundary-attempt' },
+        { id: 'active-test-history', test_attempt_id: 'active-attempt' },
+      ],
+      log,
+    })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', deleted: 2 })
+    expect(log.inCalls).toContainEqual({
+      table: 'assignments',
+      column: 'classroom_id',
+      values: ['old-classroom'],
+    })
+    expect(log.inCalls).toContainEqual({
+      table: 'tests',
+      column: 'classroom_id',
+      values: ['old-classroom'],
+    })
+    expect(log.deleteCalls).toContainEqual({
+      table: 'assignment_doc_history',
+      column: 'assignment_doc_id',
+      values: ['old-doc'],
+    })
+    expect(log.deleteCalls).toContainEqual({
+      table: 'test_attempt_history',
+      column: 'test_attempt_id',
+      values: ['old-attempt'],
+    })
+  })
+
+  it.each([
+    ['classrooms', 'Failed to fetch classrooms'],
+    ['assignments', 'Failed to fetch assignments'],
+    ['assignment_docs', 'Failed to fetch assignment docs'],
+    ['assignment_doc_history', 'Failed to delete history'],
+    ['tests', 'Failed to fetch tests'],
+    ['test_attempts', 'Failed to fetch test attempts'],
+    ['test_attempt_history', 'Failed to delete history'],
+  ])('returns 500 when %s cleanup work fails', async (table, message) => {
+    vi.stubEnv('CRON_SECRET', 'secret')
+    const mock = createCleanupMock({
+      errors: { [table]: { message: `${table} failed` } },
+    })
+    ;(mockSupabaseClient.from as any) = mock.from
+
+    const response = await GET(cronRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: message })
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,10 @@
     {
       "path": "/api/cron/nightly-log-summaries",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/cleanup-history",
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Page and chunk cleanup-history cron reads for expired classrooms, assignments, assignment docs, tests, and test attempts.
- Keep cleanup scoped through classrooms older than the 30-day Toronto cutoff and include test attempt history cleanup alongside assignment doc history.
- Schedule `/api/cron/cleanup-history` as a daily repo-managed Vercel cron and update project context docs for both cron schedules.
- Rebuild cleanup cron tests with filter-aware paged mocks covering dense parent chunking, child result pagination, assignmentless test cleanup, retention boundary behavior, and read/delete failures.

## Review Notes
- Fermat audited the original route and reviewed the patched diff. No blocking findings remained after follow-ups.
- Follow-ups addressed before PR: aligned cron config docs and added an explicit >1000 child-row pagination regression.
- I checked Vercel official docs while changing scheduling: Hobby cron jobs must be daily, and the current per-project limit is documented as 100 jobs, so two daily schedules are within the documented constraints.
- No UI changes.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/cron/cleanup-history.test.ts -- --runInBand
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:coverage
- git diff --check