### PR TITLE
Harden PageActionBar menu focus

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -779,3 +779,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `VITEST_MAX_WORKERS=4 bash scripts/verify-env.sh`
 - `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"`
 - `pnpm lint`
+## 2026-05-31 — PageActionBar mobile menu focus
+
+**Completed:**
+- Added explicit focus management for the shared `PageActionBar` mobile overflow menu.
+- Connected the overflow trigger to its menu with `aria-controls`.
+- Moved focus to the first enabled menu item on open, added arrow/Home/End menu navigation, and restored focus to the trigger on Escape, outside close, and item selection.
+- Added component coverage for trigger/menu relationships, focus movement, keyboard navigation, and focus restoration.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/PageActionBar.test.tsx tests/ui/SplitButton.test.tsx`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test`
+- `pnpm build`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3021 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh teacher/dashboard`
+- Manual Playwright mobile menu check: focus moved from `Course blueprints` to `Open classroom` with ArrowDown, Escape returned focus to `Open actions menu`, and the menu closed.
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-page-actionbar-menu-mobile-viewport.png`, `/tmp/pika-page-actionbar-menu-mobile-keyboard.png`

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { createContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createContext, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { MoreVertical } from 'lucide-react'
 import { buttonVariants } from '@/ui/Button'
 import { cn } from '@/ui/utils'
@@ -95,19 +95,64 @@ export function PageStack({
 function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const menuId = useId()
+
+  const getEnabledMenuItems = useCallback(() => {
+    return Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+    ).filter((item) => !item.disabled)
+  }, [])
+
+  const closeMenu = useCallback((options?: { restoreFocus?: boolean }) => {
+    setOpen(false)
+    if (options?.restoreFocus) {
+      buttonRef.current?.focus()
+    }
+  }, [])
 
   useEffect(() => {
     if (!open) return
 
+    const enabledItems = getEnabledMenuItems()
+    enabledItems[0]?.focus()
+
     function onMouseDown(e: MouseEvent) {
       if (!containerRef.current) return
       if (e.target instanceof Node && !containerRef.current.contains(e.target)) {
-        setOpen(false)
+        closeMenu({ restoreFocus: true })
       }
     }
 
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') {
+        closeMenu({ restoreFocus: true })
+        return
+      }
+
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) return
+
+      const enabledItems = getEnabledMenuItems()
+      if (enabledItems.length === 0) return
+
+      e.preventDefault()
+      const currentIndex = enabledItems.indexOf(document.activeElement as HTMLButtonElement)
+      const lastIndex = enabledItems.length - 1
+      const nextIndex =
+        e.key === 'Home'
+          ? 0
+          : e.key === 'End'
+            ? lastIndex
+            : e.key === 'ArrowUp'
+              ? currentIndex <= 0
+                ? lastIndex
+                : currentIndex - 1
+              : currentIndex === -1 || currentIndex === lastIndex
+                ? 0
+                : currentIndex + 1
+
+      enabledItems[nextIndex]?.focus()
     }
 
     document.addEventListener('mousedown', onMouseDown)
@@ -116,7 +161,7 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
       document.removeEventListener('mousedown', onMouseDown)
       window.removeEventListener('keydown', onKeyDown)
     }
