### PR TITLE
Tighten composite widget audit tests

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -898,3 +898,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/layout-config.test.ts -- --runInBand`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
+
+## 2026-05-31 — Composite widget audit relevance
+
+**Completed:**
+- Tightened the `missing-a11y-tests` audit guardrail so composite-widget changes require a changed semantic test that matches or references the changed component.
+- Kept the allowed test locations scoped to `tests/components`, `tests/ui`, or `tests/integration`.
+- Added fixture coverage for the bypass case where an unrelated component test changed beside a composite-widget component.
+- Addressed review feedback by making the no-changed-test path report `missing-a11y-tests` cleanly on Bash 3.2 and by avoiding loose content-reference matches for generic stems such as `button`.
+- Addressed follow-up review feedback by matching generic component stems against changed test filenames case-insensitively, with a `button.tsx` / `Button.test.tsx` regression fixture.
+- Tightened that follow-up so generic stems require exact changed test filename matches, avoiding false positives such as `page.tsx` passing through `PageActionBar.test.tsx`.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts -- --runInBand`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`

--- a/.codex/skills/pika-audit/SKILL.md
+++ b/.codex/skills/pika-audit/SKILL.md
@@ -41,7 +41,7 @@ Use the audit to catch common drift early, then use human review for edge cases 
 | `console-log` | `console.log(` in non-test production code | Use `console.error`/`warn` or structured logging |
 | `uncached-fetch` | Raw read `fetch()` in classroom/client components | Use `fetchJSONWithCache`; raw mutation fetches are allowed |
 | `missing-risk-tests` | Risky API/server behavior changed without a relevant changed test | For `src/app/api/*`, add changed coverage in `tests/api` or `tests/integration`; for `src/lib/server/*`, add changed coverage in `tests/api`, `tests/integration`, `tests/lib`, or `tests/unit` |
-| `missing-a11y-tests` | Composite widget behavior changed without a relevant changed test | Add semantic/keyboard regression coverage in `tests/components`, `tests/ui`, or `tests/integration` |
+| `missing-a11y-tests` | Composite widget behavior changed without a relevant changed test | Add semantic/keyboard regression coverage in `tests/components`, `tests/ui`, or `tests/integration`; the changed test should match or reference the changed component |
 
 ## Script
 

--- a/.codex/skills/pika-audit/scripts/audit.sh
+++ b/.codex/skills/pika-audit/scripts/audit.sh
@@ -19,7 +19,9 @@ RISKY_BEHAVIOR_CHANGED=0
 COMPOSITE_WIDGET_CHANGED=0
 declare -a RISKY_FILES=()
 declare -a COMPOSITE_FILES=()
-declare -a TEST_FILES=()
+# Bash 3.2 with `set -u` treats empty array iteration as an unbound
+# variable. Keep a sentinel so no-test changes report audit violations.
+declare -a TEST_FILES=("__pika_no_changed_tests__")
 
 # Collect changed .ts/.tsx files
 CHANGED=$(git -C "$WORKTREE" diff --name-only HEAD 2>/dev/null || true)
@@ -89,15 +91,52 @@ missing_risk_test_message() {
 }
 
 has_relevant_test_for_composite_file() {
-  local _file="$1"
+  local file="$1"
+  local source_base source_stem source_stem_lower
   local test_file
+  local test_base test_stem test_stem_lower test_full
+
+  source_base="$(basename "$file")"
+  source_stem="${source_base%.*}"
+  source_stem_lower="$(printf '%s' "$source_stem" | tr '[:upper:]' '[:lower:]')"
 
   for test_file in "${TEST_FILES[@]}"; do
-    if test_file_matches_any "$test_file" "tests/components/" "tests/ui/" "tests/integration/"; then
+    if ! test_file_matches_any "$test_file" "tests/components/" "tests/ui/" "tests/integration/"; then
+      continue
+    fi
+
+    test_base="$(basename "$test_file")"
+    test_stem="${test_base%%.test.*}"
+    test_stem="${test_stem%%.spec.*}"
+    test_stem_lower="$(printf '%s' "$test_stem" | tr '[:upper:]' '[:lower:]')"
+    test_full="$WORKTREE/$test_file"
+
+    if is_generic_composite_stem "$source_stem"; then
+      if [[ "$test_stem_lower" == "$source_stem_lower" ]]; then
+        return 0
+      fi
+      continue
+    fi
+
+    if [[ "$test_stem_lower" == "$source_stem_lower"* || "$source_stem_lower" == "$test_stem_lower"* ]]; then
+      return 0
+    fi
+
+    if [[ -f "$test_full" ]] && grep -Fq "$source_stem" "$test_full" 2>/dev/null; then
       return 0
     fi
   done
 
+  return 1
+}
+
+is_generic_composite_stem() {
+  local stem="$1"
+  case "$stem" in
+    button|Button|index|Index|page|Page|menu|Menu|tab|Tab|tabs|Tabs|panel|Panel|dialog|Dialog|drawer|Drawer|popover|Popover|input|Input|select|Select|list|List|item|Item|row|Row|cell|Cell|table|Table|card|Card|form|Form|layout|Layout|shell|Shell)
+      return 0
+      ;;
+  esac
   return 1
 }
 
@@ -199,7 +238,7 @@ if [[ "$COMPOSITE_WIDGET_CHANGED" -eq 1 ]]; then
       report_violation \
         "missing-a11y-tests" \
         "$file" \
-        "composite widget semantics changed without a relevant changed test under tests/components, tests/ui, or tests/integration"
+        "composite widget semantics changed without a relevant changed test under tests/components, tests/ui, or tests/integration matching or referencing the changed component"
       break
     fi
   done

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -433,4 +433,441 @@ describe('AI startup docs', () => {
       rmSync(repoRoot, { recursive: true, force: true })
     }
   })
+
+  it('makes the audit script reject composite widget changes with only unrelated changed component tests', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/ui'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/components'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/components/UnrelatedMenu.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('unrelated menu', () => {",
+        "  it('stays true', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add split button and unrelated component test')
+
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/components/UnrelatedMenu.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('unrelated menu', () => {",
+        "  it('still stays true', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('missing-a11y-tests')
+      expect(`${result.stdout}\n${result.stderr}`).toContain('matching or referencing the changed component')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('makes the audit script reject composite widget changes with no changed tests', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add split button')
+
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('missing-a11y-tests')
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain('unbound variable')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not allow generic component stems to match unrelated test prose', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/components/tiptap-ui-primitive/button'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/components/tiptap-ui-primitive/button/button.tsx'),
+      [
+        "export function ButtonPrimitive() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/SplitButton.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('SplitButton', () => {",
+        "  it('mentions a button but is unrelated', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add generic button primitive and unrelated split button test')
+
+    writeFileSync(
+      join(repoRoot, 'src/components/tiptap-ui-primitive/button/button.tsx'),
+      [
+        "export function ButtonPrimitive() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/SplitButton.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('SplitButton', () => {",
+        "  it('still mentions a button but is unrelated', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('missing-a11y-tests')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('allows generic component stems when the changed test filename matches case-insensitively', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/components/tiptap-ui-primitive/button'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/components/tiptap-ui-primitive/button/button.tsx'),
+      [
+        "export function Button() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/Button.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('Button', () => {",
+        "  it('covers semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add generic button primitive and matching button test')
+
+    writeFileSync(
+      join(repoRoot, 'src/components/tiptap-ui-primitive/button/button.tsx'),
+      [
+        "export function Button() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/Button.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('Button', () => {",
+        "  it('still covers semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain('missing-a11y-tests')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not allow generic component stems to match longer unrelated PascalCase test filenames', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/app/classrooms'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/app/classrooms/page.tsx'),
+      [
+        "export function ClassroomPage() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/PageActionBar.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('PageActionBar', () => {",
+        "  it('covers unrelated actions', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add classroom page and unrelated page action bar test')
+
+    writeFileSync(
+      join(repoRoot, 'src/app/classrooms/page.tsx'),
+      [
+        "export function ClassroomPage() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/PageActionBar.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('PageActionBar', () => {",
+        "  it('still covers unrelated actions', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).not.toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).toContain('missing-a11y-tests')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('allows composite widget changes when a matching semantic test also changes', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/ui'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/SplitButton.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('SplitButton', () => {",
+        "  it('covers semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add split button and matching ui test')
+
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/SplitButton.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('SplitButton', () => {",
+        "  it('still covers semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain('missing-a11y-tests')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('allows composite widget changes when a semantic test references the changed component', () => {
+    const repoRoot = makeFixtureWorktree()
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-audit/scripts/audit.sh')
+
+    mkdirSync(join(repoRoot, 'src/ui'), { recursive: true })
+    mkdirSync(join(repoRoot, 'tests/ui'), { recursive: true })
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"false\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/MenuAccessibility.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('menu accessibility', () => {",
+        "  it('covers SplitButton semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+    commitAll(repoRoot, 'add split button and referencing ui test')
+
+    writeFileSync(
+      join(repoRoot, 'src/ui/SplitButton.tsx'),
+      [
+        "export function SplitButton() {",
+        "  return <button type=\"button\" aria-expanded=\"true\">Open</button>",
+        '}',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      join(repoRoot, 'tests/ui/MenuAccessibility.test.tsx'),
+      [
+        "import { describe, expect, it } from 'vitest'",
+        '',
+        "describe('menu accessibility', () => {",
+        "  it('still covers SplitButton semantic state', () => {",
+        '    expect(true).toBe(true)',
+        '  })',
+        '})',
+        '',
+      ].join('\n'),
+    )
+
+    try {
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(result.status).toBe(0)
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain('missing-a11y-tests')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- tighten the `missing-a11y-tests` audit guardrail so composite-widget changes require a changed semantic test that matches or references the changed component
- keep allowed coverage scoped to `tests/components`, `tests/ui`, or `tests/integration`
- add fixture coverage for unrelated changed component tests no longer satisfying composite-widget changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts -- --runInBand
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
