### PR TITLE
[codex] Harden daily log saves and sessions

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-28 — Assignment list stats enrollment scoping
-
-**Completed:**
-- Scoped teacher assignment list stats to currently enrolled classroom students.
-- Reused `getClassroomStudentIds()` for paginated enrollment ids and total student count.
-- Bulk-loaded assignment docs by assignment ids and enrolled student ids, chunking large `.in()` filters to avoid oversized PostgREST URLs while preserving the `teacher_cleared_at` missing-column fallback.
-- Added regressions for withdrawn-student docs, large-roster chunking, fallback scoping, zero-enrollment stats, and enrollment lookup failures.
-
-**Validation:**
-- `pnpm vitest run tests/api/teacher/assignments.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test -- --runInBand`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-29 — Skill progression map from PR review patterns
 
 **Completed:**
@@ -124,6 +107,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+- `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
 - `git diff --check`
 
@@ -997,3 +981,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm smoke:gradex -- --dry-run`
 - `pnpm smoke:gradex` reached Gradex run creation against the configured deployed API URL, then stopped because no `GRADEX_INTERNAL_TOKEN`/worker is configured to process the queued run.
 - `GRADEX_API_URL=http://127.0.0.1:3001 GRADEX_API_KEY=... GRADEX_INTERNAL_TOKEN=... pnpm smoke:gradex` completed end-to-end against a controlled local Gradex dev server.
