### PR TITLE
[codex] Add assignment artifact link validation

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1000,3 +1000,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Post-PR draft recovery rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
 - Post-PR restored-draft autosave rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
+## 2026-06-02 — Assignment artifact validation policy
+
+**Completed:**
+- Renamed the default generic submission artifact label from `Public link` to `Link` and changed student link inputs from `Public URL` to `URL`.
+- Added link validation policy helpers for basic URL, reachable page, and expected-site checks using existing `validation_policy_json`.
+- Added compact teacher controls for link requirement validation and carried validation status into teacher artifact displays.
+- Extended generic link validation with safe URL normalization, DNS/private-host guards, host-first expected-domain rejection, bounded fetch checks, redirect caps, timeout handling, and soft `Needs review` results for inconclusive pages.
+- Updated focused unit/component/API coverage for validation policy behavior, student status copy, teacher controls, and artifact metadata.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/lib/assignment-submission-requirements.test.ts tests/components/StudentAssignmentSubmissionChecklist.test.tsx tests/components/AssignmentModal.test.tsx tests/components/AssignmentArtifactsCell.test.tsx tests/api/teacher/assignments-id.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test` failed under concurrent build load with two unrelated 5s timeouts and one updated expectation; reran the failed tests successfully with `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/unit/ai-startup-docs.test.ts tests/api/teacher/assignments-id.test.ts`.
+- Visual verification: `pika-ui-verify` classroom screenshots plus targeted teacher assignment link-policy and student submission checklist screenshots.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -1016,3 +1016,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test` failed under concurrent build load with two unrelated 5s timeouts and one updated expectation; reran the failed tests successfully with `pnpm test tests/components/TeacherStudentWorkPanel.test.tsx tests/unit/ai-startup-docs.test.ts tests/api/teacher/assignments-id.test.ts`.
 - Visual verification: `pika-ui-verify` classroom screenshots plus targeted teacher assignment link-policy and student submission checklist screenshots.
+
+## 2026-06-02 — Artifact Save disabled when unchanged
+
+**Completed:**
+- Disabled student artifact `Save` buttons until the draft URL differs from the saved artifact.
+- Included repo-link GitHub username changes in the same dirty-state check.
+- Added component regressions for unchanged generic links and repo username edits.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/StudentAssignmentSubmissionChecklist.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `git diff --check`
+- Visual verification: `pika-ui-verify` classroom screenshots plus targeted student assignment-detail screenshot confirming both unchanged artifact `Save` buttons are disabled.

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,47 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-29 — Skill progression map from PR review patterns
-
-**Completed:**
-- Reviewed recent merged PRs #665-#676 plus nearby audit-fix PRs for recurring review and self-review themes.
-- Identified repeat hotspots around enrollment-scoped authorization, PostgREST query sizing/pagination, accessibility semantics, and verification depth.
-- Wrote a concrete next-skill map anchored to those PR and review patterns for the automation memory.
-
-**Validation:**
-- `bash scripts/verify-env.sh` (failed only because `node_modules` is absent in this worktree)
-- `gh pr list --state merged --limit 12 --json number,title,mergedAt,url,author,reviewDecision`
-- `gh api graphql` against recent merged PR reviews
-
-## 2026-05-30 — Shared enrollment and list-stat guardrails
-
-**Completed:**
-- Added shared chunked/paged Supabase row loading in [`src/lib/server/query-chunks.ts`](/Users/stew/.codex/worktrees/f558/pika/src/lib/server/query-chunks.ts) to centralize filter chunking and stable pagination.
-- Added shared classroom enrollment validation in [`src/lib/server/classroom-enrollment-validation.ts`](/Users/stew/.codex/worktrees/f558/pika/src/lib/server/classroom-enrollment-validation.ts) and routed test enrollment checks through it.
-- Replaced duplicated list-stat loading logic in teacher quizzes, surveys, and tests routes with the shared loader.
-- Replaced duplicated classroom enrollment validation in assignment auto-grade and assignment repo-target routes with the shared validator.
-- Added focused regression coverage for chunked/paged row loading and 51-student enrollment validation boundaries.
-
-**Validation:**
-- `git diff --check`
-- Static readback of all touched server routes and new tests
-- Full test/lint/build not run because `node_modules` is absent in this worktree
-
-## 2026-05-30 — Accessibility and validation audit gates
-
-**Completed:**
-- Reviewed the shared guardrail refactor and found no blocking route/runtime issues on static inspection.
-- Added the governed composite-widget accessibility checklist in [`docs/guidance/ui/composite-widget-accessibility.md`](/Users/stew/.codex/worktrees/f558/pika/docs/guidance/ui/composite-widget-accessibility.md).
-- Wired the new checklist into the UI canon, design guidance, and audit prompt/skill docs.
-- Extended the Pika audit script to flag missing changed-test coverage for risky server/runtime work and composite-widget UI work, plus emit reminder output for required validation reporting.
-- Fixed one audit false positive by limiting the `manual-catch` violation to unwrapped route files instead of any wrapped route helper catch.
-- Added doc/prompt regression coverage in [`tests/unit/ui-guidance-docs.test.ts`](/Users/stew/.codex/worktrees/f558/pika/tests/unit/ui-guidance-docs.test.ts).
-
-**Validation:**
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- Full Vitest/lint/build still not run because `node_modules` is absent in this worktree
-
 ## 2026-05-30 — Validation pass completed
 
 **Completed:**
@@ -1000,6 +959,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Post-PR draft recovery rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
 - Post-PR restored-draft autosave rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
+
 ## 2026-06-02 — Assignment artifact validation policy
 
 **Completed:**
@@ -1031,3 +991,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `git diff --check`
 - Visual verification: `pika-ui-verify` classroom screenshots plus targeted student assignment-detail screenshot confirming both unchanged artifact `Save` buttons are disabled.
+
+## 2026-06-02 — Bound link reachability checks to validated DNS
+
+**Completed:**
+- Replaced generic server-side `fetch` for artifact link reachability with bounded `http`/`https` requests that connect to the already-validated public IP address.
+- Preserved the submitted host in the `Host` header and HTTPS SNI while preventing a second uncontrolled DNS lookup during the actual request.
+- Kept redirect, timeout, and body-size caps, and tightened response-body storage to the configured 24 KB limit.
+- Added a regression proving reachable-link requests use the validated public IP while preserving original host metadata.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/assignment-submission-validation.test.ts`
+- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/lib/assignment-submission-requirements.test.ts tests/components/StudentAssignmentSubmissionChecklist.test.tsx tests/components/AssignmentModal.test.tsx tests/components/AssignmentArtifactsCell.test.tsx tests/api/teacher/assignments-id.test.ts`
+- `pnpm lint`
+- `pnpm build`
+- Rereview: no remaining findings in the updated link reachability path.

--- a/docs/guidance/assignment-markdown-schema.md
+++ b/docs/guidance/assignment-markdown-schema.md
@@ -13,7 +13,7 @@ Ship a small app and submit the required evidence.
 
 ### Submission Requirements
 - repo_link | Repo link | required | Use your public GitHub repository.
