### PR TITLE
[codex] Align Gradex payloads with AI egress sanitization

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,28 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Phase two systems and UI audit fixes
-
-**Completed:**
-- Blocked teacher entry detail reads across classroom ownership boundaries.
-- Gated snapshot list/file APIs behind the UI gallery flag plus authentication, and marked them dynamic.
-- Made student notification active-test counts respect selected-student availability and grading closure.
-- Required archived-classroom ownership checks for test AI grading run ticks.
-- Removed the roster tab's dead global right-sidebar route and aligned selected-student email actions with the gradebook pattern.
-- Updated focused API/component coverage for each fixed audit finding.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/entry-id.test.ts`
-- `pnpm test tests/api/snapshots-list.test.ts tests/api/snapshots-filename.test.ts`
-- `pnpm test tests/api/teacher/test-auto-grade-runs.test.ts tests/api/student/notifications.test.ts tests/components/TeacherRosterTab.test.tsx tests/unit/layout-config.test.ts`
-- `pnpm test tests/components/ThreePanelProvider.test.tsx tests/unit/layout-config.test.ts`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=roster'`
-- Browser selected-row screenshots: `/tmp/pika-roster-selected-desktop.png`, `/tmp/pika-roster-selected-mobile.png`, `/tmp/pika-roster-selected-email-menu-desktop.png`, `/tmp/pika-roster-selected-email-menu-mobile.png`
-
 ## 2026-05-27 — Phase three audit fixes
 
 **Completed:**
@@ -1055,4 +1033,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts`
 - `pnpm test tests/unit/repo-review-ai.test.ts tests/unit/repo-review-analysis.test.ts tests/api/teacher/assignments-artifact-repo-run.test.ts tests/unit/log-summary.test.ts tests/api/cron/nightly-log-summaries.test.ts`
 - `pnpm test tests/unit/repo-review-ai.test.ts`
+
+## 2026-06-01 — Gradex egress sanitization alignment
+
+**Completed:**
+- Refactored the Gradex assignment payload builder to require Pika's standard AI sanitization context.
+- Routed Gradex assignment title, instructions, and submission text through `sanitizeAiText` before Gradex payload construction.
+- Kept Gradex-specific pseudonymous refs and local mappings while preserving extra raw-token hardening for Pika DB identifiers and bare `www.` URLs.
+- Strengthened Gradex adapter tests for roster-name initials, required sanitization context, raw identifier exclusion, and Gradex-owned provider/model settings.
+
+**Validation:**
+- `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
+- `pnpm exec tsc --noEmit`
 - `pnpm lint`

--- a/src/lib/server/gradex-assignment-payload.ts
+++ b/src/lib/server/gradex-assignment-payload.ts
@@ -1,5 +1,6 @@
 import { createHmac } from 'node:crypto'
 import { extractAssignmentArtifacts, type AssignmentArtifactType } from '@/lib/assignment-artifacts'
+import { sanitizeAiText, type AiSanitizationContext } from '@/lib/ai-sanitization'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { submissionArtifactsToAssignmentArtifacts } from '@/lib/assignment-submission-requirements'
 import { limitedMarkdownToPlainText } from '@/lib/limited-markdown'
