### PR TITLE
Disable passive assignment sidebar

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -874,6 +874,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Disabled the external right sidebar for teacher assignment summary and workspace route keys.
 - Stopped rendering the classroom route's passive assignment sidebar fallback for teacher assignments.
 - Added coverage so teacher assignments match the tests work-surface rule: no external sidebar until an integrated workspace inspector is active.
+- Fixed review feedback so disabled right-sidebar routes clear stale mobile right-drawer state.
 
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
@@ -883,4 +884,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3025 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-teacher-assignments-loaded.png`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -867,3 +867,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3024 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
 - Manual Playwright screenshots for `testMode=authoring`: `/tmp/pika-teacher-authoring.png`, `/tmp/pika-teacher-authoring-mobile.png`
+
+## 2026-05-31 — Teacher assignment passive sidebar removal
+
+**Completed:**
+- Disabled the external right sidebar for teacher assignment summary and workspace route keys.
+- Stopped rendering the classroom route's passive assignment sidebar fallback for teacher assignments.
+- Added coverage so teacher assignments match the tests work-surface rule: no external sidebar until an integrated workspace inspector is active.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/layout-config.test.ts tests/components/ThreePanelProvider.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx -- --runInBand --testTimeout=10000`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `E2E_BASE_URL=http://localhost:3025 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
+- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1384,7 +1384,7 @@ function ClassroomPageContent({
           </PageDensityProvider>
         </MainContent>
 
-        {!isTeacher && activeTab === 'today' ? null : (
+        {(!isTeacher && activeTab === 'today') || (isTeacher && activeTab === 'assignments') ? null : (
         <RightSidebar
           hideDesktopHeader={false}
           minimalMobileHeader={false}
@@ -1392,8 +1392,6 @@ function ClassroomPageContent({
             isTeacher && activeTab === 'calendar' && calendarSidebarState
               ? 'Calendar'
               : isTeacher && isAssessmentTab
-              ? ''
-              : isTeacher && activeTab === 'assignments'
               ? ''
               : activeTab === 'assignments'
               ? (selectedAssignment?.title || 'Instructions')
@@ -1416,10 +1414,6 @@ function ClassroomPageContent({
             <TeacherLessonCalendarSidebar {...calendarSidebarState} />
           ) : isTeacher && isAssessmentTab ? (
             null
-          ) : isTeacher && activeTab === 'assignments' ? (
-            <div className="p-4">
-              <p className="text-sm text-text-muted">Use the assignment workspace to review student work.</p>
-            </div>
           ) : activeTab === 'assignments' ? (
             <div>
               {selectedAssignment ? (

--- a/src/components/layout/ThreePanelProvider.tsx
+++ b/src/components/layout/ThreePanelProvider.tsx
@@ -110,6 +110,11 @@ export function ThreePanelProvider({
   const [mobileLeftOpen, setMobileLeftOpen] = useState(false)
   const [mobileRightOpen, setMobileRightOpen] = useState(false)
 
+  useEffect(() => {
+    if (config.rightSidebar.enabled) return
+    setMobileRightOpen(false)
+  }, [config.rightSidebar.enabled, routeKey])
+
   // Track if we're on desktop for desktopAlwaysOpen behavior
   const [isDesktop, setIsDesktop] = useState(false)
   useEffect(() => {

--- a/src/lib/layout-config.ts
+++ b/src/lib/layout-config.ts
@@ -113,11 +113,11 @@ export const ROUTE_CONFIGS: Record<RouteKey, LayoutConfig> = {
     mainContent: { maxWidth: 'full' },
   },
   'assignments-teacher-list': {
-    rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '50%' },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   'assignments-teacher-viewing': {
-    rightSidebar: { enabled: true, defaultOpen: true, defaultWidth: '50%', desktopAlwaysOpen: true },
+    rightSidebar: { enabled: false, defaultOpen: false, defaultWidth: '50%' },
     mainContent: { maxWidth: 'full' },
   },
   'tests-teacher': {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@/components/layout', async () => {
 
   return {
     ThreePanelProvider: ({ children, routeKey }: any) => {
-      const [isRightOpen, setRightOpen] = React.useState(routeKey === 'today')
+      const [isRightOpen, setRightOpen] = React.useState(routeKey === 'today' || routeKey === 'assignments-teacher-list')
       const [rightWidth, setRightWidth] = React.useState(320)
       const value = React.useMemo(
         () => ({
@@ -387,6 +387,13 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     renderClient()
 
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
+  })
+
+  it('does not render a passive external sidebar for teacher assignment summary', () => {
+    renderClient()
+
+    expect(screen.queryByText('Use the assignment workspace to review student work.')).not.toBeInTheDocument()
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
   })
 
   it('clears the assignments summary label while assignment edit mode is active', () => {

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -38,11 +38,14 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
 
 function SidebarStatus() {
   const { isOpen, enabled, setOpen } = useRightSidebar()
+  const { isRightOpen, openRight } = useMobileDrawer()
   return (
     <div>
       <button type="button" onClick={() => setOpen(true)}>open-right-sidebar</button>
+      <button type="button" onClick={openRight}>open-mobile-right-drawer</button>
       <span data-testid="enabled">{String(enabled)}</span>
       <span data-testid="open">{String(isOpen)}</span>
+      <span data-testid="mobile-right-open">{String(isRightOpen)}</span>
     </div>
   )
 }
@@ -101,6 +104,35 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     })
     expect(screen.getByTestId('enabled').textContent).toBe('false')
     expect(screen.getByTestId('open').textContent).toBe('false')
+  })
+
+  it('clears mobile right drawer state when navigating through teacher assignment routes', () => {
+    act(() => {
+      setViewportWidth(390)
+    })
+
+    render(<TestHarness initialRouteKey="calendar-teacher" />)
+
+    act(() => {
+      screen.getByText('open-mobile-right-drawer').click()
+    })
+    expect(screen.getByTestId('mobile-right-open').textContent).toBe('true')
+
+    act(() => {
+      screen.getByText('go-teacher-list').click()
+    })
+    expect(screen.getByTestId('enabled').textContent).toBe('false')
+    expect(screen.getByTestId('mobile-right-open').textContent).toBe('false')
+
+    act(() => {
+      screen.getByText('go-calendar').click()
+    })
+    expect(screen.getByTestId('enabled').textContent).toBe('true')
+    expect(screen.getByTestId('mobile-right-open').textContent).toBe('false')
+
+    act(() => {
+      setViewportWidth(1024)
+    })
   })
 
   it('keeps the external sidebar disabled for teacher tests', () => {

--- a/tests/components/ThreePanelProvider.test.tsx
+++ b/tests/components/ThreePanelProvider.test.tsx
@@ -24,6 +24,7 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
       <button onClick={() => setRouteKey('assignments-teacher-list')}>go-teacher-list</button>
       <button onClick={() => setRouteKey('assignments-teacher-viewing')}>go-teacher-viewing</button>
       <button onClick={() => setRouteKey('tests-teacher')}>go-tests</button>
+      <button onClick={() => setRouteKey('calendar-teacher')}>go-calendar</button>
       <button onClick={() => setRouteKey('roster')}>go-roster</button>
       <ThreePanelProvider
         routeKey={routeKey}
@@ -36,9 +37,10 @@ function TestHarness({ initialRouteKey }: { initialRouteKey: RouteKey }) {
 }
 
 function SidebarStatus() {
-  const { isOpen, enabled } = useRightSidebar()
+  const { isOpen, enabled, setOpen } = useRightSidebar()
   return (
     <div>
+      <button type="button" onClick={() => setOpen(true)}>open-right-sidebar</button>
       <span data-testid="enabled">{String(enabled)}</span>
       <span data-testid="open">{String(isOpen)}</span>
     </div>
@@ -66,26 +68,12 @@ function setViewportWidth(width: number) {
 }
 
 describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
-  it('opens sidebar when switching to a tab with defaultOpen: true', () => {
-    render(<TestHarness initialRouteKey="assignments-student" />)
-
-    // assignments-student: enabled=false, so sidebar is closed
-    expect(screen.getByTestId('enabled').textContent).toBe('false')
-    expect(screen.getByTestId('open').textContent).toBe('false')
-
-    // Switch to teacher assignment viewing: enabled=true, defaultOpen=true
-    act(() => {
-      screen.getByText('go-teacher-viewing').click()
-    })
-
-    expect(screen.getByTestId('enabled').textContent).toBe('true')
-    expect(screen.getByTestId('open').textContent).toBe('true')
-  })
-
   it('closes sidebar when switching to a tab with enabled: false', () => {
-    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
+    render(<TestHarness initialRouteKey="calendar-teacher" />)
 
-    // assignments-teacher-viewing: enabled=true, defaultOpen=true
+    act(() => {
+      screen.getByText('open-right-sidebar').click()
+    })
     expect(screen.getByTestId('open').textContent).toBe('true')
 
     // Switch to assignments-student: enabled=false
@@ -97,44 +85,30 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
-  it('reopens sidebar when returning to a default-open tab after visiting disabled tab', () => {
-    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
-
-    expect(screen.getByTestId('open').textContent).toBe('true')
-
-    // Go to assignments (disabled sidebar)
-    act(() => {
-      screen.getByText('go-assignments').click()
-    })
-    expect(screen.getByTestId('open').textContent).toBe('false')
-
-    // Return to a default-open route — this is the core bug scenario
-    act(() => {
-      screen.getByText('go-teacher-viewing').click()
-    })
-    expect(screen.getByTestId('open').textContent).toBe('true')
-  })
-
-  it('opens sidebar when switching between two enabled tabs with defaultOpen', () => {
+  it('keeps teacher assignment routes disabled', () => {
     render(<TestHarness initialRouteKey="today" />)
 
-    // Go to assignments (disabled)
+    // Go to teacher assignment summary: external sidebar is disabled.
     act(() => {
-      screen.getByText('go-assignments').click()
+      screen.getByText('go-teacher-list').click()
     })
+    expect(screen.getByTestId('enabled').textContent).toBe('false')
     expect(screen.getByTestId('open').textContent).toBe('false')
 
-    // Go to teacher assignment viewing (enabled, defaultOpen: true)
+    // Go to teacher assignment workspace: it uses the integrated work-surface split.
     act(() => {
       screen.getByText('go-teacher-viewing').click()
     })
-    expect(screen.getByTestId('enabled').textContent).toBe('true')
-    expect(screen.getByTestId('open').textContent).toBe('true')
+    expect(screen.getByTestId('enabled').textContent).toBe('false')
+    expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
   it('keeps the external sidebar disabled for teacher tests', () => {
-    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
+    render(<TestHarness initialRouteKey="calendar-teacher" />)
 
+    act(() => {
+      screen.getByText('open-right-sidebar').click()
+    })
     expect(screen.getByTestId('open').textContent).toBe('true')
 
     act(() => {
@@ -145,24 +119,12 @@ describe('ThreePanelProvider right sidebar sync on routeKey change', () => {
     expect(screen.getByTestId('open').textContent).toBe('false')
   })
 
-  it('closes sidebar when switching from a default-open tab to an enabled tab with defaultOpen: false', () => {
-    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
-
-    // assignments-teacher-viewing: enabled=true, defaultOpen=true
-    expect(screen.getByTestId('open').textContent).toBe('true')
-
-    // Switch to teacher assignment list: enabled=true, defaultOpen=false
-    act(() => {
-      screen.getByText('go-teacher-list').click()
-    })
-
-    expect(screen.getByTestId('enabled').textContent).toBe('true')
-    expect(screen.getByTestId('open').textContent).toBe('false')
-  })
-
   it('keeps the Today external sidebar disabled', () => {
-    render(<TestHarness initialRouteKey="assignments-teacher-viewing" />)
+    render(<TestHarness initialRouteKey="calendar-teacher" />)
 
+    act(() => {
+      screen.getByText('open-right-sidebar').click()
+    })
     expect(screen.getByTestId('open').textContent).toBe('true')
 
     act(() => {

--- a/tests/unit/layout-config.test.ts
+++ b/tests/unit/layout-config.test.ts
@@ -46,18 +46,23 @@ describe('getLayoutConfig', () => {
     expect(config.mainContent.maxWidth).toBe('full')
   })
 
-  it('should return 50% default width for assignments-teacher-viewing (dynamically set to 70% for student work)', () => {
+  it('should use integrated workspaces for teacher assignments instead of the external right sidebar', () => {
+    const listConfig = getLayoutConfig('assignments-teacher-list')
     const config = getLayoutConfig('assignments-teacher-viewing')
+
+    expect(listConfig.rightSidebar.enabled).toBe(false)
+    expect(listConfig.rightSidebar.defaultOpen).toBe(false)
     expect(config.rightSidebar.defaultWidth).toBe('50%')
-    expect(config.rightSidebar.defaultOpen).toBe(true)
-    expect(config.rightSidebar.desktopAlwaysOpen).toBe(true)
+    expect(config.rightSidebar.enabled).toBe(false)
+    expect(config.rightSidebar.defaultOpen).toBe(false)
+    expect(config.rightSidebar.desktopAlwaysOpen).toBeUndefined()
   })
 
-  it('should only force desktopAlwaysOpen while viewing teacher work', () => {
+  it('should not force desktopAlwaysOpen for teacher assignment routes', () => {
     const listConfig = getLayoutConfig('assignments-teacher-list')
     const viewingConfig = getLayoutConfig('assignments-teacher-viewing')
     expect(listConfig.rightSidebar.desktopAlwaysOpen).toBeUndefined()
-    expect(viewingConfig.rightSidebar.desktopAlwaysOpen).toBe(true)
+    expect(viewingConfig.rightSidebar.desktopAlwaysOpen).toBeUndefined()
   })
 
   it('should use single-pane layouts for resources and announcements tabs', () => {


### PR DESCRIPTION
## Summary
- disable the external right sidebar for teacher assignment summary/workspace route keys
- skip rendering the classroom route's passive assignment sidebar fallback for teacher assignments
- update layout and classroom tests so assignments match the integrated work-surface rule used by teacher tests

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/layout-config.test.ts tests/components/ThreePanelProvider.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx -- --runInBand --testTimeout=10000
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
- E2E_BASE_URL=http://localhost:3025 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'
