### PR TITLE
Tighten gradebook action controls

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,25 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Classroom bottom controls FAB consistency
-
-**Completed:**
-- Extended `FloatingActionCluster` with a bottom placement for full-width floating controls.
-- Migrated the teacher classroom index edit/view bottom bar off its local fixed chrome and onto the shared floating cluster.
-- Added safe-area-aware bottom placement for mobile classroom controls while preserving the existing centered desktop width.
-- Added component coverage for the migrated bottom bar class contract.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3018 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-classrooms-edit-desktop.png`, `/tmp/pika-classrooms-edit-mobile.png`
-
 ## 2026-05-31 — Assignment status badge consistency
 
 **Completed:**
@@ -949,3 +930,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `git diff --check`
 - `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` (fails in this worktree: `vitest` command unavailable because dependencies are not installed)
+
+## 2026-06-06 — Gradebook action consistency audit
+
+**Completed:**
+- Split the Gradebook floating action controls so score-display mode has its own secondary SplitButton and selected-student email actions only appear after a student selection.
+- Removed the actionable `Email (0)` empty state from the Gradebook tab to match roster-tab behavior.
+- Renamed the Gradebook settings toggle to `Gradebook column controls` in ARIA/title/tooltip text so the action describes the column editor.
+- Updated Gradebook component tests for the split score/email menus, selected-email visibility, and column-controls semantics.
+- Addressed PR review feedback by covering the score-display SplitButton primary action, not only the dropdown radio path.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/6d20a5cb-c497-4dc1-ac74-0637068c8a7f?tab=gradebook'`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
+- Manual Playwright screenshots for selected-email desktop, selected-email mobile, and selected-email dark mode.
+- `git diff --check`
+- `pnpm vitest run tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm lint`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -10,7 +10,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type Ref,
 } from 'react'
