### PR TITLE
[codex] Enforce session-log trimming

### DIFF
--- a/.ai/CURRENT.md
+++ b/.ai/CURRENT.md
@@ -31,7 +31,7 @@ Read this at the start of every AI session. Use `.ai/SESSION-LOG.md` only for re
 
 - Do not work in the hub checkout for non-trivial changes; create or open a dedicated worktree first
 - Do not tail `.ai/JOURNAL-ARCHIVE.md` by default; it is intentionally large
-- Keep `.ai/SESSION-LOG.md` as a rolling recent log and run `node scripts/trim-session-log.mjs` after appending
+- Keep `.ai/SESSION-LOG.md` rolling; immediately run `node scripts/trim-session-log.mjs` after each append
 - Do not run `supabase db push`, `supabase db reset`, or other migration-application commands as an AI agent
 - `main` accepts linear history only; `production` merges go through the protected PR flow
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -3,31 +3,10 @@
 Rolling recent session log for AI/human handoffs. Keep this file small; full historical session history lives in `.ai/JOURNAL-ARCHIVE.md`.
 
 **Rules:**
-- Append one concise entry for meaningful work at the end of a session.
-- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 60 entries.
+- Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.
+- The trim step keeps only the latest 60 entries; use `node scripts/trim-session-log.mjs --check` to verify it was not missed.
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
-
-## 2026-05-31 — History cleanup cron hardening
-
-**Completed:**
-- Scheduled `/api/cron/cleanup-history` as a daily repo-managed Vercel cron and documented both current cron schedules.
-- Routed expired-classroom, assignment, assignment-doc, test, and test-attempt discovery through paged/chunked Supabase reads.
-- Kept history cleanup scoped through classrooms whose `end_date` is older than the 30-day Toronto cutoff.
-- Added cleanup for `test_attempt_history` alongside existing assignment doc history cleanup.
-- Preserved chunked deletes for history tables and returned explicit 500s for each read/delete failure path.
-- Rebuilt cleanup cron tests with filter-aware paged mocks and regressions for dense parent chunking, child result pagination, assignmentless test cleanup, retention boundary behavior, and all read/delete errors.
-- Addressed subagent review follow-ups by aligning cron configuration docs and proving child-table pagination for >1000 docs/attempts under a single parent.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/cron/cleanup-history.test.ts -- --runInBand`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm build`
-- `pnpm test:coverage`
-- `git diff --check`
 
 ## 2026-05-31 — Gradebook FAB layering consistency
 
@@ -971,3 +950,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-06-05 — Session-log trim guardrail
+
+**Completed:**
+- Added `node scripts/trim-session-log.mjs --check` so CI and agents can detect untrimmed session logs without modifying files.
+- Updated session-log workflow guidance to require append-then-trim in the same change while keeping the 60-entry retention cap.
+- Strengthened startup and trim-script tests so missed trims point directly to `node scripts/trim-session-log.mjs`.
+
+**Validation:**
+- `pnpm install --frozen-lockfile`
+- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts`
+- `node scripts/trim-session-log.mjs --check`
+- `git diff --check`

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -41,7 +41,7 @@ All agents operate from exactly one current repo checkout/worktree.
 ## End of Session (MANDATORY)
 
 1. Append a concise session entry to `.ai/SESSION-LOG.md`.
-2. Run `node scripts/trim-session-log.mjs` to keep only the latest 60 entries so weekly automations still have about a week of evidence.
+2. Immediately run `node scripts/trim-session-log.mjs` in the same change; use `node scripts/trim-session-log.mjs --check` to verify the log is trimmed to the latest 60 entries.
 3. Update `.ai/features.json` if anything changed:
    ```bash
    node scripts/features.mjs pass <feature-id>

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -13,7 +13,7 @@ Read these files at the start of every session:
 3. [`.ai/features.json`](../.ai/features.json)
 4. [`docs/ai-instructions.md`](./ai-instructions.md)
 
-Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff context; the rolling log should retain enough entries for weekly automations to inspect roughly the last week.
+Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff context; after each append, immediately run `node scripts/trim-session-log.mjs`.
 
 ## Load Only The Docs You Need
 
@@ -48,7 +48,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: use worktree for non-trivial work; plan/discuss with `Model recommendation: <model> - <reason>` (`5.3-spark` low-risk; else `5.5 medium|high|extra high`), append `.ai/SESSION-LOG.md`; run `node scripts/trim-session-log.mjs`
+- Workflow: use worktree for non-trivial work; plan/discuss with `Model recommendation: <model> - <reason>` (`5.3-spark` low-risk; else `5.5 medium|high|extra high`), append `.ai/SESSION-LOG.md`, and immediately run `node scripts/trim-session-log.mjs`
 - Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -54,7 +54,7 @@ Do not proceed until the user approves the plan.
 ## 7) Update AI Continuity Layer
 Before ending a session:
 - Append a concise entry to `.ai/SESSION-LOG.md`.
-- Run `node scripts/trim-session-log.mjs`.
+- Immediately run `node scripts/trim-session-log.mjs` in the same change.
 - Update `.ai/features.json` if feature status changed:
   ```bash
   node scripts/features.mjs pass <feature-id>

--- a/docs/semester-plan.md
+++ b/docs/semester-plan.md
@@ -288,7 +288,7 @@ UI: Checklist-style rubric that auto-calculates total.
 | `ai-instructions.md` | 350 | 300 | Remove workflow duplication |
 | `architecture.md` | 210 | 200 | Already tight |
 | `design.md` | 715 | 400 | Move component examples to storybook/gallery |
-| `SESSION-LOG.md` | <= 60 entries | <= 60 entries | Trim with `scripts/trim-session-log.mjs` |
+| `SESSION-LOG.md` | <= 60 entries | <= 60 entries | Append, then immediately trim with `scripts/trim-session-log.mjs` |
 | **Total** | ~7200 | ~4000 | 44% reduction |
 
 ---

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -10,6 +10,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 function parseArgs(argv) {
   const args = {
+    check: false,
     keep: DEFAULT_KEEP,
     source: DEFAULT_SOURCE,
     output: DEFAULT_OUTPUT,
@@ -22,6 +23,8 @@ function parseArgs(argv) {
     if (arg === '--keep' && next) {
       args.keep = Number.parseInt(next, 10)
       index += 1
+    } else if (arg === '--check') {
+      args.check = true
     } else if (arg === '--source' && next) {
       args.source = next
       index += 1
@@ -45,8 +48,10 @@ function parseArgs(argv) {
 function usage() {
   return [
     'Usage: node scripts/trim-session-log.mjs [--keep 60] [--source .ai/SESSION-LOG.md] [--output .ai/SESSION-LOG.md]',
+    '       node scripts/trim-session-log.mjs --check [--keep 60] [--source .ai/SESSION-LOG.md]',
     '',
     'Keeps the latest session entries, where each entry starts with a markdown "## " heading.',
+    'Use --check to fail when the source has more entries than the retention window.',
   ].join('\n')
 }
 
@@ -68,8 +73,8 @@ function buildSessionLog(entries) {
     'Rolling recent session log for AI/human handoffs. Keep this file small; full historical session history lives in `.ai/JOURNAL-ARCHIVE.md`.',
     '',
     '**Rules:**',
-    '- Append one concise entry for meaningful work at the end of a session.',
-    '- Run `node scripts/trim-session-log.mjs` after appending to keep only the latest 60 entries.',
+    '- Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.',
+    '- The trim step keeps only the latest 60 entries; use `node scripts/trim-session-log.mjs --check` to verify it was not missed.',
     '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
     '- Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.',
     '',
@@ -100,6 +105,28 @@ function trimSessionLog({ keep, source, output }) {
   }
 }
 
+function checkSessionLog({ keep, source }) {
+  const sourcePath = resolve(repoRoot, source)
+  const markdown = readFileSync(sourcePath, 'utf8')
+  const entries = extractEntries(markdown)
+
+  if (entries.length === 0) {
+    throw new Error(`No session entries found in ${source}`)
+  }
+
+  if (entries.length > keep) {
+    throw new Error(
+      `${source} has ${entries.length} entries; run node scripts/trim-session-log.mjs to keep only the latest ${keep}.`,
+    )
+  }
+
+  return {
+    source,
+    total: entries.length,
+    keep,
+  }
+}
+
 try {
   const args = parseArgs(process.argv.slice(2))
 
@@ -108,10 +135,15 @@ try {
     process.exit(0)
   }
 
-  const result = trimSessionLog(args)
-  console.log(
-    `Trimmed ${result.output}: kept ${result.retained} of ${result.total} entries from ${result.source}`,
-  )
+  if (args.check) {
+    const result = checkSessionLog(args)
+    console.log(`${result.source} is trimmed: ${result.total}/${result.keep} entries`)
+  } else {
+    const result = trimSessionLog(args)
+    console.log(
+      `Trimmed ${result.output}: kept ${result.retained} of ${result.total} entries from ${result.source}`,
+    )
+  }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))
   console.error(usage())

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -89,8 +89,14 @@ describe('AI startup docs', () => {
 
     expect(sessionLog).toContain('Rolling recent session log')
     expect(sessionLog).toContain('latest 60 entries')
+    expect(sessionLog).toContain('immediately run `node scripts/trim-session-log.mjs`')
+    expect(sessionLog).toContain('node scripts/trim-session-log.mjs --check')
     expect(entryCount).toBeGreaterThan(0)
-    expect(entryCount).toBeLessThanOrEqual(60)
+    if (entryCount > 60) {
+      throw new Error(
+        `.ai/SESSION-LOG.md has ${entryCount} entries; run node scripts/trim-session-log.mjs after appending session-log entries.`,
+      )
+    }
     expect(readRepoFile('.ai/JOURNAL-ARCHIVE.md')).toContain('# Pika Project Journal')
   })
 

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -43,6 +43,7 @@ describe('trim-session-log script', () => {
 
       expect(output).toContain('# Pika Session Log')
       expect(output).toContain('latest 60 entries')
+      expect(output).toContain('Append one concise entry for meaningful work, then immediately run `node scripts/trim-session-log.mjs` in the same change.')
       expect(output).not.toContain('## 2026-05-01 - First')
       expect(output).toContain('## 2026-05-02 - Second')
       expect(output).toContain('## 2026-05-03 - Third')
@@ -94,5 +95,47 @@ describe('trim-session-log script', () => {
 
     expect(script).toContain('const DEFAULT_KEEP = 60')
     expect(script).toContain('[--keep 60]')
+    expect(script).toContain('--check')
+  })
+
+  it('checks whether the session log is already trimmed without writing it', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-check-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const original = [
+        '# Pika Session Log',
+        '',
+        '## 2026-05-01 - First',
+        'first entry',
+        '',
+        '## 2026-05-02 - Second',
+        'second entry',
+        '',
+        '## 2026-05-03 - Third',
+        'third entry',
+        '',
+      ].join('\n')
+
+      writeFileSync(sourcePath, original)
+
+      const failedCheck = spawnSync('node', [scriptPath, '--check', '--source', sourcePath, '--keep', '2'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(failedCheck.status).toBe(1)
+      expect(failedCheck.stderr).toContain('run node scripts/trim-session-log.mjs')
+      expect(readFileSync(sourcePath, 'utf8')).toBe(original)
+
+      const output = execFileSync('node', [scriptPath, '--check', '--source', sourcePath, '--keep', '3'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(output).toContain('source.md is trimmed: 3/3 entries')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Add `node scripts/trim-session-log.mjs --check` for non-mutating session-log retention checks.
- Update startup and workflow guidance so every `.ai/SESSION-LOG.md` append is immediately paired with `node scripts/trim-session-log.mjs` in the same change.
- Strengthen workflow tests so missed trims produce a direct command to run.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts`
- `node scripts/trim-session-log.mjs --check`
- `git diff --check`