### PR TITLE
Cache teacher calendar reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,27 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Assignment status badge consistency
-
-**Completed:**
-- Moved assignment status badge and icon helpers from raw Tailwind palette classes to semantic design tokens.
-- Made the assignment badge helper own the shared pill shape so student assignment list and editor badges stay aligned.
-- Added the shared status badge to the embedded student assignment editor header, which is the route students use from the assignments tab.
-- Added tests that assert semantic badge/icon contracts and reject raw palette utilities.
-- Used a read-only subagent audit to confirm the live editor route and screenshot path before visual verification.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/assignments.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/StudentAssignmentEditor.feedback-card.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:auth`
-- `E2E_BASE_URL=http://localhost:3019 pnpm e2e:verify assessment-ux-parity`
-- Reviewed screenshots: `/tmp/pika-assignment-list-desktop.png`, `/tmp/pika-assignment-editor-desktop.png`, `/tmp/pika-assignment-list-mobile.png`, `/tmp/pika-assignment-editor-mobile.png`, `artifacts/assessment-ux-parity/student-assignments-reference.png`
-
 ## 2026-05-31 — Class-days shared loader cache
 
 **Completed:**
@@ -949,3 +928,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm vitest run tests/components/TeacherGradebookTab.test.tsx`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-06-06 — Teacher calendar cache audit
+
+**Completed:**
+- Routed `/teacher/calendar` classroom list reads through `fetchJSONWithCache` with a shared teacher-classrooms cache key.
+- Reused the shared class-days client for cached class-day reads instead of raw page-level GETs.
+- Invalidated classroom and class-day caches after calendar generation, class-day toggles, classroom creation, and classroom deletion.
+- Added component coverage for cached classroom/class-day loads plus generation and toggle invalidation behavior.
+- Addressed PR review feedback by moving classroom-list caching to a shared teacher-classrooms client, invalidating it from cross-route classroom mutations, and guarding `/teacher/calendar` against stale overlapping class-day responses.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx`
+- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/CreateClassroomModal.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -28,6 +28,7 @@ import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { ClassroomRowGhost, SortableClassroomRow } from '@/components/SortableClassroomRow'
 import type { Classroom } from '@/types'
+import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 
 interface Props {
   initialClassrooms: Classroom[]
@@ -141,6 +142,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
       if (!res.ok) {
         throw new Error(data.error || 'Failed to save classroom order')
       }
+      invalidateTeacherClassrooms()
     } catch (err: any) {
       setError(err.message || 'Failed to save classroom order')
       refreshActiveClassrooms()
@@ -211,6 +213,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         throw new Error(data.error || 'Failed to archive classroom')
       }
       const updated = data.classroom || classroom
+      invalidateTeacherClassrooms()
       setActiveClassrooms((prev) => prev.filter((c) => c.id !== classroom.id))
       setArchivedClassrooms((prev) => [updated, ...prev.filter((c) => c.id !== classroom.id)])
     } catch (err: any) {
@@ -235,6 +238,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
         throw new Error(data.error || 'Failed to restore classroom')
       }
       const updated = data.classroom || classroom
