### PR TITLE
[codex] Add Gradex teacher intent context

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,46 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Classroom bottom controls FAB consistency
-
-**Completed:**
-- Extended `FloatingActionCluster` with a bottom placement for full-width floating controls.
-- Migrated the teacher classroom index edit/view bottom bar off its local fixed chrome and onto the shared floating cluster.
-- Added safe-area-aware bottom placement for mobile classroom controls while preserving the existing centered desktop width.
-- Added component coverage for the migrated bottom bar class contract.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3018 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-classrooms-edit-desktop.png`, `/tmp/pika-classrooms-edit-mobile.png`
-
-## 2026-05-31 — Assignment status badge consistency
-
-**Completed:**
-- Moved assignment status badge and icon helpers from raw Tailwind palette classes to semantic design tokens.
-- Made the assignment badge helper own the shared pill shape so student assignment list and editor badges stay aligned.
-- Added the shared status badge to the embedded student assignment editor header, which is the route students use from the assignments tab.
-- Added tests that assert semantic badge/icon contracts and reject raw palette utilities.
-- Used a read-only subagent audit to confirm the live editor route and screenshot path before visual verification.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:auth`
-- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:verify assessment-ux-parity`
-- Reviewed screenshots: `/tmp/pika-assignment-list-desktop.png`, `/tmp/pika-assignment-editor-desktop.png`, `/tmp/pika-assignment-list-mobile.png`, `/tmp/pika-assignment-editor-mobile.png`, `artifacts/assessment-ux-parity/student-assignments-reference.png`
-
 ## 2026-05-31 — Class-days shared loader cache
 
 **Completed:**
@@ -949,3 +909,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `git diff --check`
 - `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` (fails in this worktree: `vitest` command unavailable because dependencies are not installed)
+
+## 2026-06-04 — Gradex teacher intent egress
+
+**Completed:**
+- Updated the Pika Gradex assignment payload builder to include sanitized assignment instructions and sanitized assignment description in a structured teacher-context block.
+- Added explicit teacher grading guidance to the existing `assignment.instructions` field so Gradex can score against teacher intent without a contract/schema change.
+- Tightened the fixed Pika-compatible Gradex rubric descriptions for `completion`, `thinking`, and `workflow`, including keeping workflow evidence scoped to workflow/process scoring.
+- Expanded payload tests to verify teacher context is included, PII is redacted, raw emails/names do not leave Pika, and the rubric remains the same three criteria.
+
+**Validation:**
+- `pnpm test tests/lib/gradex-assignment-payload.test.ts`
+- `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-assignment-grading.test.ts tests/lib/gradex-smoke-runner.test.ts`
+- `pnpm exec tsc --noEmit`
+- `git diff --check`
+
+## 2026-06-06 — Gradex teacher intent PR prep
+
+**Completed:**
+- Reviewed the teacher-intent payload diff for PR readiness.
+- Verified the branch scope stayed limited to Gradex assignment payload construction, focused tests, and the rolling session log.
+- Reserved space for fixed teacher grading guidance so long assignment context cannot truncate it out of the Gradex instructions payload.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `git diff --check`

--- a/src/lib/server/gradex-assignment-payload.ts
+++ b/src/lib/server/gradex-assignment-payload.ts
@@ -135,6 +135,7 @@ export interface BuildPikaAssignmentGradexRunPayloadOptions {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 25_000
+const ASSIGNMENT_INSTRUCTIONS_MAX_LENGTH = 20_000
 const BARE_WWW_URL_PATTERN = /\bwww\.[^\s<>"'`]+/gi
 const IDENTITY_KEY_PATTERN = /(email|first_?name|last_?name|full_?name|display_?name|student_?name|teacher_?name|username|github_?username)/i
 const RAW_ID_KEY_PATTERN = /(^id$|_id$|id$|roster|sis|school|database|assignment_doc|classroom|created_by)/i
