### PR TITLE
Tighten announcement classroom freshness

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Teacher logs bulk-read hardening
-
-**Completed:**
-- Extracted the paginated classroom roster/profile loader into a neutral server helper shared by attendance/export and teacher logs.
-- Routed teacher logs roster, profile, and selected-date entry reads through chunked, paginated Supabase loaders.
-- Scoped selected-date log entries by currently enrolled student ids at query time so stale withdrawn-student entries cannot consume pages or appear in teacher logs.
-- Returned an explicit 500 for student profile hydration failures instead of silently rendering blank names after a failed read.
-- Chunked history-preview RPC calls and bounded the missing-RPC fallback to per-student batches.
-- Added API regressions for >1000-student roster pagination, 51-student profile/entry chunking, dense selected-date entry pagination, stale-entry scoping, profile failure handling, and history-preview RPC fallback.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/teacher/logs.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-30 — Nightly log summary bulk-read hardening
 
 **Completed:**
@@ -981,6 +961,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx`
 - `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx tests/components/StudentLessonCalendarTab.test.tsx tests/components/calendar-view-persistence.test.tsx`
+- `pnpm test`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+
+## 2026-06-04 — Announcement freshness audit
+
+**Completed:**
+- Made teacher and student announcement reloads enter loading state on classroom changes and ignore stale responses from older classroom reads.
+- Reset the student announcement read-marker guard when the classroom changes so each classroom can mark its announcements read once.
+- Added component regressions for hiding stale teacher announcements during a classroom switch and marking student announcements read once per classroom.
+- Addressed PR review findings by keying displayed announcement state to the loaded classroom id, preventing one-frame stale paints and premature student read-marker POSTs during classroom switches.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/AnnouncementsMarkdown.test.tsx`
+- `pnpm vitest run tests/components/AnnouncementsMarkdown.test.tsx tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/api/student/announcements.test.ts tests/components/StudentNotificationsProvider.test.tsx`
 - `pnpm test`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -17,12 +17,17 @@ interface Props {
 
 export function StudentAnnouncementsSection({ classroom, className }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [showAll, setShowAll] = useState(false)
   const hasMarkedRead = useRef(false)
+  const loadRequestIdRef = useRef(0)
   const notifications = useStudentNotifications()
 
   const loadAnnouncements = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
+    setLoading(true)
     try {
       const data = await fetchJSONWithCache(
         `student-announcements:${classroom.id}`,
@@ -33,12 +38,23 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
         },
         20_000,
       )
+      if (loadRequestIdRef.current !== requestId) return
       setAnnouncements(data.announcements || [])
+      setLoadedClassroomId(classroom.id)
     } catch (err) {
+      if (loadRequestIdRef.current !== requestId) return
+      setAnnouncements([])
+      setLoadedClassroomId(classroom.id)
       console.error('Error loading announcements:', err)
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId) {
+        setLoading(false)
+      }
     }
+  }, [classroom.id])
+
+  useEffect(() => {
+    hasMarkedRead.current = false
   }, [classroom.id])
 
   const markAllAsRead = useCallback(async () => {
@@ -63,12 +79,15 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     loadAnnouncements()
   }, [loadAnnouncements])
 
+  const currentAnnouncements = loadedClassroomId === classroom.id ? announcements : []
+  const isLoading = loading || loadedClassroomId !== classroom.id
+
   // Mark all as read when component mounts and announcements are loaded
   useEffect(() => {
-    if (!loading && announcements.length > 0) {
+    if (!isLoading && currentAnnouncements.length > 0) {
       markAllAsRead()
     }
-  }, [loading, announcements.length, markAllAsRead])
+  }, [isLoading, currentAnnouncements.length, markAllAsRead])
 
   function formatDate(dateString: string) {
     const date = new Date(dateString)
@@ -78,7 +97,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     return `${weekday} ${monthDay}, ${time}`
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <Spinner />
@@ -86,7 +105,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     )
   }
 
