### PR TITLE
Cache teacher blueprint reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,18 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Gradex assignment adapter payload foundation
-
-**Completed:**
-- Added a server-side Gradex assignment payload builder for Pika assignment grading.
-- Produces both the Pika adapter request and the async Gradex `grading-runs` create request, plus local pseudonym mapping for the later polling slice.
-- Sanitizes assignment text and submission text, pseudonymizes assignment/submission/student/grade refs with an HMAC salt, summarizes artifacts by type/count only, and keeps provider/model/tier selection as Gradex-owned `auto` settings.
-- Added privacy and contract coverage proving raw Pika IDs, identity fields, raw history fields, repo identities, and raw URLs are excluded from the Gradex request.
-
-**Validation:**
-- `pnpm vitest run tests/lib/gradex-assignment-payload.test.ts`
-- `pnpm exec tsc --noEmit`
-
 ## 2026-05-31 — Student exam-mode e2e telemetry coverage
 
 **Completed:**
@@ -948,3 +936,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`
+
+## 2026-06-06 — Teacher blueprints cache audit
+
+**Completed:**
+- Routed `/teacher/blueprints` list and detail reads through a verified-user-scoped `fetchJSONWithCache` helper.
+- Bypassed blueprint caching when `/api/auth/me` cannot verify a user id.
+- Invalidated blueprint caches after metadata, content, planned-site, import, AI, merge, and create mutations.
+- Addressed PR review feedback by also invalidating blueprint caches after course-package imports and blueprint instantiation from `CreateClassroomModal`.
+- Added request-generation guards so stale blueprint detail responses cannot overwrite the active selection.
+- Added component/unit coverage for scoped cache keys, stale detail responses, mutation invalidation, modal import/instantiate invalidation, and auth-scope cache bypass.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed on pre-existing blueprint component fixture gap)
+- `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/course-blueprints-route.test.ts tests/api/teacher/course-blueprint-publication-routes.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`

--- a/src/app/teacher/blueprints/page.tsx
+++ b/src/app/teacher/blueprints/page.tsx
@@ -24,6 +24,11 @@ import {
   DEFAULT_PLANNED_COURSE_SITE_CONFIG,
   slugifyCourseSiteValue,
 } from '@/lib/course-site-publishing'
+import {
+  fetchTeacherBlueprintDetail,
+  fetchTeacherBlueprints,
+  invalidateTeacherBlueprints,
+} from '@/lib/teacher-blueprints-client'
 import type {
   BlueprintMergeSuggestionSet,
   CourseBlueprint,
@@ -134,6 +139,9 @@ export default function TeacherBlueprintsPage() {
   const [mergeSelection, setMergeSelection] = useState<Record<string, boolean>>({})
   const [mergeLoading, setMergeLoading] = useState(false)
   const [mergeApplying, setMergeApplying] = useState(false)
+  const detailRequestIdRef = useRef(0)
+  const selectedBlueprintIdRef = useRef<string | null>(null)
+  selectedBlueprintIdRef.current = selectedBlueprintId
   const preferredBlueprintId = searchParams.get('blueprint')
   const fromClassroomId = searchParams.get('fromClassroom')
 
@@ -159,12 +167,7 @@ export default function TeacherBlueprintsPage() {
     setLoadingList(true)
     setError('')
     try {
-      const response = await fetch('/api/teacher/course-blueprints')
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to load course blueprints')
-      }
-      const nextBlueprints = (data.blueprints || []) as CourseBlueprint[]
+      const nextBlueprints = await fetchTeacherBlueprints()
       setBlueprints(nextBlueprints)
       setSelectedBlueprintId((current) => preferredId || current || nextBlueprints[0]?.id || null)
     } catch (err: any) {
@@ -175,15 +178,13 @@ export default function TeacherBlueprintsPage() {
   }
 
   async function loadDetail(id: string) {
+    const requestId = detailRequestIdRef.current + 1
+    detailRequestIdRef.current = requestId
     setLoadingDetail(true)
     setError('')
     try {
-      const response = await fetch(`/api/teacher/course-blueprints/${id}`)
-      const data = await response.json().catch(() => ({}))
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to load course blueprint')
-      }
-      const blueprint = data.blueprint as CourseBlueprintDetail
+      const blueprint = await fetchTeacherBlueprintDetail(id)
+      if (detailRequestIdRef.current !== requestId || selectedBlueprintIdRef.current !== id) return
       setDetail(blueprint)
       setMeta({
         title: blueprint.title,
@@ -212,8 +213,10 @@ export default function TeacherBlueprintsPage() {
       setAiPreview(null)
       setAiAnalysis(null)
     } catch (err: any) {
+      if (detailRequestIdRef.current !== requestId || selectedBlueprintIdRef.current !== id) return
       setError(err.message || 'Failed to load course blueprint')
     } finally {
+      if (detailRequestIdRef.current !== requestId || selectedBlueprintIdRef.current !== id) return
       setLoadingDetail(false)
     }
   }
@@ -224,6 +227,7 @@ export default function TeacherBlueprintsPage() {
 
   useEffect(() => {
     if (!selectedBlueprintId) {
+      detailRequestIdRef.current += 1
       setDetail(null)
       return
     }
@@ -244,6 +248,7 @@ export default function TeacherBlueprintsPage() {
       if (!response.ok) {
         throw new Error(data.error || 'Failed to save metadata')
       }
+      invalidateTeacherBlueprints()
       await loadBlueprints(selectedBlueprintId)
       await loadDetail(selectedBlueprintId)
     } catch (err: any) {
@@ -319,6 +324,7 @@ export default function TeacherBlueprintsPage() {
         }
       }
 
+      invalidateTeacherBlueprints()
       await loadBlueprints(selectedBlueprintId)
       await loadDetail(selectedBlueprintId)
     } catch (err: any) {
@@ -346,6 +352,7 @@ export default function TeacherBlueprintsPage() {
       if (!response.ok) {
         throw new Error(data.error || 'Failed to save planned site settings')
       }
+      invalidateTeacherBlueprints()
       await loadBlueprints(selectedBlueprintId)
       await loadDetail(selectedBlueprintId)
     } catch (err: any) {
@@ -405,6 +412,7 @@ export default function TeacherBlueprintsPage() {
       if (!response.ok) {
         throw new Error(data.error || 'Failed to save classroom changes to the course blueprint')
       }
+      invalidateTeacherBlueprints()
       await loadDetail(selectedBlueprintId)
       await loadMergeSuggestions(mergeClassroomId)
     } catch (err: any) {
@@ -466,6 +474,7 @@ export default function TeacherBlueprintsPage() {
       if (!response.ok) {
         throw new Error(data.errors?.join('\n') || data.error || 'Failed to import course package')
       }
+      invalidateTeacherBlueprints()
       await loadBlueprints(data.blueprint.id)
     } catch (err: any) {
       setError(err.message || 'Failed to import course package')
@@ -518,6 +527,7 @@ export default function TeacherBlueprintsPage() {
       }
       setActiveTab(aiPreview.target === 'lesson-plans' ? 'lesson-plans' : aiPreview.target)
       setAiPreview(null)
+      invalidateTeacherBlueprints()
       await loadDetail(selectedBlueprintId)
     } catch (err: any) {
       setError(err.message || 'Failed to apply copilot preview')
@@ -942,6 +952,7 @@ export default function TeacherBlueprintsPage() {
         onClose={() => setShowCreate(false)}
         onSuccess={async (blueprint) => {
           setShowCreate(false)
+          invalidateTeacherBlueprints()
           await loadBlueprints(blueprint.id)
         }}
       />

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -5,6 +5,7 @@ import { Input, Button, DialogPanel, FormField, SplitButton } from '@/ui'
 import { format } from 'date-fns'
 import type { CourseBlueprint } from '@/types'
 import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
+import { invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
 
 type WizardStep = 'name' | 'blueprint' | 'calendar'
 type CalendarMode = 'preset' | 'custom'
@@ -142,6 +143,7 @@ export function CreateClassroomModal({
       }
 
       const blueprint = data.blueprint as CourseBlueprint
+      invalidateTeacherBlueprints()
       setAvailableBlueprints((current) => {
         const withoutImported = current.filter((item) => item.id !== blueprint.id)
         return [blueprint, ...withoutImported]
@@ -194,6 +196,7 @@ export function CreateClassroomModal({
           throw new Error(instantiateData.error || 'Failed to create classroom from blueprint')
         }
         classroom = instantiateData.classroom
+        invalidateTeacherBlueprints()
       } else {
         const createResponse = await fetch('/api/teacher/classrooms', {
           method: 'POST',

--- a/src/lib/teacher-blueprints-client.ts
+++ b/src/lib/teacher-blueprints-client.ts
@@ -1,0 +1,78 @@
+import type { CourseBlueprint, CourseBlueprintDetail } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+
+type TeacherBlueprintsResponse = {
+  blueprints?: CourseBlueprint[]
+}
+
+type TeacherBlueprintDetailResponse = {
+  blueprint?: CourseBlueprintDetail
+}
+
+export const TEACHER_BLUEPRINTS_CACHE_PREFIX = 'teacher-blueprints:'
+const TEACHER_BLUEPRINTS_CACHE_TTL_MS = 20_000
+
+async function getTeacherBlueprintsCacheScope(): Promise<string | null> {
+  const response = await fetch('/api/auth/me', { cache: 'no-store' })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok || typeof data.user?.id !== 'string') {
+    return null
+  }
+  return data.user.id
+}
+
+async function fetchTeacherBlueprintsFromApi(): Promise<TeacherBlueprintsResponse> {
+  const response = await fetch('/api/teacher/course-blueprints')
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to load course blueprints')
+  }
+  return data
+}
+
+async function fetchTeacherBlueprintDetailFromApi(id: string): Promise<TeacherBlueprintDetailResponse> {
+  const response = await fetch(`/api/teacher/course-blueprints/${id}`)
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to load course blueprint')
+  }
+  return data
+}
+
+export async function fetchTeacherBlueprints(): Promise<CourseBlueprint[]> {
+  const scope = await getTeacherBlueprintsCacheScope()
+  if (!scope) {
+    const data = await fetchTeacherBlueprintsFromApi()
+    return data.blueprints || []
+  }
+
+  const data = await fetchJSONWithCache<TeacherBlueprintsResponse>(
+    `${TEACHER_BLUEPRINTS_CACHE_PREFIX}${scope}:list`,
+    fetchTeacherBlueprintsFromApi,
+    TEACHER_BLUEPRINTS_CACHE_TTL_MS,
+  )
+
+  return data.blueprints || []
+}
+
+export async function fetchTeacherBlueprintDetail(id: string): Promise<CourseBlueprintDetail> {
+  const scope = await getTeacherBlueprintsCacheScope()
+  if (!scope) {
+    const data = await fetchTeacherBlueprintDetailFromApi(id)
+    if (!data.blueprint) throw new Error('Failed to load course blueprint')
+    return data.blueprint
+  }
+
+  const data = await fetchJSONWithCache<TeacherBlueprintDetailResponse>(
+    `${TEACHER_BLUEPRINTS_CACHE_PREFIX}${scope}:detail:${id}`,
+    () => fetchTeacherBlueprintDetailFromApi(id),
+    TEACHER_BLUEPRINTS_CACHE_TTL_MS,
+  )
+
+  if (!data.blueprint) throw new Error('Failed to load course blueprint')
+  return data.blueprint
+}
+
+export function invalidateTeacherBlueprints() {
+  invalidateCachedJSONMatching(TEACHER_BLUEPRINTS_CACHE_PREFIX)
+}

--- a/tests/components/CreateClassroomModal.test.tsx
+++ b/tests/components/CreateClassroomModal.test.tsx
@@ -2,7 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
+import { invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
 import type { CourseBlueprint } from '@/types'
+
+vi.mock('@/lib/teacher-blueprints-client', () => ({
+  invalidateTeacherBlueprints: vi.fn(),
+}))
+
+vi.mock('@/lib/teacher-classrooms-client', () => ({
+  invalidateTeacherClassrooms: vi.fn(),
+}))
 
 const mockBlueprint: CourseBlueprint = {
   id: 'bp-1',
@@ -40,6 +49,7 @@ describe('CreateClassroomModal', () => {
       json: async () => ({ blueprints: [mockBlueprint] }),
     })
     vi.stubGlobal('fetch', fetchMock)
+    vi.mocked(invalidateTeacherBlueprints).mockClear()
   })
 
   afterEach(() => {
@@ -156,10 +166,55 @@ describe('CreateClassroomModal', () => {
     await waitFor(() => {
       expect(getBlueprintSelect()).toHaveValue(mockBlueprint.id)
     })
+    expect(invalidateTeacherBlueprints).toHaveBeenCalledOnce()
     expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }))
     expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
+  })
+
+  it('invalidates blueprint caches after creating a classroom from a blueprint', async () => {
+    const onSuccess = vi.fn()
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+      if (url === '/api/teacher/course-blueprints' && method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ blueprints: [mockBlueprint] }),
+        }
+      }
+      if (url === `/api/teacher/course-blueprints/${mockBlueprint.id}/instantiate` && method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({ classroom: { id: 'classroom-1', title: 'Computer Science 11 - Period 2' } }),
+        }
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    renderModal({ initialBlueprintId: mockBlueprint.id, onSuccess })
+
+    fireEvent.change(getClassroomNameInput(), {
+      target: { value: 'Computer Science 11 - Period 2' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(await screen.findByRole('combobox', { name: /course blueprint/i })).toHaveValue(mockBlueprint.id)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(await screen.findByText('Choose Calendar')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/teacher/course-blueprints/${mockBlueprint.id}/instantiate`,
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+    expect(invalidateTeacherBlueprints).toHaveBeenCalledOnce()
+    expect(onSuccess).toHaveBeenCalledWith({ id: 'classroom-1', title: 'Computer Science 11 - Period 2' })
   })
 
   it('preserves the preselected blueprint flow when launched from the blueprints page', async () => {

--- a/tests/components/TeacherBlueprintsPage.test.tsx
+++ b/tests/components/TeacherBlueprintsPage.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import TeacherBlueprintsPage from '@/app/teacher/blueprints/page'
+import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
 
 const mockPush = vi.fn()
 let searchParamsMap = new Map<string, string>()
@@ -37,6 +38,13 @@ vi.mock('@/components/CreateClassroomModal', () => ({
 
 vi.mock('@/components/Spinner', () => ({
   Spinner: () => <div>Loading…</div>,
+}))
+
+vi.mock('@/lib/request-cache', () => ({
+  fetchJSONWithCache: vi.fn((_key: string, load: () => Promise<unknown>) => load()),
+  invalidateCachedJSON: vi.fn(),
+  invalidateCachedJSONMatching: vi.fn(),
+  prefetchJSON: vi.fn(),
 }))
 
 const blueprintList = [
@@ -96,6 +104,23 @@ const blueprintDetail = {
   ],
 }
 
+const blueprintOneDetail = {
+  ...blueprintDetail,
+  id: 'b-1',
+  title: 'Blueprint One',
+  subject: '',
+  grade_level: '',
+  course_code: '',
+  linked_classrooms: [],
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
 describe('TeacherBlueprintsPage', () => {
   beforeEach(() => {
     searchParamsMap = new Map([
@@ -103,19 +128,25 @@ describe('TeacherBlueprintsPage', () => {
       ['fromClassroom', 'c-9'],
     ])
     mockPush.mockClear()
-    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+    vi.mocked(fetchJSONWithCache).mockImplementation((_key, load) => load())
+    vi.mocked(invalidateCachedJSONMatching).mockClear()
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url === '/api/teacher/course-blueprints') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ blueprints: blueprintList }),
-        })
+      const method = init?.method || 'GET'
+      if (url === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ user: { id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' } }))
       }
-      if (url === '/api/teacher/course-blueprints/b-2') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ blueprint: blueprintDetail }),
-        })
+      if (url === '/api/teacher/course-blueprints' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ blueprints: blueprintList }))
+      }
+      if (url === '/api/teacher/course-blueprints/b-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ blueprint: blueprintOneDetail }))
+      }
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ blueprint: blueprintDetail }))
+      }
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'PATCH') {
+        return Promise.resolve(jsonResponse({ blueprint: blueprintDetail }))
       }
       return Promise.reject(new Error(`Unexpected fetch: ${url}`))
     }) as any)