@@ -128,12 +129,11 @@ export interface BuildPikaAssignmentGradexRunPayloadOptions {
   submissionArtifacts?: AssignmentSubmissionArtifact[]
   pseudonymSalt?: string
   requestTimeoutMs?: number
+  sanitizationContext: AiSanitizationContext
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 25_000
-const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
-const PHONE_PATTERN = /\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g
-const URL_PATTERN = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi
+const BARE_WWW_URL_PATTERN = /\bwww\.[^\s<>"'`]+/gi
 const IDENTITY_KEY_PATTERN = /(email|first_?name|last_?name|full_?name|display_?name|student_?name|teacher_?name|username|github_?username)/i
 const RAW_ID_KEY_PATTERN = /(^id$|_id$|id$|roster|sis|school|database|assignment_doc|classroom|created_by)/i
 
@@ -176,6 +176,13 @@ function getRequiredPseudonymSalt(explicitSalt?: string): string {
     throw new Error('GRADEX_PIKA_PSEUDONYM_SALT is not configured')
   }
   return salt
+}
+
+function getRequiredSanitizationContext(context?: AiSanitizationContext): AiSanitizationContext {
+  if (!context) {
+    throw new Error('AI sanitization context is required to build a Gradex run payload')
+  }
+  return context
 }
 
 function pseudonymize(prefix: string, value: string, salt: string): string {
@@ -232,11 +239,13 @@ function collectSanitizationTokens(assignment: Assignment, assignmentDocs: Grade
   return Array.from(tokens).sort((a, b) => b.length - a.length)
 }
 
-function sanitizeText(value: string, sensitiveTokens: string[]): string {
-  let sanitized = value
-    .replace(EMAIL_PATTERN, '[email redacted]')
-    .replace(PHONE_PATTERN, '[phone redacted]')
-    .replace(URL_PATTERN, '[link redacted]')
+function sanitizeGradexText(
+  value: string,
+  sensitiveTokens: string[],
+  sanitizationContext: AiSanitizationContext,
+): string {
+  let sanitized = sanitizeAiText(value, sanitizationContext)
+    .replace(BARE_WWW_URL_PATTERN, '[url redacted]')
 
   for (const token of sensitiveTokens) {
     if (token.length < 2) continue
@@ -296,9 +305,10 @@ function normalizeSubmissionContent(
   assignmentDoc: GradexAssignmentDocInput,
   submissionArtifacts: AssignmentSubmissionArtifact[],
   sensitiveTokens: string[],
+  sanitizationContext: AiSanitizationContext,
 ): string {
   const parsedContent = parseContentField(assignmentDoc.content)
-  const text = sanitizeText(extractPlainText(parsedContent).trim(), sensitiveTokens)
+  const text = sanitizeGradexText(extractPlainText(parsedContent).trim(), sensitiveTokens, sanitizationContext)
   const artifactSummary = buildArtifactSummary(parsedContent, submissionArtifacts)
   const sections = [text, artifactSummary].filter((section) => section.trim().length > 0)
   const normalized = sections.join('\n\n').trim()
@@ -386,6 +396,7 @@ export function buildPikaAssignmentGradexRunPayload(
 
   const salt = getRequiredPseudonymSalt(opts.pseudonymSalt)
   const sensitiveTokens = collectSanitizationTokens(opts.assignment, opts.assignmentDocs)
+  const sanitizationContext = getRequiredSanitizationContext(opts.sanitizationContext)
   const instructions = limitedMarkdownToPlainText(
     getAssignmentInstructionsMarkdown(opts.assignment).markdown,
   )
@@ -394,9 +405,12 @@ export function buildPikaAssignmentGradexRunPayload(
 
   const assignmentPayload = {
     pika_assignment_ref: assignmentRef,
-    title: truncateText(sanitizeText(opts.assignment.title, sensitiveTokens).trim() || 'Untitled assignment', 240),
+    title: truncateText(
+      sanitizeGradexText(opts.assignment.title, sensitiveTokens, sanitizationContext).trim() || 'Untitled assignment',
+      240,
+    ),
     instructions: truncateText(
-      sanitizeText(instructions, sensitiveTokens).trim() || 'No assignment instructions provided.',
+      sanitizeGradexText(instructions, sensitiveTokens, sanitizationContext).trim() || 'No assignment instructions provided.',
       20_000,
     ),
   }
@@ -415,6 +429,7 @@ export function buildPikaAssignmentGradexRunPayload(
         assignmentDoc,
         artifactsByDocId.get(assignmentDoc.id) ?? [],
         sensitiveTokens,
+        sanitizationContext,
       ),
       ...(submittedAt ? { submitted_at: submittedAt } : {}),
       workflow_summary: buildWorkflowEvidence(assignmentDoc),

--- a/tests/lib/gradex-assignment-payload.test.ts
+++ b/tests/lib/gradex-assignment-payload.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { buildAiSanitizationContext } from '@/lib/ai-sanitization'
 import {
   buildPikaAssignmentGradexRunPayload,
   GRADEX_PIKA_ADAPTER_VERSION,
@@ -23,6 +24,10 @@ const assignment: Assignment = {
   created_at: '2026-05-01T12:00:00.000Z',
   updated_at: '2026-05-02T12:00:00.000Z',
 }
+
+const sanitizationContext = buildAiSanitizationContext([
+  { firstName: 'Jane', lastName: 'Student' },
+])
 
 function artifact(overrides: Partial<AssignmentSubmissionArtifact>): AssignmentSubmissionArtifact {
   return {
@@ -66,7 +71,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
                 content: [
                   {
                     type: 'text',
-                    text: 'I completed the portfolio and wrote about my design decisions. My email is student@example.com.',
+                    text: 'I completed the portfolio with Jane Student and wrote about my design decisions. My email is student@example.com.',
                   },
                 ],
               },
@@ -106,12 +111,13 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
       submissionArtifacts: [artifact({})],
       pseudonymSalt: 'stable-test-salt',
       requestTimeoutMs: 12_000,
+      sanitizationContext,
     })
 
     expect(result.pikaAdapterRequest.adapter_version).toBe(GRADEX_PIKA_ADAPTER_VERSION)
     expect(result.pikaAdapterRequest.assignment).toEqual({
       pika_assignment_ref: expect.stringMatching(/^pika-assignment-(?=.*[a-z])(?=.*\d)[a-z0-9]{32}$/),
-      title: 'Portfolio Reflection for [identity redacted]',
+      title: 'Portfolio Reflection for J.S.',
       instructions: 'Write a reflection about the portfolio. Contact [email redacted] if stuck.',
     })
     expect(result.pikaAdapterRequest.submissions).toHaveLength(1)
@@ -131,7 +137,9 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     })
 
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('[email redacted]')
-    expect(result.pikaAdapterRequest.submissions[0].content).toContain('[link redacted]')
+    expect(result.pikaAdapterRequest.submissions[0].content).toContain('[url redacted]')
+    expect(result.pikaAdapterRequest.submissions[0].content).toContain('J.S.')
+    expect(result.pikaAdapterRequest.submissions[0].content).not.toContain('Jane Student')
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('Attached Artifacts:')
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('- Repository artifact submitted')
 
@@ -227,6 +235,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
         }),
       ],
       pseudonymSalt: 'stable-test-salt',
+      sanitizationContext,
     })
 
     const serialized = JSON.stringify(result.gradexRequest)
@@ -270,6 +279,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
           authenticity_score: null,
         },
       ],
