### PR TITLE
Align UI sidebar guidance

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -885,3 +885,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `E2E_BASE_URL=http://localhost:3025 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
 - Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-teacher-assignments-loaded.png`
+
+## 2026-05-31 — UI sidebar guidance cleanup
+
+**Completed:**
+- Updated `docs/core/design.md` so the classroom shell treats `RightSidebar` as optional route-level chrome, not a default details pane.
+- Clarified the teacher work-surface canon: assignments/quizzes/tests should use integrated `TeacherWorkspaceSplit` inspectors only when active work justifies side-by-side panes.
+- Promoted the teacher workspace split audit language from proposed extraction to the current structural primitive and discouraged external right-sidebar substitutes for teacher work surfaces.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/layout-config.test.ts -- --runInBand`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -417,7 +417,9 @@ import { Card } from '@/ui'
 
 ### 3-Panel Layout System
 
-The app uses a 3-panel layout for classroom views, implemented in `src/components/layout/`:
+The app uses a shared classroom shell for classroom views, implemented in `src/components/layout/`.
+It always owns the left navigation and main content area. The external right sidebar is optional route
+chrome, not a default detail pane for every tab.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -440,7 +442,7 @@ The app uses a 3-panel layout for classroom views, implemented in `src/component
 | `ThreePanelShell` | `layout/ThreePanelShell.tsx` | CSS Grid container |
 | `LeftSidebar` | `layout/LeftSidebar.tsx` | Navigation rail (collapsible) |
 | `MainContent` | `layout/MainContent.tsx` | Primary content area |
-| `RightSidebar` | `layout/RightSidebar.tsx` | Inspector/details panel |
+| `RightSidebar` | `layout/RightSidebar.tsx` | Optional route-level inspector/details panel |
 
 #### Configuration
 
@@ -452,17 +454,30 @@ type RouteKey =
   | 'settings'
   | 'attendance'
   | 'roster'
+  | 'gradebook'
   | 'today'
   | 'assignments-student'
   | 'assignments-teacher-list'
   | 'assignments-teacher-viewing'
+  | 'tests-teacher'
+  | 'tests-student'
+  | 'calendar-teacher'
+  | 'calendar-student'
+  | 'resources-teacher'
+  | 'resources-student'
+  | 'announcements-teacher'
+  | 'announcements-student'
 
 // Example config
