### PR TITLE
Harden SplitButton menu focus

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -779,6 +779,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `VITEST_MAX_WORKERS=4 bash scripts/verify-env.sh`
 - `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"`
 - `pnpm lint`
+
 ## 2026-05-31 — PageActionBar mobile menu focus
 
 **Completed:**
@@ -798,3 +799,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3021 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh teacher/dashboard`
 - Manual Playwright mobile menu check: focus moved from `Course blueprints` to `Open classroom` with ArrowDown, Escape returned focus to `Open actions menu`, and the menu closed.
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-page-actionbar-menu-mobile-viewport.png`, `/tmp/pika-page-actionbar-menu-mobile-keyboard.png`
+
+## 2026-05-31 — SplitButton menu focus
+
+**Completed:**
+- Hardened the shared `SplitButton` menu with focus-on-open, arrow/Home/End navigation over enabled items, and focus restoration to the opener on Escape, outside close, and item selection.
+- Added semantic component coverage for disabled-item skipping, wraparound keyboard movement, Escape close behavior, and selection focus restoration.
+- Addressed review follow-ups so parent rerenders from menu focus/hover do not reset keyboard focus, existing modal actions still restore focus normally, and `DialogPanel` moves focus into modal dialogs even when they open after async menu work.
+- Verified the teacher tests tab visually after the shared primitive change.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/ui/SplitButton.test.tsx`
+- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
+- `pnpm test tests/ui/SplitButton.test.tsx tests/ui/Dialog.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
+- `pnpm test tests/ui/Dialog.test.tsx tests/ui/SplitButton.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `E2E_BASE_URL=http://localhost:3022 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -301,6 +301,16 @@ export function DialogPanel({
   ariaLabelledBy,
   children,
 }: DialogPanelProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const panel = panelRef.current
