### PR TITLE
Cap broad student entry reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -833,3 +833,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-05-31 — Student entries broad-read cap
+
+**Completed:**
+- Added a default cap for broad `/api/student/entries` reads that span all active classrooms.
+- Preserved classroom-scoped no-limit history behavior so attendance history surfaces do not mark older entries absent.
+- Added API coverage for broad default limiting, explicit broad limit capping, classroom-scoped no-limit behavior, and explicit classroom limits.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/student/entries.test.ts -- --runInBand`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`

--- a/src/app/api/student/entries/route.ts
+++ b/src/app/api/student/entries/route.ts
@@ -19,6 +19,8 @@ export const revalidate = 0
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 const VALID_MOODS: MoodEmoji[] = ['😊', '🙂', '😐']
 const MAX_CHARS = 2000
+const DEFAULT_BROAD_ENTRIES_LIMIT = 100
+const MAX_ENTRIES_LIMIT = 100
 
 type EntryContentPayload = {
   classroom_id: string
@@ -102,11 +104,11 @@ export const GET = withErrorHandler('GetStudentEntries', async (request, context
   const classroomId = searchParams.get('classroom_id')
   const limitParam = searchParams.get('limit')
 
-  let limit: number | null = null
+  let limit: number | null = classroomId ? null : DEFAULT_BROAD_ENTRIES_LIMIT
   if (limitParam) {
     const parsed = Number.parseInt(limitParam, 10)
     if (Number.isFinite(parsed) && parsed > 0) {
-      limit = Math.min(parsed, 100)
+      limit = Math.min(parsed, MAX_ENTRIES_LIMIT)
     }
   }
 

--- a/tests/api/student/entries.test.ts
+++ b/tests/api/student/entries.test.ts
@@ -62,7 +62,30 @@ describe('GET /api/student/entries', () => {
   })
 
   describe('fetching entries', () => {
-    it('should return all entries for the student', async () => {
+    it('defaults broad active-classroom entry reads to a safe limit', async () => {
+      const limitMock = vi.fn((limit: number) => ({
+        order: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'entry-1',
+              student_id: 'student-1',
+              classroom_id: 'classroom-1',
+              date: '2024-10-15',
+              text: 'Entry 1',
+              on_time: true,
+            },
+            {
+              id: 'entry-2',
+              student_id: 'student-1',
+              classroom_id: 'classroom-1',
+              date: '2024-10-14',
+              text: 'Entry 2',
+              on_time: true,
+            },
+          ],
+          error: null,
+        }),
+      }))
       const mockFrom = vi.fn((table: string) => {
         if (table === 'classroom_enrollments') {
           return {
@@ -81,27 +104,7 @@ describe('GET /api/student/entries', () => {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
                 in: vi.fn(() => ({
-                  order: vi.fn().mockResolvedValue({
-                    data: [
-                      {
-                        id: 'entry-1',
-                        student_id: 'student-1',
-                        classroom_id: 'classroom-1',
-                        date: '2024-10-15',
-                        text: 'Entry 1',
-                        on_time: true,
-                      },
-                      {
-                        id: 'entry-2',
-                        student_id: 'student-1',
-                        classroom_id: 'classroom-1',
-                        date: '2024-10-14',
-                        text: 'Entry 2',
-                        on_time: true,
-                      },
-                    ],
-                    error: null,
-                  }),
+                  limit: limitMock,
                 })),
               })),
             })),
@@ -118,12 +121,56 @@ describe('GET /api/student/entries', () => {
       expect(response.status).toBe(200)
       expect(data.entries).toHaveLength(2)
       expect(data.entries[0].id).toBe('entry-1')
+      expect(limitMock).toHaveBeenCalledWith(100)
+    })
+
+    it('caps explicit broad active-classroom entry limits at 100', async () => {
+      const limitMock = vi.fn((limit: number) => ({
+        order: vi.fn().mockResolvedValue({
+          data: [],
+          error: null,
+        }),
+      }))
+      const mockFrom = vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                is: vi.fn(() => ({
+                  data: [{ classroom_id: 'classroom-1' }],
+                  error: null,
+                })),
+              })),
+            })),
+          }
+        }
+        if (table === 'entries') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                in: vi.fn(() => ({
+                  limit: limitMock,
+                })),
+              })),
+            })),
+          }
+        }
+      })
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/student/entries?limit=500')
+
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      expect(limitMock).toHaveBeenCalledWith(100)
     })
 
     it('should filter entries by classroom_id when provided', async () => {
       // Create a mock query object that is both chainable and thenable
       const mockQuery = {
         eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
         order: vi.fn().mockReturnThis(),
         then: vi.fn((resolve: any) => resolve({
           data: [{ id: 'entry-1', classroom_id: 'classroom-2' }],
@@ -143,9 +190,39 @@ describe('GET /api/student/entries', () => {
       // Verify eq was called twice: once for student_id, once for classroom_id
       expect(mockQuery.eq).toHaveBeenCalledWith('student_id', 'student-1')
       expect(mockQuery.eq).toHaveBeenCalledWith('classroom_id', 'classroom-2')
+      expect(mockQuery.limit).not.toHaveBeenCalled()
+    })
+
+    it('applies explicit classroom-scoped limits', async () => {
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        then: vi.fn((resolve: any) => resolve({
+          data: [{ id: 'entry-1', classroom_id: 'classroom-2' }],
+          error: null,
+        })),
+      }
+
+      const mockFrom = vi.fn(() => ({
+        select: vi.fn(() => mockQuery),
+      }))
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/student/entries?classroom_id=classroom-2&limit=12')
+
+      await GET(request)
+
+      expect(mockQuery.limit).toHaveBeenCalledWith(12)
     })
 
     it('should return 500 when database query fails', async () => {
+      const limitMock = vi.fn((limit: number) => ({
+        order: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'Database error' },
+        }),
+      }))
       const mockFrom = vi.fn((table: string) => {
         if (table === 'classroom_enrollments') {
           return {
@@ -164,10 +241,7 @@ describe('GET /api/student/entries', () => {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
                 in: vi.fn(() => ({
-                  order: vi.fn().mockResolvedValue({
-                    data: null,
-                    error: { message: 'Database error' },
-                  }),
+                  limit: limitMock,
                 })),
               })),
             })),


### PR DESCRIPTION
## Summary
- default broad /api/student/entries reads across active classrooms to 100 rows
- preserve classroom-scoped no-limit behavior for attendance history surfaces
- add API coverage for broad default limiting, explicit capping, and classroom-scoped limit behavior

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/api/student/entries.test.ts -- --runInBand
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check

Risk profile: none (bounded API read behavior; no UI changes).