@@ -143,5 +174,69 @@ describe('TeacherBlueprintsPage', () => {
     expect(screen.getByText('Portable Course Package')).toBeInTheDocument()
     expect(screen.getByText(/Exports a .course-package.tar file with manifest.json and editable Markdown files./)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Quizzes' })).toBeNull()
+    expect(fetchJSONWithCache).toHaveBeenCalledWith(
+      'teacher-blueprints:teacher-1:list',
+      expect.any(Function),
+      20_000,
+    )
+    expect(fetchJSONWithCache).toHaveBeenCalledWith(
+      'teacher-blueprints:teacher-1:detail:b-2',
+      expect.any(Function),
+      20_000,
+    )
+  })
+
+  it('ignores stale detail responses after selecting a different blueprint', async () => {
+    let resolveDelayedDetail: ((response: Response) => void) | undefined
+    const delayedDetail = new Promise<Response>((resolve) => {
+      resolveDelayedDetail = resolve
+    })
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method || 'GET'
+      if (url === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ user: { id: 'teacher-1', email: 'teacher@example.com', role: 'teacher' } }))
+      }
+      if (url === '/api/teacher/course-blueprints' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ blueprints: blueprintList }))
+      }
+      if (url === '/api/teacher/course-blueprints/b-2' && method === 'GET') {
+        return delayedDetail
+      }
+      if (url === '/api/teacher/course-blueprints/b-1' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ blueprint: blueprintOneDetail }))
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    }) as any)
+
+    render(<TeacherBlueprintsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Blueprint One/ }))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Blueprint One')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      resolveDelayedDetail?.(jsonResponse({ blueprint: blueprintDetail }))
+      await delayedDetail
+    })
+
+    expect(screen.getByDisplayValue('Blueprint One')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('Blueprint Two')).toBeNull()
+  })
+
+  it('invalidates blueprint caches before reloading after saving metadata', async () => {
+    render(<TeacherBlueprintsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Blueprint Two')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Details' }))
+
+    await waitFor(() => {
+      expect(invalidateCachedJSONMatching).toHaveBeenCalledWith('teacher-blueprints:')
+    })
   })
 })

