### PR TITLE
[codex] Add Pika Gradex smoke runner

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,39 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-27 — Required submission highlight polish
-
-**Completed:**
-- Removed the visible `R` marker from required-submission artifact pills in the teacher assignment student table.
-- Kept required artifact pills/cards blue without the primary outline treatment, including a stronger full-pill fill in the teacher student table.
-- Renamed the student work content section from `Submitted artifacts` to `Required submissions`.
-- Removed per-card `Required submission`/`Optional submission` labels from the content area and added dashed missing cards for unmet required submissions.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
-- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=4ff75b59-3189-4240-ac5a-dd3e750467bf&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
-- Screenshots reviewed: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-content.png`, `/tmp/pika-teacher-content-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-pr671-required-pill-table.png`
-
-## 2026-05-27 — Test focus telemetry selected access validation
-
-**Completed:**
-- Added selected-student availability validation before student test focus telemetry response reads or inserts.
-- Blocked focus telemetry when a teacher has closed access for the selected student, while preserving legacy behavior if the availability table is absent.
-- Allowed focus telemetry when a student-specific open override applies to a globally closed test.
-- Added API regressions for selected access closure/open overrides, availability lookup failures, missing availability table fallback, and successful active telemetry logging.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/student/tests-focus-events.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm run test:coverage`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-28 — Assignment list stats enrollment scoping
 
 **Completed:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,6 +8,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
+## 2026-05-27 — Required submission highlight polish
+
+**Completed:**
+- Removed the visible `R` marker from required-submission artifact pills in the teacher assignment student table.
+- Kept required artifact pills/cards blue without the primary outline treatment, including a stronger full-pill fill in the teacher student table.
+- Renamed the student work content section from `Submitted artifacts` to `Required submissions`.
+- Removed per-card `Required submission`/`Optional submission` labels from the content area and added dashed missing cards for unmet required submissions.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx tests/components/TeacherStudentWorkPanel.test.tsx`
+- `pnpm test tests/components/AssignmentArtifactsCell.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=4ff75b59-3189-4240-ac5a-dd3e750467bf&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
+- Screenshots reviewed: `/tmp/pika-teacher-ready.png`, `/tmp/pika-teacher-content.png`, `/tmp/pika-teacher-content-mobile.png`, `/tmp/pika-student.png`, `/tmp/pika-pr671-required-pill-table.png`
+
 ## 2026-05-27 — Test focus telemetry selected access validation
 
 **Completed:**
@@ -997,3 +1013,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `git diff --check`
 - Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`, plus a full-page teacher screenshot showing the off Public Syllabus switch.
+
+## 2026-06-01 — Gradex smoke runner
+
+**Completed:**
+- Added a Pika-owned `pnpm smoke:gradex` runner that builds sanitized sample assignment data, submits it to Gradex, polls the run, fetches item results, and maps Gradex compatibility output back to Pika grade-record fields.
+- Added mocked HTTP tests for create/tick/poll/item mapping and sanitized sample assertions.
+- Updated Gradex pseudonymous refs to avoid long hex-like tokens that Gradex rejects as raw identifier-shaped data.
+- Lowercased generated Gradex artifact-summary text so it does not trip Gradex's likely-name submitted-text guard.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/lib/gradex-smoke-runner.test.ts tests/lib/gradex-assignment-payload.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm smoke:gradex -- --dry-run`
+- `pnpm smoke:gradex` reached Gradex run creation against the configured deployed API URL, then stopped because no `GRADEX_INTERNAL_TOKEN`/worker is configured to process the queued run.
+- `GRADEX_API_URL=http://127.0.0.1:3001 GRADEX_API_KEY=... GRADEX_INTERNAL_TOKEN=... pnpm smoke:gradex` completed end-to-end against a controlled local Gradex dev server.

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,14 @@ OPENAI_API_KEY=
 OPENAI_SUMMARY_MODEL=
 OPENAI_DEVELOPER_FEEDBACK_MODEL=
 
+# Gradex smoke integration (optional)
+# Used by `pnpm smoke:gradex` to submit sanitized sample assignment data to Gradex.
+GRADEX_API_URL=http://localhost:3000
+GRADEX_API_KEY=
+GRADEX_INTERNAL_TOKEN=
+GRADEX_SMOKE_POLL_ATTEMPTS=20
+GRADEX_SMOKE_POLL_INTERVAL_MS=1500
+
 # GitHub API (optional for repo review helpers)
 # Token needs `repo` scope, or `public_repo` if the repo is public.
 GITHUB_PAT=

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "measure:ai-grading-prompts": "tsx scripts/measure-ai-grading-prompts.ts",
     "dev-feedback": "node scripts/dev-feedback.mjs",
     "eval:test-ai-grading-gold-set": "tsx scripts/eval-test-ai-grading-gold-set.ts",
