### PR TITLE
[codex] Cover Gradex assignment UI cutover

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,33 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Path-aware audit test matching
-
-**Completed:**
-- Tightened the audit heuristic in [`audit.sh`](/Users/stew/.codex/worktrees/f558/pika/.codex/skills/pika-audit/scripts/audit.sh) so risky API changes require relevant changed tests under `tests/api` or `tests/integration`, while `src/lib/server/*` can still be satisfied by `tests/lib` or `tests/unit`.
-- Kept composite-widget matching scoped to `tests/components`, `tests/ui`, or `tests/integration`.
-- Added fixture-based regression tests in [`tests/unit/ai-startup-docs.test.ts`](/Users/stew/.codex/worktrees/f558/pika/tests/unit/ai-startup-docs.test.ts) proving that:
-  - a risky API change plus an unrelated unit test now fails audit,
-  - the same risky API change plus a relevant API test passes audit.
-- Updated audit guidance assertions in [`tests/unit/ui-guidance-docs.test.ts`](/Users/stew/.codex/worktrees/f558/pika/tests/unit/ui-guidance-docs.test.ts).
-
-**Validation:**
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts --reporter=verbose`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
-## 2026-05-30 — Audit message alignment
-
-**Completed:**
-- Fixed the minor audit messaging mismatch so `missing-risk-tests` now reports path-specific expectations that match the actual rule:
-  - API routes mention `tests/api` / `tests/integration`
-  - server modules mention `tests/api` / `tests/integration` / `tests/lib` / `tests/unit`
-
-**Validation:**
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts --reporter=verbose`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
 ## 2026-05-28 — Test list stats enrollment scoping
 
 **Completed:**
@@ -1011,6 +984,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm build`
 - `bash scripts/trim-session-log.mjs`
+
 ## 2026-06-02 — Gradex assignment adapter slice
 
 **Completed:**
@@ -1036,3 +1010,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Follow-up:**
 - Apply migration 078 in the target Pika environment before enabling `GRADEX_ASSIGNMENT_GRADING_ENABLED`.
 - Run a real Pika assignment UI smoke with Gradex enabled after the migration and env vars are present.
+
+## 2026-06-03 — Gradex assignment UI cutover coverage
+
+**Completed:**
+- Confirmed the existing selected-students assignment `AI Grade` action uses the background assignment run path when Gradex assignment grading is enabled.
+- Clarified the assignment auto-grade route branch as `shouldUseBackgroundRun`, covering both multi-student selections and Gradex-enabled assignment grading.
+- Added a `TeacherClassroomView` regression for one selected student: the UI posts to assignment auto-grade, receives a Gradex-marked background run, polls/ticks it, clears the selection, and reports completion.
+- Re-ran the live Pika-to-Gradex assignment smoke against `https://gradex-two.vercel.app`.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/components/TeacherClassroomView.test.tsx`
+- `pnpm exec tsc --noEmit`
+- `pnpm smoke:gradex:assignment`
+- `pnpm lint`