-import { ChevronDown, ChevronUp, Copy, Mail, Settings, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, Copy, ListFilter, Mail, Settings, X } from 'lucide-react'
 import type {
   GradebookAssessmentCell,
   GradebookAssessmentColumn,
@@ -1662,7 +1662,7 @@ export function TeacherGradebookTab({
   }
 
   const isSettingsActive = columnEditorOpen
-  const gradebookEmailOptions: SplitButtonOption[] = [
+  const scoreDisplayOptions: SplitButtonOption[] = [
     {
       id: 'show-percent',
       label: 'Show %',
@@ -1675,31 +1675,31 @@ export function TeacherGradebookTab({
       checked: scoreDisplayMode === 'raw',
       onSelect: () => handleScoreDisplayModeChange('raw'),
     },
+  ]
+  const selectedEmailOptions: SplitButtonOption[] = [
     {
       id: 'copy-selected-emails',
       label: `Copy emails (${selectedStudentEmails.length})`,
       icon: <Copy className="h-4 w-4" aria-hidden="true" />,
-      dividerBefore: true,
       onSelect: () => {
         void copySelectedEmailsToClipboard()
       },
-      disabled: selectedStudentEmails.length === 0,
     },
     {
       id: 'gmail-selected-students',
       label: 'Gmail',
       icon: <Mail className="h-4 w-4" aria-hidden="true" />,
       onSelect: () => openGmail(selectedStudentEmails),
-      disabled: selectedStudentEmails.length === 0,
     },
     {
       id: 'outlook-selected-students',
       label: 'Outlook',
       icon: <Mail className="h-4 w-4" aria-hidden="true" />,
       onSelect: () => openOutlook(selectedStudentEmails),
-      disabled: selectedStudentEmails.length === 0,
     },
   ]
+  const nextScoreDisplayMode: ScoreDisplayMode = scoreDisplayMode === 'percent' ? 'raw' : 'percent'
+  const scoreDisplayLabel = scoreDisplayMode === 'percent' ? 'Scores: %' : 'Scores: Raw'
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
@@ -1708,24 +1708,40 @@ export function TeacherGradebookTab({
           <SplitButton
             label={
               <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                <Mail className="h-4 w-4" aria-hidden="true" />
-                <span>Email ({selectedStudentEmails.length})</span>
+                <ListFilter className="h-4 w-4" aria-hidden="true" />
+                <span>{scoreDisplayLabel}</span>
               </span>
             }
-            onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
-            options={gradebookEmailOptions}
+            onPrimaryClick={() => handleScoreDisplayModeChange(nextScoreDisplayMode)}
+            options={scoreDisplayOptions}
+            variant="secondary"
             size="sm"
-            toggleAriaLabel="Gradebook email actions"
+            toggleAriaLabel="Gradebook score display actions"
             menuPlacement="down"
           />
-          <Tooltip content={isSettingsActive ? 'Hide gradebook settings' : 'Show gradebook settings'}>
+          {selectedStudentEmails.length > 0 ? (
+            <SplitButton
+              label={
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <Mail className="h-4 w-4" aria-hidden="true" />
+                  <span>Email ({selectedStudentEmails.length})</span>
+                </span>
+              }
+              onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
+              options={selectedEmailOptions}
+              size="sm"
+              toggleAriaLabel="Gradebook email actions"
+              menuPlacement="down"
+            />
+          ) : null}
+          <Tooltip content={isSettingsActive ? 'Hide gradebook column controls' : 'Show gradebook column controls'}>
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              aria-label="Gradebook settings"
+              aria-label="Gradebook column controls"
               aria-pressed={isSettingsActive}
-              title="Gradebook settings"
+              title="Gradebook column controls"
               className={[
                 'h-9 w-9 px-0',
                 isSettingsActive

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -214,23 +214,31 @@ describe('TeacherGradebookTab', () => {
     expect(firstResize).toHaveAttribute('aria-valuenow', '96')
     fireEvent.keyDown(firstResize, { key: 'ArrowRight' })
     expect(firstResize).toHaveAttribute('aria-valuenow', '104')
-    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
+    expect(screen.queryByRole('button', { name: 'Email (0)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scores: %' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Scores: %' }))
+    expect(screen.getByRole('button', { name: 'Scores: Raw' })).toBeInTheDocument()
+    expect(screen.getByRole('row', { name: /Ada Lovelace.*8\/10 10\/10 9\/10 85\.0%/ })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Scores: Raw' }))
+    expect(screen.getByRole('button', { name: 'Scores: %' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook score display actions' }))
     let gradebookMenu = screen.getByRole('menu')
     const percentToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })
     const rawToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })
     expect(percentToggle).toHaveAttribute('aria-checked', 'true')
     expect(rawToggle).toHaveAttribute('aria-checked', 'false')
-    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Copy emails (0)' })).toBeDisabled()
-    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Gmail' })).toBeDisabled()
-    expect(within(gradebookMenu).getByRole('menuitem', { name: 'Outlook' })).toBeDisabled()
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Copy emails (0)' })).not.toBeInTheDocument()
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Gmail' })).not.toBeInTheDocument()
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Outlook' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Summary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Gradebook view' })).not.toBeInTheDocument()
 
     fireEvent.click(rawToggle)
+    expect(screen.getByRole('button', { name: 'Scores: Raw' })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Ada Lovelace.*8\/10 10\/10 9\/10 85\.0%/ })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Avg.*7\/10 10\/10 8\.5\/10 77\.5%/ })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook score display actions' }))
     gradebookMenu = screen.getByRole('menu')
     expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'false')
     expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'true')
@@ -242,14 +250,14 @@ describe('TeacherGradebookTab', () => {
     expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
     gradebookMenu = screen.getByRole('menu')
-    expect(within(gradebookMenu).getByRole('separator')).toBeInTheDocument()
-    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'true')
+    expect(within(gradebookMenu).queryByRole('separator')).not.toBeInTheDocument()
+    expect(within(gradebookMenu).queryByRole('menuitemradio', { name: 'Show %' })).not.toBeInTheDocument()
     fireEvent.click(within(gradebookMenu).getByRole('menuitem', { name: 'Copy emails (1)' }))
     await waitFor(() => {
       expect(clipboardWriteText).toHaveBeenCalledWith('ada@example.com')
     })
     fireEvent.click(adaSelect)
-    expect(screen.getByRole('button', { name: 'Gradebook settings' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'Gradebook column controls' })).toHaveAttribute('aria-pressed', 'false')
 
     fireEvent.click(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ }))
     const detailPanel = screen.getByRole('region', { name: 'Ada Lovelace assessment details' })
@@ -272,7 +280,7 @@ describe('TeacherGradebookTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'First' }))
     expect(screen.getAllByRole('row')[1]).toHaveTextContent(/AdaLovelace/)
 
-    const settingsToggle = screen.getByRole('button', { name: 'Gradebook settings' })
+    const settingsToggle = screen.getByRole('button', { name: 'Gradebook column controls' })
     expect(settingsToggle).toHaveAttribute('aria-pressed', 'false')
     fireEvent.click(settingsToggle)
 
@@ -331,7 +339,7 @@ describe('TeacherGradebookTab', () => {
     expect(avgRowToggle).not.toBeChecked()
     expect(screen.getByRole('row', { name: /Avg.*70%.*100%.*85%/ })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
     expect(screen.queryByRole('row', { name: /Avg/ })).not.toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Med/ })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Last' })).not.toBeInTheDocument()
@@ -351,7 +359,7 @@ describe('TeacherGradebookTab', () => {
         </TooltipProvider>
       </AppMessageProvider>,
     )
-    expect(screen.getByRole('button', { name: 'Gradebook settings' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Gradebook column controls' })).toHaveAttribute('aria-pressed', 'true')
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
     })
@@ -410,13 +418,13 @@ describe('TeacherGradebookTab', () => {
 
     expect(await screen.findByText('Ada')).toBeInTheDocument()
 
-    const floatingCluster = screen.getByRole('button', { name: 'Gradebook email actions' }).closest('.fixed')
+    const floatingCluster = screen.getByRole('button', { name: 'Gradebook score display actions' }).closest('.fixed')
     expect(floatingCluster).toHaveClass('fixed', 'z-40')
     expect(floatingCluster?.className).not.toContain('z-[70]')
     expect(screen.getByRole('columnheader', { name: 'First' })).toHaveClass('z-30')
     expect(screen.getByRole('columnheader', { name: 'Final' })).toHaveClass('z-20', 'md:z-30')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
     expect(screen.getByRole('columnheader', { name: 'Visible' })).toHaveClass('z-30')
   })
 
@@ -430,19 +438,20 @@ describe('TeacherGradebookTab', () => {
     fireEvent.click(adaSelect)
     expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
 
     expect(onSectionChange).toHaveBeenCalledWith('settings')
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Gradebook email actions' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Email (0)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Gradebook score display actions' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook settings' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
 
     expect(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeChecked()
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Email (0)' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Email (0)' })).not.toBeInTheDocument()
   })
 
   it('renders edit controls with assessment weights only', async () => {


### PR DESCRIPTION
## Summary
- split Gradebook score-display controls from selected-student email actions
- hide Gradebook email actions until at least one student with an email is selected
- rename the settings toggle to Gradebook column controls for clearer ARIA/title/tooltip semantics
- update Gradebook component coverage for score/email menu separation and selected-email visibility

## Composite widget checklist
- Reviewed: yes
- Keyboard behavior: existing SplitButton primitive behavior unchanged; tests cover the new menu semantics with score menuitemradio state and isolated email menuitems
- Semantic state: score-display checked state, hidden empty email action, selected email action, and column-controls aria-pressed covered
- Remaining manual follow-up: none

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/6d20a5cb-c497-4dc1-ac74-0637068c8a7f?tab=gradebook'
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'
- Manual Playwright screenshots for selected-email desktop, selected-email mobile, and selected-email dark mode
- git diff --check
- pnpm vitest run tests/components/TeacherGradebookTab.test.tsx
- node scripts/trim-session-log.mjs --check
- pnpm lint
- pnpm build

## Visual verification
- Teacher desktop/mobile empty Gradebook route: passed
- Teacher desktop/mobile populated Gradebook route: passed
- Teacher selected-email desktop/mobile: passed
- Teacher selected-email dark mode: passed
- Student mobile route check: passed; student is redirected to the student classroom view or denied teacher-only route access as expected