### PR TITLE
Cache teacher lesson calendar reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Attendance export bulk-read hardening
-
-**Completed:**
-- Added a shared server attendance report loader for teacher attendance and CSV export routes.
-- Routed class-day, enrollment, profile, and entry reads through chunked, paginated loaders.
-- Scoped attendance entry reads by classroom id and currently enrolled student ids so stale withdrawn-student entries cannot consume pages or affect exports.
-- Returned explicit 500s for student profile hydration failures instead of rendering blank names after a failed read.
-- Added deterministic student ordering by email with id tie-breaks.
-- Added API regressions for >1000-student roster pagination, 51-student profile/entry chunking, dense entry pagination, stale-entry scoping, and profile failure handling.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-30 — Teacher logs bulk-read hardening
 
 **Completed:**
@@ -984,6 +964,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts`
 - `pnpm vitest run tests/api/assignment-docs/assignment-docs-id.test.ts tests/api/assignment-docs/history.test.ts tests/api/assignment-docs/submit.test.ts tests/api/assignment-docs/unsubmit.test.ts tests/api/assignment-docs/restore.test.ts tests/api/assignment-docs/artifacts.test.ts tests/lib/assignment-doc-history.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+
+## 2026-06-04 — Teacher lesson calendar cache audit
+
+**Completed:**
+- Added a shared teacher lesson-plan range cache helper with classroom-prefix invalidation.
+- Routed teacher calendar and markdown-panel lesson-plan reads through the helper.
+- Invalidated teacher lesson-plan caches after single autosaves and markdown bulk/no-op saves to avoid stale remount or refresh reads.
+- Added focused teacher calendar tests for cached remount reuse and post-autosave invalidation.
+- Addressed PR review findings by marking markdown content stale after inline autosaves, surfacing malformed successful JSON as a load error, and covering markdown sidebar reload/error behavior.
+
+**Validation:**
+- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx`
+- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/calendar-view-persistence.test.tsx`
+- `pnpm test`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
 - `pnpm lint`

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -11,11 +11,15 @@ import { TeacherEditModeControls } from '@/components/teacher-work-surface/Teach
 import { applyPendingLessonPlanChanges, lessonPlansToMarkdown, markdownToLessonPlans } from '@/lib/lesson-plan-markdown'
 import { useClassDays } from '@/hooks/useClassDays'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
