### PR TITLE
Standardize upload image API auth

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -916,3 +916,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
+
+## 2026-05-31 — Upload image route standardization
+
+**Completed:**
+- Replaced legacy direct `getSession()` handling in `/api/upload-image` with `requireAuth()`.
+- Converted upload-image validation and storage failure branches from manual `{ error }` responses to `ApiError` throws handled by `withErrorHandler`.
+- Updated API tests to cover wrapper-mapped authentication and `requireAuth` user-id filename scoping.
+- Addressed review feedback by preserving the malformed-session no-id guard before building storage filenames.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/api/upload-image.test.ts tests/unit/api-route-standards.test.ts -- --runInBand`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/api/upload-image/route.ts
+++ b/src/app/api/upload-image/route.ts
@@ -1,36 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { getSession } from '@/lib/auth'
+import { requireAuth } from '@/lib/auth'
 import { getImageValidationError } from '@/lib/image-upload'
-import { withErrorHandler } from '@/lib/api-handler'
+import { ApiError, withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
 
 export const POST = withErrorHandler('PostUploadImage', async (request: NextRequest) => {
-  // Check authentication - any logged-in user can upload
-  const session = await getSession()
-  if (!session.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const user = await requireAuth()
+  if (!user.id) {
+    throw new ApiError(401, 'Unauthorized')
   }
 
   const formData = await request.formData()
   const file = formData.get('file') as File | null
 
   if (!file) {
-    return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+    throw new ApiError(400, 'No file provided')
   }
 
   // Validate file type and size
   const validationError = getImageValidationError(file)
   if (validationError) {
-    return NextResponse.json({ error: validationError }, { status: 400 })
+    throw new ApiError(400, validationError)
   }
 
   const supabase = getServiceRoleClient()
 
   // Generate unique filename
   const ext = file.name.split('.').pop() || 'png'
-  const filename = `${session.user.id}/${Date.now()}-${crypto.randomUUID()}.${ext}`
+  const filename = `${user.id}/${Date.now()}-${crypto.randomUUID()}.${ext}`
 
   // Convert File to ArrayBuffer then to Buffer for upload
   const arrayBuffer = await file.arrayBuffer()
@@ -46,10 +45,7 @@ export const POST = withErrorHandler('PostUploadImage', async (request: NextRequ
 
   if (uploadError) {
     console.error('Upload error:', uploadError)
-    return NextResponse.json(
-      { error: 'Failed to upload image' },
-      { status: 500 }
-    )
+    throw new ApiError(500, 'Failed to upload image')
   }
 
   // Get public URL

--- a/tests/api/upload-image.test.ts
+++ b/tests/api/upload-image.test.ts
@@ -10,7 +10,7 @@ import { IMAGE_MAX_SIZE } from '@/lib/image-upload'
 
 // Mock modules
 vi.mock('@/lib/auth', () => ({
-  getSession: vi.fn(),
+  requireAuth: vi.fn(),
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -18,8 +18,14 @@ vi.mock('@/lib/supabase', () => ({
 }))
 
 // Import mocked modules
-import { getSession } from '@/lib/auth'
+import { requireAuth } from '@/lib/auth'
 import { getServiceRoleClient } from '@/lib/supabase'
+
+function mockAuthenticationError(message = 'Not authenticated') {
+  const error = new Error(message)
+  error.name = 'AuthenticationError'
+  return error
+}
 
 // Helper to create a mock file with arrayBuffer method
 function createMockFile(
@@ -54,8 +60,10 @@ describe('POST /api/upload-image', () => {
     vi.clearAllMocks()
 
     // Default mock for authenticated user
-    ;(getSession as any).mockResolvedValue({
-      user: { id: 'user-123', email: 'test@example.com', role: 'student' },
+    ;(requireAuth as any).mockResolvedValue({
+      id: 'user-123',
+      email: 'test@example.com',
+      role: 'student',
     })
 
     // Default mock for Supabase storage
@@ -79,8 +87,8 @@ describe('POST /api/upload-image', () => {
   // ==========================================================================
 
   describe('authentication', () => {
-    it('should return 401 when not authenticated', async () => {
-      ;(getSession as any).mockResolvedValue({ user: null })
+    it('should return 401 when requireAuth rejects unauthenticated requests', async () => {
+      ;(requireAuth as any).mockRejectedValueOnce(mockAuthenticationError())
 
       const request = createMockRequest(createMockFile('test.png', 'image/png', 1024))
       const response = await POST(request)
@@ -88,10 +96,14 @@ describe('POST /api/upload-image', () => {
 
       expect(response.status).toBe(401)
       expect(data.error).toBe('Unauthorized')
+      expect(getServiceRoleClient).not.toHaveBeenCalled()
     })
 
-    it('should return 401 when session has no user id', async () => {
-      ;(getSession as any).mockResolvedValue({ user: { email: 'test@example.com' } })
+    it('should return 401 when authenticated user has no id', async () => {
+      ;(requireAuth as any).mockResolvedValueOnce({
+        email: 'test@example.com',
+        role: 'student',
+      })
 
       const request = createMockRequest(createMockFile('test.png', 'image/png', 1024))
       const response = await POST(request)
@@ -99,6 +111,21 @@ describe('POST /api/upload-image', () => {
 
       expect(response.status).toBe(401)
       expect(data.error).toBe('Unauthorized')
+      expect(getServiceRoleClient).not.toHaveBeenCalled()
+    })
+
+    it('should use requireAuth user id for storage filenames', async () => {
+      ;(requireAuth as any).mockResolvedValueOnce({
+        id: 'teacher-456',
+        email: 'teacher@example.com',
+        role: 'teacher',
+      })
+
+      const request = createMockRequest(createMockFile('test.png', 'image/png', 1024))
+      await POST(request)
+
+      expect(requireAuth).toHaveBeenCalledTimes(1)
+      expect(mockStorageUpload.mock.calls[0][0]).toMatch(/^teacher-456\//)
     })
   })
 
@@ -225,7 +252,7 @@ describe('POST /api/upload-image', () => {
     })
 
     it('should return 500 for unexpected errors', async () => {
-      ;(getSession as any).mockRejectedValue(new Error('Unexpected error'))
+      ;(requireAuth as any).mockRejectedValue(new Error('Unexpected error'))
 
       const request = createMockRequest(createMockFile('test.png', 'image/png', 1024))
       const response = await POST(request)


### PR DESCRIPTION
## Summary
- route `/api/upload-image` authentication through `requireAuth()` instead of direct `getSession()` reads
- replace manual upload-image validation/storage error responses with `ApiError` throws handled by `withErrorHandler`
- update API coverage for wrapper-mapped authentication and user-id filename scoping

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/api/upload-image.test.ts tests/unit/api-route-standards.test.ts -- --runInBand`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`
