### PR TITLE
Page assignment list stats reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -819,3 +819,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `E2E_BASE_URL=http://localhost:3022 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`
+
+## 2026-05-31 — Assignment list stats pagination
+
+**Completed:**
+- Routed teacher assignment list stats reads through the shared chunked/paged Supabase loader.
+- Preserved the legacy fallback for databases without `assignment_docs.teacher_cleared_at`.
+- Added a dense 2,500-row stats regression so list stats cannot silently stop at Supabase's default page.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/teacher/assignments.test.ts tests/unit/query-chunks.test.ts -- --runInBand`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/app/api/teacher/assignments/route.ts
+++ b/src/app/api/teacher/assignments/route.ts
@@ -15,6 +15,7 @@ import {
   loadAssignmentSubmissionRequirements,
   replaceAssignmentSubmissionRequirements,
 } from '@/lib/server/assignment-submission-artifacts'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -39,18 +40,11 @@ type AssignmentStatsDocRow = {
 }
 
 const ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE = 50
+const ASSIGNMENT_LIST_STATS_PAGE_SIZE = 1000
 const ASSIGNMENT_LIST_STATS_COLUMNS =
   'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at'
 const ASSIGNMENT_LIST_STATS_FALLBACK_COLUMNS =
   'assignment_id, student_id, is_submitted, submitted_at, returned_at'