-import type { Classroom, LessonPlan, TiptapContent, Assignment, Announcement } from '@/types'
+import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 import { readCookie, writeCookie } from '@/lib/cookies'
 import { TEACHER_ASSIGNMENTS_SELECTION_EVENT, TEACHER_ASSIGNMENTS_UPDATED_EVENT } from '@/lib/events'
 import { normalizeLessonPlanMarkdown } from '@/lib/lesson-plan-content'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import {
+  fetchTeacherLessonPlansForRange,
+  invalidateTeacherLessonPlansForClassroom,
+} from '@/lib/teacher-lesson-plans-client'
 
 /**
  * Returns true if the content change is identical to the last value emitted
@@ -144,11 +148,7 @@ export function TeacherLessonCalendarTab({
     async function loadLessonPlans() {
       setLoading(true)
       try {
-        const res = await fetch(
-          `/api/teacher/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`
-        )
-        const data = await res.json()
-        const plans = data.lesson_plans || []
+        const plans = await fetchTeacherLessonPlansForRange(classroom.id, fetchRange.start, fetchRange.end)
         // Seed last-seen content so Tiptap normalization doesn't trigger saves
         lastSeenContentRef.current.clear()
         for (const plan of plans) {
@@ -230,6 +230,8 @@ export function TeacherLessonCalendarTab({
         })
         if (res.ok) {
           const data = await res.json()
+          invalidateTeacherLessonPlansForClassroom(classroom.id)
+          needsRefreshRef.current = true
           setLessonPlans((prev) => {
             if (!data.lesson_plan) {
               return prev.filter((plan) => plan.date !== date)
@@ -340,20 +342,8 @@ export function TeacherLessonCalendarTab({
     try {
       const start = classroom.start_date || fetchRange.start
       const end = classroom.end_date || fetchRange.end
-      const res = await fetch(
-        `/api/teacher/classrooms/${classroom.id}/lesson-plans?start=${start}&end=${end}`
-      )
-      if (!res.ok) {
-        if (res.status === 401 || res.status === 403) {
-          throw new Error('Not authorized to view lesson plans')
-        } else if (res.status === 404) {
-          throw new Error('Classroom not found')
-        } else {
-          throw new Error(`Failed to load lesson plans (${res.status})`)
-        }
-      }
-      const data = await res.json()
-      const plans = applyPendingLessonPlanChanges(data.lesson_plans || [], pendingChangesRef.current, classroom.id)
+      const cachedPlans = await fetchTeacherLessonPlansForRange(classroom.id, start, end)
+      const plans = applyPendingLessonPlanChanges(cachedPlans, pendingChangesRef.current, classroom.id)
       const markdown = lessonPlansToMarkdown(classroom, plans, start, end)
       setMarkdownContent(markdown)
       markdownContentRef.current = markdown
@@ -417,6 +407,7 @@ export function TeacherLessonCalendarTab({
       }
 
       if (result.plans.length === 0 && result.clearedDates.length === 0) {
+        invalidateTeacherLessonPlansForClassroom(classroom.id)
         needsRefreshRef.current = true
         setSidebarOpen(false)
         setRefreshKey((k) => k + 1)
@@ -438,6 +429,7 @@ export function TeacherLessonCalendarTab({
       }
 
       // Success - close panel and refresh calendar
+      invalidateTeacherLessonPlansForClassroom(classroom.id)
       needsRefreshRef.current = true // Force refresh on next sidebar open
       setSidebarOpen(false)
       setRefreshKey((k) => k + 1)

--- a/src/lib/teacher-lesson-plans-client.ts
+++ b/src/lib/teacher-lesson-plans-client.ts
@@ -1,0 +1,61 @@
+import type { LessonPlan } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+
+type TeacherLessonPlansResponse = {
+  lesson_plans?: LessonPlan[]
+  lessonPlans?: LessonPlan[]
+}
+
+const TEACHER_LESSON_PLANS_CACHE_TTL_MS = 20_000
+
+export function getTeacherLessonPlansCachePrefix(classroomId: string): string {
+  return `teacher-lesson-plans:${classroomId}:`
+}
+
+export function getTeacherLessonPlansCacheKey(classroomId: string, start: string, end: string): string {
+  return `${getTeacherLessonPlansCachePrefix(classroomId)}${start}:${end}`
+}
+
+export async function fetchTeacherLessonPlansForRange(
+  classroomId: string,
+  start: string,
+  end: string,
+): Promise<LessonPlan[]> {
+  const data = await fetchJSONWithCache<TeacherLessonPlansResponse>(
+    getTeacherLessonPlansCacheKey(classroomId, start, end),
+    async () => {
+      const response = await fetch(
+        `/api/teacher/classrooms/${classroomId}/lesson-plans?start=${start}&end=${end}`,
+      )
+      let data: TeacherLessonPlansResponse & { error?: unknown }
+      try {
+        data = await response.json()
+      } catch {
+        if (!response.ok) {
+          data = {}
+        } else {
+          throw new Error('Failed to parse lesson plans response')
+        }
+      }
+      if (!response.ok) {
+        let message = `Failed to load lesson plans (${response.status})`
+        if (response.status === 401 || response.status === 403) {
+          message = 'Not authorized to view lesson plans'
+        } else if (response.status === 404) {
+          message = 'Classroom not found'
+        } else if (typeof data.error === 'string') {
+          message = data.error
+        }
+        throw new Error(message)
+      }
+      return data
+    },
+    TEACHER_LESSON_PLANS_CACHE_TTL_MS,
+  )
+
+  return data.lesson_plans || data.lessonPlans || []
+}
+
+export function invalidateTeacherLessonPlansForClassroom(classroomId: string) {
+  invalidateCachedJSONMatching(getTeacherLessonPlansCachePrefix(classroomId))
+}

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TeacherLessonCalendarTab } from '@/app/classrooms/[classroomId]/TeacherLessonCalendarTab'
+import { createMockClassroom } from '../helpers/mocks'
+import { TooltipProvider } from '@/ui'
+import { invalidateTeacherLessonPlansForClassroom } from '@/lib/teacher-lesson-plans-client'
+import { invalidateCachedJSON } from '@/lib/request-cache'
+import type { CalendarSidebarState } from '@/app/classrooms/[classroomId]/TeacherLessonCalendarTab'
+import type { LessonPlan } from '@/types'
+import type { ReactNode } from 'react'
+
+const sidebarState = vi.hoisted(() => ({
+  isOpen: false,
+  toggle: vi.fn(),
+  setOpen: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useClassDays', () => ({
+  useClassDays: () => [],
+}))
+
+vi.mock('@/lib/cookies', () => ({
+  readCookie: () => 'week',
+  writeCookie: vi.fn(),
+}))
+
+vi.mock('@/components/layout', () => ({
+  useRightSidebar: () => ({
+    toggle: sidebarState.toggle,
+    isOpen: sidebarState.isOpen,
+    setOpen: sidebarState.setOpen,
+    enabled: true,
+    cssWidth: '300px',
+  }),
+}))
+
+vi.mock('@/contexts/MarkdownPreferenceContext', () => ({
+  useMarkdownPreference: () => ({ showMarkdown: true, mounted: true }),
+}))
+
+vi.mock('@/components/LessonCalendar', () => ({
+  LessonCalendar: ({ lessonPlans, onContentChange }: any) => (
+    <div data-testid="lesson-calendar" data-lesson-count={lessonPlans.length}>
+      <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Updated lesson')}>
+        Edit lesson
+      </button>
+    </div>
+  ),
+  CalendarViewMode: {},
+}))
+
+function lessonPlan(overrides: Partial<LessonPlan> = {}): LessonPlan {
+  return {
+    id: 'lesson-1',
+    classroom_id: 'classroom-1',
+    date: '2025-01-06',
+    content: { type: 'doc', content: [] },
+    content_markdown: 'Original lesson',
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>
+}
+
+describe('TeacherLessonCalendarTab', () => {
+  const classroom = createMockClassroom({
+    id: 'classroom-1',
+    start_date: '2025-01-01',
+    end_date: '2025-06-30',
+  })
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    invalidateTeacherLessonPlansForClassroom(classroom.id)
+    invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
+    sidebarState.isOpen = false
+    sidebarState.toggle.mockReset()
+    sidebarState.setOpen.mockReset()
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    invalidateTeacherLessonPlansForClassroom(classroom.id)
+    invalidateCachedJSON(`teacher-assignments:${classroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${classroom.id}`)
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('reuses cached teacher lesson plans on remount', async () => {
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+        if (url.includes('assignments')) return { assignments: [] }
+        if (url.includes('announcements')) return { announcements: [] }
+        return {}
+      },
+    }))
+
+    const first = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+    })
+
+    first.unmount()
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+    })
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(urls.filter((url) => url.includes('/lesson-plans?'))).toHaveLength(1)
+    expect(urls.filter((url) => url.includes('/assignments'))).toHaveLength(1)
+    expect(urls.filter((url) => url.includes('/announcements'))).toHaveLength(1)
+  })
+
+  it('invalidates cached teacher lesson plans after an autosaved edit', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        return {
+          ok: true,
+          json: async () => ({
+            lesson_plan: lessonPlan({
+              content_markdown: 'Updated lesson',
+              updated_at: '2025-01-02T00:00:00Z',
+            }),
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) return { lesson_plans: [lessonPlan()] }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      }
+    })
+
+    const first = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+    })
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetchMock.mock.calls.some(([url, init]) => String(url).includes('/lesson-plans/2025-01-06') && init?.method === 'PUT')).toBe(true)
+    vi.useRealTimers()
+
+    first.unmount()
+    render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-count', '1')
+    })
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(urls.filter((url) => url.includes('/lesson-plans?'))).toHaveLength(2)
+  })
+
+  it('refreshes markdown content after an inline autosave invalidates the lesson cache', async () => {
+    let lessonPlanReads = 0
+    let latestSidebarState: CalendarSidebarState | null = null
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/lesson-plans/2025-01-06') && init?.method === 'PUT') {
+        return {
+          ok: true,
+          json: async () => ({
+            lesson_plan: lessonPlan({
+              content_markdown: 'Updated lesson',
+              updated_at: '2025-01-02T00:00:00Z',
+            }),
+          }),
+        }
+      }
+
+      return {
+        ok: true,
+        json: async () => {
+          if (url.includes('lesson-plans')) {
+            lessonPlanReads += 1
+            return {
+              lesson_plans: [
+                lessonPlan({
+                  content_markdown: lessonPlanReads === 1 ? 'Original lesson' : 'Updated lesson',
+                }),
+              ],
+            }
+          }
+          if (url.includes('assignments')) return { assignments: [] }
+          if (url.includes('announcements')) return { announcements: [] }
+          return {}
+        },
+      }
+    })
+
+    sidebarState.isOpen = true
+    const view = render(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toContain('Original lesson')
+    })
+
+    sidebarState.isOpen = false
+    view.rerender(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+    )
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    vi.useRealTimers()
+
+    sidebarState.isOpen = true
+    view.rerender(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toContain('Updated lesson')
+    })
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(urls.filter((url) => url.includes('/lesson-plans?'))).toHaveLength(2)
+  })
+
+  it('surfaces malformed lesson-plan JSON as a markdown load error', async () => {
+    let latestSidebarState: CalendarSidebarState | null = null
+    fetchMock.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () => {
+        if (url.includes('lesson-plans')) {
+          throw new Error('bad json')
+        }
+        if (url.includes('assignments')) return { assignments: [] }
+        if (url.includes('announcements')) return { announcements: [] }
+        return {}
+      },
+    }))
+
+    sidebarState.isOpen = true
+    render(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownError).toBe('Failed to parse lesson plans response')
+    })
+    expect(latestSidebarState?.markdownContent).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared teacher lesson-plan range cache helper with classroom-prefix invalidation
- route teacher calendar and markdown-panel lesson-plan reads through the helper
- invalidate teacher lesson-plan cache after single autosaves and markdown bulk/no-op saves
- add focused teacher calendar tests for cached remount reuse and post-autosave invalidation

## Validation
- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx`
- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/calendar-view-persistence.test.tsx`
- `pnpm test`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`

## Notes
- No visual verification run: this slice only changes request caching/invalidation and tests, with no intended UI layout or styling change.
