### PR TITLE
Tighten assignment doc boundaries

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Test results bulk-read hardening
-
-**Completed:**
-- Routed teacher test result reads through chunked, paginated loaders for roster, responses, student availability, attempts, users, profiles, and focus events.
-- Scoped test result reads by test id and currently enrolled student ids at query time while retaining defensive enrollment filtering.
-- Preserved legacy `test_attempts` return-column and closure-column fallbacks, including databases that are missing both sets of columns.
-- Returned explicit 500 responses for availability, user, profile, and focus-event load failures instead of silently rendering partial result data.
-- Preserved exact roster totals from the paginated enrollment helper and added deterministic student tie-break ordering.
-- Added route regressions for roster pagination beyond 1000 students, 51-student filter chunking, >1000 response-row pagination, availability migration fallback, attempt schema fallbacks, and hydration/focus failures.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/tests-results.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-30 — Attendance export bulk-read hardening
 
 **Completed:**
@@ -992,3 +972,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - Baseline note: pre-edit session-start `pnpm test` failed on current `origin/main` in `tests/components/AssignmentModal.test.tsx`, `tests/components/TeacherGradebookTab.test.tsx`, and `tests/components/TeacherStudentWorkPanel.test.tsx`.
+
+## 2026-06-04 — Assignment doc boundary audit
+
+**Completed:**
+- Added a teacher read path to `GET /api/assignment-docs/[id]` that requires classroom ownership, an enrolled `student_id`, and does not create docs or mark student docs viewed.
+- Kept `PATCH /api/assignment-docs/[id]` student-only for student content saves.
+- Expanded assignment-doc GET/PATCH and history tests for teacher-owned reads, missing `student_id`, non-owner teachers, unenrolled students, draft assignment history reads, and student-only writes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts`
+- `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts tests/api/assignment-docs/submit.test.ts tests/api/assignment-docs/unsubmit.test.ts tests/api/assignment-docs/restore.test.ts tests/api/assignment-docs/artifacts.test.ts tests/lib/assignment-doc-history.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/api/assignment-docs/[id]/route.ts
+++ b/src/app/api/assignment-docs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
-import { requireRole } from '@/lib/auth'
+import { requireAuth, requireRole } from '@/lib/auth'
 import { getAssignmentInstructionsMarkdown } from '@/lib/assignment-instructions'
 import { countCharacters, countWords, isValidTiptapContent, parseContentField } from '@/lib/tiptap-content'
 import { sanitizeDocForStudent } from '@/lib/assignments'
@@ -82,14 +82,22 @@ async function loadStudentSubmissionContext(
 // GET /api/assignment-docs/[id] - Get assignment doc (creates if doesn't exist)
 // The [id] here is the assignment_id, not the doc id
 export const GET = withErrorHandler('GetAssignmentDoc', async (request, context) => {
-  const user = await requireRole('student')
+  const user = await requireAuth()
   const { id: assignmentId } = await context.params
+  const { searchParams } = new URL(request.url)
+  const requestedStudentId = searchParams.get('student_id')
   const supabase = getServiceRoleClient()
 
   // Get assignment and verify student is enrolled
   const { data: assignment, error: assignmentError } = await supabase
     .from('assignments')
-    .select('*')
+    .select(`
+      *,
+      classrooms!inner (
+        id,
+        teacher_id
+      )
+    `)
     .eq('id', assignmentId)
     .single()
 
@@ -100,19 +108,59 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
     )
   }
 
-  if (!isAssignmentVisibleToStudents(assignment)) {
-    return NextResponse.json(
-      { error: 'Assignment not found' },
-      { status: 404 }
-    )
+  let studentId = user.id
+  const assignmentData = assignment as typeof assignment & {
+    classroom_id: string
+    classrooms?: { teacher_id?: string } | Array<{ teacher_id?: string }>
   }
 
-  const access = await assertStudentCanAccessClassroom(user.id, assignment.classroom_id)
-  if (!access.ok) {
-    return NextResponse.json(
-      { error: access.error },
-      { status: access.status }
-    )
+  const classroomTeacherId = Array.isArray(assignmentData.classrooms)
+    ? assignmentData.classrooms[0]?.teacher_id
+    : assignmentData.classrooms?.teacher_id
+
+  if (user.role === 'teacher') {
+    if (classroomTeacherId !== user.id) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 403 }
+      )
+    }
+    if (!requestedStudentId) {
+      return NextResponse.json(
+        { error: 'student_id is required' },
+        { status: 400 }
+      )
+    }
+    studentId = requestedStudentId
+
+    const { data: enrollment } = await supabase
+      .from('classroom_enrollments')
+      .select('id')
+      .eq('classroom_id', assignmentData.classroom_id)
+      .eq('student_id', studentId)
+      .single()
+
+    if (!enrollment) {
+      return NextResponse.json(
+        { error: 'Not enrolled in this classroom' },
+        { status: 403 }
+      )
+    }
+  } else {
+    if (!isAssignmentVisibleToStudents(assignment)) {
+      return NextResponse.json(
+        { error: 'Assignment not found' },
+        { status: 404 }
+      )
+    }
+
+    const access = await assertStudentCanAccessClassroom(user.id, assignment.classroom_id)
+    if (!access.ok) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status }
+      )
+    }
   }
 
   // Get or create assignment doc for this student
