### PR TITLE
Tighten classroom shell freshness

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Student assessment results bulk-read hardening
-
-**Completed:**
-- Routed student quiz, survey, and test result question reads through paginated loaders.
-- Chunked and paged classroom-scoped quiz/survey response aggregation by currently enrolled student ids.
-- Chunked and paged returned-student test attempt discovery and returned test response aggregation.
-- Paged current-student quiz/test response reads used for visibility, response maps, and returned test detail summaries.
-- Preserved defense-in-depth filtering so stale or unenrolled student responses cannot affect aggregate result payloads.
-- Returned explicit 500s for current-student response read failures instead of treating failed reads as empty work.
-- Updated route and integration tests for paged Supabase mocks, dense result pagination, 51-student chunking, stale-response exclusion, and read-failure handling.
-
-**Validation:**
-- `pnpm test tests/api/student/quizzes-results.test.ts tests/api/student/surveys-route.test.ts tests/api/student/tests-results.test.ts -- --runInBand`
-- `pnpm test tests/api/integration/test-return-visibility-flow.test.ts -- --runInBand`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-31 — Student notification count hardening
 
 **Completed:**
@@ -975,6 +955,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
 - `pnpm vitest run tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+
+## 2026-06-04 — Classroom shell freshness audit
+
+**Completed:**
+- Reset the classroom page shell's local query state from the new server-provided search params when the classroom route changes so old assignment/test/student detail params cannot leak into the next classroom.
+- Made the teacher roster tab cache repeated roster reads, hide old roster rows while the next classroom loads, and ignore stale roster responses after classroom switches.
+- Scoped roster mutation completions to the classroom that started them and invalidated roster cache entries after counselor, add, upload, and removal changes.
+- Added regressions for stale test detail query params on classroom rerender plus stale/pending roster loads during classroom switches.
+- Addressed PR review feedback by deriving new-classroom query params synchronously before child props are computed and by invalidating originating-classroom roster caches before guarding UI updates after mutation completions.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/TeacherRosterTab.test.tsx`
+- `pnpm vitest run tests/components/TeacherRosterTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm vitest run tests/components/TeacherRosterTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/api/teacher/roster.test.ts tests/api/teacher/roster-add.test.ts tests/api/teacher/roster-bulk-delete.test.ts tests/api/teacher/roster-rosterId.test.ts tests/api/teacher/roster-upload-csv.test.ts`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `git diff --check`
 - `pnpm lint`

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -104,6 +104,20 @@ interface PendingExamNavigation {
   navigate: () => void
 }
 