-  }, [open])
+  }, [closeMenu, getEnabledMenuItems, open])
 
   const { normalItems, destructiveItems } = useMemo(() => {
     return {
@@ -130,11 +175,19 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
   return (
     <div className="relative" ref={containerRef}>
       <button
+        ref={buttonRef}
         type="button"
         className={ACTIONBAR_ICON_BUTTON_CLASSNAME}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={() => {
+          if (open) {
+            closeMenu({ restoreFocus: true })
+            return
+          }
+          setOpen(true)
+        }}
         aria-label="Open actions menu"
         aria-haspopup="menu"
+        aria-controls={menuId}
         aria-expanded={open}
       >
         <MoreVertical className="h-5 w-5 text-text-default" aria-hidden="true" />
@@ -142,6 +195,8 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
 
       {open && (
         <div
+          id={menuId}
+          ref={menuRef}
           role="menu"
           className="absolute right-0 z-20 mt-2 w-56 overflow-hidden rounded-md border border-border bg-surface shadow-lg"
         >
@@ -152,7 +207,7 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
               role="menuitem"
               disabled={item.disabled}
               onClick={() => {
-                setOpen(false)
+                closeMenu({ restoreFocus: true })
                 item.onSelect()
               }}
               className="w-full text-left px-3 py-2 text-sm text-text-default hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed"
@@ -170,7 +225,7 @@ function ActionBarMenu({ items }: { items: ActionBarItem[] }) {
                   role="menuitem"
                   disabled={item.disabled}
                   onClick={() => {
-                    setOpen(false)
+                    closeMenu({ restoreFocus: true })
                     item.onSelect()
                   }}
                   className="w-full text-left px-3 py-2 text-sm text-danger hover:bg-danger-bg disabled:opacity-50 disabled:cursor-not-allowed"

--- a/tests/components/PageActionBar.test.tsx
+++ b/tests/components/PageActionBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { PageActionBar, type ActionBarItem } from '@/components/PageLayout'
 
@@ -25,11 +25,12 @@ describe('PageActionBar', () => {
 
     const menuButton = screen.getByRole('button', { name: 'Open actions menu' })
     expect(menuButton).toHaveAttribute('aria-haspopup', 'menu')
+    expect(menuButton).toHaveAttribute('aria-controls')
     expect(menuButton).toHaveAttribute('aria-expanded', 'false')
     expect(menuButton.parentElement?.parentElement).toHaveClass('sm:hidden')
   })
 
-  it('opens mobile actions, groups destructive items last, and closes after selection', () => {
+  it('opens mobile actions, groups destructive items last, and closes after selection', async () => {
     const onArchive = vi.fn()
     const onDelete = vi.fn()
 
@@ -43,11 +44,15 @@ describe('PageActionBar', () => {
 
     expect(menuButton).toHaveAttribute('aria-expanded', 'true')
     const menu = screen.getByRole('menu')
+    expect(menuButton).toHaveAttribute('aria-controls', menu.id)
     expect(menu).toHaveClass('absolute', 'right-0', 'z-20', 'mt-2', 'w-56')
 
     const menuItems = within(menu).getAllByRole('menuitem')
     expect(menuItems.map((item) => item.textContent)).toEqual(['Archive', 'Delete'])
     expect(menuItems[1].parentElement).toHaveClass('border-t', 'border-border')
+    await waitFor(() => {
+      expect(within(menu).getByRole('menuitem', { name: 'Archive' })).toHaveFocus()
+    })
 
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Archive' }))
 
@@ -55,9 +60,41 @@ describe('PageActionBar', () => {
     expect(onDelete).not.toHaveBeenCalled()
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+    expect(menuButton).toHaveFocus()
   })
 
-  it('closes the mobile actions menu on escape and outside click', () => {
+  it('supports keyboard navigation and returns focus to the trigger on escape', async () => {
+    renderActionBar([
+      { id: 'archive', label: 'Archive', onSelect: vi.fn() },
+      { id: 'delete', label: 'Delete', destructive: true, onSelect: vi.fn() },
+    ])
+
+    const menuButton = screen.getByRole('button', { name: 'Open actions menu' })
+
+    fireEvent.click(menuButton)
+    const menu = screen.getByRole('menu')
+    const archiveItem = within(menu).getByRole('menuitem', { name: 'Archive' })
+    const deleteItem = within(menu).getByRole('menuitem', { name: 'Delete' })
+
+    await waitFor(() => {
+      expect(archiveItem).toHaveFocus()
+    })
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(deleteItem).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(archiveItem).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'End' })
+    expect(deleteItem).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(menuButton).toHaveFocus()
+  })
+
+  it('closes the mobile actions menu on escape and outside click', async () => {
     renderActionBar([
       { id: 'archive', label: 'Archive', onSelect: vi.fn() },
     ])
@@ -66,13 +103,18 @@ describe('PageActionBar', () => {
 
     fireEvent.click(menuButton)
     expect(screen.getByRole('menu')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Archive' })).toHaveFocus()
+    })
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(menuButton).toHaveFocus()
 
     fireEvent.click(menuButton)
     expect(screen.getByRole('menu')).toBeInTheDocument()
     fireEvent.mouseDown(document.body)
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(menuButton).toHaveFocus()
   })
 
   it('preserves disabled mobile actions without firing their handlers', () => {


### PR DESCRIPTION
## Summary
- add explicit focus management for the shared PageActionBar mobile overflow menu
- connect the trigger to its menu with aria-controls
- move focus into enabled menu items on open, support ArrowUp/ArrowDown/Home/End, and restore focus to the trigger on Escape, outside close, and item selection
- add component coverage for menu relationships, keyboard navigation, and focus restoration

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/components/PageActionBar.test.tsx tests/ui/SplitButton.test.tsx
- pnpm lint
- pnpm exec tsc --noEmit --pretty false
- pnpm test
- pnpm build
- git diff --check
- E2E_BASE_URL=http://localhost:3021 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh teacher/dashboard
- manual Playwright mobile menu check: focus moved from Course blueprints to Open classroom with ArrowDown, Escape returned focus to Open actions menu, and the menu closed

Composite widget accessibility checklist reviewed: yes. Keyboard behavior covered: yes. Semantic state covered by tests: yes. Remaining manual follow-up: none.