### PR TITLE
[codex] Sanitize repo-review AI egress

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1048,8 +1048,11 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Routed repo-review AI classification through provider refs, direct identifier redaction, and `store: false`.
 - Routed repo-review feedback generation through classroom sanitization context with pseudonymous repo/student refs and sanitized evidence/warnings.
 - Sanitized repo-review AI feedback before returning it for local persistence.
+- Addressed review feedback by sanitizing heuristic fallback feedback when OpenAI is unavailable or fails.
 - Sanitized daily log summary model output before cron persistence.
 
 **Validation:**
 - `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts`
 - `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/unit/log-summary.test.ts tests/api/cron/nightly-log-summaries.test.ts`
+- `pnpm test tests/unit/repo-review-ai.test.ts`
+- `pnpm lint`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1041,3 +1041,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
 - `git diff --check`
+
+## 2026-06-01 — Repo-review AI egress sanitization
+
+**Completed:**
+- Routed repo-review AI classification through provider refs, direct identifier redaction, and `store: false`.
+- Routed repo-review feedback generation through classroom sanitization context with pseudonymous repo/student refs and sanitized evidence/warnings.
+- Sanitized repo-review AI feedback before returning it for local persistence.
+- Sanitized daily log summary model output before cron persistence.
+
+**Validation:**
+- `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts`
+- `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/unit/log-summary.test.ts tests/api/cron/nightly-log-summaries.test.ts`

--- a/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
+++ b/src/app/api/teacher/assignments/[id]/artifact-repo/run/route.ts
@@ -19,6 +19,7 @@ import {
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
 import { loadAssignmentSubmissionArtifactsForDocs } from '@/lib/server/assignment-submission-artifacts'
 import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
+import { loadClassroomAiSanitizationContext } from '@/lib/server/ai-sanitization'
 import type { AssignmentRepoReviewConfig, AssignmentSubmissionArtifact } from '@/types'
 
 type GroupedStudent = {
@@ -201,6 +202,10 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
     dueAt: assignment.due_at,
     releasedAt: assignment.released_at,
   })
+  const sanitizationContext = await loadClassroomAiSanitizationContext(
+    supabase,
+    assignment.classroom_id,
+  )
 
   let analyzedStudents = 0
   let repoGroups = 0
@@ -247,6 +252,7 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
         config,
         identities,
         reviewWindow,