+    "smoke:gradex": "tsx scripts/gradex-smoke.ts",
     "docs:sync:test-markdown": "tsx scripts/sync-test-markdown-docs.ts",
     "e2e:install": "playwright install",
     "e2e:auth": "playwright test e2e/auth.setup.ts",

--- a/scripts/gradex-smoke.ts
+++ b/scripts/gradex-smoke.ts
@@ -1,0 +1,54 @@
+import { config } from 'dotenv'
+import { runPikaGradexSmoke, buildPikaGradexSmokeSample } from '@/lib/server/gradex-smoke-runner'
+
+config({ path: '.env.local' })
+
+const args = new Set(process.argv.slice(2))
+
+async function main() {
+  if (args.has('--dry-run')) {
+    const sample = buildPikaGradexSmokeSample()
+    console.log(JSON.stringify(sample, null, 2))
+    return
+  }
+
+  const baseUrl = requiredEnv('GRADEX_API_URL')
+  const apiKey = requiredEnv('GRADEX_API_KEY')
+  const internalToken = process.env.GRADEX_INTERNAL_TOKEN?.trim() || process.env.GRADEX_INTERNAL_SECRET?.trim()
+  const pollAttempts = parsePositiveInt(process.env.GRADEX_SMOKE_POLL_ATTEMPTS, 20)
+  const pollIntervalMs = parsePositiveInt(process.env.GRADEX_SMOKE_POLL_INTERVAL_MS, 1500)
+
+  const report = await runPikaGradexSmoke({
+    baseUrl,
+    apiKey,
+    internalToken,
+    pollAttempts,
+    pollIntervalMs,
+  })
+
+  console.log(JSON.stringify({
+    run: report.run,
+    grade_records: report.gradeRecords,
+    poll_attempts: report.pollAttempts,
+    sanitized_preview: report.sample.sanitizedPreview,
+  }, null, 2))
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} is required. Use --dry-run to inspect the sanitized sample without calling Gradex.`)
+  }
+  return value
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/src/lib/server/gradex-assignment-payload.ts
+++ b/src/lib/server/gradex-assignment-payload.ts
@@ -188,9 +188,12 @@ function getRequiredSanitizationContext(context?: AiSanitizationContext): AiSani
 function pseudonymize(prefix: string, value: string, salt: string): string {
   const digest = createHmac('sha256', salt)
     .update(`${prefix}:${value}`)
-    .digest('hex')
-    .slice(0, 30)
-  return `pika-${prefix}-${digest}a1`
+    .digest('base64url')
+    .toLowerCase()
+    .replace(/-/g, 'x')
+    .replace(/_/g, 'y')
+  const safeDigest = `${digest.slice(0, 10)}z${digest.slice(10, 20)}z${digest.slice(20, 29)}z`
+  return `pika-${prefix}-${safeDigest}`
 }
 
 function truncateText(value: string, maxLength: number): string {
@@ -298,7 +301,7 @@ function buildArtifactSummary(content: TiptapContent, submissionArtifacts: Assig
     )
   }
 
-  return lines.length > 0 ? `Attached Artifacts:\n${lines.join('\n')}` : ''
+  return lines.length > 0 ? `attached artifacts:\n${lines.join('\n')}` : ''
 }
 
 function normalizeSubmissionContent(

--- a/src/lib/server/gradex-smoke-runner.ts
+++ b/src/lib/server/gradex-smoke-runner.ts
@@ -1,0 +1,390 @@
+import { buildAiSanitizationContext } from '@/lib/ai-sanitization'
+import {
+  buildPikaAssignmentGradexRunPayload,
+  type GradexGradingRunCreateRequest,
+  type PikaGradexMapping,
+} from '@/lib/server/gradex-assignment-payload'
+import type { Assignment, AssignmentSubmissionArtifact } from '@/types'
+
+type GradexRunStatus = 'queued' | 'running' | 'completed' | 'completed_with_errors' | 'failed'
+type GradexRunItemStatus = 'queued' | 'processing' | 'completed' | 'failed' | 'skipped'
+type GradexCriterionScore = {
+  criterion_id: string
+  score: number
+}
+
+export interface GradexSmokeRunResponse {
+  id: string
+  status: GradexRunStatus
+  counts: {
+    requested: number
+    processed: number
+    completed: number
+    failed: number
+    skipped: number
+    pending: number
+  }
+  provider: string | null
+  model: string | null
+  tier: string | null
+  policy_version: string | null
+  prompt_version: string | null
+  items?: GradexSmokeRunItemSummary[]
+}
+
+export interface GradexSmokeRunItemSummary {
+  id: string
+  status: GradexRunItemStatus
+  external_submission_id: string | null
+  external_student_id: string | null
+  error: unknown | null
+}
+
+export interface GradexSmokeRunItemResponse extends GradexSmokeRunItemSummary {
+  result: {
+    provider: string
+    model: string
+    tier: string
+    policy_version: string
+    prompt_version: string
+    audit_id: string
+    token_usage: unknown | null
+    criteria_results?: GradexCriterionScore[]
+    feedback?: {
+      student?: string
+    }
+    compatibility?: {
+      pika_assignment_v1?: {
+        score_completion: number
+        score_thinking: number
+        score_workflow: number
+        feedback: string
+      }
+    }
+  } | null
+}
+
+export interface PikaGradexSmokeGradeRecord {
+  assignment_doc_id: string
+  student_id: string
+  pika_grade_record_ref: string
+  pika_submission_ref: string
+  gradex_submission_id: string
+  gradex_item_id: string
+  status: GradexRunItemStatus
+  score_completion: number | null
+  score_thinking: number | null
+  score_workflow: number | null
+  feedback: string | null
+  provider: string | null
+  model: string | null
+  tier: string | null
+  audit_id: string | null
+}
+
+export interface PikaGradexSmokeSample {
+  gradexRequest: GradexGradingRunCreateRequest
+  mappings: PikaGradexMapping[]
+  sanitizedPreview: {
+    assignmentTitle: string
+    assignmentInstructions: string
+    submissionContents: string[]
+  }
+}
+
+export interface RunPikaGradexSmokeOptions {
+  baseUrl: string
+  apiKey: string
+  internalToken?: string
+  pollAttempts?: number
+  pollIntervalMs?: number
+  fetchImpl?: typeof fetch
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface PikaGradexSmokeReport {
+  sample: PikaGradexSmokeSample
+  run: GradexSmokeRunResponse
+  gradeRecords: PikaGradexSmokeGradeRecord[]
+  pollAttempts: number
+}
+
+const TERMINAL_STATUSES = new Set<GradexRunStatus>(['completed', 'completed_with_errors', 'failed'])
+
+export function buildPikaGradexSmokeSample(): PikaGradexSmokeSample {
+  const assignment: Assignment = {
+    id: 'assignment-db-smoke-001',
+    classroom_id: 'classroom-db-smoke-001',
+    title: 'Portfolio Reflection for Jane Student',
+    description: 'Sanitized Gradex smoke assignment',
+    instructions_markdown:
+      'Write a short reflection about your portfolio. Do not include your email or personal links.',
+    rich_instructions: null,
+    due_at: '2026-06-07T21:00:00.000Z',
+    position: 1,
+    is_draft: false,
+    released_at: '2026-06-01T12:00:00.000Z',
+    track_authenticity: true,
+    points_possible: 30,
+    include_in_final: true,
+    gradebook_weight: 1,
+    created_by: 'teacher-db-smoke-001',
+    created_at: '2026-06-01T12:00:00.000Z',
+    updated_at: '2026-06-01T12:00:00.000Z',
+  }
+
+  const assignmentDocs = [
+    {
+      id: 'assignment-doc-db-smoke-001',
+      student_id: 'student-db-smoke-001',
+      submitted_at: '2026-06-01T14:30:00.000Z',
+      authenticity_score: 88,
+      authenticity_flags: [
+        {
+          timestamp: '2026-06-01T14:10:00.000Z',
+          wordDelta: 120,
+          seconds: 20,
+          wps: 6,
+          reason: 'high_wps' as const,
+        },
+      ],
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text:
+                  'Jane Student explains that the navigation was simplified, the homepage now introduces the project clearly, and the reflection connects design choices to audience needs. Contact jane.student@example.com or visit https://student.example.com/portfolio for the old draft.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ]
+
+  const submissionArtifacts: AssignmentSubmissionArtifact[] = [
+    {
+      id: 'artifact-db-smoke-001',
+      assignment_doc_id: 'assignment-doc-db-smoke-001',
+      requirement_id: 'requirement-db-smoke-001',
+      student_id: 'student-db-smoke-001',
+      type: 'link',
+      url: 'https://student.example.com/portfolio',
+      storage_path: null,
+      metadata_json: {},
+      validation_status: 'valid',
+      validation_message: null,
+      validated_at: '2026-06-01T14:20:00.000Z',
+      created_at: '2026-06-01T14:20:00.000Z',
+      updated_at: '2026-06-01T14:20:00.000Z',
+    },
+  ]
+
+  const built = buildPikaAssignmentGradexRunPayload({
+    assignment,
+    assignmentDocs,
+    submissionArtifacts,
+    pseudonymSalt: 'pika-gradex-smoke-only-salt',
+    sanitizationContext: buildAiSanitizationContext([
+      { firstName: 'Jane', lastName: 'Student' },
+    ]),
+  })
+
+  return {
+    gradexRequest: built.gradexRequest,
+    mappings: built.mappings,
+    sanitizedPreview: {
+      assignmentTitle: built.gradexRequest.assignment.title,
+      assignmentInstructions: built.gradexRequest.assignment.instructions,
+      submissionContents: built.gradexRequest.submissions.map((submission) => String(submission.content)),
+    },
+  }
+}
+
+export async function runPikaGradexSmoke(opts: RunPikaGradexSmokeOptions): Promise<PikaGradexSmokeReport> {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const sample = buildPikaGradexSmokeSample()
+  const baseUrl = normalizeBaseUrl(opts.baseUrl)
+  const pollAttempts = opts.pollAttempts ?? 20
+  const pollIntervalMs = opts.pollIntervalMs ?? 1500
+
+  let run = await requestJson<GradexSmokeRunResponse>(fetchImpl, {
+    url: `${baseUrl}/api/v1/grading-runs`,
+    method: 'POST',
+    apiKey: opts.apiKey,
+    body: sample.gradexRequest,
+    expectedStatus: 202,
+  })
+
+  let attempts = 0
+  for (; attempts < pollAttempts && !TERMINAL_STATUSES.has(run.status); attempts += 1) {
+    if (opts.internalToken) {
+      await requestJson(fetchImpl, {
+        url: `${baseUrl}/api/internal/grading-runs/tick`,
+        method: 'POST',
+        apiKey: opts.internalToken,
+        body: { runId: run.id, limit: sample.gradexRequest.submissions.length },
+        expectedStatus: 200,
+      })
+    }
+
+    await sleep(pollIntervalMs)
+    run = await getRun(fetchImpl, baseUrl, opts.apiKey, run.id)
+  }
+
+  if (!TERMINAL_STATUSES.has(run.status)) {
+    const tickHint = opts.internalToken
+      ? ''
+      : ' Configure GRADEX_INTERNAL_TOKEN for local tick processing or run a Gradex worker.'
+    throw new Error(`Gradex run ${run.id} did not finish after ${pollAttempts} poll attempts.${tickHint}`)
+  }
+
+  const itemSummaries = run.items ?? []
+  const items = await Promise.all(
+    itemSummaries.map((item) => getRunItem(fetchImpl, baseUrl, opts.apiKey, run.id, item.id)),
+  )
+
+  return {
+    sample,
+    run,
+    gradeRecords: mapGradexItemsToPikaGradeRecords(sample.mappings, items),
+    pollAttempts: attempts,
+  }
+}
+
+export function mapGradexItemsToPikaGradeRecords(
+  mappings: PikaGradexMapping[],
+  items: GradexSmokeRunItemResponse[],
+): PikaGradexSmokeGradeRecord[] {
+  const mappingBySubmissionId = new Map(
+    mappings.map((mapping) => [mapping.gradex_submission_id, mapping]),
+  )
+
+  return items.map((item) => {
+    const mapping = item.external_submission_id ? mappingBySubmissionId.get(item.external_submission_id) : undefined
+    if (!mapping) {
+      throw new Error(`Missing Pika mapping for Gradex submission ${item.external_submission_id ?? item.id}`)
+    }
+
+    const pika = item.result?.compatibility?.pika_assignment_v1
+    const criterionScores = getCriterionScores(item.result?.criteria_results)
+
+    return {
+      assignment_doc_id: mapping.assignment_doc_id,
+      student_id: mapping.student_id,
+      pika_grade_record_ref: mapping.pika_grade_record_ref,
+      pika_submission_ref: mapping.pika_submission_ref,
+      gradex_submission_id: mapping.gradex_submission_id,
+      gradex_item_id: item.id,
+      status: item.status,
+      score_completion: pika?.score_completion ?? criterionScores.completion ?? null,
+      score_thinking: pika?.score_thinking ?? criterionScores.thinking ?? null,
+      score_workflow: pika?.score_workflow ?? criterionScores.workflow ?? null,
+      feedback: pika?.feedback ?? item.result?.feedback?.student ?? null,
+      provider: item.result?.provider ?? null,
+      model: item.result?.model ?? null,
+      tier: item.result?.tier ?? null,
+      audit_id: item.result?.audit_id ?? null,
+    }
+  })
+}
+
+function getCriterionScores(criteriaResults: GradexCriterionScore[] | undefined) {
+  const scores: Partial<Record<'completion' | 'thinking' | 'workflow', number>> = {}
+  if (!Array.isArray(criteriaResults)) return scores
+
+  for (const criterion of criteriaResults) {
+    if (
+      criterion &&
+      typeof criterion === 'object' &&
+      'criterion_id' in criterion &&
+      'score' in criterion &&
+      (criterion.criterion_id === 'completion' ||
+        criterion.criterion_id === 'thinking' ||
+        criterion.criterion_id === 'workflow') &&
+      typeof criterion.score === 'number'
+    ) {
+      scores[criterion.criterion_id] = criterion.score
+    }
+  }
+
+  return scores
+}
+
+async function getRun(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  apiKey: string,
+  runId: string,
+) {
+  return requestJson<GradexSmokeRunResponse>(fetchImpl, {
+    url: `${baseUrl}/api/v1/grading-runs/${encodeURIComponent(runId)}`,
+    method: 'GET',
+    apiKey,
+    expectedStatus: 200,
+  })
+}
+
+async function getRunItem(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  apiKey: string,
+  runId: string,
+  itemId: string,
+) {
+  return requestJson<GradexSmokeRunItemResponse>(fetchImpl, {
+    url: `${baseUrl}/api/v1/grading-runs/${encodeURIComponent(runId)}/items/${encodeURIComponent(itemId)}`,
+    method: 'GET',
+    apiKey,
+    expectedStatus: 200,
+  })
+}
+
+async function requestJson<T>(
+  fetchImpl: typeof fetch,
+  opts: {
+    url: string
+    method: 'GET' | 'POST'
+    apiKey: string
+    body?: unknown
+    expectedStatus: number
+  },
+): Promise<T> {
+  const response = await fetchImpl(opts.url, {
+    method: opts.method,
+    headers: {
+      Authorization: `Bearer ${opts.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    ...(opts.body === undefined ? {} : { body: JSON.stringify(opts.body) }),
+  })
+  const body = await response.json().catch(() => null)
+  if (!response.ok || response.status !== opts.expectedStatus) {
+    throw new Error(gradexErrorMessage(body, response.status))
+  }
+  return body as T
+}
+
+function gradexErrorMessage(body: unknown, status: number): string {
+  if (body && typeof body === 'object') {
+    const error = (body as { error?: { message?: unknown } }).error
+    const details = (body as { error?: { details?: unknown } }).error?.details
+    if (typeof error?.message === 'string') {
+      return details === undefined
+        ? error.message
+        : `${error.message}: ${JSON.stringify(details)}`
+    }
+  }
+  return `Gradex request failed with status ${status}`
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, '')
+  if (!normalized) throw new Error('GRADEX_API_URL is required')
+  return normalized
+}