--- a/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
+++ b/src/app/api/teacher/assignments/[id]/auto-grade/route.ts
@@ -53,7 +53,10 @@ export const POST = withErrorHandler('PostTeacherAssignmentAutoGrade', async (re
     return NextResponse.json({ error: 'Student is not enrolled in this classroom' }, { status: 400 })
   }
 
-  if (normalizedStudentIds.length > 1 || isGradexAssignmentGradingEnabled()) {
+  const shouldUseBackgroundRun =
+    normalizedStudentIds.length > 1 || isGradexAssignmentGradingEnabled()
+
+  if (shouldUseBackgroundRun) {
     const runResult = await createOrResumeAssignmentAiGradingRun({
       assignmentId: id,
       teacherId: user.id,

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -2422,6 +2422,133 @@ describe('TeacherClassroomView', () => {
     expect(mockClearSelection).toHaveBeenCalled()
   })
 
+  it('starts and polls a Gradex assignment run from the selected-students AI Grade action', async () => {
+    mockStudentSelectionState.selectedIds = new Set(['student-1'])
+    mockStudentSelectionState.selectedCount = 1
+
+    const gradexRun = {
+      id: 'run-gradex-1',
+      assignment_id: 'assignment-1',
+      status: 'queued',
+      model: 'gradex:pika-assignment-v1',
+      requested_count: 1,
+      gradable_count: 1,
+      processed_count: 0,
+      completed_count: 0,
+      skipped_missing_count: 0,
+      skipped_empty_count: 0,
+      failed_count: 0,
+      pending_count: 1,
+      next_retry_at: null,
+      error_samples: [],
+      started_at: null,
+      completed_at: null,
+      created_at: '2026-04-20T12:00:00Z',
+    }
+
+    const autoGradeBodies: Array<Record<string, unknown>> = []
+    let assignmentFetchCount = 0
+    let statusFetchCount = 0
+    let tickFetchCount = 0
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === `/api/classrooms/${classroom.id}/class-days`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ class_days: [] }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1') {
+        assignmentFetchCount += 1
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            makeAssignmentDetails(
+              'assignment-1',
+              'Assignment One',
+              'student-1',
+              assignmentFetchCount === 1 ? null : { ...gradexRun, status: 'completed', processed_count: 1, completed_count: 1, pending_count: 0 },
+            ),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/auto-grade' && init?.method === 'POST') {
+        autoGradeBodies.push(JSON.parse(String(init.body || '{}')) as Record<string, unknown>)
+        return Promise.resolve({
+          ok: true,
+          status: 202,
+          json: async () => ({
+            mode: 'background',
+            run: gradexRun,
+          }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/auto-grade-runs/run-gradex-1') {
+        statusFetchCount += 1
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            run: {
+              ...gradexRun,
+              status: 'running',
+              started_at: '2026-04-20T12:00:30Z',
+            },
+          }),
+        })
+      }
+
+      if (url === '/api/teacher/assignments/assignment-1/auto-grade-runs/run-gradex-1/tick') {
+        tickFetchCount += 1
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            claimed: true,
+            run: {
+              ...gradexRun,
+              status: 'completed',
+              processed_count: 1,
+              completed_count: 1,
+              pending_count: 0,
+              started_at: '2026-04-20T12:00:30Z',
+              completed_at: '2026-04-20T12:01:00Z',
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    document.cookie = `${encodeURIComponent(`teacherAssignmentsSelection:${classroom.id}`)}=${encodeURIComponent('assignment-1')}; Path=/; SameSite=Lax`
+
+    render(<TeacherClassroomView classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /AI Grade/i }))
+
+    await waitFor(() => {
+      expect(autoGradeBodies).toEqual([{ student_ids: ['student-1'] }])
+    })
+    await waitFor(() => {
+      expect(tickFetchCount).toBe(1)
+    })
+    expect(statusFetchCount).toBeGreaterThanOrEqual(1)
+    expect(mockClearSelection).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockShowMessage).toHaveBeenCalledWith({ text: 'Graded 1', tone: 'info' })
+    })
+  })
+
   it('shows only unique true errors in the completion message and treats empty work as missing', async () => {
     const initialRun = {
       id: 'run-1',


### PR DESCRIPTION
## What changed

- Clarifies the assignment auto-grade route branch that chooses background assignment runs for either multi-student selections or Gradex-enabled assignment grading.
- Adds a TeacherClassroomView regression for the existing selected-students AI Grade action starting a Gradex-marked background run for one selected student, polling/ticking it, clearing selection, and reporting completion.
- Updates the rolling AI session log.

## Why

The Gradex assignment adapter is already feature-flagged behind `GRADEX_ASSIGNMENT_GRADING_ENABLED=true`. This PR locks down the UI behavior we need before relying on the existing Pika assignment AI Grade flow as the Gradex entry point.

## Validation

- `bash scripts/verify-env.sh` (full suite: 305 files, 2681 tests)
- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/components/TeacherClassroomView.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm smoke:gradex:assignment` against `https://gradex-two.vercel.app`
