### PR TITLE
Align assignment status badges

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -727,3 +727,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3018 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-classrooms-edit-desktop.png`, `/tmp/pika-classrooms-edit-mobile.png`
+
+## 2026-05-31 — Assignment status badge consistency
+
+**Completed:**
+- Moved assignment status badge and icon helpers from raw Tailwind palette classes to semantic design tokens.
+- Made the assignment badge helper own the shared pill shape so student assignment list and editor badges stay aligned.
+- Added the shared status badge to the embedded student assignment editor header, which is the route students use from the assignments tab.
+- Added tests that assert semantic badge/icon contracts and reject raw palette utilities.
+- Used a read-only subagent audit to confirm the live editor route and screenshot path before visual verification.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:auth`
+- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:verify assessment-ux-parity`
+- Reviewed screenshots: `/tmp/pika-assignment-list-desktop.png`, `/tmp/pika-assignment-editor-desktop.png`, `/tmp/pika-assignment-list-mobile.png`, `/tmp/pika-assignment-editor-mobile.png`, `artifacts/assessment-ux-parity/student-assignments-reference.png`

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -388,9 +388,7 @@ export function StudentAssignmentsTab({
                               {formatAssignmentTiming(assignment.due_at, assignment.doc)}
                             </p>
                           </div>
-                          <span
-                            className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getAssignmentStatusBadgeClass(assignment.status)}`}
-                          >
+                          <span className={getAssignmentStatusBadgeClass(assignment.status)}>
                             {getAssignmentStatusLabel(assignment.status)}
                           </span>
                         </div>

--- a/src/components/StudentAssignmentEditor.tsx
+++ b/src/components/StudentAssignmentEditor.tsx
@@ -582,34 +582,41 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
       <div className="flex min-h-0 flex-1 flex-col rounded-card border border-border bg-surface-panel shadow-elevated">
         {/* Header */}
         <div className="p-4 border-b border-border">
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="min-w-0 flex-1">
               <div className="text-sm font-medium text-text-muted truncate">
                 {assignment.title}
               </div>
             </div>
