### PR TITLE
Tighten student test history visibility

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Quiz and survey results bulk-read hardening
-
-**Completed:**
-- Routed teacher quiz and survey result response reads through the shared chunked, paginated Supabase loader.
-- Scoped result reads by assessment id and currently enrolled student ids at query time while preserving stale-row filtering as a defensive guard.
-- Routed responder user/profile hydration through chunked, paginated reads and returned explicit 500s on hydration failures instead of silently dropping names or emails.
-- Added stable response ordering and responder id tie-breaks.
-- Added route regressions for 51-student chunking, >1000 response-row pagination, stale unenrolled rows, and responder hydration failures.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/quizzes-results.test.ts --reporter=verbose`
-- `pnpm vitest run tests/api/teacher/surveys-results.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-30 — Test results bulk-read hardening
 
 **Completed:**
@@ -996,3 +976,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash scripts/verify-env.sh`
 - `gh pr checks 724 --repo codepetca/pika`
+
+## 2026-06-04 — Student test history visibility audit
+
+**Completed:**
+- Tightened `/api/student/tests/[id]/history` so student requests use the same draft, per-student availability, submitted, returned, and closed-for-grading visibility gate as the main student test route before returning history or migration hints.
+- Preserved teacher-owned history access with the existing `student_id` enrollment boundary.
+- Expanded `tests/api/student/tests-history.test.ts` for draft-hidden, student-closed-hidden, submitted-closed-allowed, and teacher-owned access cases.
+
+**Validation:**
+- `pnpm vitest run tests/api/student/tests-history.test.ts`
+- `pnpm vitest run tests/api/student/tests-history.test.ts tests/api/student/tests-id.test.ts tests/unit/test-student-access.test.ts tests/api/student/tests-documents-snapshot.test.ts tests/api/student/tests-focus-events.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- Baseline note: pre-edit session-start `pnpm test` failed on current `origin/main` in `tests/components/AssignmentModal.test.tsx`, `tests/components/TeacherGradebookTab.test.tsx`, and `tests/components/TeacherStudentWorkPanel.test.tsx`.

--- a/src/app/api/student/tests/[id]/history/route.ts
+++ b/src/app/api/student/tests/[id]/history/route.ts
@@ -1,11 +1,27 @@
 import { NextResponse } from 'next/server'
 import { requireAuth } from '@/lib/auth'