+    if (!panel) return
+    if (document.activeElement && panel.contains(document.activeElement)) return
+    panel.focus()
+  }, [isOpen])
+
   useEffect(() => {
     if (!isOpen) return
     function handleKeyDown(e: KeyboardEvent) {
@@ -321,10 +331,12 @@ export function DialogPanel({
         onClick={onClose}
       />
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={ariaLabelledBy}
-        className={`${dialogPanelStyles()} ${maxWidth} max-w-[90vw] max-h-[85vh] flex flex-col ${className ?? ''}`}
+        tabIndex={-1}
+        className={`${dialogPanelStyles()} ${maxWidth} max-w-[90vw] max-h-[85vh] flex flex-col focus:outline-none ${className ?? ''}`}
       >
         {children}
       </div>

--- a/src/ui/SplitButton.tsx
+++ b/src/ui/SplitButton.tsx
@@ -58,6 +58,11 @@ export function SplitButton({
   const { className: primaryClassName, ...restPrimaryButtonProps } = primaryButtonProps ?? {}
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null)
+  const toggleButtonRef = useRef<HTMLButtonElement | null>(null)
+  const activeTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const focusedOnOpenRef = useRef(false)
   const menuId = useId()
   const normalOptions = options.filter((option) => !option.destructive)
   const destructiveOptions = options.filter((option) => option.destructive)
@@ -69,50 +74,110 @@ export function SplitButton({
     options.forEach((option) => option.onHoverChange?.(false))
   }, [options])
 
-  const closeMenu = useCallback(() => {
+  const getEnabledMenuItems = useCallback(() => {
+    return Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitem"], [role="menuitemradio"]'
+      ) ?? []
+    ).filter((item) => !item.disabled)
+  }, [])
+
+  const closeMenu = useCallback((options?: { restoreFocus?: boolean }) => {
     clearOptionHover()
     setIsOpen(false)
+    focusedOnOpenRef.current = false
+    if (options?.restoreFocus) {
+      activeTriggerRef.current?.focus()
+    }
   }, [clearOptionHover])
 
+  const restoreFocusIfNoNewModalOpened = useCallback((existingModals: Set<Element>) => {
+    window.requestAnimationFrame(() => {
+      const currentModals = Array.from(document.querySelectorAll('[aria-modal="true"]'))
+      if (currentModals.some((modal) => !existingModals.has(modal))) return
+      const activeElement = document.activeElement
+      if (activeElement === document.body || activeElement === null) {
+        activeTriggerRef.current?.focus()
+      }
+    })
+  }, [])
+
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen) {
+      focusedOnOpenRef.current = false
+      return
+    }
+
+    if (!focusedOnOpenRef.current) {
+      getEnabledMenuItems()[0]?.focus()
+      focusedOnOpenRef.current = true
+    }
 
     function handleClickOutside(event: MouseEvent) {
       if (!containerRef.current) return
       if (!containerRef.current.contains(event.target as Node)) {
-        closeMenu()
+        closeMenu({ restoreFocus: true })
       }
     }
 
-    function handleEscape(event: KeyboardEvent) {
+    function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        closeMenu()
+        closeMenu({ restoreFocus: true })
+        return
       }
+
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+
+      const enabledItems = getEnabledMenuItems()
+      if (enabledItems.length === 0) return
+
+      event.preventDefault()
+      const currentIndex = enabledItems.indexOf(document.activeElement as HTMLButtonElement)
+      const lastIndex = enabledItems.length - 1
+      const nextIndex =
+        event.key === 'Home'
+          ? 0
+          : event.key === 'End'
+            ? lastIndex
+            : event.key === 'ArrowUp'
+              ? currentIndex <= 0
+                ? lastIndex
+                : currentIndex - 1
+              : currentIndex === -1 || currentIndex === lastIndex
+                ? 0
+                : currentIndex + 1
+
+      enabledItems[nextIndex]?.focus()
     }
 
     document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
+    window.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
+      window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [closeMenu, isOpen])
+  }, [closeMenu, getEnabledMenuItems, isOpen])
 
   function handleOptionSelect(onSelect: () => void) {
+    const existingModals = new Set(document.querySelectorAll('[aria-modal="true"]'))
     closeMenu()
     onSelect()
+    restoreFocusIfNoNewModalOpened(existingModals)
   }
 
-  function toggleMenu() {
-    setIsOpen((prev) => {
-      if (prev) clearOptionHover()
-      return !prev
-    })
+  function toggleMenu(trigger: HTMLButtonElement) {
+    if (isOpen) {
+      closeMenu({ restoreFocus: true })
+      return
+    }
+    activeTriggerRef.current = trigger
+    setIsOpen(true)
   }
 
   return (
     <div ref={containerRef} className={cn('relative inline-flex', className)}>
       <Button
+        ref={primaryButtonRef}
         type="button"
         variant={variant}
         size={size}
@@ -126,7 +191,7 @@ export function SplitButton({
           }
 
           event.stopPropagation()
-          toggleMenu()
+          toggleMenu(primaryButtonRef.current ?? event.currentTarget)
         }}
         disabled={disabled || (primaryOpensMenu && options.length === 0)}
         className={cn('rounded-r-none', primaryClassName)}
@@ -135,6 +200,7 @@ export function SplitButton({
         {label}
       </Button>
       <Button
+        ref={toggleButtonRef}
         type="button"
         variant={variant}
         size={size}
@@ -144,7 +210,7 @@ export function SplitButton({
         aria-label={toggleAriaLabel}
         onClick={(event) => {
           event.stopPropagation()
-          toggleMenu()
+          toggleMenu(toggleButtonRef.current ?? event.currentTarget)
         }}
         disabled={disabled || options.length === 0}
         className={cn('rounded-l-none border-l border-black/15 px-3', toggleButtonClassName)}
@@ -155,6 +221,7 @@ export function SplitButton({
       {isOpen && (
         <div
           id={menuId}
+          ref={menuRef}
           role="menu"
           onClick={(event) => event.stopPropagation()}
           className={cn(

--- a/tests/ui/Dialog.test.tsx
+++ b/tests/ui/Dialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useEffect, useRef } from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { AlertDialog, ConfirmDialog, ContentDialog } from '@/ui'
+import { AlertDialog, ConfirmDialog, ContentDialog, DialogPanel } from '@/ui'
 
 describe('AlertDialog', () => {
   const defaultProps = {
@@ -263,5 +264,38 @@ describe('ContentDialog', () => {
     const footerButton = closeButtons.find((btn) => btn.textContent === 'Close')!
     const footer = footerButton.parentElement!
     expect(footer.className).toContain('flex-shrink-0')
+  })
+})
+
+describe('DialogPanel', () => {
+  it('focuses the dialog panel when opened without an inner focus target', async () => {
+    render(
+      <DialogPanel isOpen onClose={vi.fn()} ariaLabelledBy="panel-title">
+        <h2 id="panel-title">Panel title</h2>
+      </DialogPanel>
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Panel title' })
+    await waitFor(() => expect(dialog).toHaveFocus())
+  })
+
+  it('does not steal focus from a child that focuses itself on open', async () => {
+    function AutofocusField() {
+      const inputRef = useRef<HTMLInputElement | null>(null)
+      useEffect(() => {
+        inputRef.current?.focus()
+      }, [])
+      return <input ref={inputRef} aria-label="Classroom name" />
+    }
+
+    render(
+      <DialogPanel isOpen onClose={vi.fn()} ariaLabelledBy="panel-title">
+        <h2 id="panel-title">Panel title</h2>
+        <AutofocusField />
+      </DialogPanel>
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Classroom name' })
+    await waitFor(() => expect(input).toHaveFocus())
   })
 })

--- a/tests/ui/SplitButton.test.tsx
+++ b/tests/ui/SplitButton.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, within } from '@testing-library/react'
-import { SplitButton } from '@/ui'
+import { useState } from 'react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { DialogPanel, SplitButton } from '@/ui'
 
 describe('SplitButton', () => {
   it('runs primary action when main button is clicked', () => {
@@ -22,7 +23,7 @@ describe('SplitButton', () => {
     expect(onSelectDraft).not.toHaveBeenCalled()
   })
 
-  it('opens menu and runs selected option action', () => {
+  it('opens menu and runs selected option action', async () => {
     const onPrimaryClick = vi.fn()
     const onSelectSchedule = vi.fn()
 
@@ -37,12 +38,14 @@ describe('SplitButton', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Choose action' }))
+    const toggle = screen.getByRole('button', { name: 'Choose action' })
+    fireEvent.click(toggle)
     fireEvent.click(screen.getByRole('menuitem', { name: 'Schedule' }))
 
     expect(onSelectSchedule).toHaveBeenCalledOnce()
     expect(onPrimaryClick).not.toHaveBeenCalled()
     expect(screen.queryByRole('menuitem', { name: 'Schedule' })).not.toBeInTheDocument()
+    await waitFor(() => expect(toggle).toHaveFocus())
   })
 
   it('can use the primary button to open the menu', () => {
@@ -106,6 +109,215 @@ describe('SplitButton', () => {
 
     fireEvent.click(option)
     expect(onHoverChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('moves focus to the first enabled menu option when opened', () => {
+    render(
+      <SplitButton
+        label="Post"
+        onPrimaryClick={vi.fn()}
+        options={[
+          { id: 'draft', label: 'Draft', onSelect: vi.fn(), disabled: true },
+          { id: 'schedule', label: 'Schedule', onSelect: vi.fn() },
+          { id: 'publish', label: 'Publish now', onSelect: vi.fn() },
+        ]}
+        toggleAriaLabel="Choose action"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose action' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Schedule' })).toHaveFocus()
+  })
+
+  it('supports arrow, home, and end keyboard navigation across enabled menu options', () => {
+    render(
+      <SplitButton
+        label="Post"
+        onPrimaryClick={vi.fn()}
+        options={[
+          { id: 'draft', label: 'Draft', onSelect: vi.fn() },
+          { id: 'schedule', label: 'Schedule', onSelect: vi.fn(), disabled: true },
+          { id: 'publish', label: 'Publish now', onSelect: vi.fn() },
+          { id: 'delete', label: 'Delete', onSelect: vi.fn(), destructive: true },
+        ]}
+        toggleAriaLabel="Choose action"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose action' }))
+
+    const draft = screen.getByRole('menuitem', { name: 'Draft' })
+    const publish = screen.getByRole('menuitem', { name: 'Publish now' })
+    const deleteOption = screen.getByRole('menuitem', { name: 'Delete' })
+
+    expect(draft).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(publish).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'End' })
+    expect(deleteOption).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(draft).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    expect(deleteOption).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'Home' })
+    expect(draft).toHaveFocus()
+  })
+
+  it('keeps keyboard focus position when menu item focus causes a parent rerender', async () => {
+    function RerenderingMenu() {
+      const [, setHoveredItem] = useState<string | null>(null)
+      return (
+        <SplitButton
+          label="Apply"
+          onPrimaryClick={vi.fn()}
+          options={[
+            {
+              id: 'grade',
+              label: 'Apply Grade',
+              onSelect: vi.fn(),
+              onHoverChange: (active) => setHoveredItem(active ? 'grade' : null),
+            },
+            {
+              id: 'comments',
+              label: 'Apply Comments',
+              onSelect: vi.fn(),
+              onHoverChange: (active) => setHoveredItem(active ? 'comments' : null),
+            },
+          ]}
+          toggleAriaLabel="Apply actions"
+        />
+      )
+    }
+
+    render(<RerenderingMenu />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply actions' }))
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Apply Comments' })).toHaveFocus()
+    })
+  })
+
+  it('closes with Escape and restores focus to the opener', () => {
+    render(
+      <SplitButton
+        label="Add"
+        onPrimaryClick={vi.fn()}
+        primaryOpensMenu
+        options={[
+          { id: 'link', label: 'Link', onSelect: vi.fn() },
+        ]}
+      />
+    )
+
+    const primary = screen.getByRole('button', { name: 'Add' })
+    fireEvent.click(primary)
+    expect(screen.getByRole('menuitem', { name: 'Link' })).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(primary).toHaveFocus()
+  })
+
+  it('does not restore focus to the opener when selected action opens a modal dialog', async () => {
+    function DialogOpeningMenu() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <SplitButton
+            label="Actions"
+            onPrimaryClick={vi.fn()}
+            options={[
+              { id: 'confirm', label: 'Open confirm', onSelect: () => setOpen(true) },
+            ]}
+            toggleAriaLabel="More actions"
+          />
+          <DialogPanel isOpen={open} onClose={() => setOpen(false)} ariaLabelledBy="confirm-title">
+            <h2 id="confirm-title">Confirm action</h2>
+          </DialogPanel>
+        </>
+      )
+    }
+
+    render(<DialogOpeningMenu />)
+
+    const toggle = screen.getByRole('button', { name: 'More actions' })
+    fireEvent.click(toggle)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open confirm' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Confirm action' })
+    expect(dialog).toBeInTheDocument()
+    await waitFor(() => expect(dialog).toHaveFocus())
+    expect(toggle).not.toHaveFocus()
+  })
+
+  it('moves focus into a modal that opens after an async menu action', async () => {
+    function AsyncDialogOpeningMenu() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <SplitButton
+            label="Actions"
+            onPrimaryClick={vi.fn()}
+            options={[
+              {
+                id: 'schedule',
+                label: 'Schedule',
+                onSelect: () => {
+                  window.setTimeout(() => setOpen(true), 20)
+                },
+              },
+            ]}
+            toggleAriaLabel="More actions"
+          />
+          <DialogPanel isOpen={open} onClose={() => setOpen(false)} ariaLabelledBy="schedule-title">
+            <h2 id="schedule-title">Schedule release</h2>
+          </DialogPanel>
+        </>
+      )
+    }
+
+    render(<AsyncDialogOpeningMenu />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Schedule' }))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Schedule release' })
+    await waitFor(() => expect(dialog).toHaveFocus())
+  })
+
+  it('restores focus for normal actions from a menu inside an existing modal dialog', async () => {
+    const onSelect = vi.fn()
+
+    render(
+      <DialogPanel isOpen onClose={vi.fn()} ariaLabelledBy="modal-title">
+        <h2 id="modal-title">Edit assignment</h2>
+        <SplitButton
+          label="Add"
+          onPrimaryClick={vi.fn()}
+          options={[
+            { id: 'link', label: 'Add link', onSelect },
+          ]}
+          toggleAriaLabel="Add submission"
+        />
+      </DialogPanel>
+    )
+
+    const toggle = screen.getByRole('button', { name: 'Add submission' })
+    fireEvent.click(toggle)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add link' }))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(screen.getByRole('dialog', { name: 'Edit assignment' })).toBeInTheDocument()
+    await waitFor(() => expect(toggle).toHaveFocus())
   })
 
   it('renders checked menu options and dividers', () => {


### PR DESCRIPTION
## Summary
- move SplitButton focus into the first enabled menu item when the menu opens
- add ArrowUp/ArrowDown/Home/End navigation across enabled menu options
- restore focus to the opener on Escape, outside close, and item selection
- add semantic SplitButton coverage for keyboard navigation and focus restoration

## Composite Widget Checklist
- checklist reviewed: yes
- keyboard behavior covered: yes
- semantic state covered by tests: yes
- remaining manual follow-up: none

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/ui/SplitButton.test.tsx
- pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- E2E_BASE_URL=http://localhost:3022 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests"
- Reviewed screenshots: /tmp/pika-teacher.png, /tmp/pika-student.png, /tmp/pika-teacher-mobile.png