### PR TITLE
[codex] Standardize AI grading egress sanitization

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -101,6 +101,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test`
 
+## 2026-06-01 — AI grading roster sanitization follow-up
+
+**Completed:**
+- Addressed PR review feedback by loading classroom roster/profile names before assignment and test AI grading egress.
+- Threaded roster-aware sanitization context through assignment grading, manual test AI suggestions, and background test auto-grading batches.
+- Sanitized test reference prompts, answer keys, sample solutions, student responses, and cached/provided references with the same context.
+- Added focused unit coverage proving known student names become initials in assignment and test grading provider prompts.
+
+**Validation:**
+- `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/tests-auto-grade.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+
 ## 2026-05-27 — Required submission artifact display
 
 **Completed:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -929,6 +929,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
 
+## 2026-06-01 — AI grading egress sanitization
+
+**Completed:**
+- Added shared AI sanitization utilities for direct identifier redaction, roster-aware initials reuse, provider pseudonym refs, and egress allow-list validation.
+- Kept log summary APIs compatible while routing their redaction helpers through the shared sanitizer.
+- Sanitized assignment grading prompt fields, artifact metadata, and generated feedback, and added `store: false` to assignment grading OpenAI requests.
+- Sanitized test grading prompt fields, answer references, student responses, and generated feedback, added `store: false`, and changed batch grading to send pseudonymous provider refs mapped back locally.
+- Documented the AI grading egress contract for the upcoming GradeX adapter.
+
+**Validation:**
+- `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/log-summary.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/lib/ai-test-grading.test.ts`
+- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/test-auto-grade-runs.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
+- `pnpm lint`
+- `pnpm test` (one unrelated `StudentAssignmentsTab` modal test failed during the full run; rerunning that file passed)
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx`
+- `pnpm build`
+- `git diff --check`
+
 ## 2026-05-31 — Upload image route standardization
 
 **Completed:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -107,10 +107,13 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Addressed PR review feedback by loading classroom roster/profile names before assignment and test AI grading egress.
 - Threaded roster-aware sanitization context through assignment grading, manual test AI suggestions, and background test auto-grading batches.
 - Sanitized test reference prompts, answer keys, sample solutions, student responses, and cached/provided references with the same context.
+- Changed classroom sanitization context loading to fail closed on roster/profile lookup errors before AI provider calls.
 - Added focused unit coverage proving known student names become initials in assignment and test grading provider prompts.
 
 **Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/tests-auto-grade.test.ts`
+- `pnpm test tests/unit/ai-sanitization-server.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/tests-auto-grade.test.ts`
 - `pnpm lint`
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/docs/guidance/ai-grading-egress.md
+++ b/docs/guidance/ai-grading-egress.md
@@ -12,6 +12,9 @@ that sanitized copy to the provider.
   student numbers, UUIDs, and street-like addresses.
 - Load classroom roster/profile names for grading paths and replace known
   student names with initials before provider egress.
+- If classroom roster/profile names cannot be loaded, fail closed before the
+  provider call instead of sending grading text with only direct-identifier
+  redaction.
 - Replace provider correlation IDs with local-only pseudonyms such as
   `response_1` or `submission_1`.
 - Keep the pseudonym-to-local-ID mapping inside Pika. Providers should never need

--- a/docs/guidance/ai-grading-egress.md
+++ b/docs/guidance/ai-grading-egress.md
@@ -10,6 +10,8 @@ that sanitized copy to the provider.
   adapter.
 - Redact direct identifiers before provider egress: emails, URLs, phone numbers,
   student numbers, UUIDs, and street-like addresses.
+- Load classroom roster/profile names for grading paths and replace known
+  student names with initials before provider egress.
 - Replace provider correlation IDs with local-only pseudonyms such as
   `response_1` or `submission_1`.
 - Keep the pseudonym-to-local-ID mapping inside Pika. Providers should never need
@@ -22,10 +24,11 @@ that sanitized copy to the provider.
 ## Current Paths
 
 - Daily log summaries use roster-aware initials plus direct identifier redaction.
-- Assignment grading now redacts assignment metadata, student work, artifact
-  metadata, and generated feedback.
-- Test grading now redacts test/question metadata, answer references, student
-  responses, and generated feedback.
+- Assignment grading loads classroom sanitization context, then sanitizes
+  assignment metadata, student work, artifact metadata, and generated feedback.
+- Test grading loads classroom sanitization context, then sanitizes
+  test/question metadata, answer references, student responses, and generated
+  feedback.
 - Test batch grading sends pseudonymous response refs and maps them back locally
   after the provider response.
 

--- a/docs/guidance/ai-grading-egress.md
+++ b/docs/guidance/ai-grading-egress.md
@@ -1,0 +1,38 @@
+# AI Grading Egress
+
+Pika keeps canonical classroom data unchanged. Any provider call for assignment
+or test grading must build an outbound-only egress payload first, then send only
+that sanitized copy to the provider.
+
+## Contract
+
+- Do not pass raw Supabase rows or UI domain objects directly to an AI provider
+  adapter.
+- Redact direct identifiers before provider egress: emails, URLs, phone numbers,
+  student numbers, UUIDs, and street-like addresses.
+- Replace provider correlation IDs with local-only pseudonyms such as
+  `response_1` or `submission_1`.
+- Keep the pseudonym-to-local-ID mapping inside Pika. Providers should never need
+  Pika user IDs, response IDs, assignment doc IDs, names, or emails.
+- Validate adapter payloads against an allow-list of expected fields before
+  sending. Unexpected fields should fail closed.
+- Set provider retention controls such as `store: false` where supported.
+- Sanitize provider output before saving feedback locally.
+
+## Current Paths
+
+- Daily log summaries use roster-aware initials plus direct identifier redaction.
+- Assignment grading now redacts assignment metadata, student work, artifact
+  metadata, and generated feedback.
+- Test grading now redacts test/question metadata, answer references, student
+  responses, and generated feedback.
+- Test batch grading sends pseudonymous response refs and maps them back locally
+  after the provider response.
+
+## GradeX Adapter Guidance
+
+GradeX should accept a sanitized grading envelope, not raw Pika rows. The adapter
+may define its own provider schema, but it should be constructed from sanitized
+text and pseudonymous refs only. If GradeX needs artifact URLs or other richer
+context, that should be an explicit profile flag with tests that prove the
+additional field is intentional.

--- a/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
+++ b/src/app/api/teacher/tests/[id]/responses/[responseId]/ai-suggest/route.ts
@@ -9,6 +9,7 @@ import {
   suggestTestOpenResponseGradeWithContext,
 } from '@/lib/ai-test-grading'
 import { withErrorHandler } from '@/lib/api-handler'
+import { loadClassroomAiSanitizationContext } from '@/lib/server/ai-sanitization'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -87,6 +88,10 @@ export const POST = withErrorHandler('AiSuggestTeacherTestGrade', async (request
   }
 
   const currentModel = getTestOpenResponseGradingModel()
+  const sanitizationContext = await loadClassroomAiSanitizationContext(
+    supabase,
+    access.test.classroom_id,
+  )
   const referenceCache = resolveReusableTestOpenResponseReferenceAnswers({
     testTitle: access.test.title,
     questionText: String(question.question_text || ''),
@@ -118,6 +123,7 @@ export const POST = withErrorHandler('AiSuggestTeacherTestGrade', async (request
       requestedStrategy: 'manual',
       resolvedStrategy: 'single',
     },
+    sanitizationContext,
   })
 
   if (

--- a/src/lib/ai-grading.ts
+++ b/src/lib/ai-grading.ts
@@ -7,7 +7,11 @@ import {
   extractOpenAIResponseUsage,
   logAiPromptTelemetry,
 } from '@/lib/ai-prompt-metrics'
-import { sanitizeAiOutputText, sanitizeAiText } from '@/lib/ai-sanitization'
+import {
+  sanitizeAiOutputText,
+  sanitizeAiText,
+  type AiSanitizationContext,
+} from '@/lib/ai-sanitization'
 import { extractPlainText } from '@/lib/tiptap-content'
 import type { TiptapContent } from '@/types'
 
@@ -319,11 +323,12 @@ export function buildAssignmentGradingRequest(opts: {
   instructions: string
   studentWork: TiptapContent
   submissionArtifacts?: AssignmentArtifact[]
+  sanitizationContext?: AiSanitizationContext | null
 }): AssignmentGradingRequest {
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
   const studentSubmission = buildStudentSubmissionText(opts.studentWork, opts.submissionArtifacts)
-  const assignmentTitle = sanitizeAiText(opts.assignmentTitle)
-  const instructions = sanitizeAiText(opts.instructions)
+  const assignmentTitle = sanitizeAiText(opts.assignmentTitle, opts.sanitizationContext ?? undefined)
+  const instructions = sanitizeAiText(opts.instructions, opts.sanitizationContext ?? undefined)
 
   return {
     model,
@@ -346,7 +351,7 @@ Feedback rules:
 Instructions: ${instructions}
 
 Student Work:
-${sanitizeAiText(studentSubmission)}`,
+${sanitizeAiText(studentSubmission, opts.sanitizationContext ?? undefined)}`,
   }
 }
 
@@ -484,6 +489,7 @@ export async function gradeStudentWork(opts: {
   previousFeedback?: string | null
   requestTimeoutMs?: number
   telemetry?: AssignmentGradingTelemetryContext
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<GradeResult> {
   const apiKey = getOpenAIKey()
   if (!apiKey) {
@@ -499,6 +505,7 @@ export async function gradeStudentWork(opts: {
     instructions: opts.instructions,
     studentWork: opts.studentWork,
     submissionArtifacts: opts.submissionArtifacts,
+    sanitizationContext: opts.sanitizationContext,
   })
   const promptMetrics = estimatePromptMetrics(request.systemPrompt, request.userPrompt)
   try {

--- a/src/lib/ai-grading.ts
+++ b/src/lib/ai-grading.ts
@@ -7,6 +7,7 @@ import {
   extractOpenAIResponseUsage,
   logAiPromptTelemetry,
 } from '@/lib/ai-prompt-metrics'
+import { sanitizeAiOutputText, sanitizeAiText } from '@/lib/ai-sanitization'
 import { extractPlainText } from '@/lib/tiptap-content'
 import type { TiptapContent } from '@/types'
 
@@ -139,6 +140,7 @@ function buildAssignmentGradingApiBody(
 ) {
   return {
     model: request.model,
+    store: false,
     input: [
       {
         role: 'system',
@@ -278,9 +280,9 @@ function buildStudentSubmissionText(
     const artifactLines = artifacts.map((artifact) => {
       const repoSummary =
         artifact.type === 'repo' && artifact.repo_owner && artifact.repo_name
-          ? ` (${artifact.repo_owner}/${artifact.repo_name})`
+          ? ` (${sanitizeAiText(artifact.repo_owner)}/${sanitizeAiText(artifact.repo_name)})`
           : ''
-      return `- ${formatArtifactLabel(artifact)}: ${artifact.url}${repoSummary}`
+      return `- ${formatArtifactLabel(artifact)}: ${sanitizeAiText(artifact.url)}${repoSummary}`
     })
     sections.push(`Attached Artifacts:\n${artifactLines.join('\n')}`)
   }
@@ -320,6 +322,8 @@ export function buildAssignmentGradingRequest(opts: {
 }): AssignmentGradingRequest {
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
   const studentSubmission = buildStudentSubmissionText(opts.studentWork, opts.submissionArtifacts)
+  const assignmentTitle = sanitizeAiText(opts.assignmentTitle)
+  const instructions = sanitizeAiText(opts.instructions)
 
   return {
     model,
@@ -338,11 +342,11 @@ Feedback rules:
 - include one sentence starting with "Strength:"
 - include one sentence starting with "Next Step:"
 - if total score is less than 30, include one sentence starting with "Improve:" and give one concrete improvement to reach full marks.`,
-    userPrompt: `Assignment: ${opts.assignmentTitle}
-Instructions: ${opts.instructions}
+    userPrompt: `Assignment: ${assignmentTitle}
+Instructions: ${instructions}
 
 Student Work:
-${studentSubmission}`,
+${sanitizeAiText(studentSubmission)}`,
   }
 }
 
@@ -451,7 +455,7 @@ function parseAssignmentGradingResponse(outputText: string, previousFeedback?: s
     })
   }
 
-  let feedback = String(parsed.feedback || '').trim()
+  let feedback = sanitizeAiOutputText(String(parsed.feedback || '').trim())
   if (!feedback) {
     throw new AssignmentAiGradingError({
       kind: 'invalid_output',

--- a/src/lib/ai-sanitization.ts
+++ b/src/lib/ai-sanitization.ts
@@ -1,0 +1,187 @@
+const DIRECT_IDENTIFIER_PATTERNS: Array<[RegExp, string]> = [
+  [/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[email redacted]'],
+  [/\bhttps?:\/\/[^\s<>"')]+/gi, '[url redacted]'],
+  [
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+    '[id redacted]',
+  ],
+  [
+    /\b(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/g,
+    '[phone redacted]',
+  ],
+  [
+    /\b(?:student\s*(?:number|id|#)|student#)\s*[:#-]?\s*\d{6,12}\b/gi,
+    '[student number redacted]',
+  ],
+  [/\b\d{8,12}\b/g, '[student number redacted]'],
+  [
+    /\b\d{1,6}\s+(?:[A-Z0-9'.-]+\s+){1,6}(?:street|st|avenue|ave|road|rd|drive|dr|court|ct|lane|ln|boulevard|blvd|way|place|pl|crescent|cres)\b/gi,
+    '[address redacted]',
+  ],
+]
+
+export type AiSanitizationStudent = {
+  firstName: string
+  lastName: string
+}
+
+export interface AiSanitizedRef {
+  providerRef: string
+  localId: string
+}
+
+export interface AiSanitizationAudit {
+  redactedDirectIdentifiers: boolean
+  nameReplacementCount: number
+}
+
+export function redactDirectIdentifiers(text: string): string {
+  return DIRECT_IDENTIFIER_PATTERNS.reduce(
+    (result, [pattern, replacement]) => result.replace(pattern, replacement),
+    text
+  )
+}
+
+/**
+ * Build a map of unique initials for each student.
+ * Handles collisions by appending an index: "J.S.1", "J.S.2".
+ */
+export function buildInitialsMap(
+  students: AiSanitizationStudent[]
+): Record<string, string> {
+  const result: Record<string, string> = {}
+  const counts: Record<string, number> = {}
+
+  for (const student of students) {
+    const fi = (student.firstName[0] || '?').toUpperCase()
+    const li = (student.lastName[0] || '?').toUpperCase()
+    const base = `${fi}.${li}.`
+    const fullName = `${student.firstName} ${student.lastName}`
+
+    counts[base] = (counts[base] || 0) + 1
+    const key = counts[base] > 1 ? `${base}${counts[base]}` : base
+
+    result[key] = fullName
+  }
+
+  for (const base of Object.keys(counts)) {
+    if (counts[base] > 1 && result[base]) {
+      const fullName = result[base]
+      delete result[base]
+      result[`${base}1`] = fullName
+    }
+  }
+
+  return result
+}
+
+export function sanitizeTextWithStudentNames(
+  text: string,
+  students: AiSanitizationStudent[],
+  initialsMap: Record<string, string>
+): string {
+  const result = replaceStudentNames(text, students, initialsMap)
+  return redactDirectIdentifiers(result.text)
+}
+
+export function sanitizeAiText(
+  text: string,
+  options?: {
+    students?: AiSanitizationStudent[]
+    initialsMap?: Record<string, string>
+  }
+): string {
+  const students = options?.students ?? []
+  const initialsMap = options?.initialsMap ?? {}
+
+  if (students.length === 0) {
+    return redactDirectIdentifiers(text)
+  }
+
+  return sanitizeTextWithStudentNames(text, students, initialsMap)
+}
+
+export function sanitizeAiOutputText(text: string): string {
+  return redactDirectIdentifiers(text)
+}
+
+export function createProviderRefMap<T extends { localId: string }>(
+  values: T[],
+  prefix: string
+): Array<T & AiSanitizedRef> {
+  return values.map((value, index) => ({
+    ...value,
+    providerRef: `${prefix}_${index + 1}`,
+  }))
+}
+
+export function mapProviderRefToLocalId(refs: AiSanitizedRef[]): Map<string, string> {
+  return new Map(refs.map((ref) => [ref.providerRef, ref.localId]))
+}
+
+export function sanitizeAiEgressRecord<T extends Record<string, unknown>>(
+  record: T,
+  allowedKeys: Array<keyof T>
+): Pick<T, keyof T> {
+  const allowed = new Set<keyof T>(allowedKeys)
+  const sanitized: Partial<T> = {}
+
+  for (const key of Object.keys(record) as Array<keyof T>) {
+    if (!allowed.has(key)) {
+      throw new Error(`Unexpected AI egress field: ${String(key)}`)
+    }
+    sanitized[key] = record[key]
+  }
+
+  return sanitized as Pick<T, keyof T>
+}
+
+function replaceStudentNames(
+  text: string,
+  students: AiSanitizationStudent[],
+  initialsMap: Record<string, string>
+): { text: string; replacementCount: number } {
+  const nameToInitials: Record<string, string> = {}
+  for (const [initials, fullName] of Object.entries(initialsMap)) {
+    nameToInitials[fullName] = initials
+  }
+
+  let result = text
+  let replacementCount = 0
+
+  const fullNames = students
+    .map((s) => `${s.firstName} ${s.lastName}`)
+    .filter((name) => name.trim().length > 1)
+    .sort((a, b) => b.length - a.length)
+
+  for (const fullName of fullNames) {
+    const initials = nameToInitials[fullName]
+    if (!initials) continue
+    const escaped = escapeRegExp(fullName)
+    result = result.replace(new RegExp(escaped, 'gi'), () => {
+      replacementCount += 1
+      return initials
+    })
+  }
+
+  for (const student of students) {
+    const fullName = `${student.firstName} ${student.lastName}`
+    const initials = nameToInitials[fullName]
+    if (!initials) continue
+
+    for (const name of [student.firstName, student.lastName]) {
+      if (!name || name.length < 2) continue
+      const escaped = escapeRegExp(name)
+      result = result.replace(new RegExp(`\\b${escaped}\\b`, 'gi'), () => {
+        replacementCount += 1
+        return initials
+      })
+    }
+  }
+
+  return { text: result, replacementCount }
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/lib/ai-sanitization.ts
+++ b/src/lib/ai-sanitization.ts
@@ -30,6 +30,11 @@ export interface AiSanitizedRef {
   localId: string
 }
 
+export interface AiSanitizationContext {
+  students: AiSanitizationStudent[]
+  initialsMap: Record<string, string>
+}
+
 export interface AiSanitizationAudit {
   redactedDirectIdentifiers: boolean
   nameReplacementCount: number
@@ -75,6 +80,15 @@ export function buildInitialsMap(
   return result
 }
 
+export function buildAiSanitizationContext(
+  students: AiSanitizationStudent[]
+): AiSanitizationContext {
+  return {
+    students,
+    initialsMap: buildInitialsMap(students),
+  }
+}
+
 export function sanitizeTextWithStudentNames(
   text: string,
   students: AiSanitizationStudent[],
@@ -86,10 +100,7 @@ export function sanitizeTextWithStudentNames(
 
 export function sanitizeAiText(
   text: string,
-  options?: {
-    students?: AiSanitizationStudent[]
-    initialsMap?: Record<string, string>
-  }
+  options?: Partial<AiSanitizationContext>
 ): string {
   const students = options?.students ?? []
   const initialsMap = options?.initialsMap ?? {}

--- a/src/lib/ai-test-grading.ts
+++ b/src/lib/ai-test-grading.ts
@@ -13,6 +13,12 @@ import {
   type AiPromptMetrics,
   type OpenAIResponseUsage,
 } from '@/lib/ai-prompt-metrics'
+import {
+  createProviderRefMap,
+  mapProviderRefToLocalId,
+  sanitizeAiOutputText,
+  sanitizeAiText,
+} from '@/lib/ai-sanitization'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
 const MAX_REFERENCE_ANSWERS = 3
@@ -288,6 +294,7 @@ function buildOpenAIJsonBody(opts: {
 }) {
   return {
     model: opts.model,
+    store: false,
     input: [
       {
         role: 'system',
@@ -517,7 +524,7 @@ function normalizeReferenceAnswers(raw: unknown): string[] {
   }
 
   const normalized = raw
-    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .map((value) => (typeof value === 'string' ? sanitizeAiOutputText(value.trim()) : ''))
     .filter((value) => value.length > 0)
 
   if (normalized.length === 0) {
@@ -787,9 +794,9 @@ Rules:
 - Provide 1-${MAX_REFERENCE_ANSWERS} concise, high-quality reference answers.
 - Each answer should describe acceptable content, not just keywords.
 - Do not include markdown code fences.${codingGuidance}`
-  const userPrompt = `Test: ${opts.testTitle}
+  const userPrompt = `Test: ${sanitizeAiText(opts.testTitle)}
 Question:
-${opts.questionText}
+${sanitizeAiText(opts.questionText)}
 
 Max points: ${opts.maxPoints}`
 
@@ -849,14 +856,16 @@ export function buildTestOpenResponsePreparedContext(input: {
   const maxPoints = Math.max(0, input.maxPoints)
   const promptProfile = input.promptProfile ?? 'manual'
   const isCodingQuestion = input.responseMonospace === true
+  const testTitle = sanitizeAiText(input.testTitle)
+  const questionText = sanitizeAiText(input.questionText)
   const promptGuideline = resolvePromptGuideline(
-    input.promptGuidelineOverride,
+    input.promptGuidelineOverride ? sanitizeAiText(input.promptGuidelineOverride) : input.promptGuidelineOverride,
     isCodingQuestion,
     promptProfile
   )
   const scoreBuckets = normalizeScoreBuckets(input.scoreBuckets, maxPoints)
-  const answerKey = normalizeAnswerKey(input.answerKey)
-  const sampleSolution = normalizeSampleSolution(input.sampleSolution)
+  const answerKey = normalizeAnswerKey(input.answerKey ? sanitizeAiText(input.answerKey) : input.answerKey)
+  const sampleSolution = normalizeSampleSolution(input.sampleSolution ? sanitizeAiText(input.sampleSolution) : input.sampleSolution)
   const normalizedReferenceAnswers =
     input.referenceAnswers != null ? normalizeReferenceAnswers(input.referenceAnswers) : []
 
@@ -913,9 +922,9 @@ ${sampleSolution}`
 Choose the nearest bucket for the score.`
     : 'No explicit score buckets were provided.'
 
-  const userPromptPrefix = `Test: ${input.testTitle}
+  const userPromptPrefix = `Test: ${testTitle}
 Question:
-${input.questionText}
+${questionText}
 
 ${gradingContext}
 ${sampleSolutionContext}
@@ -947,7 +956,7 @@ export function buildTestOpenResponseSingleUserPrompt(
   return `${prepared.userPromptPrefix}
 
 Student response:
-${responseText}`
+${sanitizeAiText(responseText)}`
 }
 
 export function buildTestOpenResponseBatchSystemPrompt(
@@ -970,8 +979,8 @@ Student responses:
 ${responses
   .map(
     (response, index) =>
-      `${index + 1}. response_id=${response.responseId}
-${response.responseText}`
+      `${index + 1}. response_id=${sanitizeAiText(response.responseId)}
+${sanitizeAiText(response.responseText)}`
   )
   .join('\n\n')}`
 }
@@ -1158,7 +1167,7 @@ export async function suggestTestOpenResponseGradeWithContext(
   }
   const score = normalizeSuggestedScore(rawScore, prepared.maxPoints, prepared.scoreBuckets)
 
-  const feedback = String(parsed?.feedback || '').trim()
+  const feedback = sanitizeAiOutputText(String(parsed?.feedback || '').trim())
   if (!feedback) {
     throw new Error('AI grade suggestion did not include feedback')
   }
@@ -1184,8 +1193,22 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
   }
   if (responses.length === 0) return []
 
+  const providerRequests = createProviderRefMap(
+    responses.map((response) => ({
+      localId: response.responseId,
+      responseText: response.responseText,
+    })),
+    'response',
+  )
+  const providerRefToLocalId = mapProviderRefToLocalId(providerRequests)
   const systemPrompt = buildTestOpenResponseBatchSystemPrompt(prepared)
-  const userPrompt = buildTestOpenResponseBatchUserPrompt(prepared, responses)
+  const userPrompt = buildTestOpenResponseBatchUserPrompt(
+    prepared,
+    providerRequests.map((response) => ({
+      responseId: response.providerRef,
+      responseText: response.responseText,
+    })),
+  )
   const promptMetrics = estimatePromptMetrics(systemPrompt, userPrompt)
   const { parsed, usage } = await callOpenAIForJson({
     apiKey,
@@ -1225,9 +1248,14 @@ export async function suggestTestOpenResponseGradesBatchWithContext(
       throw new Error('AI batch grade suggestion returned an invalid result row')
     }
 
-    resultsById.set(responseId, {
+    const localResponseId = providerRefToLocalId.get(responseId)
+    if (!localResponseId) {
+      throw new Error(`AI batch grade suggestion returned unknown response ${responseId}`)
+    }
+
+    resultsById.set(localResponseId, {
       score: normalizeSuggestedScore(rawScore, prepared.maxPoints, prepared.scoreBuckets),
-      feedback,
+      feedback: sanitizeAiOutputText(feedback),
     })
   }
 

--- a/src/lib/ai-test-grading.ts
+++ b/src/lib/ai-test-grading.ts
@@ -18,6 +18,7 @@ import {
   mapProviderRefToLocalId,
   sanitizeAiOutputText,
   sanitizeAiText,
+  type AiSanitizationContext,
 } from '@/lib/ai-sanitization'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
@@ -152,6 +153,7 @@ export interface TestOpenResponsePreparedContext {
   promptMetrics: AiPromptMetrics
   systemPrompt: string
   userPromptPrefix: string
+  sanitizationContext: AiSanitizationContext | null
 }
 
 export interface TestOpenResponseReferenceCacheResolution {
@@ -540,6 +542,20 @@ function normalizeReferenceAnswers(raw: unknown): string[] {
   return deduped
 }
 
+function sanitizeReferenceAnswers(
+  raw: unknown,
+  sanitizationContext: AiSanitizationContext | null,
+): string[] {
+  if (!Array.isArray(raw)) {
+    return normalizeReferenceAnswers(raw)
+  }
+
+  const sanitizeOptions = sanitizationContext ?? undefined
+  return normalizeReferenceAnswers(
+    raw.map((value) => (typeof value === 'string' ? sanitizeAiText(value, sanitizeOptions) : value)),
+  )
+}
+
 function normalizeScoreBuckets(raw: unknown, maxPoints: number): number[] | null {
   if (!Array.isArray(raw)) return null
 
@@ -778,7 +794,9 @@ async function generateReferenceAnswers(opts: {
   promptProfile: TestOpenResponsePromptProfile
   telemetryContext: TestOpenResponseTelemetryContext
   requestTimeoutMs?: number
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<string[]> {
+  const sanitizeOptions = opts.sanitizationContext ?? undefined
   const codingGuidance = opts.isCodingQuestion
     ? `
 - Treat this as a coding question. Provide reference answers as clear code-oriented solution outlines, including algorithm steps and expected structure.
@@ -794,9 +812,9 @@ Rules:
 - Provide 1-${MAX_REFERENCE_ANSWERS} concise, high-quality reference answers.
 - Each answer should describe acceptable content, not just keywords.
 - Do not include markdown code fences.${codingGuidance}`
-  const userPrompt = `Test: ${sanitizeAiText(opts.testTitle)}
+  const userPrompt = `Test: ${sanitizeAiText(opts.testTitle, sanitizeOptions)}
 Question:
-${sanitizeAiText(opts.questionText)}
+${sanitizeAiText(opts.questionText, sanitizeOptions)}
 
 Max points: ${opts.maxPoints}`
 
@@ -824,6 +842,7 @@ Max points: ${opts.maxPoints}`
     referenceAnswersSource: 'generated',
     responseMonospace: opts.isCodingQuestion,
     promptProfile: opts.promptProfile,
+    sanitizationContext: opts.sanitizationContext,
   })
 
   logTestPromptTelemetry({
@@ -851,23 +870,34 @@ export function buildTestOpenResponsePreparedContext(input: {
   scoreBuckets?: number[] | null
   promptGuidelineOverride?: string | null
   promptProfile?: TestOpenResponsePromptProfile
+  sanitizationContext?: AiSanitizationContext | null
 }): TestOpenResponsePreparedContext {
   const model = input.model?.trim() || getTestOpenResponseGradingModel()
   const maxPoints = Math.max(0, input.maxPoints)
   const promptProfile = input.promptProfile ?? 'manual'
   const isCodingQuestion = input.responseMonospace === true
-  const testTitle = sanitizeAiText(input.testTitle)
-  const questionText = sanitizeAiText(input.questionText)
+  const sanitizationContext = input.sanitizationContext ?? null
+  const sanitizeOptions = sanitizationContext ?? undefined
+  const testTitle = sanitizeAiText(input.testTitle, sanitizeOptions)
+  const questionText = sanitizeAiText(input.questionText, sanitizeOptions)
   const promptGuideline = resolvePromptGuideline(
-    input.promptGuidelineOverride ? sanitizeAiText(input.promptGuidelineOverride) : input.promptGuidelineOverride,
+    input.promptGuidelineOverride
+      ? sanitizeAiText(input.promptGuidelineOverride, sanitizeOptions)
+      : input.promptGuidelineOverride,
     isCodingQuestion,
     promptProfile
   )
   const scoreBuckets = normalizeScoreBuckets(input.scoreBuckets, maxPoints)
-  const answerKey = normalizeAnswerKey(input.answerKey ? sanitizeAiText(input.answerKey) : input.answerKey)
-  const sampleSolution = normalizeSampleSolution(input.sampleSolution ? sanitizeAiText(input.sampleSolution) : input.sampleSolution)
+  const answerKey = normalizeAnswerKey(
+    input.answerKey ? sanitizeAiText(input.answerKey, sanitizeOptions) : input.answerKey,
+  )
+  const sampleSolution = normalizeSampleSolution(
+    input.sampleSolution ? sanitizeAiText(input.sampleSolution, sanitizeOptions) : input.sampleSolution,
+  )
   const normalizedReferenceAnswers =
-    input.referenceAnswers != null ? normalizeReferenceAnswers(input.referenceAnswers) : []
+    input.referenceAnswers != null
+      ? sanitizeReferenceAnswers(input.referenceAnswers, sanitizationContext)
+      : []
 
   const gradingBasis: TestAiGradingBasis = answerKey ? 'teacher_key' : 'generated_reference'
   if (gradingBasis === 'generated_reference' && normalizedReferenceAnswers.length === 0) {
@@ -946,6 +976,7 @@ ${scoreBucketContext}`
     promptMetrics: estimatePromptMetrics(systemPrompt, userPromptPrefix),
     systemPrompt,
     userPromptPrefix,
+    sanitizationContext,
   }
 }
 
@@ -956,7 +987,7 @@ export function buildTestOpenResponseSingleUserPrompt(
   return `${prepared.userPromptPrefix}
 
 Student response:
-${sanitizeAiText(responseText)}`
+${sanitizeAiText(responseText, prepared.sanitizationContext ?? undefined)}`
 }
 
 export function buildTestOpenResponseBatchSystemPrompt(
@@ -980,7 +1011,7 @@ ${responses
   .map(
     (response, index) =>
       `${index + 1}. response_id=${sanitizeAiText(response.responseId)}
-${sanitizeAiText(response.responseText)}`
+${sanitizeAiText(response.responseText, prepared.sanitizationContext ?? undefined)}`
   )
   .join('\n\n')}`
 }
@@ -1032,14 +1063,20 @@ export async function prepareTestOpenResponseGradingContext(input: {
   promptProfile?: TestOpenResponsePromptProfile
   telemetryContext?: TestOpenResponseTelemetryContext
   requestTimeoutMs?: number
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<TestOpenResponsePreparedContext> {
   const model = getTestOpenResponseGradingModel()
   const maxPoints = Math.max(0, input.maxPoints)
   const promptProfile = input.promptProfile ?? 'manual'
-  const answerKey = normalizeAnswerKey(input.answerKey)
-  const sampleSolution = normalizeSampleSolution(input.sampleSolution)
+  const sanitizeOptions = input.sanitizationContext ?? undefined
+  const answerKey = normalizeAnswerKey(
+    input.answerKey ? sanitizeAiText(input.answerKey, sanitizeOptions) : input.answerKey,
+  )
+  const sampleSolution = normalizeSampleSolution(
+    input.sampleSolution ? sanitizeAiText(input.sampleSolution, sanitizeOptions) : input.sampleSolution,
+  )
   const providedReferenceAnswers = !answerKey && input.referenceAnswers != null
-    ? normalizeReferenceAnswers(input.referenceAnswers)
+    ? sanitizeReferenceAnswers(input.referenceAnswers, input.sanitizationContext ?? null)
     : null
 
   if (answerKey) {
@@ -1054,6 +1091,7 @@ export async function prepareTestOpenResponseGradingContext(input: {
       scoreBuckets: input.scoreBuckets,
       promptGuidelineOverride: input.promptGuidelineOverride,
       promptProfile,
+      sanitizationContext: input.sanitizationContext,
     })
   }
 
@@ -1070,6 +1108,7 @@ export async function prepareTestOpenResponseGradingContext(input: {
       scoreBuckets: input.scoreBuckets,
       promptGuidelineOverride: input.promptGuidelineOverride,
       promptProfile,
+      sanitizationContext: input.sanitizationContext,
     })
   }
 
@@ -1092,6 +1131,7 @@ export async function prepareTestOpenResponseGradingContext(input: {
       resolvedStrategy: 'reference_generation',
     },
     requestTimeoutMs: input.requestTimeoutMs,
+    sanitizationContext: input.sanitizationContext,
   })
 
   return buildTestOpenResponsePreparedContext({
@@ -1106,6 +1146,7 @@ export async function prepareTestOpenResponseGradingContext(input: {
     scoreBuckets: input.scoreBuckets,
     promptGuidelineOverride: input.promptGuidelineOverride,
     promptProfile,
+    sanitizationContext: input.sanitizationContext,
   })
 }
 
@@ -1293,6 +1334,7 @@ export async function suggestTestOpenResponseGrade(input: {
   promptProfile?: TestOpenResponsePromptProfile
   telemetryContext?: TestOpenResponseTelemetryContext
   requestTimeoutMs?: number
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<TestOpenResponseSuggestion> {
   const prepared = await prepareTestOpenResponseGradingContext(input)
   return suggestTestOpenResponseGradeWithContext(
@@ -1317,6 +1359,7 @@ export async function suggestTestOpenResponseGradesBatch(input: {
   telemetryContext?: TestOpenResponseTelemetryContext
   responses: TestOpenResponseBatchRequest[]
   requestTimeoutMs?: number
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<TestOpenResponseBatchSuggestion[]> {
   const prepared = await prepareTestOpenResponseGradingContext(input)
   return suggestTestOpenResponseGradesBatchWithContext(

--- a/src/lib/log-summary.ts
+++ b/src/lib/log-summary.ts
@@ -1,58 +1,12 @@
 import type { LogSummaryActionItem } from '@/types'
+import {
+  buildInitialsMap,
+  redactDirectIdentifiers,
+  sanitizeTextWithStudentNames,
+} from '@/lib/ai-sanitization'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
-
-const DIRECT_IDENTIFIER_PATTERNS: Array<[RegExp, string]> = [
-  [/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[email redacted]'],
-  [/\bhttps?:\/\/[^\s<>"')]+/gi, '[url redacted]'],
-  [
-    /\b(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/g,
-    '[phone redacted]',
-  ],
-  [
-    /\b(?:student\s*(?:number|id|#)|student#)\s*[:#-]?\s*\d{6,12}\b/gi,
-    '[student number redacted]',
-  ],
-  [/\b\d{8,12}\b/g, '[student number redacted]'],
-  [
-    /\b\d{1,6}\s+(?:[A-Z0-9'.-]+\s+){1,6}(?:street|st|avenue|ave|road|rd|drive|dr|court|ct|lane|ln|boulevard|blvd|way|place|pl|crescent|cres)\b/gi,
-    '[address redacted]',
-  ],
-]
-
-/**
- * Build a map of unique initials for each student.
- * Handles collisions by appending an index: "J.S.1", "J.S.2".
- */
-export function buildInitialsMap(
-  students: { firstName: string; lastName: string }[]
-): Record<string, string> {
-  const result: Record<string, string> = {}
-  const counts: Record<string, number> = {}
-
-  for (const student of students) {
-    const fi = (student.firstName[0] || '?').toUpperCase()
-    const li = (student.lastName[0] || '?').toUpperCase()
-    const base = `${fi}.${li}.`
-    const fullName = `${student.firstName} ${student.lastName}`
-
-    counts[base] = (counts[base] || 0) + 1
-    const key = counts[base] > 1 ? `${base}${counts[base]}` : base
-
-    result[key] = fullName
-  }
-
-  // If any base had collisions, rename the first occurrence too
-  for (const base of Object.keys(counts)) {
-    if (counts[base] > 1 && result[base]) {
-      const fullName = result[base]
-      delete result[base]
-      result[`${base}1`] = fullName
-    }
-  }
-
-  return result
-}
+export { buildInitialsMap, redactDirectIdentifiers }
 
 /**
  * Replace student names in text with their initials.
@@ -64,49 +18,7 @@ export function sanitizeEntryText(
   students: { firstName: string; lastName: string }[],
   initialsMap: Record<string, string>
 ): string {
-  // Build reverse map: fullName -> initials
-  const nameToInitials: Record<string, string> = {}
-  for (const [initials, fullName] of Object.entries(initialsMap)) {
-    nameToInitials[fullName] = initials
-  }
-
-  let result = text
-
-  // Replace full names first (longest match first to avoid partial replacements)
-  const fullNames = students
-    .map((s) => `${s.firstName} ${s.lastName}`)
-    .filter((name) => name.trim().length > 1)
-    .sort((a, b) => b.length - a.length)
-
-  for (const fullName of fullNames) {
-    const initials = nameToInitials[fullName]
-    if (!initials) continue
-    const escaped = escapeRegExp(fullName)
-    result = result.replace(new RegExp(escaped, 'gi'), initials)
-  }
-
-  // Replace individual first names and last names
-  for (const student of students) {
-    const fullName = `${student.firstName} ${student.lastName}`
-    const initials = nameToInitials[fullName]
-    if (!initials) continue
-
-    for (const name of [student.firstName, student.lastName]) {
-      if (!name || name.length < 2) continue
-      const escaped = escapeRegExp(name)
-      // Use word boundary to avoid replacing substrings inside other words
-      result = result.replace(new RegExp(`\\b${escaped}\\b`, 'gi'), initials)
-    }
-  }
-
-  return redactDirectIdentifiers(result)
-}
-
-export function redactDirectIdentifiers(text: string): string {
-  return DIRECT_IDENTIFIER_PATTERNS.reduce(
-    (result, [pattern, replacement]) => result.replace(pattern, replacement),
-    text
-  )
+  return sanitizeTextWithStudentNames(text, students, initialsMap)
 }
 
 function escapeRegExp(str: string): string {

--- a/src/lib/server/ai-sanitization.ts
+++ b/src/lib/server/ai-sanitization.ts
@@ -1,0 +1,88 @@
+import {
+  buildAiSanitizationContext,
+  type AiSanitizationContext,
+  type AiSanitizationStudent,
+} from '@/lib/ai-sanitization'
+import { loadChunkedRows } from '@/lib/server/query-chunks'
+import { getServiceRoleClient } from '@/lib/supabase'
+
+type ServiceRoleSupabase = ReturnType<typeof getServiceRoleClient>
+
+type EnrollmentRow = { student_id: string | null }
+type ProfileRow = {
+  user_id: string
+  first_name: string | null
+  last_name: string | null
+}
+type RosterNameRow = {
+  first_name: string | null
+  last_name: string | null
+}
+
+export async function loadClassroomAiSanitizationContext(
+  supabase: ServiceRoleSupabase,
+  classroomId: string,
+): Promise<AiSanitizationContext | null> {
+  try {
+    const [{ data: enrollmentRows, error: enrollmentError }, { data: rosterRows, error: rosterError }] =
+      await Promise.all([
+        supabase
+          .from('classroom_enrollments')
+          .select('student_id')
+          .eq('classroom_id', classroomId),
+        supabase
+          .from('classroom_roster')
+          .select('first_name, last_name')
+          .eq('classroom_id', classroomId),
+      ])
+
+    if (enrollmentError || rosterError) {
+      return null
+    }
+
+    const studentIds = Array.from(
+      new Set(
+        ((enrollmentRows as EnrollmentRow[] | null) ?? [])
+          .map((row) => row.student_id)
+          .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0),
+      ),
+    )
+
+    const profilesResult = studentIds.length > 0
+      ? await loadChunkedRows<ProfileRow>({
+        supabase,
+        table: 'student_profiles',
+        select: 'user_id, first_name, last_name',
+        filters: [{ column: 'user_id', values: studentIds }],
+      })
+      : { rows: [] as ProfileRow[], error: null }
+
+    if (profilesResult.error) {
+      return null
+    }
+
+    const studentsByName = new Map<string, AiSanitizationStudent>()
+    const addStudent = (firstName?: string | null, lastName?: string | null) => {
+      const student = {
+        firstName: firstName || '',
+        lastName: lastName || '',
+      }
+      const key = `${student.firstName} ${student.lastName}`.trim().toLowerCase()
+      if (!key) return
+      if (!studentsByName.has(key)) studentsByName.set(key, student)
+    }
+
+    for (const profile of profilesResult.rows) {
+      addStudent(profile.first_name, profile.last_name)
+    }
+
+    for (const row of ((rosterRows as RosterNameRow[] | null) ?? [])) {
+      addStudent(row.first_name, row.last_name)
+    }
+
+    const students = [...studentsByName.values()]
+    return students.length > 0 ? buildAiSanitizationContext(students) : null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/server/ai-sanitization.ts
+++ b/src/lib/server/ai-sanitization.ts
@@ -19,70 +19,96 @@ type RosterNameRow = {
   last_name: string | null
 }
 
+export class AiSanitizationContextLoadError extends Error {
+  readonly cause?: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'AiSanitizationContextLoadError'
+    this.cause = cause
+  }
+}
+
 export async function loadClassroomAiSanitizationContext(
   supabase: ServiceRoleSupabase,
   classroomId: string,
-): Promise<AiSanitizationContext | null> {
+): Promise<AiSanitizationContext> {
+  if (!classroomId) {
+    throw new AiSanitizationContextLoadError('Cannot load AI sanitization context without a classroom id')
+  }
+
+  let enrollmentRows: unknown
+  let rosterRows: unknown
+  let enrollmentError: unknown
+  let rosterError: unknown
+
   try {
-    const [{ data: enrollmentRows, error: enrollmentError }, { data: rosterRows, error: rosterError }] =
-      await Promise.all([
-        supabase
-          .from('classroom_enrollments')
-          .select('student_id')
-          .eq('classroom_id', classroomId),
-        supabase
-          .from('classroom_roster')
-          .select('first_name, last_name')
-          .eq('classroom_id', classroomId),
-      ])
+    const [enrollmentResult, rosterResult] = await Promise.all([
+      supabase
+        .from('classroom_enrollments')
+        .select('student_id')
+        .eq('classroom_id', classroomId),
+      supabase
+        .from('classroom_roster')
+        .select('first_name, last_name')
+        .eq('classroom_id', classroomId),
+    ])
 
-    if (enrollmentError || rosterError) {
-      return null
-    }
+    enrollmentRows = enrollmentResult.data
+    enrollmentError = enrollmentResult.error
+    rosterRows = rosterResult.data
+    rosterError = rosterResult.error
+  } catch (error) {
+    throw new AiSanitizationContextLoadError('Failed to load classroom names for AI sanitization', error)
+  }
 
-    const studentIds = Array.from(
-      new Set(
-        ((enrollmentRows as EnrollmentRow[] | null) ?? [])
-          .map((row) => row.student_id)
-          .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0),
-      ),
-    )
+  if (enrollmentError) {
+    throw new AiSanitizationContextLoadError('Failed to load classroom enrollments for AI sanitization', enrollmentError)
+  }
 
-    const profilesResult = studentIds.length > 0
-      ? await loadChunkedRows<ProfileRow>({
+  if (rosterError) {
+    throw new AiSanitizationContextLoadError('Failed to load classroom roster names for AI sanitization', rosterError)
+  }
+
+  const studentIds = Array.from(
+    new Set(
+      ((enrollmentRows as EnrollmentRow[] | null) ?? [])
+        .map((row) => row.student_id)
+        .filter((studentId): studentId is string => typeof studentId === 'string' && studentId.length > 0),
+    ),
+  )
+
+  const profilesResult = studentIds.length > 0
+    ? await loadChunkedRows<ProfileRow>({
         supabase,
         table: 'student_profiles',
         select: 'user_id, first_name, last_name',
         filters: [{ column: 'user_id', values: studentIds }],
       })
-      : { rows: [] as ProfileRow[], error: null }
+    : { rows: [] as ProfileRow[], error: null }
 
-    if (profilesResult.error) {
-      return null
-    }
-
-    const studentsByName = new Map<string, AiSanitizationStudent>()
-    const addStudent = (firstName?: string | null, lastName?: string | null) => {
-      const student = {
-        firstName: firstName || '',
-        lastName: lastName || '',
-      }
-      const key = `${student.firstName} ${student.lastName}`.trim().toLowerCase()
-      if (!key) return
-      if (!studentsByName.has(key)) studentsByName.set(key, student)
-    }
-
-    for (const profile of profilesResult.rows) {
-      addStudent(profile.first_name, profile.last_name)
-    }
-
-    for (const row of ((rosterRows as RosterNameRow[] | null) ?? [])) {
-      addStudent(row.first_name, row.last_name)
-    }
-
-    const students = [...studentsByName.values()]
-    return students.length > 0 ? buildAiSanitizationContext(students) : null
-  } catch {
-    return null
+  if (profilesResult.error) {
+    throw new AiSanitizationContextLoadError('Failed to load student profile names for AI sanitization', profilesResult.error)
   }
+
+  const studentsByName = new Map<string, AiSanitizationStudent>()
+  const addStudent = (firstName?: string | null, lastName?: string | null) => {
+    const student = {
+      firstName: firstName || '',
+      lastName: lastName || '',
+    }
+    const key = `${student.firstName} ${student.lastName}`.trim().toLowerCase()
+    if (!key) return
+    if (!studentsByName.has(key)) studentsByName.set(key, student)
+  }
+
+  for (const profile of profilesResult.rows) {
+    addStudent(profile.first_name, profile.last_name)
+  }
+
+  for (const row of ((rosterRows as RosterNameRow[] | null) ?? [])) {
+    addStudent(row.first_name, row.last_name)
+  }
+
+  return buildAiSanitizationContext([...studentsByName.values()])
 }

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -904,7 +904,6 @@ export async function tickAssignmentAiGradingRun(opts: {
     }
 
     const assignment = await loadAssignmentForRun(supabase, claimedRun.assignment_id)
-    const sanitizationContext = await loadClassroomAiSanitizationContext(supabase, assignment.classroom_id)
     const allItems = await fetchAssignmentAiGradingRunItems(supabase, claimedRun.id)
     const now = Date.now()
     const dueItems = allItems
@@ -916,6 +915,8 @@ export async function tickAssignmentAiGradingRun(opts: {
       .slice(0, ASSIGNMENT_AI_GRADING_RUN_CHUNK_SIZE)
 
     if (dueItems.length > 0) {
+      const sanitizationContext = await loadClassroomAiSanitizationContext(supabase, assignment.classroom_id)
+
       await mapWithConcurrency(
         dueItems,
         ASSIGNMENT_AI_GRADING_ITEM_CONCURRENCY,

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -8,6 +8,8 @@ import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
 import { analyzeAuthenticity } from '@/lib/authenticity'
 import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
+import type { AiSanitizationContext } from '@/lib/ai-sanitization'
+import { loadClassroomAiSanitizationContext } from '@/lib/server/ai-sanitization'
 import {
   loadAssignmentSubmissionArtifactsForDoc,
   loadAssignmentSubmissionArtifactsForDocs,
@@ -55,6 +57,7 @@ type GradeAssignmentDocWithAiOptions = {
   }
   gradedBy?: string | null
   requestTimeoutMs?: number
+  sanitizationContext?: AiSanitizationContext | null
   telemetry?: {
     operation?: string
     requestedStrategy?: string | null
@@ -322,6 +325,7 @@ export async function gradeAssignmentDocWithAi({
   assignmentDoc,
   gradedBy,
   requestTimeoutMs,
+  sanitizationContext,
   telemetry,
 }: GradeAssignmentDocWithAiOptions): Promise<void> {
   const studentWork = parseContentField(assignmentDoc.content)
@@ -338,6 +342,10 @@ export async function gradeAssignmentDocWithAi({
     return
   }
 
+  const resolvedSanitizationContext =
+    sanitizationContext ??
+    await loadClassroomAiSanitizationContext(supabase, assignment.classroom_id)
+
   const result = await gradeStudentWork({
     assignmentTitle: assignment.title,
     instructions: getAssignmentInstructionsText(assignment),
@@ -345,6 +353,7 @@ export async function gradeAssignmentDocWithAi({
     submissionArtifacts,
     previousFeedback: assignmentDoc.feedback,
     requestTimeoutMs,
+    sanitizationContext: resolvedSanitizationContext,
     telemetry: {
       feature: 'assignment_auto_grade',
       operation: telemetry?.operation ?? 'single_grade',
@@ -545,8 +554,9 @@ async function processAssignmentAiRunItem(opts: {
   assignment: Assignment
   run: AssignmentAiGradingRun
   item: AssignmentAiGradingRunItem
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<void> {
-  const { supabase, assignment, run, item } = opts
+  const { supabase, assignment, run, item, sanitizationContext } = opts
   const attemptCount = item.attempt_count + 1
   const now = new Date().toISOString()
 
@@ -627,6 +637,7 @@ async function processAssignmentAiRunItem(opts: {
       assignmentDoc,
       gradedBy: run.triggered_by,
       requestTimeoutMs: ASSIGNMENT_AI_GRADING_REQUEST_TIMEOUT_MS,
+      sanitizationContext,
       telemetry: {
         operation: 'background_batch_item',
         requestedStrategy: 'background_chunked',
@@ -893,6 +904,7 @@ export async function tickAssignmentAiGradingRun(opts: {
     }
 
     const assignment = await loadAssignmentForRun(supabase, claimedRun.assignment_id)
+    const sanitizationContext = await loadClassroomAiSanitizationContext(supabase, assignment.classroom_id)
     const allItems = await fetchAssignmentAiGradingRunItems(supabase, claimedRun.id)
     const now = Date.now()
     const dueItems = allItems
@@ -913,6 +925,7 @@ export async function tickAssignmentAiGradingRun(opts: {
             assignment,
             run: claimedRun,
             item,
+            sanitizationContext,
           })
         },
       )

--- a/src/lib/server/test-ai-grading-runs.ts
+++ b/src/lib/server/test-ai-grading-runs.ts
@@ -1233,10 +1233,6 @@ export async function tickTestAiGradingRun(opts: {
     }
 
     const test = await loadTestForRun(supabase, claimedRun.test_id)
-    const sanitizationContext = await loadClassroomAiSanitizationContext(
-      supabase,
-      test.classroom_id,
-    )
     const allItems = await fetchTestAiGradingRunItems(supabase, claimedRun.id)
     const now = Date.now()
     const dueItems = allItems
@@ -1248,6 +1244,10 @@ export async function tickTestAiGradingRun(opts: {
       .slice(0, TEST_AI_GRADING_RUN_CHUNK_SIZE)
 
     if (dueItems.length > 0) {
+      const sanitizationContext = await loadClassroomAiSanitizationContext(
+        supabase,
+        test.classroom_id,
+      )
       const responseIds = dueItems.map((item) => item.response_id)
       const questionIds = Array.from(new Set(dueItems.map((item) => item.question_id)))
 

--- a/src/lib/server/test-ai-grading-runs.ts
+++ b/src/lib/server/test-ai-grading-runs.ts
@@ -7,6 +7,8 @@ import {
   suggestTestOpenResponseGradeWithContext,
   suggestTestOpenResponseGradesBatchWithContext,
 } from '@/lib/ai-test-grading'
+import type { AiSanitizationContext } from '@/lib/ai-sanitization'
+import { loadClassroomAiSanitizationContext } from '@/lib/server/ai-sanitization'
 import { getServiceRoleClient } from '@/lib/supabase'
 import {
   isMissingTestAttemptReturnColumnsError,
@@ -261,10 +263,10 @@ async function fetchLatestActiveRun(
 async function loadTestForRun(
   supabase: ServiceRoleSupabase,
   testId: string,
-): Promise<{ id: string; title: string }> {
+): Promise<{ id: string; title: string; classroom_id: string }> {
   const { data, error } = await supabase
     .from('tests')
-    .select('id, title')
+    .select('id, title, classroom_id')
     .eq('id', testId)
     .single()
 
@@ -275,6 +277,7 @@ async function loadTestForRun(
   return {
     id: data.id,
     title: typeof data.title === 'string' ? data.title : 'Untitled Test',
+    classroom_id: String(data.classroom_id || ''),
   }
 }
 
@@ -979,8 +982,9 @@ async function processQuestionBatch(opts: {
   question: OpenQuestionRow
   items: TestAiGradingRunItem[]
   responsesById: Map<string, { id: string; response_text: string | null }>
+  sanitizationContext?: AiSanitizationContext | null
 }): Promise<void> {
-  const { supabase, run, testTitle, question, items, responsesById } = opts
+  const { supabase, run, testTitle, question, items, responsesById, sanitizationContext } = opts
   const model = run.model ?? getTestOpenResponseGradingModel()
   const cacheResolution = resolveReusableTestOpenResponseReferenceAnswers({
     testTitle,
@@ -1012,6 +1016,7 @@ async function processQuestionBatch(opts: {
         runId: run.id,
       },
       requestTimeoutMs: TEST_AI_GRADING_REQUEST_TIMEOUT_MS,
+      sanitizationContext,
     })
 
     if (
@@ -1228,6 +1233,10 @@ export async function tickTestAiGradingRun(opts: {
     }
 
     const test = await loadTestForRun(supabase, claimedRun.test_id)
+    const sanitizationContext = await loadClassroomAiSanitizationContext(
+      supabase,
+      test.classroom_id,
+    )
     const allItems = await fetchTestAiGradingRunItems(supabase, claimedRun.id)
     const now = Date.now()
     const dueItems = allItems
@@ -1295,6 +1304,7 @@ export async function tickTestAiGradingRun(opts: {
             question: group.question,
             items: group.items,
             responsesById,
+            sanitizationContext,
           })
         },
       )

--- a/tests/api/teacher/tests-ai-suggest.test.ts
+++ b/tests/api/teacher/tests-ai-suggest.test.ts
@@ -4,9 +4,11 @@ import { POST } from '@/app/api/teacher/tests/[id]/responses/[responseId]/ai-sug
 
 const {
   mockAssertTeacherOwnsTest,
+  mockLoadClassroomAiSanitizationContext,
   mockValidateSelectedTestStudentEnrollment,
 } = vi.hoisted(() => ({
   mockAssertTeacherOwnsTest: vi.fn(),
+  mockLoadClassroomAiSanitizationContext: vi.fn(),
   mockValidateSelectedTestStudentEnrollment: vi.fn(),
 }))
 
@@ -25,6 +27,10 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@/lib/server/tests', () => ({
   assertTeacherOwnsTest: mockAssertTeacherOwnsTest,
   validateSelectedTestStudentEnrollment: mockValidateSelectedTestStudentEnrollment,
+}))
+
+vi.mock('@/lib/server/ai-sanitization', () => ({
+  loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
 }))
 
 const getTestOpenResponseGradingModel = vi.fn(() => 'gpt-5-nano')
@@ -63,6 +69,10 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
       ok: true,
       enrolledStudentIds: new Set(['student-1']),
       missingStudentIds: [],
+    })
+    mockLoadClassroomAiSanitizationContext.mockResolvedValue({
+      students: [],
+      initialsMap: {},
     })
   })
 
@@ -134,12 +144,20 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
       'classroom-1',
       ['student-1']
     )
+    expect(mockLoadClassroomAiSanitizationContext).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+    )
     expect(prepareTestOpenResponseGradingContext).toHaveBeenCalledWith(
       expect.objectContaining({
         answerKey: expect.stringContaining('semi-permeable membrane'),
         sampleSolution: expect.stringContaining('explainOsmosis'),
         responseMonospace: true,
         promptProfile: 'manual',
+        sanitizationContext: {
+          students: [],
+          initialsMap: {},
+        },
       })
     )
     expect(suggestTestOpenResponseGradeWithContext).toHaveBeenCalledTimes(1)
@@ -170,6 +188,7 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
     expect(response.status).toBe(400)
     expect(data.error).toBe('Student is not enrolled in this classroom')
     expect(prepareTestOpenResponseGradingContext).not.toHaveBeenCalled()
+    expect(mockLoadClassroomAiSanitizationContext).not.toHaveBeenCalled()
     expect(suggestTestOpenResponseGradeWithContext).not.toHaveBeenCalled()
   })
 
@@ -191,6 +210,29 @@ describe('POST /api/teacher/tests/[id]/responses/[responseId]/ai-suggest', () =>
     expect(response.status).toBe(500)
     expect(data.error).toBe('Failed to validate student enrollment')
     expect(prepareTestOpenResponseGradingContext).not.toHaveBeenCalled()
+    expect(mockLoadClassroomAiSanitizationContext).not.toHaveBeenCalled()
     expect(suggestTestOpenResponseGradeWithContext).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when classroom sanitization context cannot be loaded', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setupResponseRow()
+    mockLoadClassroomAiSanitizationContext.mockRejectedValueOnce(
+      new Error('Failed to load classroom names for AI sanitization'),
+    )
+
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/responses/response-1/ai-suggest', {
+        method: 'POST',
+      }),
+      { params: Promise.resolve({ id: 'test-1', responseId: 'response-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Internal server error')
+    expect(prepareTestOpenResponseGradingContext).not.toHaveBeenCalled()
+    expect(suggestTestOpenResponseGradeWithContext).not.toHaveBeenCalled()
+    consoleError.mockRestore()
   })
 })

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockSupabaseClient } = vi.hoisted(() => ({
+const { mockLoadClassroomAiSanitizationContext, mockSupabaseClient } = vi.hoisted(() => ({
+  mockLoadClassroomAiSanitizationContext: vi.fn(),
   mockSupabaseClient: {
     from: vi.fn(),
     rpc: vi.fn(),
@@ -10,6 +11,10 @@ const { mockSupabaseClient } = vi.hoisted(() => ({
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/lib/server/ai-sanitization', () => ({
+  loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
 }))
 
 import {
@@ -267,6 +272,10 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.rpc.mockReset()
+    mockLoadClassroomAiSanitizationContext.mockResolvedValue({
+      students: [],
+      initialsMap: {},
+    })
   })
 
   it('creates the batch through the atomic RPC with queued and skipped item rows', async () => {

--- a/tests/lib/test-ai-grading-runs.test.ts
+++ b/tests/lib/test-ai-grading-runs.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  mockLoadClassroomAiSanitizationContext,
   mockSupabaseClient,
   prepareTestOpenResponseGradingContext,
   resolveReusableTestOpenResponseReferenceAnswers,
   suggestTestOpenResponseGradeWithContext,
   suggestTestOpenResponseGradesBatchWithContext,
 } = vi.hoisted(() => ({
+  mockLoadClassroomAiSanitizationContext: vi.fn(),
   mockSupabaseClient: {
     from: vi.fn(),
     rpc: vi.fn(),
@@ -24,6 +26,10 @@ vi.mock('@/lib/supabase', () => ({
 vi.mock('@/lib/server/tests', () => ({
   isMissingTestAttemptReturnColumnsError: vi.fn(() => false),
   isMissingTestResponseAiColumnsError: vi.fn(() => false),
+}))
+
+vi.mock('@/lib/server/ai-sanitization', () => ({
+  loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
 }))
 
 vi.mock('@/lib/ai-test-grading', () => ({
@@ -217,6 +223,7 @@ function buildTickHarness(opts: {
               data: {
                 id: 'test-1',
                 title: 'Test One',
+                classroom_id: 'classroom-1',
               },
               error: null,
             })),
@@ -288,6 +295,10 @@ describe('tickTestAiGradingRun', () => {
     vi.clearAllMocks()
     mockSupabaseClient.from.mockReset()
     mockSupabaseClient.rpc.mockReset()
+    mockLoadClassroomAiSanitizationContext.mockResolvedValue({
+      students: [],
+      initialsMap: {},
+    })
     resolveReusableTestOpenResponseReferenceAnswers.mockReturnValue({
       expectedCacheKey: 'cache-key',
       cacheHit: true,

--- a/tests/unit/ai-grading.test.ts
+++ b/tests/unit/ai-grading.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { gradeStudentWork, hasGradableAssignmentSubmission } from '@/lib/ai-grading'
+import { buildAiSanitizationContext } from '@/lib/ai-sanitization'
 
 describe('gradeStudentWork prompt rules', () => {
   const originalApiKey = process.env.OPENAI_API_KEY
@@ -186,6 +187,45 @@ describe('gradeStudentWork prompt rules', () => {
     expect(userPrompt).not.toContain('416-555-1212')
     expect(result.feedback).toContain('[email redacted]')
     expect(result.feedback).toContain('[phone redacted]')
+  })
+
+  it('replaces known student names in assignment grading input', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"score_completion":8,"score_thinking":8,"score_workflow":8,"feedback":"Strength: Strong reflection. Next Step: add evidence. Improve: Include one more example."}',
+      }),
+    })
+
+    await gradeStudentWork({
+      assignmentTitle: 'Reflection for Alice Brown',
+      instructions: 'Alice Brown should explain the design choice.',
+      studentWork: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Alice Brown revised the project after feedback.' }],
+          },
+        ],
+      },
+      sanitizationContext: buildAiSanitizationContext([
+        { firstName: 'Alice', lastName: 'Brown' },
+      ]),
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(userPrompt).toContain('Reflection for A.B.')
+    expect(userPrompt).toContain('A.B. should explain the design choice.')
+    expect(userPrompt).toContain('A.B. revised the project after feedback.')
+    expect(userPrompt).not.toContain('Alice Brown')
+    expect(userPrompt).not.toContain('Alice')
+    expect(userPrompt).not.toContain('Brown')
   })
 
   it('parses structured output from response content when output_text is absent', async () => {

--- a/tests/unit/ai-grading.test.ts
+++ b/tests/unit/ai-grading.test.ts
@@ -53,6 +53,7 @@ describe('gradeStudentWork prompt rules', () => {
     expect(systemPrompt).toContain('sentence starting with "Next Step:"')
     expect(systemPrompt).toContain('total score is less than 30')
     expect(gradingBody.max_output_tokens).toBe(220)
+    expect(gradingBody.store).toBe(false)
     expect(gradingBody.reasoning).toEqual({ effort: 'minimal' })
     expect(gradingBody.text?.format).toEqual(
       expect.objectContaining({
@@ -111,7 +112,7 @@ describe('gradeStudentWork prompt rules', () => {
 
     expect(systemPrompt).toContain('Treat attached artifacts')
     expect(userPrompt).toContain('Attached Artifacts:')
-    expect(userPrompt).toContain('- Link: https://student.example.com/portfolio')
+    expect(userPrompt).toContain('- Link: [url redacted]')
   })
 
   it('accepts artifact-only submissions when building the grading prompt', async () => {
@@ -146,7 +147,45 @@ describe('gradeStudentWork prompt rules', () => {
 
     expect(result.score_completion).toBe(8)
     expect(userPrompt).toContain('Attached Artifacts:')
-    expect(userPrompt).toContain('- Image: https://cdn.example.com/submission-images/final-site.png')
+    expect(userPrompt).toContain('- Image: [url redacted]')
+  })
+
+  it('redacts direct identifiers from assignment grading input and output', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"score_completion":7,"score_thinking":7,"score_workflow":7,"feedback":"Strength: alex@example.com included evidence. Next Step: remove phone 416-555-1212. Improve: Add a conclusion."}',
+      }),
+    })
+
+    const result = await gradeStudentWork({
+      assignmentTitle: 'Reflection for alex@example.com',
+      instructions: 'Submit to https://example.com and include student number 123456789.',
+      studentWork: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'My email is alex@example.com and my number is 416-555-1212.' }],
+          },
+        ],
+      },
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(userPrompt).toContain('Reflection for [email redacted]')
+    expect(userPrompt).toContain('[url redacted]')
+    expect(userPrompt).toContain('[student number redacted]')
+    expect(userPrompt).toContain('[phone redacted]')
+    expect(userPrompt).not.toContain('alex@example.com')
+    expect(userPrompt).not.toContain('416-555-1212')
+    expect(result.feedback).toContain('[email redacted]')
+    expect(result.feedback).toContain('[phone redacted]')
   })
 
   it('parses structured output from response content when output_text is absent', async () => {

--- a/tests/unit/ai-sanitization-server.test.ts
+++ b/tests/unit/ai-sanitization-server.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockLoadChunkedRows } = vi.hoisted(() => ({
+  mockLoadChunkedRows: vi.fn(),
+}))
+
+vi.mock('@/lib/server/query-chunks', () => ({
+  loadChunkedRows: mockLoadChunkedRows,
+}))
+
+import {
+  AiSanitizationContextLoadError,
+  loadClassroomAiSanitizationContext,
+} from '@/lib/server/ai-sanitization'
+
+function buildQueryResult(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(async () => ({ data, error })),
+    })),
+  }
+}
+
+describe('loadClassroomAiSanitizationContext', () => {
+  beforeEach(() => {
+    mockLoadChunkedRows.mockReset()
+  })
+
+  it('builds a roster-aware context from enrollment profiles and roster rows', async () => {
+    mockLoadChunkedRows.mockResolvedValue({
+      rows: [
+        { user_id: 'student-1', first_name: 'Alice', last_name: 'Brown' },
+      ],
+      error: null,
+    })
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') {
+          return buildQueryResult([{ student_id: 'student-1' }])
+        }
+        if (table === 'classroom_roster') {
+          return buildQueryResult([{ first_name: 'Bob', last_name: 'Carter' }])
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    const context = await loadClassroomAiSanitizationContext(supabase as any, 'classroom-1')
+
+    expect(context.students).toEqual([
+      { firstName: 'Alice', lastName: 'Brown' },
+      { firstName: 'Bob', lastName: 'Carter' },
+    ])
+    expect(context.initialsMap).toEqual({
+      'A.B.': 'Alice Brown',
+      'B.C.': 'Bob Carter',
+    })
+  })
+
+  it('returns an empty context after successful empty roster/profile reads', async () => {
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') return buildQueryResult([])
+        if (table === 'classroom_roster') return buildQueryResult([])
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    const context = await loadClassroomAiSanitizationContext(supabase as any, 'classroom-1')
+
+    expect(context).toEqual({
+      students: [],
+      initialsMap: {},
+    })
+    expect(mockLoadChunkedRows).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when enrollment names cannot be loaded', async () => {
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') {
+          return buildQueryResult(null, { message: 'enrollments failed' })
+        }
+        if (table === 'classroom_roster') return buildQueryResult([])
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    await expect(
+      loadClassroomAiSanitizationContext(supabase as any, 'classroom-1'),
+    ).rejects.toThrow(AiSanitizationContextLoadError)
+  })
+
+  it('fails closed when profile names cannot be loaded', async () => {
+    mockLoadChunkedRows.mockResolvedValue({
+      rows: [],
+      error: { message: 'profiles failed' },
+    })
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'classroom_enrollments') {
+          return buildQueryResult([{ student_id: 'student-1' }])
+        }
+        if (table === 'classroom_roster') return buildQueryResult([])
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    await expect(
+      loadClassroomAiSanitizationContext(supabase as any, 'classroom-1'),
+    ).rejects.toThrow('Failed to load student profile names for AI sanitization')
+  })
+})

--- a/tests/unit/ai-sanitization.test.ts
+++ b/tests/unit/ai-sanitization.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildInitialsMap,
+  createProviderRefMap,
+  mapProviderRefToLocalId,
+  redactDirectIdentifiers,
+  sanitizeAiEgressRecord,
+  sanitizeAiOutputText,
+  sanitizeAiText,
+  sanitizeTextWithStudentNames,
+} from '@/lib/ai-sanitization'
+
+describe('ai-sanitization', () => {
+  it('redacts direct identifiers used in AI egress payloads', () => {
+    const text = [
+      'Email alex@example.com.',
+      'Call 416-555-1212.',
+      'Student number 123456789.',
+      'Lives at 123 Main Street.',
+      'Open https://example.com/work.',
+      'Internal id 018f3f57-7b4b-7123-8c04-48ac061c1111.',
+    ].join(' ')
+
+    expect(redactDirectIdentifiers(text)).toBe(
+      [
+        'Email [email redacted].',
+        'Call [phone redacted].',
+        '[student number redacted].',
+        'Lives at [address redacted].',
+        'Open [url redacted]',
+        'Internal id [id redacted].',
+      ].join(' ')
+    )
+  })
+
+  it('replaces known student names and direct identifiers before provider egress', () => {
+    const students = [
+      { firstName: 'Alice', lastName: 'Brown' },
+      { firstName: 'Bob', lastName: 'Carter' },
+    ]
+    const initialsMap = buildInitialsMap(students)
+
+    const sanitized = sanitizeTextWithStudentNames(
+      'Alice Brown worked with Bob and shared bob@example.com.',
+      students,
+      initialsMap,
+    )
+
+    expect(sanitized).toBe('A.B. worked with B.C. and shared [email redacted].')
+  })
+
+  it('falls back to direct identifier redaction without a roster map', () => {
+    expect(sanitizeAiText('Contact me at alex@example.com.')).toBe('Contact me at [email redacted].')
+  })
+
+  it('sanitizes provider output before local persistence', () => {
+    expect(sanitizeAiOutputText('Next Step: email alex@example.com.')).toBe(
+      'Next Step: email [email redacted].'
+    )
+  })
+
+  it('creates local-only provider refs and maps them back', () => {
+    const refs = createProviderRefMap(
+      [
+        { localId: '018f3f57-7b4b-7123-8c04-48ac061c1111', responseText: 'One' },
+        { localId: '018f3f57-7b4b-7123-8c04-48ac061c2222', responseText: 'Two' },
+      ],
+      'response',
+    )
+
+    expect(refs.map((ref) => ref.providerRef)).toEqual(['response_1', 'response_2'])
+    expect(mapProviderRefToLocalId(refs).get('response_2')).toBe(
+      '018f3f57-7b4b-7123-8c04-48ac061c2222'
+    )
+  })
+
+  it('rejects unexpected adapter egress fields', () => {
+    expect(() =>
+      sanitizeAiEgressRecord(
+        {
+          prompt: 'Grade this',
+          student_id: '018f3f57-7b4b-7123-8c04-48ac061c1111',
+        },
+        ['prompt'],
+      )
+    ).toThrow('Unexpected AI egress field: student_id')
+  })
+})

--- a/tests/unit/ai-test-grading.test.ts
+++ b/tests/unit/ai-test-grading.test.ts
@@ -13,6 +13,7 @@ import {
   suggestTestOpenResponseGradesBatchWithContext,
   suggestTestOpenResponseGrade,
 } from '@/lib/ai-test-grading'
+import { buildAiSanitizationContext } from '@/lib/ai-sanitization'
 import { GRADE_11CS_JAVA_CODEHS_PROMPT_GUIDELINE } from '@/lib/test-ai-prompt-guideline'
 
 describe('suggestTestOpenResponseGrade', () => {
@@ -344,6 +345,41 @@ describe('suggestTestOpenResponseGrade', () => {
       name: 'test_single_grade',
       strict: true,
     })
+  })
+
+  it('replaces known student names in test grading prompts', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"score": 4, "feedback": "Strength: Clear claim. Next Step: add one supporting example."}',
+      }),
+    })
+
+    await suggestTestOpenResponseGrade({
+      testTitle: 'Unit 1 Test for Alice Brown',
+      questionText: 'Explain why Alice Brown chose this strategy.',
+      responseText: 'Alice Brown chose it because it was efficient.',
+      maxPoints: 5,
+      answerKey: 'Alice Brown should explain efficiency and correctness.',
+      sampleSolution: 'Alice Brown can compare the runtime to another approach.',
+      sanitizationContext: buildAiSanitizationContext([
+        { firstName: 'Alice', lastName: 'Brown' },
+      ]),
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(userPrompt).toContain('Unit 1 Test for A.B.')
+    expect(userPrompt).toContain('Explain why A.B. chose this strategy.')
+    expect(userPrompt).toContain('A.B. should explain efficiency and correctness.')
+    expect(userPrompt).toContain('A.B. chose it because it was efficient.')
+    expect(userPrompt).not.toContain('Alice Brown')
+    expect(userPrompt).not.toContain('Alice')
+    expect(userPrompt).not.toContain('Brown')
   })
 
   it('retries batch grading once with a larger output cap when the first response is incomplete', async () => {

--- a/tests/unit/ai-test-grading.test.ts
+++ b/tests/unit/ai-test-grading.test.ts
@@ -337,6 +337,7 @@ describe('suggestTestOpenResponseGrade', () => {
     const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
 
     expect(gradingBody.reasoning).toEqual({ effort: 'minimal' })
+    expect(gradingBody.store).toBe(false)
     expect(gradingBody.max_output_tokens).toBe(220)
     expect(gradingBody.text?.format).toMatchObject({
       type: 'json_schema',
@@ -361,7 +362,7 @@ describe('suggestTestOpenResponseGrade', () => {
           output_parsed: {
             results: [
               {
-                response_id: 'response-1',
+                response_id: 'response_1',
                 score: 4,
                 feedback: 'Good explanation. Add one key vocabulary word.',
               },
@@ -405,7 +406,7 @@ describe('suggestTestOpenResponseGrade', () => {
         output_parsed: {
           results: [
             {
-              response_id: 'response-1',
+              response_id: 'response_1',
               score: 4,
               feedback: 'Good explanation. Add one key vocabulary word.',
             },
@@ -625,7 +626,7 @@ describe('suggestTestOpenResponseGradesBatch', () => {
       ok: true,
       json: async () => ({
         output_text:
-          '{"results":[{"response_id":"response-1","score":5,"feedback":"Excellent answer."},{"response_id":"response-2","score":3,"feedback":"Good start. Add one more key detail."}]}',
+          '{"results":[{"response_id":"response_1","score":5,"feedback":"Excellent answer."},{"response_id":"response_2","score":3,"feedback":"Good start. Add one more key detail."}]}',
       }),
     })
 
@@ -661,7 +662,7 @@ describe('suggestTestOpenResponseGradesBatch', () => {
       ok: true,
       json: async () => ({
         output_text:
-          '{"results":[{"response_id":"response-1","score":5,"feedback":"Excellent answer."},{"response_id":"response-2","score":3,"feedback":"Good start. Add one more key detail."}]}',
+          '{"results":[{"response_id":"response_1","score":5,"feedback":"Excellent answer."},{"response_id":"response_2","score":3,"feedback":"Good start. Add one more key detail."}]}',
       }),
     })
 
@@ -680,6 +681,63 @@ describe('suggestTestOpenResponseGradesBatch', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(suggestions).toHaveLength(2)
+  })
+
+  it('uses pseudonymous provider refs instead of local response ids in batch prompts', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"results":[{"response_id":"response_1","score":5,"feedback":"Excellent answer for alex@example.com."}]}',
+      }),
+    })
+
+    const localResponseId = '018f3f57-7b4b-7123-8c04-48ac061c1111'
+    const suggestions = await suggestTestOpenResponseGradesBatch({
+      testTitle: 'Unit 3 Test',
+      questionText: 'Explain what a method does for https://example.com.',
+      maxPoints: 5,
+      answerKey: 'A method groups reusable instructions.',
+      responses: [
+        { responseId: localResponseId, responseText: 'Email me at alex@example.com.' },
+      ],
+    })
+
+    const gradingRequest = fetchMock.mock.calls[0]?.[1]
+    const gradingBody = JSON.parse(String(gradingRequest?.body ?? '{}'))
+    const userPrompt = gradingBody.input?.[1]?.content?.[0]?.text as string
+
+    expect(userPrompt).toContain('response_id=response_1')
+    expect(userPrompt).toContain('[email redacted]')
+    expect(userPrompt).toContain('[url redacted]')
+    expect(userPrompt).not.toContain(localResponseId)
+    expect(userPrompt).not.toContain('alex@example.com')
+    expect(suggestions[0].responseId).toBe(localResponseId)
+    expect(suggestions[0].feedback).toContain('[email redacted]')
+  })
+
+  it('rejects unknown provider refs in batch output', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        output_text:
+          '{"results":[{"response_id":"response_99","score":5,"feedback":"Excellent answer."}]}',
+      }),
+    })
+
+    await expect(
+      suggestTestOpenResponseGradesBatch({
+        testTitle: 'Unit 3 Test',
+        questionText: 'Explain what a method does.',
+        maxPoints: 5,
+        answerKey: 'A method groups reusable instructions.',
+        responses: [
+          { responseId: 'response-1', responseText: 'A method is reusable code.' },
+        ],
+      }),
+    ).rejects.toThrow('AI batch grade suggestion returned unknown response response_99')
   })
 })
 


### PR DESCRIPTION
## Summary
- add a shared AI sanitization boundary for direct identifier redaction, roster-aware initials reuse, provider pseudonym refs, and egress allow-list validation
- route log-summary redaction through the shared sanitizer while keeping existing APIs compatible
- sanitize assignment/test grading prompt inputs and generated feedback; set OpenAI grading requests to `store: false`
- change test batch grading to send pseudonymous provider refs such as `response_1` and map them back locally
- document the GradeX-facing AI grading egress contract

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/log-summary.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/lib/ai-test-grading.test.ts`
- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/test-auto-grade-runs.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
- `pnpm lint`
- `pnpm test` (one unrelated `StudentAssignmentsTab` modal test failed during the full run; rerunning that file passed)
- `pnpm test tests/components/StudentAssignmentsTab.test.tsx`
- `pnpm build`
- `git diff --check`

## Review Notes
- Assignment artifact URLs are now redacted by default. If GradeX needs artifact inspection, add an explicit opt-in egress profile with tests rather than passing URLs through by default.
- Batch test grading provider refs are local-only and intentionally differ from real Pika response IDs.