-import { assertStudentCanAccessTest, assertTeacherOwnsTest } from '@/lib/server/tests'
+import {
+  assertStudentCanAccessTest,
+  assertTeacherOwnsTest,
+  getEffectiveStudentTestAccess,
+  getTestStudentAvailabilityState,
+  isMissingTestAttemptClosureColumnsError,
+  isMissingTestAttemptReturnColumnsError,
+} from '@/lib/server/tests'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { withErrorHandler } from '@/lib/api-handler'
+import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
+import type { QuizStatus } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+
+type AttemptRow = {
+  id: string
+  is_submitted: boolean
+  returned_at: string | null
+  closed_for_grading_at: string | null
+}
 
 // GET /api/student/tests/[id]/history - Get test draft history for student/teacher
 export const GET = withErrorHandler('GetStudentTestHistory', async (request, context) => {
@@ -16,6 +32,7 @@ export const GET = withErrorHandler('GetStudentTestHistory', async (request, con
   const supabase = getServiceRoleClient()
 
   let studentId = user.id
+  let studentTestStatus: QuizStatus = 'draft'
 
   if (user.role === 'teacher') {
     if (!requestedStudentId) {
@@ -43,22 +60,96 @@ export const GET = withErrorHandler('GetStudentTestHistory', async (request, con
     if (!access.ok) {
       return NextResponse.json({ error: access.error }, { status: access.status })
     }
+    studentTestStatus = access.test.status
+
+    if (access.test.status === 'draft') {
+      return NextResponse.json({ error: 'Test not found' }, { status: 404 })
+    }
   }
 
-  const { data: attempt, error: attemptError } = await supabase
-    .from('test_attempts')
-    .select('id')
-    .eq('test_id', testId)
-    .eq('student_id', studentId)
-    .maybeSingle()
+  let attempt: AttemptRow | null = null
+  let attemptError: { code?: string; message?: string; details?: string; hint?: string } | null = null
+  let attemptTableMissing = false
+
+  {
+    const attemptResult = await supabase
+      .from('test_attempts')
+      .select('id, is_submitted, returned_at, closed_for_grading_at')
+      .eq('test_id', testId)
+      .eq('student_id', studentId)
+      .maybeSingle()
+
+    attempt = (attemptResult.data as AttemptRow | null) || null
+    attemptError = attemptResult.error
+  }
+
+  if (
+    attemptError &&
+    (isMissingTestAttemptReturnColumnsError(attemptError) ||
+      isMissingTestAttemptClosureColumnsError(attemptError))
+  ) {
+    const legacyAttemptResult = await supabase
+      .from('test_attempts')
+      .select('id, is_submitted')
+      .eq('test_id', testId)
+      .eq('student_id', studentId)
+      .maybeSingle()
+
+    attempt = legacyAttemptResult.data
+      ? {
+          ...(legacyAttemptResult.data as { id: string; is_submitted: boolean }),
+          returned_at: null,
+          closed_for_grading_at: null,
+        }
+      : null
+    attemptError = legacyAttemptResult.error
+  }
 
   if (attemptError?.code === 'PGRST205') {
-    return NextResponse.json({ history: [], attemptId: null, migration_required: true })
+    attemptTableMissing = true
+    attemptError = null
   }
 
   if (attemptError) {
     console.error('Error fetching test attempt for history:', attemptError)
     return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+  }
+
+  if (user.role !== 'teacher') {
+    const { data: responses, error: responsesError } = await supabase
+      .from('test_responses')
+      .select('selected_option, response_text')
+      .eq('test_id', testId)
+      .eq('student_id', user.id)
+
+    if (responsesError) {
+      console.error('Error checking student test history responses:', responsesError)
+      return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+    }
+
+    const isLockedForGrading = Boolean(attempt?.closed_for_grading_at)
+    const hasSubmitted =
+      Boolean(attempt?.is_submitted) || (!isLockedForGrading && hasAnyMeaningfulTestResponse(responses))
+    const availabilityResult = await getTestStudentAvailabilityState(supabase, testId, user.id)
+    if (availabilityResult.error && !availabilityResult.missingTable) {
+      console.error('Error checking student test history availability:', availabilityResult.error)
+      return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+    }
+
+    const accessState = getEffectiveStudentTestAccess({
+      testStatus: studentTestStatus,
+      accessState: availabilityResult.state,
+      hasSubmitted,
+      returnedAt: attempt?.returned_at || null,
+      isLockedForGrading,
+    })
+    if (!accessState.can_start_or_continue && !accessState.can_view_submitted) {
+      return NextResponse.json({ error: 'Test not found' }, { status: 404 })
+    }
+  }
+
+  if (attemptTableMissing) {
+    return NextResponse.json({ history: [], attemptId: null, migration_required: true })
   }
 
   if (!attempt) {

--- a/tests/api/student/tests-history.test.ts
+++ b/tests/api/student/tests-history.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/student/tests/[id]/history/route'
+import * as serverTests from '@/lib/server/tests'
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -14,33 +15,91 @@ vi.mock('@/lib/auth', () => ({
   })),
 }))
 
-vi.mock('@/lib/server/tests', () => ({
-  assertStudentCanAccessTest: vi.fn(async () => ({
-    ok: true,
-    test: { id: 'test-1', classroom_id: 'classroom-1' },
-  })),
-  assertTeacherOwnsTest: vi.fn(async () => ({
-    ok: true,
-    test: { id: 'test-1', classroom_id: 'classroom-1' },
-  })),
-}))
+vi.mock('@/lib/server/tests', async () => {
+  const actual = await vi.importActual<any>('@/lib/server/tests')
+  return {
+    ...actual,
+    assertStudentCanAccessTest: vi.fn(async () => ({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'active' },
+    })),
+    assertTeacherOwnsTest: vi.fn(async () => ({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'draft' },
+    })),
+    getTestStudentAvailabilityState: vi.fn(async () => ({
+      state: null,
+      missingTable: false,
+      error: null,
+    })),
+  }
+})
 
 const mockSupabaseClient = { from: vi.fn() }
+
+function mockMaybeSingle(result: { data: unknown; error: unknown }) {
+  const query = {
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue(result),
+    })),
+  }
+  return query
+}
+
+function mockThenableRows(result: { data: unknown; error: unknown }) {
+  const chain = {
+    eq: vi.fn(() => chain),
+    then: vi.fn((resolve: (value: typeof result) => unknown) => resolve(result)),
+  }
+  return {
+    select: vi.fn(() => chain),
+  }
+}
+
+function mockHistoryRows(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue(result),
+    })),
+  }
+}
+
+function mockSingle(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(result),
+    })),
+  }
+}
 
 describe('GET /api/student/tests/[id]/history', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValue({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'active' },
+    } as any)
+    vi.mocked(serverTests.assertTeacherOwnsTest).mockResolvedValue({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'draft' },
+    } as any)
+    vi.mocked(serverTests.getTestStudentAvailabilityState).mockResolvedValue({
+      state: null,
+      missingTable: false,
+      error: null,
+    })
   })
 
   it('returns empty history when no attempt exists', async () => {
     ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
       if (table === 'test_attempts') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockReturnThis(),
-            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-          })),
-        }
+        return mockMaybeSingle({ data: null, error: null })
+      }
+      if (table === 'test_responses') {
+        return mockThenableRows({ data: [], error: null })
       }
       throw new Error(`Unexpected table: ${table}`)
     })