--- a/tests/unit/teacher-blueprints-client.test.ts
+++ b/tests/unit/teacher-blueprints-client.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchTeacherBlueprints, invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
+describe('teacher blueprints client', () => {
+  afterEach(() => {
+    invalidateTeacherBlueprints()
+    vi.unstubAllGlobals()
+  })
+
+  it('bypasses shared caching when the current user id cannot be verified', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ error: 'Temporary auth failure' }, false))
+      .mockResolvedValueOnce(jsonResponse({ blueprints: [{ id: 'teacher-a-blueprint' }] }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Temporary auth failure' }, false))
+      .mockResolvedValueOnce(jsonResponse({ blueprints: [{ id: 'teacher-b-blueprint' }] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchTeacherBlueprints()).resolves.toEqual([{ id: 'teacher-a-blueprint' }])
+    await expect(fetchTeacherBlueprints()).resolves.toEqual([{ id: 'teacher-b-blueprint' }])
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/teacher/course-blueprints')
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/teacher/course-blueprints')
+  })
+})


### PR DESCRIPTION
## Summary
- add a teacher blueprints client that scopes list/detail caches by verified /api/auth/me user id
- route /teacher/blueprints list/detail reads through the cache helper and bypass caching when auth scope cannot be verified
- invalidate blueprint caches after blueprint mutations and guard against stale detail responses overwriting the active selection
- add coverage for scoped cache keys, stale detail responses, mutation invalidation, and auth-scope cache bypass

## Validation
- pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts
- pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/course-blueprints-route.test.ts tests/api/teacher/course-blueprint-publication-routes.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- pnpm test