### PR TITLE
[codex] Guard teacher attendance freshness

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -963,3 +963,26 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts`
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
+## 2026-06-05 — Skill progression map refresh
+
+**Completed:**
+- Reviewed startup context, current repo invariants, and recent merged PR history before making recommendations.
+- Collected evidence from merged PRs `#719`, `#724`, `#725`, `#726`, `#728`, `#729`, `#730`, `#731`, `#732`, `#733`, `#734`, `#735`, `#736`, plus self-review notes on `#709` and `#711`.
+- Identified recurring themes around classroom freshness/cache invalidation, contract-boundary hardening, component regression testing, and Gradex integration follow-through.
+
+**Validation:**
+- `bash scripts/verify-env.sh` (fails: `node_modules` missing in this worktree)
+- `gh pr list --state merged --limit 12 --json number,title,mergedAt,author,labels,url`
+- `gh pr view <pr> --json number,title,mergedAt,files,reviews,url`
+- `gh api graphql` against recent merged PR review metadata
+
+## 2026-06-05 — Teacher attendance freshness guards
+
+**Completed:**
+- Added request-generation guards to `TeacherAttendanceTab` so stale classroom/date log responses cannot repaint the active teacher daily view after a classroom switch or date change.
+- Reset teacher attendance local state on classroom changes so date/selection/loading state reinitializes against the next classroom instead of carrying the prior classroom forward.
+- Added matching request-generation guards to `LogSummary` and created regression tests covering stale classroom summary responses plus stale teacher-log responses after a classroom switch.
+
+**Validation:**
+- `git diff --check`
+- `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` (fails in this worktree: `vitest` command unavailable because dependencies are not installed)

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,44 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Gradebook FAB layering consistency
-
-**Completed:**
-- Removed the teacher Gradebook action bar's local `z-[70]` floating-cluster override so it uses the shared teacher work-surface FAB layer.
-- Lowered Gradebook sticky table header/body z-index tiers so table chrome remains below the shared FAB and global overlays retain priority.
-- Added component coverage for the Gradebook floating cluster, table sticky layers, and settings-mode header layering.
-
-**Validation:**
-- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/ui/SplitButton.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3016 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-gradebook-email-menu-desktop.png`, `/tmp/pika-gradebook-email-menu-mobile.png`, `/tmp/pika-gradebook-settings-desktop.png`
-
-## 2026-05-31 — Student survey FAB cluster consistency
-
-**Completed:**
-- Extracted the shared floating action cluster layout used by teacher work surfaces.
-- Kept teacher work-surface action bars on the shared cluster through the existing wrapper.
-- Routed student survey response/results actions through the shared cluster so desktop centering follows `--main-content-center-x` like other classroom FABs.
-- Added component coverage for the student survey FAB layer and main-content centering class.
-- Created and cleaned up a temporary active survey for visual verification.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `bash scripts/verify-env.sh`
-- `pnpm test tests/components/StudentSurveyPanel.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3017 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&surveyId=5fc24952-20e0-4512-93f5-8c3800826e5f'`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student-survey-fab-desktop.png`, `/tmp/pika-student-survey-response-form-desktop.png`, `/tmp/pika-student-survey-response-form-mobile.png`
-
 ## 2026-05-31 — Classroom bottom controls FAB consistency
 
 **Completed:**