-
-function chunkIds(ids: string[], chunkSize: number): string[][] {
-  const chunks: string[][] = []
-  for (let index = 0; index < ids.length; index += chunkSize) {
-    chunks.push(ids.slice(index, index + chunkSize))
-  }
-  return chunks
-}
 
 async function loadAssignmentDocsForListStats(
   supabase: any,
@@ -61,57 +55,49 @@ async function loadAssignmentDocsForListStats(
     return { docs: [], error: null }
   }
 
-  const selectDocs = (columns: string, assignmentIdChunk: string[], studentIdChunk: string[]) =>
-    supabase
-      .from('assignment_docs')
-      .select(columns)
-      .in('assignment_id', assignmentIdChunk)
-      .in('student_id', studentIdChunk)
+  const filters = [
+    { column: 'assignment_id', values: assignmentIds },
+    { column: 'student_id', values: studentIds },
+  ]
+  const withMailboxTracking = await loadChunkedRows<AssignmentStatsDocRow>({
+    supabase,
+    table: 'assignment_docs',
+    select: ASSIGNMENT_LIST_STATS_COLUMNS,
+    filters,
+    chunkSize: ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE,
+    pageSize: ASSIGNMENT_LIST_STATS_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
 
-  const docs: AssignmentStatsDocRow[] = []
-  let useMailboxTracking = true
-
-  for (const assignmentIdChunk of chunkIds(assignmentIds, ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE)) {
-    for (const studentIdChunk of chunkIds(studentIds, ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE)) {
-      if (useMailboxTracking) {
-        const withMailboxTracking = await selectDocs(
-          ASSIGNMENT_LIST_STATS_COLUMNS,
-          assignmentIdChunk,
-          studentIdChunk
-        )
-
-        if (!withMailboxTracking.error) {
-          docs.push(...(withMailboxTracking.data || []))
-          continue
-        }
-
-        if (!isMissingAssignmentTeacherClearedAtColumnError(withMailboxTracking.error)) {
-          return { docs: [], error: withMailboxTracking.error }
-        }
-
-        useMailboxTracking = false
-      }
-
-      const fallback = await selectDocs(
-        ASSIGNMENT_LIST_STATS_FALLBACK_COLUMNS,
-        assignmentIdChunk,
-        studentIdChunk
-      )
-
-      if (fallback.error) {
-        return { docs: [], error: fallback.error }
-      }
-
-      docs.push(
-        ...(fallback.data || []).map((doc: Omit<AssignmentStatsDocRow, 'teacher_cleared_at'>) => ({
-          ...doc,
-          teacher_cleared_at: null,
-        }))
-      )
-    }
+  if (!withMailboxTracking.error) {
+    return { docs: withMailboxTracking.rows, error: null }
   }
 
-  return { docs, error: null }
+  if (!isMissingAssignmentTeacherClearedAtColumnError(withMailboxTracking.error)) {
+    return { docs: [], error: withMailboxTracking.error }
+  }
+
+  const fallback = await loadChunkedRows<Omit<AssignmentStatsDocRow, 'teacher_cleared_at'>>({
+    supabase,
+    table: 'assignment_docs',
+    select: ASSIGNMENT_LIST_STATS_FALLBACK_COLUMNS,
+    filters,
+    chunkSize: ASSIGNMENT_LIST_STATS_FILTER_CHUNK_SIZE,
+    pageSize: ASSIGNMENT_LIST_STATS_PAGE_SIZE,
+    pageOrderColumn: 'id',
+  })
+
+  if (fallback.error) {
+    return { docs: [], error: fallback.error }
+  }
+
+  return {
+    docs: fallback.rows.map((doc) => ({
+      ...doc,
+      teacher_cleared_at: null,
+    })),
+    error: null,
+  }
 }
 
 // GET /api/teacher/assignments?classroom_id=xxx - List assignments for a classroom

--- a/tests/api/teacher/assignments.test.ts
+++ b/tests/api/teacher/assignments.test.ts
@@ -39,10 +39,15 @@ function buildAssignmentDocsStatsTable(options: {
   firstError?: unknown
   fallbackError?: unknown
   inCalls?: Array<{ columns: string; column: string; values: string[] }>
+  orderCalls?: Array<{ columns: string; column: string; options: Record<string, unknown> }>
+  rangeCalls?: Array<{ columns: string; from: number; to: number }>
 }) {
   return {
     select: vi.fn((columns: string) => {
       let selectedAssignmentIds: string[] = []
+      let selectedStudentIds: string[] = []
+      let rangeStart: number | null = null
+      let rangeEnd: number | null = null
       const query: any = {
         in: vi.fn((column: string, values: string[]) => {
           options.inCalls?.push({ columns, column, values })
@@ -51,19 +56,38 @@ function buildAssignmentDocsStatsTable(options: {
             return query
           }
           if (column === 'student_id') {
-            if (columns.includes('teacher_cleared_at') && options.firstError) {
-              return Promise.resolve({ data: null, error: options.firstError })
-            }
-
-            const rows = options.docs.filter(
-              (doc) => selectedAssignmentIds.includes(doc.assignment_id) && values.includes(doc.student_id)
-            )
-            return Promise.resolve({
-              data: rows,
-              error: columns.includes('teacher_cleared_at') ? null : options.fallbackError ?? null,
-            })
+            selectedStudentIds = values
+            return query
           }
           return query
+        }),
+        order: vi.fn((column: string, orderOptions: Record<string, unknown>) => {
+          options.orderCalls?.push({ columns, column, options: orderOptions })
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          options.rangeCalls?.push({ columns, from, to })
+          rangeStart = from
+          rangeEnd = to
+          return query
+        }),
+        then: vi.fn((resolve: any) => {
+          if (columns.includes('teacher_cleared_at') && options.firstError) {
+            return resolve({ data: null, error: options.firstError })
+          }
+
+          const rows = options.docs.filter(
+            (doc) => selectedAssignmentIds.includes(doc.assignment_id) && selectedStudentIds.includes(doc.student_id)
+          )
+          const pagedRows =
+            rangeStart === null || rangeEnd === null
+              ? rows
+              : rows.slice(rangeStart, rangeEnd + 1)
+
+          return resolve({
+            data: pagedRows,
+            error: columns.includes('teacher_cleared_at') ? null : options.fallbackError ?? null,
+          })
         }),
       }
       return query
@@ -334,6 +358,122 @@ describe('GET /api/teacher/assignments', () => {
       new Set(assignmentRows.map((assignment) => assignment.id))
     )
     expect(new Set(studentFilterCalls.flatMap((call) => call.values))).toEqual(new Set(studentIds))
+  })
+
+  it('paginates dense assignment doc stats chunks past the Supabase default row cap', async () => {
+    const studentIds = Array.from({ length: 50 }, (_, index) => `student-${index + 1}`)
+    const assignmentRows = Array.from({ length: 50 }, (_, index) => ({
+      id: `assignment-${index + 1}`,
+      classroom_id: 'c1',
+      title: `Essay Draft ${index + 1}`,
+      description: '',
+      instructions_markdown: null,
+      rich_instructions: null,
+      due_at: '2026-03-14T23:59:59.000Z',
+    }))
+    const docs = assignmentRows.flatMap((assignment) =>
+      studentIds.map((studentId) => ({
+        assignment_id: assignment.id,
+        student_id: studentId,
+        is_submitted: true,
+        submitted_at: '2026-03-13T10:00:00.000Z',
+        returned_at: null,
+        teacher_cleared_at: null,
+      }))
+    )
+    const assignmentDocRangeCalls: Array<{ columns: string; from: number; to: number }> = []
+    const assignmentDocOrderCalls: Array<{ columns: string; column: string; options: Record<string, unknown> }> = []
+
+    mockGetClassroomStudentIds.mockResolvedValueOnce({
+      studentIds,
+      studentIdSet: new Set(studentIds),
+      totalStudents: studentIds.length,
+      error: null,
+    })
+
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        const builder: any = {}
+        builder.order = vi
+          .fn()
+          .mockImplementationOnce(() => builder)
+          .mockResolvedValue({ data: assignmentRows, error: null })
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: builder.order,
+            })),
+          })),
+        }
+      }
+
+      if (table === 'assignment_docs') {
+        return buildAssignmentDocsStatsTable({
+          docs,
+          orderCalls: assignmentDocOrderCalls,
+          rangeCalls: assignmentDocRangeCalls,
+        })
+      }
+
+      if (table === 'assignment_submission_requirements') {
+        return buildEmptySubmissionRequirementsTable()
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments?classroom_id=c1')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.assignments).toHaveLength(50)
+    expect(data.assignments[0].stats).toEqual({
+      total_students: 50,
+      submitted: 50,
+      late: 0,
+    })
+    expect(data.assignments[49].stats).toEqual({
+      total_students: 50,
+      submitted: 50,
+      late: 0,
+    })
+    expect(assignmentDocOrderCalls).toEqual([
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        column: 'id',
+        options: { ascending: true },
+      },
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        column: 'id',
+        options: { ascending: true },
+      },
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        column: 'id',
+        options: { ascending: true },
+      },
+    ])
+    expect(assignmentDocRangeCalls).toEqual([
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        from: 0,
+        to: 999,
+      },
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        from: 1000,
+        to: 1999,
+      },
+      {
+        columns: 'assignment_id, student_id, is_submitted, submitted_at, returned_at, teacher_cleared_at',
+        from: 2000,
+        to: 2999,
+      },
+    ])
   })
 
   it('falls back only to returned_at when teacher_cleared_at is missing', async () => {


### PR DESCRIPTION
## Summary
- route teacher assignment list stats reads through the shared chunked/paged Supabase loader
- keep the legacy teacher_cleared_at fallback while paging fallback reads too
- add a dense 2,500-row assignment_docs regression for list stats pagination

## Risk
- systems/data-access slice; no migrations or UI changes
- fixes silent stats truncation when a 50-assignment x 50-student chunk exceeds Supabase default row limits

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/teacher/assignments.test.ts tests/unit/query-chunks.test.ts -- --runInBand
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh