### PR TITLE
[codex] Document Codex model recommendation workflow

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -995,3 +995,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-06-01 — Codex model recommendation workflow
+
+**Completed:**
+- Added a Codex model recommendation policy to `docs/ai-instructions.md`, including `5.3-spark` guidance and `5.5` reasoning-level guidance.
+- Added a startup checklist reminder to state the recommendation before implementation.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
+- `git diff --check`

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -18,7 +18,7 @@
 [ ] Read: docs/ai-instructions.md
 [ ] Check features: node scripts/features.mjs next
 [ ] Load task-specific docs routed by docs/ai-instructions.md
-[ ] Plan before coding: state task, propose approach, wait for approval
+[ ] Plan before coding: task, model, approach, approval
 ```
 
 Do not code if verification fails. Read `.ai/SESSION-LOG.md` only for recent handoff context; `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -48,7 +48,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: do non-trivial work in a dedicated worktree, plan before coding, append a concise `.ai/SESSION-LOG.md` entry, and trim it with `node scripts/trim-session-log.mjs` while preserving the default weekly evidence window
+- Workflow: use worktree for non-trivial work; plan/discuss with `Model recommendation: <model> - <reason>` (`5.3-spark` low-risk; else `5.5 medium|high|extra high`), append `.ai/SESSION-LOG.md`; run `node scripts/trim-session-log.mjs`
 - Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map


### PR DESCRIPTION
## Summary
- Add Codex model recommendation to the required planning workflow.
- Include `5.3-spark` for low-risk work and `5.5 medium|high|extra high` for higher-risk work.
- Update the startup checklist and session log.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
- `git diff --check`