### PR TITLE
Cache student history reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -949,3 +949,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-05-31 — Student history cache reuse
+
+**Completed:**
+- Added a shared student entries client helper that caches `/api/student/entries` reads by classroom and optional limit.
+- Routed classroom student history and standalone student history class-day/entry reads through shared cached helpers.
+- Routed the today tab’s entry history refresh through the shared student entries cache and invalidated classroom entry caches after successful saves.
+- Added component coverage proving student history remounts reuse cached class days and entries, plus save invalidation coverage in today-tab history tests.
+- Addressed PR review feedback by clearing stale history rows after failed reloads, cancelling stale history requests after classroom changes, and invalidating/updating entry caches on save conflicts without caching partial conflict payloads as full history rows.
+- Spawned new read-only audit tracks for accessibility/mobile consistency, API standardization, classroom action surfaces, and client caching/freshness.
+
+**Validation:**
+- `pnpm vitest run tests/components/StudentHistoryTab.test.tsx tests/components/StudentTodayTabHistory.test.tsx`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/StudentHistoryTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentHistoryTab.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { PageActionBar, PageContent, PageLayout } from '@/components/PageLayout'
 import { entryHasContent, getAttendanceIcon } from '@/lib/attendance'
+import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
+import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
 import { getTodayInToronto } from '@/lib/timezone'
 import type { AttendanceStatus, ClassDay, Classroom, Entry } from '@/types'
 
@@ -22,16 +24,17 @@ export function StudentHistoryTab({ classroom }: Props) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    let cancelled = false
+
     async function load() {
       setLoading(true)
+      setRows([])
       try {
-        const classDaysRes = await fetch(`/api/classrooms/${classroom.id}/class-days`)
-        const classDaysData = await classDaysRes.json()
-        const classDays: ClassDay[] = (classDaysData.class_days || []).filter((d: ClassDay) => d.is_class_day)
-
-        const entriesRes = await fetch(`/api/student/entries?classroom_id=${classroom.id}`)
-        const entriesData = await entriesRes.json()
-        const entries: Entry[] = entriesData.entries || []
+        const [classDaysData, entries] = await Promise.all([
+          fetchClassDaysForClassroom(classroom.id),
+          fetchStudentEntriesForClassroom(classroom.id),
+        ])
+        const classDays: ClassDay[] = classDaysData.filter((d: ClassDay) => d.is_class_day)
 
         const entryMap = new Map(entries.map(e => [e.date, e]))
         const today = getTodayInToronto()
@@ -51,14 +54,22 @@ export function StudentHistoryTab({ classroom }: Props) {
           })
           .sort((a, b) => b.date.localeCompare(a.date))
 
+        if (cancelled) return
         setRows(nextRows)
       } catch (err) {
         console.error('Error loading history:', err)
+        if (cancelled) return
+        setRows([])
       } finally {
+        if (cancelled) return
         setLoading(false)
       }
     }
     load()