+function buildInitialQueryString(
+  initialSearchParams: Record<string, string | undefined> | undefined,
+  initialTab: string | undefined,
+) {
+  const initial = new URLSearchParams()
+  for (const [key, value] of Object.entries(initialSearchParams || {})) {
+    if (value) initial.set(key, value)
+  }
+  if (!initial.get('tab') && initialTab) {
+    initial.set('tab', initialTab)
+  }
+  return initial.toString()
+}
+
 export function ClassroomPageClient({
   classroom,
   user,
@@ -125,26 +139,31 @@ export function ClassroomPageClient({
     [isTeacher]
   )
 
-  const [queryString, setQueryString] = useState(() => {
-    const initial = new URLSearchParams()
-    for (const [key, value] of Object.entries(initialSearchParams || {})) {
-      if (value) initial.set(key, value)
-    }
-    if (!initial.get('tab') && initialTab) {
-      initial.set('tab', initialTab)
-    }
-    return initial.toString()
-  })
+  const initialQueryString = buildInitialQueryString(initialSearchParams, initialTab)
+  const routeQueryKey = `${classroom.id}\n${initialQueryString}`
+  const [queryString, setQueryString] = useState(initialQueryString)
   const queryStringRef = useRef(queryString)
+  const routeQueryKeyRef = useRef(routeQueryKey)
+  const effectiveQueryString =
+    routeQueryKeyRef.current === routeQueryKey ? queryString : initialQueryString
+  queryStringRef.current = effectiveQueryString
 
   useEffect(() => {
-    queryStringRef.current = queryString
-  }, [queryString])
+    queryStringRef.current = effectiveQueryString
+  }, [effectiveQueryString])
+
+  useEffect(() => {
+    routeQueryKeyRef.current = routeQueryKey
+    queryStringRef.current = initialQueryString
+    setQueryString(initialQueryString)
+  }, [initialQueryString, routeQueryKey])
 
   useEffect(() => {
     const syncFromLocation = () => {
       const fromLocation = new URLSearchParams(window.location.search)
-      setQueryString(fromLocation.toString())
+      const next = fromLocation.toString()
+      queryStringRef.current = next
+      setQueryString(next)
     }
     syncFromLocation()
     window.addEventListener('popstate', syncFromLocation)
@@ -171,7 +190,7 @@ export function ClassroomPageClient({
     [basePath]
   )
 
-  const activeSearchParams = useMemo(() => new URLSearchParams(queryString), [queryString])
+  const activeSearchParams = useMemo(() => new URLSearchParams(effectiveQueryString), [effectiveQueryString])
   const tab = activeSearchParams.get('tab')
   const activeTab = (validTabs as readonly string[]).includes(tab ?? '') ? (tab as string) : defaultTab
 

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
@@ -26,6 +26,7 @@ import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 
 type Role = 'student' | 'teacher'
 
@@ -120,6 +121,10 @@ export function TeacherRosterTab({ classroom }: Props) {
   const [isRemoving, setIsRemoving] = useState(false)
   const [selectedRosterId, setSelectedRosterId] = useState<string | null>(null)
   const [detailPaneWidth, setDetailPaneWidth] = useState(50)
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
 
   // Selection state
   const { showMessage } = useAppMessage()
@@ -129,8 +134,14 @@ export function TeacherRosterTab({ classroom }: Props) {
   const [editingCounselorValue, setEditingCounselorValue] = useState('')
   const [isSavingCounselor, setIsSavingCounselor] = useState(false)
 
+  const hasCurrentRoster = loadedClassroomId === classroom.id
+  const currentRoster = useMemo(
+    () => (hasCurrentRoster ? roster : []),
+    [hasCurrentRoster, roster],
+  )
+
   const sortedRoster = useMemo(() => {
-    const rows = [...roster]
+    const rows = [...currentRoster]
     rows.sort((a, b) =>
       compareByNameFields(
         { firstName: a.first_name, lastName: a.last_name, id: a.email },
@@ -140,47 +151,83 @@ export function TeacherRosterTab({ classroom }: Props) {
       )
     )
     return rows
-  }, [roster, sortColumn, sortDirection])
+  }, [currentRoster, sortColumn, sortDirection])
 
   const rosterIds = useMemo(() => sortedRoster.map((r) => r.id), [sortedRoster])
   const joinedCount = useMemo(() => sortedRoster.filter((r) => r.joined).length, [sortedRoster])
   const { selectedIds, toggleSelect, toggleSelectAll, allSelected, clearSelection } = useStudentSelection(rosterIds)
+  const isRosterLoading = loading || !hasCurrentRoster
 
   function onSort(column: 'first_name' | 'last_name') {
     setSortState((prev) => toggleSort(prev, column))
   }
 
   async function loadRoster() {
+    const classroomId = classroom.id
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
     setLoading(true)
     setError('')
     try {
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster`)
-      const data = await res.json()
-      if (!res.ok) {
-        if (res.status === 401 || res.status === 403) {
-          try {
-            const meRes = await fetch('/api/auth/me')
-            const meData = await meRes.json().catch(() => ({}))
-            const role = (meData?.user?.role ?? null) as Role | null
-            if (role && role !== 'teacher') {
-              throw new Error('You are not signed in as a teacher. Log out and sign back in as a teacher (student sign-in in another tab replaces the session).')
+      const data = await fetchJSONWithCache(
+        `teacher-roster:${classroomId}`,
+        async () => {
+          const res = await fetch(`/api/teacher/classrooms/${classroomId}/roster`)
+          const data = await res.json()
+          if (!res.ok) {
+            if (res.status === 401 || res.status === 403) {
+              try {
+                const meData = await fetchJSONWithCache(
+                  'auth-me:roster-error',
+                  async () => {
+                    const meRes = await fetch('/api/auth/me')
+                    return meRes.json().catch(() => ({}))
+                  },
+                  2_000,
+                )
+                const role = (meData?.user?.role ?? null) as Role | null
+                if (role && role !== 'teacher') {
+                  throw new Error('You are not signed in as a teacher. Log out and sign back in as a teacher (student sign-in in another tab replaces the session).')
+                }
+              } catch {
+                // Fallback to generic message below
+              }
             }
-          } catch {
-            // Fallback to generic message below
+            throw new Error(data.error || 'Failed to load roster')
           }
-        }
-        throw new Error(data.error || 'Failed to load roster')
-      }
+          return data
+        },
+        20_000,
+      )
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setRoster(normalizeRosterRows(data.roster || []))
+      setLoadedClassroomId(classroomId)
       clearSelection()
     } catch (err: any) {
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
+      setRoster([])
+      setLoadedClassroomId(classroomId)
       setError(err.message || 'Failed to load roster')
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        setLoading(false)
+      }
     }
   }
 
   useEffect(() => {
+    loadRequestIdRef.current += 1
+    setRoster([])
+    setLoadedClassroomId(null)
+    setError('')
+    setPendingRemoval(null)
+    setSelectedRosterId(null)
+    setUploadModalOpen(false)
+    setAddModalOpen(false)
+    setIsRemoving(false)
+    setEditingCounselorId(null)
+    setEditingCounselorValue('')
+    setIsSavingCounselor(false)
     loadRoster()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [classroom.id])
@@ -188,12 +235,13 @@ export function TeacherRosterTab({ classroom }: Props) {
   async function confirmRemoveStudent() {
     if (!pendingRemoval || pendingRemoval.rows.length === 0) return
     if (isReadOnly) return
+    const classroomId = classroom.id
     setIsRemoving(true)
     setError('')
     const fallbackError = pendingRemoval.rows.length > 1 ? 'Failed to remove students' : 'Failed to remove student'
 
     try {
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/bulk-delete`, {
+      const res = await fetch(`/api/teacher/classrooms/${classroomId}/roster/bulk-delete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ roster_ids: pendingRemoval.rows.map((row) => row.rosterId) }),
@@ -202,12 +250,17 @@ export function TeacherRosterTab({ classroom }: Props) {
       if (!res.ok) {
         throw new Error(data.error || fallbackError)
       }
+      invalidateCachedJSON(`teacher-roster:${classroomId}`)
+      if (currentClassroomIdRef.current !== classroomId) return
       setPendingRemoval(null)
       await loadRoster()
     } catch (err: any) {
+      if (currentClassroomIdRef.current !== classroomId) return
       setError(err.message || fallbackError)
     } finally {
-      setIsRemoving(false)
+      if (currentClassroomIdRef.current === classroomId) {
+        setIsRemoving(false)
+      }
     }
   }
 
@@ -224,11 +277,11 @@ export function TeacherRosterTab({ classroom }: Props) {
     preserveScrollPosition: preserveRosterTableScrollPosition,
   } = useScrollPositionMemory<HTMLDivElement>({
     key: `${classroom.id}:roster`,
-    enabled: !loading,
+    enabled: !isRosterLoading,
     restoreToken: [
       selectedRosterId ?? 'none',
       sortedRoster.length,
-      loading ? 'loading' : 'ready',
+      isRosterLoading ? 'loading' : 'ready',
     ].join(':'),
   })
   const selectRosterId = useCallback((nextRosterId: string | null) => {
@@ -237,10 +290,10 @@ export function TeacherRosterTab({ classroom }: Props) {
   }, [preserveRosterTableScrollPosition])
 
   useEffect(() => {
-    if (selectedRosterId && !roster.some((row) => row.id === selectedRosterId)) {
+    if (selectedRosterId && !currentRoster.some((row) => row.id === selectedRosterId)) {
       setSelectedRosterId(null)
     }
-  }, [roster, selectedRosterId])
+  }, [currentRoster, selectedRosterId])
 
   async function copyToClipboard(emails: string[], label: string) {
     const text = emails.join(', ')
@@ -293,11 +346,12 @@ export function TeacherRosterTab({ classroom }: Props) {
 
   async function saveCounselorEmail(rosterId: string) {
     if (isReadOnly) return
+    const classroomId = classroom.id
     setIsSavingCounselor(true)
     setError('')
 
     try {
-      const res = await fetch(`/api/teacher/classrooms/${classroom.id}/roster/${rosterId}`, {
+      const res = await fetch(`/api/teacher/classrooms/${classroomId}/roster/${rosterId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ counselor_email: editingCounselorValue.trim() || null }),
@@ -306,6 +360,8 @@ export function TeacherRosterTab({ classroom }: Props) {
       if (!res.ok) {
         throw new Error(data.error || 'Failed to update counselor email')
       }
+      invalidateCachedJSON(`teacher-roster:${classroomId}`)
+      if (currentClassroomIdRef.current !== classroomId) return
       // Update local state
       setRoster((prev) =>
         prev.map((r) =>
@@ -315,9 +371,12 @@ export function TeacherRosterTab({ classroom }: Props) {
       setEditingCounselorId(null)
       setEditingCounselorValue('')
     } catch (err: any) {
+      if (currentClassroomIdRef.current !== classroomId) return
       setError(err.message || 'Failed to update counselor email')
     } finally {
-      setIsSavingCounselor(false)
+      if (currentClassroomIdRef.current === classroomId) {
+        setIsSavingCounselor(false)
+      }
     }
   }
 
@@ -334,6 +393,11 @@ export function TeacherRosterTab({ classroom }: Props) {
   function openRemoveStudentDialog(rows: RosterRow[]) {
     if (rows.length === 0 || isReadOnly) return
     setPendingRemoval({ rows: rows.map(toRemovalTarget) })
+  }
+
+  function refreshRosterAfterMutation() {
+    invalidateCachedJSON(`teacher-roster:${classroom.id}`)
+    void loadRoster()
   }
 
   function getRemovalMenuLabel(rowCount: number) {
@@ -373,7 +437,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       id: 'upload-csv',
       label: '+ CSV',
       onSelect: () => setUploadModalOpen(true),
-      disabled: isReadOnly || loading,
+      disabled: isReadOnly || isRosterLoading,
     },
   ]
 
@@ -382,7 +446,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       id: 'remove-student',
       label: <span className="text-danger">{getRemovalMenuLabel(removalTargetRows.length)}</span>,
       onSelect: () => openRemoveStudentDialog(removalTargetRows),
-      disabled: isReadOnly || loading || isRemoving || removalTargetRows.length === 0,
+      disabled: isReadOnly || isRosterLoading || isRemoving || removalTargetRows.length === 0,
       destructive: true,
     })
   }
@@ -449,11 +513,11 @@ export function TeacherRosterTab({ classroom }: Props) {
           <SplitButton
             label="+ Students"
             onPrimaryClick={() => {
-              if (isReadOnly || loading) return
+              if (isReadOnly || isRosterLoading) return
               setAddModalOpen(true)
             }}
             options={rosterActionOptions}
-            disabled={isReadOnly || loading}
+            disabled={isReadOnly || isRosterLoading}
             size="sm"
             toggleAriaLabel="Roster actions"
             menuPlacement="down"
@@ -552,7 +616,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     </div>
   )
 
-  const workspace = loading ? (
+  const workspace = isRosterLoading ? (
     <div className="flex flex-1 justify-center py-12">
       <Spinner size="lg" />
     </div>
@@ -762,14 +826,14 @@ export function TeacherRosterTab({ classroom }: Props) {
         isOpen={isAddModalOpen}
         onClose={() => setAddModalOpen(false)}
         classroomId={classroom.id}
-        onSuccess={loadRoster}
+        onSuccess={refreshRosterAfterMutation}
       />
 
       <UploadRosterModal
         isOpen={isUploadModalOpen}
         onClose={() => setUploadModalOpen(false)}
         classroomId={classroom.id}
-        onSuccess={loadRoster}
+        onSuccess={refreshRosterAfterMutation}
       />
 
       <ConfirmDialog

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -6,6 +6,7 @@ import type { Classroom } from '@/types'
 
 const mockFetchJSONWithCache = vi.hoisted(() => vi.fn())
 const mockAssignmentsToMarkdown = vi.hoisted(() => vi.fn())
+const mockTeacherTestsTabProps = vi.hoisted(() => vi.fn())
 const mockClassDays = vi.hoisted(() => [
   { id: 'day-today', classroom_id: 'classroom-1', date: '2026-05-12', is_class_day: true, prompt_text: null },
   { id: 'day-last', classroom_id: 'classroom-1', date: '2026-05-11', is_class_day: true, prompt_text: null },
@@ -255,16 +256,19 @@ vi.mock('@/app/classrooms/[classroomId]/StudentAnnouncementsTab', () => ({
   StudentAnnouncementsTab: () => <div />,
 }))
 vi.mock('@/app/classrooms/[classroomId]/TeacherTestsTab', () => ({
-  TeacherTestsTab: ({ onSelectTest }: any) => (
-    <div>
-      <button
-        type="button"
-        onClick={() => onSelectTest?.({ id: 'test-1', title: 'Test One' })}
-      >
-        Select test workspace
-      </button>
-    </div>
-  ),
+  TeacherTestsTab: (props: any) => {
+    mockTeacherTestsTabProps(props)
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => props.onSelectTest?.({ id: 'test-1', title: 'Test One' })}
+        >
+          Select test workspace
+        </button>
+      </div>
+    )
+  },
 }))
 vi.mock('@/app/classrooms/[classroomId]/StudentQuizzesTab', () => ({
   StudentQuizzesTab: () => <div />,
@@ -294,16 +298,21 @@ const classroom: Classroom = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
-function renderClient(options?: { initialTab?: string; initialSearchParams?: Record<string, string | undefined> }) {
+function renderClient(options?: {
+  classroom?: Classroom
+  initialTab?: string
+  initialSearchParams?: Record<string, string | undefined>
+}) {
+  const targetClassroom = options?.classroom ?? classroom
   const initialTab = options?.initialTab ?? 'assignments'
   const initialSearchParams = options?.initialSearchParams ?? { tab: initialTab }
 
   return render(
     <MarkdownPreferenceProvider>
       <ClassroomPageClient
-        classroom={classroom}
+        classroom={targetClassroom}
         user={{ id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' }}
-        teacherClassrooms={[classroom]}
+        teacherClassrooms={[targetClassroom]}
         initialTab={initialTab}
         initialSearchParams={initialSearchParams}
       />
@@ -338,6 +347,7 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     })
     mockFetchJSONWithCache.mockReset()
     mockAssignmentsToMarkdown.mockReset()
+    mockTeacherTestsTabProps.mockReset()
     mockFetchJSONWithCache.mockResolvedValue({
       assignments: [
         {
@@ -501,6 +511,71 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select test workspace' }))
 
     expect(screen.getByTestId('app-shell-page-title')).toBeEmptyDOMElement()
+  })
+
+  it('resets stale tests detail query params when the classroom route changes', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Chemistry' }
+    window.history.replaceState(
+      {},
+      '',
+      '/classrooms/classroom-1?tab=tests&testId=old-test&testMode=grading&testStudentId=old-student',
+    )
+
+    const view = renderClient({
+      classroom,
+      initialTab: 'tests',
+      initialSearchParams: {
+        tab: 'tests',
+        testId: 'old-test',
+        testMode: 'grading',
+        testStudentId: 'old-student',
+      },
+    })
+
+    await waitFor(() => {
+      expect(mockTeacherTestsTabProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          classroom,
+          selectedTestId: 'old-test',
+          selectedTestMode: 'grading',
+          selectedTestStudentId: 'old-student',
+        }),
+      )
+    })
+
+    mockTeacherTestsTabProps.mockClear()
+
+    view.rerender(
+      <MarkdownPreferenceProvider>
+        <ClassroomPageClient
+          classroom={secondClassroom}
+          user={{ id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' }}
+          teacherClassrooms={[secondClassroom]}
+          initialTab="tests"
+          initialSearchParams={{ tab: 'tests' }}
+        />
+      </MarkdownPreferenceProvider>,
+    )
+
+    expect(
+      mockTeacherTestsTabProps.mock.calls.some(([props]) =>
+        props.classroom?.id === secondClassroom.id &&
+        (props.selectedTestId === 'old-test' ||
+          props.selectedTestMode === 'grading' ||
+          props.selectedTestStudentId === 'old-student')
+      ),
+    ).toBe(false)
+
+    await waitFor(() => {
+      expect(mockTeacherTestsTabProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          classroom: secondClassroom,
+          selectedTestId: null,
+          selectedTestMode: null,
+          selectedTestStudentId: null,
+        }),
+      )
+    })
   })
 
   it('does not open assignment markdown when assignment edit mode activates', async () => {

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TeacherRosterTab } from '@/app/classrooms/[classroomId]/TeacherRosterTab'
 import type { Classroom } from '@/types'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 
 vi.mock('@/components/AddStudentsModal', () => ({
   AddStudentsModal: () => null,
@@ -84,13 +85,23 @@ function mockRosterFetch() {
   return fetchMock
 }
 
-function renderRoster() {
+function renderRoster(targetClassroom = classroom) {
   return render(
     <TooltipProvider>
       <AppMessageProvider>
-        <TeacherRosterTab classroom={classroom} />
+        <TeacherRosterTab classroom={targetClassroom} />
       </AppMessageProvider>
     </TooltipProvider>,
+  )
+}
+
+function renderRosterElement(targetClassroom = classroom) {
+  return (
+    <TooltipProvider>
+      <AppMessageProvider>
+        <TeacherRosterTab classroom={targetClassroom} />
+      </AppMessageProvider>
+    </TooltipProvider>
   )
 }
 
@@ -119,7 +130,98 @@ function getRequestBody(call: unknown[]) {
 describe('TeacherRosterTab', () => {
   afterEach(() => {
     cleanup()
+    invalidateCachedJSONMatching('teacher-roster:')
+    invalidateCachedJSONMatching('auth-me:')
     vi.unstubAllGlobals()
+  })
+
+  it('ignores stale roster loads after switching classrooms', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Second Roster' }
+    let resolveFirstRoster: (() => void) | null = null
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster` && method === 'GET') {
+        return new Promise((resolve) => {
+          resolveFirstRoster = () => resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ roster: [rosterRow] }),
+          })
+        })
+      }
+
+      if (url === `/api/teacher/classrooms/${secondClassroom.id}/roster` && method === 'GET') {
+        return mockJson({ roster: [secondRosterRow] })
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = renderRoster()
+
+    await waitFor(() => {
+      expect(resolveFirstRoster).toEqual(expect.any(Function))
+    })
+
+    view.rerender(renderRosterElement(secondClassroom))
+
+    expect(await screen.findByText('Grace')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveFirstRoster?.()
+    })
+
+    expect(screen.getByText('Grace')).toBeInTheDocument()
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+  })
+
+  it('hides the current roster while the next classroom roster loads', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Second Roster' }
+    let resolveSecondRoster: (() => void) | null = null
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+
+      if (url === `/api/teacher/classrooms/${classroom.id}/roster` && method === 'GET') {
+        return mockJson({ roster: [rosterRow] })
+      }
+
+      if (url === `/api/teacher/classrooms/${secondClassroom.id}/roster` && method === 'GET') {
+        return new Promise((resolve) => {
+          resolveSecondRoster = () => resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ roster: [secondRosterRow] }),
+          })
+        })
+      }
+
+      throw new Error(`Unhandled fetch: ${method} ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = renderRoster()
+
+    expect(await screen.findByText('Ada')).toBeInTheDocument()
+
+    view.rerender(renderRosterElement(secondClassroom))
+
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(resolveSecondRoster).toEqual(expect.any(Function))
+    })
+    await act(async () => {
+      resolveSecondRoster?.()
+    })
+
+    expect(await screen.findByText('Grace')).toBeInTheDocument()
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument()
   })
 
   it('opens single-student removal from the floating roster actions dropdown with confirmation', async () => {


### PR DESCRIPTION
## Summary
- reset classroom page shell query state from new route search params so stale test/assignment detail params do not leak into the next classroom
- cache and invalidate teacher roster reads while ignoring stale roster loads after classroom switches
- clear transient roster selection/edit/removal state on classroom changes and scope roster mutation completions to the originating classroom

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/TeacherRosterTab.test.tsx
- pnpm vitest run tests/components/TeacherRosterTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
- pnpm vitest run tests/components/TeacherRosterTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/api/teacher/roster.test.ts tests/api/teacher/roster-add.test.ts tests/api/teacher/roster-bulk-delete.test.ts tests/api/teacher/roster-rosterId.test.ts tests/api/teacher/roster-upload-csv.test.ts
- bash .codex/skills/pika-audit/scripts/audit.sh
- git diff --check
- pnpm lint
- pnpm build
- pnpm test

UI verification: not run; this slice changes state freshness and tests only, not layout/styling.