@@ -963,6 +925,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts`
 - `node scripts/trim-session-log.mjs --check`
 - `git diff --check`
+
 ## 2026-06-05 — Skill progression map refresh
 
 **Completed:**

--- a/src/app/classrooms/[classroomId]/LogSummary.tsx
+++ b/src/app/classrooms/[classroomId]/LogSummary.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import type { LogSummaryActionItem } from '@/types'
 
@@ -23,19 +23,36 @@ export function LogSummary({ classroomId, date, onStudentClick }: LogSummaryProp
   const [summaryStatus, setSummaryStatus] = useState<SummaryStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const requestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroomId)
+  const currentDateRef = useRef(date)
+  currentClassroomIdRef.current = classroomId
+  currentDateRef.current = date
 
   useEffect(() => {
     if (!date) {
+      requestIdRef.current += 1
       setSummary(null)
       setSummaryStatus(null)
+      setError(null)
       setLoading(false)
       return
     }
 
-    let cancelled = false
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
     setLoading(true)
     setError(null)
+    setSummary(null)
     setSummaryStatus(null)
+
+    function isCurrentRequest() {
+      return (
+        requestIdRef.current === requestId &&
+        currentClassroomIdRef.current === classroomId &&
+        currentDateRef.current === date
+      )
+    }
 
     async function fetchSummary() {
       try {
@@ -46,24 +63,25 @@ export function LogSummary({ classroomId, date, onStudentClick }: LogSummaryProp
           throw new Error('Failed to load summary')
         }
         const data = await res.json()
-        if (!cancelled) {
-          setSummary(data.summary)
-          setSummaryStatus(data.summary_status || (data.summary ? 'ready' : null))
-        }
+        if (!isCurrentRequest()) return
+        setSummary(data.summary)
+        setSummaryStatus(data.summary_status || (data.summary ? 'ready' : null))
       } catch (err) {
-        if (!cancelled) {
-          console.error('Error fetching log summary:', err)
-          setError('Failed to load summary')
-        }
+        if (!isCurrentRequest()) return
+        console.error('Error fetching log summary:', err)
+        setError('Failed to load summary')
       } finally {
-        if (!cancelled) {
-          setLoading(false)
-        }
+        if (!isCurrentRequest()) return
+        setLoading(false)
       }
     }
 
     fetchSummary()
-    return () => { cancelled = true }
+    return () => {
+      if (requestIdRef.current === requestId) {
+        requestIdRef.current += 1
+      }
+    }
   }, [classroomId, date])
 
   if (loading) {

--- a/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAttendanceTab.tsx
@@ -100,7 +100,11 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null)
   const dateInputRef = useRef<HTMLInputElement | null>(null)
   const selectedWorkspaceRef = useRef<HTMLDivElement | null>(null)
+  const onSelectEntryRef = useRef(onSelectEntry)
   const hasLoadedOnceRef = useRef(false)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  const currentSelectedDateRef = useRef('')
   const [detailPaneWidth, setDetailPaneWidth] = useState(50)
   const [summaryPanelCollapsed, setSummaryPanelCollapsed] = useState(false)
   const [summaryPanelHeight, setSummaryPanelHeight] = useState(SUMMARY_PANEL_DEFAULT_HEIGHT)
@@ -119,6 +123,28 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     column: SortColumn
     direction: 'asc' | 'desc'
   }>({ column: 'last_name', direction: 'asc' })
+  currentClassroomIdRef.current = classroom.id
+  currentSelectedDateRef.current = selectedDate
+  onSelectEntryRef.current = onSelectEntry
+
+  const isCurrentLogsRequest = useCallback((requestId: number, classroomId: string, date: string) => {
+    return (
+      loadRequestIdRef.current === requestId &&
+      currentClassroomIdRef.current === classroomId &&
+      currentSelectedDateRef.current === date
+    )
+  }, [])
+
+  useEffect(() => {
+    loadRequestIdRef.current += 1
+    hasLoadedOnceRef.current = false
+    setLogs([])
+    setLoading(true)
+    setRefreshing(false)
+    setSelectedDate('')
+    setSelectedStudentId(null)
+    onSelectEntryRef.current?.(null, '', null)
+  }, [classroom.id])
 
   // Set initial date once class days are loaded from context
   useEffect(() => {
@@ -158,11 +184,17 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
     async function loadLogs() {
       if (!selectedDate) return
       if (!isActive) return
-      if (!isClassDayOnDate(classDays, selectedDate)) {
+      const classroomId = classroom.id
+      const date = selectedDate
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
+
+      if (!isClassDayOnDate(classDays, date)) {
+        if (!isCurrentLogsRequest(requestId, classroomId, date)) return
         setLogs([])
         hasLoadedOnceRef.current = true
         setSelectedStudentId(null)
-        onSelectEntry?.(null, '', null)
+        onSelectEntryRef.current?.(null, '', null)
         setLoading(false)
         setRefreshing(false)
         return
@@ -174,8 +206,9 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
         setLoading(true)
       }
       try {
-        const res = await fetch(`/api/teacher/logs?classroom_id=${classroom.id}&date=${selectedDate}`)
+        const res = await fetch(`/api/teacher/logs?classroom_id=${classroomId}&date=${date}`)
         const data = await res.json()
+        if (!isCurrentLogsRequest(requestId, classroomId, date)) return
         const rawLogs = data.logs || []
         const mappedLogs = rawLogs.map((log: any) => ({
           ...log,
@@ -185,17 +218,19 @@ export const TeacherAttendanceTab = forwardRef<TeacherAttendanceTabHandle, Props
 
         // Clear selection when date changes so summary is visible
         setSelectedStudentId(null)
-        onSelectEntry?.(null, '', null)
+        onSelectEntryRef.current?.(null, '', null)
         hasLoadedOnceRef.current = true
       } catch (err) {
+        if (!isCurrentLogsRequest(requestId, classroomId, date)) return
         console.error('Error loading logs:', err)
       } finally {
+        if (!isCurrentLogsRequest(requestId, classroomId, date)) return
         setLoading(false)
         setRefreshing(false)
       }
     }
     loadLogs()
-  }, [classroom.id, classDays, selectedDate, onSelectEntry, isActive])
+  }, [classroom.id, classDays, selectedDate, isActive, isCurrentLogsRequest])
 
   const isClassDay = useMemo(() => {
     if (!selectedDate) return true

--- a/src/contexts/ClassDaysContext.tsx
+++ b/src/contexts/ClassDaysContext.tsx
@@ -55,6 +55,9 @@ export function ClassDaysProvider({ classroomId, children }: ClassDaysProviderPr
 
   // Initial load
   useEffect(() => {
+    loadSequenceRef.current += 1
+    setClassDays([])
+    setIsLoading(true)
     loadClassDays()
   }, [loadClassDays])
 

--- a/tests/components/LogSummary.test.tsx
+++ b/tests/components/LogSummary.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { LogSummary } from '@/app/classrooms/[classroomId]/LogSummary'
+
+function mockJson(data: unknown, ok = true) {
+  return Promise.resolve({ ok, json: () => Promise.resolve(data) }) as any
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('LogSummary', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores an older classroom summary response after switching classrooms', async () => {
+    const firstRequest = deferred<any>()
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/teacher/log-summary?classroom_id=classroom-1&date=2026-05-05') {
+        return firstRequest.promise
+      }
+      if (url === '/api/teacher/log-summary?classroom_id=classroom-2&date=2026-05-07') {
+        return mockJson({
+          summary: null,
+          summary_status: 'pending',
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(
+      <LogSummary classroomId="classroom-1" date="2026-05-05" />
+    )
+
+    rerender(<LogSummary classroomId="classroom-2" date="2026-05-07" />)
+
+    expect(await screen.findByText('Summary will be available after the nightly run.')).toBeInTheDocument()
+
+    firstRequest.resolve(await mockJson({
+      summary: {
+        overview: 'Old summary should stay hidden.',
+        action_items: [],
+        generated_at: '2026-05-05T12:00:00.000Z',
+      },
+      summary_status: 'ready',
+    }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Old summary should stay hidden.')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Summary will be available after the nightly run.')).toBeInTheDocument()
+  })
+})

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -501,6 +501,7 @@ describe('TeacherAttendanceTab', () => {
 
     const { rerender } = render(<TeacherAttendanceTab classroom={classroom} />)
 
+    todayMock.today = '2026-05-08'
     classDaysMock.classDays = [
       {
         id: 'day-2',

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -481,7 +481,7 @@ describe('TeacherAttendanceTab', () => {
       if (url === '/api/teacher/logs?classroom_id=classroom-1&date=2026-05-05') {
         return firstRequest.promise
       }
-      if (url === '/api/teacher/logs?classroom_id=classroom-2&date=2026-05-07') {
+      if (url === '/api/teacher/logs?classroom_id=classroom-2&date=2026-05-05') {
         return mockJson({
           logs: [
             {
@@ -489,7 +489,7 @@ describe('TeacherAttendanceTab', () => {
               student_email: 'student2@example.com',
               student_first_name: 'Second',
               student_last_name: 'Student',
-              entry: entry({ id: 'entry-2', student_id: 'student-2', classroom_id: 'classroom-2', date: '2026-05-07' }),
+              entry: entry({ id: 'entry-2', student_id: 'student-2', classroom_id: 'classroom-2', date: '2026-05-05' }),
               history_preview: [],
             },
           ],
@@ -501,12 +501,11 @@ describe('TeacherAttendanceTab', () => {
 
     const { rerender } = render(<TeacherAttendanceTab classroom={classroom} />)
 
-    todayMock.today = '2026-05-08'
     classDaysMock.classDays = [
       {
         id: 'day-2',
         classroom_id: 'classroom-2',
-        date: '2026-05-07',
+        date: '2026-05-05',
         prompt_text: null,
         is_class_day: true,
       },

--- a/tests/components/TeacherAttendanceTab.test.tsx
+++ b/tests/components/TeacherAttendanceTab.test.tsx
@@ -78,6 +78,13 @@ const classroom: Classroom = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
+const secondClassroom: Classroom = {
+  ...classroom,
+  id: 'classroom-2',
+  title: 'Second Classroom',
+  class_code: 'DEF456',
+}
+
 function entry(overrides: Partial<Entry>): Entry {
   return {
     id: 'entry-1',
@@ -101,6 +108,16 @@ const longLogText =
 
 function mockJson(data: unknown, ok = true) {
   return Promise.resolve({ ok, json: () => Promise.resolve(data) }) as any
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
 }
 
 function mockLogsFetch() {
@@ -445,5 +462,76 @@ describe('TeacherAttendanceTab', () => {
     })
     expect(screen.getByRole('columnheader', { name: 'Log' })).toBeInTheDocument()
     expect(container.querySelector('.daily-table-enter')).toBeInTheDocument()
+  })
+
+  it('ignores an older classroom log request after switching classrooms', async () => {
+    const firstRequest = deferred<any>()
+    classDaysMock.classDays = [
+      {
+        id: 'day-1',
+        classroom_id: 'classroom-1',
+        date: '2026-05-05',
+        prompt_text: null,
+        is_class_day: true,
+      },
+    ]
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/teacher/logs?classroom_id=classroom-1&date=2026-05-05') {
+        return firstRequest.promise
+      }
+      if (url === '/api/teacher/logs?classroom_id=classroom-2&date=2026-05-07') {
+        return mockJson({
+          logs: [
+            {
+              student_id: 'student-2',
+              student_email: 'student2@example.com',
+              student_first_name: 'Second',
+              student_last_name: 'Student',
+              entry: entry({ id: 'entry-2', student_id: 'student-2', classroom_id: 'classroom-2', date: '2026-05-07' }),
+              history_preview: [],
+            },
+          ],
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<TeacherAttendanceTab classroom={classroom} />)
+
+    classDaysMock.classDays = [
+      {
+        id: 'day-2',
+        classroom_id: 'classroom-2',
+        date: '2026-05-07',
+        prompt_text: null,
+        is_class_day: true,
+      },
+    ]
+
+    rerender(<TeacherAttendanceTab classroom={secondClassroom} />)
+
+    expect(await screen.findByRole('cell', { name: 'Second', exact: true })).toBeInTheDocument()
+    expect(screen.queryByRole('cell', { name: 'Student1', exact: true })).not.toBeInTheDocument()
+
+    firstRequest.resolve(await mockJson({
+      logs: [
+        {
+          student_id: 'student-1',
+          student_email: 'student1@example.com',
+          student_first_name: 'Student1',
+          student_last_name: 'Test',
+          entry: entry({ text: longLogText }),
+          history_preview: [],
+        },
+      ],
+    }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('cell', { name: 'Student1', exact: true })).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('cell', { name: 'Second', exact: true })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- guard teacher attendance log fetches against stale classroom/date responses
- reset teacher attendance local state on classroom switches
- guard log summary fetches and add regressions for stale classroom responses

## Testing
- `git diff --check`
- `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` *(fails in this worktree: `vitest` command not found because dependencies are not installed)*
