### PR TITLE
[codex] Add open join classroom mode

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,25 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Phase three audit fixes
-
-**Completed:**
-- Added shared selected-student enrollment validation for teacher test mutation routes.
-- Blocked test AI auto-grade run creation and open-response grade clearing when any selected student is outside the test classroom.
-- Normalized teacher settings controls toward `@/ui` primitives: shared segmented section switcher, cards, `FormField`, `Input`, `Select`, and a FormField-compatible textarea.
-- Fixed the syllabus lesson-plan visibility select's accessible label and added settings switcher coverage.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=settings&section=general'`
-- Browser screenshots: `/tmp/pika-settings-general-full-desktop.png`, `/tmp/pika-settings-general-full-mobile.png`, `/tmp/pika-settings-class-days-desktop.png`, `/tmp/pika-settings-class-days-mobile.png`, `/tmp/pika-settings-general-dark-desktop.png`
-- `pnpm test tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/tests-clear-open-grades.test.ts tests/unit/test-student-access.test.ts`
-- `pnpm build`
-- `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx`
-- `pnpm test`
-
 ## 2026-05-27 — Daily log history selected date clarity
 
 **Completed:**
@@ -1068,6 +1049,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Replaced the Settings join checkbox and right-aligned segmented control with matching left-aligned two-choice toggles.
 - Updated the toggle states so `Allow`/`Roster` sit on the left and `Disallow`/`Open` sit on the right.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
+
+## 2026-06-01 — Joining tooltip copy consolidation
+
+**Completed:**
+- Moved the allow-new-students and join-mode explanatory copy into the `Joining` info tooltip.
+- Left the Settings rows as compact `Allow / Disallow` and `Roster / Open` toggles.
 
 **Validation:**
 - `pnpm test tests/components/TeacherSettingsTab.test.tsx`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Assignment return enrollment validation
-
-**Completed:**
-- Validated selected student enrollment before loading or mutating assignment return docs.
-- Skipped assignment doc reads/updates for selected students who are no longer enrolled.
-- Preserved unavailable-student response semantics while adding explicit not-enrolled counts and ids.
-- Added regressions for enrollment query failures, fully unenrolled selections, and stale existing assignment docs.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/assignments-id-return.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm run test:coverage`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-27 — Assignment repo target enrollment validation
 
 **Completed:**
@@ -1008,3 +991,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a full-page teacher screenshot for Public Syllabus switches.
 - `bash scripts/verify-env.sh` still has an unrelated timeout in `tests/components/TeacherStudentWorkPanel.test.tsx`.
+
+## 2026-06-01 — Settings switch off-state polish
+
+**Completed:**
+- Removed the X icon from settings switches.
+- Made off and disabled switch thumbs use the neutral grey token while preserving the blue on state.
+- Kept disabled switches on a neutral track with subtle opacity.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a full-page teacher screenshot showing the off Public Syllabus switch.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,24 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Teacher assessment enrollment scoping
-
-**Completed:**
-- Scoped teacher quiz result aggregates and responder hydration to current classroom enrollments.
-- Scoped teacher survey result aggregates, text/link responses, and responder hydration to current classroom enrollments.
-- Scoped teacher quiz and survey list response stats to enrolled student IDs before counting respondents.
-- Added paginated enrollment ID loading to avoid Supabase row-cap truncation.
-- Added fail-closed enrollment/response-stat query handling and regressions with stale/unenrolled response rows.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/quizzes-results.test.ts tests/api/teacher/quizzes-route.test.ts tests/api/teacher/surveys-route.test.ts tests/api/teacher/surveys-results.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm run test:coverage`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-27 — Assignment return enrollment validation
 
 **Completed:**
@@ -1009,3 +991,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build` after clearing stale `.next`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a mobile confirmation-dialog screenshot.
+
+## 2026-06-01 — Settings switch consistency
+
+**Completed:**
+- Replaced the settings page checkbox controls with a shared switch-row pattern.
+- Simplified the joining rows so each switch sits on the left with short state copy on the right.
+- Kept off states visually clear with the X thumb marker and muted switch styling.
+- Updated focused settings coverage for the markdown display switch semantics.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a full-page teacher screenshot for Public Syllabus switches.
+- `bash scripts/verify-env.sh` still has an unrelated timeout in `tests/components/TeacherStudentWorkPanel.test.tsx`.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,28 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Assessment authoring accessibility audit
-
-**Completed:**
-- Added accessible names for quiz/test question prompts, options, answer keys, sample solutions, correct-answer radios, remove buttons, markdown editors, and quiz delete controls.
-- Replaced the assessment workspace mode strip with the shared tab-style `TeacherWorkSurfaceModeBar`.
-- Wired the shared mode bar tabs to labelled `tabpanel` content after PR review flagged the incomplete ARIA tab pattern.
-- Fixed a narrow mobile overlap in the test question accordion header after visual review.
-- Added focused component coverage for mode tab semantics and authoring control names.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherWorkSurfaceModeBar.test.tsx --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=210e30d4-f085-4c86-94d3-ee14bb66fd03&testMode=authoring'`
-- `E2E_BASE_URL=http://localhost:3015 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- Reviewed screenshots: `/tmp/pika-test-question-editor-teacher-fixed.png`, `/tmp/pika-test-question-editor-teacher-mobile-fixed.png`, `/tmp/pika-survey-code-editor-teacher.png`, `/tmp/pika-survey-code-editor-teacher-mobile.png`, plus teacher/student/teacher-mobile captures from the verifier.
-
 ## 2026-05-27 — Teacher assessment enrollment scoping
 
 **Completed:**
@@ -1017,3 +995,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
+
+## 2026-06-01 — Regenerate join link layout
+
+**Completed:**
+- Changed the regenerate confirmation title to `Generate new join code and link?`.
+- Moved the refresh icon into a separate warning button after the join URL copy control.
+- Shortened the desktop join URL copy control so it no longer stretches across the row.
+- Updated focused coverage for the new refresh button label and dialog title.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build` after clearing stale `.next`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a mobile confirmation-dialog screenshot.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1062,3 +1062,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus mocked open-join roster desktop/mobile and student join form screenshots.
+
+## 2026-06-01 — Open join settings toggle polish
+
+**Completed:**
+- Replaced the Settings join checkbox and right-aligned segmented control with matching left-aligned two-choice toggles.
+- Updated the toggle states so `Allow`/`Roster` sit on the left and `Disallow`/`Open` sit on the right.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1046,3 +1046,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
+## 2026-06-01 — Open join classroom access mode
+
+**Completed:**
+- Added `classrooms.join_policy` and `classroom_roster.join_source` migration defaults/checks.
+- Added teacher Settings controls for `Roster` vs `Open join`, keeping `allow_enrollment` as the master join switch.
+- Updated student join-by-code flow so roster mode remains strict, while open join asks for first/last name and self-creates the roster/profile/enrollment rows.
+- Stamped manual roster adds as `manual`, CSV uploads as `csv`, and self-joins as `open_join`.
+- Added an `Open join` roster badge and source detail field for teacher review.
+
+**Validation:**
+- `pnpm test tests/api/student/classrooms-join.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/teacher/roster.test.ts tests/api/teacher/roster-add.test.ts tests/api/teacher/roster-upload-csv.test.ts tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm test`
+- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/api/student/classrooms-join.test.ts tests/api/teacher/roster.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus mocked open-join roster desktop/mobile and student join form screenshots.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,27 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Next systems/UI audit slice
-
-**Completed:**
-- Hardened student test document snapshot access to respect draft status, selected-student availability, submitted work, grading lock state, and returned work.
-- Scoped student test result aggregates to currently enrolled students whose attempts have been returned.
-- Kept returned assignment grade/feedback fields visible while stripping teacher-only draft feedback and AI suggestion fields.
-- Added accessible names for student survey link/text responses, student open-response test answers, and teacher announcement body textareas.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/student/tests-documents-snapshot.test.ts tests/api/student/tests-results.test.ts tests/unit/assignments.test.ts tests/api/student/assignments.test.ts tests/components/StudentSurveyPanel.test.tsx tests/components/StudentQuizForm.test.tsx tests/components/AnnouncementsMarkdown.test.tsx`
-- `pnpm vitest run tests/api/integration/test-return-visibility-flow.test.ts --reporter=verbose`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=announcements'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- UI screenshots reviewed from `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png` for each tab run.
-- `pnpm test`
-- `bash scripts/verify-env.sh`
-
 ## 2026-05-27 — Student quiz/survey result enrollment scoping
 
 **Completed:**
@@ -980,6 +959,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm test tests/unit/ai-startup-docs.test.ts`
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
@@ -1028,3 +1008,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a mobile confirmation-dialog screenshot after clicking the refresh icon.
+
+## 2026-06-01 — Join copy affordance styling
+
+**Completed:**
+- Styled the join code and join URL copy buttons with primary underlined text so they read as clickable copy controls.
+- Kept the warning refresh icon visually distinct from the copy actions.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,58 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Daily log history selected date clarity
-
-**Completed:**
-- Changed the teacher Daily student-log inspector to keep entries in newest-first chronological order instead of pinning the selected entry above newer logs.
-- Highlighted the selected date in place with a selected-card treatment and bold date label.
-- Added an in-order highlighted `No log for this date.` row for selected dates without a student log.
-- Added focused component coverage for chronological selected entries, empty selected dates, and removal of the old `Selected date -` label.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/StudentLogHistory.test.tsx tests/components/TeacherAttendanceTab.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-- `git diff --check`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=attendance'`
-- Browser screenshots: `/tmp/pika-teacher-daily-selected-history.png`, `/tmp/pika-teacher-daily-empty-selected-history.png`
-
-## 2026-05-27 — Phase four audit fixes
-
-**Completed:**
-- Added selected-student classroom enrollment validation to the teacher test return route before availability checks, finalization, response reads, or the return RPC.
-- Scoped teacher test result aggregation and open-response stats to currently enrolled classroom students.
-- Normalized the shared feedback dialog to use `@/ui` primitives for the dialog import, category segmented control, and submit button.
-- Updated focused API and integration coverage for selected test return/results enrollment scoping.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/tests-return.test.ts tests/api/teacher/tests-results.test.ts`
-- `pnpm test tests/api/integration/test-return-visibility-flow.test.ts`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Feedback dialog screenshots: `/tmp/pika-feedback-teacher-desktop-light-idle.png`, `/tmp/pika-feedback-teacher-desktop-light-error.png`, `/tmp/pika-feedback-teacher-desktop-light-submitting.png`, `/tmp/pika-feedback-teacher-desktop-light-success.png`, `/tmp/pika-feedback-teacher-mobile-dark-idle.png`, `/tmp/pika-feedback-student-desktop-dark-idle.png`, `/tmp/pika-feedback-student-mobile-light-error.png`
-- `pnpm test`
-- `pnpm build`
-
-## 2026-05-27 — Test results enrolled response query
-
-**Completed:**
-- Loaded classroom enrollments before teacher test response reads.
-- Scoped the service-role `test_responses` query to current classroom `student_id`s and skipped the query when no students are enrolled.
-- Kept the defensive in-memory response filter and updated route coverage to assert the scoped response query.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/tests-results.test.ts`
-- `pnpm vitest run tests/api/teacher/tests-results.test.ts tests/api/integration/test-return-visibility-flow.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
 ## 2026-06-01 — AI grading roster sanitization follow-up
 
 **Completed:**
@@ -1027,6 +975,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
+
 ## 2026-06-01 — Open join classroom access mode
 
 **Completed:**
@@ -1067,3 +1016,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
+
+## 2026-06-01 — Joining row copy refinement
+
+**Completed:**
+- Restored brief row-level copy for joining controls while keeping the tooltip concise.
+- Added an X marker inside the off-side toggle thumb.
+- Linked the roster-mode row copy to the classroom roster tab.
+- Added focused coverage for the visible joining copy and roster link.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/unit/ai-startup-docs.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`; checked the Disallow/X off state and restored the classroom to allowed.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,22 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Student quiz/survey result enrollment scoping
-
-**Completed:**
-- Scoped student quiz result aggregates to current classroom enrollments before aggregating class responses.
-- Scoped student survey result aggregates and text/link response lists to current classroom enrollments.
-- Kept defensive in-memory filtering after scoped Supabase `.in('student_id', ...)` response reads.
-- Added API regressions that include stale/unenrolled response rows and assert enrolled-only result payloads.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts --reporter=verbose`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `git diff --check`
-
 ## 2026-05-27 — Assessment authoring accessibility audit
 
 **Completed:**
@@ -1014,6 +998,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Completed:**
 - Styled the join code and join URL copy buttons with primary underlined text so they read as clickable copy controls.
 - Kept the warning refresh icon visually distinct from the copy actions.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
+
+## 2026-06-01 — Join copy highlighted controls
+
+**Completed:**
+- Reverted the link-like underlined text styling on the join code and URL.
+- Highlighted the full join code and join URL controls with the existing subtle primary treatment so the whole textbox reads as clickable-to-copy.
+- Left the warning refresh icon separate from the copy controls.
 
 **Validation:**
 - `pnpm test tests/components/TeacherSettingsTab.test.tsx`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Required submission artifact display
-
-**Completed:**
-- Preserved structured required-submission artifacts as first-class teacher table items before adding free-floating content artifacts.
-- Added requirement title/metadata to teacher artifact display objects so student detail cards show labels like `Published demo` instead of generic `Public link`.
-- Highlighted required-submission artifact pills/cards and kept ordinary content-extracted artifacts visually regular.
-- Added regression coverage for multi-artifact teacher rows, required-submission labels, and student detail artifact titles.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/lib/assignment-submission-requirements.test.ts tests/api/teacher/assignments-id.test.ts tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx -- --testTimeout=10000`
-- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx -- --testTimeout=10000`
-- `pnpm lint`
-- `pnpm test`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=34d744b5-2644-4ca1-baf2-e86270d0590a&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
-- Browser screenshots: `/tmp/pika-teacher-details-artifacts.png`, `/tmp/pika-student-loaded.png`, `/tmp/pika-teacher-mobile.png`
-
 ## 2026-05-27 — Next systems/UI audit slice
 
 **Completed:**
@@ -984,6 +967,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm test tests/unit/ai-startup-docs.test.ts`
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
@@ -1029,3 +1013,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
+
+## 2026-06-01 — Settings name and join-code controls
+
+**Completed:**
+- Renamed the Settings `Course Name` field to `Classroom name`, including validation and save messages.
+- Replaced the separate `New code` button with a warning-colored refresh icon attached to the join-code control.
+- Kept the join-code copy action on the code itself.
+- Removed the regenerate-code confirmation dialog description so the title stands alone.
+- Added focused coverage that the refresh icon opens the title-only confirmation dialog.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a mobile confirmation-dialog screenshot after clicking the refresh icon.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,22 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Assignment repo target enrollment validation
-
-**Completed:**
-- Validated current classroom enrollment before teacher repo-target override reads, deletes, or saves.
-- Failed closed on enrollment query errors and returned the existing not-enrolled bad request for stale students.
-- Added API coverage for unenrolled overrides, enrollment query failures, enrolled override saves, and override resets.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/assignments-repo-targets-studentId.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm run test:coverage`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-27 — Test response enrollment validation
 
 **Completed:**
@@ -998,6 +982,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Removed the X icon from settings switches.
 - Made off and disabled switch thumbs use the neutral grey token while preserving the blue on state.
 - Kept disabled switches on a neutral track with subtle opacity.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a full-page teacher screenshot showing the off Public Syllabus switch.
+
+## 2026-06-01 — Settings switch blue thumb restore
+
+**Completed:**
+- Restored the settings switch thumb to blue for off and disabled states.
+- Kept the off/disabled track neutral and left the X icon removed.
+- Removed whole-switch opacity so the thumb does not wash out.
 
 **Validation:**
 - `pnpm test tests/components/TeacherSettingsTab.test.tsx`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — AI grading roster sanitization follow-up
-
-**Completed:**
-- Addressed PR review feedback by loading classroom roster/profile names before assignment and test AI grading egress.
-- Threaded roster-aware sanitization context through assignment grading, manual test AI suggestions, and background test auto-grading batches.
-- Sanitized test reference prompts, answer keys, sample solutions, student responses, and cached/provided references with the same context.
-- Changed classroom sanitization context loading to fail closed on roster/profile lookup errors before AI provider calls.
-- Added focused unit coverage proving known student names become initials in assignment and test grading provider prompts.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/tests-auto-grade.test.ts`
-- `pnpm test tests/unit/ai-sanitization-server.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/tests-auto-grade.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-05-27 — Required submission artifact display
 
 **Completed:**
@@ -1033,3 +1016,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`; checked the Disallow/X off state and restored the classroom to allowed.
+
+## 2026-06-01 — Roster join row wording
+
+**Completed:**
+- Changed the roster-mode row copy to `Only students on roster can join.` with a lowercase `view roster` link.
+- Matched the roster-mode row emphasis to the allow-new-joins row copy.
+- Updated focused settings coverage for the new copy and link text.
+
+**Validation:**
+- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.

