### PR TITLE
Cache shared class days loader

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -748,3 +748,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3019 pnpm e2e:auth`
 - `E2E_BASE_URL=http://localhost:3019 pnpm e2e:verify assessment-ux-parity`
 - Reviewed screenshots: `/tmp/pika-assignment-list-desktop.png`, `/tmp/pika-assignment-editor-desktop.png`, `/tmp/pika-assignment-list-mobile.png`, `/tmp/pika-assignment-editor-mobile.png`, `artifacts/assessment-ux-parity/student-assignments-reference.png`
+
+## 2026-05-31 — Class-days shared loader cache
+
+**Completed:**
+- Added a shared client loader for classroom class-days backed by `fetchJSONWithCache`.
+- Routed `ClassDaysProvider` and fallback `useClassDays` reads through the shared loader to dedupe concurrent consumers.
+- Routed the teacher assignments summary class-days read through the same loader so non-OK class-days responses do not cache empty successes.
+- Invalidated the class-days cache on explicit provider refresh, class-days update events, and teacher calendar generate/toggle mutations.
+- Added latest-request guards so an older class-days response cannot overwrite state after a forced refresh.
+- Added direct context/hook coverage for cache deduplication, forced refresh, stale response ordering, update-event invalidation, failed responses, and avoiding double-fetches inside the provider.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/contexts/ClassDaysContext.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/components/StudentLessonCalendarTab.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`

--- a/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherCalendarTab.tsx
@@ -10,6 +10,7 @@ import type { ClassDay, Classroom } from '@/types'
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, addMonths, parseISO } from 'date-fns'
 import { getTodayInToronto } from '@/lib/timezone'
 import { CLASS_DAYS_UPDATED_EVENT } from '@/lib/events'
+import { invalidateClassDaysForClassroom } from '@/lib/class-days-client'
 
 interface Props {
   classroom: Classroom
@@ -86,6 +87,7 @@ export function TeacherCalendarTab({ classroom }: Props) {
       }
       showMessage({ text: `Generated ${data.count ?? 0} days`, tone: 'success' })
       // Notify context and other components to refresh class days
+      invalidateClassDaysForClassroom(classroom.id)
       window.dispatchEvent(new CustomEvent(CLASS_DAYS_UPDATED_EVENT, { detail: { classroomId: classroom.id } }))
     } catch (err: any) {
       setError(err.message || 'Failed to generate class days')
@@ -134,6 +136,7 @@ export function TeacherCalendarTab({ classroom }: Props) {
         return next
       })
       // Notify other components (e.g., calendar) that class days changed
+      invalidateClassDaysForClassroom(classroom.id)
       window.dispatchEvent(new CustomEvent(CLASS_DAYS_UPDATED_EVENT, { detail: { classroomId: classroom.id } }))
     } catch (err: any) {
       setError(err.message || 'Failed to update day')

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -106,6 +106,7 @@ import {
 import { applyDirection, compareByNameFields, toggleSort as toggleSortState } from '@/lib/table-sort'
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { safeSessionGetJson, safeSessionSetJson } from '@/lib/client-storage'
 
@@ -706,7 +707,7 @@ export function TeacherClassroomView({
       setLoading(true)
     }
     try {
-      const [assignmentsData, materialsData, surveysData, classDaysRes] = await Promise.all([
+      const [assignmentsData, materialsData, surveysData, classDaysData] = await Promise.all([
         fetchJSONWithCache(
           `teacher-assignments:${classroom.id}`,
           async () => {
@@ -734,20 +735,15 @@ export function TeacherClassroomView({
           },
           20_000,
         ).catch(() => ({ surveys: [] })),
-        fetchJSONWithCache(
-          `class-days:${classroom.id}`,
-          async () => {
-            const response = await fetch(`/api/classrooms/${classroom.id}/class-days`)
-            if (!response.ok) return { class_days: [] }
-            return response.json().catch(() => ({ class_days: [] }))
-          },
-          20_000,
-        ),
+        fetchClassDaysForClassroom(classroom.id).catch((err) => {
+          console.error('Error loading class days:', err)
+          return []
+        }),
       ])
       setAssignments(assignmentsData.assignments || [])
       setMaterials(materialsData.materials || [])
       setSurveys(surveysData.surveys || [])
-      setClassDays(classDaysRes.class_days || [])
+      setClassDays(classDaysData)
       setHasLoadedOnce(true)
       window.dispatchEvent(
         new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {

--- a/src/contexts/ClassDaysContext.tsx
+++ b/src/contexts/ClassDaysContext.tsx
@@ -1,8 +1,12 @@
 'use client'
 
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react'
 import type { ClassDay } from '@/types'
 import { CLASS_DAYS_UPDATED_EVENT } from '@/lib/events'
+import {
+  fetchClassDaysForClassroom,
+  invalidateClassDaysForClassroom,
+} from '@/lib/class-days-client'
 
 interface ClassDaysContextValue {
   classDays: ClassDay[]
@@ -24,16 +28,28 @@ interface ClassDaysProviderProps {
 export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderProps) {
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const loadSequenceRef = useRef(0)
 
-  const loadClassDays = useCallback(async () => {
+  const loadClassDays = useCallback(async (options?: { force?: boolean }) => {
+    const loadSequence = loadSequenceRef.current + 1
+    loadSequenceRef.current = loadSequence
+
     try {
-      const res = await fetch(`/api/classrooms/${classroomId}/class-days`)
-      const data = await res.json()
-      setClassDays(data.class_days || [])
+      if (options?.force) {
+        invalidateClassDaysForClassroom(classroomId)
+      }
+      const nextClassDays = await fetchClassDaysForClassroom(classroomId)
+      if (loadSequenceRef.current === loadSequence) {
+        setClassDays(nextClassDays)
+      }
     } catch (err) {
-      console.error('Error loading class days:', err)
+      if (loadSequenceRef.current === loadSequence) {
+        console.error('Error loading class days:', err)
+      }
     } finally {
-      setIsLoading(false)
+      if (loadSequenceRef.current === loadSequence) {
+        setIsLoading(false)
+      }
     }
   }, [classroomId])
 
@@ -46,7 +62,7 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
   useEffect(() => {
     const handleClassDaysUpdated = (e: CustomEvent<{ classroomId: string }>) => {
       if (e.detail.classroomId === classroomId) {
-        loadClassDays()
+        loadClassDays({ force: true })
       }
     }
 
@@ -57,7 +73,7 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
   }, [classroomId, loadClassDays])
 
   return (
-    <ClassDaysContext.Provider value={{ classDays, isLoading, refresh: loadClassDays }}>
+    <ClassDaysContext.Provider value={{ classDays, isLoading, refresh: () => loadClassDays({ force: true }) }}>
       {children}
     </ClassDaysContext.Provider>
   )
@@ -90,25 +106,38 @@ export function useClassDays(classroomId: string): ClassDay[] {
     // Skip fetching if we have context - provider handles it
     if (hasContext) return
 
-    async function loadClassDays() {
+    let isActive = true
+    let loadSequence = 0
+
+    async function loadClassDays(options?: { force?: boolean }) {
+      loadSequence += 1
+      const currentLoadSequence = loadSequence
+
       try {
-        const res = await fetch(`/api/classrooms/${classroomId}/class-days`)
-        const data = await res.json()
-        setFallbackClassDays(data.class_days || [])
+        if (options?.force) {
+          invalidateClassDaysForClassroom(classroomId)
+        }
+        const nextClassDays = await fetchClassDaysForClassroom(classroomId)
+        if (isActive && currentLoadSequence === loadSequence) {
+          setFallbackClassDays(nextClassDays)
+        }
       } catch (err) {
-        console.error('Error loading class days:', err)
+        if (isActive && currentLoadSequence === loadSequence) {
+          console.error('Error loading class days:', err)
+        }
       }
     }
     loadClassDays()
 
     const handleClassDaysUpdated = (e: CustomEvent<{ classroomId: string }>) => {
       if (e.detail.classroomId === classroomId) {
-        loadClassDays()
+        loadClassDays({ force: true })
       }
     }
 
     window.addEventListener(CLASS_DAYS_UPDATED_EVENT, handleClassDaysUpdated as EventListener)
     return () => {
+      isActive = false
       window.removeEventListener(CLASS_DAYS_UPDATED_EVENT, handleClassDaysUpdated as EventListener)
     }
   }, [classroomId, hasContext])

--- a/src/lib/class-days-client.ts
+++ b/src/lib/class-days-client.ts
@@ -1,0 +1,34 @@
+import type { ClassDay } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+
+type ClassDaysResponse = {
+  class_days?: ClassDay[]
+}
+
+const CLASS_DAYS_CACHE_TTL_MS = 20_000
+
+export function getClassDaysCacheKey(classroomId: string): string {
+  return `class-days:${classroomId}`
+}
+
+export async function fetchClassDaysForClassroom(classroomId: string): Promise<ClassDay[]> {
+  const data = await fetchJSONWithCache<ClassDaysResponse>(
+    getClassDaysCacheKey(classroomId),
+    async () => {
+      const response = await fetch(`/api/classrooms/${classroomId}/class-days`)
+      const data = await response.json().catch(() => ({ class_days: [] }))
+      if (!response.ok) {
+        const message = typeof data.error === 'string' ? data.error : 'Failed to load class days'
+        throw new Error(message)
+      }
+      return data
+    },
+    CLASS_DAYS_CACHE_TTL_MS,
+  )
+
+  return data.class_days || []
+}
+
+export function invalidateClassDaysForClassroom(classroomId: string) {
+  invalidateCachedJSON(getClassDaysCacheKey(classroomId))
+}

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -7,6 +7,7 @@ import type { Classroom, ClassworkMaterial, SurveyWithStats } from '@/types'
 
 const mockFetchJSONWithCache = vi.fn()
 const mockInvalidateCachedJSON = vi.fn()
+const mockFetchClassDaysForClassroom = vi.fn()
 const mockToggleSelect = vi.fn()
 const mockToggleSelectAll = vi.fn()
 const mockClearSelection = vi.fn()
@@ -401,6 +402,10 @@ vi.mock('@/lib/request-cache', () => ({
   invalidateCachedJSON: (...args: any[]) => mockInvalidateCachedJSON(...args),
 }))
 
+vi.mock('@/lib/class-days-client', () => ({
+  fetchClassDaysForClassroom: (...args: any[]) => mockFetchClassDaysForClassroom(...args),
+}))
+
 vi.mock('@/hooks/use-window-size', () => ({
   useWindowSize: () => ({ width: 1440, height: 900 }),
 }))
@@ -597,6 +602,8 @@ describe('TeacherClassroomView', () => {
     window.sessionStorage.clear()
     clearSelectionCookie()
     clearAssignmentWorkspaceStudentCookie()
+    mockFetchClassDaysForClassroom.mockReset()
+    mockFetchClassDaysForClassroom.mockResolvedValue([])
     mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
       if (key === `teacher-assignments:${classroom.id}`) {
         return Promise.resolve({
@@ -635,6 +642,25 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('uses the shared class-days client without caching failed class-day loads as empty successes', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchClassDaysForClassroom.mockRejectedValueOnce(new Error('Class days unavailable'))
+
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    expect(mockFetchClassDaysForClassroom).toHaveBeenCalledWith(classroom.id)
+    expect(mockFetchJSONWithCache).not.toHaveBeenCalledWith(
+      `class-days:${classroom.id}`,
+      expect.any(Function),
+      expect.any(Number),
+    )
+    expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
   })
 
   it('keeps New visible with an Edit Markdown dropdown action while edit mode is active', async () => {

--- a/tests/contexts/ClassDaysContext.test.tsx
+++ b/tests/contexts/ClassDaysContext.test.tsx
@@ -1,0 +1,259 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ClassDaysProvider,
+  useClassDays,
+  useClassDaysContext,
+} from '@/contexts/ClassDaysContext'
+import { CLASS_DAYS_UPDATED_EVENT } from '@/lib/events'
+import { invalidateCachedJSON } from '@/lib/request-cache'
+import type { ClassDay } from '@/types'
+
+function classDay(date: string, isClassDay = true): ClassDay {
+  return {
+    date,
+    is_class_day: isClassDay,
+    prompt_text: null,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function ContextProbe({ label = 'probe' }: { label?: string }) {
+  const { classDays, isLoading, refresh } = useClassDaysContext()
+  return (
+    <div>
+      <div data-testid={`${label}-loading`}>{String(isLoading)}</div>
+      <div data-testid={`${label}-dates`}>{classDays.map((day) => day.date).join(',')}</div>
+      <button type="button" onClick={() => void refresh()}>
+        Refresh {label}
+      </button>
+    </div>
+  )
+}
+
+function ClassDaysProbe({ classroomId }: { classroomId: string }) {
+  const classDays = useClassDays(classroomId)
+  return <div data-testid="class-days-hook">{classDays.map((day) => day.date).join(',')}</div>
+}
+
+describe('ClassDaysProvider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    invalidateCachedJSON('class-days:classroom-1')
+    invalidateCachedJSON('class-days:classroom-2')
+  })
+
+  afterEach(() => {
+    invalidateCachedJSON('class-days:classroom-1')
+    invalidateCachedJSON('class-days:classroom-2')
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('deduplicates concurrent provider loads through the shared request cache', async () => {
+    const load = deferred<{ class_days: ClassDay[] }>()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        json: () => load.promise,
+      } as Response),
+    )
+
+    render(
+      <>
+        <ClassDaysProvider classroomId="classroom-1">
+          <ContextProbe label="first" />
+        </ClassDaysProvider>
+        <ClassDaysProvider classroomId="classroom-1">
+          <ContextProbe label="second" />
+        </ClassDaysProvider>
+      </>,
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/api/classrooms/classroom-1/class-days')
+
+    await act(async () => {
+      load.resolve({ class_days: [classDay('2026-05-01')] })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('first-loading')).toHaveTextContent('false')
+      expect(screen.getByTestId('second-loading')).toHaveTextContent('false')
+    })
+    expect(screen.getByTestId('first-dates')).toHaveTextContent('2026-05-01')
+    expect(screen.getByTestId('second-dates')).toHaveTextContent('2026-05-01')
+  })
+
+  it('forces a fresh load when refresh is called', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-01')] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-02')] }),
+      } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    await screen.findByText('2026-05-01')
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Refresh probe' }).click()
+    })
+
+    await screen.findByText('2026-05-02')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores stale class-days responses that resolve after a forced refresh', async () => {
+    const initialLoad = deferred<{ class_days: ClassDay[] }>()
+    const refreshLoad = deferred<{ class_days: ClassDay[] }>()
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => initialLoad.promise,
+        } as Response),
+      )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => refreshLoad.promise,
+        } as Response),
+      )
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Refresh probe' }).click()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      refreshLoad.resolve({ class_days: [classDay('2026-05-02')] })
+    })
+
+    await screen.findByText('2026-05-02')
+
+    await act(async () => {
+      initialLoad.resolve({ class_days: [classDay('2026-05-01')] })
+    })
+
+    expect(screen.getByTestId('probe-dates')).toHaveTextContent('2026-05-02')
+  })
+
+  it('invalidates cached class days before handling a matching update event', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-01')] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-03')] }),
+      } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    await screen.findByText('2026-05-01')
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(CLASS_DAYS_UPDATED_EVENT, { detail: { classroomId: 'classroom-2' } }),
+      )
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(CLASS_DAYS_UPDATED_EVENT, { detail: { classroomId: 'classroom-1' } }),
+      )
+    })
+
+    await screen.findByText('2026-05-03')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('lets useClassDays read provider state without a second request', async () => {
+    const fetchMock = vi.mocked(fetch)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ class_days: [classDay('2026-05-01')] }),
+    } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ClassDaysProbe classroomId="classroom-1" />
+      </ClassDaysProvider>,
+    )
+
+    await screen.findByText('2026-05-01')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache failed class-days responses', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchMock = vi.mocked(fetch)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Class days unavailable' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ class_days: [classDay('2026-05-04')] }),
+      } as Response)
+
+    render(
+      <ClassDaysProvider classroomId="classroom-1">
+        <ContextProbe />
+      </ClassDaysProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-loading')).toHaveTextContent('false')
+    })
+    expect(screen.getByTestId('probe-dates')).toHaveTextContent('')
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Refresh probe' }).click()
+    })
+
+    await screen.findByText('2026-05-04')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
+  })
+})


### PR DESCRIPTION
## Summary
- Add a shared class-days client loader backed by `fetchJSONWithCache`.
- Route `ClassDaysProvider` and fallback `useClassDays` reads through the shared loader to dedupe repeated class-days requests.
- Invalidate class-days cache on explicit refresh, class-days update events, and teacher calendar generate/toggle mutations.
- Add direct context/hook coverage for cache deduplication and refresh invalidation behavior.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/contexts/ClassDaysContext.test.tsx tests/components/TeacherAttendanceTab.test.tsx tests/components/StudentTodayTabHistory.test.tsx tests/components/StudentLessonCalendarTab.test.tsx
- pnpm lint
- pnpm exec tsc --noEmit --pretty false
- pnpm test
- pnpm build
- git diff --check