@@ -120,7 +168,7 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
     .from('assignment_docs')
     .select('*')
     .eq('assignment_id', assignmentId)
-    .eq('student_id', user.id)
+    .eq('student_id', studentId)
     .single()
 
   // Track whether this request cleared an assignment notification.
@@ -128,6 +176,21 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
 
   if (docError) {
     if (docError.code === 'PGRST116') {
+      if (user.role === 'teacher') {
+        const submissionContext = await loadStudentSubmissionContext(supabase, assignmentId, null, studentId)
+        const feedbackEntries = await loadAssignmentFeedbackEntries(assignmentId, studentId)
+        return NextResponse.json({
+          assignment: {
+            ...assignment,
+            instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
+          },
+          doc: null,
+          feedback_entries: feedbackEntries,
+          ...submissionContext,
+          wasFirstView: false,
+        })
+      }
+
       const { data: created, error: createError } = await supabase
         .from('assignment_docs')
         .insert({
@@ -201,6 +264,21 @@ export const GET = withErrorHandler('GetAssignmentDoc', async (request, context)
   // Parse content if it's a string (for backwards compatibility)
   if (existingDoc) {
     existingDoc.content = parseContentField(existingDoc.content)
+  }
+
+  if (user.role === 'teacher') {
+    const feedbackEntries = await loadAssignmentFeedbackEntries(assignmentId, studentId)
+    const submissionContext = await loadStudentSubmissionContext(supabase, assignmentId, existingDoc.id, studentId)
+    return NextResponse.json({
+      assignment: {
+        ...assignment,
+        instructions_markdown: getAssignmentInstructionsMarkdown(assignment).markdown,
+      },
+      doc: existingDoc,
+      feedback_entries: feedbackEntries,
+      ...submissionContext,
+      wasFirstView: false,
+    })
   }
 
   // Mark as viewed if this request clears a first-view or returned-feedback notification.

--- a/tests/api/assignment-docs/assignment-docs-id.test.ts
+++ b/tests/api/assignment-docs/assignment-docs-id.test.ts
@@ -5,9 +5,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET, PATCH } from '@/app/api/assignment-docs/[id]/route'
 import { NextRequest } from 'next/server'
+import * as auth from '@/lib/auth'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
-vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'student-1', role: 'student' })) }))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn(async () => ({ id: 'student-1', role: 'student' })),
+  requireRole: vi.fn(async () => ({ id: 'student-1', role: 'student' })),
+}))
 vi.mock('@/lib/server/classrooms', () => ({
   assertStudentCanAccessClassroom: vi.fn(async () => ({
     ok: true,
@@ -18,7 +22,10 @@ vi.mock('@/lib/server/classrooms', () => ({
 const mockSupabaseClient = { from: vi.fn() }
 
 describe('GET /api/assignment-docs/[id]', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(auth.requireAuth).mockResolvedValue({ id: 'student-1', role: 'student' } as any)
+  })
 
   it('should return 404 when assignment does not exist', async () => {
     const mockFrom = vi.fn((table: string) => {
@@ -158,10 +165,205 @@ describe('GET /api/assignment-docs/[id]', () => {
       viewed_at: expect.stringMatching(/^20/),
     })
   })
+
+  it('lets the classroom teacher read an enrolled student assignment doc without marking it viewed', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    const viewedUpdate = vi.fn()
+    const enrollmentFilters: Array<[string, unknown]> = []
+    const docFilters: Array<[string, unknown]> = []
+    const existingDoc = {
+      id: 'doc-1',
+      assignment_id: 'assign-1',
+      student_id: 'student-1',
+      content: JSON.stringify({ type: 'doc', content: [] }),
+      viewed_at: null,
+      returned_at: null,
+      feedback_returned_at: null,
+    }
+    const mockFrom = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: true,
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        const enrollmentChain = {
+          eq: vi.fn((column: string, value: unknown) => {
+            enrollmentFilters.push([column, value])
+            return enrollmentChain
+          }),
+          single: vi.fn().mockResolvedValue({ data: { id: 'enroll-1' }, error: null }),
+        }
+        return {
+          select: vi.fn(() => enrollmentChain),
+        }
+      }
+      if (table === 'assignment_docs') {
+        const docChain = {
+          eq: vi.fn((column: string, value: unknown) => {
+            docFilters.push([column, value])
+            return docChain
+          }),
+          single: vi.fn().mockResolvedValue({ data: existingDoc, error: null }),
+        }
+        return {
+          select: vi.fn(() => docChain),
+          update: viewedUpdate,
+        }
+      }
+      if (table === 'assignment_feedback_entries') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            then: vi.fn((resolve: any) => resolve({ data: [], error: null })),
+          })),
+        }
+      }
+    })
+    ;(mockSupabaseClient.from as any) = mockFrom
+
+    const request = new NextRequest('http://localhost:3000/api/assignment-docs/assign-1?student_id=student-1')
+    const response = await GET(request, { params: { id: 'assign-1' } })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.doc.id).toBe('doc-1')
+    expect(data.doc.content).toEqual({ type: 'doc', content: [] })
+    expect(data.wasFirstView).toBe(false)
+    expect(viewedUpdate).not.toHaveBeenCalled()
+    expect(enrollmentFilters).toEqual([
+      ['classroom_id', 'class-1'],
+      ['student_id', 'student-1'],
+    ])
+    expect(docFilters).toEqual([
+      ['assignment_id', 'assign-1'],
+      ['student_id', 'student-1'],
+    ])
+  })
+
+  it('requires student_id for teacher reads', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('student_id is required')
+  })
+
+  it('blocks teacher reads for assignments they do not own', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-2', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1?student_id=student-1'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('blocks teacher reads for students outside the assignment classroom', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1?student_id=student-2'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Not enrolled in this classroom')
+  })
 })
 
 describe('PATCH /api/assignment-docs/[id]', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(auth.requireRole).mockResolvedValue({ id: 'student-1', role: 'student' } as any)
+  })
 
   it('should return 403 when trying to update submitted doc', async () => {
     const mockFrom = vi.fn((table: string) => {
@@ -329,5 +531,24 @@ describe('PATCH /api/assignment-docs/[id]', () => {
     expect(historyUpdate).toHaveBeenCalled()
     expect(historyInsert).not.toHaveBeenCalled()
     dateSpy.mockRestore()
+  })
+
+  it('keeps assignment doc content updates student-only', async () => {
+    const error = new Error('Forbidden: student role required')
+    error.name = 'AuthorizationError'
+    vi.mocked(auth.requireRole).mockRejectedValueOnce(error)
+
+    const response = await PATCH(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ content: { type: 'doc', content: [] } }),
+      }),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Forbidden')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
   })
 })

