### PR TITLE
[codex] Share survey FAB cluster

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -687,3 +687,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3016 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-gradebook-email-menu-desktop.png`, `/tmp/pika-gradebook-email-menu-mobile.png`, `/tmp/pika-gradebook-settings-desktop.png`
+
+## 2026-05-31 — Student survey FAB cluster consistency
+
+**Completed:**
+- Extracted the shared floating action cluster layout used by teacher work surfaces.
+- Kept teacher work-surface action bars on the shared cluster through the existing wrapper.
+- Routed student survey response/results actions through the shared cluster so desktop centering follows `--main-content-center-x` like other classroom FABs.
+- Added component coverage for the student survey FAB layer and main-content centering class.
+- Created and cleaned up a temporary active survey for visual verification.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3017 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&surveyId=5fc24952-20e0-4512-93f5-8c3800826e5f'`
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student-survey-fab-desktop.png`, `/tmp/pika-student-survey-response-form-desktop.png`, `/tmp/pika-student-survey-response-form-mobile.png`

--- a/src/components/FloatingActionCluster.tsx
+++ b/src/components/FloatingActionCluster.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { cn } from '@/ui/utils'
+
+const FLOATING_ACTION_CLUSTER_CLASS =
+  'fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur lg:left-[var(--main-content-center-x,50%)] lg:transition-[left] lg:duration-200 lg:ease-out'
+
+export function FloatingActionCluster({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn(FLOATING_ACTION_CLUSTER_CLASS, className)}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ExternalLink, Pencil } from 'lucide-react'
 import { Button, Card, Input } from '@/ui'
+import { FloatingActionCluster } from '@/components/FloatingActionCluster'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { Spinner } from '@/components/Spinner'
 import { SurveyOptionResultBar } from '@/components/surveys/SurveyOptionResultBar'
@@ -233,7 +234,7 @@ export function StudentSurveyPanel({
   const showResponseForm = isEditingResponse || !canViewResults
   const showResults = canViewResults
   const surveyActionFab = canViewResults && canRespond ? (
-    <div className="fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur">
+    <FloatingActionCluster>
       <Button
         type="button"
         size="sm"
@@ -243,7 +244,7 @@ export function StudentSurveyPanel({
         <Pencil className="mr-1 h-4 w-4" aria-hidden="true" />
         {isEditingResponse ? 'View results' : hasSubmitted ? 'Edit response' : 'Respond'}
       </Button>
-    </div>
+    </FloatingActionCluster>
   ) : null
 
   return (

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
@@ -1,10 +1,8 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { FloatingActionCluster } from '@/components/FloatingActionCluster'
 import { cn } from '@/ui/utils'
-
-const TEACHER_WORK_SURFACE_FLOATING_ACTION_CLUSTER_CLASS =
-  'fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur lg:left-[var(--main-content-center-x,50%)] lg:transition-[left] lg:duration-200 lg:ease-out'
 
 interface TeacherWorkSurfaceActionBarProps {
   label?: ReactNode
@@ -26,9 +24,9 @@ export function TeacherWorkSurfaceFloatingActionCluster({
   className?: string
 }) {
   return (
-    <div className={cn(TEACHER_WORK_SURFACE_FLOATING_ACTION_CLUSTER_CLASS, className)}>
+    <FloatingActionCluster className={className}>
       {children}
-    </div>
+    </FloatingActionCluster>
   )
 }
 

--- a/tests/components/StudentSurveyPanel.test.tsx
+++ b/tests/components/StudentSurveyPanel.test.tsx
@@ -94,7 +94,10 @@ describe('StudentSurveyPanel', () => {
 
     expect(await screen.findByRole('heading', { name: 'Quick Poll' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Respond' })).toBeInTheDocument()
+    const responseAction = screen.getByRole('button', { name: 'Respond' })
+    expect(responseAction).toBeInTheDocument()
+    expect(responseAction.parentElement).toHaveClass('fixed', 'top-[3.25rem]', 'z-40')
+    expect(responseAction.parentElement?.className).toContain('lg:left-[var(--main-content-center-x,50%)]')
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Class results' })).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Extract the shared fixed floating action cluster into `FloatingActionCluster`.
- Keep teacher work-surface FABs on that shared cluster through the existing wrapper.
- Route student survey response/results actions through the shared cluster so desktop centering follows the classroom main-content center.
- Add component coverage for the student survey FAB layer and `lg:left-[var(--main-content-center-x,50%)]` contract.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `bash scripts/verify-env.sh`
- `pnpm test tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `E2E_BASE_URL=http://localhost:3017 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&surveyId=5fc24952-20e0-4512-93f5-8c3800826e5f"`

## Visual Verification
- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`.
- Reviewed `/tmp/pika-student-survey-fab-desktop.png`, `/tmp/pika-student-survey-response-form-desktop.png`, `/tmp/pika-student-survey-response-form-mobile.png`.
- Temporary survey fixture was deleted after capture.