### PR TITLE
[codex] Fix gradebook summary grade colors

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-28 — Quiz list stats chunked pagination
-
-**Completed:**
-- Added chunked and paginated quiz question and response stats loading for teacher quiz lists.
-- Ordered paged quiz stat reads by stable row id to prevent offset pagination skips or duplicates.
-- Preserved enrolled-student scoping while preventing large quiz lists or rosters from exceeding Supabase `.in()` and default row-limit behavior.
-- Chunked assessment draft overlay reads and pinned the existing active-quiz overlay behavior to match quiz detail parity.
-- Returned a clear 500 when quiz question stat loading fails instead of silently reporting zero questions.
-- Added regressions for stat load failures, 51x51 filter chunking, paginated stat rows, and active-list draft overlays.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/quizzes-route.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-28 — Survey list stats chunked pagination
 
 **Completed:**
@@ -1020,3 +1000,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/components/TeacherGradebookTab.test.tsx`
 - `pnpm lint`
 - Visual verification: `pika-ui-verify` on `classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook` (teacher desktop, student mobile, teacher mobile) plus loaded table screenshots, open dropdown screenshot, and exact-70 boundary screenshot.
+
+## 2026-06-03 — Gradebook summary red color fix
+
+**Completed:**
+- Moved grade color classes onto inner value spans in the gradebook final column, assessment Avg/Med summary cells, and final Avg/Med summary cells so they reliably override `DataTableCell`'s default text color.
+- Added a regression proving below-50 student final marks and Avg/Med summary values render with `text-danger`, while 50-69.9 remains warning and exact 70 remains default.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm lint`
+- Visual verification: targeted Playwright screenshots with intercepted below-50 final and Avg/Med summary values on teacher desktop/mobile, plus student mobile unaffected view.

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -1187,10 +1187,11 @@ function AssessmentMatrixTable({
                         FINAL_COLUMN_SEPARATOR_CLASS,
                         isSelected ? 'bg-surface-selected group-hover:bg-surface-selected' : 'bg-surface group-hover:bg-surface-hover',
                         !visibleColumns.final ? 'bg-surface-2 text-text-muted' : '',
-                        visibleColumns.final ? getGradePercentTextClass(student.final_percent) : '',
                       ].join(' ')}
                     >
-                      {formatPercent(student.final_percent)}
+                      <span className={visibleColumns.final ? getGradePercentTextClass(student.final_percent) : 'text-text-muted'}>
+                        {formatPercent(student.final_percent)}
+                      </span>
                     </DataTableCell>
                   ) : null}
                 </DataTableRow>
@@ -1250,10 +1251,11 @@ function AssessmentMatrixTable({
                           className={[
                             'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
-                            scoreTextClass,
                           ].join(' ')}
                         >
-                          {formatColumnStat(stats, column, 'average', displayMode)}
+                          <span className={scoreTextClass}>
+                            {formatColumnStat(stats, column, 'average', displayMode)}
+                          </span>
                         </DataTableCell>
                       )
                     })}
@@ -1264,10 +1266,11 @@ function AssessmentMatrixTable({
                         className={[
                           'whitespace-nowrap bg-surface-2 text-xs font-semibold tabular-nums md:sticky md:right-0 md:z-10',
                           FINAL_COLUMN_SEPARATOR_CLASS,
-                          visibleColumns.final ? getGradePercentTextClass(finalAverage) : 'text-text-muted',
                         ].join(' ')}
                       >
-                        {formatCompactPercent(finalAverage)}
+                        <span className={visibleColumns.final ? getGradePercentTextClass(finalAverage) : 'text-text-muted'}>
+                          {formatCompactPercent(finalAverage)}
+                        </span>
                       </DataTableCell>
                     ) : null}
                   </DataTableRow>
@@ -1317,10 +1320,11 @@ function AssessmentMatrixTable({
                           className={[
                             'min-w-16 px-2 text-xs font-normal tabular-nums',
                             editColumnBorderClass,
-                            scoreTextClass,
                           ].join(' ')}
                         >
-                          {formatColumnStat(stats, column, 'median', displayMode)}
+                          <span className={scoreTextClass}>
+                            {formatColumnStat(stats, column, 'median', displayMode)}
+                          </span>
                         </DataTableCell>
                       )
                     })}
