### PR TITLE
[codex] Add Gradex assignment grading adapter

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,22 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Validation pass completed
-
-**Completed:**
-- Installed worktree dependencies with `pnpm install --frozen-lockfile`.
-- Ran focused validation for the new guardrail and guidance work.
-- Fixed one over-strict unit-test expectation in [`tests/unit/query-chunks.test.ts`](/Users/stew/.codex/worktrees/f558/pika/tests/unit/query-chunks.test.ts) after confirming the loader legitimately re-applies filter chunks across pagination pages.
-- Fixed one TypeScript build issue in [`src/lib/server/query-chunks.ts`](/Users/stew/.codex/worktrees/f558/pika/src/lib/server/query-chunks.ts) by adding an explicit recursive return type for the internal `visit` helper.
-
-**Validation:**
-- `pnpm install --frozen-lockfile`
-- `pnpm vitest run tests/unit/query-chunks.test.ts tests/unit/classroom-enrollment-validation.test.ts tests/unit/ui-guidance-docs.test.ts tests/api/teacher/assignments-auto-grade.test.ts --reporter=verbose`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-30 — Path-aware audit test matching
 
 **Completed:**
@@ -1007,3 +991,29 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Rereview: no remaining findings in the updated link reachability path.
+
+## 2026-06-02 — Gradex assignment adapter slice
+
+**Completed:**
+- Deployed Gradex production from merged `main` and re-ran the Pika Gradex smoke against `https://gradex-two.vercel.app`.
+- Added feature-flagged Pika assignment grading integration for Gradex: `GRADEX_ASSIGNMENT_GRADING_ENABLED=true` routes assignment auto-grade selections through background runs marked `gradex:pika-assignment-v1`.
+- Added migration `078_assignment_gradex_run_metadata.sql` for storing Gradex run status metadata on Pika assignment AI grading runs.
+- Added a server-side Gradex assignment processor that submits sanitized Pika payloads, stores the Gradex run ID, polls Gradex, and maps completed results back into Pika grade fields.
+- Addressed PR review findings by adding Gradex transport retry handling, terminal-run unresolved item reconciliation, fetch timeouts, and a pseudonymous run idempotency marker in Gradex assignment metadata.
+- Addressed re-review feedback by making Gradex submit/poll honor queued item `next_retry_at` backoff before making another remote request.
+- Kept the existing Pika/OpenAI grading path as the default when the Gradex flag is off.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/lib/gradex-assignment-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-smoke-runner.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test tests/unit/migration-filenames.test.ts tests/unit/ai-startup-docs.test.ts tests/unit/trim-session-log.test.ts`
+- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/lib/gradex-assignment-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-smoke-runner.test.ts tests/unit/migration-filenames.test.ts`
+- `pnpm smoke:gradex -- --dry-run`
+- `GRADEX_API_URL=https://gradex-two.vercel.app GRADEX_INTERNAL_TOKEN= GRADEX_INTERNAL_SECRET= GRADEX_SMOKE_POLL_INTERVAL_MS=1000 GRADEX_SMOKE_POLL_ATTEMPTS=60 pnpm smoke:gradex`
+- `pnpm build`
+
+**Follow-up:**
+- Apply migration 078 in the target Pika environment before enabling `GRADEX_ASSIGNMENT_GRADING_ENABLED`.
+- Run a real Pika assignment UI smoke with Gradex enabled after the migration and env vars are present.

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ GRADEX_INTERNAL_TOKEN=
 GRADEX_SMOKE_POLL_ATTEMPTS=20
 GRADEX_SMOKE_POLL_INTERVAL_MS=1500
 
+# Gradex assignment grading integration (optional, disabled by default)
+# When true, assignment background auto-grade runs submit sanitized data to Gradex
+# instead of grading each item directly inside Pika.
+GRADEX_ASSIGNMENT_GRADING_ENABLED=false
+GRADEX_PIKA_PSEUDONYM_SALT=
+
 # GitHub API (optional for repo review helpers)
 # Token needs `repo` scope, or `public_repo` if the repo is public.
 GITHUB_PAT=

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -10,6 +10,7 @@ import {
   gradeAssignmentDocWithAi,
   markAssignmentDocMissingGrade,
 } from '@/lib/server/assignment-ai-grading-runs'
+import { isGradexAssignmentGradingEnabled } from '@/lib/server/gradex-assignment-grading'
 import { loadAssignmentSubmissionArtifactsForDoc } from '@/lib/server/assignment-submission-artifacts'
 import { validateClassroomStudentIds } from '@/lib/server/classroom-enrollment-validation'
 import { assertTeacherCanMutateAssignment } from '@/lib/server/repo-review'
@@ -52,7 +53,7 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
     return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
   }
 
