### PR TITLE
Tighten classroom resource sidebar freshness

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-30 — Nightly log summary bulk-read hardening
-
-**Completed:**
-- Routed nightly log-summary active-classroom discovery through paginated entry reads.
-- Chunked class-day filtering for discovered classroom ids.
-- Loaded per-classroom enrollments before summary entries and scoped summary entry reads to currently enrolled students.
-- Paged enrollment, roster-name, and selected entry reads, and chunked student profile hydration.
-- Returned skip/failure for required profile reads instead of generating summaries with incomplete redaction context.
-- Added cron regressions for active-entry pagination, 51-classroom class-day chunking, scoped dense entry pagination, stale withdrawn-student exclusion, profile chunking, and profile-read failures.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/api/cron/nightly-log-summaries.test.ts --reporter=verbose`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm vitest run --coverage --no-file-parallelism --reporter=dot`
-- `git diff --check`
-
 ## 2026-05-31 — Teacher assignment detail bulk-read hardening
 
 **Completed:**
@@ -984,3 +964,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-06-04 — Resource sidebar freshness audit
+
+**Completed:**
+- Added a shared client helper for teacher and student classroom resource reads, cache keys, and cross-role invalidation after teacher saves.
+- Made teacher and student resource sidebars ignore stale responses from older classroom reads and only render content for the classroom that actually finished loading.
+- Added sidebar regressions for hiding stale teacher/student resources during classroom switches and invalidating student resource cache after a teacher save.
+- Addressed PR review feedback by scoping pending teacher resource autosave drafts and save completions to their classroom id so blur/unload saves and stale in-flight saves cannot corrupt the newly selected classroom state.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx`
+- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx tests/components/ResourcesTab.test.tsx tests/api/teacher/resources.test.ts tests/api/student/resources.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/StudentClassResourcesSidebar.tsx
+++ b/src/app/classrooms/[classroomId]/StudentClassResourcesSidebar.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextViewer } from '@/components/editor'
 import type { Classroom, TiptapContent } from '@/types'
-import { fetchJSONWithCache } from '@/lib/request-cache'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { isEmpty } from '@/lib/tiptap-content'
+import { fetchStudentClassResources } from '@/lib/class-resources-client'
 
 interface Props {
   classroom: Classroom
@@ -15,33 +15,37 @@ interface Props {
 export function StudentClassResourcesSidebar({ classroom }: Props) {
   const [loading, setLoading] = useState(true)
   const [content, setContent] = useState<TiptapContent | null>(null)
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
+  const loadRequestIdRef = useRef(0)
   const showLoadingSpinner = useDelayedBusy(loading)
 
   useEffect(() => {
     async function loadResources() {
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
       setLoading(true)
       try {
-        const data = await fetchJSONWithCache(
-          `student-resources:${classroom.id}`,
-          async () => {
-            const res = await fetch(`/api/student/classrooms/${classroom.id}/resources`)
-            if (!res.ok) throw new Error('Failed to load resources')
-            return res.json()
-          },
-          20_000,
-        )
-        setContent(data.resources?.content || null)
+        const loadedContent = await fetchStudentClassResources(classroom.id)
+        if (loadRequestIdRef.current !== requestId) return
+        setContent(loadedContent)
+        setLoadedClassroomId(classroom.id)
       } catch (err) {
+        if (loadRequestIdRef.current !== requestId) return
+        setContent(null)
+        setLoadedClassroomId(classroom.id)
         console.error('Error loading resources:', err)
       } finally {
-        setLoading(false)
+        if (loadRequestIdRef.current === requestId) {
+          setLoading(false)
+        }
       }
     }
 
     loadResources()
   }, [classroom.id])
 
-  const hasContent = content ? !isEmpty(content) : false
+  const currentContent = loadedClassroomId === classroom.id ? content : null
+  const hasContent = currentContent ? !isEmpty(currentContent) : false
 
   if (showLoadingSpinner) {
     return (
@@ -55,7 +59,7 @@ export function StudentClassResourcesSidebar({ classroom }: Props) {
     <div className="px-3 py-3">
       {hasContent ? (
         <div className="rounded-lg bg-surface p-4 shadow-sm">
-          <RichTextViewer content={content!} />
+          <RichTextViewer content={currentContent!} />
         </div>
       ) : (
         <div className="rounded-lg border border-border bg-surface-2 p-4">

--- a/src/app/classrooms/[classroomId]/TeacherClassResourcesSidebar.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassResourcesSidebar.tsx
@@ -4,12 +4,20 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { RichTextEditor } from '@/components/editor'
 import type { Classroom, TiptapContent } from '@/types'
-import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { isEmpty } from '@/lib/tiptap-content'
+import {
+  fetchTeacherClassResources,
+  invalidateClassResourcesForClassroom,
+} from '@/lib/class-resources-client'
 
 const EMPTY_DOC: TiptapContent = { type: 'doc', content: [] }
 const AUTOSAVE_DEBOUNCE_MS = 2000
+
+type PendingResourceDraft = {
+  classroomId: string
+  content: TiptapContent
+}
 
 interface Props {
   classroom: Classroom
@@ -18,35 +26,47 @@ interface Props {
 export function TeacherClassResourcesSidebar({ classroom }: Props) {
   const [loading, setLoading] = useState(true)
   const [content, setContent] = useState<TiptapContent>(EMPTY_DOC)
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
   const showLoadingSpinner = useDelayedBusy(loading)
 
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const pendingContentRef = useRef<TiptapContent | null>(null)
+  const pendingContentRef = useRef<PendingResourceDraft | null>(null)
   const lastSavedContentRef = useRef<string>('')
+  const currentClassroomIdRef = useRef(classroom.id)
+  const loadRequestIdRef = useRef(0)
   const isArchived = !!classroom.archived_at
+  currentClassroomIdRef.current = classroom.id
 
   useEffect(() => {
     async function loadResources() {
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
+      pendingContentRef.current = null
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
+      }
+      setSaveStatus('saved')
       setLoading(true)
       try {
-        const data = await fetchJSONWithCache(
-          `teacher-resources:${classroom.id}`,
-          async () => {
-            const res = await fetch(`/api/teacher/classrooms/${classroom.id}/resources`)
-            if (!res.ok) throw new Error('Failed to load resources')
-            return res.json()
-          },
-          20_000,
-        )
-        const loadedContent = data.resources?.content || EMPTY_DOC
+        const loadedContent = await fetchTeacherClassResources(classroom.id) ?? EMPTY_DOC
+        if (loadRequestIdRef.current !== requestId) return
         setContent(loadedContent)
         lastSavedContentRef.current = JSON.stringify(loadedContent)
         setSaveStatus('saved')
+        setLoadedClassroomId(classroom.id)
       } catch (err) {
+        if (loadRequestIdRef.current !== requestId) return
+        setContent(EMPTY_DOC)
+        lastSavedContentRef.current = JSON.stringify(EMPTY_DOC)
+        setSaveStatus('saved')
+        setLoadedClassroomId(classroom.id)
         console.error('Error loading resources:', err)
       } finally {
-        setLoading(false)
+        if (loadRequestIdRef.current === requestId) {
+          setLoading(false)
+        }
       }
     }
 
@@ -54,16 +74,25 @@ export function TeacherClassResourcesSidebar({ classroom }: Props) {
   }, [classroom.id])
 
   const saveContent = useCallback(async (newContent: TiptapContent) => {
+    const saveClassroomId = classroom.id
     const newContentStr = JSON.stringify(newContent)
     if (newContentStr === lastSavedContentRef.current) {
-      setSaveStatus('saved')
+      const pending = pendingContentRef.current
+      if (pending?.classroomId === saveClassroomId && JSON.stringify(pending.content) === newContentStr) {
+        pendingContentRef.current = null
+      }
+      if (currentClassroomIdRef.current === saveClassroomId) {
+        setSaveStatus('saved')
+      }
       return
     }
 
-    setSaveStatus('saving')
+    if (currentClassroomIdRef.current === saveClassroomId) {
+      setSaveStatus('saving')
+    }
 
     try {
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/resources`, {
+      const res = await fetch(`/api/teacher/classrooms/${saveClassroomId}/resources`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: newContent }),
@@ -73,20 +102,34 @@ export function TeacherClassResourcesSidebar({ classroom }: Props) {
         throw new Error('Failed to save')
       }
 