--- a/src/app/api/student/classrooms/join/route.ts
+++ b/src/app/api/student/classrooms/join/route.ts
@@ -6,11 +6,18 @@ import { withErrorHandler } from '@/lib/api-handler'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+function cleanOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
 // POST /api/student/classrooms/join - Join classroom by code or ID
 export const POST = withErrorHandler('PostStudentJoinClassroom', async (request, context) => {
   const user = await requireRole('student')
   const body = await request.json()
   const { classCode, classroomId } = body
+  const firstName = cleanOptionalString(body.firstName)
+  const lastName = cleanOptionalString(body.lastName)
+  const studentNumber = cleanOptionalString(body.studentNumber)
 
   if (!classCode && !classroomId) {
     return NextResponse.json(
@@ -25,7 +32,7 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
   // Find classroom by code or ID
   let query = supabase
     .from('classrooms')
-    .select('id, title, class_code, term_label, allow_enrollment, archived_at')
+    .select('id, title, class_code, term_label, allow_enrollment, join_policy, archived_at')
 
   const looksLikeUuid =
     typeof classroomId === 'string' &&
@@ -101,6 +108,8 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
     )
   }
 
+  const joinPolicy = classroom.join_policy === 'open_join' ? 'open_join' : 'roster'
+
   const { data: rosterEntry, error: rosterError } = await supabase
     .from('classroom_roster')
     .select('student_number, first_name, last_name')
@@ -108,11 +117,63 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
     .eq('email', normalizedEmail)
     .single()
 
-  if (rosterError || !rosterEntry) {
+  if (rosterError && rosterError.code !== 'PGRST116') {
+    console.error('Error checking classroom roster:', rosterError)
+    return NextResponse.json(
+      { error: 'Failed to join classroom' },
+      { status: 500 }
+    )
+  }
+
+  let effectiveRosterEntry = rosterEntry
+
+  if (!effectiveRosterEntry && joinPolicy === 'roster') {
     return NextResponse.json(
       { error: 'Your email is not on the roster for this classroom.', code: 'not_on_roster' },
       { status: 403 }
     )
+  }
+
+  if (!effectiveRosterEntry && joinPolicy === 'open_join') {
+    if (!firstName || !lastName) {
+      return NextResponse.json(
+        {
+          error: 'First name and last name are required to join this classroom.',
+          code: 'profile_required',
+          requiredFields: ['firstName', 'lastName'],
+        },
+        { status: 400 }
+      )
+    }
+
+    effectiveRosterEntry = {
+      student_number: studentNumber,
+      first_name: firstName,
+      last_name: lastName,
+    }
+
+    const { error: rosterUpsertError } = await supabase
+      .from('classroom_roster')
+      .upsert(
+        {
+          classroom_id: classroom.id,
+          email: normalizedEmail,
+          student_number: studentNumber,
+          first_name: firstName,
+          last_name: lastName,
+          counselor_email: null,
+          join_source: 'open_join',
+        },
+        { onConflict: 'classroom_id,email' }
+      )
+
+    if (rosterUpsertError) {
+      console.error('Error creating open-join roster row:', rosterUpsertError)
+      return NextResponse.json(
+        { error: 'Failed to join classroom' },
+        { status: 500 }
+      )
+    }
   }
 
   // Enroll student
@@ -133,15 +194,15 @@ export const POST = withErrorHandler('PostStudentJoinClassroom', async (request,
     )
   }
 
-  if (rosterEntry.first_name && rosterEntry.last_name) {
+  if (effectiveRosterEntry?.first_name && effectiveRosterEntry?.last_name) {
     await supabase
       .from('student_profiles')
       .upsert(
         {
           user_id: user.id,
-          student_number: rosterEntry.student_number || null,
-          first_name: rosterEntry.first_name,
-          last_name: rosterEntry.last_name,
+          student_number: effectiveRosterEntry.student_number || null,
+          first_name: effectiveRosterEntry.first_name,
+          last_name: effectiveRosterEntry.last_name,
         },
         { onConflict: 'user_id' }
       )

--- a/src/app/api/teacher/classrooms/[id]/roster/add/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/add/route.ts
@@ -50,6 +50,7 @@ export const POST = withErrorHandler('PostAddRosterStudents', async (request, co
       last_name: lastName,
       student_number: studentNumber || null,
       counselor_email: counselorEmail?.toLowerCase().trim() || null,
+      join_source: 'manual',
     })
   }
 

--- a/src/app/api/teacher/classrooms/[id]/roster/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/route.ts
@@ -24,7 +24,7 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
 
   const { data: rosterRows, error: rosterError } = await supabase
     .from('classroom_roster')
-    .select('id, email, student_number, first_name, last_name, counselor_email, created_at, updated_at')
+    .select('id, email, student_number, first_name, last_name, counselor_email, join_source, created_at, updated_at')
     .eq('classroom_id', classroomId)
 
   if (rosterError) {
@@ -72,6 +72,7 @@ export const GET = withErrorHandler('GetClassroomRoster', async (_request, conte
       first_name: r.first_name ?? null,
       last_name: r.last_name ?? null,
       counselor_email: r.counselor_email ?? null,
+      join_source: r.join_source === 'open_join' || r.join_source === 'csv' ? r.join_source : 'manual',
       created_at: r.created_at,
       updated_at: r.updated_at,
       joined: !!joined,

--- a/src/app/api/teacher/classrooms/[id]/roster/upload-csv/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/roster/upload-csv/route.ts
@@ -152,6 +152,7 @@ export const POST = withErrorHandler('PostUploadRosterCsv', async (request, cont
     last_name: s.lastName || null,
     student_number: s.studentNumber || null,
     counselor_email: s.counselorEmail || null,
+    join_source: 'csv',
   }))
 
   const { data: upserted, error: upsertError } = await supabase

--- a/src/app/api/teacher/classrooms/[id]/route.ts
+++ b/src/app/api/teacher/classrooms/[id]/route.ts
@@ -51,6 +51,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     classCode,
     termLabel,
     allowEnrollment,
+    joinPolicy,
     archived,
     lessonPlanVisibility,
     actualSiteSlug,
@@ -65,6 +66,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     classCode === undefined &&
     termLabel === undefined &&
     allowEnrollment === undefined &&
+    joinPolicy === undefined &&
     archived === undefined &&
     lessonPlanVisibility === undefined &&
     actualSiteSlug === undefined &&
@@ -96,6 +98,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
     classCode !== undefined ||
     termLabel !== undefined ||
     allowEnrollment !== undefined ||
+    joinPolicy !== undefined ||
     lessonPlanVisibility !== undefined ||
     actualSiteSlug !== undefined ||
     actualSitePublished !== undefined ||
@@ -134,6 +137,7 @@ export const PATCH = withErrorHandler('PatchUpdateClassroom', async (request, co
   if (classCode !== undefined) updates.class_code = classCode
   if (termLabel !== undefined) updates.term_label = termLabel
   if (allowEnrollment !== undefined) updates.allow_enrollment = !!allowEnrollment
+  if (joinPolicy !== undefined) updates.join_policy = joinPolicy
   if (lessonPlanVisibility !== undefined) updates.lesson_plan_visibility = lessonPlanVisibility
   if (actualSiteSlug !== undefined) updates.actual_site_slug = actualSiteSlug
   if (actualSitePublished !== undefined) updates.actual_site_published = actualSitePublished

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -20,7 +20,7 @@ import {
   SortableHeaderCell,
   TableCard,
 } from '@/components/DataTable'
-import type { Classroom } from '@/types'
+import type { Classroom, RosterJoinSource } from '@/types'
 import { Check, Copy, Mail, Pencil, X } from 'lucide-react'
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { compareByNameFields, toggleSort } from '@/lib/table-sort'
@@ -36,6 +36,7 @@ interface RosterRow {
   last_name: string | null
   student_number: string | null
   counselor_email: string | null
+  join_source: RosterJoinSource
   created_at: string
   updated_at: string
   joined: boolean
@@ -64,6 +65,7 @@ function normalizeRosterRows(raw: any[]): RosterRow[] {
       last_name: row.last_name ?? null,
       student_number: row.student_number ?? null,
       counselor_email: row.counselor_email ?? null,
+      join_source: row.join_source === 'open_join' || row.join_source === 'csv' ? row.join_source : 'manual',
       created_at: row.created_at,
       updated_at: row.updated_at,
       joined: !!row.joined,
@@ -89,6 +91,16 @@ function formatRosterDate(iso: string | null): string {
   } catch {
     return iso
   }
+}
+
+function JoinSourceBadge({ source }: { source: RosterJoinSource }) {
+  if (source !== 'open_join') return null
+
+  return (
+    <span className="inline-flex shrink-0 rounded-badge border border-border bg-surface-2 px-2 py-0.5 text-[11px] font-medium text-text-muted">
+      Open join
+    </span>
+  )
 }
 
 export function TeacherRosterTab({ classroom }: Props) {
@@ -491,6 +503,12 @@ export function TeacherRosterTab({ classroom }: Props) {
           <div className="text-xs text-text-muted">Joined</div>
           <div className="text-text-default">{selectedRosterRow.joined ? 'Yes' : 'No'}</div>
         </div>
+        <div>
+          <div className="text-xs text-text-muted">Source</div>
+          <div className="text-text-default">
+            {selectedRosterRow.join_source === 'open_join' ? 'Open join' : selectedRosterRow.join_source === 'csv' ? 'CSV' : 'Manual'}
+          </div>
+        </div>
       </div>
       <div>
         <div className="text-xs text-text-muted">Counselor</div>
@@ -636,7 +654,12 @@ export function TeacherRosterTab({ classroom }: Props) {
                         </DataTableCell>
                         <DataTableCell>{row.first_name ?? '—'}</DataTableCell>
                         <DataTableCell>{row.last_name ?? '—'}</DataTableCell>
-                        <DataTableCell className="hidden text-text-muted md:table-cell">{row.email}</DataTableCell>
+                        <DataTableCell className="hidden text-text-muted md:table-cell">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="truncate">{row.email}</span>
+                            <JoinSourceBadge source={row.join_source} />
+                          </div>
+                        </DataTableCell>
                         <DataTableCell className="hidden text-text-muted lg:table-cell">
                           {editingCounselorId === row.id ? (
                             <div className="flex items-center gap-1">

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -458,31 +458,16 @@ export function TeacherSettingsTab({
             />
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
-              <div className="flex w-full min-w-0 sm:w-auto">
-                <Button
-                  type="button"
-                  variant="subtle"
-                  size="md"
-                  onClick={() => copyWithNotice('Join code', joinCode)}
-                  aria-label="Copy join code"
-                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold sm:flex-none"
-                >
-                  {joinCode}
-                </Button>
-
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="md"
-                  onClick={() => setShowRegenerateConfirm(true)}
-                  disabled={isRegenerating || isReadOnly}
-                  aria-label="Generate new join code"
-                  title="Generate new join code"
-                  className="h-11 w-11 shrink-0 rounded-l-none border-warning bg-warning-bg px-0 text-warning hover:bg-warning-bg focus:ring-warning"
-                >
-                  <RefreshCw className={cn('h-4 w-4', isRegenerating ? 'animate-spin' : '')} aria-hidden="true" />
-                </Button>
-              </div>
+              <Button
+                type="button"
+                variant="subtle"
+                size="md"
+                onClick={() => copyWithNotice('Join code', joinCode)}
+                aria-label="Copy join code"
+                className="w-full justify-start font-mono text-base font-semibold sm:w-auto"
+              >
+                {joinCode}
+              </Button>
 
               <Button
                 type="button"
@@ -491,9 +476,22 @@ export function TeacherSettingsTab({
                 onClick={() => copyWithNotice('Join link', joinLink)}
                 aria-label="Copy join link"
                 title={joinLink}
-                className="w-full min-w-0 justify-start font-mono text-xs sm:flex-1"
+                className="w-full min-w-0 justify-start font-mono text-xs sm:w-[30rem] sm:max-w-[45vw]"
               >
                 <span className="min-w-0 truncate">{joinLink}</span>
+              </Button>
+
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => setShowRegenerateConfirm(true)}
+                disabled={isRegenerating || isReadOnly}
+                aria-label="Generate new join code and link"
+                title="Generate new join code and link"
+                className="h-11 w-11 shrink-0 border-warning bg-warning-bg px-0 text-warning hover:bg-warning-bg focus:ring-warning"
+              >
+                <RefreshCw className={cn('h-4 w-4', isRegenerating ? 'animate-spin' : '')} aria-hidden="true" />
               </Button>
             </div>
 
@@ -729,7 +727,7 @@ export function TeacherSettingsTab({
 
             <ConfirmDialog
               isOpen={showRegenerateConfirm}
-              title="Generate new join code?"
+              title="Generate new join code and link?"
               confirmLabel={isRegenerating ? 'Generating...' : 'Generate'}
               cancelLabel="Cancel"
               confirmVariant="danger"

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -465,7 +465,7 @@ export function TeacherSettingsTab({
                   size="md"
                   onClick={() => copyWithNotice('Join code', joinCode)}
                   aria-label="Copy join code"
-                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold sm:flex-none"
+                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold text-primary underline underline-offset-4 hover:text-primary-hover sm:flex-none"
                 >
                   {joinCode}
                 </Button>
@@ -491,7 +491,7 @@ export function TeacherSettingsTab({
                 onClick={() => copyWithNotice('Join link', joinLink)}
                 aria-label="Copy join link"
                 title={joinLink}
-                className="w-full min-w-0 justify-start font-mono text-xs sm:flex-1"
+                className="w-full min-w-0 justify-start font-mono text-xs text-primary underline underline-offset-4 hover:text-primary-hover sm:flex-1"
               >
                 <span className="min-w-0 truncate">{joinLink}</span>
               </Button>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -49,11 +49,6 @@ const SYLLABUS_LESSON_PLAN_SCOPE_OPTIONS = [
   { value: 'all', label: 'All lesson plans' },
 ]
 
-const JOIN_POLICY_OPTIONS: Array<{ value: ClassroomJoinPolicy; label: string }> = [
-  { value: 'roster', label: 'Roster' },
-  { value: 'open_join', label: 'Open join' },
-]
-
 function visibleActualSiteConfig(config: ActualCourseSiteConfig | null | undefined): ActualCourseSiteConfig {
   return {
     ...(config || DEFAULT_ACTUAL_COURSE_SITE_CONFIG),
@@ -90,6 +85,53 @@ function SettingsHeading({ title, tooltip }: { title: string; tooltip?: string }
   )
 }
 
+function TwoChoiceToggle({
+  leftLabel,
+  rightLabel,
+  checked,
+  onChange,
+  disabled,
+  ariaLabel,
+}: {
+  leftLabel: string
+  rightLabel: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  disabled?: boolean
+  ariaLabel: string
+}) {
+  return (
+    <div className="inline-flex items-center gap-2 text-sm">
+      <span className={cn('min-w-12 text-right', checked ? 'font-semibold text-text-default' : 'text-text-muted')}>
+        {leftLabel}
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          'relative h-7 w-14 rounded-full border border-border bg-surface-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-page',
+          disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-surface-hover',
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            'absolute left-0 top-1 h-5 w-5 rounded-full bg-primary shadow-sm transition-transform',
+            checked ? 'translate-x-1' : 'translate-x-7',
+          )}
+        />
+      </button>
+      <span className={cn('min-w-14', checked ? 'text-text-muted' : 'font-semibold text-text-default')}>
+        {rightLabel}
+      </span>
+    </div>
+  )
+}
+
 interface SettingsTextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   hasError?: boolean
 }
@@ -118,7 +160,6 @@ export function TeacherSettingsTab({
 }: Props) {
   const router = useRouter()
   const section: SettingsSection = sectionParam === 'class-days' ? 'class-days' : 'general'
-  const allowEnrollmentId = useId()
   const titleId = useId()
   const actualSiteSlugId = useId()
   const actualOverviewId = useId()
@@ -444,38 +485,35 @@ export function TeacherSettingsTab({
               </Button>
             </div>
 
-            <div className="flex items-center gap-3 border-t border-border pt-2">
-              <input
-                id={allowEnrollmentId}
-                type="checkbox"
+            <div className="flex flex-col gap-2 border-t border-border pt-3 sm:flex-row sm:items-center">
+              <TwoChoiceToggle
+                leftLabel="Allow"
+                rightLabel="Disallow"
                 checked={allowEnrollment}
-                onChange={(e) => saveAllowEnrollment(e.target.checked)}
+                onChange={saveAllowEnrollment}
                 disabled={saving || isReadOnly}
-                className="h-4 w-4"
+                ariaLabel="Allow new students to join"
               />
-              <label htmlFor={allowEnrollmentId} className="text-sm text-text-default">
-                Allow new students to join
-              </label>
+              <div className="text-sm font-medium text-text-default">Allow new students to join</div>
               {saving && <span className="text-sm text-text-muted">Saving...</span>}
             </div>
 
             <div className="space-y-2 border-t border-border pt-3">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <TwoChoiceToggle
+                  leftLabel="Roster"
+                  rightLabel="Open"
+                  checked={joinPolicy === 'roster'}
+                  onChange={(isRoster) => saveJoinPolicy(isRoster ? 'roster' : 'open_join')}
+                  disabled={saving || isReadOnly || !allowEnrollment}
+                  ariaLabel="Join mode"
+                />
                 <div>
                   <div className="text-sm font-medium text-text-default">Join mode</div>
                   <div className="text-xs text-text-muted">
                     Roster requires a matching email. Open join lets any signed-in student with the code join.
                   </div>
                 </div>
-                <SegmentedControl
-                  ariaLabel="Join mode"
-                  value={joinPolicy}
-                  options={JOIN_POLICY_OPTIONS.map((option) => ({
-                    ...option,
-                    disabled: saving || isReadOnly || !allowEnrollment,
-                  }))}
-                  onChange={saveJoinPolicy}
-                />
               </div>
 
               {allowEnrollment && joinPolicy === 'open_join' ? (

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -3,7 +3,7 @@
 import { forwardRef, useMemo, useState, useId, type ReactNode, type TextareaHTMLAttributes } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Info, RefreshCw, X } from 'lucide-react'
+import { Info, RefreshCw } from 'lucide-react'
 import {
   Button,
   Card,
@@ -107,23 +107,22 @@ function SettingsSwitch({
       onClick={() => onChange(!checked)}
       className={cn(
         'relative h-7 w-14 shrink-0 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-page',
-        checked ? 'border-primary bg-info-bg' : 'border-border bg-surface-2',
         disabled
-          ? 'cursor-not-allowed opacity-60'
+          ? 'cursor-not-allowed border-border bg-surface-2 opacity-70'
           : checked
             ? 'hover:border-primary-hover hover:bg-info-bg-hover'
             : 'hover:bg-surface-hover',
+        !disabled && (checked ? 'border-primary bg-info-bg' : 'border-border bg-surface-2'),
       )}
     >
       <span
         aria-hidden="true"
         className={cn(
-          'absolute left-0 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm transition-transform',
+          'absolute left-0 top-1 h-5 w-5 rounded-full shadow-sm transition-transform',
           checked ? 'translate-x-7' : 'translate-x-1',
+          disabled || !checked ? 'bg-border-strong' : 'bg-primary',
         )}
-      >
-        {!checked ? <X className="h-3 w-3 text-text-inverse" strokeWidth={3} /> : null}
-      </span>
+      />
     </button>
   )
 }

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -519,13 +519,13 @@ export function TeacherSettingsTab({
                 <div className="text-sm text-text-muted">
                   {joinPolicy === 'roster' ? (
                     <>
-                      Roster requires matching email.{' '}
+                      <span className="font-medium text-text-default">Only students on roster can join.</span>{' '}
                       <Link href={`/classrooms/${classroom.id}?tab=roster`} className="text-primary underline">
-                        View roster
+                        view roster
                       </Link>
                     </>
                   ) : (
-                    'Open join via code/link.'
+                    <span className="font-medium text-text-default">Open join via code/link.</span>
                   )}
                 </div>
               </div>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { forwardRef, useMemo, useState, useId, type ReactNode, type TextareaHTMLAttributes } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Info } from 'lucide-react'
+import { Info, X } from 'lucide-react'
 import {
   Button,
   Card,
@@ -120,10 +121,12 @@ function TwoChoiceToggle({
         <span
           aria-hidden="true"
           className={cn(
-            'absolute left-0 top-1 h-5 w-5 rounded-full bg-primary shadow-sm transition-transform',
+            'absolute left-0 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm transition-transform',
             checked ? 'translate-x-1' : 'translate-x-7',
           )}
-        />
+        >
+          {!checked ? <X className="h-3 w-3 text-text-inverse" strokeWidth={3} /> : null}
+        </span>
       </button>
       <span className={cn('min-w-14', checked ? 'text-text-muted' : 'font-semibold text-text-default')}>
         {rightLabel}
@@ -451,16 +454,7 @@ export function TeacherSettingsTab({
           <SettingsPanel>
             <SettingsHeading
               title="Joining"
-              tooltip={
-                <div className="space-y-2">
-                  <p>
-                    <span className="font-semibold">Allow new students to join:</span> turns new joins on or off for this classroom.
-                  </p>
-                  <p>
-                    <span className="font-semibold">Join mode:</span> Roster requires a matching email. Open lets any signed-in student with the code join after entering their name.
-                  </p>
-                </div>
-              }
+              tooltip="Control new joins and whether students must be on the roster."
             />
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
@@ -506,6 +500,9 @@ export function TeacherSettingsTab({
                 disabled={saving || isReadOnly}
                 ariaLabel="Allow new students to join"
               />
+              <div className="text-sm text-text-default">
+                {allowEnrollment ? 'Allow new joins' : 'Disallow new joins'}
+              </div>
               {saving && <span className="text-sm text-text-muted">Saving...</span>}
             </div>
 
@@ -519,6 +516,18 @@ export function TeacherSettingsTab({
                   disabled={saving || isReadOnly || !allowEnrollment}
                   ariaLabel="Join mode"
                 />
+                <div className="text-sm text-text-muted">
+                  {joinPolicy === 'roster' ? (
+                    <>
+                      Roster requires matching email.{' '}
+                      <Link href={`/classrooms/${classroom.id}?tab=roster`} className="text-primary underline">
+                        View roster
+                      </Link>
+                    </>
+                  ) : (
+                    'Open join via code/link.'
+                  )}
+                </div>
               </div>
 
               {allowEnrollment && joinPolicy === 'open_join' ? (

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -70,7 +70,7 @@ function SettingsPanel({ children, className }: { children: ReactNode; className
   )
 }
 
-function SettingsHeading({ title, tooltip }: { title: string; tooltip?: string }) {
+function SettingsHeading({ title, tooltip }: { title: string; tooltip?: ReactNode }) {
   return (
     <div className="flex items-center gap-2">
       <div className="text-sm font-semibold text-text-default">{title}</div>
@@ -449,7 +449,19 @@ export function TeacherSettingsTab({
           </SettingsPanel>
 
           <SettingsPanel>
-            <SettingsHeading title="Joining" tooltip="Control how students can join this classroom" />
+            <SettingsHeading
+              title="Joining"
+              tooltip={
+                <div className="space-y-2">
+                  <p>
+                    <span className="font-semibold">Allow new students to join:</span> turns new joins on or off for this classroom.
+                  </p>
+                  <p>
+                    <span className="font-semibold">Join mode:</span> Roster requires a matching email. Open lets any signed-in student with the code join after entering their name.
+                  </p>
+                </div>
+              }
+            />
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
               <Button
@@ -494,7 +506,6 @@ export function TeacherSettingsTab({
                 disabled={saving || isReadOnly}
                 ariaLabel="Allow new students to join"
               />
-              <div className="text-sm font-medium text-text-default">Allow new students to join</div>
               {saving && <span className="text-sm text-text-muted">Saving...</span>}
             </div>
 
@@ -508,12 +519,6 @@ export function TeacherSettingsTab({
                   disabled={saving || isReadOnly || !allowEnrollment}
                   ariaLabel="Join mode"
                 />
-                <div>
-                  <div className="text-sm font-medium text-text-default">Join mode</div>
-                  <div className="text-xs text-text-muted">
-                    Roster requires a matching email. Open join lets any signed-in student with the code join.
-                  </div>
-                </div>
               </div>
 
               {allowEnrollment && joinPolicy === 'open_join' ? (

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -108,7 +108,7 @@ function SettingsSwitch({
       className={cn(
         'relative h-7 w-14 shrink-0 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-page',
         disabled
-          ? 'cursor-not-allowed border-border bg-surface-2 opacity-70'
+          ? 'cursor-not-allowed border-border bg-surface-2'
           : checked
             ? 'hover:border-primary-hover hover:bg-info-bg-hover'
             : 'hover:bg-surface-hover',
@@ -120,7 +120,7 @@ function SettingsSwitch({
         className={cn(
           'absolute left-0 top-1 h-5 w-5 rounded-full shadow-sm transition-transform',
           checked ? 'translate-x-7' : 'translate-x-1',
-          disabled || !checked ? 'bg-border-strong' : 'bg-primary',
+          'bg-primary',
         )}
       />
     </button>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -86,51 +86,67 @@ function SettingsHeading({ title, tooltip }: { title: string; tooltip?: ReactNod
   )
 }
 
-function TwoChoiceToggle({
-  leftLabel,
-  rightLabel,
+function SettingsSwitch({
   checked,
   onChange,
   disabled,
   ariaLabel,
 }: {
-  leftLabel: string
-  rightLabel: string
   checked: boolean
   onChange: (checked: boolean) => void
   disabled?: boolean
   ariaLabel: string
 }) {
   return (
-    <div className="inline-flex items-center gap-2 text-sm">
-      <span className={cn('min-w-12 text-right', checked ? 'font-semibold text-text-default' : 'text-text-muted')}>
-        {leftLabel}
-      </span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        aria-label={ariaLabel}
-        disabled={disabled}
-        onClick={() => onChange(!checked)}
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'relative h-7 w-14 shrink-0 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-page',
+        checked ? 'border-primary bg-info-bg' : 'border-border bg-surface-2',
+        disabled
+          ? 'cursor-not-allowed opacity-60'
+          : checked
+            ? 'hover:border-primary-hover hover:bg-info-bg-hover'
+            : 'hover:bg-surface-hover',
+      )}
+    >
+      <span
+        aria-hidden="true"
         className={cn(
-          'relative h-7 w-14 rounded-full border border-border bg-surface-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-page',
-          disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-surface-hover',
+          'absolute left-0 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm transition-transform',
+          checked ? 'translate-x-7' : 'translate-x-1',
         )}
       >
-        <span
-          aria-hidden="true"
-          className={cn(
-            'absolute left-0 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary shadow-sm transition-transform',
-            checked ? 'translate-x-1' : 'translate-x-7',
-          )}
-        >
-          {!checked ? <X className="h-3 w-3 text-text-inverse" strokeWidth={3} /> : null}
-        </span>
-      </button>
-      <span className={cn('min-w-14', checked ? 'text-text-muted' : 'font-semibold text-text-default')}>
-        {rightLabel}
+        {!checked ? <X className="h-3 w-3 text-text-inverse" strokeWidth={3} /> : null}
       </span>
+    </button>
+  )
+}
+
+function SettingsSwitchRow({
+  checked,
+  onChange,
+  disabled,
+  ariaLabel,
+  children,
+  className,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  disabled?: boolean
+  ariaLabel: string
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      <SettingsSwitch checked={checked} onChange={onChange} disabled={disabled} ariaLabel={ariaLabel} />
+      <div className={cn('min-w-0 text-sm', disabled ? 'text-text-muted' : 'text-text-default')}>{children}</div>
     </div>
   )
 }
@@ -168,7 +184,6 @@ export function TeacherSettingsTab({
   const actualOverviewId = useId()
   const actualOutlineId = useId()
   const actualLessonPlanScopeId = useId()
-  const showMarkdownId = useId()
   const isReadOnly = !!classroom.archived_at
   const { showMarkdown, mounted: markdownMounted, setShowMarkdown } = useMarkdownPreference()
   const [title, setTitle] = useState(classroom.title)
@@ -495,44 +510,38 @@ export function TeacherSettingsTab({
               </Button>
             </div>
 
-            <div className="flex flex-col gap-2 border-t border-border pt-3 sm:flex-row sm:items-center">
-              <TwoChoiceToggle
-                leftLabel="Allow"
-                rightLabel="Disallow"
-                checked={allowEnrollment}
-                onChange={saveAllowEnrollment}
-                disabled={saving || isReadOnly}
-                ariaLabel="Allow new students to join"
-              />
-              <div className="text-sm text-text-default">
-                {allowEnrollment ? 'Allow new joins' : 'Disallow new joins'}
+            <div className="flex flex-col gap-2 border-t border-border pt-3">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <SettingsSwitchRow
+                  checked={allowEnrollment}
+                  onChange={saveAllowEnrollment}
+                  disabled={saving || isReadOnly}
+                  ariaLabel="Allow new students to join"
+                >
+                  <span className="font-medium">{allowEnrollment ? 'Allow new joins' : 'Disallow new joins'}</span>
+                </SettingsSwitchRow>
+                {saving && <span className="text-sm text-text-muted">Saving...</span>}
               </div>
-              {saving && <span className="text-sm text-text-muted">Saving...</span>}
             </div>
 
             <div className="space-y-2 border-t border-border pt-3">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                <TwoChoiceToggle
-                  leftLabel="Roster"
-                  rightLabel="Open"
-                  checked={joinPolicy === 'roster'}
-                  onChange={(isRoster) => saveJoinPolicy(isRoster ? 'roster' : 'open_join')}
-                  disabled={saving || isReadOnly || !allowEnrollment}
-                  ariaLabel="Join mode"
-                />
-                <div className="text-sm text-text-muted">
-                  {joinPolicy === 'roster' ? (
-                    <>
-                      <span className="font-medium text-text-default">Only students on roster can join.</span>{' '}
-                      <Link href={`/classrooms/${classroom.id}?tab=roster`} className="text-primary underline">
-                        view roster
-                      </Link>
-                    </>
-                  ) : (
-                    <span className="font-medium text-text-default">Open join via code/link.</span>
-                  )}
-                </div>
-              </div>
+              <SettingsSwitchRow
+                checked={joinPolicy === 'roster'}
+                onChange={(isRoster) => saveJoinPolicy(isRoster ? 'roster' : 'open_join')}
+                disabled={saving || isReadOnly || !allowEnrollment}
+                ariaLabel="Join mode"
+              >
+                {joinPolicy === 'roster' ? (
+                  <>
+                    <span className="font-medium text-text-default">Only students on roster can join.</span>{' '}
+                    <Link href={`/classrooms/${classroom.id}?tab=roster`} className="text-primary underline">
+                      view roster
+                    </Link>
+                  </>
+                ) : (
+                  <span className="font-medium text-text-default">Open join via code/link.</span>
+                )}
+              </SettingsSwitchRow>
 
               {allowEnrollment && joinPolicy === 'open_join' ? (
                 <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
@@ -564,16 +573,13 @@ export function TeacherSettingsTab({
           <SettingsPanel>
             <div className="text-sm font-semibold text-text-default">Display</div>
 
-            <label htmlFor={showMarkdownId} className="flex items-center gap-3 text-sm text-text-default">
-              <input
-                id={showMarkdownId}
-                type="checkbox"
-                checked={markdownMounted ? showMarkdown : true}
-                onChange={(event) => setShowMarkdown(event.target.checked)}
-                className="h-4 w-4"
-              />
-              Show markdown
-            </label>
+            <SettingsSwitchRow
+              checked={markdownMounted ? showMarkdown : true}
+              onChange={setShowMarkdown}
+              ariaLabel="Show markdown"
+            >
+              <span className="font-medium">Show markdown</span>
+            </SettingsSwitchRow>
           </SettingsPanel>
 
           <SettingsPanel className="space-y-4">
@@ -600,16 +606,14 @@ export function TeacherSettingsTab({
               </div>
             </div>
 
-            <label className="flex items-center gap-3 text-sm text-text-default">
-              <input
-                type="checkbox"
-                checked={actualSitePublished}
-                onChange={(e) => setActualSitePublished(e.target.checked)}
-                disabled={siteSaving || isReadOnly}
-                className="h-4 w-4"
-              />
-              Publish this classroom syllabus
-            </label>
+            <SettingsSwitchRow
+              checked={actualSitePublished}
+              onChange={setActualSitePublished}
+              disabled={siteSaving || isReadOnly}
+              ariaLabel="Publish this classroom syllabus"
+            >
+              <span className="font-medium">Publish this classroom syllabus</span>
+            </SettingsSwitchRow>
 
             <div className="grid gap-3 md:grid-cols-2">
               {(
@@ -621,23 +625,26 @@ export function TeacherSettingsTab({
                   ['lesson_plans', 'Lesson plans'],
                   ['announcements', 'Announcements'],
                 ] as Array<[keyof ActualCourseSiteConfig, string]>
-              ).map(([key, label]) => (
-                <label key={key} className="flex items-center gap-3 text-sm text-text-default">
-                  <input
-                    type="checkbox"
-                    checked={typeof actualSiteConfig[key] === 'boolean' ? (actualSiteConfig[key] as boolean) : false}
-                    onChange={(e) =>
+              ).map(([key, label]) => {
+                const checked = typeof actualSiteConfig[key] === 'boolean' ? (actualSiteConfig[key] as boolean) : false
+
+                return (
+                  <SettingsSwitchRow
+                    key={key}
+                    checked={checked}
+                    onChange={(nextChecked) =>
                       setActualSiteConfig((current) => ({
                         ...current,
-                        [key]: e.target.checked,
+                        [key]: nextChecked,
                       }))
                     }
                     disabled={siteSaving || isReadOnly}
-                    className="h-4 w-4"
-                  />
-                  {label}
-                </label>
-              ))}
+                    ariaLabel={label}
+                  >
+                    <span className={checked ? 'font-medium' : undefined}>{label}</span>
+                  </SettingsSwitchRow>
+                )
+              })}
             </div>
 
             <FormField label="Lesson plan visibility on syllabus" htmlFor={actualLessonPlanScopeId}>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -461,11 +461,11 @@ export function TeacherSettingsTab({
               <div className="flex w-full min-w-0 sm:w-auto">
                 <Button
                   type="button"
-                  variant="secondary"
+                  variant="subtle"
                   size="md"
                   onClick={() => copyWithNotice('Join code', joinCode)}
                   aria-label="Copy join code"
-                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold text-primary underline underline-offset-4 hover:text-primary-hover sm:flex-none"
+                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold sm:flex-none"
                 >
                   {joinCode}
                 </Button>
@@ -486,12 +486,12 @@ export function TeacherSettingsTab({
 
               <Button
                 type="button"
-                variant="secondary"
+                variant="subtle"
                 size="md"
                 onClick={() => copyWithNotice('Join link', joinLink)}
                 aria-label="Copy join link"
                 title={joinLink}
-                className="w-full min-w-0 justify-start font-mono text-xs text-primary underline underline-offset-4 hover:text-primary-hover sm:flex-1"
+                className="w-full min-w-0 justify-start font-mono text-xs sm:flex-1"
               >
                 <span className="min-w-0 truncate">{joinLink}</span>
               </Button>

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -20,7 +20,7 @@ import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_ACTUAL_COURSE_SITE_CONFIG, slugifyCourseSiteValue } from '@/lib/course-site-publishing'
 import { TeacherCalendarTab } from './TeacherCalendarTab'
-import type { ActualCourseSiteConfig, Classroom, LessonPlanVisibility } from '@/types'
+import type { ActualCourseSiteConfig, Classroom, ClassroomJoinPolicy, LessonPlanVisibility } from '@/types'
 
 const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
 
@@ -47,6 +47,11 @@ const SYLLABUS_LESSON_PLAN_SCOPE_OPTIONS = [
   { value: 'current_week', label: 'Current week (and earlier)' },
   { value: 'one_week_ahead', label: 'One week ahead' },
   { value: 'all', label: 'All lesson plans' },
+]
+
+const JOIN_POLICY_OPTIONS: Array<{ value: ClassroomJoinPolicy; label: string }> = [
+  { value: 'roster', label: 'Roster' },
+  { value: 'open_join', label: 'Open join' },
 ]
 
 function visibleActualSiteConfig(config: ActualCourseSiteConfig | null | undefined): ActualCourseSiteConfig {
@@ -127,6 +132,7 @@ export function TeacherSettingsTab({
   const [titleError, setTitleError] = useState<string>('')
   const [joinCode, setJoinCode] = useState(classroom.class_code)
   const [allowEnrollment, setAllowEnrollment] = useState<boolean>(classroom.allow_enrollment)
+  const [joinPolicy, setJoinPolicy] = useState<ClassroomJoinPolicy>(classroom.join_policy || 'roster')
   const [saving, setSaving] = useState(false)
   const [enrollmentError, setEnrollmentError] = useState<string>('')
   const [joinCodeError, setJoinCodeError] = useState<string>('')
@@ -218,6 +224,29 @@ export function TeacherSettingsTab({
         throw new Error(data.error || 'Failed to update settings')
       }
       setAllowEnrollment(!!data.classroom?.allow_enrollment)
+      showMessage({ text: 'Settings saved', tone: 'success' })
+    } catch (err: any) {
+      setEnrollmentError(err.message || 'Failed to update settings')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function saveJoinPolicy(nextValue: ClassroomJoinPolicy) {
+    if (isReadOnly || nextValue === joinPolicy) return
+    setSaving(true)
+    setEnrollmentError('')
+    try {
+      const res = await fetch(`/api/teacher/classrooms/${classroom.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ joinPolicy: nextValue }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to update settings')
+      }
+      setJoinPolicy(data.classroom?.join_policy || nextValue)
       showMessage({ text: 'Settings saved', tone: 'success' })
     } catch (err: any) {
       setEnrollmentError(err.message || 'Failed to update settings')
@@ -379,7 +408,7 @@ export function TeacherSettingsTab({
           </SettingsPanel>
 
           <SettingsPanel>
-            <SettingsHeading title="Join Code" tooltip="Students must be on the roster to join" />
+            <SettingsHeading title="Joining" tooltip="Control how students can join this classroom" />
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
               <Button
@@ -425,9 +454,35 @@ export function TeacherSettingsTab({
                 className="h-4 w-4"
               />
               <label htmlFor={allowEnrollmentId} className="text-sm text-text-default">
-                Allow joining
+                Allow new students to join
               </label>
               {saving && <span className="text-sm text-text-muted">Saving...</span>}
+            </div>
+
+            <div className="space-y-2 border-t border-border pt-3">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="text-sm font-medium text-text-default">Join mode</div>
+                  <div className="text-xs text-text-muted">
+                    Roster requires a matching email. Open join lets any signed-in student with the code join.
+                  </div>
+                </div>
+                <SegmentedControl
+                  ariaLabel="Join mode"
+                  value={joinPolicy}
+                  options={JOIN_POLICY_OPTIONS.map((option) => ({
+                    ...option,
+                    disabled: saving || isReadOnly || !allowEnrollment,
+                  }))}
+                  onChange={saveJoinPolicy}
+                />
+              </div>
+
+              {allowEnrollment && joinPolicy === 'open_join' ? (
+                <div className="rounded-md border border-warning bg-warning-bg px-3 py-2 text-sm text-warning">
+                  Anyone with this code or link can join after entering their name.
+                </div>
+              ) : null}
             </div>
 
             {joinCodeError && <div className="text-sm text-danger">{joinCodeError}</div>}

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -3,7 +3,7 @@
 import { forwardRef, useMemo, useState, useId, type ReactNode, type TextareaHTMLAttributes } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Info, X } from 'lucide-react'
+import { Info, RefreshCw, X } from 'lucide-react'
 import {
   Button,
   Card,
@@ -226,7 +226,7 @@ export function TeacherSettingsTab({
     if (isReadOnly) return
     const trimmed = title.trim()
     if (!trimmed) {
-      setTitleError('Course name cannot be empty')
+      setTitleError('Classroom name cannot be empty')
       return
     }
     if (trimmed === classroom.title) {
@@ -242,12 +242,12 @@ export function TeacherSettingsTab({
       })
       const data = await res.json()
       if (!res.ok) {
-        throw new Error(data.error || 'Failed to update course name')
+        throw new Error(data.error || 'Failed to update classroom name')
       }
       setTitle(data.classroom?.title || trimmed)
-      showMessage({ text: 'Course name updated', tone: 'success' })
+      showMessage({ text: 'Classroom name updated', tone: 'success' })
     } catch (err: any) {
-      setTitleError(err.message || 'Failed to update course name')
+      setTitleError(err.message || 'Failed to update classroom name')
     } finally {
       setTitleSaving(false)
     }
@@ -429,9 +429,9 @@ export function TeacherSettingsTab({
       {section === 'general' ? (
         <PageContent className="space-y-4 pt-0">
           <SettingsPanel>
-            <SettingsHeading title="Course Name" tooltip="Name shown to students and in reports" />
+            <SettingsHeading title="Classroom name" tooltip="Name shown to students and in reports" />
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-              <FormField label="Course Name" htmlFor={titleId} hideLabel error={titleError} className="flex-1">
+              <FormField label="Classroom name" htmlFor={titleId} hideLabel error={titleError} className="flex-1">
                 <Input
                   type="text"
                   value={title}
@@ -444,7 +444,7 @@ export function TeacherSettingsTab({
                     }
                   }}
                   disabled={titleSaving || isReadOnly}
-                  placeholder="Enter course name"
+                  placeholder="Enter classroom name"
                 />
               </FormField>
               {titleSaving && <span className="text-sm text-text-muted sm:pt-2">Saving...</span>}
@@ -458,25 +458,31 @@ export function TeacherSettingsTab({
             />
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
-              <Button
-                type="button"
-                variant="secondary"
-                size="md"
-                onClick={() => copyWithNotice('Join code', joinCode)}
-                aria-label="Copy join code"
-                className="w-full justify-start font-mono text-base font-semibold sm:w-auto"
-              >
-                {joinCode}
-              </Button>
+              <div className="flex w-full min-w-0 sm:w-auto">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="md"
+                  onClick={() => copyWithNotice('Join code', joinCode)}
+                  aria-label="Copy join code"
+                  className="min-w-0 flex-1 justify-start rounded-r-none border-r-0 font-mono text-base font-semibold sm:flex-none"
+                >
+                  {joinCode}
+                </Button>
 
-              <Button
-                variant="secondary"
-                onClick={() => setShowRegenerateConfirm(true)}
-                disabled={isRegenerating || isReadOnly}
-                className="w-full sm:w-auto"
-              >
-                {isRegenerating ? 'Generating...' : 'New code'}
-              </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="md"
+                  onClick={() => setShowRegenerateConfirm(true)}
+                  disabled={isRegenerating || isReadOnly}
+                  aria-label="Generate new join code"
+                  title="Generate new join code"
+                  className="h-11 w-11 shrink-0 rounded-l-none border-warning bg-warning-bg px-0 text-warning hover:bg-warning-bg focus:ring-warning"
+                >
+                  <RefreshCw className={cn('h-4 w-4', isRegenerating ? 'animate-spin' : '')} aria-hidden="true" />
+                </Button>
+              </div>
 
               <Button
                 type="button"
@@ -724,8 +730,7 @@ export function TeacherSettingsTab({
             <ConfirmDialog
               isOpen={showRegenerateConfirm}
               title="Generate new join code?"
-              description="This replaces the current code. Students will need the new code/link to join."
-              confirmLabel={isRegenerating ? 'Generating…' : 'New code'}
+              confirmLabel={isRegenerating ? 'Generating...' : 'Generate'}
               cancelLabel="Cancel"
               confirmVariant="danger"
               isConfirmDisabled={isRegenerating || isReadOnly}

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { Spinner } from '@/components/Spinner'
+import { Button, FormField, Input } from '@/ui'
 
 export default function JoinClassroomPage() {
   const router = useRouter()
@@ -11,54 +12,85 @@ export default function JoinClassroomPage() {
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [needsProfile, setNeedsProfile] = useState(false)
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [studentNumber, setStudentNumber] = useState('')
+  const [profileSubmitting, setProfileSubmitting] = useState(false)
 
-  useEffect(() => {
-    async function joinClassroom() {
-      try {
-        const trimmedCode = String(code || '').trim()
-        const isUuid =
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-            trimmedCode
-          )
+  async function joinClassroom(profile?: { firstName: string; lastName: string; studentNumber?: string }) {
+    try {
+      const trimmedCode = String(code || '').trim()
+      const isUuid =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          trimmedCode
+        )
 
-        // Try to join by code or ID
-        const response = await fetch('/api/student/classrooms/join', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            classCode: trimmedCode,
-            ...(isUuid ? { classroomId: trimmedCode } : {}),
-          }),
-        })
+      const response = await fetch('/api/student/classrooms/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classCode: trimmedCode,
+          ...(isUuid ? { classroomId: trimmedCode } : {}),
+          ...(profile || {}),
+        }),
+      })
 
-        if (response.status === 401) {
-          router.push(`/login?next=${encodeURIComponent(`/join/${trimmedCode}`)}`)
+      if (response.status === 401) {
+        router.push(`/login?next=${encodeURIComponent(`/join/${trimmedCode}`)}`)
+        return
+      }
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        if (data?.code === 'profile_required') {
+          setNeedsProfile(true)
+          setError('')
+          setLoading(false)
           return
         }
-
-        const data = await response.json()
-
-        if (!response.ok) {
-          if (data?.code === 'enrollment_closed') {
-            throw new Error('Enrollment is closed. Ask your teacher to enable enrollment in Settings.')
-          }
-          if (data?.code === 'not_on_roster') {
-            throw new Error('Your email is not on the roster. Make sure you are signed in with your board email and ask your teacher to add you.')
-          }
-          throw new Error(data?.error || 'Unable to join. Check your code and school email, or ask your teacher to add you.')
+        if (data?.code === 'enrollment_closed') {
+          throw new Error('Enrollment is closed. Ask your teacher to enable enrollment in Settings.')
         }
-
-        // Redirect to student dashboard with the new classroom selected
-        router.push(`/classrooms/${data.classroom.id}?tab=today`)
-      } catch (err: any) {
-        console.error('Join error:', err)
-        setError(err.message || 'An error occurred')
-        setLoading(false)
+        if (data?.code === 'not_on_roster') {
+          throw new Error('Your email is not on the roster. Use the email your teacher added, or ask your teacher to add you.')
+        }
+        throw new Error(data?.error || 'Unable to join. Check your code and email, or ask your teacher to add you.')
       }
+
+      router.push(`/classrooms/${data.classroom.id}?tab=today`)
+    } catch (err: any) {
+      console.error('Join error:', err)
+      setError(err.message || 'An error occurred')
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    joinClassroom()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code, router])
+
+  async function submitProfile(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedFirstName = firstName.trim()
+    const trimmedLastName = lastName.trim()
+
+    if (!trimmedFirstName || !trimmedLastName) {
+      setError('First name and last name are required.')
+      return
     }
 
-    joinClassroom()
-  }, [code, router])
+    setProfileSubmitting(true)
+    setError('')
+    await joinClassroom({
+      firstName: trimmedFirstName,
+      lastName: trimmedLastName,
+      studentNumber: studentNumber.trim() || undefined,
+    })
+    setProfileSubmitting(false)
+  }
 
   if (loading) {
     return (
@@ -71,21 +103,80 @@ export default function JoinClassroomPage() {
     )
   }
 
+  if (needsProfile) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-page p-4">
+        <form
+          onSubmit={submitProfile}
+          className="w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-lg"
+        >
+          <div className="mb-5">
+            <h1 className="text-2xl font-bold text-text-default">Join classroom</h1>
+            <p className="mt-2 text-sm text-text-muted">
+              Enter the name your teacher will recognize.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <FormField label="First name">
+              <Input
+                value={firstName}
+                onChange={(event) => setFirstName(event.target.value)}
+                autoComplete="given-name"
+                disabled={profileSubmitting}
+                required
+              />
+            </FormField>
+
+            <FormField label="Last name">
+              <Input
+                value={lastName}
+                onChange={(event) => setLastName(event.target.value)}
+                autoComplete="family-name"
+                disabled={profileSubmitting}
+                required
+              />
+            </FormField>
+
+            <FormField label="Student number or lab ID (optional)">
+              <Input
+                value={studentNumber}
+                onChange={(event) => setStudentNumber(event.target.value)}
+                autoComplete="off"
+                disabled={profileSubmitting}
+              />
+            </FormField>
+
+            {error ? (
+              <div className="rounded-md border border-danger bg-danger-bg px-3 py-2 text-sm text-danger">
+                {error}
+              </div>
+            ) : null}
+
+            <Button type="submit" className="w-full" disabled={profileSubmitting}>
+              {profileSubmitting ? 'Joining...' : 'Join'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4">
-        <div className="max-w-md w-full bg-surface rounded-lg shadow-lg p-8 text-center">
-          <div className="text-danger text-5xl mb-4">⚠️</div>
-          <h1 className="text-2xl font-bold text-text-default mb-2">
+      <div className="flex min-h-screen items-center justify-center bg-page p-4">
+        <div className="w-full max-w-md rounded-lg border border-border bg-surface p-8 text-center shadow-lg">
+          <h1 className="mb-2 text-2xl font-bold text-text-default">
             Unable to Join
           </h1>
-          <p className="text-text-muted mb-6">{error}</p>
-          <button
+          <p className="mb-6 text-text-muted">{error}</p>
+          <Button
+            type="button"
+            variant="secondary"
             onClick={() => router.push('/join')}
-            className="text-primary hover:underline"
           >
             Try a different code
-          </button>
+          </Button>
         </div>
       </div>
     )

--- a/src/lib/server/classrooms.ts
+++ b/src/lib/server/classrooms.ts
@@ -23,6 +23,7 @@ export function hydrateClassroomRecord(row: Record<string, any>): Classroom {
     actual_site_config: normalizeActualCourseSiteConfig(
       row.actual_site_config ?? DEFAULT_ACTUAL_COURSE_SITE_CONFIG
     ),
+    join_policy: row.join_policy === 'open_join' ? 'open_join' : 'roster',
     course_overview_markdown: row.course_overview_markdown ?? '',
     course_outline_markdown: row.course_outline_markdown ?? '',
   }

--- a/src/lib/validations/teacher.ts
+++ b/src/lib/validations/teacher.ts
@@ -91,6 +91,7 @@ export const updateClassroomPublishingSchema = z.object({
   classCode: z.string().optional(),
   termLabel: z.string().optional(),
   allowEnrollment: z.boolean().optional(),
+  joinPolicy: z.enum(['roster', 'open_join']).optional(),
   archived: z.boolean().optional(),
   lessonPlanVisibility: z.enum(['current_week', 'one_week_ahead', 'all']).optional(),
   actualSiteSlug: slugSchema.nullable().optional(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,10 @@ export type AttendanceStatus = 'present' | 'absent' | 'pending'
 
 export type MoodEmoji = '😊' | '🙂' | '😐' | '😟' | '😢'
 
+export type ClassroomJoinPolicy = 'roster' | 'open_join'
+
+export type RosterJoinSource = 'manual' | 'csv' | 'open_join'
+
 export interface User {
   id: string
   email: string
@@ -73,6 +77,7 @@ export interface Classroom {
   position?: number
   term_label: string | null
   allow_enrollment: boolean
+  join_policy: ClassroomJoinPolicy
   start_date: string | null // YYYY-MM-DD, inclusive
   end_date: string | null // YYYY-MM-DD, inclusive
   lesson_plan_visibility: LessonPlanVisibility

--- a/supabase/migrations/077_open_join_policy.sql
+++ b/supabase/migrations/077_open_join_policy.sql
@@ -1,0 +1,37 @@
+alter table public.classrooms
+  add column if not exists join_policy text not null default 'roster';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'classrooms_join_policy_check'
+  ) then
+    alter table public.classrooms
+      add constraint classrooms_join_policy_check
+      check (join_policy in ('roster', 'open_join'));
+  end if;
+end $$;
+
+alter table public.classroom_roster
+  add column if not exists join_source text not null default 'manual';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'classroom_roster_join_source_check'
+  ) then
+    alter table public.classroom_roster
+      add constraint classroom_roster_join_source_check
+      check (join_source in ('manual', 'csv', 'open_join'));
+  end if;
+end $$;
+
+comment on column public.classrooms.join_policy is
+  'Student join access mode: roster requires a matching classroom_roster email; open_join allows verified students with code/link to self-roster.';
+
+comment on column public.classroom_roster.join_source is
+  'How the roster row was created: manual teacher entry, csv upload, or open_join self-enrollment.';

--- a/tests/api/student/classrooms-join.test.ts
+++ b/tests/api/student/classrooms-join.test.ts
@@ -184,6 +184,157 @@ describe('POST /api/student/classrooms/join', () => {
       expect(data.code).toBe('not_on_roster')
     })
 
+    it('should ask for profile details when open join has no roster row', async () => {
+      const mockFrom = vi.fn((table: string) => {
+        if (table === 'classrooms') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'classroom-1',
+                    title: 'Math 101',
+                    class_code: 'MATH101',
+                    term_label: 'Fall 2024',
+                    allow_enrollment: true,
+                    join_policy: 'open_join',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+        if (table === 'classroom_enrollments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            })),
+          }
+        }
+        if (table === 'classroom_roster') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+                })),
+              })),
+            })),
+          }
+        }
+      })
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/student/classrooms/join', {
+        method: 'POST',
+        body: JSON.stringify({ classCode: 'MATH101' }),
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.code).toBe('profile_required')
+      expect(data.requiredFields).toEqual(['firstName', 'lastName'])
+    })
+
+    it('should self-roster and enroll student for open join with profile details', async () => {
+      const rosterUpsert = vi.fn().mockResolvedValue({ error: null })
+      const profileUpsert = vi.fn().mockResolvedValue({ error: null })
+      const mockInsert = vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'enrollment-new-1' },
+            error: null,
+          }),
+        })),
+      }))
+
+      const mockFrom = vi.fn((table: string) => {
+        if (table === 'classrooms') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: 'classroom-1',
+                    title: 'Math 101',
+                    class_code: 'MATH101',
+                    term_label: 'Fall 2024',
+                    allow_enrollment: true,
+                    join_policy: 'open_join',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+        if (table === 'classroom_enrollments') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            })),
+            insert: mockInsert,
+          }
+        }
+        if (table === 'classroom_roster') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+                })),
+              })),
+            })),
+            upsert: rosterUpsert,
+          }
+        }
+        if (table === 'student_profiles') {
+          return { upsert: profileUpsert }
+        }
+      })
+      ;(mockSupabaseClient.from as any) = mockFrom
+
+      const request = new NextRequest('http://localhost:3000/api/student/classrooms/join', {
+        method: 'POST',
+        body: JSON.stringify({
+          classCode: 'MATH101',
+          firstName: ' Ada ',
+          lastName: ' Lovelace ',
+          studentNumber: '',
+        }),
+      })
+
+      const response = await POST(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(201)
+      expect(data.success).toBe(true)
+      expect(rosterUpsert).toHaveBeenCalledWith({
+        classroom_id: 'classroom-1',
+        email: 'test@student.com',
+        student_number: null,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        counselor_email: null,
+        join_source: 'open_join',
+      }, { onConflict: 'classroom_id,email' })
+      expect(profileUpsert).toHaveBeenCalledWith({
+        user_id: 'student-1',
+        student_number: null,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+      }, { onConflict: 'user_id' })
+      expect(mockInsert).toHaveBeenCalledWith({
+        classroom_id: 'classroom-1',
+        student_id: 'student-1',
+      })
+    })
+
     it('should enroll student when classroom found by code', async () => {
       const mockInsert = vi.fn(() => ({
         select: vi.fn(() => ({

--- a/tests/api/teacher/classrooms-id.test.ts
+++ b/tests/api/teacher/classrooms-id.test.ts
@@ -198,6 +198,32 @@ describe('PATCH /api/teacher/classrooms/[id]', () => {
     const data = await response.json()
     expect(data.error).toBe('A syllabus slug is required before publishing the syllabus')
   })
+
+  it('should update join policy', async () => {
+    const mockUpdate = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'c-1', teacher_id: 'teacher-1', archived_at: null, join_policy: 'open_join' },
+            error: null,
+          }),
+        }),
+      }),
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn(() => ({ update: mockUpdate }))
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/classrooms/c-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ joinPolicy: 'open_join' }),
+    })
+
+    const response = await PATCH(request, { params: { id: 'c-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.classroom.join_policy).toBe('open_join')
+    expect(mockUpdate).toHaveBeenCalledWith({ join_policy: 'open_join' })
+  })
 })
 
 describe('DELETE /api/teacher/classrooms/[id]', () => {

--- a/tests/api/teacher/roster-add.test.ts
+++ b/tests/api/teacher/roster-add.test.ts
@@ -40,6 +40,12 @@ describe('POST /api/teacher/classrooms/[id]/roster/add', () => {
   })
 
   it('upserts into classroom_roster', async () => {
+    const upsertMock = vi.fn(() => ({
+      select: vi.fn().mockResolvedValue({
+        data: [{ id: 'r-1', email: 'a@student.com' }],
+        error: null,
+      }),
+    }))
     const mockFrom = vi.fn((table: string) => {
       if (table === 'classrooms') {
         return {
@@ -52,12 +58,7 @@ describe('POST /api/teacher/classrooms/[id]/roster/add', () => {
       }
       if (table === 'classroom_roster') {
         return {
-          upsert: vi.fn(() => ({
-            select: vi.fn().mockResolvedValue({
-              data: [{ id: 'r-1', email: 'a@student.com' }],
-              error: null,
-            }),
-          })),
+          upsert: upsertMock,
         }
       }
       throw new Error(`Unexpected table: ${table}`)
@@ -77,5 +78,11 @@ describe('POST /api/teacher/classrooms/[id]/roster/add', () => {
     const data = await response.json()
     expect(response.status).toBe(200)
     expect(data.upsertedCount).toBe(1)
+    expect(upsertMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        email: 'a@student.com',
+        join_source: 'manual',
+      }),
+    ], { onConflict: 'classroom_id,email' })
   })
 })

--- a/tests/api/teacher/roster-upload-csv.test.ts
+++ b/tests/api/teacher/roster-upload-csv.test.ts
@@ -103,6 +103,12 @@ describe('POST /api/teacher/classrooms/[id]/roster/upload-csv', () => {
       expect(data.needsConfirmation).toBeUndefined()
       expect(data.success).toBe(true)
       expect(upsertMock).toHaveBeenCalled()
+      expect(upsertMock).toHaveBeenCalledWith([
+        expect.objectContaining({
+          email: 'same@student.com',
+          join_source: 'csv',
+        }),
+      ], { onConflict: 'classroom_id,email' })
     })
 
     it('proceeds directly when no existing students found', async () => {
@@ -162,6 +168,12 @@ describe('POST /api/teacher/classrooms/[id]/roster/upload-csv', () => {
       expect(data.success).toBe(true)
       expect(data.upsertedCount).toBe(1)
       expect(upsertMock).toHaveBeenCalled()
+      expect(upsertMock).toHaveBeenCalledWith([
+        expect.objectContaining({
+          email: 'a@student.com',
+          join_source: 'csv',
+        }),
+      ], { onConflict: 'classroom_id,email' })
     })
 
     it('skips preview check when confirmed is true', async () => {

--- a/tests/api/teacher/roster.test.ts
+++ b/tests/api/teacher/roster.test.ts
@@ -50,6 +50,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
                   first_name: 'Ada',
                   last_name: 'Lovelace',
                   counselor_email: 'c@example.com',
+                  join_source: 'open_join',
                   created_at: '2026-04-01T12:00:00.000Z',
                   updated_at: '2026-04-02T12:00:00.000Z',
                 },
@@ -60,6 +61,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
                   first_name: null,
                   last_name: null,
                   counselor_email: null,
+                  join_source: null,
                   created_at: '2026-04-03T12:00:00.000Z',
                   updated_at: '2026-04-04T12:00:00.000Z',
                 },
@@ -99,6 +101,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
       expect.objectContaining({
         id: 'r-1',
         email: 'Joined@Example.com',
+        join_source: 'open_join',
         joined: true,
         student_id: 'student-1',
         joined_at: '2026-04-05T12:00:00.000Z',
@@ -106,6 +109,7 @@ describe('GET /api/teacher/classrooms/[id]/roster', () => {
       expect.objectContaining({
         id: 'r-2',
         email: 'waiting@example.com',
+        join_source: 'manual',
         joined: false,
         student_id: null,
         joined_at: null,

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -41,7 +41,7 @@ function Wrapper({ children }: { children: ReactNode }) {
   )
 }
 
-describe('TeacherSettingsTab - Course Name Editing', () => {
+describe('TeacherSettingsTab - Classroom name Editing', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
     mockRefresh.mockClear()
@@ -54,10 +54,10 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     cleanup()
   })
 
-  it('renders with course name prefilled', () => {
+  it('renders with classroom name prefilled', () => {
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     expect(input).toHaveValue('Test Course')
     expect(screen.queryByLabelText('Quizzes')).toBeNull()
   })
@@ -124,7 +124,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'Updated Course' } })
     fireEvent.blur(input)
 
@@ -147,7 +147,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'Enter Saved' } })
     fireEvent.keyDown(input, { key: 'Enter' })
 
@@ -158,16 +158,16 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ title: 'Enter Saved' })
   })
 
-  it('shows error when course name is empty', async () => {
+  it('shows error when classroom name is empty', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: '' } })
     fireEvent.blur(input)
 
-    expect(screen.getByText('Course name cannot be empty')).toBeInTheDocument()
+    expect(screen.getByText('Classroom name cannot be empty')).toBeInTheDocument()
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -176,7 +176,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     // Change to same value
     fireEvent.change(input, { target: { value: 'Test Course' } })
     fireEvent.blur(input)
@@ -193,12 +193,12 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'New Name' } })
     fireEvent.blur(input)
 
     await waitFor(() => {
-      expect(screen.getByText('Course name updated')).toBeInTheDocument()
+      expect(screen.getByText('Classroom name updated')).toBeInTheDocument()
     })
   })
 
@@ -211,12 +211,12 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'Refreshed' } })
     fireEvent.blur(input)
 
     await waitFor(() => {
-      expect(screen.getByText('Course name updated')).toBeInTheDocument()
+      expect(screen.getByText('Classroom name updated')).toBeInTheDocument()
     })
     expect(mockRefresh).not.toHaveBeenCalled()
   })
@@ -230,7 +230,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'Will Fail' } })
     fireEvent.blur(input)
 
@@ -246,7 +246,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={archivedClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     expect(input).toBeDisabled()
   })
 
@@ -260,7 +260,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'New Title' } })
     fireEvent.blur(input)
 
@@ -283,7 +283,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
     })
   })
 
-  it('trims whitespace from course name before saving', async () => {
+  it('trims whitespace from classroom name before saving', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -292,7 +292,7 @@ describe('TeacherSettingsTab - Course Name Editing', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: '  Trimmed  ' } })
     fireEvent.blur(input)
 
@@ -336,6 +336,15 @@ describe('TeacherSettingsTab - Allow Joining', () => {
     const [url, options] = fetchMock.mock.calls[0]
     expect(url).toBe('/api/teacher/classrooms/cls-123')
     expect(JSON.parse(options.body)).toEqual({ allowEnrollment: false })
+  })
+
+  it('opens a title-only confirmation before generating a new join code', () => {
+    render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate new join code' }))
+
+    expect(screen.getByRole('dialog', { name: 'Generate new join code?' })).toBeInTheDocument()
+    expect(screen.queryByText('This replaces the current code. Students will need the new code/link to join.')).not.toBeInTheDocument()
   })
 
   it('saves the open join mode', async () => {
@@ -434,7 +443,7 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
     cleanup()
   })
 
-  it('auto-clears course name success message after 2 seconds', async () => {
+  it('auto-clears classroom name success message after 2 seconds', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -443,7 +452,7 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const input = screen.getByLabelText('Course Name')
+    const input = screen.getByLabelText('Classroom name')
     fireEvent.change(input, { target: { value: 'New Name' } })
     fireEvent.blur(input)
 
@@ -453,7 +462,7 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
     })
 
     // Success message should appear
-    expect(screen.getByText('Course name updated')).toBeInTheDocument()
+    expect(screen.getByText('Classroom name updated')).toBeInTheDocument()
 
     // Advance time to trigger the short auto-clear
     await act(async () => {
@@ -461,7 +470,7 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
     })
 
     // Success message should be gone
-    expect(screen.queryByText('Course name updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Classroom name updated')).not.toBeInTheDocument()
   })
 
   it('auto-clears enrollment success message after 2 seconds', async () => {

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -77,13 +77,13 @@ describe('TeacherSettingsTab - Classroom name Editing', () => {
   it('persists the show markdown display setting from the general settings tab', async () => {
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const markdownToggle = await screen.findByRole('checkbox', { name: 'Show markdown' })
-    expect(markdownToggle).toBeChecked()
+    const markdownToggle = await screen.findByRole('switch', { name: 'Show markdown' })
+    expect(markdownToggle).toHaveAttribute('aria-checked', 'true')
 
     fireEvent.click(markdownToggle)
 
     await waitFor(() => {
-      expect(markdownToggle).not.toBeChecked()
+      expect(markdownToggle).toHaveAttribute('aria-checked', 'false')
     })
     expect(window.localStorage.getItem('pika_show_markdown')).toBe('false')
     expect(screen.queryByLabelText('Course overview')).not.toBeInTheDocument()

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -341,9 +341,9 @@ describe('TeacherSettingsTab - Allow Joining', () => {
   it('opens a title-only confirmation before generating a new join code', () => {
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Generate new join code' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Generate new join code and link' }))
 
-    expect(screen.getByRole('dialog', { name: 'Generate new join code?' })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Generate new join code and link?' })).toBeInTheDocument()
     expect(screen.queryByText('This replaces the current code. Students will need the new code/link to join.')).not.toBeInTheDocument()
   })
 

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -349,6 +349,12 @@ describe('TeacherSettingsTab - Allow Joining', () => {
 
     const joinMode = screen.getByRole('switch', { name: 'Join mode' })
     expect(joinMode).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByText('Allow new joins')).toBeInTheDocument()
+    expect(screen.getByText(/Roster requires matching email/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View roster' })).toHaveAttribute(
+      'href',
+      '/classrooms/cls-123?tab=roster',
+    )
 
     fireEvent.click(joinMode)
 

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -323,10 +323,10 @@ describe('TeacherSettingsTab - Allow Joining', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const checkbox = screen.getByLabelText('Allow new students to join')
-    expect(checkbox).toBeChecked()
+    const toggle = screen.getByRole('switch', { name: 'Allow new students to join' })
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
 
-    fireEvent.click(checkbox)
+    fireEvent.click(toggle)
 
     await waitFor(() => {
       expect(screen.getByText('Settings saved')).toBeInTheDocument()
@@ -347,8 +347,10 @@ describe('TeacherSettingsTab - Allow Joining', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const joinMode = screen.getByRole('group', { name: 'Join mode' })
-    fireEvent.click(within(joinMode).getByRole('button', { name: 'Open join' }))
+    const joinMode = screen.getByRole('switch', { name: 'Join mode' })
+    expect(joinMode).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(joinMode)
 
     await waitFor(() => {
       expect(screen.getByText('Anyone with this code or link can join after entering their name.')).toBeInTheDocument()
@@ -465,8 +467,8 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const checkbox = screen.getByLabelText('Allow new students to join')
-    fireEvent.click(checkbox)
+    const toggle = screen.getByRole('switch', { name: 'Allow new students to join' })
+    fireEvent.click(toggle)
 
     // Advance microtasks to let the fetch resolve, but not the timeout
     await act(async () => {

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -24,6 +24,7 @@ const mockClassroom: Classroom = {
   class_code: 'ABC123',
   term_label: null,
   allow_enrollment: true,
+  join_policy: 'roster',
   start_date: '2026-01-01',
   end_date: '2026-06-01',
   created_at: '2026-01-01T00:00:00Z',
@@ -322,7 +323,7 @@ describe('TeacherSettingsTab - Allow Joining', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const checkbox = screen.getByLabelText('Allow joining')
+    const checkbox = screen.getByLabelText('Allow new students to join')
     expect(checkbox).toBeChecked()
 
     fireEvent.click(checkbox)
@@ -335,6 +336,27 @@ describe('TeacherSettingsTab - Allow Joining', () => {
     const [url, options] = fetchMock.mock.calls[0]
     expect(url).toBe('/api/teacher/classrooms/cls-123')
     expect(JSON.parse(options.body)).toEqual({ allowEnrollment: false })
+  })
+
+  it('saves the open join mode', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ classroom: { ...mockClassroom, join_policy: 'open_join' } }),
+    })
+
+    render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
+
+    const joinMode = screen.getByRole('group', { name: 'Join mode' })
+    fireEvent.click(within(joinMode).getByRole('button', { name: 'Open join' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Anyone with this code or link can join after entering their name.')).toBeInTheDocument()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0]
+    expect(JSON.parse(options.body)).toEqual({ joinPolicy: 'open_join' })
   })
 })
 
@@ -443,7 +465,7 @@ describe('TeacherSettingsTab - Success message auto-clear', () => {
 
     render(<TeacherSettingsTab classroom={mockClassroom} />, { wrapper: Wrapper })
 
-    const checkbox = screen.getByLabelText('Allow joining')
+    const checkbox = screen.getByLabelText('Allow new students to join')
     fireEvent.click(checkbox)
 
     // Advance microtasks to let the fetch resolve, but not the timeout

--- a/tests/components/TeacherSettingsTab.test.tsx
+++ b/tests/components/TeacherSettingsTab.test.tsx
@@ -350,8 +350,8 @@ describe('TeacherSettingsTab - Allow Joining', () => {
     const joinMode = screen.getByRole('switch', { name: 'Join mode' })
     expect(joinMode).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByText('Allow new joins')).toBeInTheDocument()
-    expect(screen.getByText(/Roster requires matching email/)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'View roster' })).toHaveAttribute(
+    expect(screen.getByText('Only students on roster can join.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'view roster' })).toHaveAttribute(
       'href',
       '/classrooms/cls-123?tab=roster',
     )


### PR DESCRIPTION
## Summary

Adds a teacher-controlled classroom join mode so Pika can support both roster-locked classes and open-code/open-link classes.

## What changed

- Added `classrooms.join_policy` with `roster` as the default and `open_join` as the opt-in mode.
- Added `classroom_roster.join_source` to record whether a row came from manual entry, CSV upload, or open join.
- Updated teacher Settings with `Roster` and `Open join` mode controls while keeping `allow_enrollment` as the master join switch.
- Updated student join-by-code flow so open-join classes prompt for first name, last name, and optional student number/lab ID before self-creating roster/profile/enrollment rows.
- Added source visibility in the teacher roster table and inspector.

## Impact

Existing classrooms stay roster-locked by default. Teachers can opt into open join for summer/lab groups where they do not know student emails in advance.

## Validation

- `pnpm test tests/api/student/classrooms-join.test.ts tests/api/teacher/classrooms-id.test.ts tests/api/teacher/roster.test.ts tests/api/teacher/roster-add.test.ts tests/api/teacher/roster-upload-csv.test.ts tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherRosterTab.test.tsx`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- Visual verification for Settings desktop/mobile/student, mocked open-join roster desktop/mobile, and student open-join form