+        sanitizationContext,
       })
       const repoName = formatRepoReviewRepoName(config)
       const results = await Promise.all(
@@ -273,6 +279,7 @@ export const POST = withErrorHandler('RunTeacherAssignmentArtifactRepoAnalysis',
               .filter((warning) => !warning.student_id || warning.student_id === student.studentId)
               .map((warning) => warning.message),
             confidence: analysis.confidence,
+            sanitizationContext,
           })
 
           return {

--- a/src/lib/log-summary.ts
+++ b/src/lib/log-summary.ts
@@ -2,6 +2,7 @@ import type { LogSummaryActionItem } from '@/types'
 import {
   buildInitialsMap,
   redactDirectIdentifiers,
+  sanitizeAiOutputText,
   sanitizeTextWithStudentNames,
 } from '@/lib/ai-sanitization'
 
@@ -135,11 +136,11 @@ export async function callOpenAIForSummary(
   const obj = parsed as Record<string, unknown>
 
   return {
-    overview: String(obj.overview || ''),
+    overview: sanitizeAiOutputText(String(obj.overview || '')),
     action_items: Array.isArray(obj.action_items)
       ? obj.action_items.map((item: any) => ({
-          text: String(item.text || ''),
-          initials: String(item.initials || ''),
+          text: sanitizeAiOutputText(String(item.text || '')),
+          initials: sanitizeAiOutputText(String(item.initials || '')),
         }))
       : [],
   }

--- a/src/lib/repo-review-ai.ts
+++ b/src/lib/repo-review-ai.ts
@@ -1,4 +1,11 @@
 import { z } from 'zod'
+import {
+  createProviderRefMap,
+  mapProviderRefToLocalId,
+  sanitizeAiOutputText,
+  sanitizeAiText,
+  type AiSanitizationContext,
+} from '@/lib/ai-sanitization'
 import type { RepoReviewEvidenceItem, RepoReviewSemanticBreakdown } from '@/types'
 
 const DEFAULT_MODEL = 'gpt-5-nano'
@@ -79,7 +86,16 @@ export interface RepoReviewFeedbackInput {
   evidence: RepoReviewEvidenceItem[]
   warnings: string[]
   confidence: number
+  sanitizationContext?: AiSanitizationContext
 }
+
+type SanitizedRepoReviewValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SanitizedRepoReviewValue[]
+  | { [key: string]: SanitizedRepoReviewValue }
 
 function parseJsonResponse<T>(outputText: string, schema: z.ZodSchema<T>): T {
   let jsonText = outputText
@@ -170,11 +186,37 @@ export function buildHeuristicRepoReviewFeedback(input: RepoReviewFeedbackInput)
   }
 }
 
-export async function classifyAmbiguousRepoReviewChanges(items: Array<{ id: string; summary: string }>): Promise<Record<string, string>> {
+function sanitizeRepoReviewValue(value: unknown, context?: AiSanitizationContext): SanitizedRepoReviewValue {
+  if (typeof value === 'string') return sanitizeAiText(value, context)
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeRepoReviewValue(item, context))
+  if (typeof value === 'object' && value) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        sanitizeRepoReviewValue(nested, context),
+      ]),
+    )
+  }
+  return null
+}
+
+export async function classifyAmbiguousRepoReviewChanges(
+  items: Array<{ id: string; summary: string }>,
+  sanitizationContext?: AiSanitizationContext,
+): Promise<Record<string, string>> {
   const apiKey = getOpenAIKey()
   if (!apiKey || items.length === 0) return {}
 
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
+  const providerItems = createProviderRefMap(
+    items.map((item) => ({
+      localId: item.id,
+      summary: sanitizeAiText(item.summary, sanitizationContext),
+    })),
+    'change',
+  )
+  const providerRefToLocalId = mapProviderRefToLocalId(providerItems)
   const systemPrompt = `You classify software change summaries into one category.
 
 Allowed categories:
@@ -190,8 +232,8 @@ Allowed categories:
 Respond with JSON only:
 {"items":[{"id":"...","category":"feature"}]}`
 
-  const userPrompt = items
-    .map((item) => `- ${item.id}: ${item.summary}`)
+  const userPrompt = providerItems
+    .map((item) => `- ${item.providerRef}: ${item.summary}`)
     .join('\n')
 
   const res = await fetch('https://api.openai.com/v1/responses', {
@@ -202,6 +244,7 @@ Respond with JSON only:
     },
     body: JSON.stringify({
       model,
+      store: false,
       input: [
         { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
         { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
@@ -218,7 +261,12 @@ Respond with JSON only:
   if (!outputText) return {}
 
   const parsed = parseJsonResponse(outputText, classificationSchema)
-  return Object.fromEntries(parsed.items.map((item) => [item.id, item.category]))
+  return Object.fromEntries(
+    parsed.items.flatMap((item) => {
+      const localId = providerRefToLocalId.get(item.id)
+      return localId ? [[localId, item.category]] : []
+    }),
+  )
 }
 
 export async function gradeRepoReviewFeedback(input: RepoReviewFeedbackInput): Promise<RepoReviewFeedbackResult> {
@@ -246,11 +294,11 @@ Rules:
 Respond with JSON only:
 {"score_completion":0,"score_thinking":0,"score_workflow":0,"summary":"","strengths":[""],"concerns":[""],"feedback":"","confidence":0.0}`
 
+  const sanitizationContext = input.sanitizationContext
   const userPrompt = JSON.stringify({
-    assignment_title: input.assignmentTitle,
-    repo_name: input.repoName,
-    student_name: input.studentName,
-    github_login: input.githubLogin,
+    assignment_title: sanitizeAiText(input.assignmentTitle, sanitizationContext),
+    repo_ref: 'repo_1',
+    student_ref: 'student_1',
     metrics: {
       commit_count: input.commitCount,
       active_days: input.activeDays,
@@ -261,12 +309,12 @@ Respond with JSON only:
       spread_score: input.spreadScore,
       iteration_score: input.iterationScore,
       review_activity_count: input.reviewActivityCount,
-      areas: input.areas,
+      areas: input.areas.map((area) => sanitizeAiText(area, sanitizationContext)),
       semantic_breakdown: input.semanticBreakdown,
       confidence: input.confidence,
     },
-    evidence: input.evidence,
-    warnings: input.warnings,
+    evidence: sanitizeRepoReviewValue(input.evidence, sanitizationContext),
+    warnings: input.warnings.map((warning) => sanitizeAiText(warning, sanitizationContext)),
   })
 
   try {
@@ -278,6 +326,7 @@ Respond with JSON only:
       },
       body: JSON.stringify({
         model,
+        store: false,
         input: [
           { role: 'system', content: [{ type: 'input_text', text: systemPrompt }] },
           { role: 'user', content: [{ type: 'input_text', text: userPrompt }] },
@@ -305,7 +354,10 @@ Respond with JSON only:
 
     return {
       ...parsed,
-      feedback: formattedFeedback,
+      summary: sanitizeAiOutputText(parsed.summary),
+      strengths: parsed.strengths.map(sanitizeAiOutputText),
+      concerns: parsed.concerns.map(sanitizeAiOutputText),
+      feedback: sanitizeAiOutputText(formattedFeedback),
       model,
     }
   } catch {

--- a/src/lib/repo-review-ai.ts
+++ b/src/lib/repo-review-ai.ts
@@ -186,6 +186,19 @@ export function buildHeuristicRepoReviewFeedback(input: RepoReviewFeedbackInput)
   }
 }
 
+function sanitizeRepoReviewFeedbackResult(
+  result: RepoReviewFeedbackResult,
+  context?: AiSanitizationContext,
+): RepoReviewFeedbackResult {
+  return {
+    ...result,
+    summary: sanitizeAiText(result.summary, context),
+    strengths: result.strengths.map((strength) => sanitizeAiText(strength, context)),
+    concerns: result.concerns.map((concern) => sanitizeAiText(concern, context)),
+    feedback: sanitizeAiText(result.feedback, context),
+  }
+}
+
 function sanitizeRepoReviewValue(value: unknown, context?: AiSanitizationContext): SanitizedRepoReviewValue {
   if (typeof value === 'string') return sanitizeAiText(value, context)
   if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value
@@ -272,7 +285,10 @@ Respond with JSON only:
 export async function gradeRepoReviewFeedback(input: RepoReviewFeedbackInput): Promise<RepoReviewFeedbackResult> {
   const apiKey = getOpenAIKey()
   if (!apiKey) {
-    return buildHeuristicRepoReviewFeedback(input)
+    return sanitizeRepoReviewFeedbackResult(
+      buildHeuristicRepoReviewFeedback(input),
+      input.sanitizationContext,
+    )
   }
 
   const model = process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
@@ -335,13 +351,19 @@ Respond with JSON only:
     })
 
     if (!res.ok) {
-      return buildHeuristicRepoReviewFeedback(input)
+      return sanitizeRepoReviewFeedbackResult(
+        buildHeuristicRepoReviewFeedback(input),
+        input.sanitizationContext,
+      )
     }
 
     const payload = await res.json()
     const outputText = extractResponseOutputText(payload)
     if (!outputText) {
-      return buildHeuristicRepoReviewFeedback(input)
+      return sanitizeRepoReviewFeedbackResult(
+        buildHeuristicRepoReviewFeedback(input),
+        input.sanitizationContext,
+      )
     }
 
     const parsed = parseJsonResponse(outputText, feedbackSchema)
@@ -361,6 +383,9 @@ Respond with JSON only:
       model,
     }
   } catch {
-    return buildHeuristicRepoReviewFeedback(input)
+    return sanitizeRepoReviewFeedbackResult(
+      buildHeuristicRepoReviewFeedback(input),
+      input.sanitizationContext,
+    )
   }
 }

--- a/src/lib/repo-review.ts
+++ b/src/lib/repo-review.ts
@@ -1,6 +1,7 @@
 import { formatInTimeZone } from 'date-fns-tz'
 import { classifyAmbiguousRepoReviewChanges } from '@/lib/repo-review-ai'
 import { parseGitHubRepoReference } from '@/lib/github-repos'
+import type { AiSanitizationContext } from '@/lib/ai-sanitization'
 import type {
   AssignmentRepoReviewConfig,
   RepoReviewEvidenceItem,
@@ -643,8 +644,9 @@ export async function analyzeRepoReviewAssignment(opts: {
   config: AssignmentRepoReviewConfig
   identities: RepoReviewStudentIdentityInput[]
   reviewWindow: RepoReviewWindow
+  sanitizationContext?: AiSanitizationContext
 }): Promise<RepoReviewAnalysisResult> {
-  const { config, identities, reviewWindow } = opts
+  const { config, identities, reviewWindow, sanitizationContext } = opts
   const warnings: RepoReviewWarning[] = []
   const { commits: commitSummaries, truncated } = await listCommits(
     config.repo_owner,
@@ -691,7 +693,8 @@ export async function analyzeRepoReviewAssignment(opts: {
       .map((commit) => ({
         id: commit.sha,
         summary: buildAmbiguousClassificationSummary(commit.message, commit.files),
-      }))
+      })),
+    sanitizationContext,
   ).catch((error): Record<string, string> => {
     warnings.push({
       code: 'ai-classification-failed',

--- a/tests/api/teacher/assignments-artifact-repo-run.test.ts
+++ b/tests/api/teacher/assignments-artifact-repo-run.test.ts
@@ -10,6 +10,7 @@ const {
   mockSaveAssignmentRepoTarget,
   mockValidatePublicGitHubRepo,
   mockAssertTeacherCanMutateAssignment,
+  mockLoadClassroomAiSanitizationContext,
 } = vi.hoisted(() => ({
   mockSupabaseClient: { from: vi.fn() },
   mockAnalyzeRepoReviewAssignment: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockSaveAssignmentRepoTarget: vi.fn(),
   mockValidatePublicGitHubRepo: vi.fn(),
   mockAssertTeacherCanMutateAssignment: vi.fn(),
+  mockLoadClassroomAiSanitizationContext: vi.fn(),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -50,6 +52,10 @@ vi.mock('@/lib/server/assignment-repo-targets', () => ({
 
 vi.mock('@/lib/server/repo-review', () => ({
   assertTeacherCanMutateAssignment: mockAssertTeacherCanMutateAssignment,
+}))
+
+vi.mock('@/lib/server/ai-sanitization', () => ({
+  loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
 }))
 
 import { POST } from '@/app/api/teacher/assignments/[id]/artifact-repo/run/route'
@@ -151,6 +157,10 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
       title: 'Repo review',
       due_at: '2026-04-20T03:59:00.000Z',
       released_at: '2026-04-01T12:00:00.000Z',
+    })
+    mockLoadClassroomAiSanitizationContext.mockResolvedValue({
+      students: [{ firstName: 'Sam', lastName: 'Lee' }],
+      initialsMap: { 'S.L.': 'Sam Lee' },
     })
   })
 
@@ -291,6 +301,22 @@ describe('POST /api/teacher/assignments/[id]/artifact-repo/run', () => {
       validationStatus: 'valid',
       repoOwner: 'codepetca',
       repoName: 'pika',
+    }))
+    expect(mockLoadClassroomAiSanitizationContext).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      'classroom-1',
+    )
+    expect(mockAnalyzeRepoReviewAssignment).toHaveBeenCalledWith(expect.objectContaining({
+      sanitizationContext: {
+        students: [{ firstName: 'Sam', lastName: 'Lee' }],
+        initialsMap: { 'S.L.': 'Sam Lee' },
+      },
+    }))
+    expect(mockGradeRepoReviewFeedback).toHaveBeenCalledWith(expect.objectContaining({
+      sanitizationContext: {
+        students: [{ firstName: 'Sam', lastName: 'Lee' }],
+        initialsMap: { 'S.L.': 'Sam Lee' },
+      },
     }))
     expect(harness.insertedRuns).toHaveLength(1)
     expect(harness.insertedResults).toEqual([

--- a/tests/unit/log-summary.test.ts
+++ b/tests/unit/log-summary.test.ts
@@ -261,9 +261,9 @@ describe('callOpenAIForSummary', () => {
 
   it('calls OpenAI and parses JSON response', async () => {
     const mockResponse = {
-      overview: 'Students are doing well overall.',
+      overview: 'Students are doing well overall. Contact alex@example.com.',
       action_items: [
-        { text: 'J.S. asked about deadline.', initials: 'J.S.' },
+        { text: 'J.S. asked about deadline at 416-555-1212.', initials: 'J.S.' },
       ],
     }
 
@@ -273,9 +273,9 @@ describe('callOpenAIForSummary', () => {
     } as Response)
 
     const result = await callOpenAIForSummary('system prompt', 'user prompt')
-    expect(result.overview).toBe('Students are doing well overall.')
+    expect(result.overview).toBe('Students are doing well overall. Contact [email redacted].')
     expect(result.action_items).toEqual([
-      { text: 'J.S. asked about deadline.', initials: 'J.S.' },
+      { text: 'J.S. asked about deadline at [phone redacted].', initials: 'J.S.' },
     ])
 
     const requestInit = fetchMock.mock.calls[0][1] as RequestInit

--- a/tests/unit/repo-review-ai.test.ts
+++ b/tests/unit/repo-review-ai.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildAiSanitizationContext } from '@/lib/ai-sanitization'
+import {
+  classifyAmbiguousRepoReviewChanges,
+  gradeRepoReviewFeedback,
+} from '@/lib/repo-review-ai'
+
+describe('repo-review AI egress', () => {
+  const originalFetch = global.fetch
+  const originalApiKey = process.env.OPENAI_API_KEY
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    process.env.OPENAI_API_KEY = originalApiKey
+    vi.restoreAllMocks()
+  })
+
+  it('sends provider refs and sanitized summaries for ambiguous classification', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({
+        output_text: JSON.stringify({
+          items: [{ id: 'change_1', category: 'bugfix' }],
+        }),
+      }), { status: 200 }),
+    )
+    global.fetch = fetchMock as typeof fetch
+
+    const result = await classifyAmbiguousRepoReviewChanges([
+      {
+        id: '018f3f57-7b4b-7123-8c04-48ac061c1111',
+        summary: 'Alex Lee fixed login after emailing alex@example.com.',
+      },
+    ])
+
+    expect(result).toEqual({
+      '018f3f57-7b4b-7123-8c04-48ac061c1111': 'bugfix',
+    })
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
+    expect(body.store).toBe(false)
+    const userPrompt = body.input[1].content[0].text
+    expect(userPrompt).toContain('change_1')
+    expect(userPrompt).not.toContain('018f3f57-7b4b-7123-8c04-48ac061c1111')
+    expect(userPrompt).toContain('[email redacted]')
+  })
+
+  it('sanitizes repo-review grading prompts and returned feedback', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({
+        output_text: JSON.stringify({
+          score_completion: 8,
+          score_thinking: 7,
+          score_workflow: 6,
+          summary: 'Email alex@example.com for details.',
+          strengths: ['Sam Lee made steady commits.'],
+          concerns: ['Call 416-555-1212.'],
+          feedback: 'Solid evidence for Sam Lee.',
+          confidence: 0.8,
+        }),
+      }), { status: 200 }),
+    )
+    global.fetch = fetchMock as typeof fetch
+    const sanitizationContext = buildAiSanitizationContext([
+      { firstName: 'Sam', lastName: 'Lee' },
+    ])
+
+    const result = await gradeRepoReviewFeedback({
+      assignmentTitle: 'Essay for Sam Lee',
+      repoName: 'student-login/private-repo',
+      studentName: 'Sam Lee',
+      githubLogin: 'samlee',
+      commitCount: 2,
+      activeDays: 2,
+      sessionCount: 1,
+      burstRatio: 0.2,
+      weightedContribution: 1,
+      relativeContributionShare: 1,
+      spreadScore: 0.7,
+      iterationScore: 0.6,
+      reviewActivityCount: 0,
+      areas: ['src'],
+      semanticBreakdown: { feature: 1 },
+      evidence: [
+        {
+          type: 'commit',
+          id: 'commit-1',
+          title: 'Sam Lee added page',
+          summary: 'Contact Sam Lee at sam@example.com.',
+        },
+      ],
+      warnings: ['Sam Lee had one warning.'],
+      confidence: 0.9,
+      sanitizationContext,
+    })
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
+    expect(body.store).toBe(false)
+    const promptPayload = JSON.parse(body.input[1].content[0].text)
+    expect(promptPayload).toMatchObject({
+      assignment_title: 'Essay for S.L.',
+      repo_ref: 'repo_1',
+      student_ref: 'student_1',
+    })
+    expect(JSON.stringify(promptPayload)).not.toContain('Sam Lee')
+    expect(JSON.stringify(promptPayload)).not.toContain('sam@example.com')
+    expect(JSON.stringify(promptPayload)).not.toContain('samlee')
+    expect(JSON.stringify(promptPayload)).toContain('[email redacted]')
+
+    expect(result.summary).toBe('Email [email redacted] for details.')
+    expect(result.concerns[0]).toBe('Call [phone redacted].')
+    expect(result.feedback).toContain('[email redacted]')
+  })
+})

--- a/tests/unit/repo-review-ai.test.ts
+++ b/tests/unit/repo-review-ai.test.ts
@@ -114,4 +114,41 @@ describe('repo-review AI egress', () => {
     expect(result.concerns[0]).toBe('Call [phone redacted].')
     expect(result.feedback).toContain('[email redacted]')
   })
+
+  it('sanitizes heuristic fallback feedback before persistence', async () => {
+    delete process.env.OPENAI_API_KEY
+    const sanitizationContext = buildAiSanitizationContext([
+      { firstName: 'Sam', lastName: 'Lee' },
+    ])
+
+    const result = await gradeRepoReviewFeedback({
+      assignmentTitle: 'Repo review',
+      repoName: 'student-login/private-repo',
+      studentName: 'Sam Lee',
+      githubLogin: 'samlee',
+      commitCount: 1,
+      activeDays: 1,
+      sessionCount: 1,
+      burstRatio: 0.9,
+      weightedContribution: 1,
+      relativeContributionShare: 1,
+      spreadScore: 0.2,
+      iterationScore: 0.2,
+      reviewActivityCount: 0,
+      areas: ['src'],
+      semanticBreakdown: { feature: 1 },
+      evidence: [],
+      warnings: ['Sam Lee emailed sam@example.com.'],
+      confidence: 0.8,
+      sanitizationContext,
+    })
+
+    expect(result.model).toBe('heuristic')
+    expect(result.summary).toBe('S.L. contributed 100% of mapped weighted work in student-login/private-repo.')
+    expect(result.concerns).toContain('S.L. emailed [email redacted].')
+    expect(result.feedback).not.toContain('Sam Lee')
+    expect(result.feedback).not.toContain('sam@example.com')
+    expect(result.feedback).toContain('S.L.')
+    expect(result.feedback).toContain('[email redacted]')
+  })
 })


### PR DESCRIPTION
## Summary
- sanitize repo-review AI classification and feedback prompts before OpenAI egress
- pass classroom AI sanitization context into repo-review grading and use provider refs instead of local identifiers
- set store: false on repo-review OpenAI calls and sanitize daily log summary model output before persistence

## Validation
- pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts
- pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/unit/log-summary.test.ts tests/api/cron/nightly-log-summaries.test.ts
- pnpm lint