--- a/tests/api/assignment-docs/history.test.ts
+++ b/tests/api/assignment-docs/history.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/app/api/assignment-docs/[id]/history/route'
 import { NextRequest } from 'next/server'
+import * as auth from '@/lib/auth'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireAuth: vi.fn(async () => ({ id: 'student-1', role: 'student' })) }))
@@ -16,6 +17,7 @@ const mockSupabaseClient = { from: vi.fn() }
 describe('GET /api/assignment-docs/[id]/history', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(auth.requireAuth).mockResolvedValue({ id: 'student-1', role: 'student' } as any)
   })
 
   it('returns empty history when no doc exists', async () => {
@@ -58,5 +60,206 @@ describe('GET /api/assignment-docs/[id]/history', () => {
     expect(response.status).toBe(200)
     expect(data.history).toEqual([])
     expect(data.docId).toBe(null)
+  })
+
+  it('requires student_id for teacher history reads', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: true,
+                  released_at: null,
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/history'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('student_id is required')
+  })
+
+  it('blocks teacher history reads for assignments they do not own', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-2', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: true,
+                  released_at: null,
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/history?student_id=student-1'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('blocks teacher history reads for students outside the assignment classroom', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: true,
+                  released_at: null,
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/history?student_id=student-2'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Not enrolled in this classroom')
+  })
+
+  it('lets the classroom teacher read enrolled student history for draft assignments', async () => {
+    vi.mocked(auth.requireAuth).mockResolvedValueOnce({ id: 'teacher-1', role: 'teacher' } as any)
+    const enrollmentFilters: Array<[string, unknown]> = []
+    const docFilters: Array<[string, unknown]> = []
+    const historyFilters: Array<[string, unknown]> = []
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'assignments') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'assign-1',
+                  classroom_id: 'class-1',
+                  is_draft: true,
+                  released_at: null,
+                  classrooms: { id: 'class-1', teacher_id: 'teacher-1' },
+                },
+                error: null,
+              }),
+            })),
+          })),
+        }
+      }
+      if (table === 'classroom_enrollments') {
+        const enrollmentChain = {
+          eq: vi.fn((column: string, value: unknown) => {
+            enrollmentFilters.push([column, value])
+            return enrollmentChain
+          }),
+          single: vi.fn().mockResolvedValue({ data: { id: 'enroll-1' }, error: null }),
+        }
+        return {
+          select: vi.fn(() => enrollmentChain),
+        }
+      }
+      if (table === 'assignment_docs') {
+        const docChain = {
+          eq: vi.fn((column: string, value: unknown) => {
+            docFilters.push([column, value])
+            return docChain
+          }),
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'doc-1' },
+            error: null,
+          }),
+        }
+        return {
+          select: vi.fn(() => docChain),
+        }
+      }
+      if (table === 'assignment_doc_history') {
+        const historyChain = {
+          eq: vi.fn((column: string, value: unknown) => {
+            historyFilters.push([column, value])
+            return historyChain
+          }),
+          order: vi.fn().mockResolvedValue({
+            data: [{ id: 'history-1', assignment_doc_id: 'doc-1', snapshot: { type: 'doc', content: [] } }],
+            error: null,
+          }),
+        }
+        return {
+          select: vi.fn(() => historyChain),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/assignment-docs/assign-1/history?student_id=student-1'),
+      { params: { id: 'assign-1' } }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.docId).toBe('doc-1')
+    expect(data.history).toHaveLength(1)
+    expect(enrollmentFilters).toEqual([
+      ['classroom_id', 'class-1'],
+      ['student_id', 'student-1'],
+    ])
+    expect(docFilters).toEqual([
+      ['assignment_id', 'assign-1'],
+      ['student_id', 'student-1'],
+    ])
+    expect(historyFilters).toEqual([
+      ['assignment_doc_id', 'doc-1'],
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- Add a teacher read path to `GET /api/assignment-docs/[id]` that requires classroom ownership, an enrolled `student_id`, and does not create docs or mark student docs viewed.
- Keep `PATCH /api/assignment-docs/[id]` student-only for student content saves.
- Expand assignment-doc GET/PATCH and history API tests for teacher-owned reads, missing `student_id`, non-owner teachers, unenrolled students, draft assignment history reads, and student-only writes.

## Why
The systems audit flagged assignment-doc route drift: history already supported teacher-scoped reads, while the main doc route only accepted students and the tests did not lock teacher boundary behavior. This aligns the read contract while preserving the student-only write path.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts`
- `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts tests/api/assignment-docs/submit.test.ts tests/api/assignment-docs/unsubmit.test.ts tests/api/assignment-docs/restore.test.ts tests/api/assignment-docs/artifacts.test.ts tests/lib/assignment-doc-history.test.ts`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`
