### PR TITLE
Invalidate gradebook caches after grading

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -966,3 +966,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-05-31 — Gradebook cache invalidation after grading
+
+**Completed:**
+- Added a shared `invalidateGradebookForClassroom()` helper for `gradebook:<classroomId>:` cache keys.
+- Routed the gradebook detail refresh path through the helper.
+- Invalidated gradebook caches when assignment grade-update events arrive, including auto-grade paths that refresh without a full doc payload.
+- Invalidated gradebook caches after test grading row updates, batch auto-grade completion, batch return, unsubmit, and attempt deletion refreshes.
+- Added focused component coverage for assignment and test grade-update invalidation.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/hooks/useGradebookData.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -107,6 +107,7 @@ import { applyDirection, compareByNameFields, toggleSort as toggleSortState } fr
 import type { SortDirection } from '@/lib/table-sort'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
+import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { safeSessionGetJson, safeSessionSetJson } from '@/lib/client-storage'
 
@@ -1969,7 +1970,9 @@ export function TeacherClassroomView({
     function onGradeUpdated(event: Event) {
       const customEvent = event as CustomEvent<TeacherGradeUpdatedEventDetail>
       const detail = customEvent.detail
-      if (!detail?.assignmentId || !detail?.studentId || !detail?.doc) return
+      if (!detail?.assignmentId || !detail?.studentId) return
+      invalidateGradebookForClassroom(classroom.id)
+      if (!detail.doc) return
       const updatedDoc = detail.doc
       queueClassPaneScrollRestore()
 
@@ -1997,7 +2000,7 @@ export function TeacherClassroomView({
 
     window.addEventListener(TEACHER_GRADE_UPDATED_EVENT, onGradeUpdated)
     return () => window.removeEventListener(TEACHER_GRADE_UPDATED_EVENT, onGradeUpdated)
-  }, [queueClassPaneScrollRestore])
+  }, [classroom.id, queueClassPaneScrollRestore])
 
   function toggleSort(column: 'first' | 'last' | 'status') {
     setSortState((prev) => toggleSortState(prev, column))

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -44,6 +44,7 @@ import {
   type TeacherTestGradingRowUpdatedEventDetail,
 } from '@/lib/events'
 import { getDisplayAssessmentTitle } from '@/lib/assessment-titles'
+import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { getQuizExitCount } from '@/lib/quizzes'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
@@ -1106,6 +1107,7 @@ export function TeacherTestsTab({
       const detail = (event as CustomEvent<TeacherTestGradingRowUpdatedEventDetail>).detail
       if (!detail || detail.testId !== selectedTestId) return
 
+      invalidateGradebookForClassroom(classroom.id)
       setGradingStudents((prev) =>
         prev.map((student) => {
           if (student.student_id !== detail.studentId) return student
@@ -1123,7 +1125,7 @@ export function TeacherTestsTab({
 
     window.addEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
     return () => window.removeEventListener(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, handleGradingRowUpdate)
-  }, [selectedTestId, selectedWorkspaceTab, workspaceState])
+  }, [classroom.id, selectedTestId, selectedWorkspaceTab, workspaceState])
 
   useEffect(() => {
     if (!onTestGradingContextChange) return
@@ -1248,6 +1250,7 @@ export function TeacherTestsTab({
     clearBatchSelection()
     void loadGradingRows()
     setTestGradingPanelRefreshToken((prev) => prev + 1)
+    invalidateGradebookForClassroom(classroom.id)
     onTestGradingDataRefresh?.()
 
     if (message.error) {
@@ -1258,7 +1261,7 @@ export function TeacherTestsTab({
       setGradingInfo('')
       setGradingError('')
     }
-  }, [activeTestAiRun, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
+  }, [activeTestAiRun, classroom.id, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
   function handleOpenTest(test: QuizWithStats) {
     navigateTestWorkspace({ testId: test.id, mode: 'grading', studentId: null })
@@ -1469,6 +1472,7 @@ export function TeacherTestsTab({
       }
       await loadGradingRows()
       setTestGradingPanelRefreshToken((prev) => prev + 1)
+      invalidateGradebookForClassroom(classroom.id)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Auto-grade failed')
@@ -1507,6 +1511,7 @@ export function TeacherTestsTab({
       }
       await loadGradingRows()
       setTestGradingPanelRefreshToken((prev) => prev + 1)
+      invalidateGradebookForClassroom(classroom.id)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Return failed')
@@ -1623,6 +1628,7 @@ export function TeacherTestsTab({
       setPendingUnsubmitStudent(null)
       await loadGradingRows()
       setTestGradingPanelRefreshToken((prev) => prev + 1)
+      invalidateGradebookForClassroom(classroom.id)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Unsubmit failed')
@@ -1658,6 +1664,7 @@ export function TeacherTestsTab({
       setPendingDeleteStudentAttemptIds(null)
       await loadGradingRows()
       setTestGradingPanelRefreshToken((prev) => prev + 1)
+      invalidateGradebookForClassroom(classroom.id)
       onTestGradingDataRefresh?.()
     } catch (error: any) {
       setGradingError(error.message || 'Delete failed')

--- a/src/hooks/useGradebookData.ts
+++ b/src/hooks/useGradebookData.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
-import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
+import { fetchJSONWithCache } from '@/lib/request-cache'
 import type { GradebookClassSummary, GradebookStudentDetail, GradebookStudentSummary } from '@/types'
 
 interface UseGradebookDataOptions {
@@ -65,7 +66,7 @@ export function useGradebookData({
 
   const handleGradebookClassSummaryChange = useCallback((summary: GradebookClassSummary | null) => {
     setGradebookClassSummary(summary)
-    invalidateCachedJSONMatching(`gradebook:${classroomId}:`)
+    invalidateGradebookForClassroom(classroomId)
     setDetailRefreshToken((previous) => previous + 1)
   }, [classroomId])
 

--- a/src/lib/gradebook-cache.ts
+++ b/src/lib/gradebook-cache.ts
@@ -1,0 +1,5 @@
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
+
+export function invalidateGradebookForClassroom(classroomId: string) {
+  invalidateCachedJSONMatching(`gradebook:${classroomId}:`)
+}

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -2,11 +2,12 @@ import { forwardRef, useEffect } from 'react'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherClassroomView } from '@/app/classrooms/[classroomId]/TeacherClassroomView'
-import { TEACHER_ASSIGNMENTS_SELECTION_EVENT } from '@/lib/events'
+import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_GRADE_UPDATED_EVENT } from '@/lib/events'
 import type { Classroom, ClassworkMaterial, SurveyWithStats } from '@/types'
 
 const mockFetchJSONWithCache = vi.fn()
 const mockInvalidateCachedJSON = vi.fn()
+const mockInvalidateGradebookForClassroom = vi.fn()
 const mockFetchClassDaysForClassroom = vi.fn()
 const mockToggleSelect = vi.fn()
 const mockToggleSelectAll = vi.fn()
@@ -402,6 +403,10 @@ vi.mock('@/lib/request-cache', () => ({
   invalidateCachedJSON: (...args: any[]) => mockInvalidateCachedJSON(...args),
 }))
 
+vi.mock('@/lib/gradebook-cache', () => ({
+  invalidateGradebookForClassroom: (...args: any[]) => mockInvalidateGradebookForClassroom(...args),
+}))
+
 vi.mock('@/lib/class-days-client', () => ({
   fetchClassDaysForClassroom: (...args: any[]) => mockFetchClassDaysForClassroom(...args),
 }))
@@ -595,6 +600,7 @@ describe('TeacherClassroomView', () => {
     mockUseOverlayMessage.mockReset()
     mockIsVisibleAtNow.mockReset()
     mockUpdateModeLayout.mockReset()
+    mockInvalidateGradebookForClassroom.mockReset()
     mockIsVisibleAtNow.mockReturnValue(true)
     mockStudentSelectionState.selectedIds = new Set<string>()
     mockStudentSelectionState.allSelected = false
@@ -642,6 +648,28 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+  })
+
+  it('invalidates gradebook caches when assignment grade updates arrive', async () => {
+    render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
+    })
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_GRADE_UPDATED_EVENT, {
+          detail: {
+            assignmentId: 'assignment-1',
+            studentId: 'student-1',
+            doc: null,
+          },
+        })
+      )
+    })
+
+    expect(mockInvalidateGradebookForClassroom).toHaveBeenCalledWith(classroom.id)
   })
 
   it('uses the shared class-days client without caching failed class-day loads as empty successes', async () => {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -4,16 +4,21 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
-import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { TEACHER_QUIZZES_UPDATED_EVENT, TEACHER_TEST_GRADING_ROW_UPDATED_EVENT } from '@/lib/events'
 import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
 import type { QuizWithStats } from '@/types'
 
 const { setOpenMock } = vi.hoisted(() => ({
   setOpenMock: vi.fn(),
 }))
+const mockInvalidateGradebookForClassroom = vi.hoisted(() => vi.fn())
 
 vi.mock('@/components/layout', () => ({
   useRightSidebar: () => ({ setOpen: setOpenMock }),
+}))
+
+vi.mock('@/lib/gradebook-cache', () => ({
+  invalidateGradebookForClassroom: mockInvalidateGradebookForClassroom,
 }))
 
 vi.mock('@/components/QuizDetailPanel', () => ({
@@ -262,6 +267,7 @@ describe('TeacherTestsTab', () => {
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     setOpenMock.mockReset()
+    mockInvalidateGradebookForClassroom.mockClear()
   })
 
   afterEach(() => {
@@ -1051,6 +1057,38 @@ describe('TeacherTestsTab', () => {
       studentId: 'student-1',
       studentName: 'Alice Zephyr',
     })
+  })
+
+  it('invalidates gradebook caches when test grading rows update', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+      })
+      .mockResolvedValueOnce(makeResultsResponse())
+
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_TEST_GRADING_ROW_UPDATED_EVENT, {
+          detail: {
+            testId: 'test-1',
+            studentId: 'student-1',
+            pointsEarned: 4,
+            pointsPossible: 5,
+            percent: 80,
+            gradedOpenResponses: 1,
+            ungradedOpenResponses: 0,
+          },
+        })
+      )
+    })
+
+    expect(mockInvalidateGradebookForClassroom).toHaveBeenCalledWith(classroom.id)
   })
 
   it('moves the selected grading student with up and down arrows', async () => {


### PR DESCRIPTION
## Summary
- Add `invalidateGradebookForClassroom()` for the shared `gradebook:<classroomId>:` cache boundary.
- Invalidate gradebook caches when assignment grade-update events arrive.
- Invalidate gradebook caches after test grading row updates, batch auto-grade completion, return, unsubmit, and attempt deletion refreshes.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/hooks/useGradebookData.test.ts tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
- pnpm lint
- pnpm build