--- a/tests/lib/gradex-assignment-payload.test.ts
+++ b/tests/lib/gradex-assignment-payload.test.ts
@@ -140,7 +140,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('[url redacted]')
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('J.S.')
     expect(result.pikaAdapterRequest.submissions[0].content).not.toContain('Jane Student')
-    expect(result.pikaAdapterRequest.submissions[0].content).toContain('Attached Artifacts:')
+    expect(result.pikaAdapterRequest.submissions[0].content).toContain('attached artifacts:')
     expect(result.pikaAdapterRequest.submissions[0].content).toContain('- Repository artifact submitted')
 
     expect(result.gradexRequest.assignment).toEqual({
@@ -245,6 +245,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     expect(serialized).not.toContain('teacher-db-123')
     expect(serialized).not.toContain('assignment-doc-db-456')
     expect(serialized).not.toContain('student-db-789')
+    expect(serialized).not.toMatch(/\b[0-9a-f]{24}\b/i)
     expect(serialized).not.toContain('Jane Student')
     expect(serialized).not.toContain('student@example.com')
     expect(serialized).not.toContain('roster-db-123')

--- a/tests/lib/gradex-smoke-runner.test.ts
+++ b/tests/lib/gradex-smoke-runner.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildPikaGradexSmokeSample,
+  mapGradexItemsToPikaGradeRecords,
+  runPikaGradexSmoke,
+  type GradexSmokeRunItemResponse,
+  type GradexSmokeRunResponse,
+} from '@/lib/server/gradex-smoke-runner'
+
+describe('Pika Gradex smoke runner', () => {
+  it('builds a sanitized sample Gradex request from Pika-shaped assignment data', () => {
+    const sample = buildPikaGradexSmokeSample()
+    const serialized = JSON.stringify(sample.gradexRequest)
+
+    expect(sample.gradexRequest.settings).toMatchObject({
+      grading_profile: 'pika-assignment-v1',
+      provider: 'auto',
+      tier: 'auto',
+    })
+    expect(sample.gradexRequest.submissions).toHaveLength(1)
+    expect(serialized).toContain('J.S.')
+    expect(serialized).toContain('[email redacted]')
+    expect(serialized).toContain('[url redacted]')
+    expect(serialized).not.toContain('Jane Student')
+    expect(serialized).not.toContain('jane.student@example.com')
+    expect(serialized).not.toContain('student.example.com')
+    expect(serialized).not.toContain('assignment-doc-db-smoke-001')
+    expect(serialized).not.toMatch(/\b[0-9a-f]{24}\b/i)
+    expect(sample.mappings[0].assignment_doc_id).toBe('assignment-doc-db-smoke-001')
+  })
+
+  it('posts, ticks, polls, fetches items, and maps Gradex results back to Pika grade fields', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+
+      if (url === 'https://gradex.example.test/api/v1/grading-runs' && method === 'POST') {
+        expect(init?.headers).toMatchObject({ Authorization: 'Bearer gx_test_key' })
+        return jsonResponse(202, runResponse('queued'))
+      }
+
+      if (url === 'https://gradex.example.test/api/internal/grading-runs/tick' && method === 'POST') {
+        expect(init?.headers).toMatchObject({ Authorization: 'Bearer internal_test' })
+        expect(JSON.parse(String(init?.body))).toMatchObject({ runId: 'run_1', limit: 1 })
+        return jsonResponse(200, { processed: 1 })
+      }
+
+      if (url === 'https://gradex.example.test/api/v1/grading-runs/run_1' && method === 'GET') {
+        return jsonResponse(200, runResponse('completed'))
+      }
+
+      if (url === 'https://gradex.example.test/api/v1/grading-runs/run_1/items/item_1' && method === 'GET') {
+        return jsonResponse(200, itemResponse())
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`)
+    })
+
+    const report = await runPikaGradexSmoke({
+      baseUrl: 'https://gradex.example.test/',
+      apiKey: 'gx_test_key',
+      internalToken: 'internal_test',
+      fetchImpl,
+      sleep: async () => undefined,
+      pollAttempts: 3,
+    })
+
+    expect(report.run.status).toBe('completed')
+    expect(report.gradeRecords).toEqual([
+      expect.objectContaining({
+        assignment_doc_id: 'assignment-doc-db-smoke-001',
+        student_id: 'student-db-smoke-001',
+        gradex_item_id: 'item_1',
+        status: 'completed',
+        score_completion: 8,
+        score_thinking: 7,
+        score_workflow: 9,
+        feedback: 'Strength: clear reflection. Next step: add one specific example.',
+        provider: 'heuristic',
+        model: 'heuristic-local',
+        tier: 'tier_0',
+        audit_id: 'audit_1',
+      }),
+    ])
+    expect(fetchImpl).toHaveBeenCalledTimes(4)
+  })
+
+  it('fails closed when a Gradex item cannot be mapped to a local Pika record', () => {
+    const sample = buildPikaGradexSmokeSample()
+    expect(() =>
+      mapGradexItemsToPikaGradeRecords(sample.mappings, [
+        {
+          ...itemResponse(),
+          external_submission_id: 'unknown-submission',
+        },
+      ]),
+    ).toThrow('Missing Pika mapping')
+  })
+
+  it('maps Gradex criterion results when compatibility output is absent', () => {
+    const sample = buildPikaGradexSmokeSample()
+    const record = mapGradexItemsToPikaGradeRecords(sample.mappings, [
+      {
+        ...itemResponse(),
+        result: {
+          ...itemResponse().result!,
+          compatibility: undefined,
+          criteria_results: [
+            { criterion_id: 'completion', score: 6 },
+            { criterion_id: 'thinking', score: 7 },
+            { criterion_id: 'workflow', score: 8 },
+          ],
+          feedback: {
+            student: 'Strength: organized submission. Next step: add evidence.',
+          },
+        },
+      },
+    ])[0]
+
+    expect(record).toMatchObject({
+      score_completion: 6,
+      score_thinking: 7,
+      score_workflow: 8,
+      feedback: 'Strength: organized submission. Next step: add evidence.',
+    })
+  })
+})
+
+function runResponse(status: GradexSmokeRunResponse['status']): GradexSmokeRunResponse {
+  return {
+    id: 'run_1',
+    status,
+    counts: {
+      requested: 1,
+      processed: status === 'completed' ? 1 : 0,
+      completed: status === 'completed' ? 1 : 0,
+      failed: 0,
+      skipped: 0,
+      pending: status === 'completed' ? 0 : 1,
+    },
+    provider: status === 'completed' ? 'heuristic' : null,
+    model: status === 'completed' ? 'heuristic-local' : null,
+    tier: status === 'completed' ? 'tier_0' : null,
+    policy_version: status === 'completed' ? 'gradex-routing-policy-v1' : null,
+    prompt_version: status === 'completed' ? 'gradex-essay-rubric-v1' : null,
+    items: [
+      {
+        id: 'item_1',
+        status: status === 'completed' ? 'completed' : 'queued',
+        external_submission_id: buildPikaGradexSmokeSample().mappings[0].gradex_submission_id,
+        external_student_id: buildPikaGradexSmokeSample().mappings[0].gradex_student_id,
+        error: null,
+      },
+    ],
+  }
+}
+
+function itemResponse(): GradexSmokeRunItemResponse {
+  const mapping = buildPikaGradexSmokeSample().mappings[0]
+  return {
+    id: 'item_1',
+    status: 'completed',
+    external_submission_id: mapping.gradex_submission_id,
+    external_student_id: mapping.gradex_student_id,
+    error: null,
+    result: {
+      provider: 'heuristic',
+      model: 'heuristic-local',
+      tier: 'tier_0',
+      policy_version: 'gradex-routing-policy-v1',
+      prompt_version: 'gradex-essay-rubric-v1',
+      audit_id: 'audit_1',
+      token_usage: null,
+      compatibility: {
+        pika_assignment_v1: {
+          score_completion: 8,
+          score_thinking: 7,
+          score_workflow: 9,
+          feedback: 'Strength: clear reflection. Next step: add one specific example.',
+        },
+      },
+    },
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## Summary
- add `pnpm smoke:gradex` to build sanitized sample Pika assignment data, submit it to Gradex, poll the run, fetch item results, and map results back to Pika grade-record fields
- add mocked smoke-runner tests for create/tick/poll/item mapping and mapping fallback from Gradex criterion results
- adjust Gradex adapter pseudonymous refs and generated artifact summary text so Gradex's sanitized-payload guard accepts Pika egress payloads

## Validation
- `bash scripts/verify-env.sh`
- `pnpm test tests/unit/ai-startup-docs.test.ts tests/lib/gradex-smoke-runner.test.ts tests/lib/gradex-assignment-payload.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm smoke:gradex -- --dry-run`
- local e2e smoke against controlled Gradex dev server: `GRADEX_API_URL=http://127.0.0.1:3001 GRADEX_API_KEY=... GRADEX_INTERNAL_TOKEN=... GRADEX_SMOKE_POLL_INTERVAL_MS=25 GRADEX_SMOKE_POLL_ATTEMPTS=20 pnpm smoke:gradex`

## Notes
- The configured deployed Gradex API accepted run creation after the payload fixes, but did not process the queued run because Pika does not currently have a `GRADEX_INTERNAL_TOKEN` and the deployed worker/tick path is not available to this script.