-- link | Public link | required | Paste the deployed project or demo URL.
+- link | Link | required | Paste the deployed project or demo URL.
 - image | Screenshot | optional | Upload a screenshot of the working app.
 ---
 ```

--- a/src/app/api/assignment-docs/[id]/artifacts/[requirementId]/route.ts
+++ b/src/app/api/assignment-docs/[id]/artifacts/[requirementId]/route.ts
@@ -141,6 +141,7 @@ export const PUT = withErrorHandler('PutAssignmentSubmissionArtifact', async (re
     type: requirement.type,
     url,
     githubLogin,
+    validationPolicy: requirement.validation_policy_json,
   })
 
   const metadata = {

--- a/src/components/AssignmentArtifactsCell.tsx
+++ b/src/components/AssignmentArtifactsCell.tsx
@@ -45,6 +45,16 @@ function getSubmissionArtifactStatusLabel(artifact: AssignmentArtifact): string 
   return null
 }
 
+function getArtifactValidationLabel(artifact: AssignmentArtifact): string {
+  if (artifact.validation_status === 'valid') {
+    return artifact.validation_level === 'verified' ? 'Verified' : 'Saved'
+  }
+  if (artifact.validation_status === 'warning' || artifact.validation_status === 'inaccessible') return 'Needs review'
+  if (artifact.validation_status === 'invalid') return 'Fix needed'
+  if (artifact.validation_status === 'pending') return 'Checking'
+  return 'Added'
+}
+
 function getArtifactIconClassName(artifact: AssignmentArtifact) {
   return [
     'h-3.5 w-3.5 shrink-0',
@@ -115,7 +125,15 @@ function ArtifactsTooltipList({
                   {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
                 </span>
                 <span className="block truncate text-[11px] text-text-muted">
-                  {statusLabel ?? getArtifactKindLabel(artifact)} . {artifact.url}
+                  {statusLabel ?? getArtifactKindLabel(artifact)} . {getArtifactValidationLabel(artifact)}
+                </span>
+                {artifact.validation_message ? (
+                  <span className="block truncate text-[11px] text-warning">
+                    {artifact.validation_message}
+                  </span>
+                ) : null}
+                <span className="block truncate text-[11px] text-text-muted">
+                  {artifact.url}
                 </span>
               </span>
             </a>
@@ -230,8 +248,14 @@ export function AssignmentArtifactsCell({
                     {getArtifactTypeLabel(artifact)} . {getArtifactSummary(artifact)}
                   </span>
                   <span className="mt-0.5 block truncate text-xs text-text-muted">
-                    {statusLabel ?? getArtifactKindLabel(artifact)} . {artifact.url}
+                    {statusLabel ?? getArtifactKindLabel(artifact)} . {getArtifactValidationLabel(artifact)}
                   </span>
+                  {artifact.validation_message ? (
+                    <span className="mt-0.5 block truncate text-xs text-warning">
+                      {artifact.validation_message}
+                    </span>
+                  ) : null}
+                  <span className="mt-0.5 block truncate text-xs text-text-muted">{artifact.url}</span>
                 </span>
                 <ExternalLink className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
               </a>

--- a/src/components/AssignmentSubmissionRequirementsEditor.tsx
+++ b/src/components/AssignmentSubmissionRequirementsEditor.tsx
@@ -19,9 +19,12 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { FolderGit2, GripVertical, ImageIcon, Link2, Trash2 } from 'lucide-react'
 import { useRef, useState } from 'react'
-import { Button, ConfirmDialog, FormField, Input, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
+import { Button, ConfirmDialog, FormField, Input, Select, SplitButton, Tooltip, TooltipProvider, cn } from '@/ui'
 import {
   DEFAULT_REQUIREMENT_LABELS,
+  LINK_VALIDATION_MODE_LABELS,
+  normalizeAssignmentSubmissionValidationPolicy,
+  type AssignmentLinkValidationMode,
   type AssignmentSubmissionRequirementDraft,
 } from '@/lib/assignment-submission-requirements'
 import type { AssignmentSubmissionRequirementType } from '@/types'
@@ -39,6 +42,12 @@ const TYPE_OPTIONS: Array<{
   { type: 'link', label: 'Link' },
   { type: 'repo_link', label: 'Repo' },
   { type: 'image', label: 'Image' },
+]
+
+const LINK_VALIDATION_OPTIONS: Array<{ value: AssignmentLinkValidationMode; label: string }> = [
+  { value: 'format_only', label: LINK_VALIDATION_MODE_LABELS.format_only },
+  { value: 'reachable', label: LINK_VALIDATION_MODE_LABELS.reachable },
+  { value: 'expected_domain', label: LINK_VALIDATION_MODE_LABELS.expected_domain },
 ]
 
 function RequirementIcon({ type }: { type: AssignmentSubmissionRequirementType }) {
@@ -62,6 +71,18 @@ function AddRequirementLabel({ type, label }: {
 
 function withPositions(requirements: AssignmentSubmissionRequirementDraft[]) {
   return requirements.map((requirement, position) => ({ ...requirement, position }))
+}
+
+function buildLinkValidationPolicyPatch(
+  mode: AssignmentLinkValidationMode,
+  expectedDomain: string
+): Record<string, unknown> {
+  if (mode === 'format_only') return {}
+  if (mode === 'reachable') return { mode }
+  return {
+    mode,
+    expected_domains: expectedDomain.trim() ? [expectedDomain.trim()] : [],
+  }
 }
 
 interface SortableRequirementRowProps {
@@ -97,6 +118,34 @@ function SortableRequirementRow({
     transform: CSS.Transform.toString(transform),
     transition: isDragging ? undefined : transition,
   }
+  const linkPolicy = normalizeAssignmentSubmissionValidationPolicy(
+    requirement.type,
+    requirement.validation_policy_json
+  )
+  const rawMode = typeof requirement.validation_policy_json?.mode === 'string'
+    ? requirement.validation_policy_json.mode
+    : ''
+  const linkValidationMode = LINK_VALIDATION_OPTIONS.some((option) => option.value === rawMode)
+    ? rawMode as AssignmentLinkValidationMode
+    : linkPolicy.mode
+  const rawExpectedDomains = Array.isArray(requirement.validation_policy_json?.expected_domains)
+    ? requirement.validation_policy_json.expected_domains
+    : []
+  const expectedDomain = typeof rawExpectedDomains[0] === 'string'
+    ? rawExpectedDomains[0]
+    : linkPolicy.expected_domains[0] ?? ''
+
+  function updateLinkValidationMode(mode: AssignmentLinkValidationMode) {
+    onUpdate(index, {
+      validation_policy_json: buildLinkValidationPolicyPatch(mode, expectedDomain),
+    })
+  }
+
+  function updateExpectedDomain(domain: string) {
+    onUpdate(index, {
+      validation_policy_json: buildLinkValidationPolicyPatch('expected_domain', domain),
+    })
+  }
 
   return (
     <div
@@ -125,33 +174,57 @@ function SortableRequirementRow({
         </button>
         <RequirementIcon type={requirement.type} />
       </div>
-      <div className="grid gap-2 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto]">
-        <FormField label="Label" hideLabel>
-          <Input
-            value={requirement.label ?? ''}
-            disabled={disabled}
-            onChange={(event) => onUpdate(index, { label: event.target.value })}
-            placeholder="Submission label"
-          />
-        </FormField>
-        <FormField label="Instructions" hideLabel>
-          <Input
-            value={requirement.instructions ?? ''}
-            disabled={disabled}
-            onChange={(event) => onUpdate(index, { instructions: event.target.value })}
-            placeholder="Optional helper text"
-          />
-        </FormField>
-        <label className="flex items-end gap-2 pb-2 text-sm text-text-default">
-          <input
-            type="checkbox"
-            checked={requirement.required !== false}
-            disabled={disabled}
-            onChange={(event) => onUpdate(index, { required: event.target.checked })}
-            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
-          />
-          Required
-        </label>
+      <div className="grid gap-2">
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto]">
+          <FormField label="Label" hideLabel>
+            <Input
+              value={requirement.label ?? ''}
+              disabled={disabled}
+              onChange={(event) => onUpdate(index, { label: event.target.value })}
+              placeholder="Submission label"
+            />
+          </FormField>
+          <FormField label="Instructions" hideLabel>
+            <Input
+              value={requirement.instructions ?? ''}
+              disabled={disabled}
+              onChange={(event) => onUpdate(index, { instructions: event.target.value })}
+              placeholder="Optional helper text"
+            />
+          </FormField>
+          <label className="flex items-end gap-2 pb-2 text-sm text-text-default">
+            <input
+              type="checkbox"
+              checked={requirement.required !== false}
+              disabled={disabled}
+              onChange={(event) => onUpdate(index, { required: event.target.checked })}
+              className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+            />
+            Required
+          </label>
+        </div>
+        {requirement.type === 'link' ? (
+          <div className="grid gap-2 rounded-md border border-border bg-surface-2 p-2 sm:grid-cols-[minmax(9rem,0.4fr)_minmax(0,1fr)]">
+            <FormField label="Check">
+              <Select
+                value={linkValidationMode}
+                options={LINK_VALIDATION_OPTIONS}
+                disabled={disabled}
+                onChange={(event) => updateLinkValidationMode(event.target.value as AssignmentLinkValidationMode)}
+              />
+            </FormField>
+            {linkValidationMode === 'expected_domain' ? (
+              <FormField label="Expected domain">
+                <Input
+                  value={expectedDomain}
+                  disabled={disabled}
+                  placeholder="codehs.com"
+                  onChange={(event) => updateExpectedDomain(event.target.value)}
+                />
+              </FormField>
+            ) : null}
+          </div>
+        ) : null}
       </div>
       <div className="flex items-center justify-end gap-1">
         <Tooltip content="Remove">

--- a/src/components/StudentAssignmentSubmissionChecklist.tsx
+++ b/src/components/StudentAssignmentSubmissionChecklist.tsx
@@ -65,6 +65,10 @@ function buildDraftState(
   return next
 }
 
+function normalizeDraftValue(value: string | null | undefined) {
+  return (value ?? '').trim()
+}
+
 export function StudentAssignmentSubmissionChecklist({
   assignmentId,
   requirements,
@@ -170,6 +174,14 @@ export function StudentAssignmentSubmissionChecklist({
           const requirement = item.requirement
           const draft = drafts[requirement.id] ?? { url: '', githubLogin: '' }
           const isSaving = savingRequirementId === requirement.id
+          const savedGithubLogin =
+            typeof item.artifact?.metadata_json?.github_login === 'string'
+              ? item.artifact.metadata_json.github_login
+              : githubIdentity?.github_login ?? ''
+          const hasChanges =
+            normalizeDraftValue(draft.url) !== normalizeDraftValue(item.artifact?.url) ||
+            (requirement.type === 'repo_link' &&
+              normalizeDraftValue(draft.githubLogin) !== normalizeDraftValue(savedGithubLogin))
 
           return (
             <div key={requirement.id} className="grid gap-3 px-4 py-3 lg:grid-cols-[minmax(0,12rem)_minmax(0,1fr)]">
@@ -244,7 +256,7 @@ export function StudentAssignmentSubmissionChecklist({
                     <Button
                       type="button"
                       variant="secondary"
-                      disabled={disabled || isSaving}
+                      disabled={disabled || isSaving || !hasChanges}
                       onClick={() => saveUrlArtifact(requirement)}
                     >
                       {isSaving ? 'Saving...' : 'Save'}

--- a/src/components/StudentAssignmentSubmissionChecklist.tsx
+++ b/src/components/StudentAssignmentSubmissionChecklist.tsx
@@ -31,11 +31,14 @@ function RequirementIcon({ type }: { type: AssignmentSubmissionRequirement['type
 }
 
 function StatusIcon({ item }: { item: ReturnType<typeof getSubmissionRequirementCompletion>['items'][number] }) {
-  if (item.isPresent && !item.isBlocking) {
-    return <CheckCircle2 className="h-4 w-4 text-success" aria-hidden="true" />
-  }
   if (item.artifact?.validation_status === 'pending') {
     return <Loader2 className="h-4 w-4 animate-spin text-text-muted" aria-hidden="true" />
+  }
+  if (item.isPresent && item.artifact?.validation_status === 'valid') {
+    return <CheckCircle2 className="h-4 w-4 text-success" aria-hidden="true" />
+  }
+  if (item.isPresent && !item.artifact?.validation_status) {
+    return <CheckCircle2 className="h-4 w-4 text-success" aria-hidden="true" />
   }
   return <AlertCircle className="h-4 w-4 text-warning" aria-hidden="true" />
 }
@@ -218,7 +221,7 @@ export function StudentAssignmentSubmissionChecklist({
               ) : (
                 <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
                   <div className={requirement.type === 'repo_link' ? 'grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(9rem,0.35fr)]' : ''}>
-                    <FormField label={requirement.type === 'repo_link' ? 'Repository URL' : 'Public URL'}>
+                    <FormField label={requirement.type === 'repo_link' ? 'Repository URL' : 'URL'}>
                       <Input
                         value={draft.url}
                         disabled={disabled || isSaving}

--- a/src/components/TeacherStudentWorkPanel.tsx
+++ b/src/components/TeacherStudentWorkPanel.tsx
@@ -70,7 +70,7 @@ function RequiredSubmissionsList({
   function getArtifactFallbackLabel(artifact: AssignmentArtifact) {
     if (artifact.type === 'repo') return 'Repo link'
     if (artifact.type === 'image') return 'Image'
-    return 'Public link'
+    return 'Link'
   }
 
   function getArtifactKindLabel(artifact: AssignmentArtifact) {

--- a/src/lib/assignment-artifacts.ts
+++ b/src/lib/assignment-artifacts.ts
@@ -10,6 +10,9 @@ export interface AssignmentArtifact {
   is_required_submission?: boolean
   requirement_id?: string
   requirement_required?: boolean
+  validation_status?: 'missing' | 'pending' | 'valid' | 'warning' | 'invalid' | 'inaccessible'
+  validation_message?: string | null
+  validation_level?: string
   repo_owner?: string
   repo_name?: string
   normalized_url?: string

--- a/src/lib/assignment-submission-requirements.ts
+++ b/src/lib/assignment-submission-requirements.ts
@@ -13,9 +13,31 @@ export const ASSIGNMENT_SUBMISSION_REQUIREMENT_TYPES: AssignmentSubmissionRequir
 
 export const DEFAULT_REQUIREMENT_LABELS: Record<AssignmentSubmissionRequirementType, string> = {
   repo_link: 'Repo link',
-  link: 'Public link',
+  link: 'Link',
   image: 'Screenshot',
 }
+
+export type AssignmentLinkValidationMode =
+  | 'format_only'
+  | 'reachable'
+  | 'expected_domain'
+
+export interface AssignmentSubmissionValidationPolicy {
+  mode: AssignmentLinkValidationMode
+  expected_domains: string[]
+}
+
+export const LINK_VALIDATION_MODE_LABELS: Record<AssignmentLinkValidationMode, string> = {
+  format_only: 'Basic URL',
+  reachable: 'Reachable page',
+  expected_domain: 'Expected site',
+}
+
+const LINK_VALIDATION_MODES = new Set<AssignmentLinkValidationMode>([
+  'format_only',
+  'reachable',
+  'expected_domain',
+])
 
 export type AssignmentSubmissionRequirementDraft = {
   id?: string
@@ -25,6 +47,63 @@ export type AssignmentSubmissionRequirementDraft = {
   required?: boolean | null
   position?: number | null
   validation_policy_json?: Record<string, unknown> | null
+}
+
+function normalizeExpectedDomain(value: unknown): string | null {
+  const raw = String(value ?? '').trim().toLowerCase()
+  if (!raw) return null
+
+  const withoutProtocol = raw.replace(/^https?:\/\//, '')
+  const hostname = withoutProtocol.split('/')[0]?.replace(/^www\./, '') ?? ''
+  if (!hostname || hostname.includes(':')) return null
+  if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(hostname)) return null
+  return hostname
+}
+
+export function normalizeAssignmentSubmissionValidationPolicy(
+  type: AssignmentSubmissionRequirementType,
+  policy: Record<string, unknown> | null | undefined
+): AssignmentSubmissionValidationPolicy {
+  if (type !== 'link') {
+    return {
+      mode: 'format_only',
+      expected_domains: [],
+    }
+  }
+
+  const rawMode = typeof policy?.mode === 'string' ? policy.mode : ''
+  const mode = LINK_VALIDATION_MODES.has(rawMode as AssignmentLinkValidationMode)
+    ? rawMode as AssignmentLinkValidationMode
+    : 'format_only'
+  const expectedDomains = Array.isArray(policy?.expected_domains)
+    ? policy.expected_domains
+        .map(normalizeExpectedDomain)
+        .filter((domain): domain is string => Boolean(domain))
+    : []
+
+  return {
+    mode: mode === 'expected_domain' && expectedDomains.length === 0 ? 'format_only' : mode,
+    expected_domains: Array.from(new Set(expectedDomains)),
+  }
+}
+
+export function buildAssignmentSubmissionValidationPolicyJson(
+  type: AssignmentSubmissionRequirementType,
+  policy: Partial<AssignmentSubmissionValidationPolicy>
+): Record<string, unknown> {
+  const normalized = normalizeAssignmentSubmissionValidationPolicy(type, {
+    mode: policy.mode,
+    expected_domains: policy.expected_domains,
+  })
+
+  if (type !== 'link' || normalized.mode === 'format_only') return {}
+
+  return {
+    mode: normalized.mode,
+    ...(normalized.expected_domains.length > 0
+      ? { expected_domains: normalized.expected_domains }
+      : {}),
+  }
 }
 
 export type SubmissionRequirementCompletionItem = {
@@ -66,7 +145,10 @@ export function normalizeAssignmentSubmissionRequirementDrafts(
         instructions: draft.instructions?.trim() || '',
         required: draft.required !== false,
         position,
-        validation_policy_json: draft.validation_policy_json ?? {},
+        validation_policy_json: buildAssignmentSubmissionValidationPolicyJson(
+          draft.type,
+          normalizeAssignmentSubmissionValidationPolicy(draft.type, draft.validation_policy_json)
+        ),
       }
     })
 }
@@ -98,9 +180,9 @@ export function getSubmissionArtifactStatusLabel(
 
   switch (artifact.validation_status) {
     case 'valid':
-      return 'Checked'
+      return artifact.metadata_json?.validation_level === 'verified' ? 'Verified' : 'Saved'
     case 'warning':
-      return 'Warning'
+      return 'Needs review'
     case 'inaccessible':
       return 'Needs review'
     case 'pending':
@@ -168,11 +250,18 @@ function getRequirementArtifactFields(
   artifact: AssignmentSubmissionArtifact,
   requirement?: AssignmentSubmissionRequirement | null
 ) {
+  const validationLevel = typeof artifact.metadata_json?.validation_level === 'string'
+    ? artifact.metadata_json.validation_level
+    : undefined
+
   return {
     title: requirement?.label?.trim() || DEFAULT_REQUIREMENT_LABELS[artifact.type],
     is_required_submission: requirement?.required ?? true,
     requirement_id: artifact.requirement_id,
     requirement_required: requirement?.required ?? true,
+    validation_status: artifact.validation_status,
+    validation_message: artifact.validation_message,
+    ...(validationLevel ? { validation_level: validationLevel } : {}),
   }
 }
 

--- a/src/lib/server/assignment-submission-validation.ts
+++ b/src/lib/server/assignment-submission-validation.ts
@@ -1,5 +1,8 @@
 import { isIP } from 'node:net'
 import { lookup } from 'node:dns/promises'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import type { IncomingMessage, RequestOptions } from 'node:http'
 import { parseGitHubRepoReference } from '@/lib/github-repos'
 import {
   normalizeAssignmentSubmissionValidationPolicy,
@@ -35,8 +38,14 @@ type LinkReachabilityResult = {
 }
 
 type PublicResolutionResult =
-  | { ok: true }
+  | { ok: true; address: string; family: 4 | 6 }
   | { ok: false; error: string }
+
+type BoundedHttpResponse = {
+  status: number
+  location: string | null
+  body: string
+}
 
 export function getGitHubIdentityValidationFromArtifact(
   validation: ArtifactValidationResult
@@ -181,8 +190,13 @@ async function validatePublicUrlResolution(url: string): Promise<PublicResolutio
     return { ok: false, error: 'Enter a public http or https URL.' }
   }
 
-  if (isIP(normalizeHostnameForIpCheck(hostname)) !== 0) {
-    return { ok: true }
+  const literalIpVersion = isIP(normalizeHostnameForIpCheck(hostname))
+  if (literalIpVersion === 4 || literalIpVersion === 6) {
+    return {
+      ok: true,
+      address: normalizeHostnameForIpCheck(hostname),
+      family: literalIpVersion,
+    }
   }
 
   try {
@@ -193,7 +207,15 @@ async function validatePublicUrlResolution(url: string): Promise<PublicResolutio
     if (addresses.some((address) => isBlockedIpAddress(address.address))) {
       return { ok: false, error: 'Enter a public http or https URL.' }
     }
-    return { ok: true }
+    const selectedAddress = addresses.find((address) => address.family === 4 || address.family === 6)
+    if (!selectedAddress || (selectedAddress.family !== 4 && selectedAddress.family !== 6)) {
+      return { ok: false, error: 'Pika could not resolve this link right now.' }
+    }
+    return {
+      ok: true,
+      address: selectedAddress.address,
+      family: selectedAddress.family,
+    }
   } catch {
     return { ok: false, error: 'Pika could not resolve this link right now.' }
   }
@@ -244,24 +266,84 @@ function isLoginLikePage(url: string, html: string): boolean {
   return loginSignals.some((signal) => haystack.includes(signal))
 }
 
-async function readSmallResponseBody(response: Response): Promise<string> {
-  if (!response.body) return ''
-  const reader = response.body.getReader()
-  const chunks: Uint8Array[] = []
+async function readSmallResponseBody(response: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
   let total = 0
 
-  try {
-    while (total < LINK_VALIDATION_MAX_BODY_CHARS) {
-      const result = await reader.read()
-      if (result.done) break
-      chunks.push(result.value)
-      total += result.value.byteLength
-    }
-  } finally {
-    reader.cancel().catch(() => {})
+  return await new Promise((resolve, reject) => {
+    response.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      if (total < LINK_VALIDATION_MAX_BODY_CHARS) {
+        const remaining = LINK_VALIDATION_MAX_BODY_CHARS - total
+        chunks.push(buffer.subarray(0, remaining))
+        total += Math.min(buffer.byteLength, remaining)
+      }
+      if (total >= LINK_VALIDATION_MAX_BODY_CHARS) {
+        response.destroy()
+        resolve(Buffer.concat(chunks).subarray(0, LINK_VALIDATION_MAX_BODY_CHARS).toString('utf8'))
+      }
+    })
+    response.on('end', () => {
+      resolve(Buffer.concat(chunks).subarray(0, LINK_VALIDATION_MAX_BODY_CHARS).toString('utf8'))
+    })
+    response.on('error', (error) => {
+      if (total >= LINK_VALIDATION_MAX_BODY_CHARS) return
+      reject(error)
+    })
+  })
+}
+
+async function requestSmallPublicUrl(
+  url: string,
+  resolution: Extract<PublicResolutionResult, { ok: true }>
+): Promise<BoundedHttpResponse> {
+  const parsed = new URL(url)
+  const isHttps = parsed.protocol === 'https:'
+  const request = isHttps ? httpsRequest : httpRequest
+  const options: RequestOptions = {
+    protocol: parsed.protocol,
+    hostname: resolution.address,
+    family: resolution.family,
+    port: parsed.port ? Number(parsed.port) : isHttps ? 443 : 80,
+    path: `${parsed.pathname}${parsed.search}`,
+    method: 'GET',
+    headers: {
+      Host: parsed.host,
+      Accept: 'text/html,application/xhtml+xml,text/plain;q=0.8,*/*;q=0.4',
+      Range: `bytes=0-${LINK_VALIDATION_MAX_BODY_CHARS - 1}`,
+    },
+    timeout: LINK_VALIDATION_TIMEOUT_MS,
+    ...(isHttps ? { servername: parsed.hostname } : {}),
   }
 
-  return new TextDecoder().decode(Buffer.concat(chunks).subarray(0, LINK_VALIDATION_MAX_BODY_CHARS))
+  return await new Promise((resolve, reject) => {
+    const req = request(options, async (response) => {
+      const status = response.statusCode ?? 0
+      const locationHeader = response.headers.location
+      const location = Array.isArray(locationHeader) ? locationHeader[0] ?? null : locationHeader ?? null
+
+      if (status >= 300 && status < 400) {
+        response.resume()
+        resolve({ status, location, body: '' })
+        return
+      }
+
+      try {
+        const body = await readSmallResponseBody(response)
+        resolve({ status, location, body })
+      } catch (error) {
+        reject(error)
+      }
+    })
+
+    req.on('timeout', () => {
+      const error = new Error('Request timed out')
+      error.name = 'TimeoutError'
+      req.destroy(error)
+    })
+    req.on('error', reject)
+    req.end()
+  })
 }
 
 async function checkPublicLinkReachability(url: string): Promise<LinkReachabilityResult> {
@@ -281,19 +363,10 @@ async function checkPublicLinkReachability(url: string): Promise<LinkReachabilit
     }
 
     try {
-      const response = await fetch(currentUrl, {
-        method: 'GET',
-        redirect: 'manual',
-        cache: 'no-store',
-        signal: AbortSignal.timeout(LINK_VALIDATION_TIMEOUT_MS),
-        headers: {
-          Accept: 'text/html,application/xhtml+xml,text/plain;q=0.8,*/*;q=0.4',
-          Range: `bytes=0-${LINK_VALIDATION_MAX_BODY_CHARS - 1}`,
-        },
-      })
+      const response = await requestSmallPublicUrl(currentUrl, resolution)
 
       if (response.status >= 300 && response.status < 400) {
-        const nextUrl = resolveRedirectUrl(currentUrl, response.headers.get('location'))
+        const nextUrl = resolveRedirectUrl(currentUrl, response.location)
         if (!nextUrl) {
           return {
             ok: false,
@@ -308,14 +381,13 @@ async function checkPublicLinkReachability(url: string): Promise<LinkReachabilit
         continue
       }
 
-      const body = await readSmallResponseBody(response)
       return {
-        ok: response.ok,
+        ok: response.status >= 200 && response.status < 300,
         finalUrl: currentUrl,
         status: response.status,
-        title: getHtmlTitle(body),
-        loginLike: isLoginLikePage(currentUrl, body),
-        error: response.ok ? null : `Page returned HTTP ${response.status}.`,
+        title: getHtmlTitle(response.body),
+        loginLike: isLoginLikePage(currentUrl, response.body),
+        error: response.status >= 200 && response.status < 300 ? null : `Page returned HTTP ${response.status}.`,
       }
     } catch (error) {
       return {

--- a/src/lib/server/assignment-submission-validation.ts
+++ b/src/lib/server/assignment-submission-validation.ts
@@ -1,5 +1,10 @@
 import { isIP } from 'node:net'
+import { lookup } from 'node:dns/promises'
 import { parseGitHubRepoReference } from '@/lib/github-repos'
+import {
+  normalizeAssignmentSubmissionValidationPolicy,
+  type AssignmentSubmissionValidationPolicy,
+} from '@/lib/assignment-submission-requirements'
 import { validatePublicGitHubRepo } from '@/lib/server/assignment-repo-targets'
 import type {
   AssignmentArtifactValidationStatus,
@@ -7,6 +12,9 @@ import type {
 } from '@/types'
 
 const GITHUB_API_BASE = 'https://api.github.com'
+const LINK_VALIDATION_TIMEOUT_MS = 3500
+const LINK_VALIDATION_REDIRECT_LIMIT = 3
+const LINK_VALIDATION_MAX_BODY_CHARS = 24_000
 
 export type ArtifactValidationResult = {
   validation_status: AssignmentArtifactValidationStatus
@@ -16,6 +24,19 @@ export type ArtifactValidationResult = {
   github_login_validation_status?: 'valid' | 'invalid' | 'inaccessible'
   github_login_validation_message?: string | null
 }
+
+type LinkReachabilityResult = {
+  ok: boolean
+  finalUrl: string
+  status: number | null
+  title: string | null
+  loginLike: boolean
+  error: string | null
+}
+
+type PublicResolutionResult =
+  | { ok: true }
+  | { ok: false; error: string }
 
 export function getGitHubIdentityValidationFromArtifact(
   validation: ArtifactValidationResult
@@ -148,6 +169,178 @@ export function normalizePublicUrl(value: string | null | undefined): string | n
   }
 }
 
+async function validatePublicUrlResolution(url: string): Promise<PublicResolutionResult> {
+  let hostname = ''
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    return { ok: false, error: 'Enter a public http or https URL.' }
+  }
+
+  if (isBlockedPublicLinkHostname(hostname)) {
+    return { ok: false, error: 'Enter a public http or https URL.' }
+  }
+
+  if (isIP(normalizeHostnameForIpCheck(hostname)) !== 0) {
+    return { ok: true }
+  }
+
+  try {
+    const addresses = await lookup(hostname, { all: true, verbatim: true })
+    if (addresses.length === 0) {
+      return { ok: false, error: 'Pika could not resolve this link right now.' }
+    }
+    if (addresses.some((address) => isBlockedIpAddress(address.address))) {
+      return { ok: false, error: 'Enter a public http or https URL.' }
+    }
+    return { ok: true }
+  } catch {
+    return { ok: false, error: 'Pika could not resolve this link right now.' }
+  }
+}
+
+function getComparableHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, '')
+  } catch {
+    return null
+  }
+}
+
+function hostnameMatchesExpected(hostname: string, expectedDomains: string[]): boolean {
+  const comparable = hostname.toLowerCase().replace(/^www\./, '')
+  return expectedDomains.some((domain) => comparable === domain || comparable.endsWith(`.${domain}`))
+}
+
+function resolveRedirectUrl(currentUrl: string, location: string | null): string | null {
+  if (!location) return null
+
+  try {
+    return normalizePublicUrl(new URL(location, currentUrl).href)
+  } catch {
+    return null
+  }
+}
+
+function getHtmlTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  if (!match?.[1]) return null
+  return match[1].replace(/\s+/g, ' ').trim().slice(0, 140) || null
+}
+
+function isLoginLikePage(url: string, html: string): boolean {
+  const haystack = `${url}\n${html.slice(0, LINK_VALIDATION_MAX_BODY_CHARS)}`.toLowerCase()
+  const loginSignals = [
+    'sign in',
+    'signin',
+    'log in',
+    'login',
+    'password',
+    'authentication required',
+    'access denied',
+    'permission denied',
+    'private',
+  ]
+  return loginSignals.some((signal) => haystack.includes(signal))
+}
+
+async function readSmallResponseBody(response: Response): Promise<string> {
+  if (!response.body) return ''
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  try {
+    while (total < LINK_VALIDATION_MAX_BODY_CHARS) {
+      const result = await reader.read()
+      if (result.done) break
+      chunks.push(result.value)
+      total += result.value.byteLength
+    }
+  } finally {
+    reader.cancel().catch(() => {})
+  }
+
+  return new TextDecoder().decode(Buffer.concat(chunks).subarray(0, LINK_VALIDATION_MAX_BODY_CHARS))
+}
+
+async function checkPublicLinkReachability(url: string): Promise<LinkReachabilityResult> {
+  let currentUrl = url
+
+  for (let redirectCount = 0; redirectCount <= LINK_VALIDATION_REDIRECT_LIMIT; redirectCount += 1) {
+    const resolution = await validatePublicUrlResolution(currentUrl)
+    if (!resolution.ok) {
+      return {
+        ok: false,
+        finalUrl: currentUrl,
+        status: null,
+        title: null,
+        loginLike: false,
+        error: resolution.error,
+      }
+    }
+
+    try {
+      const response = await fetch(currentUrl, {
+        method: 'GET',
+        redirect: 'manual',
+        cache: 'no-store',
+        signal: AbortSignal.timeout(LINK_VALIDATION_TIMEOUT_MS),
+        headers: {
+          Accept: 'text/html,application/xhtml+xml,text/plain;q=0.8,*/*;q=0.4',
+          Range: `bytes=0-${LINK_VALIDATION_MAX_BODY_CHARS - 1}`,
+        },
+      })
+
+      if (response.status >= 300 && response.status < 400) {
+        const nextUrl = resolveRedirectUrl(currentUrl, response.headers.get('location'))
+        if (!nextUrl) {
+          return {
+            ok: false,
+            finalUrl: currentUrl,
+            status: response.status,
+            title: null,
+            loginLike: false,
+            error: 'Redirect target is not a public URL.',
+          }
+        }
+        currentUrl = nextUrl
+        continue
+      }
+
+      const body = await readSmallResponseBody(response)
+      return {
+        ok: response.ok,
+        finalUrl: currentUrl,
+        status: response.status,
+        title: getHtmlTitle(body),
+        loginLike: isLoginLikePage(currentUrl, body),
+        error: response.ok ? null : `Page returned HTTP ${response.status}.`,
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        finalUrl: currentUrl,
+        status: null,
+        title: null,
+        loginLike: false,
+        error: error instanceof Error && error.name === 'TimeoutError'
+          ? 'Pika could not reach this link before the check timed out.'
+          : 'Pika could not reach this link right now.',
+      }
+    }
+  }
+
+  return {
+    ok: false,
+    finalUrl: currentUrl,
+    status: null,
+    title: null,
+    loginLike: false,
+    error: 'Link redirected too many times.',
+  }
+}
+
 function getGitHubToken(): string | null {
   const key = process.env.GITHUB_PAT?.trim() || process.env.GITHUB_FEEDBACK_TOKEN?.trim() || ''
   return key || null
@@ -199,6 +392,7 @@ export async function validateAssignmentSubmissionArtifactValue(opts: {
   url?: string | null
   storagePath?: string | null
   githubLogin?: string | null
+  validationPolicy?: Record<string, unknown> | null
 }): Promise<ArtifactValidationResult> {
   if (opts.type === 'image') {
     if (!opts.storagePath?.trim()) {
@@ -284,10 +478,87 @@ export async function validateAssignmentSubmissionArtifactValue(opts: {
     }
   }
 
+  const policy: AssignmentSubmissionValidationPolicy = normalizeAssignmentSubmissionValidationPolicy(
+    opts.type,
+    opts.validationPolicy
+  )
+  if (policy.mode === 'format_only') {
+    return {
+      validation_status: 'valid',
+      validation_message: null,
+      metadata_json: {
+        validation: 'format_only',
+        validation_level: 'format_only',
+      },
+      normalized_url: normalizedUrl,
+    }
+  }
+
+  const initialHostname = getComparableHostname(normalizedUrl)
+  if (policy.mode === 'expected_domain' && initialHostname && !hostnameMatchesExpected(initialHostname, policy.expected_domains)) {
+    return {
+      validation_status: 'invalid',
+      validation_message: `Link must point to ${policy.expected_domains.join(' or ')}.`,
+      metadata_json: {
+        validation: policy.mode,
+        validation_level: 'format_only',
+        checked_host: initialHostname,
+        expected_domains: policy.expected_domains,
+      },
+      normalized_url: normalizedUrl,
+    }
+  }
+
+  const reachability = await checkPublicLinkReachability(normalizedUrl)
+  const finalHostname = getComparableHostname(reachability.finalUrl)
+  const metadata = {
+    validation: policy.mode,
+    validation_level: 'verified',
+    final_url: reachability.finalUrl,
+    checked_host: finalHostname,
+    http_status: reachability.status,
+    page_title: reachability.title,
+    expected_domains: policy.expected_domains,
+  }
+
+  if (policy.mode === 'expected_domain' && finalHostname && !hostnameMatchesExpected(finalHostname, policy.expected_domains)) {
+    return {
+      validation_status: 'invalid',
+      validation_message: `Link must point to ${policy.expected_domains.join(' or ')}.`,
+      metadata_json: metadata,
+      normalized_url: normalizedUrl,
+    }
+  }
+
+  if (!reachability.ok) {
+    return {
+      validation_status: 'warning',
+      validation_message: reachability.error ?? 'Pika could not verify this link right now.',
+      metadata_json: {
+        ...metadata,
+        validation_level: 'review',
+      },
+      normalized_url: normalizedUrl,
+    }
+  }
+
+  if (reachability.loginLike) {
+    return {
+      validation_status: 'warning',
+      validation_message: 'This page may require login or extra access. Your teacher may need to review it.',
+      metadata_json: {
+        ...metadata,
+        validation_level: 'review',
+        login_like: true,
+      },
+      normalized_url: normalizedUrl,
+    }
+  }
+
   return {
     validation_status: 'valid',
     validation_message: null,
-    metadata_json: { validation: 'format_only' },
+    metadata_json: metadata,
     normalized_url: normalizedUrl,
   }
 }

--- a/tests/api/teacher/assignments-id.test.ts
+++ b/tests/api/teacher/assignments-id.test.ts
@@ -462,6 +462,8 @@ describe('GET /api/teacher/assignments/[id]', () => {
         is_required_submission: true,
         requirement_id: 'req-1',
         requirement_required: true,
+        validation_status: 'valid',
+        validation_message: null,
       },
       {
         type: 'link',
@@ -470,6 +472,8 @@ describe('GET /api/teacher/assignments/[id]', () => {
         is_required_submission: true,
         requirement_id: 'req-2',
         requirement_required: true,
+        validation_status: 'valid',
+        validation_message: null,
       },
       {
         type: 'repo',
@@ -478,6 +482,8 @@ describe('GET /api/teacher/assignments/[id]', () => {
         is_required_submission: true,
         requirement_id: 'req-3',
         requirement_required: true,
+        validation_status: 'valid',
+        validation_message: null,
         repo_owner: 'codepetca',
         repo_name: 'pika',
         normalized_url: 'https://github.com/codepetca/pika',

--- a/tests/components/AssignmentModal.test.tsx
+++ b/tests/components/AssignmentModal.test.tsx
@@ -184,7 +184,8 @@ describe('AssignmentModal', () => {
       expect(screen.getByRole('menuitem', { name: 'Link' })).toHaveTextContent('+')
       fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
 
-      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+      expect(requirementsGroup.getByDisplayValue('Link')).toBeInTheDocument()
+      expect(requirementsGroup.getByLabelText('Check')).toHaveValue('format_only')
       expect(requirementsGroup.getByPlaceholderText('Optional helper text')).toBeInTheDocument()
       expect(requirementsGroup.queryByText('1 item')).not.toBeInTheDocument()
       expect(requirementsGroup.queryByRole('button', { name: 'Move requirement up' })).not.toBeInTheDocument()
@@ -239,7 +240,7 @@ describe('AssignmentModal', () => {
                 id: 'requirement-link',
                 assignment_id: baseAssignment.id,
                 type: 'link',
-                label: 'Public link',
+                label: 'Link',
                 instructions: '',
                 required: true,
                 position: 0,
@@ -253,7 +254,7 @@ describe('AssignmentModal', () => {
         await Promise.resolve()
       })
 
-      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+      expect(requirementsGroup.getByDisplayValue('Link')).toBeInTheDocument()
       expect(requirementsGroup.getByDisplayValue('Repo link')).toBeInTheDocument()
       expect(screen.getByText('Unsaved')).toBeInTheDocument()
     })
@@ -269,7 +270,7 @@ describe('AssignmentModal', () => {
               id: 'requirement-link',
               assignment_id: baseAssignment.id,
               type: 'link',
-              label: 'Public link',
+              label: 'Link',
               instructions: '',
               required: true,
               position: 0,
@@ -287,19 +288,50 @@ describe('AssignmentModal', () => {
       fireEvent.click(requirementsGroup.getByRole('button', { name: 'Remove requirement' }))
 
       let dialog = screen.getByRole('dialog', { name: 'Remove required submission?' })
-      expect(within(dialog).getByText('This removes "Public link" from the assignment.')).toBeInTheDocument()
+      expect(within(dialog).getByText('This removes "Link" from the assignment.')).toBeInTheDocument()
 
       fireEvent.click(within(dialog).getByRole('button', { name: 'Keep' }))
       expect(screen.queryByRole('dialog', { name: 'Remove required submission?' })).not.toBeInTheDocument()
-      expect(requirementsGroup.getByDisplayValue('Public link')).toBeInTheDocument()
+      expect(requirementsGroup.getByDisplayValue('Link')).toBeInTheDocument()
 
       fireEvent.click(requirementsGroup.getByRole('button', { name: 'Remove requirement' }))
       dialog = screen.getByRole('dialog', { name: 'Remove required submission?' })
       fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }))
 
       expect(screen.queryByRole('dialog', { name: 'Remove required submission?' })).not.toBeInTheDocument()
-      expect(requirementsGroup.queryByDisplayValue('Public link')).not.toBeInTheDocument()
+      expect(requirementsGroup.queryByDisplayValue('Link')).not.toBeInTheDocument()
       expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    })
+
+    it('stores expected-domain policy for link submissions without adding setup friction for other types', () => {
+      render(
+        <AssignmentModal
+          isOpen={true}
+          classroomId="classroom-1"
+          assignment={baseAssignment}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      )
+
+      const requirementsGroup = within(screen.getByRole('group', { name: 'Required submissions' }))
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Add submission' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Link' }))
+
+      fireEvent.change(requirementsGroup.getByLabelText('Check'), {
+        target: { value: 'expected_domain' },
+      })
+      fireEvent.change(requirementsGroup.getByLabelText('Expected domain'), {
+        target: { value: 'codehs.com' },
+      })
+
+      fireEvent.click(requirementsGroup.getByRole('button', { name: 'Choose submission type' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Repo' }))
+
+      expect(requirementsGroup.getByLabelText('Check')).toHaveValue('expected_domain')
+      expect(requirementsGroup.getByLabelText('Expected domain')).toHaveValue('codehs.com')
+      expect(requirementsGroup.getAllByDisplayValue('Repo link')).toHaveLength(1)
+      expect(requirementsGroup.getAllByLabelText('Check')).toHaveLength(1)
     })
 
     it('shows save status indicator', () => {

--- a/tests/components/StudentAssignmentSubmissionChecklist.test.tsx
+++ b/tests/components/StudentAssignmentSubmissionChecklist.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { StudentAssignmentSubmissionChecklist } from '@/components/StudentAssignmentSubmissionChecklist'
 import type {
@@ -62,6 +62,56 @@ describe('StudentAssignmentSubmissionChecklist', () => {
     expect(screen.getByLabelText('URL')).toBeInTheDocument()
     expect(screen.queryByLabelText('Public URL')).not.toBeInTheDocument()
     expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('disables saving an unchanged link until the student edits it', () => {
+    render(
+      <StudentAssignmentSubmissionChecklist
+        assignmentId="assignment-1"
+        requirements={[requirement({})]}
+        artifacts={[artifact({})]}
+        githubIdentity={null}
+        onArtifactsChange={vi.fn()}
+        onError={vi.fn()}
+      />
+    )
+
+    const urlInput = screen.getByLabelText('URL')
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.change(urlInput, { target: { value: 'https://codehs.com/sandbox/updated' } })
+
+    expect(saveButton).toBeEnabled()
+  })
+
+  it('enables saving a repo link when the GitHub username changes', () => {
+    render(
+      <StudentAssignmentSubmissionChecklist
+        assignmentId="assignment-1"
+        requirements={[requirement({
+          type: 'repo_link',
+          label: 'Project repo',
+        })]}
+        artifacts={[artifact({
+          type: 'repo_link',
+          metadata_json: { github_login: 'saved-user' },
+        })]}
+        githubIdentity={{ github_id: 1234, github_login: 'saved-user' }}
+        onArtifactsChange={vi.fn()}
+        onError={vi.fn()}
+      />
+    )
+
+    const githubInput = screen.getByLabelText('GitHub username')
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.change(githubInput, { target: { value: 'updated-user' } })
+
+    expect(saveButton).toBeEnabled()
   })
 
   it('shows policy warning results as needs review without removing the saved URL', () => {

--- a/tests/components/StudentAssignmentSubmissionChecklist.test.tsx
+++ b/tests/components/StudentAssignmentSubmissionChecklist.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { StudentAssignmentSubmissionChecklist } from '@/components/StudentAssignmentSubmissionChecklist'
+import type {
+  AssignmentSubmissionArtifact,
+  AssignmentSubmissionRequirement,
+} from '@/types'
+
+function requirement(
+  overrides: Partial<AssignmentSubmissionRequirement>
+): AssignmentSubmissionRequirement {
+  return {
+    id: overrides.id ?? 'req-link',
+    assignment_id: 'assignment-1',
+    type: overrides.type ?? 'link',
+    label: overrides.label ?? 'CodeHS public view',
+    instructions: overrides.instructions ?? '',
+    required: overrides.required ?? true,
+    position: overrides.position ?? 0,
+    validation_policy_json: overrides.validation_policy_json ?? {},
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+  }
+}
+
+function artifact(
+  overrides: Partial<AssignmentSubmissionArtifact>
+): AssignmentSubmissionArtifact {
+  return {
+    id: overrides.id ?? 'artifact-1',
+    assignment_doc_id: 'doc-1',
+    requirement_id: overrides.requirement_id ?? 'req-link',
+    student_id: 'student-1',
+    type: overrides.type ?? 'link',
+    url: overrides.url ?? 'https://codehs.com/sandbox/example',
+    storage_path: overrides.storage_path ?? null,
+    metadata_json: overrides.metadata_json ?? {},
+    validation_status: overrides.validation_status ?? 'valid',
+    validation_message: overrides.validation_message ?? null,
+    validated_at: '2026-06-01T00:00:00.000Z',
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+  }
+}
+
+describe('StudentAssignmentSubmissionChecklist', () => {
+  it('uses the teacher label and generic URL copy for link requirements', () => {
+    render(
+      <StudentAssignmentSubmissionChecklist
+        assignmentId="assignment-1"
+        requirements={[requirement({})]}
+        artifacts={[artifact({
+          metadata_json: { validation_level: 'format_only' },
+        })]}
+        githubIdentity={null}
+        onArtifactsChange={vi.fn()}
+        onError={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('CodeHS public view')).toBeInTheDocument()
+    expect(screen.getByLabelText('URL')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Public URL')).not.toBeInTheDocument()
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('shows policy warning results as needs review without removing the saved URL', () => {
+    render(
+      <StudentAssignmentSubmissionChecklist
+        assignmentId="assignment-1"
+        requirements={[requirement({})]}
+        artifacts={[artifact({
+          validation_status: 'warning',
+          validation_message: 'This page may require login.',
+          metadata_json: { validation_level: 'review' },
+        })]}
+        githubIdentity={null}
+        onArtifactsChange={vi.fn()}
+        onError={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Needs review')).toBeInTheDocument()
+    expect(screen.getByText('This page may require login.')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('https://codehs.com/sandbox/example')).toBeInTheDocument()
+  })
+})

--- a/tests/lib/assignment-submission-requirements.test.ts
+++ b/tests/lib/assignment-submission-requirements.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   getSubmissionRequirementCompletion,
+  getSubmissionArtifactStatusLabel,
+  normalizeAssignmentSubmissionValidationPolicy,
   normalizeAssignmentSubmissionRequirementDrafts,
   submissionArtifactsToAssignmentArtifacts,
 } from '@/lib/assignment-submission-requirements'
@@ -16,7 +18,7 @@ function requirement(
     id: overrides.id ?? 'req-1',
     assignment_id: 'assignment-1',
     type: overrides.type ?? 'link',
-    label: overrides.label ?? 'Public link',
+    label: overrides.label ?? 'Link',
     instructions: overrides.instructions ?? '',
     required: overrides.required ?? true,
     position: overrides.position ?? 0,
@@ -72,6 +74,31 @@ describe('normalizeAssignmentSubmissionRequirementDrafts', () => {
       },
     ])
   })
+
+  it('normalizes link validation policy without requiring a migration', () => {
+    expect(normalizeAssignmentSubmissionValidationPolicy('link', {
+      mode: 'expected_domain',
+      expected_domains: [' https://www.CodeHS.com/sandbox ', 'codehs.com'],
+    })).toEqual({
+      mode: 'expected_domain',
+      expected_domains: ['codehs.com'],
+    })
+
+    expect(normalizeAssignmentSubmissionValidationPolicy('link', {
+      mode: 'expected_domain',
+      expected_domains: [],
+    })).toEqual({
+      mode: 'format_only',
+      expected_domains: [],
+    })
+
+    expect(normalizeAssignmentSubmissionValidationPolicy('repo_link', {
+      mode: 'reachable',
+    })).toEqual({
+      mode: 'format_only',
+      expected_domains: [],
+    })
+  })
 })
 
 describe('getSubmissionRequirementCompletion', () => {
@@ -108,6 +135,22 @@ describe('getSubmissionRequirementCompletion', () => {
     expect(invalidCompletion.canSubmit).toBe(false)
     expect(invalidCompletion.blockingRequirementIds).toEqual(['req-1'])
   })
+
+  it('labels format-only links as saved and verified links as verified', () => {
+    expect(getSubmissionArtifactStatusLabel(artifact({
+      validation_status: 'valid',
+      metadata_json: { validation_level: 'format_only' },
+    }))).toBe('Saved')
+
+    expect(getSubmissionArtifactStatusLabel(artifact({
+      validation_status: 'valid',
+      metadata_json: { validation_level: 'verified' },
+    }))).toBe('Verified')
+
+    expect(getSubmissionArtifactStatusLabel(artifact({
+      validation_status: 'warning',
+    }))).toBe('Needs review')
+  })
 })
 
 describe('submissionArtifactsToAssignmentArtifacts', () => {
@@ -137,6 +180,8 @@ describe('submissionArtifactsToAssignmentArtifacts', () => {
         is_required_submission: true,
         requirement_id: 'req-1',
         requirement_required: true,
+        validation_status: 'valid',
+        validation_message: null,
         repo_owner: 'codepetca',
         repo_name: 'pika',
         normalized_url: 'https://github.com/codepetca/pika',
@@ -148,6 +193,8 @@ describe('submissionArtifactsToAssignmentArtifacts', () => {
         is_required_submission: true,
         requirement_id: 'req-2',
         requirement_required: true,
+        validation_status: 'valid',
+        validation_message: null,
       },
     ])
   })
@@ -174,6 +221,8 @@ describe('submissionArtifactsToAssignmentArtifacts', () => {
         is_required_submission: false,
         requirement_id: 'req-demo',
         requirement_required: false,
+        validation_status: 'valid',
+        validation_message: null,
       },
     ])
   })

--- a/tests/unit/assignment-submission-validation.test.ts
+++ b/tests/unit/assignment-submission-validation.test.ts
@@ -7,6 +7,17 @@ import {
   validateAssignmentSubmissionArtifactValue,
 } from '@/lib/server/assignment-submission-validation'
 
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+}))
+
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsMocks.lookup,
+  default: {
+    lookup: dnsMocks.lookup,
+  },
+}))
+
 vi.mock('@/lib/server/assignment-repo-targets', () => ({
   validatePublicGitHubRepo: vi.fn(async (repoUrl: string) => ({
     repoUrl: 'https://github.com/codepetca/pika',
@@ -93,9 +104,104 @@ describe('assignment submission validation helpers', () => {
     expect(result).toEqual({
       validation_status: 'valid',
       validation_message: null,
-      metadata_json: { validation: 'format_only' },
+      metadata_json: {
+        validation: 'format_only',
+        validation_level: 'format_only',
+      },
       normalized_url: 'https://example.com/missing',
     })
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('verifies reachable links when the teacher asks for a page check', async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('<title>Student Project</title>', {
+      status: 200,
+    })))
+
+    const result = await validateAssignmentSubmissionArtifactValue({
+      type: 'link',
+      url: 'https://example.com/project',
+      validationPolicy: { mode: 'reachable' },
+    })
+
+    expect(result.validation_status).toBe('valid')
+    expect(result.validation_message).toBeNull()
+    expect(result.metadata_json).toMatchObject({
+      validation: 'reachable',
+      validation_level: 'verified',
+      final_url: 'https://example.com/project',
+      checked_host: 'example.com',
+      http_status: 200,
+      page_title: 'Student Project',
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  it('flags expected-domain links when the final host does not match', async () => {
+    const fetchSpy = vi.fn(async () => new Response('<title>Wrong site</title>', {
+      status: 200,
+    }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await validateAssignmentSubmissionArtifactValue({
+      type: 'link',
+      url: 'https://example.com/project',
+      validationPolicy: {
+        mode: 'expected_domain',
+        expected_domains: ['codehs.com'],
+      },
+    })
+
+    expect(result).toMatchObject({
+      validation_status: 'invalid',
+      validation_message: 'Link must point to codehs.com.',
+      normalized_url: 'https://example.com/project',
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+
+  it('marks unreachable policy-checked links for teacher review instead of blocking as inaccessible', async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('Not found', {
+      status: 404,
+    })))
+
+    const result = await validateAssignmentSubmissionArtifactValue({
+      type: 'link',
+      url: 'https://example.com/missing',
+      validationPolicy: { mode: 'reachable' },
+    })
+
+    expect(result.validation_status).toBe('warning')
+    expect(result.validation_message).toBe('Page returned HTTP 404.')
+    expect(result.metadata_json).toMatchObject({
+      validation: 'reachable',
+      validation_level: 'review',
+      http_status: 404,
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  it('does not fetch policy-checked links that resolve to private addresses', async () => {
+    const fetchSpy = vi.fn()
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }])
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await validateAssignmentSubmissionArtifactValue({
+      type: 'link',
+      url: 'https://internal.example.com/project',
+      validationPolicy: { mode: 'reachable' },
+    })
+
+    expect(result.validation_status).toBe('warning')
+    expect(result.validation_message).toBe('Enter a public http or https URL.')
     expect(fetchSpy).not.toHaveBeenCalled()
 
     vi.unstubAllGlobals()

--- a/tests/unit/assignment-submission-validation.test.ts
+++ b/tests/unit/assignment-submission-validation.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getGitHubIdentityValidationFromArtifact,
   isBlockedPublicLinkHostname,
@@ -11,12 +12,41 @@ const dnsMocks = vi.hoisted(() => ({
   lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
 }))
 
+const requestMocks = vi.hoisted(() => ({
+  httpRequest: vi.fn(),
+  httpsRequest: vi.fn(),
+}))
+
 vi.mock('node:dns/promises', () => ({
   lookup: dnsMocks.lookup,
   default: {
     lookup: dnsMocks.lookup,
   },
 }))
+
+vi.mock('node:http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:http')>()
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      request: requestMocks.httpRequest,
+    },
+    request: requestMocks.httpRequest,
+  }
+})
+
+vi.mock('node:https', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:https')>()
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      request: requestMocks.httpsRequest,
+    },
+    request: requestMocks.httpsRequest,
+  }
+})
 
 vi.mock('@/lib/server/assignment-repo-targets', () => ({
   validatePublicGitHubRepo: vi.fn(async (repoUrl: string) => ({
@@ -29,7 +59,63 @@ vi.mock('@/lib/server/assignment-repo-targets', () => ({
   })),
 }))
 
+function mockBoundedHttpResponse(opts: {
+  status?: number
+  body?: string
+  location?: string
+  transport?: 'http' | 'https'
+} = {}) {
+  const {
+    status = 200,
+    body = '<title>Student Project</title>',
+    location,
+    transport = 'https',
+  } = opts
+  const requestMock = transport === 'http' ? requestMocks.httpRequest : requestMocks.httpsRequest
+
+  requestMock.mockImplementationOnce((_options, callback) => {
+    const request = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>
+      destroy: ReturnType<typeof vi.fn>
+    }
+    request.end = vi.fn(() => {
+      const response = new EventEmitter() as EventEmitter & {
+        statusCode: number
+        headers: Record<string, string>
+        resume: ReturnType<typeof vi.fn>
+        destroy: ReturnType<typeof vi.fn>
+      }
+      response.statusCode = status
+      response.headers = location ? { location } : {}
+      response.resume = vi.fn(() => {
+        process.nextTick(() => response.emit('end'))
+        return response
+      })
+      response.destroy = vi.fn()
+
+      process.nextTick(() => {
+        callback(response)
+        if (status < 300 || status >= 400) {
+          response.emit('data', Buffer.from(body))
+        }
+        response.emit('end')
+      })
+    })
+    request.destroy = vi.fn((error?: Error) => {
+      if (error) process.nextTick(() => request.emit('error', error))
+    })
+    return request
+  })
+}
+
 describe('assignment submission validation helpers', () => {
+  beforeEach(() => {
+    dnsMocks.lookup.mockReset()
+    dnsMocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+    requestMocks.httpRequest.mockReset()
+    requestMocks.httpsRequest.mockReset()
+  })
+
   it('normalizes GitHub logins without accepting invalid names', () => {
     expect(normalizeGitHubLogin('@student-dev')).toBe('student-dev')
     expect(normalizeGitHubLogin('-bad')).toBeNull()
@@ -117,9 +203,7 @@ describe('assignment submission validation helpers', () => {
 
   it('verifies reachable links when the teacher asks for a page check', async () => {
     dnsMocks.lookup.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('<title>Student Project</title>', {
-      status: 200,
-    })))
+    mockBoundedHttpResponse()
 
     const result = await validateAssignmentSubmissionArtifactValue({
       type: 'link',
@@ -138,15 +222,17 @@ describe('assignment submission validation helpers', () => {
       page_title: 'Student Project',
     })
 
-    vi.unstubAllGlobals()
+    expect(requestMocks.httpsRequest).toHaveBeenCalledWith(expect.objectContaining({
+      hostname: '93.184.216.34',
+      servername: 'example.com',
+      family: 4,
+      headers: expect.objectContaining({
+        Host: 'example.com',
+      }),
+    }), expect.any(Function))
   })
 
   it('flags expected-domain links when the final host does not match', async () => {
-    const fetchSpy = vi.fn(async () => new Response('<title>Wrong site</title>', {
-      status: 200,
-    }))
-    vi.stubGlobal('fetch', fetchSpy)
-
     const result = await validateAssignmentSubmissionArtifactValue({
       type: 'link',
       url: 'https://example.com/project',
@@ -161,16 +247,15 @@ describe('assignment submission validation helpers', () => {
       validation_message: 'Link must point to codehs.com.',
       normalized_url: 'https://example.com/project',
     })
-    expect(fetchSpy).not.toHaveBeenCalled()
-
-    vi.unstubAllGlobals()
+    expect(requestMocks.httpsRequest).not.toHaveBeenCalled()
   })
 
   it('marks unreachable policy-checked links for teacher review instead of blocking as inaccessible', async () => {
     dnsMocks.lookup.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('Not found', {
+    mockBoundedHttpResponse({
       status: 404,
-    })))
+      body: 'Not found',
+    })
 
     const result = await validateAssignmentSubmissionArtifactValue({
       type: 'link',
@@ -185,14 +270,10 @@ describe('assignment submission validation helpers', () => {
       validation_level: 'review',
       http_status: 404,
     })
-
-    vi.unstubAllGlobals()
   })
 
   it('does not fetch policy-checked links that resolve to private addresses', async () => {
-    const fetchSpy = vi.fn()
     dnsMocks.lookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }])
-    vi.stubGlobal('fetch', fetchSpy)
 
     const result = await validateAssignmentSubmissionArtifactValue({
       type: 'link',
@@ -202,8 +283,6 @@ describe('assignment submission validation helpers', () => {
 
     expect(result.validation_status).toBe('warning')
     expect(result.validation_message).toBe('Enter a public http or https URL.')
-    expect(fetchSpy).not.toHaveBeenCalled()
-
-    vi.unstubAllGlobals()
+    expect(requestMocks.httpsRequest).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- Rename generic assignment submission link copy from `Public link` / `Public URL` to `Link` / `URL` so teacher-provided labels carry the specific meaning.
- Add low-effort teacher validation controls for link requirements: basic URL, reachable page, and expected site.
- Extend generic link validation to support policy-aware checks with safe URL normalization, DNS/private-host guards, redirect caps, timeout handling, bounded response reads, and soft `Needs review` results for inconclusive pages.
- Surface validation status and messages in student submission rows and teacher artifact displays.

## Review Notes

- Self-review found one runtime-platform risk before PR creation: policy-checked generic links now fetch external URLs, so I added DNS/private resolved-address blocking before fetch and covered it in tests.
- Remaining residual risk: DNS can theoretically change between lookup and fetch. The guard materially improves SSRF posture, but this is still not a sandboxed browser or proxy-level egress policy.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/unit/assignment-submission-validation.test.ts tests/lib/assignment-submission-requirements.test.ts tests/components/StudentAssignmentSubmissionChecklist.test.tsx tests/components/AssignmentModal.test.tsx tests/components/AssignmentArtifactsCell.test.tsx tests/api/teacher/assignments-id.test.ts`
- `pnpm lint`
- `pnpm build`
- Visual verification: `pika-ui-verify` classroom screenshots plus targeted teacher assignment link-policy and student submission checklist screenshots.

Note: an earlier full `pnpm test` run while `pnpm build` was also running had two unrelated 5s timeout failures and one expected assertion update. The failed tests were rerun successfully after the expectation update.