### PR TITLE
Harden snapshot gallery access and loading

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,22 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Validation pass completed
-
-**Completed:**
-- Installed worktree dependencies with `pnpm install --frozen-lockfile`.
-- Ran focused validation for the new guardrail and guidance work.
-- Fixed one over-strict unit-test expectation in [`tests/unit/query-chunks.test.ts`](/Users/stew/.codex/worktrees/f558/pika/tests/unit/query-chunks.test.ts) after confirming the loader legitimately re-applies filter chunks across pagination pages.
-- Fixed one TypeScript build issue in [`src/lib/server/query-chunks.ts`](/Users/stew/.codex/worktrees/f558/pika/src/lib/server/query-chunks.ts) by adding an explicit recursive return type for the internal `visit` helper.
-
-**Validation:**
-- `pnpm install --frozen-lockfile`
-- `pnpm vitest run tests/unit/query-chunks.test.ts tests/unit/classroom-enrollment-validation.test.ts tests/unit/ui-guidance-docs.test.ts tests/api/teacher/assignments-auto-grade.test.ts --reporter=verbose`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-30 — Path-aware audit test matching
 
 **Completed:**
@@ -1007,3 +991,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Rereview: no remaining findings in the updated link reachability path.
+
+## 2026-06-02 — Snapshot gallery phase-2 hardening
+
+**Completed:**
+- Added server-side hardening for `/snapshots-gallery` in [`src/app/snapshots-gallery/page.tsx`](/Users/stew/.codex/worktrees/pika/snapshot-gallery-phase2/src/app/snapshots-gallery/page.tsx):
+  - Gate for `ENABLE_UI_GALLERY === 'true'` with `notFound()`.
+  - Enforce authenticated teacher access via `requireSnapshotGalleryAccess()`.
+  - Redirect unauthenticated users to `/login` and 404 on authorization failures.
+- Hardened snapshot client loading in [`src/app/snapshots-gallery/SnapshotGallery.tsx`](/Users/stew/.codex/worktrees/pika/snapshot-gallery-phase2/src/app/snapshots-gallery/SnapshotGallery.tsx):
+  - Added non-OK HTTP response handling.
+  - Added runtime payload-shape validation before rendering.
+  - Added explicit error state and recoverable "no matching snapshots" filter-empty state.
+- Added regression coverage for snapshot gallery client loading in [`tests/components/SnapshotGallery.test.tsx`](/Users/stew/.codex/worktrees/pika/snapshot-gallery-phase2/tests/components/SnapshotGallery.test.tsx).
+
+**Validation:**
+- `pnpm exec vitest run tests/components/SnapshotGallery.test.tsx tests/api/snapshots-list.test.ts tests/api/snapshots-filename.test.ts`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm build`
+- `bash scripts/trim-session-log.mjs`

--- a/src/app/snapshots-gallery/SnapshotGallery.tsx
+++ b/src/app/snapshots-gallery/SnapshotGallery.tsx
@@ -9,22 +9,92 @@ interface Snapshot {
   name: string
 }
 
+interface SnapshotListResponse {
+  snapshots: Snapshot[]
+}
+
+function isSnapshotListResponse(value: unknown): value is SnapshotListResponse {
+  if (!value || typeof value !== 'object' || !('snapshots' in value)) {
+    return false
+  }
+
+  const snapshots = (value as { snapshots: unknown }).snapshots
+  if (!Array.isArray(snapshots)) {
+    return false
+  }
+
+  return snapshots.every(
+    (snapshot) =>
+      snapshot &&
+      typeof snapshot === 'object' &&
+      'filename' in snapshot &&
+      'name' in snapshot &&
+      typeof (snapshot as Snapshot).filename === 'string' &&
+      typeof (snapshot as Snapshot).name === 'string'
+  )
+}
+
+function formatErrorMessage(status: number) {
+  if (status === 401) {
+    return 'You must be signed in as an authorized user to view this page.'
+  }
+
+  if (status === 403) {
+    return 'The snapshot gallery is not available in this environment.'
+  }
+
+  if (status === 404) {
+    return 'The snapshot gallery is disabled.'
+  }
+
+  return `Unable to load snapshots (HTTP ${status}).`
+}
+
 export function SnapshotGallery() {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
   const [filter, setFilter] = useState<'all' | 'auth' | 'teacher' | 'student'>('all')
 
   useEffect(() => {
-    fetch('/api/snapshots/list')
-      .then((res) => res.json())
-      .then((data) => {
-        setSnapshots(data.snapshots)
-        setLoading(false)
-      })
-      .catch((err) => {
-        console.error('Failed to load snapshots:', err)
-        setLoading(false)
-      })
+    let cancelled = false
+
+    const loadSnapshots = async () => {
+      try {
+        const response = await fetch('/api/snapshots/list')
+
+        if (!response.ok) {
+          const body = await response.text().catch(() => '')
+          const message = body.trim() || formatErrorMessage(response.status)
+          throw new Error(message)
+        }
+
+        const data = await response.json()
+        if (!isSnapshotListResponse(data)) {
+          throw new Error('Unexpected snapshot list response format.')
+        }
+
+        if (!cancelled) {
+          setSnapshots(data.snapshots)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Failed to load snapshots:', err)
+          setError(err instanceof Error ? err.message : 'Failed to load snapshots.')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    setLoading(true)
+    void loadSnapshots()
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const filteredSnapshots = snapshots.filter((snapshot) => {
@@ -46,6 +116,18 @@ export function SnapshotGallery() {
     )
   }
 
+  if (error) {
+    return (
+      <div className="min-h-screen bg-page flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-danger mb-2">Unable to load snapshots</h1>
+          <p className="text-text-muted">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  const hasSnapshots = filteredSnapshots.length > 0
   if (snapshots.length === 0) {
     return (
       <div className="min-h-screen bg-page flex items-center justify-center">
@@ -54,6 +136,19 @@ export function SnapshotGallery() {
           <p className="text-text-muted mb-4">
             Run <code className="bg-surface-2 px-2 py-1 rounded">pnpm run e2e:snapshots:update</code> to
             generate snapshots
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!hasSnapshots) {
+    return (
+      <div className="min-h-screen bg-page flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-text-default mb-2">No matching snapshots</h1>
+          <p className="text-text-muted mb-4">
+            Try changing the filter to view a different snapshot set.
           </p>
         </div>
       </div>

--- a/src/app/snapshots-gallery/page.tsx
+++ b/src/app/snapshots-gallery/page.tsx
@@ -6,11 +6,31 @@
  *
  * Each snapshot is clickable to view full-size in a new tab.
  */
+import { AuthenticationError, AuthorizationError, requireSnapshotGalleryAccess } from '@/lib/auth'
+import { notFound, redirect } from 'next/navigation'
 import { SnapshotGallery } from './SnapshotGallery'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-export default function SnapshotsPage() {
+export default async function SnapshotsPage() {
+  if (process.env.ENABLE_UI_GALLERY !== 'true') {
+    notFound()
+  }
+
+  try {
+    await requireSnapshotGalleryAccess()
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      redirect('/login')
+    }
+
+    if (error instanceof AuthorizationError) {
+      notFound()
+    }
+
+    throw error
+  }
+
   return <SnapshotGallery />
 }

--- a/tests/components/SnapshotGallery.test.tsx
+++ b/tests/components/SnapshotGallery.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SnapshotGallery } from '@/app/snapshots-gallery/SnapshotGallery'
+
+interface MockResponseInit {
+  status?: number
+  ok?: boolean
+  json?: () => Promise<unknown>
+  text?: () => Promise<string>
+}
+
+function mockResponse(payload: unknown, init: MockResponseInit = {}) {
+  return {
+    status: init.status ?? 200,
+    ok: init.ok ?? (init.status === undefined || (init.status >= 200 && init.status < 300)),
+    json: init.json ?? (() => Promise.resolve(payload)),
+    text: init.text ?? (() => Promise.resolve(typeof payload === 'string' ? payload : JSON.stringify(payload))),
+  } as Response
+}
+
+describe('SnapshotGallery', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders snapshots when the API returns valid data', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse({
+      snapshots: [
+        { filename: 'teacher-home.png', name: 'Teacher Home' },
+        { filename: 'student-home.png', name: 'Student Home' },
+      ],
+    })))
+
+    render(<SnapshotGallery />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Teacher Home')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('2 snapshots captured')).toBeInTheDocument()
+  })
+
+  it('shows an error state for non-OK API responses', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse('Unauthorized', {
+      status: 401,
+      ok: false,
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({ error: 'Unauthorized' }),
+    })))
+
+    render(<SnapshotGallery />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unable to load snapshots' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/signed in as an authorized user/i)).toBeInTheDocument()
+  })
+
+  it('handles malformed snapshot payloads safely', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => mockResponse({ notSnapshots: true })))
+
+    render(<SnapshotGallery />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unable to load snapshots' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Unexpected snapshot list response format.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Add server-side guardrail to /snapshots-gallery: require `ENABLE_UI_GALLERY=true`, enforce `requireSnapshotGalleryAccess()`, redirect unauthenticated users to `/login`, and return 404 for authorization failures.
- Harden client-side snapshot list loading against non-OK responses and malformed payloads, with explicit user-facing error state and filter-empty state.
- Add component regression coverage for snapshot gallery success/error/malformed payload behavior.

## Files
- `src/app/snapshots-gallery/page.tsx`
- `src/app/snapshots-gallery/SnapshotGallery.tsx`
- `tests/components/SnapshotGallery.test.tsx`

## Validation
- `pnpm exec vitest run tests/components/SnapshotGallery.test.tsx tests/api/snapshots-list.test.ts tests/api/snapshots-filename.test.ts`
- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build`

## Review
### Findings
1) No blocking issues found.
2) Runtime and compile checks pass in this branch.
3) Small behavior change: non-OK responses now surface explicit error text instead of silently falling back; this is intended hardening and aligns with restricted admin-only gallery requirement.

## Notes
- This PR is ready for review and merge pending normal CI.