-  if (announcements.length === 0) {
+  if (currentAnnouncements.length === 0) {
     return (
       <div className={cn('rounded-lg border border-border bg-surface-2 p-4', className ?? 'max-w-2xl mx-auto')}>
         <p className="text-sm text-text-muted">No announcements yet.</p>
@@ -94,7 +113,7 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     )
   }
 
-  const sortedAnnouncements = sortAnnouncementsNewestFirst(announcements)
+  const sortedAnnouncements = sortAnnouncementsNewestFirst(currentAnnouncements)
 
   return (
     <div className={cn('space-y-3', className ?? 'max-w-2xl mx-auto')}>
@@ -120,13 +139,13 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
         )
       })}
 
-      {!showAll && announcements.length > 5 && (
+      {!showAll && currentAnnouncements.length > 5 && (
         <Button
           variant="secondary"
           onClick={() => setShowAll(true)}
           className="w-full"
         >
-          Show {announcements.length - 5} older announcement{announcements.length - 5 === 1 ? '' : 's'}
+          Show {currentAnnouncements.length - 5} older announcement{currentAnnouncements.length - 5 === 1 ? '' : 's'}
         </Button>
       )}
     </div>

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -73,6 +73,7 @@ function parseDateTime(isoString: string): { date: string; time: string } {
 
 export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [showAll, setShowAll] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -99,10 +100,14 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
   const newTextareaRef = useRef<HTMLTextAreaElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const editDropdownRef = useRef<HTMLDivElement>(null)
+  const loadRequestIdRef = useRef(0)
 
   const isReadOnly = !!classroom.archived_at
 
   const loadAnnouncements = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
+    setLoading(true)
     try {
       const data = await fetchJSONWithCache(
         `teacher-announcements:${classroom.id}`,
@@ -113,11 +118,18 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
         },
         20_000,
       )
+      if (loadRequestIdRef.current !== requestId) return
       setAnnouncements(data.announcements || [])
+      setLoadedClassroomId(classroom.id)
     } catch (err) {
+      if (loadRequestIdRef.current !== requestId) return
+      setAnnouncements([])
+      setLoadedClassroomId(classroom.id)
       console.error('Error loading announcements:', err)
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId) {
+        setLoading(false)
+      }
     }
   }, [classroom.id])
 
@@ -386,7 +398,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     setShowEditScheduleDropdown(true)
   }
 
-  if (loading) {
+  const currentAnnouncements = loadedClassroomId === classroom.id ? announcements : []
+  const isLoading = loading || loadedClassroomId !== classroom.id
+
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <Spinner />
@@ -536,7 +551,7 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       ) : null}
 
       {/* Empty state */}