+      invalidateTeacherClassrooms()
       setArchivedClassrooms((prev) => prev.filter((c) => c.id !== classroom.id))
       setActiveClassrooms((prev) => [updated, ...prev.filter((c) => c.id !== classroom.id)])
     } catch (err: any) {
@@ -254,6 +258,7 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
       if (!res.ok) {
         throw new Error(data.error || 'Failed to delete classroom')
       }
+      invalidateTeacherClassrooms()
       setArchivedClassrooms((prev) => prev.filter((c) => c.id !== classroom.id))
     } catch (err: any) {
       setError(err.message || 'Failed to delete classroom')

--- a/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherSettingsTab.tsx
@@ -29,6 +29,7 @@ import {
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useMarkdownPreference } from '@/contexts/MarkdownPreferenceContext'
 import { DEFAULT_ACTUAL_COURSE_SITE_CONFIG, slugifyCourseSiteValue } from '@/lib/course-site-publishing'
+import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 import { TeacherCalendarTab } from './TeacherCalendarTab'
 import type { ActualCourseSiteConfig, Classroom, ClassroomJoinPolicy, LessonPlanVisibility } from '@/types'
 
@@ -354,6 +355,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to update classroom name')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setTitle(data.classroom?.title || trimmed)
       showMessage({ text: 'Classroom name updated', tone: 'success' })
@@ -384,6 +386,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to update settings')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setAllowEnrollment(!!data.classroom?.allow_enrollment)
       showMessage({ text: 'Settings saved', tone: 'success' })
@@ -414,6 +417,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to update settings')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setJoinPolicy(data.classroom?.join_policy || nextValue)
       showMessage({ text: 'Settings saved', tone: 'success' })
@@ -445,6 +449,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to regenerate join code')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setJoinCode(data.classroom?.class_code || newCode)
       showMessage({ text: 'Join code regenerated', tone: 'success' })
@@ -476,6 +481,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to update visibility setting')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setLessonPlanVisibility(data.classroom?.lesson_plan_visibility || value)
       showMessage({ text: 'Visibility updated', tone: 'success' })
@@ -512,6 +518,7 @@ export function TeacherSettingsTab({
       if (!res.ok) {
         throw new Error(data.error || 'Failed to save syllabus settings')
       }
+      invalidateTeacherClassrooms()
       if (!isCurrentFormGeneration(classroomId, formGeneration)) return
       setActualSiteSlug(data.classroom?.actual_site_slug || '')
       setActualSitePublished(!!data.classroom?.actual_site_published)

--- a/src/app/teacher/calendar/page.tsx
+++ b/src/app/teacher/calendar/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Button, ConfirmDialog, AlertDialog, Tooltip } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
@@ -8,6 +8,8 @@ import { PageActionBar, PageContent, PageLayout, type ActionBarItem } from '@/co
 import { useAlertDialog } from '@/hooks/useAlertDialog'
 import { useDeleteClassroom } from '@/hooks/useDeleteClassroom'
 import type { ClassDay, Classroom } from '@/types'
+import { fetchClassDaysForClassroom, invalidateClassDaysForClassroom } from '@/lib/class-days-client'
+import { fetchTeacherClassrooms, invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 import {
   format,
   startOfMonth,
@@ -39,10 +41,15 @@ export default function CalendarPage() {
   const [startYear, setStartYear] = useState(currentYear)
   const [endMonth, setEndMonth] = useState(1) // January
   const [endYear, setEndYear] = useState(currentYear + 1)
+  const classDaysRequestIdRef = useRef(0)
+  const selectedClassroomIdRef = useRef<string | null>(null)
+  selectedClassroomIdRef.current = selectedClassroom?.id ?? null
 
   const { alertState, showError, showSuccess, closeAlert } = useAlertDialog()
 
   const handleDeleteSuccess = useCallback((deletedId: string) => {
+    invalidateTeacherClassrooms()
+    invalidateClassDaysForClassroom(deletedId)
     const updatedClassrooms = classrooms.filter(c => c.id !== deletedId)
     setClassrooms(updatedClassrooms)
     setSelectedClassroom(updatedClassrooms.length > 0 ? updatedClassrooms[0] : null)
@@ -95,14 +102,13 @@ export default function CalendarPage() {
   useEffect(() => {
     async function loadClassrooms() {
       try {
-        const response = await fetch('/api/teacher/classrooms')
-        const data = await response.json()
+        const nextClassrooms = await fetchTeacherClassrooms()
 
-        setClassrooms(data.classrooms || [])
+        setClassrooms(nextClassrooms)
 
         // Auto-select first classroom
-        if (data.classrooms && data.classrooms.length > 0) {
-          setSelectedClassroom(data.classrooms[0])
+        if (nextClassrooms.length > 0) {
+          setSelectedClassroom(nextClassrooms[0])
         }
       } catch (err) {
         console.error('Error loading classrooms:', err)
@@ -117,15 +123,19 @@ export default function CalendarPage() {
   const loadClassDays = useCallback(async () => {
     const classroomId = selectedClassroom?.id
     if (!classroomId) return
+    const requestId = classDaysRequestIdRef.current + 1
+    classDaysRequestIdRef.current = requestId
 
     setLoadingCalendar(true)
     try {
-      const response = await fetch(`/api/classrooms/${classroomId}/class-days`)
-      const data = await response.json()
-      setClassDays(data.class_days || [])
+      const nextClassDays = await fetchClassDaysForClassroom(classroomId)
+      if (classDaysRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
+      setClassDays(nextClassDays)
     } catch (err) {
+      if (classDaysRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
       console.error('Error loading class days:', err)
     } finally {
+      if (classDaysRequestIdRef.current !== requestId || selectedClassroomIdRef.current !== classroomId) return
       setLoadingCalendar(false)
     }
   }, [selectedClassroom?.id])
@@ -133,6 +143,7 @@ export default function CalendarPage() {
   // Load calendar when classroom selected
   useEffect(() => {
     if (!selectedClassroom) {
+      classDaysRequestIdRef.current += 1
       setClassDays([])
       return
     }
@@ -171,9 +182,9 @@ export default function CalendarPage() {
 
       if (response.ok) {
         // Refresh classroom list to pick up start/end date updates.
-        const classroomsRes = await fetch('/api/teacher/classrooms')
-        const classroomsData = await classroomsRes.json()
-        const nextClassrooms: Classroom[] = classroomsData.classrooms || []
+        invalidateTeacherClassrooms()
+        invalidateClassDaysForClassroom(selectedClassroom.id)
+        const nextClassrooms = await fetchTeacherClassrooms()
         setClassrooms(nextClassrooms)
         const refreshed = nextClassrooms.find(c => c.id === selectedClassroom.id) ?? null
         if (refreshed) setSelectedClassroom(refreshed)
@@ -204,6 +215,7 @@ export default function CalendarPage() {
       })
 
       if (response.ok) {
+        invalidateClassDaysForClassroom(selectedClassroom.id)
         await loadClassDays()
       }
     } catch (err) {
@@ -212,6 +224,8 @@ export default function CalendarPage() {
   }
 
   function handleClassroomCreated(classroom: Classroom) {
+    invalidateTeacherClassrooms()
+    invalidateClassDaysForClassroom(classroom.id)
     setClassrooms([classroom, ...classrooms])
     setSelectedClassroom(classroom)
   }

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { Input, Button, DialogPanel, FormField, SplitButton } from '@/ui'
 import { format } from 'date-fns'
 import type { CourseBlueprint } from '@/types'
+import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 
 type WizardStep = 'name' | 'blueprint' | 'calendar'
 type CalendarMode = 'preset' | 'custom'
@@ -216,6 +217,7 @@ export function CreateClassroomModal({
         })
       }
 
+      invalidateTeacherClassrooms()
       onSuccess(classroom)
       resetForm()
       onClose()

--- a/src/hooks/useDeleteClassroom.ts
+++ b/src/hooks/useDeleteClassroom.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import type { Classroom } from '@/types'
+import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 
 interface UseDeleteClassroomOptions {
   onSuccess: (deletedId: string) => void
@@ -38,6 +39,7 @@ export function useDeleteClassroom({ onSuccess, onError }: UseDeleteClassroomOpt
         return
       }
 
+      invalidateTeacherClassrooms()
       onSuccess(classroomToDelete.id)
     } catch (err) {
       console.error('Error deleting classroom:', err)

--- a/src/lib/teacher-classrooms-client.ts
+++ b/src/lib/teacher-classrooms-client.ts
@@ -1,0 +1,31 @@
+import type { Classroom } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+
+type TeacherClassroomsResponse = {
+  classrooms?: Classroom[]
+}
+
+export const TEACHER_CLASSROOMS_CACHE_KEY = 'teacher-classrooms:list'
+const TEACHER_CLASSROOMS_CACHE_TTL_MS = 20_000
+
+export async function fetchTeacherClassrooms(): Promise<Classroom[]> {
+  const data = await fetchJSONWithCache<TeacherClassroomsResponse>(
+    TEACHER_CLASSROOMS_CACHE_KEY,
+    async () => {
+      const response = await fetch('/api/teacher/classrooms')
+      const data = await response.json().catch(() => ({ classrooms: [] }))
+      if (!response.ok) {
+        const message = typeof data.error === 'string' ? data.error : 'Failed to load classrooms'
+        throw new Error(message)
+      }
+      return data
+    },
+    TEACHER_CLASSROOMS_CACHE_TTL_MS,
+  )
+
+  return data.classrooms || []
+}
+
+export function invalidateTeacherClassrooms() {
+  invalidateCachedJSON(TEACHER_CLASSROOMS_CACHE_KEY)
+}

--- a/tests/components/TeacherCalendarPage.test.tsx
+++ b/tests/components/TeacherCalendarPage.test.tsx
@@ -1,0 +1,248 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import CalendarPage from '@/app/teacher/calendar/page'
+import { AppMessageProvider, TooltipProvider } from '@/ui'
+import { createMockClassroom } from '../helpers/mocks'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import type { ClassDay, Classroom } from '@/types'
+
+vi.mock('@/components/CreateClassroomModal', () => ({
+  CreateClassroomModal: () => null,
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div>Loading...</div>,
+}))
+
+vi.mock('@/components/PageLayout', () => ({
+  PageLayout: ({ children }: any) => <div>{children}</div>,
+  PageContent: ({ children }: any) => <div>{children}</div>,
+  PageActionBar: ({ primary, actions = [] }: any) => (
+    <div>
+      <div data-testid="calendar-action-primary">{primary}</div>
+      {actions.map((action: any) => (
+        <button key={action.id} type="button" onClick={action.onSelect}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: vi.fn((_key: string, load: () => Promise<unknown>) => load()),
+  invalidateCachedJSON: vi.fn(),
+  invalidateCachedJSONMatching: vi.fn(),
+  prefetchJSON: vi.fn(),
+}))
+
+function renderCalendarPage() {
+  return render(
+    <TooltipProvider>
+      <AppMessageProvider>
+        <CalendarPage />
+      </AppMessageProvider>
+    </TooltipProvider>,
+  )
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
+function classDay(date: string, isClassDay = true): ClassDay {
+  return {
+    date,
+    is_class_day: isClassDay,
+    prompt_text: null,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function installFetchMock(options?: {
+  classrooms?: Classroom[]
+  classDays?: ClassDay[]
+  classDaysByClassroom?: Record<string, ClassDay[] | Promise<{ class_days: ClassDay[] }>>
+}) {
+  const classrooms = options?.classrooms ?? [
+    createMockClassroom({
+      id: 'c1',
+      title: 'Calendar Class',
+      class_code: 'CAL01',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+    }),
+  ]
+  const classDays = options?.classDays ?? []
+
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+
+    if (url === '/api/teacher/classrooms' && method === 'GET') {
+      return Promise.resolve(jsonResponse({ classrooms }))
+    }
+
+    if (url === '/api/classrooms/c1/class-days' && method === 'GET') {
+      const payload = options?.classDaysByClassroom?.c1 ?? classDays
+      return Promise.resolve({
+        ok: true,
+        json: async () => Array.isArray(payload) ? { class_days: payload } : payload,
+      } as Response)
+    }
+
+    if (url === '/api/classrooms/c2/class-days' && method === 'GET') {
+      const payload = options?.classDaysByClassroom?.c2 ?? []
+      return Promise.resolve({
+        ok: true,
+        json: async () => Array.isArray(payload) ? { class_days: payload } : payload,
+      } as Response)
+    }
+
+    if (url === '/api/classrooms/c1/class-days' && method === 'POST') {
+      return Promise.resolve(jsonResponse({ ok: true }))
+    }
+
+    if (url === '/api/classrooms/c1/class-days' && method === 'PATCH') {
+      return Promise.resolve(jsonResponse({ ok: true }))
+    }
+
+    return Promise.reject(new Error(`Unexpected fetch: ${method} ${url}`))
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('Teacher calendar page', () => {
+  beforeEach(() => {
+    vi.mocked(fetchJSONWithCache).mockImplementation((_key, load) => load())
+    vi.mocked(invalidateCachedJSON).mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('loads classrooms and class days through the shared request cache', async () => {
+    installFetchMock()
+
+    renderCalendarPage()
+
+    expect(await screen.findByText('Create Calendar')).toBeInTheDocument()
+    expect(fetchJSONWithCache).toHaveBeenCalledWith(
+      'teacher-classrooms:list',
+      expect.any(Function),
+      20_000,
+    )
+    expect(fetchJSONWithCache).toHaveBeenCalledWith(
+      'class-days:c1',
+      expect.any(Function),
+      20_000,
+    )
+  })
+
+  it('invalidates classroom and class-day reads after generating a calendar', async () => {
+    const fetchMock = installFetchMock()
+
+    renderCalendarPage()
+
+    expect(await screen.findByText('Create Calendar')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Semester 2/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Calendar' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/classrooms/c1/class-days',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+    expect(invalidateCachedJSON).toHaveBeenCalledWith('teacher-classrooms:list')
+    expect(invalidateCachedJSON).toHaveBeenCalledWith('class-days:c1')
+  })
+
+  it('ignores stale class-day responses after switching classrooms', async () => {
+    const firstClassroom = createMockClassroom({
+      id: 'c1',
+      title: 'First Class',
+      class_code: 'FIRST',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+    })
+    const secondClassroom = createMockClassroom({
+      id: 'c2',
+      title: 'Second Class',
+      class_code: 'SECOND',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+    })
+    const firstLoad = deferred<{ class_days: ClassDay[] }>()
+    const secondLoad = deferred<{ class_days: ClassDay[] }>()
+    installFetchMock({
+      classrooms: [firstClassroom, secondClassroom],
+      classDaysByClassroom: {
+        c1: firstLoad.promise,
+        c2: secondLoad.promise,
+      },
+    })
+
+    renderCalendarPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Second Class/ }))
+
+    await act(async () => {
+      secondLoad.resolve({ class_days: [classDay('2026-06-09')] })
+    })
+
+    await screen.findByRole('button', { name: '9' })
+
+    await act(async () => {
+      firstLoad.resolve({ class_days: [classDay('2026-06-08'), classDay('2026-06-10')] })
+    })
+
+    expect(screen.getAllByText('Second Class')).toHaveLength(2)
+    const actionPrimary = screen.getByTestId('calendar-action-primary')
+    expect(within(actionPrimary).getByText('Second Class')).toBeInTheDocument()
+    expect(actionPrimary).toHaveTextContent('1 class days')
+    expect(
+      screen.queryByText((_, element) => element?.textContent?.includes('2 class days') ?? false)
+    ).not.toBeInTheDocument()
+  })
+
+  it('invalidates class-day reads after toggling a class day', async () => {
+    const fetchMock = installFetchMock({
+      classDays: [classDay('2026-06-08')],
+    })
+
+    renderCalendarPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: '8' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/classrooms/c1/class-days',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({
+            date: '2026-06-08',
+            is_class_day: false,
+          }),
+        }),
+      )
+    })
+    expect(invalidateCachedJSON).toHaveBeenCalledWith('class-days:c1')
+  })
+})


### PR DESCRIPTION
## Summary
- route /teacher/calendar classroom list reads through a shared teacher-classrooms fetchJSONWithCache client
- reuse the shared class-days client for cached class-day GETs
- invalidate classroom/class-day cache entries after generation, class-day toggles, classroom creation, deletion, archive/restore, reorder, and settings updates
- guard calendar class-day loads so stale overlapping responses cannot overwrite the currently selected classroom
- add component coverage for cache usage, invalidation behavior, and out-of-order class-day responses

## Risk profile
- Systems/data-flow slice; no UI layout/styling change.
- Risk profile: none. This deduplicates repeated GETs and invalidates after existing classroom/class-day mutations.
- Model recommendation used: GPT-5.5 medium for client cache/invalidation behavior and component regression coverage.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/TeacherCalendarPage.test.tsx
- pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts
- pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/CreateClassroomModal.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- pnpm test

## UI verification
- Not run: no visual layout, styling, or interaction presentation changed; this is a systems/cache slice.