### PR TITLE
[codex] Share classroom bottom controls cluster

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -708,3 +708,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3017 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&surveyId=5fc24952-20e0-4512-93f5-8c3800826e5f'`
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student-survey-fab-desktop.png`, `/tmp/pika-student-survey-response-form-desktop.png`, `/tmp/pika-student-survey-response-form-mobile.png`
+
+## 2026-05-31 — Classroom bottom controls FAB consistency
+
+**Completed:**
+- Extended `FloatingActionCluster` with a bottom placement for full-width floating controls.
+- Migrated the teacher classroom index edit/view bottom bar off its local fixed chrome and onto the shared floating cluster.
+- Added safe-area-aware bottom placement for mobile classroom controls while preserving the existing centered desktop width.
+- Added component coverage for the migrated bottom bar class contract.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3018 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-classrooms-edit-desktop.png`, `/tmp/pika-classrooms-edit-mobile.png`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -21,6 +21,7 @@ import {
 import { useRouter, usePathname } from 'next/navigation'
 import { Archive, CircleDot, LoaderCircle, Plus } from 'lucide-react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
+import { FloatingActionCluster } from '@/components/FloatingActionCluster'
 import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { Button, ConfirmDialog, SegmentedControl } from '@/ui'
 import { Spinner } from '@/components/Spinner'
@@ -472,9 +473,9 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         ) : null}
       </PageContent>
 
-      <div
+      <FloatingActionCluster
+        placement="bottom"
         data-testid="classroom-bottom-controls"
-        className="fixed bottom-4 left-1/2 z-40 w-[calc(100vw-3.5rem)] max-w-[40.5rem] -translate-x-1/2 rounded-card bg-surface/95 py-2 pl-3 pr-1 shadow-elevated backdrop-blur"
       >
         <div className="relative min-h-9">
           {isEditingClassrooms ? (
@@ -512,7 +513,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
             className="absolute right-0 top-1/2 -translate-y-1/2"
           />
         </div>
-      </div>
+      </FloatingActionCluster>
 
       <CreateClassroomModal
         isOpen={showCreate}

--- a/src/components/FloatingActionCluster.tsx
+++ b/src/components/FloatingActionCluster.tsx
@@ -1,20 +1,28 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { cn } from '@/ui/utils'
 
-const FLOATING_ACTION_CLUSTER_CLASS =
-  'fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur lg:left-[var(--main-content-center-x,50%)] lg:transition-[left] lg:duration-200 lg:ease-out'
+const FLOATING_ACTION_CLUSTER_CLASSES = {
+  top: 'fixed left-1/2 top-[3.25rem] z-40 w-max max-w-[calc(100vw-1rem)] -translate-x-1/2 rounded-lg bg-surface/95 p-1 shadow-elevated backdrop-blur lg:left-[var(--main-content-center-x,50%)] lg:transition-[left] lg:duration-200 lg:ease-out',
+  bottom: 'fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100vw-3.5rem)] max-w-[40.5rem] -translate-x-1/2 rounded-lg bg-surface/95 py-2 pl-3 pr-1 shadow-elevated backdrop-blur',
+} as const
+
+interface FloatingActionClusterProps extends ComponentPropsWithoutRef<'div'> {
+  placement?: keyof typeof FLOATING_ACTION_CLUSTER_CLASSES
+}
 
 export function FloatingActionCluster({
   children,
   className,
-}: {
-  children: ReactNode
-  className?: string
-}) {
+  placement = 'top',
+  ...props
+}: FloatingActionClusterProps) {
   return (
-    <div className={cn(FLOATING_ACTION_CLUSTER_CLASS, className)}>
+    <div
+      {...props}
+      className={cn(FLOATING_ACTION_CLUSTER_CLASSES[placement], className)}
+    >
       {children}
     </div>
   )

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -72,10 +72,16 @@ describe('TeacherClassroomsIndex', () => {
     renderTeacherClassroomsIndex(classrooms)
 
     const editButton = screen.getByRole('button', { name: 'Edit' })
+    const bottomControls = screen.getByTestId('classroom-bottom-controls')
     const card = screen.getByTestId('classroom-card')
 
+    expect(bottomControls).toHaveClass('fixed', 'left-1/2', 'z-40', 'rounded-lg', 'bg-surface/95')
+    expect(bottomControls).toHaveClass('shadow-elevated', 'backdrop-blur')
+    expect(bottomControls.className).toContain('bottom-[calc(1rem+env(safe-area-inset-bottom))]')
+    expect(bottomControls.className).toContain('max-w-[40.5rem]')
+    expect(bottomControls).not.toHaveClass('rounded-card')
     expect(
-      within(screen.getByTestId('classroom-bottom-controls')).getByRole('button', { name: 'Edit' })
+      within(bottomControls).getByRole('button', { name: 'Edit' })
     ).toBe(editButton)
     expect(card.compareDocumentPosition(editButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Extend `FloatingActionCluster` with a bottom placement for full-width floating controls.
- Migrate the teacher classroom index bottom edit/view bar from local fixed chrome to the shared cluster.
- Add safe-area-aware bottom positioning for mobile while preserving the existing centered desktop width.
- Add focused component coverage for the migrated bottom bar class contract.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `E2E_BASE_URL=http://localhost:3018 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`

## Visual Verification
- Reviewed default captures: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`.
- Reviewed teacher edit-mode captures: `/tmp/pika-classrooms-edit-desktop.png`, `/tmp/pika-classrooms-edit-mobile.png`.

## UI Guidance
- Guidance read: `docs/core/design.md`, `src/ui/README.md`, `docs/guidance/ui/README.md`, `docs/guidance/ui/stable.md`, `docs/guides/ai-ui-testing.md`.
- Stable guidance followed: yes.
- Experimental guidance introduced: no.
- Human promotion needed: no.
- Composite widget accessibility checklist reviewed: not applicable; this slice changes placement chrome, not widget behavior.