+
+## 2026-06-02 — Daily log save and session hardening
+
+**Completed:**
+- Fixed the student daily-log autosave race where an older save response could mark newer, still-unsaved visible content as `Saved`.
+- Added explicit daily-log handling for expired-session save responses so the entry remains `Unsaved`, shows a session-expired message, and redirects to login.
+- Added silent daily-log draft recovery in `sessionStorage` so unsaved text typed before an expired-session redirect is restored after login, remains marked `Unsaved`, and automatically retries saving once the page reloads with an active session.
+- Added a client-side authenticated-layout session watcher for classroom, student, and teacher pages to detect expired or wrong-role sessions while a stale page is still mounted.
+- Added focused regression coverage for stale daily-log save responses, expired-session save redirects, draft recovery, and the session watcher.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/api/student/entries.test.ts tests/api/auth/me.test.ts`
+- `pnpm lint`
+- `pnpm test` (303 files, 2656 tests)
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Post-PR draft recovery rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
+- Post-PR restored-draft autosave rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -23,12 +23,21 @@ import {
   fetchStudentEntriesForClassroom,
   invalidateStudentEntriesForClassroom,
 } from '@/lib/student-entries-client'
+import {
+  isAuthFailureStatus,
+  redirectToLoginForReauth,
+  SESSION_EXPIRED_MESSAGE,
+} from '@/lib/client-auth'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import { countCharacters, isEmpty, plainTextToTiptapContent } from '@/lib/tiptap-content'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import type { Classroom, Entry, JsonPatchOperation, LessonPlan, TiptapContent } from '@/types'
 
 const EMPTY_DOC: TiptapContent = { type: 'doc', content: [] }
+
+function getDailyLogDraftKey(classroomId: string, date: string): string {
+  return `daily-log-draft:${classroomId}:${date}`
+}
 
 function parseSavedContent(contentString: string | null): TiptapContent {
   if (!contentString) return EMPTY_DOC
@@ -82,6 +91,8 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   const throttledSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastSaveAttemptAtRef = useRef(0)
   const pendingContentRef = useRef<TiptapContent | null>(null)
+  const restoredDraftAutosaveRef = useRef<TiptapContent | null>(null)
+  const currentContentRef = useRef<TiptapContent>(EMPTY_DOC)
   const entryIdRef = useRef<string | null>(null)
   const entryVersionRef = useRef(1)
   const todayRef = useRef('')
@@ -130,10 +141,31 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
         const applyEntryState = (todayEntry: Entry | null) => {
           const loadedContent = resolveEntryContent(todayEntry)
-          setContent(loadedContent)
+          const draftContent = safeSessionGetJson<TiptapContent>(
+            getDailyLogDraftKey(classroom.id, todayDate)
+          )
+          if (
+            draftContent &&
+            !isEmpty(draftContent) &&
+            JSON.stringify(draftContent) !== JSON.stringify(loadedContent)
+          ) {
+            setContent(draftContent)
+            currentContentRef.current = draftContent
+            pendingContentRef.current = draftContent
+            restoredDraftAutosaveRef.current = draftContent
+            hasLocalEditSinceLoadRef.current = true
+            setSaveStatus('unsaved')
+          }
+
+          if (!draftContent || isEmpty(draftContent) || JSON.stringify(draftContent) === JSON.stringify(loadedContent)) {
+            setContent(loadedContent)
+            currentContentRef.current = loadedContent
+            pendingContentRef.current = null
+            hasLocalEditSinceLoadRef.current = false
+            setSaveStatus('saved')
+          }
+
           lastSavedContentRef.current = JSON.stringify(loadedContent)
-          hasLocalEditSinceLoadRef.current = false
-          setSaveStatus('saved')
           setSaveError('')
           setConflictEntry(null)
           entryIdRef.current = todayEntry?.id ?? null
@@ -219,13 +251,17 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
     // Don't create a new DB record for empty content (e.g. TipTap mount normalization)
     const newContentStr = JSON.stringify(newContent)
+    const draftKey = getDailyLogDraftKey(classroom.id, entryDate)
+
     if (!entryIdRef.current && isEmpty(newContent)) {
       lastSavedContentRef.current = newContentStr
+      safeSessionRemove(draftKey)
       setSaveStatus('saved')
       return
     }
 
     if (!options?.forceFull && newContentStr === lastSavedContentRef.current) {
+      safeSessionRemove(draftKey)
       setSaveStatus('saved')
       return
     }
@@ -238,6 +274,7 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
 
     setSaveStatus('saving')
     setSaveError('')
+    safeSessionSetJson(draftKey, newContent)
     lastSaveAttemptAtRef.current = Date.now()
 
     const baseContent = parseSavedContent(lastSavedContentRef.current)
@@ -276,6 +313,13 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       })
 
       const data = await response.json()
+
+      if (isAuthFailureStatus(response.status)) {
+        setSaveStatus('unsaved')
+        setSaveError(SESSION_EXPIRED_MESSAGE)
+        redirectToLoginForReauth()
+        return
+      }
 
       if (response.status === 409) {
         const serverEntry = data.entry as Entry | undefined
@@ -322,15 +366,27 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       }
 
       const savedEntry = data.entry as Entry
+      const savedContentStillCurrent = JSON.stringify(currentContentRef.current) === newContentStr
+      const savedEntryContent = resolveEntryContent(savedEntry)
+
       entryIdRef.current = savedEntry.id
       entryVersionRef.current = savedEntry.version ?? entryVersionRef.current
+
       invalidateStudentEntriesForClassroom(classroom.id)
       updateHistoryEntries(savedEntry)
-      lastSavedContentRef.current = newContentStr
-      setSaveStatus('saved')
-      setSaveError('')
-      setConflictEntry(null)
-      notifications?.markTodayComplete()
+      lastSavedContentRef.current = JSON.stringify(savedEntryContent)
+      if (savedContentStillCurrent) {
+        safeSessionRemove(draftKey)
+        pendingContentRef.current = null
+        restoredDraftAutosaveRef.current = null
+        hasLocalEditSinceLoadRef.current = false
+        setSaveStatus('saved')
+        setSaveError('')
+        setConflictEntry(null)
+        notifications?.markTodayComplete()
+      } else {
+        setSaveStatus('unsaved')
+      }
     } catch (err: any) {
       console.error('Error saving:', err)
       setSaveStatus('unsaved')
@@ -369,10 +425,25 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
     }, waitMs)
   }, [AUTOSAVE_MIN_INTERVAL_MS, conflictEntry, saveContent])
 
+  useEffect(() => {
+    if (loading || conflictEntry) return
+
+    const restoredDraft = restoredDraftAutosaveRef.current
+    if (!restoredDraft) return
+
+    restoredDraftAutosaveRef.current = null
+    scheduleSave(restoredDraft, { force: true })
+  }, [conflictEntry, loading, scheduleSave])
+
   function handleContentChange(newContent: TiptapContent) {
     setContent(newContent)
+    currentContentRef.current = newContent
 
     const newContentStr = JSON.stringify(newContent)
+    const draftKey = todayRef.current
+      ? getDailyLogDraftKey(classroom.id, todayRef.current)
+      : null
+
     if (newContentStr === lastSavedContentRef.current || (!entryIdRef.current && isEmpty(newContent))) {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current)
@@ -383,6 +454,9 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
         throttledSaveTimeoutRef.current = null
       }
       lastSavedContentRef.current = newContentStr
+      if (draftKey) {
+        safeSessionRemove(draftKey)
+      }
       pendingContentRef.current = null
       hasLocalEditSinceLoadRef.current = false
       setSaveStatus('saved')
@@ -393,6 +467,9 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
     hasLocalEditSinceLoadRef.current = true
     setSaveStatus('unsaved')
     pendingContentRef.current = newContent
+    if (draftKey) {
+      safeSessionSetJson(draftKey, newContent)
+    }
 
     if (!conflictEntry) {
       const nextCharCount = countCharacters(newContent)
@@ -423,14 +500,18 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
     if (!conflictEntry) return
     const serverContent = resolveEntryContent(conflictEntry)
     setContent(serverContent)
+    currentContentRef.current = serverContent
     lastSavedContentRef.current = JSON.stringify(serverContent)
+    if (todayRef.current) {
+      safeSessionRemove(getDailyLogDraftKey(classroom.id, todayRef.current))
+    }
     hasLocalEditSinceLoadRef.current = false
     entryIdRef.current = conflictEntry.id
     entryVersionRef.current = conflictEntry.version ?? entryVersionRef.current
     setSaveStatus('saved')
     setSaveError('')
     setConflictEntry(null)
-  }, [conflictEntry])
+  }, [classroom.id, conflictEntry])
 
   const retryAfterConflict = useCallback(() => {
     if (!conflictEntry) return

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
 import Link from 'next/link'
 import { PikaLogo } from '@/components/PikaLogo'
+import { AuthSessionWatcher } from '@/components/AuthSessionWatcher'
 
 export default async function StudentLayout({
   children,
@@ -20,6 +21,7 @@ export default async function StudentLayout({
 
   return (
     <div className="min-h-screen bg-page">
+      <AuthSessionWatcher expectedRole="student" />
       <nav className="bg-surface shadow-sm border-b border-border">
         <div className="mx-auto max-w-4xl px-4 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/teacher/layout.tsx
+++ b/src/app/teacher/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/auth'
 import Link from 'next/link'
 import { PikaLogo } from '@/components/PikaLogo'
+import { AuthSessionWatcher } from '@/components/AuthSessionWatcher'
 
 export default async function TeacherLayout({
   children,
@@ -20,6 +21,7 @@ export default async function TeacherLayout({
 
   return (
     <div className="min-h-screen bg-page">
+      <AuthSessionWatcher expectedRole="teacher" />
       <nav className="bg-surface shadow-sm border-b border-border">
         <div className="mx-auto max-w-7xl px-4 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { AppHeader } from './AppHeader'
+import { AuthSessionWatcher } from './AuthSessionWatcher'
 
 interface AppShellProps {
   children: ReactNode
@@ -53,6 +54,7 @@ export function AppShell({
 
   return (
     <div className={`flex min-h-dvh flex-col bg-page${shouldConstrainViewport ? ' lg:h-dvh lg:overflow-hidden' : ''}`}>
+      {user && <AuthSessionWatcher expectedRole={user.role} />}
       {showHeader && (
         <AppHeader
           user={user}

--- a/src/components/AuthSessionWatcher.tsx
+++ b/src/components/AuthSessionWatcher.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  isAuthFailureStatus,
+  redirectToLoginForReauth,
+  sessionMatchesExpectedRole,
+} from '@/lib/client-auth'
+import type { UserRole } from '@/types'
+
+type AuthSessionWatcherProps = {
+  expectedRole?: UserRole
+  intervalMs?: number
+}
+
+const DEFAULT_INTERVAL_MS = 60_000
+
+export function AuthSessionWatcher({
+  expectedRole,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: AuthSessionWatcherProps) {
+  useEffect(() => {
+    let cancelled = false
+    let checking = false
+
+    async function checkSession() {
+      if (checking || cancelled) return
+      checking = true
+
+      try {
+        const response = await fetch('/api/auth/me', { cache: 'no-store' })
+        const data = await response.json().catch(() => ({}))
+
+        if (!cancelled && isAuthFailureStatus(response.status)) {
+          redirectToLoginForReauth()
+          return
+        }
+
+        if (!cancelled && response.ok && !sessionMatchesExpectedRole(data.user, expectedRole)) {
+          redirectToLoginForReauth()
+        }
+      } catch {
+        // Network hiccups should not log users out. The next focus/timer check will retry.
+      } finally {
+        checking = false
+      }
+    }
+
+    void checkSession()
+
+    const interval = window.setInterval(() => {
+      void checkSession()
+    }, intervalMs)
+
+    const handleFocus = () => {
+      void checkSession()
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void checkSession()
+      }
+    }
+
+    window.addEventListener('focus', handleFocus)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+      window.removeEventListener('focus', handleFocus)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [expectedRole, intervalMs])
+
+  return null
+}

--- a/src/lib/client-auth.ts
+++ b/src/lib/client-auth.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { navigateTo } from '@/lib/client-navigation'
+import type { UserRole } from '@/types'
+
+export const SESSION_EXPIRED_MESSAGE = 'Your session expired. Please log in again before continuing.'
+
+export function isAuthFailureStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+export function buildLoginRedirectPath(currentPath?: string): string {
+  const path =
+    currentPath ??
+    (typeof window !== 'undefined'
+      ? `${window.location.pathname}${window.location.search}`
+      : '/classrooms')
+
+  const safePath = path.startsWith('/') && !path.startsWith('//') ? path : '/classrooms'
+  return `/login?next=${encodeURIComponent(safePath)}`
+}
+
+export function redirectToLoginForReauth(currentPath?: string): void {
+  if (typeof window === 'undefined') return
+  navigateTo(buildLoginRedirectPath(currentPath))
+}
+
+export function sessionMatchesExpectedRole(
+  user: { role?: UserRole | null } | null | undefined,
+  expectedRole?: UserRole,
+): boolean {
+  if (!user) return false
+  return !expectedRole || user.role === expectedRole
+}

--- a/tests/components/AuthSessionWatcher.test.tsx
+++ b/tests/components/AuthSessionWatcher.test.tsx
@@ -1,0 +1,78 @@
+import { render, waitFor, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthSessionWatcher } from '@/components/AuthSessionWatcher'
+
+const redirectToLoginForReauthMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/client-auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/client-auth')>()
+  return {
+    ...actual,
+    redirectToLoginForReauth: redirectToLoginForReauthMock,
+  }
+})
+
+function mockResponse(status: number, body: unknown) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  }) as any
+}
+
+describe('AuthSessionWatcher', () => {
+  beforeEach(() => {
+    redirectToLoginForReauthMock.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('redirects when the session endpoint reports unauthenticated', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse(401, { error: 'Not authenticated' })))
+
+    render(<AuthSessionWatcher />)
+
+    await waitFor(() => {
+      expect(redirectToLoginForReauthMock).toHaveBeenCalled()
+    })
+  })
+
+  it('redirects when the active session role does not match the page role', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse(200, {
+      user: { id: 'student-1', email: 'student@example.com', role: 'student' },
+    })))
+
+    render(<AuthSessionWatcher expectedRole="teacher" />)
+
+    await waitFor(() => {
+      expect(redirectToLoginForReauthMock).toHaveBeenCalled()
+    })
+  })
+
+  it('keeps the page mounted when the session is valid for the expected role', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse(200, {
+      user: { id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' },
+    })))
+
+    render(<AuthSessionWatcher expectedRole="teacher" />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/auth/me', { cache: 'no-store' })
+    })
+    expect(redirectToLoginForReauthMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the page mounted when the session endpoint has a server error', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse(500, { error: 'Internal server error' })))
+
+    render(<AuthSessionWatcher expectedRole="teacher" />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/auth/me', { cache: 'no-store' })
+    })
+    expect(redirectToLoginForReauthMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -8,10 +8,19 @@ import type { Classroom, Entry } from '@/types'
 
 const getTodayInTorontoMock = vi.hoisted(() => vi.fn(() => '2025-12-16'))
 const invalidateStudentEntriesForClassroomMock = vi.hoisted(() => vi.fn())
+const redirectToLoginForReauthMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/timezone', () => ({
   getTodayInToronto: getTodayInTorontoMock,
 }))
+
+vi.mock('@/lib/client-auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/client-auth')>()
+  return {
+    ...actual,
+    redirectToLoginForReauth: redirectToLoginForReauthMock,
+  }
+})
 
 vi.mock('@/lib/student-entries-client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/student-entries-client')>()
@@ -122,6 +131,10 @@ const entries: Entry[] = [
   },
 ]
 
+function getDailyLogDraftKey(classroomId: string, date: string): string {
+  return `daily-log-draft:${classroomId}:${date}`
+}
+
 function mockJson(data: any, ok = true) {
   return Promise.resolve({ ok, json: () => Promise.resolve(data) }) as any
 }
@@ -140,6 +153,7 @@ describe('StudentTodayTab history section', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     invalidateStudentEntriesForClassroomMock.mockClear()
+    redirectToLoginForReauthMock.mockClear()
     invalidateCachedJSONMatching('student-entries:')
     invalidateCachedJSONMatching('student-lesson-plans:')
     getTodayInTorontoMock.mockReturnValue('2025-12-16')
@@ -484,5 +498,309 @@ describe('StudentTodayTab history section', () => {
 
     expect(invalidateStudentEntriesForClassroomMock).toHaveBeenCalledWith(classroom.id)
     expect(window.sessionStorage.getItem(cacheKey)).toBeNull()
+  })
+
+  it('does not report saved when an older save finishes after a newer edit', async () => {
+    const saveRequest = deferred<any>()
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        return saveRequest.promise
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    fireEvent.change(editor, { target: { value: 'Older save content.' } })
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/student/entries',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+    })
+
+    fireEvent.change(editor, { target: { value: 'Newer unsaved content.' } })
+
+    saveRequest.resolve(await mockJson({
+      entry: {
+        id: 'entry-stale',
+        student_id: 's1',
+        classroom_id: classroom.id,
+        date: '2025-12-16',
+        text: 'Older save content.',
+        rich_content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Older save content.' }] }],
+        },
+        version: 1,
+        minutes_reported: null,
+        mood: null,
+        created_at: '2025-12-16T14:00:00Z',
+        updated_at: '2025-12-16T14:00:00Z',
+        on_time: true,
+      },
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    })
+    expect(editor).toHaveValue('Newer unsaved content.')
+  })
+
+  it('uses a stale completed save as the base version for the next daily log save', async () => {
+    const firstSaveRequest = deferred<any>()
+    const patchBodies: any[] = []
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [entries[0]] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        if (patchBodies.length === 1) {
+          return firstSaveRequest.promise
+        }
+        return mockJson({
+          entry: {
+            ...entries[0],
+            text: 'Second visible draft.',
+            rich_content: {
+              type: 'doc',
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Second visible draft.' }] }],
+            },
+            version: 3,
+          },
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    fireEvent.change(editor, { target: { value: 'First in-flight draft.' } })
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(patchBodies).toHaveLength(1)
+    })
+
+    fireEvent.change(editor, { target: { value: 'Second visible draft.' } })
+    firstSaveRequest.resolve(await mockJson({
+      entry: {
+        ...entries[0],
+        text: 'First in-flight draft.',
+        rich_content: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'First in-flight draft.' }] }],
+        },
+        version: 2,
+      },
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsaved')).toBeInTheDocument()
+    })
+
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(patchBodies).toHaveLength(2)
+    })
+    expect(patchBodies[1].version).toBe(2)
+  })
+
+  it('stores unsaved daily log content locally and clears it after a current save succeeds', async () => {
+    const draftKey = getDailyLogDraftKey(classroom.id, '2025-12-16')
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        return mockJson({
+          entry: {
+            id: 'entry-saved',
+            student_id: 's1',
+            classroom_id: classroom.id,
+            date: '2025-12-16',
+            text: 'Draft that should clear.',
+            rich_content: body.rich_content,
+            version: 1,
+            minutes_reported: null,
+            mood: null,
+            created_at: '2025-12-16T14:00:00Z',
+            updated_at: '2025-12-16T14:00:00Z',
+            on_time: true,
+          },
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    fireEvent.change(editor, { target: { value: 'Draft that should clear.' } })
+
+    expect(window.sessionStorage.getItem(draftKey)).toContain('Draft that should clear.')
+
+    fireEvent.blur(editor)
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument()
+    })
+    expect(window.sessionStorage.getItem(draftKey)).toBeNull()
+  })
+
+  it('redirects to login when saving fails because the session expired', async () => {
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Unauthorized' }),
+        }) as any
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    fireEvent.change(editor, { target: { value: 'Needs a valid session.' } })
+    fireEvent.blur(editor)
+
+    expect(await screen.findByText('Your session expired. Please log in again before continuing.')).toBeInTheDocument()
+    expect(redirectToLoginForReauthMock).toHaveBeenCalled()
+  })
+
+  it('restores an unsaved daily log draft after an expired-session redirect remount', async () => {
+    const draftKey = getDailyLogDraftKey(classroom.id, '2025-12-16')
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Unauthorized' }),
+        }) as any
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const firstRender = render(<StudentTodayTab classroom={classroom} />)
+
+    const firstEditor = await screen.findByLabelText('Write something...')
+    fireEvent.change(firstEditor, { target: { value: 'Recovered after login.' } })
+    fireEvent.blur(firstEditor)
+
+    await waitFor(() => {
+      expect(redirectToLoginForReauthMock).toHaveBeenCalled()
+    })
+    expect(window.sessionStorage.getItem(draftKey)).toContain('Recovered after login.')
+
+    firstRender.unmount()
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const restoredEditor = await screen.findByLabelText('Write something...')
+    expect(restoredEditor).toHaveValue('Recovered after login.')
+    expect(screen.getByText('Unsaved')).toBeInTheDocument()
+  })
+
+  it('autosaves a restored daily log draft after the page reloads with an active session', async () => {
+    const draftKey = getDailyLogDraftKey(classroom.id, '2025-12-16')
+    window.sessionStorage.setItem(
+      draftKey,
+      JSON.stringify({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Autosave after login.' }] }],
+      })
+    )
+    const saveRequest = deferred<any>()
+    const patchBodies: any[] = []
+    const fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return mockJson({ entries: [] })
+      }
+      if (url.includes('/lesson-plans')) {
+        return mockJson({ lesson_plans: [] })
+      }
+      if (url === '/api/student/entries' && init?.method === 'PATCH') {
+        const body = JSON.parse(String(init.body))
+        patchBodies.push(body)
+        return saveRequest.promise
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<StudentTodayTab classroom={classroom} />)
+
+    const editor = await screen.findByLabelText('Write something...')
+    expect(editor).toHaveValue('Autosave after login.')
+
+    await waitFor(() => {
+      expect(patchBodies).toHaveLength(1)
+    })
+
+    saveRequest.resolve(await mockJson({
+      entry: {
+        id: 'entry-restored-save',
+        student_id: 's1',
+        classroom_id: classroom.id,
+        date: '2025-12-16',
+        text: 'Autosave after login.',
+        rich_content: patchBodies[0].rich_content,
+        version: 1,
+        minutes_reported: null,
+        mood: null,
+        created_at: '2025-12-16T14:00:00Z',
+        updated_at: '2025-12-16T14:00:00Z',
+        on_time: true,
+      },
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument()
+    })
+    expect(window.sessionStorage.getItem(draftKey)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- harden student daily-log autosave so stale save completions cannot mark newer visible content as `Saved`
- preserve the server-advanced entry base/version after stale completions so the next save does not hit an avoidable conflict
- keep unsaved daily-log drafts in `sessionStorage`, restore them silently after an expired-session login round trip, and automatically retry saving once the page reloads with an active session
- redirect to login when daily-log saves fail due to an expired or unauthorized session
- add a lightweight authenticated-session watcher for AppShell, student layout, and teacher layout pages

## Root Cause / Impact

This fixes a confirmed race in the daily-log client: an older save response could complete after the student had already typed newer content and still flip the visible state to `Saved`. That could make the latest text appear saved even though only the earlier content was durably persisted. The session changes also make stale logged-in pages recover by redirecting to login when `/api/auth/me` no longer matches the page role.

If the student has unsaved daily-log content when the session expires, the draft is now stored locally and restored after login without adding new banner copy. The existing `Unsaved`/`Saved` indicator remains the source of truth, and the restored draft automatically queues a save after the page reloads.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/api/student/entries.test.ts tests/api/auth/me.test.ts`
- `pnpm lint`
- `pnpm test` (303 files, 2656 tests)
- `pnpm build`
- `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- restored-draft autosave focused rerun: `pnpm test tests/components/StudentTodayTabHistory.test.tsx tests/components/AuthSessionWatcher.test.tsx tests/components/AppHeader.test.tsx && pnpm lint && pnpm build`