+
+    return () => {
+      cancelled = true
+    }
   }, [classroom.id])
 
   if (loading) {

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -11,12 +11,18 @@ import { useClassDaysContext } from '@/hooks/useClassDays'
 import { format, parseISO } from 'date-fns'
 import {
   safeSessionGetJson,
+  safeSessionRemove,
   safeSessionSetJson,
 } from '@/lib/client-storage'
 import {
   getStudentEntryHistoryCacheKey,
   upsertEntryIntoHistory,
 } from '@/lib/student-entry-history'
+import { fetchJSONWithCache } from '@/lib/request-cache'
+import {
+  fetchStudentEntriesForClassroom,
+  invalidateStudentEntriesForClassroom,
+} from '@/lib/student-entries-client'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import { countCharacters, isEmpty, plainTextToTiptapContent } from '@/lib/tiptap-content'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
@@ -96,12 +102,24 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
         const cached = safeSessionGetJson<Entry[]>(historyCacheKey)
 
         // Fetch today's lesson plan (class days come from context)
-        const lessonPlanPromise = fetch(
-          `/api/student/classrooms/${classroom.id}/lesson-plans?start=${todayDate}&end=${todayDate}`
+        const lessonPlanPromise = fetchJSONWithCache<{ lesson_plans?: LessonPlan[]; lessonPlans?: LessonPlan[] }>(
+          `student-lesson-plans:${classroom.id}:${todayDate}:${todayDate}`,
+          async () => {
+            const response = await fetch(
+              `/api/student/classrooms/${classroom.id}/lesson-plans?start=${todayDate}&end=${todayDate}`
+            )
+            const data = await response.json().catch(() => ({ lesson_plans: [] }))
+            if (!response.ok) {
+              throw new Error(
+                typeof data.error === 'string' ? data.error : 'Failed to load lesson plan'
+              )
+            }
+            return data
+          },
+          20_000,
         )
-          .then(r => r.json())
           .then(data => {
-            const plans = data.lesson_plans || []
+            const plans = data.lesson_plans || data.lessonPlans || []
             const todayPlan = plans.find((p: LessonPlan) => p.date === todayDate) || null
             onLessonPlanLoad?.(todayPlan)
           })
@@ -129,16 +147,8 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           setLoading(false)
         }
 
-        const entriesUrl = `/api/student/entries?classroom_id=${classroom.id}&limit=${historyLimit}`
-        const entriesPromise = fetch(entriesUrl)
-          .then(response => {
-            if (!response.ok) {
-              throw new Error('Failed to load entries')
-            }
-            return response.json()
-          })
-          .then(data => {
-            const entries: Entry[] = data.entries || []
+        const entriesPromise = fetchStudentEntriesForClassroom(classroom.id, { limit: historyLimit })
+          .then(entries => {
             if (hasLocalEditSinceLoadRef.current) {
               setHistoryEntries(prev => {
                 const currentTodayEntry = prev.find((e: Entry) => e.date === todayDate) || null
@@ -271,7 +281,25 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
         const serverEntry = data.entry as Entry | undefined
         if (serverEntry) {
           setConflictEntry(serverEntry)
+          if (serverEntry.date) {
+            updateHistoryEntries(serverEntry)
+          } else {
+            safeSessionRemove(
+              getStudentEntryHistoryCacheKey({
+                classroomId: classroom.id,
+                limit: historyLimit,
+              })
+            )
+          }
+        } else {
+          safeSessionRemove(
+            getStudentEntryHistoryCacheKey({
+              classroomId: classroom.id,
+              limit: historyLimit,
+            })
+          )
         }
+        invalidateStudentEntriesForClassroom(classroom.id)
         if (saveTimeoutRef.current) {
           clearTimeout(saveTimeoutRef.current)
         }
@@ -296,6 +324,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       const savedEntry = data.entry as Entry
       entryIdRef.current = savedEntry.id
       entryVersionRef.current = savedEntry.version ?? entryVersionRef.current
+      invalidateStudentEntriesForClassroom(classroom.id)
       updateHistoryEntries(savedEntry)
       lastSavedContentRef.current = newContentStr
       setSaveStatus('saved')
@@ -307,7 +336,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       setSaveStatus('unsaved')
       setSaveError(err.message || 'Failed to save')
     }
-  }, [MAX_CHARS, classroom.id, updateHistoryEntries, notifications])
+  }, [MAX_CHARS, classroom.id, historyLimit, updateHistoryEntries, notifications])
 
   const scheduleSave = useCallback((
     newContent: TiptapContent,

--- a/src/app/student/history/page.tsx
+++ b/src/app/student/history/page.tsx
@@ -6,6 +6,8 @@ import { Spinner } from '@/components/Spinner'
 import { format, parse } from 'date-fns'
 import type { Entry, ClassDay, AttendanceStatus, Classroom } from '@/types'
 import { entryHasContent, getAttendanceIcon, getAttendanceLabel } from '@/lib/attendance'
+import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
+import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
 import { getTodayInToronto } from '@/lib/timezone'
 
 interface HistoryEntry {
@@ -53,28 +55,26 @@ export default function HistoryPage() {
 
   // Load history when classroom selected
   useEffect(() => {
+    let cancelled = false
+
     if (!selectedClassroom) {
       setHistory([])
+      setLoadingHistory(false)
       return
     }
 
     async function loadHistory() {
       if (!selectedClassroom) return
       setLoadingHistory(true)
+      setHistory([])
       try {
-        // Fetch class days
-        const classDaysRes = await fetch(
-          `/api/classrooms/${selectedClassroom.id}/class-days`
-        )
-        const classDaysData = await classDaysRes.json()
-        const classDays: ClassDay[] = (classDaysData.class_days || []).filter(
+        const [classDaysData, entries] = await Promise.all([
+          fetchClassDaysForClassroom(selectedClassroom.id),
+          fetchStudentEntriesForClassroom(selectedClassroom.id),
+        ])
+        const classDays: ClassDay[] = classDaysData.filter(
           (day: ClassDay) => day.is_class_day
         )
-
-        // Fetch entries
-        const entriesRes = await fetch(`/api/student/entries?classroom_id=${selectedClassroom.id}`)
-        const entriesData = await entriesRes.json()
-        const entries: Entry[] = entriesData.entries || []
 
         // Build history
         const entryMap = new Map<string, Entry>()
@@ -102,15 +102,23 @@ export default function HistoryPage() {
         // Sort by date descending
         historyData.sort((a, b) => b.date.localeCompare(a.date))
 
+        if (cancelled) return
         setHistory(historyData)
       } catch (err) {
         console.error('Error loading history:', err)
+        if (cancelled) return
+        setHistory([])
       } finally {
+        if (cancelled) return
         setLoadingHistory(false)
       }
     }
 
     loadHistory()
+
+    return () => {
+      cancelled = true
+    }
   }, [selectedClassroom])
 
   async function handleJoinClassroom(e: FormEvent) {

--- a/src/lib/client-storage.ts
+++ b/src/lib/client-storage.ts
@@ -79,3 +79,11 @@ export function safeSessionSetJson(key: string, value: unknown) {
   }
 }
 
+export function safeSessionRemove(key: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(key)
+  } catch {
+    // Ignore sessionStorage unavailable errors.
+  }
+}

--- a/src/lib/student-entries-client.ts
+++ b/src/lib/student-entries-client.ts
@@ -1,0 +1,54 @@
+import type { Entry } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+
+type StudentEntriesResponse = {
+  entries?: Entry[]
+}
+
+type StudentEntriesOptions = {
+  limit?: number
+}
+
+const STUDENT_ENTRIES_CACHE_TTL_MS = 15_000
+
+export function getStudentEntriesCachePrefix(classroomId: string): string {
+  return `student-entries:${classroomId}:`
+}
+
+export function getStudentEntriesCacheKey(
+  classroomId: string,
+  options: StudentEntriesOptions = {},
+): string {
+  const scope = typeof options.limit === 'number' ? `limit:${options.limit}` : 'all'
+  return `${getStudentEntriesCachePrefix(classroomId)}${scope}`
+}
+
+export async function fetchStudentEntriesForClassroom(
+  classroomId: string,
+  options: StudentEntriesOptions = {},
+): Promise<Entry[]> {
+  const data = await fetchJSONWithCache<StudentEntriesResponse>(
+    getStudentEntriesCacheKey(classroomId, options),
+    async () => {
+      const params = new URLSearchParams({ classroom_id: classroomId })
+      if (typeof options.limit === 'number') {
+        params.set('limit', String(options.limit))
+      }
+
+      const response = await fetch(`/api/student/entries?${params.toString()}`)
+      const data = await response.json().catch(() => ({ entries: [] }))
+      if (!response.ok) {
+        const message = typeof data.error === 'string' ? data.error : 'Failed to load entries'
+        throw new Error(message)
+      }
+      return data
+    },
+    STUDENT_ENTRIES_CACHE_TTL_MS,
+  )
+
+  return data.entries || []
+}
+
+export function invalidateStudentEntriesForClassroom(classroomId: string) {
+  invalidateCachedJSONMatching(getStudentEntriesCachePrefix(classroomId))
+}

--- a/tests/components/StudentHistoryTab.test.tsx
+++ b/tests/components/StudentHistoryTab.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { StudentHistoryTab } from '@/app/classrooms/[classroomId]/StudentHistoryTab'
+import { invalidateClassDaysForClassroom } from '@/lib/class-days-client'
+import { invalidateStudentEntriesForClassroom } from '@/lib/student-entries-client'
+import type { Classroom, Entry } from '@/types'
+
+vi.mock('@/lib/timezone', () => ({
+  getTodayInToronto: () => '2025-05-10',
+}))
+
+const classroom: Classroom = {
+  id: 'c1',
+  teacher_id: 't1',
+  title: 'Test Class',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'hidden',
+  archived_at: null,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}
+
+const secondClassroom: Classroom = {
+  ...classroom,
+  id: 'c2',
+  title: 'Second Class',
+  class_code: 'DEF456',
+}
+
+const entries: Entry[] = [
+  {
+    id: 'entry-1',
+    student_id: 'student-1',
+    classroom_id: 'c1',
+    date: '2025-05-09',
+    text: 'Completed the lesson.',
+    rich_content: null,
+    version: 1,
+    minutes_reported: null,
+    mood: null,
+    created_at: '2025-05-09T12:00:00Z',
+    updated_at: '2025-05-09T12:00:00Z',
+    on_time: true,
+  },
+]
+
+function mockJson(data: unknown, ok = true) {
+  return Promise.resolve({ ok, json: () => Promise.resolve(data) }) as any
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('StudentHistoryTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    invalidateClassDaysForClassroom(classroom.id)
+    invalidateClassDaysForClassroom(secondClassroom.id)
+    invalidateStudentEntriesForClassroom(classroom.id)
+    invalidateStudentEntriesForClassroom(secondClassroom.id)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('reuses cached class days and entry history across remounts', async () => {
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return mockJson({
+          class_days: [
+            { id: 'day-1', classroom_id: 'c1', date: '2025-05-09', prompt_text: null, is_class_day: true },
+            { id: 'day-2', classroom_id: 'c1', date: '2025-05-08', prompt_text: null, is_class_day: true },
+            { id: 'day-3', classroom_id: 'c1', date: '2025-05-07', prompt_text: null, is_class_day: false },
+          ],
+        })
+      }
+      if (url === `/api/student/entries?classroom_id=${classroom.id}`) {
+        return mockJson({ entries })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const firstRender = render(<StudentHistoryTab classroom={classroom} />)
+
+    expect(await screen.findByText('2025-05-09')).toBeInTheDocument()
+    expect(screen.getByText('2025-05-08')).toBeInTheDocument()
+    expect(screen.queryByText('2025-05-07')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('present')).toBeInTheDocument()
+    expect(screen.getByLabelText('absent')).toBeInTheDocument()
+
+    firstRender.unmount()
+    render(<StudentHistoryTab classroom={classroom} />)
+
+    expect(await screen.findByText('2025-05-09')).toBeInTheDocument()
+
+    const classDayFetches = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes('/class-days')
+    )
+    const entryFetches = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes('/api/student/entries?')
+    )
+
+    expect(classDayFetches).toHaveLength(1)
+    expect(entryFetches).toHaveLength(1)
+  })
+
+  it('clears stale rows when a later classroom history load fails', async () => {
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return mockJson({
+          class_days: [
+            { id: 'day-1', classroom_id: 'c1', date: '2025-05-09', prompt_text: null, is_class_day: true },
+          ],
+        })
+      }
+      if (url === `/api/student/entries?classroom_id=${classroom.id}`) {
+        return mockJson({ entries })
+      }
+      if (url === `/api/classrooms/${secondClassroom.id}/class-days`) {
+        return mockJson({ error: 'Forbidden' }, false)
+      }
+      if (url === `/api/student/entries?classroom_id=${secondClassroom.id}`) {
+        return mockJson({ entries: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<StudentHistoryTab classroom={classroom} />)
+
+    expect(await screen.findByText('2025-05-09')).toBeInTheDocument()
+
+    rerender(<StudentHistoryTab classroom={secondClassroom} />)
+
+    expect(await screen.findByText('No class days yet')).toBeInTheDocument()
+    expect(screen.queryByText('2025-05-09')).not.toBeInTheDocument()
+  })
+
+  it('ignores an older classroom history request after switching classrooms', async () => {
+    const firstClassDaysRequest = deferred<any>()
+    const firstEntriesRequest = deferred<any>()
+
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return firstClassDaysRequest.promise
+      }
+      if (url === `/api/student/entries?classroom_id=${classroom.id}`) {
+        return firstEntriesRequest.promise
+      }
+      if (url === `/api/classrooms/${secondClassroom.id}/class-days`) {
+        return mockJson({ error: 'Forbidden' }, false)
+      }
+      if (url === `/api/student/entries?classroom_id=${secondClassroom.id}`) {
+        return mockJson({ entries: [] })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<StudentHistoryTab classroom={classroom} />)
+
+    rerender(<StudentHistoryTab classroom={secondClassroom} />)
+
+    expect(await screen.findByText('No class days yet')).toBeInTheDocument()
+
+    firstClassDaysRequest.resolve(await mockJson({
+      class_days: [
+        { id: 'day-1', classroom_id: 'c1', date: '2025-05-09', prompt_text: null, is_class_day: true },
+      ],
+    }))
+    firstEntriesRequest.resolve(await mockJson({ entries }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('2025-05-09')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -3,13 +3,26 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { StudentTodayTab } from '@/app/classrooms/[classroomId]/StudentTodayTab'
 import { getStudentEntryHistoryCacheKey } from '@/lib/student-entry-history'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 import type { Classroom, Entry } from '@/types'
 
 const getTodayInTorontoMock = vi.hoisted(() => vi.fn(() => '2025-12-16'))
+const invalidateStudentEntriesForClassroomMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/timezone', () => ({
   getTodayInToronto: getTodayInTorontoMock,
 }))
+
+vi.mock('@/lib/student-entries-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/student-entries-client')>()
+  return {
+    ...actual,
+    invalidateStudentEntriesForClassroom: (classroomId: string) => {
+      invalidateStudentEntriesForClassroomMock(classroomId)
+      return actual.invalidateStudentEntriesForClassroom(classroomId)
+    },
+  }
+})
 
 vi.mock('@/components/editor', async () => {
   const React = await import('react')
@@ -126,6 +139,9 @@ function deferred<T>() {
 describe('StudentTodayTab history section', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    invalidateStudentEntriesForClassroomMock.mockClear()
+    invalidateCachedJSONMatching('student-entries:')
+    invalidateCachedJSONMatching('student-lesson-plans:')
     getTodayInTorontoMock.mockReturnValue('2025-12-16')
     window.sessionStorage.clear()
     document.cookie = 'pika_student_today_history=; Max-Age=0; Path=/'
@@ -421,5 +437,52 @@ describe('StudentTodayTab history section', () => {
     )
     expect(saveCall).toBeDefined()
     expect(JSON.parse(String(saveCall?.[1]?.body)).date).toBe('2025-05-11')
+    expect(invalidateStudentEntriesForClassroomMock).toHaveBeenCalledWith(classroom.id)
+  })
+
+  it('invalidates entry caches and clears session history on partial save conflict', async () => {
+    const cacheKey = getStudentEntryHistoryCacheKey({ classroomId: classroom.id, limit: 12 })
+    getTodayInTorontoMock.mockReturnValue('2025-12-16')
+    const serverEntry = {
+      id: entries[0].id,
+      text: 'Server conflict version.',
+      rich_content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Server conflict version.' }] }],
+      },
+      version: 2,
+    }
+
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ error: 'Entry updated elsewhere', entry: serverEntry }),
+        }) as any
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    fireEvent.change(editor, { target: { value: 'Local draft.' } })
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(screen.getByText('Entry updated elsewhere')).toBeInTheDocument()
+    })
+
+    expect(invalidateStudentEntriesForClassroomMock).toHaveBeenCalledWith(classroom.id)
+    expect(window.sessionStorage.getItem(cacheKey)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Add a shared cached student entries client helper keyed by classroom and optional limit.
- Route student history class-day and entry reads through cached helpers in both the classroom tab and standalone student history page.
- Reuse the shared student entries cache from the Today tab and invalidate it after successful entry saves.

## Validation
- pnpm vitest run tests/components/StudentHistoryTab.test.tsx tests/components/StudentTodayTabHistory.test.tsx
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
- pnpm lint
- pnpm build