-      {announcements.length === 0 && !isCreating && (
+      {currentAnnouncements.length === 0 && !isCreating && (
         <div className="rounded-lg border border-border bg-surface-2 p-4">
           <p className="text-sm text-text-muted">
             No announcements yet. Create one to share updates with your students.
@@ -545,8 +560,8 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       )}
 
       {/* Announcements list */}
-      {announcements.length > 0 && (() => {
-        const sortedAnnouncements = sortAnnouncementsNewestFirst(announcements)
+      {currentAnnouncements.length > 0 && (() => {
+        const sortedAnnouncements = sortAnnouncementsNewestFirst(currentAnnouncements)
         const displayedAnnouncements = showAll ? sortedAnnouncements : sortedAnnouncements.slice(0, 5)
 
         return (

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
 import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
@@ -46,6 +46,12 @@ const markdownAnnouncement: Announcement = {
   scheduled_for: null,
   created_at: '2026-05-13T12:00:00.000Z',
   updated_at: '2026-05-13T12:00:00.000Z',
+}
+
+const secondClassroom: Classroom = {
+  ...classroom,
+  id: 'classroom-announcements-second',
+  title: 'Second Announcements',
 }
 
 function mockAnnouncementFetch(announcements: Announcement[] = [markdownAnnouncement]) {
@@ -171,5 +177,121 @@ describe('announcement markdown rendering', () => {
     expect(link).toHaveAttribute('target', '_blank')
     expect(screen.getByText('Unit update')).toBeInTheDocument()
     expect(screen.getByText('bring notes')).toBeInTheDocument()
+  })
+
+  it('does not keep stale teacher announcements visible while loading another classroom', async () => {
+    let resolveSecondRead: ((response: Response) => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes(secondClassroom.id)) {
+          return new Promise<Response>((resolve) => {
+            resolveSecondRead = resolve
+          })
+        }
+
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const secondAnnouncement: Announcement = {
+      ...markdownAnnouncement,
+      id: 'second-announcement',
+      classroom_id: secondClassroom.id,
+      title: 'Second classroom update',
+    }
+
+    const view = render(<TeacherAnnouncementsSection classroom={classroom} />)
+
+    await screen.findByText('Unit update')
+
+    view.rerender(<TeacherAnnouncementsSection classroom={secondClassroom} />)
+
+    expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveSecondRead?.(
+        new Response(JSON.stringify({ announcements: [secondAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    expect(await screen.findByText('Second classroom update')).toBeInTheDocument()
+  })
+
+  it('marks student announcements read once per classroom', async () => {
+    const markedReadUrls: string[] = []
+    let resolveSecondRead: ((response: Response) => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (init?.method === 'POST') {
+          markedReadUrls.push(url)
+          return new Response(JSON.stringify({ success: true, marked: 1 }), { status: 200 })
+        }
+
+        if (url.includes(secondClassroom.id)) {
+          return new Promise<Response>((resolve) => {
+            resolveSecondRead = resolve
+          })
+        }
+
+        return new Response(JSON.stringify({ announcements: [markdownAnnouncement] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }),
+    )
+
+    const view = render(<StudentAnnouncementsSection classroom={classroom} />)
+
+    await screen.findByText('Unit update')
+    await waitFor(() => {
+      expect(markedReadUrls).toEqual([
+        `/api/student/classrooms/${classroom.id}/announcements`,
+      ])
+    })
+
+    view.rerender(<StudentAnnouncementsSection classroom={secondClassroom} />)
+
+    expect(markedReadUrls).toEqual([
+      `/api/student/classrooms/${classroom.id}/announcements`,
+    ])
+
+    await act(async () => {
+      resolveSecondRead?.(
+        new Response(
+          JSON.stringify({
+            announcements: [
+              {
+                ...markdownAnnouncement,
+                id: 'second-student-announcement',
+                classroom_id: secondClassroom.id,
+                title: 'Second student update',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+    })
+
+    await screen.findByText('Second student update')
+    await waitFor(() => {
+      expect(markedReadUrls).toEqual([
+        `/api/student/classrooms/${classroom.id}/announcements`,
+        `/api/student/classrooms/${secondClassroom.id}/announcements`,
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Summary
- make teacher and student announcement reloads enter loading state when the classroom changes
- ignore stale announcement responses from older classroom reads
- reset the student announcement read-marker guard on classroom changes so each classroom can mark announcements read once
- add component regressions for stale teacher announcement display and per-classroom student read marking

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/components/AnnouncementsMarkdown.test.tsx`
- `pnpm vitest run tests/components/AnnouncementsMarkdown.test.tsx tests/api/teacher/announcements.test.ts tests/api/teacher/announcements-id.test.ts tests/api/student/announcements.test.ts tests/components/StudentNotificationsProvider.test.tsx`
- `pnpm test`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`

## Notes
- No visual verification run: this slice changes data freshness/loading behavior and tests, with no intended layout or styling change.
- Audit emitted the standard composite-widget accessibility reminder; no composite widget roles, keyboard behavior, or ARIA semantics were changed.