-ROUTE_CONFIGS['attendance'] = {
+ROUTE_CONFIGS['calendar-teacher'] = {
   rightSidebar: { enabled: true, defaultOpen: false, defaultWidth: '50%' },
   mainContent: { maxWidth: 'full' },
 }
 ```
+
+Most classroom tabs keep `rightSidebar.enabled = false`. Teacher assignments and teacher tests use
+their own integrated workspace splits when active review work needs an inspector; they should not
+enable the external `RightSidebar` just to reserve future detail space.
 
 #### Usage Pattern
 
@@ -483,16 +498,19 @@ const routeKey = getRouteKeyFromTab(activeTab, user.role)
       {/* Tab content */}
     </MainContent>
 
-    <RightSidebar title="Details">
-      {/* Inspector content - varies by tab */}
-    </RightSidebar>
+    {rightSidebarRouteIsEnabled ? (
+      <RightSidebar title="Details">
+        {/* Route-level inspector content, only for tabs that explicitly own it */}
+      </RightSidebar>
+    ) : null}
   </ThreePanelShell>
 </ThreePanelProvider>
 ```
 
 #### Passing Content to RightSidebar
 
-Content is passed to RightSidebar at the page level via callbacks:
+Content can be passed to `RightSidebar` at the page level via callbacks when the tab truly owns a
+route-level inspector:
 
 ```tsx
 // State at page level
@@ -511,12 +529,18 @@ const [selectedItem, setSelectedItem] = useState<Item | null>(null)
 </RightSidebar>
 ```
 
+Do not use this pattern to create passive no-selection panes for teacher assignments, teacher tests,
+or similar work surfaces. Those tabs should render summary states full-width and switch to
+`TeacherWorkspaceSplit` inside the selected workspace only when the current mode and selection make
+side-by-side work useful.
+
 #### Responsive Behavior
 
 - **Desktop (lg+)**: 3-column grid with smooth width transitions
-- **Mobile**: Single column, sidebars become overlay drawers
+- **Mobile**: Single column; enabled sidebars become overlay drawers
+- Disabled right-sidebar routes clear stale mobile right-drawer state on route changes
 - Use `useMobileDrawer()` hook to control mobile drawer state
-- Use `useRightSidebar()` hook to toggle/control right panel
+- Use `useRightSidebar()` hook to toggle/control the right panel only on routes that enable it
 
 #### Hooks
 

--- a/docs/guidance/ui/audit-teacher-work-surfaces.md
+++ b/docs/guidance/ui/audit-teacher-work-surfaces.md
@@ -56,7 +56,7 @@ These are the current or proposed structural primitives for the teacher work-sur
 | --- | --- | --- | --- | --- | --- |
 | Page-shell primitives (`PageLayout`, `PageActionBar`, `PageContent`, `PageStack`) | assignments, quizzes/tests | shared already | stable | keep as primitives | now |
 | Calm empty-state container via `EmptyState` | quizzes/tests today, assignments via similar composition | intended family-wide | stable | keep as primitive | now |
-| Teacher workspace split container derived from assignments | assignment viewing/grading + shell sidebar behavior | intended for quizzes/tests later | experimental candidate | extract as new primitive | now |
+| Teacher workspace split container derived from assignments | integrated assignment viewing/grading panes | adopted by tests when grading needs side-by-side work | stable structural primitive | keep as primitive | now |
 | Shared teacher work-item card variant | `SortableAssignmentCard`, `QuizCard`, emerging test card variants | partial convergence only | experimental | revisit after convergence | later |
 | Generic teacher list/detail container | no single owner yet | conceptually repeated | unstable | do not extract yet | never for now |
 
@@ -82,7 +82,7 @@ These should not be extracted into primitives.
 | Quiz/test authoring rules, question editing, and validation | `TeacherQuizzesTab`, `QuizModal`, question editors | stable per feature | keep feature-local | now |
 | Test grading batch actions, AI grading strategy, and return flows | `TeacherQuizzesTab` | feature-local | keep feature-local | now |
 | Assessment-specific workspace mode state machines | assignments/tests/quizzes owners | feature-local | keep feature-local | now |
-| Right-sidebar open/close decisions tied to route/query behavior | `ClassroomPageClient`, layout hooks | mixed structural/feature-local | keep feature-local until split primitive is extracted | later |
+| Route-level right-sidebar open/close decisions | `ClassroomPageClient`, layout hooks | shell-level, not teacher-family default | keep route-local and disabled for teacher work surfaces unless a route-level inspector is explicitly justified | now |
 
 ## Current Assignment Audit
 
@@ -109,9 +109,10 @@ These are present or recently present patterns that should not be treated as reu
 
 ## Extraction Roadmap
 
-### Now: teacher workspace split
+### Current: teacher workspace split
 
-The first extraction target remains a reusable teacher workspace split derived from assignments.
+The reusable teacher workspace split now exists and should be treated as the structural primitive
+for active two-pane teacher workspaces.
 
 Responsibilities:
 
@@ -136,10 +137,12 @@ Non-goals:
 - no grading logic
 - no routing/query management beyond what a layout primitive strictly needs
 
-Adoption order:
+Adoption rule:
 
-1. assignments adopt it first
-2. teacher quizzes/tests adopt it only when their workspace state truly matches the pattern
+- teacher assignments and teacher tests may use it where the current workspace state truly matches
+  active primary-plus-inspector work
+- do not enable the classroom route's external `RightSidebar` as a substitute for the workspace split
+  in teacher assignment, quiz, or test summary/workspace states
 
 ### Later: teacher work-item card convergence
 

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -248,6 +248,10 @@ an older joined split is explicitly desired.
 - The right sidebar should be closed or visually inactive by default in `entry` and `summary`.
 - Open the inspector only when the current workspace mode and current selection justify active side-by-side work.
 - Desktop split layouts are workspace tools, not default family chrome.
+- For teacher assignments, teacher quizzes, and teacher tests, prefer an integrated `TeacherWorkspaceSplit`
+  inside the selected workspace over the classroom route's external `RightSidebar`.
+- Keep the external route-level `RightSidebar` disabled for this family unless a future task explicitly
+  defines a route-level inspector that is not part of the selected work surface.
 
 ### Top-tab justification
 
@@ -316,7 +320,8 @@ If a screen shows unwanted pane or chrome behavior, check ownership in this orde
 Typical ownership examples:
 
 - summary/workspace transitions often live in the feature tab component
-- passive no-selection panes may live in `ClassroomPageClient`
+- passive no-selection panes may live in `ClassroomPageClient` or route config; remove them at the owner
+  that creates the empty pane instead of hiding them locally
 - persistent blank columns may be owned by route config in `src/lib/layout-config.ts`
 
 Do not paper over an outer-shell problem only inside the local tab component.


### PR DESCRIPTION
## Summary
- update the core design docs so the classroom `RightSidebar` is optional route-level chrome, not a default details pane
- clarify teacher work-surface guidance so assignments/quizzes/tests use integrated `TeacherWorkspaceSplit` inspectors only when active work justifies side-by-side panes
- mark the teacher workspace split as the current structural primitive and discourage external right-sidebar substitutes for teacher work surfaces

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/layout-config.test.ts -- --runInBand
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
