### PR TITLE
Tighten classwork classroom freshness

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Teacher assignment detail bulk-read hardening
-
-**Completed:**
-- Routed teacher assignment detail enrollment reads through pagination.
-- Chunked and paged student profile, assignment doc, doc-history, and structured submission artifact reads.
-- Scoped assignment docs to currently enrolled student ids so withdrawn-student docs cannot consume pages or drive artifact/history hydration.
-- Returned explicit 500s for profile, doc, history, and artifact read failures instead of rendering partial detail data.
-- Added regressions for >1000-student detail pagination, 51-student chunking, stale withdrawn-student doc exclusion, dense history pagination, read-failure handling, and artifact helper chunking/pagination.
-- Addressed subagent review follow-up by tightening paged-table mocks so missing filtered columns no longer pass rows through.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/assignments-id.test.ts tests/lib/assignment-submission-artifacts.test.ts tests/unit/query-chunks.test.ts -- --runInBand`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm test:coverage`
-- `git diff --check`
-
 ## 2026-05-31 — Student assessment results bulk-read hardening
 
 **Completed:**
@@ -977,6 +957,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx`
 - `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx tests/components/ResourcesTab.test.tsx tests/api/teacher/resources.test.ts tests/api/student/resources.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+
+## 2026-06-04 — Classwork materials freshness audit
+
+**Completed:**
+- Made the student assignments/materials/surveys tab reset loaded state on classroom changes, hide previous classroom classwork while the next classroom loads, and ignore stale classwork responses.
+- Guarded teacher classwork summary loads and rendered teacher classwork only from data loaded for the current classroom so older assignment/material/survey/class-day reads cannot overwrite or remain interactive under a new classroom shell.
+- Added component regressions for active student classroom switches, stale teacher classwork load completion after switching classrooms, and hiding already-loaded teacher classwork while the next classroom loads.
+- Addressed PR review feedback by requiring the selected teacher assignment workspace to belong to the currently loaded classroom before loading details, exposing workspace props, or accepting stale detail completions.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `pnpm vitest run tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
 - `pnpm lint`

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -48,6 +48,7 @@ export function StudentAssignmentsTab({
   const [assignments, setAssignments] = useState<AssignmentWithStatus[]>([])
   const [materials, setMaterials] = useState<ClassworkMaterial[]>([])
   const [surveys, setSurveys] = useState<StudentSurveyView[]>([])
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [hasLoaded, setHasLoaded] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -60,12 +61,30 @@ export function StudentAssignmentsTab({
   })
   const editorRef = useRef<StudentAssignmentEditorHandle>(null)
   const wasActiveRef = useRef(isActive)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
+  const hasCurrentClassroomData = loadedClassroomId === classroom.id
+  const currentAssignments = useMemo(
+    () => (hasCurrentClassroomData ? assignments : []),
+    [assignments, hasCurrentClassroomData],
+  )
+  const currentMaterials = useMemo(
+    () => (hasCurrentClassroomData ? materials : []),
+    [hasCurrentClassroomData, materials],
+  )
+  const currentSurveys = useMemo(
+    () => (hasCurrentClassroomData ? surveys : []),
+    [hasCurrentClassroomData, surveys],
+  )
   const showBlockingSpinner = useDelayedBusy(
-    loading && assignments.length === 0 && materials.length === 0 && surveys.length === 0
+    loading && currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0
   )
 
   const loadAssignments = useCallback(
     async (options?: { preserveContent?: boolean }) => {
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
       const preserveContent = options?.preserveContent ?? false
       if (preserveContent) {
         setRefreshing(true)
@@ -102,19 +121,39 @@ export function StudentAssignmentsTab({
             20_000,
           ).catch(() => ({ surveys: [] })),
         ])
+        if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
         setAssignments(assignmentsData.assignments || [])
         setMaterials(materialsData.materials || [])
         setSurveys(surveysData.surveys || [])
+        setLoadedClassroomId(classroom.id)
         setHasLoaded(true)
       } catch (err) {
+        if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
+        setAssignments([])
+        setMaterials([])
+        setSurveys([])
+        setLoadedClassroomId(classroom.id)
+        setHasLoaded(true)
         console.error('Error loading assignments:', err)
       } finally {
-        setLoading(false)
-        setRefreshing(false)
+        if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
+          setLoading(false)
+          setRefreshing(false)
+        }
       }
     },
     [classroom.id]
   )
+
+  useEffect(() => {
+    loadRequestIdRef.current += 1
+    setAssignments([])
+    setMaterials([])
+    setSurveys([])
+    setLoadedClassroomId(null)
+    setHasLoaded(false)
+    setRefreshing(false)
+  }, [classroom.id])
 
   useEffect(() => {
     if (isActive && !hasLoaded) {
@@ -130,22 +169,22 @@ export function StudentAssignmentsTab({
 
   const selectedAssignment = useMemo(() => {
     if (!selectedAssignmentId) return null
-    return assignments.find((a) => a.id === selectedAssignmentId) ?? null
-  }, [assignments, selectedAssignmentId])
+    return currentAssignments.find((a) => a.id === selectedAssignmentId) ?? null
+  }, [currentAssignments, selectedAssignmentId])
 
   const selectedMaterial = useMemo(() => {
     if (!selectedMaterialId) return null
-    return materials.find((material) => material.id === selectedMaterialId) ?? null
-  }, [materials, selectedMaterialId])
+    return currentMaterials.find((material) => material.id === selectedMaterialId) ?? null
+  }, [currentMaterials, selectedMaterialId])
 
   const selectedSurvey = useMemo(() => {
     if (!selectedSurveyId) return null
-    return surveys.find((survey) => survey.id === selectedSurveyId) ?? null
-  }, [selectedSurveyId, surveys])
+    return currentSurveys.find((survey) => survey.id === selectedSurveyId) ?? null
+  }, [currentSurveys, selectedSurveyId])
 
   const classworkItems = useMemo(
-    () => buildOrderedClassworkItems(assignments, materials, surveys),
-    [assignments, materials, surveys],
+    () => buildOrderedClassworkItems(currentAssignments, currentMaterials, currentSurveys),
+    [currentAssignments, currentMaterials, currentSurveys],
   )
 
   const view: StudentAssignmentsView = useMemo(() => {
@@ -299,7 +338,7 @@ export function StudentAssignmentsTab({
                 </div>
               </Card>
             ) : view === 'summary' ? (
-              assignments.length === 0 && materials.length === 0 && surveys.length === 0 ? (
+              currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0 ? (
                 <EmptyState
                   title="No classwork yet"
                   description="When your teacher posts assignments, materials, or surveys, they will show up here."

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -606,6 +606,7 @@ export function TeacherClassroomView({
   const [assignments, setAssignments] = useState<AssignmentWithStats[]>([])
   const [materials, setMaterials] = useState<ClassworkMaterial[]>([])
   const [surveys, setSurveys] = useState<SurveyWithStats[]>([])
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
   const [classDays, setClassDays] = useState<ClassDay[]>([])
   const [loading, setLoading] = useState(true)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
@@ -690,10 +691,29 @@ export function TeacherClassroomView({
   const [classPaneRestoreCounter, setClassPaneRestoreCounter] = useState(0)
   const [refreshCounter, setRefreshCounter] = useState(0)
   const tableContainerRef = useRef<HTMLDivElement>(null)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
   const wasActiveRef = useRef(isActive)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
+  currentClassroomIdRef.current = classroom.id
+  const hasCurrentClassroomData = loadedClassroomId === classroom.id
+  const currentAssignments = useMemo(
+    () => (hasCurrentClassroomData ? assignments : []),
+    [assignments, hasCurrentClassroomData],
+  )
+  const currentMaterials = useMemo(
+    () => (hasCurrentClassroomData ? materials : []),
+    [hasCurrentClassroomData, materials],
+  )
+  const currentSurveys = useMemo(
+    () => (hasCurrentClassroomData ? surveys : []),
+    [hasCurrentClassroomData, surveys],
+  )
   const showSummarySpinner = useDelayedBusy(
-    loading && assignments.length === 0 && materials.length === 0 && surveys.length === 0
+    (loading || !hasCurrentClassroomData)
+      && currentAssignments.length === 0
+      && currentMaterials.length === 0
+      && currentSurveys.length === 0
   )
   const { showMessage } = useAppMessage()
   const {
@@ -702,6 +722,8 @@ export function TeacherClassroomView({
   } = useAssignmentGradingLayout(classroom.id, workspaceWidth)
 
   const loadAssignments = useCallback(async (options?: { preserveContent?: boolean }) => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
     const preserveContent = options?.preserveContent ?? false
     if (!preserveContent) {
       setLoading(true)
@@ -740,10 +762,12 @@ export function TeacherClassroomView({
           return []
         }),
       ])
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
       setAssignments(assignmentsData.assignments || [])
       setMaterials(materialsData.materials || [])
       setSurveys(surveysData.surveys || [])
       setClassDays(classDaysData)
+      setLoadedClassroomId(classroom.id)
       setHasLoadedOnce(true)
       window.dispatchEvent(
         new CustomEvent(TEACHER_ASSIGNMENTS_UPDATED_EVENT, {
@@ -751,10 +775,39 @@ export function TeacherClassroomView({
         })
       )
     } catch (err) {
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return
+      setAssignments([])
+      setMaterials([])
+      setSurveys([])
+      setClassDays([])
+      setLoadedClassroomId(classroom.id)
+      setHasLoadedOnce(true)
       console.error('Error loading assignments:', err)
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroom.id) {
+        setLoading(false)
+      }
     }
+  }, [classroom.id])
+
+  useEffect(() => {
+    loadRequestIdRef.current += 1
+    setAssignments([])
+    setMaterials([])
+    setSurveys([])
+    setClassDays([])
+    setLoadedClassroomId(null)
+    setHasLoadedOnce(false)
+    setSelection({ mode: 'summary' })
+    setEditAssignment(null)
+    setEditMaterial(null)
+    setPendingMaterialDelete(null)
+    setPendingSurveyDelete(null)
+    setSurveyModalId(null)
+    setSelectedAssignmentData(null)
+    setAssignmentAiGradingRun(null)
+    setSelectedAssignmentError('')
+    setSelectedAssignmentLoading(false)
   }, [classroom.id])
 
   useEffect(() => {
@@ -919,8 +972,8 @@ export function TeacherClassroomView({
   }, [selection.mode, selectedStudentId, splitPaneViewState.view])
 
   const classworkItems = useMemo(
-    () => buildOrderedClassworkItems(assignments, materials, surveys),
-    [assignments, materials, surveys],
+    () => buildOrderedClassworkItems(currentAssignments, currentMaterials, currentSurveys),
+    [currentAssignments, currentMaterials, currentSurveys],
   )
 
   const handleDragEnd = useCallback(
@@ -998,6 +1051,7 @@ export function TeacherClassroomView({
   useEffect(() => {
     if (isUrlSelectionControlled) return
     if (loading) return
+    if (!hasCurrentClassroomData) return
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     const value = readCookie(cookieName)
     if (!value || value === 'summary') {
@@ -1006,11 +1060,11 @@ export function TeacherClassroomView({
     }
     if (value.startsWith('survey:')) {
       const surveyId = value.slice('survey:'.length)
-      const survey = surveys.find((item) => item.id === surveyId)
+      const survey = currentSurveys.find((item) => item.id === surveyId)
       setSelection(survey ? { mode: 'survey', surveyId } : { mode: 'summary' })
       return
     }
-    const assignment = assignments.find((a) => a.id === value)
+    const assignment = currentAssignments.find((a) => a.id === value)
     if (!assignment) {
       setSelection({ mode: 'summary' })
       return
@@ -1022,15 +1076,16 @@ export function TeacherClassroomView({
     } else {
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, isUrlSelectionControlled, loading, surveys])
+  }, [classroom.id, currentAssignments, currentSurveys, hasCurrentClassroomData, isUrlSelectionControlled, loading])
 
   useEffect(() => {
     if (!isUrlSelectionControlled) return
     if (loading) return
+    if (!hasCurrentClassroomData) return
 
     const cookieName = `teacherAssignmentsSelection:${classroom.id}`
     if (selectedSurveyIdProp) {
-      const survey = surveys.find((item) => item.id === selectedSurveyIdProp)
+      const survey = currentSurveys.find((item) => item.id === selectedSurveyIdProp)
       if (survey) {
         writeCookie(cookieName, `survey:${selectedSurveyIdProp}`)
         setSelection({ mode: 'survey', surveyId: selectedSurveyIdProp })
@@ -1050,7 +1105,7 @@ export function TeacherClassroomView({
       return
     }
 
-    const assignment = assignments.find((a) => a.id === value)
+    const assignment = currentAssignments.find((a) => a.id === value)
     if (!assignment) {
       writeCookie(cookieName, 'summary')
       setSelection({ mode: 'summary' })
@@ -1072,7 +1127,7 @@ export function TeacherClassroomView({
       writeCookie(cookieName, value)
       setSelection({ mode: 'assignment', assignmentId: value })
     }
-  }, [assignments, classroom.id, isUrlSelectionControlled, loading, selectedAssignmentIdProp, selectedSurveyIdProp, surveys, updateSearchParams])
+  }, [classroom.id, currentAssignments, currentSurveys, hasCurrentClassroomData, isUrlSelectionControlled, loading, selectedAssignmentIdProp, selectedSurveyIdProp, updateSearchParams])
 
   useEffect(() => {
     function onSelectionEvent(e: Event) {
@@ -1086,7 +1141,7 @@ export function TeacherClassroomView({
         setSelection({ mode: 'summary' })
         return
       }
-      const assignment = assignments.find((a) => a.id === value)
+      const assignment = currentAssignments.find((a) => a.id === value)
       if (!assignment) {
         setSelection({ mode: 'summary' })
         return
@@ -1102,10 +1157,19 @@ export function TeacherClassroomView({
 
     window.addEventListener(TEACHER_ASSIGNMENTS_SELECTION_EVENT, onSelectionEvent)
     return () => window.removeEventListener(TEACHER_ASSIGNMENTS_SELECTION_EVENT, onSelectionEvent)
-  }, [assignments, classroom.id, isUrlSelectionControlled])
+  }, [classroom.id, currentAssignments, isUrlSelectionControlled])
+
+  const selectedAssignmentSummary = useMemo(() => {
+    if (selection.mode !== 'assignment') return null
+    return currentAssignments.find((item) => item.id === selection.assignmentId) ?? null
+  }, [currentAssignments, selection])
+  const selectedAssignmentBelongsToCurrentClassroom =
+    selection.mode === 'assignment' &&
+    hasCurrentClassroomData &&
+    selectedAssignmentSummary?.classroom_id === classroom.id
 
   useEffect(() => {
-    if (selection.mode !== 'assignment') {
+    if (selection.mode !== 'assignment' || !selectedAssignmentBelongsToCurrentClassroom) {
       setSelectedAssignmentData(null)
       setAssignmentAiGradingRun(null)
       setSelectedAssignmentError('')
@@ -1114,23 +1178,27 @@ export function TeacherClassroomView({
     }
 
     const assignmentId = selection.assignmentId
+    const classroomId = classroom.id
+    let ignore = false
 
-	    async function loadSelectedAssignment() {
-	      setSelectedAssignmentLoading(true)
-	      setSelectedAssignmentError('')
-	      try {
-	        const data = await fetchJSONWithCache(
-	          `teacher-assignment-detail:${assignmentId}:${refreshCounter}`,
-	          async () => {
-	            const response = await fetch(`/api/teacher/assignments/${assignmentId}`)
-	            const payload = await response.json()
-	            if (!response.ok) {
-	              throw new Error(payload.error || 'Failed to load assignment')
-	            }
-	            return payload
-	          },
-	          2_000,
-	        )
+    async function loadSelectedAssignment() {
+      setSelectedAssignmentLoading(true)
+      setSelectedAssignmentError('')
+      try {
+        const data = await fetchJSONWithCache(
+          `teacher-assignment-detail:${assignmentId}:${refreshCounter}`,
+          async () => {
+            const response = await fetch(`/api/teacher/assignments/${assignmentId}`)
+            const payload = await response.json()
+            if (!response.ok) {
+              throw new Error(payload.error || 'Failed to load assignment')
+            }
+            return payload
+          },
+          2_000,
+        )
+
+        if (ignore || currentClassroomIdRef.current !== classroomId) return
 
         setSelectedAssignmentData({
           assignment: data.assignment,
@@ -1138,16 +1206,22 @@ export function TeacherClassroomView({
         })
         setAssignmentAiGradingRun((data.active_ai_grading_run as AssignmentAiGradingRunSummary | null) ?? null)
       } catch (err: any) {
+        if (ignore || currentClassroomIdRef.current !== classroomId) return
         setSelectedAssignmentError(err.message || 'Failed to load assignment')
         setSelectedAssignmentData(null)
         setAssignmentAiGradingRun(null)
       } finally {
-        setSelectedAssignmentLoading(false)
+        if (!ignore && currentClassroomIdRef.current === classroomId) {
+          setSelectedAssignmentLoading(false)
+        }
       }
     }
 
     loadSelectedAssignment()
-  }, [assignments, refreshCounter, selection])
+    return () => {
+      ignore = true
+    }
+  }, [classroom.id, refreshCounter, selectedAssignmentBelongsToCurrentClassroom, selection])
 
   useEffect(() => {
     if (selection.mode !== 'assignment') {
@@ -1158,23 +1232,25 @@ export function TeacherClassroomView({
   }, [selection])
 
   const activeSelectedAssignmentData = useMemo(() => {
-    if (selection.mode !== 'assignment' || !selectedAssignmentData) return null
+    if (selection.mode !== 'assignment' || !selectedAssignmentBelongsToCurrentClassroom || !selectedAssignmentData) {
+      return null
+    }
+    if (selectedAssignmentData.assignment.classroom_id !== classroom.id) return null
     return selectedAssignmentData.assignment.id === selection.assignmentId
       ? selectedAssignmentData
       : null
-  }, [selectedAssignmentData, selection])
+  }, [classroom.id, selectedAssignmentBelongsToCurrentClassroom, selectedAssignmentData, selection])
 
   const activeAssignmentAiRun = useMemo(() => {
-    if (selection.mode !== 'assignment' || !assignmentAiGradingRun) return null
+    if (selection.mode !== 'assignment' || !selectedAssignmentBelongsToCurrentClassroom || !assignmentAiGradingRun) {
+      return null
+    }
     return assignmentAiGradingRun.assignment_id === selection.assignmentId
       ? assignmentAiGradingRun
       : null
-  }, [assignmentAiGradingRun, selection])
+  }, [assignmentAiGradingRun, selectedAssignmentBelongsToCurrentClassroom, selection])
   const activeAssignmentAiRunId = activeAssignmentAiRun?.id ?? null
   const hasActiveAssignmentAiRun = isAssignmentAiGradingRunActive(activeAssignmentAiRun)
-  const selectedAssignmentSummary = selection.mode === 'assignment'
-    ? assignments.find((item) => item.id === selection.assignmentId) ?? null
-    : null
 
   // Notify parent about selected assignment for sidebar
   useEffect(() => {
@@ -1727,7 +1803,7 @@ export function TeacherClassroomView({
     return currentStudentRows.find((student) => student.student_id === selectedStudentId) ?? null
   }, [currentStudentRows, selectedStudentId])
   const activeSelectedStudentId = selectedStudentRow?.student_id ?? null
-  const selectedAssignmentId = selection.mode === 'assignment' ? selection.assignmentId : null
+  const selectedAssignmentId = selectedAssignmentBelongsToCurrentClassroom ? selection.assignmentId : null
   const splitPaneViewSessionKey = selectedAssignmentId
     ? getAssignmentSplitPaneViewSessionKey(classroom.id, selectedAssignmentId)
     : null
@@ -1770,8 +1846,8 @@ export function TeacherClassroomView({
   const selectedSurveyId = selection.mode === 'survey' ? selection.surveyId : null
   const selectedSurvey = useMemo(() => {
     if (!selectedSurveyId) return null
-    return surveys.find((survey) => survey.id === selectedSurveyId) ?? null
-  }, [selectedSurveyId, surveys])
+    return currentSurveys.find((survey) => survey.id === selectedSurveyId) ?? null
+  }, [currentSurveys, selectedSurveyId])
 
   const patchSelectedSurvey = useCallback(async (update: Record<string, unknown>) => {
     if (!selectedSurveyId) return
@@ -2517,7 +2593,7 @@ export function TeacherClassroomView({
     <div className="flex justify-center py-8">
       <Spinner />
     </div>
-  ) : assignments.length === 0 && materials.length === 0 && surveys.length === 0 ? (
+  ) : currentAssignments.length === 0 && currentMaterials.length === 0 && currentSurveys.length === 0 ? (
     <div className="py-6 text-center text-sm text-text-muted">
       No classwork yet
     </div>

--- a/tests/components/StudentAssignmentsTab.test.tsx
+++ b/tests/components/StudentAssignmentsTab.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { forwardRef, useEffect, useImperativeHandle } from 'react'
 import { StudentAssignmentsTab } from '@/app/classrooms/[classroomId]/StudentAssignmentsTab'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 import type { Classroom, AssignmentWithStatus, ClassworkMaterial } from '@/types'
 
 // --- Mocks ---
@@ -113,6 +114,13 @@ function mockFetchClasswork(assignments: AssignmentWithStatus[], materials: Clas
 }
 
 const mockFetchAssignments = mockFetchClasswork
+
+function mockJSONResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  }
+}
 
 describe('StudentAssignmentsTab', () => {
   beforeEach(() => {
@@ -317,6 +325,71 @@ describe('StudentAssignmentsTab', () => {
     expect(cards[0]).toHaveClass('border-border')
     expect(cards[0]).not.toHaveClass('border-primary/40')
     expect(cards[0].querySelector('.border-l-2')).not.toBeInTheDocument()
+  })
+
+  it('reloads active classwork on classroom change without showing stale classwork', async () => {
+    invalidateCachedJSONMatching('student-assignments:')
+    invalidateCachedJSONMatching('student-materials:')
+    invalidateCachedJSONMatching('student-surveys:')
+    const firstClassroom = { ...classroom, id: 'cls-first-classwork' }
+    const secondClassroom = { ...classroom, id: 'cls-second-classwork' }
+    let resolveSecondAssignments: (() => void) | null = null
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/student/assignments') && url.includes(firstClassroom.id)) {
+          return mockJSONResponse({
+            assignments: [
+              makeAssignment({
+                id: 'asgn-first',
+                classroom_id: firstClassroom.id,
+                title: 'First classroom assignment',
+              }),
+            ],
+          })
+        }
+        if (url.includes('/api/student/assignments') && url.includes(secondClassroom.id)) {
+          return new Promise((resolve) => {
+            resolveSecondAssignments = () => resolve(mockJSONResponse({
+              assignments: [
+                makeAssignment({
+                  id: 'asgn-second',
+                  classroom_id: secondClassroom.id,
+                  title: 'Second classroom assignment',
+                }),
+              ],
+            }))
+          })
+        }
+        if (url.includes('/materials')) {
+          return mockJSONResponse({ materials: [] })
+        }
+        if (url.includes('/api/student/surveys')) {
+          return mockJSONResponse({ surveys: [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      }),
+    )
+
+    const view = render(<StudentAssignmentsTab classroom={firstClassroom} />)
+
+    await screen.findByText('First classroom assignment')
+
+    view.rerender(<StudentAssignmentsTab classroom={secondClassroom} />)
+
+    expect(screen.queryByText('First classroom assignment')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(resolveSecondAssignments).toEqual(expect.any(Function))
+    })
+    await act(async () => {
+      resolveSecondAssignments?.()
+    })
+
+    expect(await screen.findByText('Second classroom assignment')).toBeInTheDocument()
+    expect(screen.queryByText('First classroom assignment')).not.toBeInTheDocument()
   })
 
   it('freezes assignment card timing once work is submitted', async () => {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -691,6 +691,223 @@ describe('TeacherClassroomView', () => {
     expect(consoleError).toHaveBeenCalledWith('Error loading class days:', expect.any(Error))
   })
 
+  it('ignores stale teacher classwork loads after switching classrooms', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Chemistry' }
+    let resolveFirstAssignments: (() => void) | null = null
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return new Promise((resolve) => {
+          resolveFirstAssignments = () => resolve({
+            assignments: [
+              makeAssignmentSummary('assignment-first', 'First classroom assignment', {
+                classroom_id: classroom.id,
+              }),
+            ],
+          })
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      if (key === `teacher-assignments:${secondClassroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-second', 'Second classroom assignment', {
+              classroom_id: secondClassroom.id,
+            }),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${secondClassroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${secondClassroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      return fetcher()
+    })
+
+    const view = render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    await waitFor(() => {
+      expect(resolveFirstAssignments).toEqual(expect.any(Function))
+    })
+
+    view.rerender(<TeacherClassroomView classroom={secondClassroom} selectedAssignmentId={null} />)
+
+    expect(await screen.findByRole('button', { name: 'Second classroom assignment' })).toBeInTheDocument()
+
+    await act(async () => {
+      resolveFirstAssignments?.()
+    })
+
+    expect(screen.getByRole('button', { name: 'Second classroom assignment' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'First classroom assignment' })).not.toBeInTheDocument()
+  })
+
+  it('hides already-loaded teacher classwork while the next classroom loads', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Chemistry' }
+    let resolveSecondAssignments: (() => void) | null = null
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-first', 'First classroom assignment', {
+              classroom_id: classroom.id,
+            }),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({
+          materials: [
+            makeMaterialSummary('material-first', 'First classroom material', {
+              classroom_id: classroom.id,
+            }),
+          ],
+        })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      if (key === `teacher-assignments:${secondClassroom.id}`) {
+        return new Promise((resolve) => {
+          resolveSecondAssignments = () => resolve({
+            assignments: [
+              makeAssignmentSummary('assignment-second', 'Second classroom assignment', {
+                classroom_id: secondClassroom.id,
+              }),
+            ],
+          })
+        })
+      }
+      if (key === `teacher-materials:${secondClassroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${secondClassroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      return fetcher()
+    })
+
+    const view = render(<TeacherClassroomView classroom={classroom} selectedAssignmentId={null} />)
+
+    await screen.findByRole('button', { name: 'First classroom assignment' })
+    expect(screen.getByRole('button', { name: 'Open First classroom material' })).toBeInTheDocument()
+
+    view.rerender(<TeacherClassroomView classroom={secondClassroom} selectedAssignmentId={null} />)
+
+    expect(screen.queryByRole('button', { name: 'First classroom assignment' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open First classroom material' })).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(resolveSecondAssignments).toEqual(expect.any(Function))
+    })
+    await act(async () => {
+      resolveSecondAssignments?.()
+    })
+
+    expect(await screen.findByRole('button', { name: 'Second classroom assignment' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'First classroom assignment' })).not.toBeInTheDocument()
+  })
+
+  it('hides the selected assignment workspace while the next classroom loads', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Chemistry' }
+    let resolveSecondAssignments: (() => void) | null = null
+    let detailFetchCount = 0
+
+    mockFetchJSONWithCache.mockImplementation((key: string, fetcher: () => Promise<unknown>) => {
+      if (key === `teacher-assignments:${classroom.id}`) {
+        return Promise.resolve({
+          assignments: [
+            makeAssignmentSummary('assignment-first', 'First classroom assignment', {
+              classroom_id: classroom.id,
+            }),
+          ],
+        })
+      }
+      if (key === `teacher-materials:${classroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${classroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      if (key === `teacher-assignments:${secondClassroom.id}`) {
+        return new Promise((resolve) => {
+          resolveSecondAssignments = () => resolve({
+            assignments: [
+              makeAssignmentSummary('assignment-second', 'Second classroom assignment', {
+                classroom_id: secondClassroom.id,
+              }),
+            ],
+          })
+        })
+      }
+      if (key === `teacher-materials:${secondClassroom.id}`) {
+        return Promise.resolve({ materials: [] })
+      }
+      if (key === `teacher-surveys:${secondClassroom.id}`) {
+        return Promise.resolve({ surveys: [] })
+      }
+      return fetcher()
+    })
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url === '/api/teacher/assignments/assignment-first') {
+        detailFetchCount += 1
+        const details = makeAssignmentDetails('assignment-first', 'First classroom assignment', 'student-1')
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...details,
+            assignment: {
+              ...details.assignment,
+              classroom_id: classroom.id,
+            },
+          }),
+        })
+      }
+
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: `Unhandled fetch: ${url}` }),
+      })
+    })
+
+    const view = render(
+      <TeacherClassroomView
+        classroom={classroom}
+        selectedAssignmentId="assignment-first"
+      />,
+    )
+
+    expect(await screen.findByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-first:student-1')
+    expect(detailFetchCount).toBe(1)
+
+    view.rerender(
+      <TeacherClassroomView
+        classroom={secondClassroom}
+        selectedAssignmentId="assignment-first"
+      />,
+    )
+
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(resolveSecondAssignments).toEqual(expect.any(Function))
+    })
+    await act(async () => {
+      resolveSecondAssignments?.()
+    })
+
+    expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
+    expect(detailFetchCount).toBe(1)
+  })
+
   it('keeps New visible with an Edit Markdown dropdown action while edit mode is active', async () => {
     const onEditModeChange = vi.fn()
     const onOpenMarkdownEditor = vi.fn()


### PR DESCRIPTION
## Summary
- Reset student classwork loaded state on classroom changes and render only data loaded for the current classroom.
- Ignore stale student and teacher classwork responses using request/current-classroom guards.
- Add regressions for active student classroom switches and stale teacher classwork loads resolving after a classroom switch.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `pnpm vitest run tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `git diff --check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## UI verification
- Not run. This slice changes classwork data freshness/loading behavior and keeps existing layout/styling unchanged.