@@ -54,6 +113,98 @@ describe('GET /api/student/tests/[id]/history', () => {
     expect(response.status).toBe(200)
     expect(data.history).toEqual([])
     expect(data.attemptId).toBeNull()
+  })
+
+  it('hides draft tests from student history', async () => {
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'draft' },
+    } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn()
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Test not found')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('hides active tests that are closed for this student before submission', async () => {
+    vi.mocked(serverTests.getTestStudentAvailabilityState).mockResolvedValueOnce({
+      state: 'closed',
+      missingTable: false,
+      error: null,
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return mockMaybeSingle({
+          data: {
+            id: 'attempt-1',
+            is_submitted: false,
+            returned_at: null,
+            closed_for_grading_at: null,
+          },
+          error: null,
+        })
+      }
+      if (table === 'test_responses') {
+        return mockThenableRows({ data: [], error: null })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Test not found')
+  })
+
+  it('returns history for a submitted closed test', async () => {
+    vi.mocked(serverTests.assertStudentCanAccessTest).mockResolvedValueOnce({
+      ok: true,
+      test: { id: 'test-1', classroom_id: 'classroom-1', status: 'closed' },
+    } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'test_attempts') {
+        return mockMaybeSingle({
+          data: {
+            id: 'attempt-1',
+            is_submitted: true,
+            returned_at: null,
+            closed_for_grading_at: null,
+          },
+          error: null,
+        })
+      }
+      if (table === 'test_responses') {
+        return mockThenableRows({ data: [], error: null })
+      }
+      if (table === 'test_attempt_history') {
+        return mockHistoryRows({
+          data: [{ id: 'history-1', test_attempt_id: 'attempt-1', patch: [], snapshot: {} }],
+          error: null,
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.attemptId).toBe('attempt-1')
+    expect(data.history).toHaveLength(1)
   })
 
   it('requires student_id for teacher requests', async () => {
@@ -72,5 +223,47 @@ describe('GET /api/student/tests/[id]/history', () => {
 
     expect(response.status).toBe(400)
     expect(data.error).toBe('student_id is required')
+  })
+
+  it('keeps teacher-owned history access independent from student availability state', async () => {
+    const { requireAuth } = await import('@/lib/auth')
+    ;(requireAuth as any).mockResolvedValueOnce({
+      id: 'teacher-1',
+      email: 'teacher@example.com',
+      role: 'teacher',
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classroom_enrollments') {
+        return mockSingle({ data: { id: 'enrollment-1' }, error: null })
+      }
+      if (table === 'test_attempts') {
+        return mockMaybeSingle({
+          data: {
+            id: 'attempt-1',
+            is_submitted: false,
+            returned_at: null,
+            closed_for_grading_at: null,
+          },
+          error: null,
+        })
+      }
+      if (table === 'test_attempt_history') {
+        return mockHistoryRows({
+          data: [{ id: 'history-1', test_attempt_id: 'attempt-1', patch: [], snapshot: {} }],
+          error: null,
+        })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history?student_id=student-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.attemptId).toBe('attempt-1')
+    expect(serverTests.getTestStudentAvailabilityState).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Gate `/api/student/tests/[id]/history` student requests with the same draft, per-student availability, submitted, returned, and closed-for-grading access model used by the main student test route.
- Preserve teacher-owned history access through the existing `student_id` enrollment check.
- Expand the history route API tests for draft-hidden, student-closed-hidden, submitted-closed-allowed, and teacher-owned access cases.

## Why
The audit found that history access only checked classroom enrollment for students. That meant a student with a prior attempt could still fetch history metadata even when the test itself would now be hidden by draft or availability rules.

## Validation
- `pnpm vitest run tests/api/student/tests-history.test.ts`
- `pnpm vitest run tests/api/student/tests-history.test.ts tests/api/student/tests-id.test.ts tests/unit/test-student-access.test.ts tests/api/student/tests-documents-snapshot.test.ts tests/api/student/tests-focus-events.test.ts`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`

## Baseline Note
Pre-edit session-start `pnpm test` on current `origin/main` failed in unrelated component tests:
- `tests/components/AssignmentModal.test.tsx` (`updates draft and closes on save`)
- `tests/components/TeacherGradebookTab.test.tsx` (`renders the assessment matrix and delegates settings navigation` timeout)
- `tests/components/TeacherStudentWorkPanel.test.tsx` (`autosaves comment-only edits after switching to draft` timeout)