@@ -145,7 +146,8 @@ export const PIKA_ASSIGNMENT_GRADEX_RUBRIC: GradexRubric = {
     {
       id: 'completion',
       label: 'Completion',
-      description: 'Did the student complete all parts of the assignment?',
+      description:
+        'Grade whether the submission satisfies the sanitized assignment instructions, required deliverables, and teacher-stated constraints.',
       kind: 'content',
       scale: { min: 0, max: 10 },
       weight: 1,
@@ -154,7 +156,8 @@ export const PIKA_ASSIGNMENT_GRADEX_RUBRIC: GradexRubric = {
     {
       id: 'thinking',
       label: 'Thinking',
-      description: 'Does the work show depth of thought, analysis, or understanding?',
+      description:
+        'Grade reasoning, evidence, reflection, and understanding according to the teacher-stated intent; do not over-penalize surface polish unless the assignment asks for it.',
       kind: 'thinking',
       scale: { min: 0, max: 10 },
       weight: 1,
@@ -163,7 +166,8 @@ export const PIKA_ASSIGNMENT_GRADEX_RUBRIC: GradexRubric = {
     {
       id: 'workflow',
       label: 'Workflow',
-      description: 'Is the work organized, clear, well-presented, and supported by process evidence?',
+      description:
+        'Grade only organization and sanitized process evidence here; workflow evidence must not change Completion or Thinking unless the rubric explicitly says it should.',
       kind: 'workflow',
       scale: { min: 0, max: 10 },
       weight: 1,
@@ -258,6 +262,67 @@ function sanitizeGradexText(
   }
 
   return sanitized
+}
+
+function normalizeForComparison(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+function sanitizedAssignmentSection(
+  value: string,
+  sensitiveTokens: string[],
+  sanitizationContext: AiSanitizationContext,
+): string {
+  return sanitizeGradexText(value, sensitiveTokens, sanitizationContext).trim()
+}
+
+function buildAssignmentGradingInstructions(
+  assignment: Assignment,
+  sensitiveTokens: string[],
+  sanitizationContext: AiSanitizationContext,
+): string {
+  const instructionText = limitedMarkdownToPlainText(
+    getAssignmentInstructionsMarkdown(assignment).markdown,
+  )
+  const descriptionText = limitedMarkdownToPlainText(String(assignment.description ?? ''))
+
+  const sections: Array<{ label: string; value: string }> = []
+  const seen = new Set<string>()
+
+  for (const section of [
+    { label: 'Assignment instructions', value: instructionText },
+    { label: 'Assignment description', value: descriptionText },
+  ]) {
+    const sanitized = sanitizedAssignmentSection(
+      section.value,
+      sensitiveTokens,
+      sanitizationContext,
+    )
+    const normalized = normalizeForComparison(sanitized)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    sections.push({ label: section.label, value: sanitized })
+  }
+
+  const teacherContext =
+    sections.length > 0
+      ? sections.map((section) => `${section.label}:\n${section.value}`).join('\n\n')
+      : 'Assignment instructions:\nNo assignment instructions provided.'
+
+  const gradingGuidance = [
+    'Teacher grading guidance:',
+    '- Use the assignment context above as the teacher intent for this grading run.',
+    '- Score Completion against required deliverables, constraints, and what the student was asked to produce.',
+    '- Score Thinking for reasoning, evidence, reflection, and understanding; avoid harshly penalizing polish unless the assignment asks for polish.',
+    '- Score Workflow only from sanitized process evidence and organization signals.',
+  ].join('\n')
+  const separator = '\n\n'
+  const teacherContextMaxLength = Math.max(
+    0,
+    ASSIGNMENT_INSTRUCTIONS_MAX_LENGTH - separator.length - gradingGuidance.length,
+  )
+
+  return `${truncateText(teacherContext, teacherContextMaxLength)}${separator}${gradingGuidance}`
 }
 
 function groupArtifactsByDocId(artifacts: AssignmentSubmissionArtifact[] = []) {
@@ -402,8 +467,10 @@ export function buildPikaAssignmentGradexRunPayload(
   const salt = getRequiredPseudonymSalt(opts.pseudonymSalt)
   const sensitiveTokens = collectSanitizationTokens(opts.assignment, opts.assignmentDocs)
   const sanitizationContext = getRequiredSanitizationContext(opts.sanitizationContext)
-  const instructions = limitedMarkdownToPlainText(
-    getAssignmentInstructionsMarkdown(opts.assignment).markdown,
+  const instructions = buildAssignmentGradingInstructions(
+    opts.assignment,
+    sensitiveTokens,
+    sanitizationContext,
   )
   const artifactsByDocId = groupArtifactsByDocId(opts.submissionArtifacts)
   const assignmentRef = pseudonymizePikaGradexRef('assignment', opts.assignment.id, salt)
@@ -416,7 +483,7 @@ export function buildPikaAssignmentGradexRunPayload(
     ),
     instructions: truncateText(
       sanitizeGradexText(instructions, sensitiveTokens, sanitizationContext).trim() || 'No assignment instructions provided.',
-      20_000,
+      ASSIGNMENT_INSTRUCTIONS_MAX_LENGTH,
     ),
   }
 

--- a/tests/lib/gradex-assignment-payload.test.ts
+++ b/tests/lib/gradex-assignment-payload.test.ts
@@ -12,7 +12,8 @@ const assignment: Assignment = {
   id: 'assignment-db-123',
   classroom_id: 'classroom-db-123',
   title: 'Portfolio Reflection for Jane Student',
-  description: 'Fallback description',
+  description:
+    'Teacher priority: reward clear reflection about design decisions and process evidence. Ignore minor spelling issues unless they block meaning. Contact Jane Student at teacher@example.com.',
   instructions_markdown: 'Write a reflection about the portfolio. Contact teacher@example.com if stuck.',
   rich_instructions: null,
   due_at: '2026-05-15T19:00:00.000Z',
@@ -118,8 +119,23 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     expect(result.pikaAdapterRequest.assignment).toEqual({
       pika_assignment_ref: expect.stringMatching(/^pika-assignment-(?=.*[a-z])(?=.*\d)[a-z0-9]{32}$/),
       title: 'Portfolio Reflection for J.S.',
-      instructions: 'Write a reflection about the portfolio. Contact [email redacted] if stuck.',
+      instructions: expect.stringContaining('Assignment instructions:'),
     })
+    expect(result.pikaAdapterRequest.assignment.instructions).toContain(
+      'Write a reflection about the portfolio. Contact [email redacted] if stuck.',
+    )
+    expect(result.pikaAdapterRequest.assignment.instructions).toContain(
+      'Assignment description:\nTeacher priority: reward clear reflection about design decisions and process evidence.',
+    )
+    expect(result.pikaAdapterRequest.assignment.instructions).toContain(
+      'Ignore minor spelling issues unless they block meaning.',
+    )
+    expect(result.pikaAdapterRequest.assignment.instructions).toContain('Teacher grading guidance:')
+    expect(result.pikaAdapterRequest.assignment.instructions).toContain(
+      'Score Completion against required deliverables',
+    )
+    expect(result.pikaAdapterRequest.assignment.instructions).not.toContain('Jane Student')
+    expect(result.pikaAdapterRequest.assignment.instructions).not.toContain('teacher@example.com')
     expect(result.pikaAdapterRequest.submissions).toHaveLength(1)
     expect(result.pikaAdapterRequest.submissions[0]).toEqual({
       pika_grade_record_ref: expect.stringMatching(/^pika-grade-(?=.*[a-z])(?=.*\d)[a-z0-9]{32}$/),
@@ -158,6 +174,12 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
       'thinking',
       'workflow',
     ])
+    const criteriaById = Object.fromEntries(
+      result.gradexRequest.rubric.criteria.map((criterion) => [criterion.id, criterion]),
+    )
+    expect(criteriaById.completion.description).toContain('teacher-stated constraints')
+    expect(criteriaById.thinking.description).toContain('teacher-stated intent')
+    expect(criteriaById.workflow.description).toContain('workflow evidence must not change Completion or Thinking')
     expect(result.gradexRequest.settings).toEqual({
       grading_profile: GRADEX_PIKA_ASSIGNMENT_PROFILE,
       model_profile: 'calibration',
@@ -247,6 +269,7 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     expect(serialized).not.toContain('student-db-789')
     expect(serialized).not.toMatch(/\b[0-9a-f]{24}\b/i)
     expect(serialized).not.toContain('Jane Student')
+    expect(serialized).not.toContain('teacher@example.com')
     expect(serialized).not.toContain('student@example.com')
     expect(serialized).not.toContain('roster-db-123')
     expect(serialized).not.toContain('assignment_doc_history')
@@ -258,6 +281,36 @@ describe('buildPikaAssignmentGradexRunPayload', () => {
     expect(serialized).not.toContain('github.com')
     expect(serialized).not.toContain('jane-student')
     expect(serialized).not.toContain('artifact-db-999')
+  })
+
+  it('preserves teacher grading guidance when assignment context is long', () => {
+    const result = buildPikaAssignmentGradexRunPayload({
+      assignment: {
+        ...assignment,
+        instructions_markdown: 'Write a detailed reflection. '.repeat(500),
+        description: 'Teacher priority: connect decisions to evidence. '.repeat(1_000),
+      },
+      assignmentDocs: [
+        {
+          id: 'assignment-doc-db-456',
+          assignment_id: 'assignment-db-123',
+          student_id: 'student-db-789',
+          content: { type: 'doc', content: [] },
+          authenticity_score: null,
+          authenticity_flags: null,
+          student_name: 'Jane Student',
+        },
+      ],
+      submissionArtifacts: [],
+      pseudonymSalt: 'stable-test-salt',
+      sanitizationContext,
+    })
+
+    expect(result.gradexRequest.assignment.instructions.length).toBeLessThanOrEqual(20_000)
+    expect(result.gradexRequest.assignment.instructions).toContain('Teacher grading guidance:')
+    expect(result.gradexRequest.assignment.instructions).toContain(
+      'Score Workflow only from sanitized process evidence and organization signals.',
+    )
   })
 
   it('uses stable salted pseudonymous refs and changes them when the salt changes', () => {


### PR DESCRIPTION
## Summary

- Includes sanitized assignment instructions and sanitized assignment description in the Pika Gradex assignment payload so Gradex can grade against teacher intent.
- Tightens the fixed Pika-compatible Gradex rubric descriptions for Completion, Thinking, and Workflow.
- Keeps fixed teacher grading guidance inside the existing assignment instructions field without a schema change, including when assignment context is long.
- Expands payload tests around teacher context, PII redaction, rubric shape, and long-context truncation behavior.

## Validation

- `bash scripts/verify-env.sh`
- `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/lib/gradex-assignment-grading.test.ts tests/lib/gradex-smoke-runner.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `git diff --check origin/main..HEAD`

## Review Notes

I reviewed the final diff for privacy and contract risk. One issue found during review was that long assignment context could truncate the appended teacher grading guidance; this PR fixes that by reserving space for the fixed guidance and adds a regression test.