@@ -1331,10 +1335,11 @@ function AssessmentMatrixTable({
                         className={[
                           'whitespace-nowrap bg-surface-2 text-xs font-semibold tabular-nums md:sticky md:right-0 md:z-10',
                           FINAL_COLUMN_SEPARATOR_CLASS,
-                          visibleColumns.final ? getGradePercentTextClass(finalMedian) : 'text-text-muted',
                         ].join(' ')}
                       >
-                        {formatCompactPercent(finalMedian)}
+                        <span className={visibleColumns.final ? getGradePercentTextClass(finalMedian) : 'text-text-muted'}>
+                          {formatCompactPercent(finalMedian)}
+                        </span>
                       </DataTableCell>
                     ) : null}
                   </DataTableRow>

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -362,11 +362,11 @@ describe('TeacherGradebookTab', () => {
     const grace = response.students.find((student) => student.student_id === 'student-2')
     if (!grace) throw new Error('Missing Grace fixture')
 
-    grace.final_percent = 60
+    grace.final_percent = 40
     grace.assessment_scores[0] = {
       ...grace.assessment_scores[0],
-      earned: 4,
-      percent: 40,
+      earned: 1,
+      percent: 10,
       is_graded: true,
     }
     grace.assessment_scores[2] = {
@@ -383,15 +383,25 @@ describe('TeacherGradebookTab', () => {
 
     renderGradebook('grades')
 
-    const graceRow = await screen.findByRole('row', { name: /Grace Hopper.*40%.*70%.*60\.0%/ })
-    expect(within(graceRow).getByText('40%')).toHaveClass('text-danger')
-    expect(within(graceRow).getByText('60.0%')).toHaveClass('text-warning')
+    const graceRow = await screen.findByRole('row', { name: /Grace Hopper.*10%.*70%.*40\.0%/ })
+    expect(within(graceRow).getByText('40.0%')).toHaveClass('text-danger')
+    expect(within(graceRow).getByText('10%')).toHaveClass('text-danger')
     expect(within(graceRow).getByText('70%')).toHaveClass('text-text-default')
+
+    const avgRow = screen.getByRole('row', { name: /Avg.*45%.*100%.*80%.*62\.5%/ })
+    expect(within(avgRow).getByText('45%')).toHaveClass('text-danger')
+    expect(within(avgRow).getByText('80%')).toHaveClass('text-text-default')
+    expect(within(avgRow).getByText('62.5%')).toHaveClass('text-warning')
+
+    const medRow = screen.getByRole('row', { name: /Med.*45%.*100%.*80%.*62\.5%/ })
+    expect(within(medRow).getByText('45%')).toHaveClass('text-danger')
+    expect(within(medRow).getByText('80%')).toHaveClass('text-text-default')
+    expect(within(medRow).getByText('62.5%')).toHaveClass('text-warning')
 
     fireEvent.click(graceRow)
     const detailPanel = screen.getByRole('region', { name: 'Grace Hopper assessment details' })
-    expect(within(detailPanel).getByText('60.0%')).toHaveClass('text-warning')
-    expect(within(detailPanel).getByText('40%')).toHaveClass('text-danger')
+    expect(within(detailPanel).getByText('40.0%')).toHaveClass('text-danger')
+    expect(within(detailPanel).getByText('10%')).toHaveClass('text-danger')
     expect(within(detailPanel).getByText('70%')).toHaveClass('text-text-default')
   })
 


### PR DESCRIPTION
## Summary
- Move grade color classes onto inner value spans for gradebook final marks and Avg/Med summary values so they override the table cell default text color.
- Extend the gradebook component regression to cover below-50 final marks and summary values, 50-69.9 warning values, and exact-70 default values.
- Update the session log with the validation record.

## Root cause
`DataTableCell` applies a default text color on the cell. Final and summary values previously put grade color classes on the same cell, so the default table text styling could win and prevent below-50 values from rendering red.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm test tests/components/TeacherGradebookTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- Targeted Playwright screenshots with intercepted below-50 final and Avg/Med summary values on teacher desktop/mobile, plus student mobile unaffected view.