-            <div
-              className={`text-xs ${
-                saveStatus === 'saved'
-                  ? 'text-success'
-                  : saveStatus === 'saving'
-                    ? 'text-text-muted'
-                    : 'text-warning'
-              }`}
-            >
-              {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
-            </div>
-            <Tooltip content={isHistoryOpen ? 'Hide history' : 'Show history'}>
-              <button
-                type="button"
-                onClick={handleHistoryToggle}
-                className="p-1.5 rounded-md border border-border text-text-muted hover:bg-surface-hover"
-                aria-expanded={isHistoryOpen}
-                aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
+            <div className="flex shrink-0 items-center gap-2">
+              {isEmbedded ? (
+                <span data-testid="assignment-status-badge" className={getAssignmentStatusBadgeClass(status)}>
+                  {getAssignmentStatusLabel(status)}
+                </span>
+              ) : null}
+              <div
+                className={`text-xs ${
+                  saveStatus === 'saved'
+                    ? 'text-success'
+                    : saveStatus === 'saving'
+                      ? 'text-text-muted'
+                      : 'text-warning'
+                }`}
               >
-                <History className="h-4 w-4" aria-hidden="true" />
-              </button>
-            </Tooltip>
+                {saveStatus === 'saved' ? 'Saved' : saveStatus === 'saving' ? 'Saving...' : 'Unsaved'}
+              </div>
+              <Tooltip content={isHistoryOpen ? 'Hide history' : 'Show history'}>
+                <button
+                  type="button"
+                  onClick={handleHistoryToggle}
+                  className="p-1.5 rounded-md border border-border text-text-muted hover:bg-surface-hover"
+                  aria-expanded={isHistoryOpen}
+                  aria-label={isHistoryOpen ? 'Hide history' : 'Show history'}
+                >
+                  <History className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </Tooltip>
+            </div>
           </div>
         </div>
 
@@ -893,7 +900,7 @@ export const StudentAssignmentEditor = forwardRef<StudentAssignmentEditorHandle,
               </div>
             </div>
             <div className="flex items-center gap-3">
-              <span className={`px-3 py-1 rounded text-sm font-medium ${getAssignmentStatusBadgeClass(status)}`}>
+              <span className={getAssignmentStatusBadgeClass(status)}>
                 {getAssignmentStatusLabel(status)}
               </span>
               {canUnsubmit ? (

--- a/src/lib/assignments.ts
+++ b/src/lib/assignments.ts
@@ -244,26 +244,19 @@ export function getAssignmentStatusLabel(status: AssignmentStatus): string {
  * Get badge styling classes for assignment status
  */
 export function getAssignmentStatusBadgeClass(status: AssignmentStatus): string {
-  switch (status) {
-    case 'not_started':
-      return 'bg-gray-100 text-gray-700'
-    case 'in_progress':
-      return 'bg-blue-100 text-blue-700'
-    case 'in_progress_late':
-      return 'bg-yellow-100 text-yellow-700'
-    case 'submitted_on_time':
-      return 'bg-green-100 text-green-700'
-    case 'submitted_late':
-      return 'bg-orange-100 text-orange-700'
-    case 'graded':
-      return 'bg-purple-100 text-purple-700'
-    case 'returned':
-      return 'bg-blue-100 text-blue-700'
-    case 'resubmitted':
-      return 'bg-orange-100 text-orange-700'
-    default:
-      return 'bg-gray-100 text-gray-700'
+  const baseClassName = 'inline-flex shrink-0 items-center rounded-badge px-2.5 py-1 text-xs font-semibold'
+  const toneClasses: Record<AssignmentStatus, string> = {
+    not_started: 'bg-surface-2 text-text-muted',
+    in_progress: 'bg-warning-bg text-warning',
+    in_progress_late: 'bg-warning-bg text-warning',
+    submitted_on_time: 'bg-success-bg text-success',
+    submitted_late: 'bg-warning-bg text-warning',
+    graded: 'bg-success-bg text-success',
+    returned: 'bg-info-bg text-primary',
+    resubmitted: 'bg-warning-bg text-warning',
   }
+
+  return `${baseClassName} ${toneClasses[status] ?? toneClasses.not_started}`
 }
 
 /**
@@ -271,26 +264,18 @@ export function getAssignmentStatusBadgeClass(status: AssignmentStatus): string 
  * Used for the colored status icons in the student table.
  */
 export function getAssignmentStatusIconClass(status: AssignmentStatus): string {
-  switch (status) {
-    case 'not_started':
-      return 'text-gray-400'
-    case 'in_progress':
-      return 'text-yellow-500'
-    case 'in_progress_late':
-      return 'text-yellow-500'
-    case 'submitted_on_time':
-      return 'text-green-500'
-    case 'submitted_late':
-      return 'text-green-500'
-    case 'graded':
-      return 'text-purple-500'
-    case 'returned':
-      return 'text-blue-500'
-    case 'resubmitted':
-      return 'text-orange-500'
-    default:
-      return 'text-gray-400'
+  const classes: Record<AssignmentStatus, string> = {
+    not_started: 'text-text-muted',
+    in_progress: 'text-warning',
+    in_progress_late: 'text-warning',
+    submitted_on_time: 'text-success',
+    submitted_late: 'text-success',
+    graded: 'text-success',
+    returned: 'text-primary',
+    resubmitted: 'text-warning',
   }
+
+  return classes[status] ?? classes.not_started
 }
 
 /**

--- a/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
+++ b/tests/components/StudentAssignmentEditor.feedback-card.test.tsx
@@ -187,4 +187,25 @@ describe('StudentAssignmentEditor feedback card rendering', () => {
     expect(screen.queryByRole('link', { name: 'https://github.com/codepetca/pika' })).not.toBeInTheDocument()
     expect(screen.queryByText('@student1-demo')).not.toBeInTheDocument()
   })
+
+  it('renders the embedded status badge with the shared assignment badge contract', async () => {
+    mockLoadResponses(makeDoc({ returned_at: '2026-02-15T00:00:00Z' }))
+
+    render(<StudentAssignmentEditor classroomId="classroom-1" assignmentId="assignment-1" variant="embedded" />)
+
+    const badge = await screen.findByTestId('assignment-status-badge')
+
+    expect(badge).toHaveTextContent('Returned')
+    expect(badge).toHaveClass(
+      'inline-flex',
+      'shrink-0',
+      'rounded-badge',
+      'px-2.5',
+      'text-xs',
+      'font-semibold',
+      'bg-info-bg',
+      'text-primary',
+    )
+    expect(badge.className).not.toMatch(/\b(?:bg|text)-(?:gray|blue|yellow|green|orange|purple)-\d{2,3}\b/)
+  })
 })

--- a/tests/unit/assignments.test.ts
+++ b/tests/unit/assignments.test.ts
@@ -684,56 +684,37 @@ describe('assignment utilities', () => {
   // ==========================================================================
 
   describe('getAssignmentStatusBadgeClass', () => {
-    it('should return gray classes for not_started', () => {
-      const classes = getAssignmentStatusBadgeClass('not_started')
-      expect(classes).toContain('gray')
+    const rawPaletteUtilityPattern =
+      /\b(?:bg|text)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}\b/
+
+    it.each([
+      ['not_started', 'bg-surface-2', 'text-text-muted'],
+      ['in_progress', 'bg-warning-bg', 'text-warning'],
+      ['in_progress_late', 'bg-warning-bg', 'text-warning'],
+      ['submitted_on_time', 'bg-success-bg', 'text-success'],
+      ['submitted_late', 'bg-warning-bg', 'text-warning'],
+      ['graded', 'bg-success-bg', 'text-success'],
+      ['returned', 'bg-info-bg', 'text-primary'],
+      ['resubmitted', 'bg-warning-bg', 'text-warning'],
+    ] as const)('returns semantic badge classes for %s', (status, bgClass, textClass) => {
+      const classes = getAssignmentStatusBadgeClass(status)
+
+      expect(classes).toContain('inline-flex')
+      expect(classes).toContain('rounded-badge')
+      expect(classes).toContain('px-2.5')
+      expect(classes).toContain('text-xs')
+      expect(classes).toContain('font-semibold')
+      expect(classes).toContain(bgClass)
+      expect(classes).toContain(textClass)
+      expect(classes).not.toMatch(rawPaletteUtilityPattern)
     })
 
-    it('should return blue classes for in_progress', () => {
-      const classes = getAssignmentStatusBadgeClass('in_progress')
-      expect(classes).toContain('blue')
-    })
-
-    it('should return yellow classes for in_progress_late', () => {
-      const classes = getAssignmentStatusBadgeClass('in_progress_late')
-      expect(classes).toContain('yellow')
-    })
-
-    it('should return green classes for submitted_on_time', () => {
-      const classes = getAssignmentStatusBadgeClass('submitted_on_time')
-      expect(classes).toContain('green')
-    })
-
-    it('should return orange classes for submitted_late', () => {
-      const classes = getAssignmentStatusBadgeClass('submitted_late')
-      expect(classes).toContain('orange')
-    })
-
-    it('should return purple classes for graded', () => {
-      const classes = getAssignmentStatusBadgeClass('graded')
-      expect(classes).toContain('purple')
-    })
-
-    it('should return blue classes for returned', () => {
-      const classes = getAssignmentStatusBadgeClass('returned')
-      expect(classes).toContain('blue')
-    })
-
-    it('should return orange classes for resubmitted', () => {
-      const classes = getAssignmentStatusBadgeClass('resubmitted')
-      expect(classes).toContain('orange')
-    })
-
-    it('should return gray classes for invalid status', () => {
+    it('defaults invalid statuses to the muted semantic badge', () => {
       const classes = getAssignmentStatusBadgeClass('invalid_status' as any)
-      expect(classes).toContain('gray')
-    })
 
-    it('should return Tailwind utility classes', () => {
-      const classes = getAssignmentStatusBadgeClass('in_progress')
-      // Should have background and text classes
-      expect(classes).toMatch(/bg-\w+/)
-      expect(classes).toMatch(/text-\w+/)
+      expect(classes).toContain('bg-surface-2')
+      expect(classes).toContain('text-text-muted')
+      expect(classes).not.toMatch(rawPaletteUtilityPattern)
     })
   })
 
@@ -742,40 +723,30 @@ describe('assignment utilities', () => {
   // ==========================================================================
 
   describe('getAssignmentStatusIconClass', () => {
-    it('should return gray for not_started', () => {
-      expect(getAssignmentStatusIconClass('not_started')).toBe('text-gray-400')
+    const rawPaletteUtilityPattern =
+      /\btext-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}\b/
+
+    it.each([
+      ['not_started', 'text-text-muted'],
+      ['in_progress', 'text-warning'],
+      ['in_progress_late', 'text-warning'],
+      ['submitted_on_time', 'text-success'],
+      ['submitted_late', 'text-success'],
+      ['graded', 'text-success'],
+      ['returned', 'text-primary'],
+      ['resubmitted', 'text-warning'],
+    ] as const)('returns semantic icon class for %s', (status, iconClass) => {
+      const classes = getAssignmentStatusIconClass(status)
+
+      expect(classes).toBe(iconClass)
+      expect(classes).not.toMatch(rawPaletteUtilityPattern)
     })
 
-    it('should return yellow for in_progress', () => {
-      expect(getAssignmentStatusIconClass('in_progress')).toBe('text-yellow-500')
-    })
+    it('defaults invalid statuses to the muted semantic icon class', () => {
+      const classes = getAssignmentStatusIconClass('invalid_status' as any)
 
-    it('should return yellow for in_progress_late', () => {
-      expect(getAssignmentStatusIconClass('in_progress_late')).toBe('text-yellow-500')
-    })
-
-    it('should return green for submitted_on_time', () => {
-      expect(getAssignmentStatusIconClass('submitted_on_time')).toBe('text-green-500')
-    })
-
-    it('should return green for submitted_late', () => {
-      expect(getAssignmentStatusIconClass('submitted_late')).toBe('text-green-500')
-    })
-
-    it('should return purple for graded', () => {
-      expect(getAssignmentStatusIconClass('graded')).toBe('text-purple-500')
-    })
-
-    it('should return blue for returned', () => {
-      expect(getAssignmentStatusIconClass('returned')).toBe('text-blue-500')
-    })
-
-    it('should return orange for resubmitted', () => {
-      expect(getAssignmentStatusIconClass('resubmitted')).toBe('text-orange-500')
-    })
-
-    it('should return gray for invalid status', () => {
-      expect(getAssignmentStatusIconClass('invalid_status' as any)).toBe('text-gray-400')
+      expect(classes).toBe('text-text-muted')
+      expect(classes).not.toMatch(rawPaletteUtilityPattern)
     })
   })
 


### PR DESCRIPTION
## Summary
- Move assignment status badge and icon helpers from raw Tailwind palette utilities to semantic design tokens.
- Make assignment status badges own the shared rounded-badge pill contract and reuse it in the student assignment list and embedded editor header.
- Add unit/component coverage for semantic badge/icon classes and the embedded student editor badge.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx
- pnpm lint
- pnpm exec tsc --noEmit --pretty false
- pnpm test
- pnpm build
- git diff --check
- E2E_BASE_URL=http://localhost:3019 pnpm e2e:auth
- E2E_BASE_URL=http://localhost:3019 pnpm e2e:verify assessment-ux-parity
- Visual review of /tmp/pika-assignment-list-desktop.png, /tmp/pika-assignment-editor-desktop.png, /tmp/pika-assignment-list-mobile.png, /tmp/pika-assignment-editor-mobile.png