-  if (normalizedStudentIds.length > 1) {
+  if (normalizedStudentIds.length > 1 || isGradexAssignmentGradingEnabled()) {
     const runResult = await createOrResumeAssignmentAiGradingRun({
       assignmentId: id,
       teacherId: user.id,

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -14,6 +14,12 @@ import {
   loadAssignmentSubmissionArtifactsForDoc,
   loadAssignmentSubmissionArtifactsForDocs,
 } from '@/lib/server/assignment-submission-artifacts'
+import {
+  GRADEX_ASSIGNMENT_RUN_MODEL,
+  isGradexAssignmentGradingEnabled,
+  isGradexAssignmentRun,
+  submitOrPollGradexAssignmentRun,
+} from '@/lib/server/gradex-assignment-grading'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { parseContentField } from '@/lib/tiptap-content'
 import type {
@@ -82,6 +88,10 @@ type SupabaseSchemaError = {
 
 function getModelAlias(): string {
   return process.env.OPENAI_GRADING_MODEL?.trim() || DEFAULT_MODEL
+}
+
+function getAssignmentRunModelAlias(): string {
+  return isGradexAssignmentGradingEnabled() ? GRADEX_ASSIGNMENT_RUN_MODEL : getModelAlias()
 }
 
 function normalizeStudentIds(studentIds: string[]): string[] {
@@ -810,7 +820,7 @@ export async function createOrResumeAssignmentAiGradingRun(opts: {
   const { data: run, error: runError } = await supabase.rpc('create_assignment_ai_grading_run_atomic', {
     p_assignment_id: opts.assignmentId,
     p_teacher_id: opts.teacherId,
-    p_model: getModelAlias(),
+    p_model: getAssignmentRunModelAlias(),
     p_requested_student_ids: normalizedStudentIds,
     p_selection_hash: selectionHash,
     p_gradable_count: gradableCount,
@@ -905,6 +915,20 @@ export async function tickAssignmentAiGradingRun(opts: {
 
     const assignment = await loadAssignmentForRun(supabase, claimedRun.assignment_id)
     const allItems = await fetchAssignmentAiGradingRunItems(supabase, claimedRun.id)
+    if (isGradexAssignmentRun(claimedRun)) {
+      await submitOrPollGradexAssignmentRun({
+        supabase,
+        assignment,
+        run: claimedRun,
+        items: allItems,
+      })
+
+      return {
+        run: await refreshAssignmentAiGradingRun(supabase, claimedRun.id, { clearLease: true }),
+        claimed: true,
+      }
+    }
+
     const now = Date.now()
     const dueItems = allItems
       .filter((item) => {

--- a/src/lib/server/gradex-assignment-grading.ts
+++ b/src/lib/server/gradex-assignment-grading.ts
@@ -1,0 +1,619 @@
+import { loadClassroomAiSanitizationContext } from '@/lib/server/ai-sanitization'
+import { loadAssignmentSubmissionArtifactsForDocs } from '@/lib/server/assignment-submission-artifacts'
+import {
+  buildPikaAssignmentGradexRunPayload,
+  getRequiredPseudonymSalt,
+  pseudonymizePikaGradexRef,
+  type PikaGradexMapping,
+} from '@/lib/server/gradex-assignment-payload'
+import { mapGradexItemsToPikaGradeRecords, type GradexSmokeRunItemResponse, type GradexSmokeRunResponse } from '@/lib/server/gradex-smoke-runner'
+import { sanitizeAiOutputText } from '@/lib/ai-sanitization'
+import type { Assignment, AssignmentAiGradingRun, AssignmentAiGradingRunItem, AssignmentSubmissionArtifact, AuthenticityFlag } from '@/types'
+
+export const GRADEX_ASSIGNMENT_RUN_MODEL = 'gradex:pika-assignment-v1'
+
+const TERMINAL_GRADEX_STATUSES = new Set(['completed', 'completed_with_errors', 'failed'])
+const RETRYABLE_GRADEX_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504])
+const GRADEX_ASSIGNMENT_MAX_ATTEMPTS = 3
+const GRADEX_ASSIGNMENT_RETRY_BACKOFF_SECONDS = [15, 60, 180]
+
+type ServiceRoleSupabase = {
+  from: (table: string) => any
+}
+
+type GradexAssignmentDocRow = {
+  id: string
+  student_id: string
+  content: unknown
+  submitted_at?: string | null
+  authenticity_score?: number | null
+  authenticity_flags?: AuthenticityFlag[] | null
+}
+
+type GradexConfig = {
+  baseUrl: string
+  apiKey: string
+}
+
+class GradexRetryableRequestError extends Error {
+  readonly code: string
+  readonly status?: number
+
+  constructor(message: string, code: string, status?: number) {
+    super(message)
+    this.name = 'GradexRetryableRequestError'
+    this.code = code
+    this.status = status
+  }
+}
+
+export function isGradexAssignmentGradingEnabled(): boolean {
+  return process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED?.trim().toLowerCase() === 'true'
+}
+
+export function isGradexAssignmentRun(run: Pick<AssignmentAiGradingRun, 'model'>): boolean {
+  return run.model === GRADEX_ASSIGNMENT_RUN_MODEL
+}
+
+function getGradexConfig(): GradexConfig {
+  const baseUrl = process.env.GRADEX_API_URL?.trim().replace(/\/+$/, '')
+  const apiKey = process.env.GRADEX_API_KEY?.trim()
+
+  if (!baseUrl || !apiKey) {
+    throw new Error('Gradex assignment grading is enabled but GRADEX_API_URL or GRADEX_API_KEY is missing')
+  }
+
+  return { baseUrl, apiKey }
+}
+
+function isAssignmentGradexMetadataSchemaError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const record = error as { code?: string; message?: string; details?: string | null; hint?: string | null }
+  if (record.code === 'PGRST204' || record.code === '42703') return true
+  const combined = `${record.message ?? ''} ${record.details ?? ''} ${record.hint ?? ''}`.toLowerCase()
+  return combined.includes('gradex_run_id') || combined.includes('gradex_status')
+}
+
+function assertGradexMetadataUpdate(error: unknown): void {
+  if (!error) return
+  if (isAssignmentGradexMetadataSchemaError(error)) {
+    throw new Error('Assignment Gradex run metadata columns are unavailable. Apply migration 078.')
+  }
+  throw new Error('Failed to update assignment Gradex run metadata')
+}
+
+function isTerminalGradexRun(run: Pick<GradexSmokeRunResponse, 'status'>): boolean {
+  return TERMINAL_GRADEX_STATUSES.has(run.status)
+}
+
+async function requestGradexJson<T>(
+  config: GradexConfig,
+  opts: {
+    path: string
+    method: 'GET' | 'POST'
+    body?: unknown
+    expectedStatus: number
+    timeoutMs?: number
+  },
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 25_000
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  let response: Response
+
+  try {
+    response = await fetch(`${config.baseUrl}${opts.path}`, {
+      method: opts.method,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      ...(opts.body === undefined ? {} : { body: JSON.stringify(opts.body) }),
+    })
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError'
+    throw new GradexRetryableRequestError(
+      aborted ? 'Gradex request timed out' : 'Gradex request failed before a response was received',
+      aborted ? 'gradex_timeout' : 'gradex_network_error',
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  const body = await response.json().catch(() => null)
+  if (!response.ok || response.status !== opts.expectedStatus) {
+    if (RETRYABLE_GRADEX_STATUS_CODES.has(response.status)) {
+      throw new GradexRetryableRequestError(formatGradexError(body, response.status), 'gradex_retryable_http_error', response.status)
+    }
+    throw new Error(formatGradexError(body, response.status))
+  }
+  return body as T
+}
+
+function isGradexRetryableRequestError(error: unknown): error is GradexRetryableRequestError {
+  return error instanceof GradexRetryableRequestError
+}
+
+function formatGradexError(body: unknown, status: number): string {
+  if (body && typeof body === 'object') {
+    const error = (body as { error?: { message?: unknown; details?: unknown } }).error
+    if (typeof error?.message === 'string') {
+      return error.details === undefined
+        ? error.message
+        : `${error.message}: ${JSON.stringify(error.details)}`
+    }
+  }
+  return `Gradex request failed with status ${status}`
+}
+
+async function loadGradexRunInputs(opts: {
+  supabase: ServiceRoleSupabase
+  assignment: Assignment
+  items: AssignmentAiGradingRunItem[]
+}): Promise<{
+  assignmentDocs: GradexAssignmentDocRow[]
+  submissionArtifacts: AssignmentSubmissionArtifact[]
+  mappings: PikaGradexMapping[]
+  gradexRequest: ReturnType<typeof buildPikaAssignmentGradexRunPayload>['gradexRequest']
+}> {
+  const itemByDocId = new Map(
+    opts.items
+      .filter((item) => item.assignment_doc_id)
+      .map((item) => [item.assignment_doc_id!, item]),
+  )
+  const docIds = Array.from(itemByDocId.keys())
+
+  if (docIds.length === 0) {
+    throw new Error('Gradex assignment run has no gradable assignment documents')
+  }
+
+  const { data: docs, error: docsError } = await opts.supabase
+    .from('assignment_docs')
+    .select('id, student_id, content, submitted_at, authenticity_score, authenticity_flags')
+    .in('id', docIds)
+
+  if (docsError) {
+    throw new Error('Failed to load assignment submissions for Gradex grading')
+  }
+
+  const docById = new Map(
+    ((docs as GradexAssignmentDocRow[] | null) ?? []).map((doc) => [doc.id, doc]),
+  )
+  const assignmentDocs = docIds
+    .map((docId) => docById.get(docId))
+    .filter((doc): doc is GradexAssignmentDocRow => !!doc)
+
+  if (assignmentDocs.length !== docIds.length) {
+    throw new Error('Gradex assignment run is missing one or more assignment documents')
+  }
+
+  const submissionArtifacts = await loadAssignmentSubmissionArtifactsForDocs(opts.supabase as any, docIds)
+  const sanitizationContext = await loadClassroomAiSanitizationContext(opts.supabase as any, opts.assignment.classroom_id)
+  const built = buildPikaAssignmentGradexRunPayload({
+    assignment: opts.assignment,
+    assignmentDocs,
+    submissionArtifacts,
+    sanitizationContext,
+  })
+
+  return {
+    assignmentDocs,
+    submissionArtifacts,
+    mappings: built.mappings,
+    gradexRequest: built.gradexRequest,
+  }
+}
+
+async function updateRunGradexMetadata(
+  supabase: ServiceRoleSupabase,
+  runId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const { error } = await supabase
+    .from('assignment_ai_grading_runs')
+    .update(payload)
+    .eq('id', runId)
+
+  assertGradexMetadataUpdate(error)
+}
+
+async function updateRunItem(
+  supabase: ServiceRoleSupabase,
+  itemId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const { error } = await supabase
+    .from('assignment_ai_grading_run_items')
+    .update(payload)
+    .eq('id', itemId)
+
+  if (error) {
+    throw new Error('Failed to update assignment AI grading run item')
+  }
+}
+
+function getGradexRetryAt(attemptCount: number): string {
+  const index = Math.max(0, Math.min(attemptCount - 1, GRADEX_ASSIGNMENT_RETRY_BACKOFF_SECONDS.length - 1))
+  return new Date(Date.now() + GRADEX_ASSIGNMENT_RETRY_BACKOFF_SECONDS[index] * 1000).toISOString()
+}
+
+function isDueGradexItem(item: AssignmentAiGradingRunItem, nowMs: number): boolean {
+  if (!item.assignment_doc_id || (item.status !== 'queued' && item.status !== 'processing')) {
+    return false
+  }
+  if (!item.next_retry_at) return true
+
+  const retryAt = new Date(item.next_retry_at).getTime()
+  return !Number.isFinite(retryAt) || retryAt <= nowMs
+}
+
+function getDueGradexItems(items: AssignmentAiGradingRunItem[], nowMs = Date.now()): AssignmentAiGradingRunItem[] {
+  return items.filter((item) => isDueGradexItem(item, nowMs))
+}
+
+async function markGradexItemsForRetryOrFailure(opts: {
+  supabase: ServiceRoleSupabase
+  items: AssignmentAiGradingRunItem[]
+  errorCode: string
+  errorMessage: string
+  now: string
+}): Promise<void> {
+  await Promise.all(
+    opts.items
+      .filter((item) => item.assignment_doc_id && (item.status === 'queued' || item.status === 'processing'))
+      .map((item) => {
+        const attemptCount = item.attempt_count + 1
+        const exhausted = attemptCount >= GRADEX_ASSIGNMENT_MAX_ATTEMPTS
+        return updateRunItem(opts.supabase, item.id, {
+          status: exhausted ? 'failed' : 'queued',
+          attempt_count: attemptCount,
+          next_retry_at: exhausted ? null : getGradexRetryAt(attemptCount),
+          last_error_code: opts.errorCode,
+          last_error_message: opts.errorMessage,
+          completed_at: exhausted ? opts.now : null,
+        })
+      }),
+  )
+}
+
+async function handleRetryableGradexError(opts: {
+  supabase: ServiceRoleSupabase
+  items: AssignmentAiGradingRunItem[]
+  error: GradexRetryableRequestError
+  now: string
+}): Promise<void> {
+  await markGradexItemsForRetryOrFailure({
+    supabase: opts.supabase,
+    items: opts.items,
+    errorCode: opts.error.code,
+    errorMessage: opts.error.message,
+    now: opts.now,
+  })
+}
+
+async function failUnresolvedGradexItems(opts: {
+  supabase: ServiceRoleSupabase
+  items: AssignmentAiGradingRunItem[]
+  completedAssignmentDocIds: Set<string>
+  errorCode: string
+  errorMessage: string
+  now: string
+}): Promise<void> {
+  await Promise.all(
+    opts.items
+      .filter((item) =>
+        item.assignment_doc_id &&
+        (item.status === 'queued' || item.status === 'processing') &&
+        !opts.completedAssignmentDocIds.has(item.assignment_doc_id)
+      )
+      .map((item) =>
+        updateRunItem(opts.supabase, item.id, {
+          status: 'failed',
+          attempt_count: item.attempt_count + 1,
+          next_retry_at: null,
+          last_error_code: opts.errorCode,
+          last_error_message: opts.errorMessage,
+          completed_at: opts.now,
+        }),
+      ),
+  )
+}
+
+function withPseudonymousRunMetadata(
+  request: ReturnType<typeof buildPikaAssignmentGradexRunPayload>['gradexRequest'],
+  runId: string,
+) {
+  const runRef = pseudonymizePikaGradexRef('run', runId, getRequiredPseudonymSalt())
+  return {
+    ...request,
+    assignment: {
+      ...request.assignment,
+      metadata: {
+        ...request.assignment.metadata,
+        client_run_ref: runRef,
+        idempotency_key: runRef,
+      },
+    },
+  }
+}
+
+async function submitGradexAssignmentRun(opts: {
+  supabase: ServiceRoleSupabase
+  assignment: Assignment
+  run: AssignmentAiGradingRun
+  items: AssignmentAiGradingRunItem[]
+}): Promise<void> {
+  const config = getGradexConfig()
+  const dueItems = getDueGradexItems(opts.items)
+  if (dueItems.length === 0) {
+    return
+  }
+
+  const { gradexRequest } = await loadGradexRunInputs({
+    supabase: opts.supabase,
+    assignment: opts.assignment,
+    items: dueItems,
+  })
+  const now = new Date().toISOString()
+  const requestWithRunMetadata = withPseudonymousRunMetadata(gradexRequest, opts.run.id)
+
+  await Promise.all(
+    dueItems.map((item) =>
+      updateRunItem(opts.supabase, item.id, {
+        status: 'processing',
+        started_at: item.started_at ?? now,
+        next_retry_at: null,
+      }),
+    ),
+  )
+
+  let gradexRun: GradexSmokeRunResponse
+  try {
+    gradexRun = await requestGradexJson<GradexSmokeRunResponse>(config, {
+      path: '/api/v1/grading-runs',
+      method: 'POST',
+      body: requestWithRunMetadata,
+      expectedStatus: 202,
+      timeoutMs: gradexRequest.settings.request_timeout_ms,
+    })
+  } catch (error) {
+    if (isGradexRetryableRequestError(error)) {
+      await handleRetryableGradexError({
+        supabase: opts.supabase,
+        items: dueItems,
+        error,
+        now,
+      })
+      return
+    }
+    throw error
+  }
+
+  await updateRunGradexMetadata(opts.supabase, opts.run.id, {
+    gradex_run_id: gradexRun.id,
+    gradex_status: gradexRun.status,
+    gradex_submitted_at: now,
+    gradex_last_polled_at: now,
+  })
+}
+
+function isValidScore(value: number | null): value is number {
+  return value != null && Number.isInteger(value) && value >= 0 && value <= 10
+}
+
+function formatGradexModel(record: {
+  provider: string | null
+  model: string | null
+  tier: string | null
+}) {
+  const modelParts = [record.provider, record.model, record.tier].filter(Boolean)
+  return modelParts.length > 0 ? `gradex:${modelParts.join('/')}` : GRADEX_ASSIGNMENT_RUN_MODEL
+}
+
+async function applyCompletedGradexRecord(opts: {
+  supabase: ServiceRoleSupabase
+  run: AssignmentAiGradingRun
+  item: AssignmentAiGradingRunItem
+  record: ReturnType<typeof mapGradexItemsToPikaGradeRecords>[number]
+  now: string
+}): Promise<void> {
+  if (
+    !isValidScore(opts.record.score_completion) ||
+    !isValidScore(opts.record.score_thinking) ||
+    !isValidScore(opts.record.score_workflow) ||
+    !opts.record.feedback?.trim()
+  ) {
+    await updateRunItem(opts.supabase, opts.item.id, {
+      status: 'failed',
+      attempt_count: opts.item.attempt_count + 1,
+      last_error_code: 'invalid_gradex_result',
+      last_error_message: 'Gradex completed without complete Pika assignment scores and feedback',
+      completed_at: opts.now,
+    })
+    return
+  }
+
+  const feedback = sanitizeAiOutputText(opts.record.feedback.trim())
+  const { error } = await opts.supabase
+    .from('assignment_docs')
+    .update({
+      score_completion: opts.record.score_completion,
+      score_thinking: opts.record.score_thinking,
+      score_workflow: opts.record.score_workflow,
+      teacher_feedback_draft: feedback,
+      teacher_feedback_draft_updated_at: opts.now,
+      ai_feedback_suggestion: feedback,
+      ai_feedback_suggested_at: opts.now,
+      ai_feedback_model: formatGradexModel(opts.record),
+      graded_at: opts.now,
+      graded_by: opts.run.triggered_by,
+    })
+    .eq('id', opts.record.assignment_doc_id)
+
+  if (error) {
+    await updateRunItem(opts.supabase, opts.item.id, {
+      status: 'failed',
+      attempt_count: opts.item.attempt_count + 1,
+      last_error_code: 'save_gradex_grade_failed',
+      last_error_message: `Failed to save Gradex grade for student ${opts.item.student_id}`,
+      completed_at: opts.now,
+    })
+    return
+  }
+
+  await updateRunItem(opts.supabase, opts.item.id, {
+    status: 'completed',
+    attempt_count: opts.item.attempt_count + 1,
+    last_error_code: null,
+    last_error_message: null,
+    completed_at: opts.now,
+  })
+}
+
+async function pollGradexAssignmentRun(opts: {
+  supabase: ServiceRoleSupabase
+  assignment: Assignment
+  run: AssignmentAiGradingRun
+  items: AssignmentAiGradingRunItem[]
+}): Promise<void> {
+  const config = getGradexConfig()
+  const gradexRunId = opts.run.gradex_run_id
+  if (!gradexRunId) {
+    throw new Error('Gradex assignment run has not been submitted')
+  }
+
+  const now = new Date().toISOString()
+  const dueItems = getDueGradexItems(opts.items)
+  if (dueItems.length === 0) {
+    return
+  }
+
+  let gradexRun: GradexSmokeRunResponse
+  try {
+    gradexRun = await requestGradexJson<GradexSmokeRunResponse>(config, {
+      path: `/api/v1/grading-runs/${encodeURIComponent(gradexRunId)}`,
+      method: 'GET',
+      expectedStatus: 200,
+    })
+  } catch (error) {
+    if (isGradexRetryableRequestError(error)) {
+      await handleRetryableGradexError({
+        supabase: opts.supabase,
+        items: dueItems,
+        error,
+        now,
+      })
+      return
+    }
+    throw error
+  }
+
+  await updateRunGradexMetadata(opts.supabase, opts.run.id, {
+    gradex_status: gradexRun.status,
+    gradex_last_polled_at: now,
+  })
+
+  if (!isTerminalGradexRun(gradexRun)) {
+    return
+  }
+
+  const { mappings } = await loadGradexRunInputs({
+    supabase: opts.supabase,
+    assignment: opts.assignment,
+    items: dueItems,
+  })
+  const itemByAssignmentDocId = new Map(
+    dueItems
+      .filter((item) => item.assignment_doc_id)
+      .map((item) => [item.assignment_doc_id!, item]),
+  )
+  let itemDetails: GradexSmokeRunItemResponse[]
+  try {
+    itemDetails = await Promise.all(
+      (gradexRun.items ?? []).map((item) =>
+        requestGradexJson<GradexSmokeRunItemResponse>(config, {
+          path: `/api/v1/grading-runs/${encodeURIComponent(gradexRunId)}/items/${encodeURIComponent(item.id)}`,
+          method: 'GET',
+          expectedStatus: 200,
+        }),
+      ),
+    )
+  } catch (error) {
+    if (isGradexRetryableRequestError(error)) {
+      await handleRetryableGradexError({
+        supabase: opts.supabase,
+        items: dueItems,
+        error,
+        now,
+      })
+      return
+    }
+    throw error
+  }
+
+  let records: ReturnType<typeof mapGradexItemsToPikaGradeRecords>
+  try {
+    records = mapGradexItemsToPikaGradeRecords(mappings, itemDetails)
+  } catch (error) {
+    await markGradexItemsForRetryOrFailure({
+      supabase: opts.supabase,
+      items: dueItems,
+      errorCode: 'gradex_mapping_failed',
+      errorMessage: error instanceof Error ? error.message : 'Failed to map Gradex results to Pika records',
+      now,
+    })
+    return
+  }
+  const resolvedAssignmentDocIds = new Set<string>()
+
+  await Promise.all(
+    records.map(async (record) => {
+      const item = itemByAssignmentDocId.get(record.assignment_doc_id)
+      if (!item) return
+      resolvedAssignmentDocIds.add(record.assignment_doc_id)
+
+      if (record.status !== 'completed') {
+        await updateRunItem(opts.supabase, item.id, {
+          status: 'failed',
+          attempt_count: item.attempt_count + 1,
+          last_error_code: 'gradex_item_failed',
+          last_error_message: 'Gradex failed this assignment submission',
+          completed_at: now,
+        })
+        return
+      }
+
+      await applyCompletedGradexRecord({
+        supabase: opts.supabase,
+        run: opts.run,
+        item,
+        record,
+        now,
+      })
+    }),
+  )
+
+  await failUnresolvedGradexItems({
+    supabase: opts.supabase,
+    items: dueItems,
+    completedAssignmentDocIds: resolvedAssignmentDocIds,
+    errorCode: 'gradex_item_missing',
+    errorMessage: `Gradex run ended with status ${gradexRun.status} without a result for this submission`,
+    now,
+  })
+}
+
+export async function submitOrPollGradexAssignmentRun(opts: {
+  supabase: ServiceRoleSupabase
+  assignment: Assignment
+  run: AssignmentAiGradingRun
+  items: AssignmentAiGradingRunItem[]
+}): Promise<void> {
+  if (!opts.run.gradex_run_id) {
+    await submitGradexAssignmentRun(opts)
+    return
+  }
+
+  await pollGradexAssignmentRun(opts)
+}

--- a/src/lib/server/gradex-assignment-payload.ts
+++ b/src/lib/server/gradex-assignment-payload.ts
@@ -56,6 +56,8 @@ export interface GradexGradingRunCreateRequest {
     metadata: {
       adapter_version: typeof GRADEX_PIKA_ADAPTER_VERSION
       client: 'pika'
+      client_run_ref?: string
+      idempotency_key?: string
     }
   }
   rubric: GradexRubric
@@ -170,7 +172,7 @@ export const PIKA_ASSIGNMENT_GRADEX_RUBRIC: GradexRubric = {
   ],
 }
 
-function getRequiredPseudonymSalt(explicitSalt?: string): string {
+export function getRequiredPseudonymSalt(explicitSalt?: string): string {
   const salt = explicitSalt?.trim() || process.env.GRADEX_PIKA_PSEUDONYM_SALT?.trim()
   if (!salt) {
     throw new Error('GRADEX_PIKA_PSEUDONYM_SALT is not configured')
@@ -185,7 +187,7 @@ function getRequiredSanitizationContext(context?: AiSanitizationContext): AiSani
   return context
 }
 
-function pseudonymize(prefix: string, value: string, salt: string): string {
+export function pseudonymizePikaGradexRef(prefix: string, value: string, salt: string): string {
   const digest = createHmac('sha256', salt)
     .update(`${prefix}:${value}`)
     .digest('base64url')
@@ -404,7 +406,7 @@ export function buildPikaAssignmentGradexRunPayload(
     getAssignmentInstructionsMarkdown(opts.assignment).markdown,
   )
   const artifactsByDocId = groupArtifactsByDocId(opts.submissionArtifacts)
-  const assignmentRef = pseudonymize('assignment', opts.assignment.id, salt)
+  const assignmentRef = pseudonymizePikaGradexRef('assignment', opts.assignment.id, salt)
 
   const assignmentPayload = {
     pika_assignment_ref: assignmentRef,
@@ -419,9 +421,9 @@ export function buildPikaAssignmentGradexRunPayload(
   }
 
   const submissions = opts.assignmentDocs.map((assignmentDoc) => {
-    const submissionRef = pseudonymize('submission', assignmentDoc.id, salt)
-    const studentRef = pseudonymize('student', assignmentDoc.student_id, salt)
-    const gradeRef = pseudonymize('grade', assignmentDoc.id, salt)
+    const submissionRef = pseudonymizePikaGradexRef('submission', assignmentDoc.id, salt)
+    const studentRef = pseudonymizePikaGradexRef('student', assignmentDoc.student_id, salt)
+    const gradeRef = pseudonymizePikaGradexRef('grade', assignmentDoc.id, salt)
     const submittedAt = normalizeIsoDate(assignmentDoc.submitted_at)
 
     return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -378,6 +378,10 @@ export interface AssignmentAiGradingRun {
   status: AssignmentAiGradingRunStatus
   triggered_by: string
   model: string | null
+  gradex_run_id?: string | null
+  gradex_status?: string | null
+  gradex_submitted_at?: string | null
+  gradex_last_polled_at?: string | null
   requested_student_ids_json: string[]
   selection_hash: string
   requested_count: number

--- a/supabase/migrations/078_assignment_gradex_run_metadata.sql
+++ b/supabase/migrations/078_assignment_gradex_run_metadata.sql
@@ -1,0 +1,9 @@
+alter table public.assignment_ai_grading_runs
+  add column if not exists gradex_run_id text,
+  add column if not exists gradex_status text,
+  add column if not exists gradex_submitted_at timestamptz,
+  add column if not exists gradex_last_polled_at timestamptz;
+
+create index if not exists idx_assignment_ai_grading_runs_gradex_run_id
+  on public.assignment_ai_grading_runs (gradex_run_id)
+  where gradex_run_id is not null;

--- a/tests/api/teacher/assignments-auto-grade.test.ts
+++ b/tests/api/teacher/assignments-auto-grade.test.ts
@@ -79,6 +79,7 @@ function mockAutoGradeTables(opts: {
 describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
     assertTeacherCanMutateAssignment.mockResolvedValue({
       id: 'assignment-1',
       classroom_id: 'classroom-1',
@@ -190,6 +191,38 @@ describe('POST /api/teacher/assignments/[id]/auto-grade', () => {
         }),
       }),
     )
+  })
+
+  it('uses a background run for a single student when Gradex assignment grading is enabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    mockAutoGradeTables({
+      enrolledIds: ['student-1'],
+    })
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/assignments/assignment-1/auto-grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        student_ids: ['student-1'],
+      }),
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'assignment-1' }) })
+    const data = await response.json()
+
+    expect(response.status).toBe(202)
+    expect(data).toEqual({
+      mode: 'background',
+      run: expect.objectContaining({
+        id: 'run-1',
+        status: 'queued',
+      }),
+    })
+    expect(createOrResumeAssignmentAiGradingRun).toHaveBeenCalledWith({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-1'],
+    })
+    expect(gradeAssignmentDocWithAi).not.toHaveBeenCalled()
   })
 
   it('marks legacy stringified empty docs as missing without calling the grader', async () => {

--- a/tests/lib/assignment-ai-grading-runs.test.ts
+++ b/tests/lib/assignment-ai-grading-runs.test.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockLoadClassroomAiSanitizationContext, mockSupabaseClient } = vi.hoisted(() => ({
+const { mockLoadClassroomAiSanitizationContext, mockSubmitOrPollGradexAssignmentRun, mockSupabaseClient } = vi.hoisted(() => ({
   mockLoadClassroomAiSanitizationContext: vi.fn(),
+  mockSubmitOrPollGradexAssignmentRun: vi.fn(),
   mockSupabaseClient: {
     from: vi.fn(),
     rpc: vi.fn(),
@@ -15,6 +16,14 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/server/ai-sanitization', () => ({
   loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
+}))
+
+vi.mock('@/lib/server/gradex-assignment-grading', () => ({
+  GRADEX_ASSIGNMENT_RUN_MODEL: 'gradex:pika-assignment-v1',
+  isGradexAssignmentGradingEnabled: () =>
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED?.trim().toLowerCase() === 'true',
+  isGradexAssignmentRun: (run: { model: string | null }) => run.model === 'gradex:pika-assignment-v1',
+  submitOrPollGradexAssignmentRun: mockSubmitOrPollGradexAssignmentRun,
 }))
 
 import {
@@ -98,6 +107,7 @@ function buildRunItemsTable(items: unknown[] = []) {
 
 function buildTickHarness(opts: {
   skipReason: 'missing_doc' | 'empty_doc'
+  model?: string
   assignmentDoc: {
     id: string
     student_id: string
@@ -112,7 +122,7 @@ function buildTickHarness(opts: {
     assignment_id: 'assignment-1',
     status: 'queued',
     triggered_by: 'teacher-1',
-    model: 'gpt-5-nano',
+    model: opts.model ?? 'gpt-5-nano',
     selection_hash: buildSelectionHash(['student-1']),
     requested_student_ids_json: ['student-1'],
     requested_count: 1,
@@ -272,6 +282,8 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSupabaseClient.rpc.mockReset()
+    mockSubmitOrPollGradexAssignmentRun.mockResolvedValue(undefined)
+    delete process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED
     mockLoadClassroomAiSanitizationContext.mockResolvedValue({
       students: [],
       initialsMap: {},
@@ -360,6 +372,59 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
             skip_reason: null,
           }),
         ],
+      }),
+    )
+  })
+
+  it('marks created assignment runs for Gradex when the Gradex grading flag is enabled', async () => {
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    const runsTable = buildRunsTable()
+    const assignmentDocsTable = buildAssignmentDocsTable([
+      {
+        id: 'doc-gradable',
+        student_id: 'student-gradable',
+        content: JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        }),
+      },
+    ])
+    const assignmentSubmissionArtifactsTable = buildAssignmentSubmissionArtifactsTable()
+
+    ;(mockSupabaseClient.from as any).mockImplementation((table: string) => {
+      if (table === 'assignment_ai_grading_runs') return runsTable
+      if (table === 'assignment_docs') return assignmentDocsTable
+      if (table === 'assignment_submission_artifacts') return assignmentSubmissionArtifactsTable
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    mockSupabaseClient.rpc.mockResolvedValue({
+      data: {
+        id: 'run-1',
+        assignment_id: 'assignment-1',
+        status: 'queued',
+        model: 'gradex:pika-assignment-v1',
+        created_at: '2026-04-21T12:00:00.000Z',
+      },
+      error: null,
+    })
+
+    const result = await createOrResumeAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      teacherId: 'teacher-1',
+      studentIds: ['student-gradable'],
+    })
+
+    expect(result.kind).toBe('created')
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      'create_assignment_ai_grading_run_atomic',
+      expect.objectContaining({
+        p_model: 'gradex:pika-assignment-v1',
       }),
     )
   })
@@ -562,6 +627,46 @@ describe('createOrResumeAssignmentAiGradingRun', () => {
       last_error_code: 'save_missing_grade_failed',
       last_error_message: 'Failed to save missing grade for student student-1',
     }))
+  })
+
+  it('delegates Gradex-marked runs to the Gradex assignment processor', async () => {
+    const harness = buildTickHarness({
+      model: 'gradex:pika-assignment-v1',
+      skipReason: 'empty_doc',
+      assignmentDoc: {
+        id: 'doc-1',
+        student_id: 'student-1',
+        content: JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Final submission' }],
+            },
+          ],
+        }),
+        feedback: null,
+        authenticity_score: null,
+      },
+      upsertError: null,
+    })
+
+    const result = await tickAssignmentAiGradingRun({
+      assignmentId: 'assignment-1',
+      runId: 'run-1',
+    })
+
+    expect(result.claimed).toBe(true)
+    expect(result.run).toEqual(expect.objectContaining({
+      id: 'run-1',
+      status: 'running',
+    }))
+    expect(mockSubmitOrPollGradexAssignmentRun).toHaveBeenCalledWith({
+      supabase: mockSupabaseClient,
+      assignment: expect.objectContaining({ id: 'assignment-1' }),
+      run: expect.objectContaining({ id: 'run-1', model: 'gradex:pika-assignment-v1' }),
+      items: harness.items,
+    })
   })
 
   it('marks an empty-doc item failed when saving the Missing grade fails', async () => {

--- a/tests/lib/gradex-assignment-grading.test.ts
+++ b/tests/lib/gradex-assignment-grading.test.ts
@@ -1,0 +1,546 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockBuildPikaAssignmentGradexRunPayload,
+  mockLoadAssignmentSubmissionArtifactsForDocs,
+  mockLoadClassroomAiSanitizationContext,
+  mockMapGradexItemsToPikaGradeRecords,
+} = vi.hoisted(() => ({
+  mockBuildPikaAssignmentGradexRunPayload: vi.fn(),
+  mockLoadAssignmentSubmissionArtifactsForDocs: vi.fn(),
+  mockLoadClassroomAiSanitizationContext: vi.fn(),
+  mockMapGradexItemsToPikaGradeRecords: vi.fn(),
+}))
+
+vi.mock('@/lib/server/assignment-submission-artifacts', () => ({
+  loadAssignmentSubmissionArtifactsForDocs: mockLoadAssignmentSubmissionArtifactsForDocs,
+}))
+
+vi.mock('@/lib/server/ai-sanitization', () => ({
+  loadClassroomAiSanitizationContext: mockLoadClassroomAiSanitizationContext,
+}))
+
+vi.mock('@/lib/server/gradex-assignment-payload', () => ({
+  buildPikaAssignmentGradexRunPayload: mockBuildPikaAssignmentGradexRunPayload,
+  getRequiredPseudonymSalt: () => 'test-pseudonym-salt',
+  pseudonymizePikaGradexRef: (prefix: string, value: string) => `pika-${prefix}-${value}`,
+}))
+
+vi.mock('@/lib/server/gradex-smoke-runner', () => ({
+  mapGradexItemsToPikaGradeRecords: mockMapGradexItemsToPikaGradeRecords,
+}))
+
+import {
+  GRADEX_ASSIGNMENT_RUN_MODEL,
+  isGradexAssignmentGradingEnabled,
+  submitOrPollGradexAssignmentRun,
+} from '@/lib/server/gradex-assignment-grading'
+
+describe('Gradex assignment grading processor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'true'
+    process.env.GRADEX_API_URL = 'https://gradex.example.test/'
+    process.env.GRADEX_API_KEY = 'gx_test_key'
+    mockLoadAssignmentSubmissionArtifactsForDocs.mockResolvedValue([])
+    mockLoadClassroomAiSanitizationContext.mockResolvedValue({ students: [], initialsMap: {} })
+    mockBuildPikaAssignmentGradexRunPayload.mockReturnValue({
+      gradexRequest: {
+        assignment: {
+          external_assignment_id: 'pika-assignment-safe',
+          title: 'Safe Assignment',
+          instructions: 'Safe instructions',
+          type: 'essay',
+          metadata: { adapter_version: 'pika-assignment-adapter-v1', client: 'pika' },
+        },
+        rubric: { version: 'pika-essay-ctw-v1', criteria: [] },
+        settings: {
+          grading_profile: 'pika-assignment-v1',
+          model_profile: 'calibration',
+          provider: 'auto',
+          tier: 'auto',
+          prompt_version: 'gradex-essay-rubric-v1',
+          feedback_style: 'balanced',
+          confidence_threshold: 0.65,
+          request_timeout_ms: 25_000,
+        },
+        submissions: [],
+        workflow_evidence_by_submission_id: {},
+      },
+      mappings: [
+        {
+          assignment_doc_id: 'doc-1',
+          student_id: 'student-1',
+          pika_grade_record_ref: 'pika-grade-safe',
+          pika_submission_ref: 'pika-submission-safe',
+          pika_student_ref: 'pika-student-safe',
+          gradex_submission_id: 'pika-submission-safe',
+          gradex_student_id: 'pika-student-safe',
+        },
+      ],
+    })
+  })
+
+  it('uses an explicit feature flag for Gradex assignment grading', () => {
+    expect(isGradexAssignmentGradingEnabled()).toBe(true)
+    process.env.GRADEX_ASSIGNMENT_GRADING_ENABLED = 'false'
+    expect(isGradexAssignmentGradingEnabled()).toBe(false)
+  })
+
+  it('submits a sanitized Gradex run and stores remote run metadata', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe('https://gradex.example.test/api/v1/grading-runs')
+      expect(init?.method).toBe('POST')
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer gx_test_key' })
+      expect(JSON.parse(String(init?.body))).toEqual(
+        expect.objectContaining({
+          assignment: expect.objectContaining({
+            metadata: expect.objectContaining({
+              client_run_ref: expect.stringMatching(/^pika-run-/),
+              idempotency_key: expect.stringMatching(/^pika-run-/),
+            }),
+          }),
+        }),
+      )
+      return jsonResponse(202, {
+        id: 'gradex-run-1',
+        status: 'queued',
+        counts: { requested: 1, processed: 0, completed: 0, failed: 0, skipped: 0, pending: 1 },
+        provider: null,
+        model: null,
+        tier: null,
+        policy_version: null,
+        prompt_version: null,
+        items: [],
+      })
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: null }),
+      items: [item()],
+    })
+
+    expect(mockBuildPikaAssignmentGradexRunPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignment: expect.objectContaining({ id: 'assignment-1' }),
+        assignmentDocs: [expect.objectContaining({ id: 'doc-1' })],
+        sanitizationContext: { students: [], initialsMap: {} },
+      }),
+    )
+    expect(supabase.itemUpdates).toEqual([
+      expect.objectContaining({
+        table: 'assignment_ai_grading_run_items',
+        id: 'item-1',
+        payload: expect.objectContaining({ status: 'processing' }),
+      }),
+    ])
+    expect(supabase.runUpdates).toEqual([
+      expect.objectContaining({
+        id: 'run-1',
+        payload: expect.objectContaining({
+          gradex_run_id: 'gradex-run-1',
+          gradex_status: 'queued',
+          gradex_submitted_at: expect.any(String),
+          gradex_last_polled_at: expect.any(String),
+        }),
+      }),
+    ])
+  })
+
+  it('polls a completed Gradex run and maps results into Pika grade fields', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input)
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer gx_test_key' })
+      if (url === 'https://gradex.example.test/api/v1/grading-runs/gradex-run-1') {
+        return jsonResponse(200, {
+          id: 'gradex-run-1',
+          status: 'completed',
+          counts: { requested: 1, processed: 1, completed: 1, failed: 0, skipped: 0, pending: 0 },
+          provider: 'openai',
+          model: 'gpt-5-nano',
+          tier: 'tier_1',
+          policy_version: 'gradex-routing-policy-v1',
+          prompt_version: 'gradex-essay-rubric-v1',
+          items: [{ id: 'gradex-item-1', status: 'completed', external_submission_id: 'pika-submission-safe', external_student_id: 'pika-student-safe', error: null }],
+        })
+      }
+      if (url === 'https://gradex.example.test/api/v1/grading-runs/gradex-run-1/items/gradex-item-1') {
+        return jsonResponse(200, {
+          id: 'gradex-item-1',
+          status: 'completed',
+          external_submission_id: 'pika-submission-safe',
+          external_student_id: 'pika-student-safe',
+          error: null,
+          result: { provider: 'openai', model: 'gpt-5-nano', tier: 'tier_1', audit_id: 'audit-1' },
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+    mockMapGradexItemsToPikaGradeRecords.mockReturnValue([
+      {
+        assignment_doc_id: 'doc-1',
+        student_id: 'student-1',
+        pika_grade_record_ref: 'pika-grade-safe',
+        pika_submission_ref: 'pika-submission-safe',
+        gradex_submission_id: 'pika-submission-safe',
+        gradex_item_id: 'gradex-item-1',
+        status: 'completed',
+        score_completion: 8,
+        score_thinking: 7,
+        score_workflow: 9,
+        feedback: 'Strength: clear work. Next step: add one example.',
+        provider: 'openai',
+        model: 'gpt-5-nano',
+        tier: 'tier_1',
+        audit_id: 'audit-1',
+      },
+    ])
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: 'gradex-run-1' }),
+      items: [item({ status: 'processing' })],
+    })
+
+    expect(supabase.docUpdates).toEqual([
+      expect.objectContaining({
+        id: 'doc-1',
+        payload: expect.objectContaining({
+          score_completion: 8,
+          score_thinking: 7,
+          score_workflow: 9,
+          teacher_feedback_draft: 'Strength: clear work. Next step: add one example.',
+          ai_feedback_model: 'gradex:openai/gpt-5-nano/tier_1',
+          graded_by: 'teacher-1',
+        }),
+      }),
+    ])
+    expect(supabase.itemUpdates).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        payload: expect.objectContaining({
+          status: 'completed',
+          attempt_count: 1,
+          last_error_code: null,
+        }),
+      }),
+    ])
+  })
+
+  it('queues a retry instead of throwing when a Gradex submission request is retryable', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse(503, {
+        error: { message: 'Gradex temporarily unavailable' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: null }),
+      items: [item()],
+    })
+
+    expect(supabase.runUpdates).toEqual([])
+    expect(supabase.itemUpdates).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        payload: expect.objectContaining({ status: 'processing' }),
+      }),
+      expect.objectContaining({
+        id: 'item-1',
+        payload: expect.objectContaining({
+          status: 'queued',
+          attempt_count: 1,
+          last_error_code: 'gradex_retryable_http_error',
+          last_error_message: 'Gradex temporarily unavailable',
+          next_retry_at: expect.any(String),
+          completed_at: null,
+        }),
+      }),
+    ])
+  })
+
+  it('does not resubmit before a queued Gradex item retry is due', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: null }),
+      items: [
+        item({
+          status: 'queued',
+          attempt_count: 1,
+          next_retry_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      ],
+    })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(mockBuildPikaAssignmentGradexRunPayload).not.toHaveBeenCalled()
+    expect(supabase.itemUpdates).toEqual([])
+    expect(supabase.runUpdates).toEqual([])
+  })
+
+  it('queues a retry instead of throwing when a Gradex poll request is retryable', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse(429, {
+        error: { message: 'Rate limited' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: 'gradex-run-1' }),
+      items: [item({ status: 'processing' })],
+    })
+
+    expect(supabase.runUpdates).toEqual([])
+    expect(supabase.itemUpdates).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        payload: expect.objectContaining({
+          status: 'queued',
+          attempt_count: 1,
+          last_error_code: 'gradex_retryable_http_error',
+          last_error_message: 'Rate limited',
+          next_retry_at: expect.any(String),
+          completed_at: null,
+        }),
+      }),
+    ])
+  })
+
+  it('does not poll before a processing Gradex item retry is due', async () => {
+    const supabase = buildSupabase()
+    const fetchImpl = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: 'gradex-run-1' }),
+      items: [
+        item({
+          status: 'processing',
+          attempt_count: 1,
+          next_retry_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      ],
+    })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(mockBuildPikaAssignmentGradexRunPayload).not.toHaveBeenCalled()
+    expect(supabase.itemUpdates).toEqual([])
+    expect(supabase.runUpdates).toEqual([])
+  })
+
+  it('fails unresolved local items when Gradex ends without item results', async () => {
+    const supabase = buildSupabase()
+    mockMapGradexItemsToPikaGradeRecords.mockReturnValue([])
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer gx_test_key' })
+      expect(String(input)).toBe('https://gradex.example.test/api/v1/grading-runs/gradex-run-1')
+      return jsonResponse(200, {
+        id: 'gradex-run-1',
+        status: 'failed',
+        counts: { requested: 1, processed: 1, completed: 0, failed: 1, skipped: 0, pending: 0 },
+        provider: null,
+        model: null,
+        tier: null,
+        policy_version: null,
+        prompt_version: null,
+        items: [],
+      })
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await submitOrPollGradexAssignmentRun({
+      supabase: supabase.client,
+      assignment: assignment(),
+      run: run({ gradex_run_id: 'gradex-run-1' }),
+      items: [item({ status: 'processing' })],
+    })
+
+    expect(supabase.runUpdates).toEqual([
+      expect.objectContaining({
+        id: 'run-1',
+        payload: expect.objectContaining({
+          gradex_status: 'failed',
+          gradex_last_polled_at: expect.any(String),
+        }),
+      }),
+    ])
+    expect(supabase.itemUpdates).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        payload: expect.objectContaining({
+          status: 'failed',
+          attempt_count: 1,
+          last_error_code: 'gradex_item_missing',
+          last_error_message: 'Gradex run ended with status failed without a result for this submission',
+          completed_at: expect.any(String),
+        }),
+      }),
+    ])
+  })
+})
+
+function assignment() {
+  return {
+    id: 'assignment-1',
+    classroom_id: 'classroom-1',
+    title: 'Assignment One',
+    description: null,
+    instructions_markdown: 'Instructions',
+    rich_instructions: null,
+    due_at: null,
+    position: 1,
+    is_draft: false,
+    released_at: null,
+    track_authenticity: true,
+    points_possible: 30,
+    include_in_final: true,
+    gradebook_weight: 1,
+    created_by: 'teacher-1',
+    created_at: '2026-06-01T12:00:00.000Z',
+    updated_at: '2026-06-01T12:00:00.000Z',
+  }
+}
+
+function run(overrides: Partial<any> = {}) {
+  return {
+    id: 'run-1',
+    assignment_id: 'assignment-1',
+    status: 'running',
+    triggered_by: 'teacher-1',
+    model: GRADEX_ASSIGNMENT_RUN_MODEL,
+    gradex_run_id: null,
+    requested_student_ids_json: ['student-1'],
+    selection_hash: 'selection-hash',
+    requested_count: 1,
+    gradable_count: 1,
+    processed_count: 0,
+    completed_count: 0,
+    skipped_missing_count: 0,
+    skipped_empty_count: 0,
+    failed_count: 0,
+    error_samples_json: [],
+    lease_token: null,
+    lease_expires_at: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-06-01T12:00:00.000Z',
+    updated_at: '2026-06-01T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function item(overrides: Partial<any> = {}) {
+  return {
+    id: 'item-1',
+    run_id: 'run-1',
+    assignment_id: 'assignment-1',
+    student_id: 'student-1',
+    assignment_doc_id: 'doc-1',
+    queue_position: 0,
+    status: 'queued',
+    skip_reason: null,
+    attempt_count: 0,
+    next_retry_at: null,
+    last_error_code: null,
+    last_error_message: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-06-01T12:00:00.000Z',
+    updated_at: '2026-06-01T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function buildSupabase() {
+  const runUpdates: Array<{ table: string; id: string; payload: Record<string, unknown> }> = []
+  const itemUpdates: Array<{ table: string; id: string; payload: Record<string, unknown> }> = []
+  const docUpdates: Array<{ table: string; id: string; payload: Record<string, unknown> }> = []
+
+  return {
+    runUpdates,
+    itemUpdates,
+    docUpdates,
+    client: {
+      from(table: string) {
+        if (table === 'assignment_docs') {
+          return {
+            select: vi.fn(() => ({
+              in: vi.fn(async () => ({
+                data: [
+                  {
+                    id: 'doc-1',
+                    student_id: 'student-1',
+                    content: { type: 'doc', content: [] },
+                    submitted_at: '2026-06-01T12:00:00.000Z',
+                    authenticity_score: 88,
+                    authenticity_flags: [],
+                  },
+                ],
+                error: null,
+              })),
+            })),
+            update: vi.fn((payload: Record<string, unknown>) => ({
+              eq: vi.fn(async (_field: string, id: string) => {
+                docUpdates.push({ table, id, payload })
+                return { error: null }
+              }),
+            })),
+          }
+        }
+
+        if (table === 'assignment_ai_grading_runs') {
+          return {
+            update: vi.fn((payload: Record<string, unknown>) => ({
+              eq: vi.fn(async (_field: string, id: string) => {
+                runUpdates.push({ table, id, payload })
+                return { error: null }
+              }),
+            })),
+          }
+        }
+
+        if (table === 'assignment_ai_grading_run_items') {
+          return {
+            update: vi.fn((payload: Record<string, unknown>) => ({
+              eq: vi.fn(async (_field: string, id: string) => {
+                itemUpdates.push({ table, id, payload })
+                return { error: null }
+              }),
+            })),
+          }
+        }
+
+        throw new Error(`Unexpected table: ${table}`)
+      },
+    },
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## What changed

- Adds a feature-flagged Gradex assignment grading adapter path for Pika assignment auto-grade runs.
- Stores remote Gradex run metadata on `assignment_ai_grading_runs` so Pika can submit once, poll later, and map results back to assignment docs.
- Keeps existing local OpenAI assignment grading as the default path unless `GRADEX_ASSIGNMENT_GRADING_ENABLED=true`.
- Adds tests for flag behavior, background run delegation, Gradex submit/poll mapping, and migration numbering.

## Why

This is the first production-facing Pika adapter slice for the Gradex boundary: Pika sanitizes/pseudonymizes classroom data, submits the sanitized grading job to Gradex, polls results, and maps Gradex results back into Pika grade fields.

## Validation

- `bash scripts/verify-env.sh` passed: 303 files, 2654 tests
- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/lib/gradex-assignment-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-smoke-runner.test.ts tests/unit/migration-filenames.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm exec tsc --noEmit` after build regenerated `.next/types`
- `git diff --check`

## Notes

- Migration `078_assignment_gradex_run_metadata.sql` is created but not applied by the agent. Humans still apply Supabase migrations manually.
- `pnpm exec tsc --noEmit` failed once before `pnpm build` because stale `.next/types` referenced missing generated files; after build regenerated them, standalone typecheck passed.
