### PR TITLE
Cache student lesson calendar reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -932,3 +932,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-05-31 — Student lesson calendar cache reuse
+
+**Completed:**
+- Routed student lesson calendar assignment reads through the shared `student-assignments:<classroomId>` cache key.
+- Routed student lesson calendar announcement reads through the shared `student-announcements:<classroomId>` cache key.
+- Routed student lesson calendar lesson-plan reads through a range-specific `student-lesson-plans:<classroomId>:<start>:<end>` cache key.
+- Added remount coverage proving the calendar reuses cached lesson plans, assignments, and announcements.
+- Addressed review feedback by isolating per-endpoint load failures and strengthening remount coverage to wait for completed cached data.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts -- --runInBand`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -8,6 +8,7 @@ import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useClassDays } from '@/hooks/useClassDays'
 import { readCookie, writeCookie } from '@/lib/cookies'
+import { fetchJSONWithCache } from '@/lib/request-cache'
 import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 
 interface Props {
@@ -48,15 +49,43 @@ export function StudentLessonCalendarTab({
     async function loadCalendarData() {
       setLoading(true)
       try {
-        const [lessonPlansRes, assignmentsRes, announcementsRes] = await Promise.all([
-          fetch(`/api/student/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`),
-          fetch(`/api/student/assignments?classroom_id=${classroom.id}`),
-          fetch(`/api/student/classrooms/${classroom.id}/announcements`),
-        ])
         const [lessonPlansData, assignmentsData, announcementsData] = await Promise.all([
-          lessonPlansRes.json(),
-          assignmentsRes.json(),
-          announcementsRes.json(),
+          fetchJSONWithCache<{ lesson_plans?: LessonPlan[]; max_date?: string | null }>(
+            `student-lesson-plans:${classroom.id}:${fetchRange.start}:${fetchRange.end}`,
+            async () => {
+              const res = await fetch(`/api/student/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`)
+              if (!res.ok) throw new Error('Failed to load lesson plans')
+              return res.json()
+            },
+            20_000,
+          ).catch((err) => {
+            console.error('Error loading lesson plans:', err)
+            return { lesson_plans: [], max_date: null }
+          }),
+          fetchJSONWithCache<{ assignments?: Assignment[] }>(
+            `student-assignments:${classroom.id}`,
+            async () => {
+              const res = await fetch(`/api/student/assignments?classroom_id=${classroom.id}`)
+              if (!res.ok) throw new Error('Failed to load assignments')
+              return res.json()
+            },
+            20_000,
+          ).catch((err) => {
+            console.error('Error loading calendar assignments:', err)
+            return { assignments: [] }
+          }),
+          fetchJSONWithCache<{ announcements?: Announcement[] }>(
+            `student-announcements:${classroom.id}`,
+            async () => {
+              const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`)
+              if (!res.ok) throw new Error('Failed to load announcements')
+              return res.json()
+            },
+            20_000,
+          ).catch((err) => {
+            console.error('Error loading calendar announcements:', err)
+            return { announcements: [] }
+          }),
         ])
         setLessonPlans(lessonPlansData.lesson_plans || [])
         setMaxDate(lessonPlansData.max_date || null)

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import { StudentLessonCalendarTab } from '@/app/classrooms/[classroomId]/StudentLessonCalendarTab'
 import { createMockClassroom } from '../helpers/mocks'
+import { invalidateCachedJSON } from '@/lib/request-cache'
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -17,7 +18,14 @@ vi.mock('@/lib/cookies', () => ({
 }))
 
 vi.mock('@/components/LessonCalendar', () => ({
-  LessonCalendar: () => <div data-testid="lesson-calendar" />,
+  LessonCalendar: ({ lessonPlans, assignments, announcements }: any) => (
+    <div
+      data-testid="lesson-calendar"
+      data-lesson-count={lessonPlans.length}
+      data-assignment-count={assignments.length}
+      data-announcement-count={announcements.length}
+    />
+  ),
   CalendarViewMode: {},
 }))
 
@@ -29,11 +37,17 @@ describe('StudentLessonCalendarTab', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    invalidateCachedJSON(`student-lesson-plans:${classroom.id}:2025-01-01:2025-06-30`)
+    invalidateCachedJSON(`student-assignments:${classroom.id}`)
+    invalidateCachedJSON(`student-announcements:${classroom.id}`)
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
 
   afterEach(() => {
+    invalidateCachedJSON(`student-lesson-plans:${classroom.id}:2025-01-01:2025-06-30`)
+    invalidateCachedJSON(`student-assignments:${classroom.id}`)
+    invalidateCachedJSON(`student-announcements:${classroom.id}`)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -92,6 +106,73 @@ describe('StudentLessonCalendarTab', () => {
 
     // Wait a tick — no additional calls should fire
     await new Promise((r) => setTimeout(r, 50))
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('reuses calendar data cache keys on remount', async () => {
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url.includes('lesson-plans')) return { lesson_plans: [{ id: 'lesson-1' }] }
+        if (url.includes('assignments')) return { assignments: [{ id: 'assignment-1' }] }
+        if (url.includes('announcements')) return { announcements: [{ id: 'announcement-1' }] }
+        return {}
+      },
+    }))
+
+    const first = render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-count', '1')
+    })
+
+    first.unmount()
+    render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-count', '1')
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(urls.filter((url) => url.includes('lesson-plans'))).toHaveLength(1)
+    expect(urls.filter((url) => url.includes('assignments'))).toHaveLength(1)
+    expect(urls.filter((url) => url.includes('announcements'))).toHaveLength(1)
+  })
+
+  it('keeps lesson plans visible when ancillary calendar reads fail', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('assignments')) {
+        return {
+          ok: false,
+          json: async () => ({ error: 'Failed' }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [{ id: 'lesson-1' }] }
+          if (url.includes('announcements')) return { announcements: [{ id: 'announcement-1' }] }
+          return {}
+        },
+      }
+    })
+
+    render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-count', '0')
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-count', '1')
+    })
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Summary
- route student lesson calendar lesson-plan, assignment, and announcement reads through `fetchJSONWithCache`
- reuse existing `student-assignments:<classroomId>` and `student-announcements:<classroomId>` keys
- add a range-specific `student-lesson-plans:<classroomId>:<start>:<end>` key and remount coverage proving no duplicate reads within TTL

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts -- --runInBand`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`
