### PR TITLE
[codex] Polish gradebook grade controls

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,25 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-28 — Test list stats enrollment scoping
-
-**Completed:**
-- Scoped teacher test list respondent, submission, and availability stats to paginated current classroom enrollments.
-- Added chunked stats loaders for test questions, attempts, responses, availability overrides, and draft overlays to avoid oversized Supabase `.in()` filters on large test lists or rosters.
-- Returned a clear 500 when classroom enrollment loading fails instead of reporting empty stats.
-- Applied assessment draft overlays only to draft tests so active/closed list rows match canonical test metadata.
-- Added regressions for enrollment failures, current-enrollment scoping, 51x51 chunking, and stale draft overlays.
-
-**Validation:**
-- `pnpm vitest run tests/api/teacher/tests-route.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-28 — Quiz list stats chunked pagination
 
 **Completed:**
@@ -1025,3 +1006,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm smoke:gradex:assignment`
 - `pnpm lint`
+
+## 2026-06-03 — Gradebook grade color bands
+
+**Completed:**
+- Added shared grade percentage text coloring in the teacher gradebook: below 50% uses danger text, 50% up to but not including 70% uses warning text, and 70% or higher remains default text.
+- Applied the bands to assessment cells, final grades, summary rows, and the selected-student detail panel while keeping ungraded/hidden values muted.
+- Persisted the gradebook email split button at zero selected students and moved `Show %` / `Show Raw` into its dropdown as radio-style menu items.
+- Added component coverage for red, amber, exact-70 default, and default grade bands plus the persistent split-button score-display menu.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm lint`
+- Visual verification: `pika-ui-verify` on `classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook` (teacher desktop, student mobile, teacher mobile) plus loaded table screenshots, open dropdown screenshot, and exact-70 boundary screenshot.

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -20,10 +20,8 @@ import type {
 import {
   Button,
   Input,
-  SegmentedControl,
   SplitButton,
   Tooltip,
-  type SegmentedControlOption,
   type SplitButtonOption,
   useAppMessage,
 } from '@/ui'
@@ -126,6 +124,20 @@ function formatCompactPercent(value: number | null): string {
   if (value == null) return '—'
   const rounded = round2(value)
   return `${Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)}%`
+}
+
+function getGradePercentTextClass(percent: number | null | undefined): string {
+  if (percent == null || !Number.isFinite(percent)) return 'text-text-muted'
+  if (percent < 50) return 'text-danger'
+  if (percent < 70) return 'text-warning'
+  return 'text-text-default'
+}
+
+function getAssessmentCellPercent(cell: GradebookAssessmentCell | null): number | null {
+  if (!cell?.is_graded) return null
+  if (cell.percent != null) return cell.percent
+  if (cell.earned != null && cell.possible > 0) return (cell.earned / cell.possible) * 100
+  return null
 }
 
 function formatWeightShare(weight: number, total: number): string {
@@ -416,7 +428,10 @@ function StudentAssessmentPanel({
         <div className="flex shrink-0 items-start gap-2">
           <div className="rounded-md bg-surface-2 px-2 py-1 text-right">
             <div className="text-[10px] font-semibold uppercase tracking-normal text-text-muted">Final</div>
-            <div className="text-sm font-semibold tabular-nums text-text-default">
+            <div className={[
+              'text-sm font-semibold tabular-nums',
+              getGradePercentTextClass(student.final_percent),
+            ].join(' ')}>
               {formatPercent(student.final_percent)}
             </div>
           </div>
@@ -442,6 +457,9 @@ function StudentAssessmentPanel({
               const secondaryScore = displayMode === 'raw' ? percentScore : rawScore
               const statusDisplay = getGradebookAssessmentStatusDisplay(cell?.status)
               const key = getAssessmentColumnKey(column)
+              const scoreTextClass = cell?.is_graded
+                ? getGradePercentTextClass(getAssessmentCellPercent(cell))
+                : 'text-text-muted'
               return (
                 <div key={key} className="px-3 py-2.5">
                   <div className="flex items-start justify-between gap-3">
@@ -470,11 +488,11 @@ function StudentAssessmentPanel({
                     <div className="shrink-0 text-right">
                       <div className={[
                         'text-sm font-normal tabular-nums',
-                        cell?.is_graded ? 'text-text-default' : 'text-text-muted',
+                        scoreTextClass,
                       ].join(' ')}>
                         {primaryScore}
                       </div>
-                      <div className="mt-1 text-xs tabular-nums text-text-muted">
+                      <div className={['mt-1 text-xs tabular-nums', scoreTextClass].join(' ')}>
                         {secondaryScore}
                       </div>
                     </div>
@@ -1140,6 +1158,9 @@ function AssessmentMatrixTable({
                   {renderedAssessmentColumns.map((column) => {
                     const hidden = hiddenAssessmentColumnKeys.has(getAssessmentColumnKey(column))
                     const cell = getAssessmentCell(student, column)
+                    const scoreTextClass = hidden
+                      ? 'text-text-muted'
+                      : getGradePercentTextClass(getAssessmentCellPercent(cell))
                     return (
                       <DataTableCell
                         key={`${student.student_id}:${column.assessment_type}:${column.assessment_id}`}
@@ -1149,7 +1170,7 @@ function AssessmentMatrixTable({
                         <span
                           className={[
                             'font-normal',
-                            hidden || !cell?.is_graded ? 'text-text-muted' : 'text-text-default',
+                            scoreTextClass,
                           ].join(' ')}
                         >
                           {formatAssessmentScore(cell, displayMode)}
@@ -1166,6 +1187,7 @@ function AssessmentMatrixTable({
                         FINAL_COLUMN_SEPARATOR_CLASS,
                         isSelected ? 'bg-surface-selected group-hover:bg-surface-selected' : 'bg-surface group-hover:bg-surface-hover',
                         !visibleColumns.final ? 'bg-surface-2 text-text-muted' : '',
+                        visibleColumns.final ? getGradePercentTextClass(student.final_percent) : '',
                       ].join(' ')}
                     >
                       {formatPercent(student.final_percent)}
@@ -1218,6 +1240,9 @@ function AssessmentMatrixTable({
                     {renderedAssessmentColumns.map((column) => {
                       const hidden = hiddenAssessmentColumnKeys.has(getAssessmentColumnKey(column))
                       const stats = getColumnStats(students, column)
+                      const scoreTextClass = hidden
+                        ? 'text-text-muted'
+                        : getGradePercentTextClass(stats.averagePercent)
                       return (
                         <DataTableCell
                           key={`average:${column.assessment_type}:${column.assessment_id}`}
@@ -1225,7 +1250,7 @@ function AssessmentMatrixTable({
                           className={[
                             'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
-                            hidden ? 'text-text-muted' : 'text-text-default',
+                            scoreTextClass,
                           ].join(' ')}
                         >
                           {formatColumnStat(stats, column, 'average', displayMode)}
@@ -1239,7 +1264,7 @@ function AssessmentMatrixTable({
                         className={[
                           'whitespace-nowrap bg-surface-2 text-xs font-semibold tabular-nums md:sticky md:right-0 md:z-10',
                           FINAL_COLUMN_SEPARATOR_CLASS,
-                          visibleColumns.final ? 'text-text-default' : 'text-text-muted',
+                          visibleColumns.final ? getGradePercentTextClass(finalAverage) : 'text-text-muted',
                         ].join(' ')}
                       >
                         {formatCompactPercent(finalAverage)}
@@ -1282,6 +1307,9 @@ function AssessmentMatrixTable({
                     {renderedAssessmentColumns.map((column) => {
                       const hidden = hiddenAssessmentColumnKeys.has(getAssessmentColumnKey(column))
                       const stats = getColumnStats(students, column)
+                      const scoreTextClass = hidden
+                        ? 'text-text-muted'
+                        : getGradePercentTextClass(stats.medianPercent)
                       return (
                         <DataTableCell
                           key={`median:${column.assessment_type}:${column.assessment_id}`}
@@ -1289,7 +1317,7 @@ function AssessmentMatrixTable({
                           className={[
                             'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
-                            hidden ? 'text-text-muted' : 'text-text-default',
+                            scoreTextClass,
                           ].join(' ')}
                         >
                           {formatColumnStat(stats, column, 'median', displayMode)}
@@ -1303,7 +1331,7 @@ function AssessmentMatrixTable({
                         className={[
                           'whitespace-nowrap bg-surface-2 text-xs font-semibold tabular-nums md:sticky md:right-0 md:z-10',
                           FINAL_COLUMN_SEPARATOR_CLASS,
-                          visibleColumns.final ? 'text-text-default' : 'text-text-muted',
+                          visibleColumns.final ? getGradePercentTextClass(finalMedian) : 'text-text-muted',
                         ].join(' ')}
                       >
                         {formatCompactPercent(finalMedian)}
@@ -1388,7 +1416,6 @@ export function TeacherGradebookTab({
     () => getValidEmailList(selectedStudents.map((student) => student.student_email)),
     [selectedStudents],
   )
-  const someStudentsSelected = selectedIds.size > 0
   const {
     scrollRef: gradebookTableScrollRef,
     preserveScrollPosition: preserveGradebookTableScrollPosition,
@@ -1630,22 +1657,24 @@ export function TeacherGradebookTab({
   }
 
   const isSettingsActive = columnEditorOpen
-  const showSelectedStudentEmailActions = someStudentsSelected && !isSettingsActive
-  const scoreDisplayOptions = [
-    {
-      value: 'percent',
-      label: 'Show %',
-    },
-    {
-      value: 'raw',
-      label: 'Show Raw',
-    },
-  ] satisfies Array<SegmentedControlOption<ScoreDisplayMode>>
   const gradebookEmailOptions: SplitButtonOption[] = [
+    {
+      id: 'show-percent',
+      label: 'Show %',
+      checked: scoreDisplayMode === 'percent',
+      onSelect: () => handleScoreDisplayModeChange('percent'),
+    },
+    {
+      id: 'show-raw',
+      label: 'Show Raw',
+      checked: scoreDisplayMode === 'raw',
+      onSelect: () => handleScoreDisplayModeChange('raw'),
+    },
     {
       id: 'copy-selected-emails',
       label: `Copy emails (${selectedStudentEmails.length})`,
       icon: <Copy className="h-4 w-4" aria-hidden="true" />,
+      dividerBefore: true,
       onSelect: () => {
         void copySelectedEmailsToClipboard()
       },
@@ -1671,28 +1700,18 @@ export function TeacherGradebookTab({
     <TeacherWorkSurfaceActionBar
       center={
         <div className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-1.5">
-          {showSelectedStudentEmailActions ? (
-            <SplitButton
-              label={
-                <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <Mail className="h-4 w-4" aria-hidden="true" />
-                  <span>Email ({selectedStudentEmails.length})</span>
-                </span>
-              }
-              onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
-              options={gradebookEmailOptions}
-              disabled={selectedStudentEmails.length === 0}
-              size="sm"
-              toggleAriaLabel="Gradebook email actions"
-              menuPlacement="down"
-            />
-          ) : null}
-          <SegmentedControl
-            ariaLabel="Gradebook score display"
-            value={scoreDisplayMode}
-            options={scoreDisplayOptions}
-            onChange={handleScoreDisplayModeChange}
-            className="h-9"
+          <SplitButton
+            label={
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <Mail className="h-4 w-4" aria-hidden="true" />
+                <span>Email ({selectedStudentEmails.length})</span>
+              </span>
+            }
+            onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
+            options={gradebookEmailOptions}
+            size="sm"
+            toggleAriaLabel="Gradebook email actions"
+            menuPlacement="down"
           />
           <Tooltip content={isSettingsActive ? 'Hide gradebook settings' : 'Show gradebook settings'}>
             <Button

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -214,30 +214,36 @@ describe('TeacherGradebookTab', () => {
     expect(firstResize).toHaveAttribute('aria-valuenow', '96')
     fireEvent.keyDown(firstResize, { key: 'ArrowRight' })
     expect(firstResize).toHaveAttribute('aria-valuenow', '104')
-    const scoreDisplayGroup = screen.getByRole('group', { name: 'Gradebook score display' })
-    const percentToggle = within(scoreDisplayGroup).getByRole('button', { name: 'Show %' })
-    const rawToggle = within(scoreDisplayGroup).getByRole('button', { name: 'Show Raw' })
-    expect(percentToggle).toHaveAttribute('aria-pressed', 'true')
-    expect(rawToggle).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
+    let gradebookMenu = screen.getByRole('menu')
+    const percentToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })
+    const rawToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })
+    expect(percentToggle).toHaveAttribute('aria-checked', 'true')
+    expect(rawToggle).toHaveAttribute('aria-checked', 'false')
+    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Copy emails (0)' })).toBeDisabled()
+    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Gmail' })).toBeDisabled()
+    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Outlook' })).toBeDisabled()
     expect(screen.queryByRole('button', { name: 'Summary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Gradebook view' })).not.toBeInTheDocument()
 
     fireEvent.click(rawToggle)
     expect(screen.getByRole('row', { name: /Ada Lovelace.*8\/10 10\/10 9\/10 85\.0%/ })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Avg.*7\/10 10\/10 8\.5\/10 77\.5%/ })).toBeInTheDocument()
-    expect(percentToggle).toHaveAttribute('aria-pressed', 'false')
-    expect(rawToggle).toHaveAttribute('aria-pressed', 'true')
-    fireEvent.click(percentToggle)
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
+    gradebookMenu = screen.getByRole('menu')
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'false')
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' }))
     expect(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ })).toBeInTheDocument()
 
     const adaSelect = screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })
     fireEvent.click(adaSelect)
     expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
-    const gradebookMenu = screen.getByRole('menu')
-    expect(within(gradebookMenu).queryByRole('separator')).not.toBeInTheDocument()
-    expect(within(gradebookMenu).queryByRole('menuitemradio', { name: 'Show %' })).not.toBeInTheDocument()
+    gradebookMenu = screen.getByRole('menu')
+    expect(within(gradebookMenu).getByRole('separator')).toBeInTheDocument()
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'true')
     fireEvent.click(within(gradebookMenu).getByRole('menuitem', { name: 'Copy emails (1)' }))
     await waitFor(() => {
       expect(clipboardWriteText).toHaveBeenCalledWith('ada@example.com')
@@ -351,13 +357,50 @@ describe('TeacherGradebookTab', () => {
     })
   })
 
+  it('color codes grade text by percentage band', async () => {
+    const response = gradebookResponse()
+    const grace = response.students.find((student) => student.student_id === 'student-2')
+    if (!grace) throw new Error('Missing Grace fixture')
+
+    grace.final_percent = 60
+    grace.assessment_scores[0] = {
+      ...grace.assessment_scores[0],
+      earned: 4,
+      percent: 40,
+      is_graded: true,
+    }
+    grace.assessment_scores[2] = {
+      ...grace.assessment_scores[2],
+      earned: 7,
+      percent: 70,
+      is_graded: true,
+    }
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => response,
+    })
+
+    renderGradebook('grades')
+
+    const graceRow = await screen.findByRole('row', { name: /Grace Hopper.*40%.*70%.*60\.0%/ })
+    expect(within(graceRow).getByText('40%')).toHaveClass('text-danger')
+    expect(within(graceRow).getByText('60.0%')).toHaveClass('text-warning')
+    expect(within(graceRow).getByText('70%')).toHaveClass('text-text-default')
+
+    fireEvent.click(graceRow)
+    const detailPanel = screen.getByRole('region', { name: 'Grace Hopper assessment details' })
+    expect(within(detailPanel).getByText('60.0%')).toHaveClass('text-warning')
+    expect(within(detailPanel).getByText('40%')).toHaveClass('text-danger')
+    expect(within(detailPanel).getByText('70%')).toHaveClass('text-text-default')
+  })
+
   it('keeps gradebook floating controls on the shared overlay layer', async () => {
     renderGradebook('grades')
 
     expect(await screen.findByText('Ada')).toBeInTheDocument()
 
-    const scoreDisplayGroup = screen.getByRole('group', { name: 'Gradebook score display' })
-    const floatingCluster = scoreDisplayGroup.parentElement?.parentElement
+    const floatingCluster = screen.getByRole('button', { name: 'Gradebook email actions' }).closest('.fixed')
     expect(floatingCluster).toHaveClass('fixed', 'z-40')
     expect(floatingCluster?.className).not.toContain('z-[70]')
     expect(screen.getByRole('columnheader', { name: 'First' })).toHaveClass('z-30')
@@ -381,13 +424,15 @@ describe('TeacherGradebookTab', () => {
 
     expect(onSectionChange).toHaveBeenCalledWith('settings')
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Gradebook email actions' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
 
     expect(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeChecked()
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
   })
 
   it('renders edit controls with assessment weights only', async () => {


### PR DESCRIPTION
## Summary

- Color-code teacher gradebook grade text so marks below 50% use danger text, marks from 50% up to but not including 70% use warning text, and 70% or higher stays default text.
- Apply grade color bands to assessment cells, final grades, summary rows, and the selected-student detail panel while keeping ungraded and hidden values muted.
- Keep the gradebook email split button visible at zero selected students and move `Show %` / `Show Raw` into its dropdown as radio-style choices.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
- `pnpm lint`
- Playwright visual verification on `classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook`, including teacher desktop/mobile, student mobile, loaded table screenshots, open dropdown screenshot, and exact-70 boundary screenshot.