-      invalidateCachedJSON(`teacher-resources:${classroom.id}`)
-      invalidateCachedJSON(`student-resources:${classroom.id}`)
+      invalidateClassResourcesForClassroom(saveClassroomId)
+      if (currentClassroomIdRef.current !== saveClassroomId) {
+        return
+      }
+
       lastSavedContentRef.current = newContentStr
-      setSaveStatus('saved')
+      const pending = pendingContentRef.current
+      const pendingMatchesSavedDraft =
+        pending?.classroomId === saveClassroomId && JSON.stringify(pending.content) === newContentStr
+      if (!pending || pendingMatchesSavedDraft) {
+        pendingContentRef.current = null
+        setSaveStatus('saved')
+      }
     } catch (err) {
       console.error('Error saving resources:', err)
-      setSaveStatus('unsaved')
+      if (currentClassroomIdRef.current === saveClassroomId) {
+        setSaveStatus('unsaved')
+      }
     }
   }, [classroom.id])
 
   const handleContentChange = useCallback((newContent: TiptapContent) => {
     setContent(newContent)
     setSaveStatus('unsaved')
-    pendingContentRef.current = newContent
+    pendingContentRef.current = {
+      classroomId: classroom.id,
+      content: newContent,
+    }
 
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current)
@@ -95,25 +138,28 @@ export function TeacherClassResourcesSidebar({ classroom }: Props) {
     saveTimeoutRef.current = setTimeout(() => {
       saveContent(newContent)
     }, AUTOSAVE_DEBOUNCE_MS)
-  }, [saveContent])
+  }, [classroom.id, saveContent])
 
   const handleBlur = useCallback(() => {
-    if (saveStatus === 'unsaved' && pendingContentRef.current) {
+    const pending = pendingContentRef.current
+    if (saveStatus === 'unsaved' && pending?.classroomId === classroom.id) {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
       }
-      saveContent(pendingContentRef.current)
+      saveContent(pending.content)
     }
-  }, [saveStatus, saveContent])
+  }, [classroom.id, saveStatus, saveContent])
 
   useEffect(() => {
     const handleBeforeUnload = () => {
-      if (pendingContentRef.current) {
-        const contentStr = JSON.stringify(pendingContentRef.current)
+      const pending = pendingContentRef.current
+      if (pending) {
+        const contentStr = JSON.stringify(pending.content)
         if (contentStr !== lastSavedContentRef.current) {
           navigator.sendBeacon(
-            `/api/teacher/classrooms/${classroom.id}/resources`,
-            new Blob([JSON.stringify({ content: pendingContentRef.current })], { type: 'application/json' }),
+            `/api/teacher/classrooms/${pending.classroomId}/resources`,
+            new Blob([JSON.stringify({ content: pending.content })], { type: 'application/json' }),
           )
         }
       }
@@ -129,7 +175,8 @@ export function TeacherClassResourcesSidebar({ classroom }: Props) {
     }
   }, [classroom.id])
 
-  const hasContent = !isEmpty(content)
+  const currentContent = loadedClassroomId === classroom.id ? content : EMPTY_DOC
+  const hasContent = !isEmpty(currentContent)
   if (showLoadingSpinner) {
     return (
       <div className="flex h-full items-center justify-center p-6">
@@ -163,7 +210,7 @@ export function TeacherClassResourcesSidebar({ classroom }: Props) {
 
         <div className="rounded-lg bg-surface p-4 shadow-sm">
           <RichTextEditor
-            content={content}
+            content={currentContent}
             onChange={handleContentChange}
             onBlur={handleBlur}
             placeholder="Add resources for your students..."

--- a/src/lib/class-resources-client.ts
+++ b/src/lib/class-resources-client.ts
@@ -1,0 +1,75 @@
+import type { TiptapContent } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+
+type ClassResources = {
+  id?: string
+  classroom_id?: string
+  content?: TiptapContent
+  updated_at?: string
+  updated_by?: string
+}
+
+type ClassResourcesResponse = {
+  resources?: ClassResources | null
+  error?: unknown
+}
+
+const CLASS_RESOURCES_CACHE_TTL_MS = 20_000
+
+export function getTeacherClassResourcesCacheKey(classroomId: string): string {
+  return `teacher-resources:${classroomId}`
+}
+
+export function getStudentClassResourcesCacheKey(classroomId: string): string {
+  return `student-resources:${classroomId}`
+}
+
+async function parseClassResourcesResponse(response: Response, fallbackMessage: string): Promise<ClassResourcesResponse> {
+  let data: ClassResourcesResponse
+  try {
+    data = await response.json()
+  } catch {
+    if (!response.ok) {
+      data = {}
+    } else {
+      throw new Error(`${fallbackMessage}: invalid response`)
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(typeof data.error === 'string' ? data.error : fallbackMessage)
+  }
+
+  return data
+}
+
+export async function fetchTeacherClassResources(classroomId: string): Promise<TiptapContent | null> {
+  const data = await fetchJSONWithCache<ClassResourcesResponse>(
+    getTeacherClassResourcesCacheKey(classroomId),
+    async () => {
+      const response = await fetch(`/api/teacher/classrooms/${classroomId}/resources`)
+      return parseClassResourcesResponse(response, 'Failed to load resources')
+    },
+    CLASS_RESOURCES_CACHE_TTL_MS,
+  )
+
+  return data.resources?.content ?? null
+}
+
+export async function fetchStudentClassResources(classroomId: string): Promise<TiptapContent | null> {
+  const data = await fetchJSONWithCache<ClassResourcesResponse>(
+    getStudentClassResourcesCacheKey(classroomId),
+    async () => {
+      const response = await fetch(`/api/student/classrooms/${classroomId}/resources`)
+      return parseClassResourcesResponse(response, 'Failed to load resources')
+    },
+    CLASS_RESOURCES_CACHE_TTL_MS,
+  )
+
+  return data.resources?.content ?? null
+}
+
+export function invalidateClassResourcesForClassroom(classroomId: string) {
+  invalidateCachedJSON(getTeacherClassResourcesCacheKey(classroomId))
+  invalidateCachedJSON(getStudentClassResourcesCacheKey(classroomId))
+}

--- a/tests/components/ClassResourcesSidebar.test.tsx
+++ b/tests/components/ClassResourcesSidebar.test.tsx
@@ -1,0 +1,315 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TeacherClassResourcesSidebar } from '@/app/classrooms/[classroomId]/TeacherClassResourcesSidebar'
+import { StudentClassResourcesSidebar } from '@/app/classrooms/[classroomId]/StudentClassResourcesSidebar'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
+import type { Classroom, TiptapContent, TiptapNode } from '@/types'
+
+vi.mock('@/components/editor', () => {
+  function extractText(content: TiptapContent | null | undefined): string {
+    function fromNode(node: TiptapNode): string {
+      return [node.text, ...(node.content ?? []).map(fromNode)].filter(Boolean).join(' ')
+    }
+
+    return (content?.content ?? []).map(fromNode).join(' ')
+  }
+
+  function contentDoc(text: string): TiptapContent {
+    return {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+    }
+  }
+
+  return {
+    RichTextEditor: ({ content, onBlur, onChange }: any) => (
+      <div>
+        <div data-testid="rich-text-editor">{extractText(content)}</div>
+        <button type="button" onClick={() => onChange(contentDoc('Updated teacher resources'))}>
+          Change teacher resources
+        </button>
+        <button type="button" onClick={() => onBlur?.()}>
+          Blur resources editor
+        </button>
+      </div>
+    ),
+    RichTextViewer: ({ content }: any) => (
+      <div data-testid="rich-text-viewer">{extractText(content)}</div>
+    ),
+  }
+})
+
+const classroom: Classroom = {
+  id: 'classroom-resources',
+  teacher_id: 'teacher-1',
+  title: 'Resources Classroom',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: '2026-02-01',
+  end_date: '2026-06-30',
+  lesson_plan_visibility: 'current_week',
+  source_blueprint_id: null,
+  source_blueprint_origin: null,
+  actual_site_slug: null,
+  actual_site_published: false,
+  actual_site_config: {
+    overview: true,
+    outline: true,
+    resources: true,
+    assignments: true,
+    quizzes: true,
+    tests: true,
+    lesson_plans: true,
+    announcements: true,
+    lesson_plan_scope: 'current_week',
+  },
+  course_overview_markdown: '',
+  course_outline_markdown: '',
+  archived_at: null,
+  created_at: '2026-05-13T00:00:00.000Z',
+  updated_at: '2026-05-13T00:00:00.000Z',
+}
+
+const secondClassroom: Classroom = {
+  ...classroom,
+  id: 'classroom-resources-second',
+  title: 'Second Resources',
+}
+
+function contentDoc(text: string): TiptapContent {
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  }
+}
+
+function resourceResponse(text: string | null): Response {
+  return new Response(
+    JSON.stringify({
+      resources: text
+        ? {
+            id: `resources-${text}`,
+            classroom_id: classroom.id,
+            content: contentDoc(text),
+          }
+        : null,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
+}
+
+describe('class resources sidebars', () => {
+  beforeEach(() => {
+    invalidateCachedJSONMatching('teacher-resources:')
+    invalidateCachedJSONMatching('student-resources:')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not keep stale teacher resources visible while loading another classroom', async () => {
+    let resolveSecondRead: ((response: Response) => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes(secondClassroom.id)) {
+          return new Promise<Response>((resolve) => {
+            resolveSecondRead = resolve
+          })
+        }
+
+        return resourceResponse('First teacher resources')
+      }),
+    )
+
+    const view = render(<TeacherClassResourcesSidebar classroom={classroom} />)
+
+    await screen.findByText('First teacher resources')
+
+    view.rerender(<TeacherClassResourcesSidebar classroom={secondClassroom} />)
+
+    expect(screen.queryByText('First teacher resources')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveSecondRead?.(resourceResponse('Second teacher resources'))
+    })
+
+    expect(await screen.findByText('Second teacher resources')).toBeInTheDocument()
+  })
+
+  it('does not keep stale student resources visible while loading another classroom', async () => {
+    let resolveSecondRead: ((response: Response) => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes(secondClassroom.id)) {
+          return new Promise<Response>((resolve) => {
+            resolveSecondRead = resolve
+          })
+        }
+
+        return resourceResponse('First student resources')
+      }),
+    )
+
+    const view = render(<StudentClassResourcesSidebar classroom={classroom} />)
+
+    await screen.findByText('First student resources')
+
+    view.rerender(<StudentClassResourcesSidebar classroom={secondClassroom} />)
+
+    expect(screen.queryByText('First student resources')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveSecondRead?.(resourceResponse('Second student resources'))
+    })
+
+    expect(await screen.findByText('Second student resources')).toBeInTheDocument()
+  })
+
+  it('does not save a pending teacher edit to the next classroom after switching', async () => {
+    const writeUrls: string[] = []
+    let resolveSecondRead: ((response: Response) => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (init?.method === 'PUT') {
+          writeUrls.push(url)
+          return resourceResponse('Updated teacher resources')
+        }
+
+        if (url.includes(secondClassroom.id)) {
+          return new Promise<Response>((resolve) => {
+            resolveSecondRead = resolve
+          })
+        }
+
+        return resourceResponse('First teacher resources')
+      }),
+    )
+
+    const view = render(<TeacherClassResourcesSidebar classroom={classroom} />)
+
+    await screen.findByText('First teacher resources')
+    fireEvent.click(screen.getByRole('button', { name: 'Change teacher resources' }))
+
+    view.rerender(<TeacherClassResourcesSidebar classroom={secondClassroom} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Blur resources editor' }))
+
+    expect(writeUrls).toEqual([])
+
+    await act(async () => {
+      resolveSecondRead?.(resourceResponse('Second teacher resources'))
+    })
+
+    expect(await screen.findByText('Second teacher resources')).toBeInTheDocument()
+    expect(writeUrls).toEqual([])
+  })
+
+  it('does not let an in-flight teacher save clear a next-classroom pending edit', async () => {
+    const writeUrls: string[] = []
+    let resolveFirstSave: (() => void) | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (init?.method === 'PUT') {
+          writeUrls.push(url)
+          if (url.includes(classroom.id)) {
+            return new Promise<Response>((resolve) => {
+              resolveFirstSave = () => resolve(resourceResponse('Updated teacher resources'))
+            })
+          }
+
+          return resourceResponse('Updated teacher resources')
+        }
+
+        if (url.includes(secondClassroom.id)) {
+          return resourceResponse('Second teacher resources')
+        }
+
+        return resourceResponse('First teacher resources')
+      }),
+    )
+
+    const view = render(<TeacherClassResourcesSidebar classroom={classroom} />)
+
+    await screen.findByText('First teacher resources')
+    fireEvent.click(screen.getByRole('button', { name: 'Change teacher resources' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Blur resources editor' }))
+
+    await waitFor(() => {
+      expect(writeUrls).toEqual([`/api/teacher/classrooms/${classroom.id}/resources`])
+    })
+
+    view.rerender(<TeacherClassResourcesSidebar classroom={secondClassroom} />)
+    await screen.findByText('Second teacher resources')
+    fireEvent.click(screen.getByRole('button', { name: 'Change teacher resources' }))
+
+    await act(async () => {
+      resolveFirstSave?.()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Blur resources editor' }))
+
+    await waitFor(() => {
+      expect(writeUrls).toEqual([
+        `/api/teacher/classrooms/${classroom.id}/resources`,
+        `/api/teacher/classrooms/${secondClassroom.id}/resources`,
+      ])
+    })
+  })
+
+  it('invalidates teacher and student resource caches after a teacher save', async () => {
+    const readUrls: string[] = []
+    const writeUrls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (init?.method === 'PUT') {
+          writeUrls.push(url)
+          return resourceResponse('Updated teacher resources')
+        }
+
+        readUrls.push(url)
+        if (url.includes('/api/student/')) {
+          return resourceResponse('Student resources')
+        }
+
+        return resourceResponse('Teacher resources')
+      }),
+    )
+
+    const studentView = render(<StudentClassResourcesSidebar classroom={classroom} />)
+    await screen.findByText('Student resources')
+    studentView.unmount()
+
+    const teacherView = render(<TeacherClassResourcesSidebar classroom={classroom} />)
+    await screen.findByText('Teacher resources')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change teacher resources' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Blur resources editor' }))
+
+    await waitFor(() => {
+      expect(writeUrls).toEqual([`/api/teacher/classrooms/${classroom.id}/resources`])
+    })
+    teacherView.unmount()
+
+    render(<StudentClassResourcesSidebar classroom={classroom} />)
+    await screen.findByText('Student resources')
+
+    expect(readUrls.filter((url) => url.includes('/api/student/'))).toEqual([
+      `/api/student/classrooms/${classroom.id}/resources`,
+      `/api/student/classrooms/${classroom.id}/resources`,
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Add a shared client helper for cached teacher/student classroom resource reads and cross-role invalidation after teacher saves.
- Ignore stale resource read responses when switching classrooms in teacher and student resource sidebars.
- Add focused sidebar regressions for stale classroom switches and teacher-save cache invalidation.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx`
- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx tests/components/ResourcesTab.test.tsx tests/api/teacher/resources.test.ts tests/api/student/resources.test.ts`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## UI verification
- Not run. This slice changes resource-sidebar data freshness/cache behavior and keeps existing sidebar layout/styling unchanged.