+      sanitizationContext,
     }
 
     const first = buildPikaAssignmentGradexRunPayload({
@@ -301,6 +311,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
         assignment,
         assignmentDocs: [],
         pseudonymSalt: 'stable-test-salt',
+        sanitizationContext,
       }),
     ).toThrow('At least one assignment doc is required')
 
@@ -314,7 +325,24 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
             content: { type: 'doc', content: [] },
           },
         ],
+        sanitizationContext,
       }),
     ).toThrow('GRADEX_PIKA_PSEUDONYM_SALT is not configured')
+  })
+
+  it('requires the standard AI sanitization context before building Gradex egress', () => {
+    expect(() =>
+      buildPikaAssignmentGradexRunPayload({
+        assignment,
+        assignmentDocs: [
+          {
+            id: 'assignment-doc-db-456',
+            student_id: 'student-db-789',
+            content: { type: 'doc', content: [] },
+          },
+        ],
+        pseudonymSalt: 'stable-test-salt',
+      } as any),
+    ).toThrow('AI sanitization context is required')
   })
 })


### PR DESCRIPTION
## Summary
- require Pika's standard AI sanitization context when building Gradex assignment payloads
- route Gradex assignment title, instructions, and submission text through `sanitizeAiText`
- keep Gradex HMAC pseudonymous refs and raw-token hardening for local Pika identifiers
- strengthen Gradex adapter tests for roster-name initials, raw identifier exclusion, and missing context failure

## Validation
- pnpm test tests/lib/gradex-assignment-payload.test.ts tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts
- pnpm exec tsc --noEmit
- pnpm lint
- git diff --check