### PR TITLE
Cache student classroom reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,18 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Student exam-mode e2e telemetry coverage
-
-**Completed:**
-- Extended the existing student exam-mode Playwright flow for sustained window loss.
-- Asserted that a sustained resize records a window/full-screen exit and does not increment route-exit telemetry.
-- Preserved existing checks for content locking, restoration, and open-response draft survival.
-
-**Validation:**
-- `VITEST_MAX_WORKERS=4 bash scripts/verify-env.sh`
-- `E2E_BASE_URL=http://localhost:3100 pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "locks content only after sustained window loss"`
-- `pnpm lint`
-
 ## 2026-05-31 — PageActionBar mobile menu focus
 
 **Completed:**
@@ -951,6 +939,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed on pre-existing blueprint component fixture gap)
 - `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts`
 - `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/course-blueprints-route.test.ts tests/api/teacher/course-blueprint-publication-routes.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+
+## 2026-06-06 — Student classrooms cache audit
+
+**Completed:**
+- Added a verified-user-scoped `student-classrooms` client for `/api/student/classrooms` repeated reads.
+- Routed `/student/history` classroom list reads through the shared cache helper.
+- Invalidated student classroom caches after joining from `/student/history` and `/join/[code]`.
+- Added coverage for scoped list caching, auth-scope cache bypass, history-page cache usage, and join invalidation.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/components/StudentHistoryTab.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/api/student/classrooms.test.ts tests/api/student/classrooms-join.test.ts tests/api/student/classrooms-id.test.ts tests/unit/request-cache.test.ts`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type FormEvent } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { Spinner } from '@/components/Spinner'
 import { Button, FormField, Input } from '@/ui'
+import { invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
 
 export default function JoinClassroomPage() {
   const router = useRouter()
@@ -59,6 +60,7 @@ export default function JoinClassroomPage() {
         throw new Error(data?.error || 'Unable to join. Check your code and email, or ask your teacher to add you.')
       }
 
+      invalidateStudentClassrooms()
       router.push(`/classrooms/${data.classroom.id}?tab=today`)
     } catch (err: any) {
       console.error('Join error:', err)

--- a/src/app/student/history/page.tsx
+++ b/src/app/student/history/page.tsx
@@ -8,6 +8,7 @@ import type { Entry, ClassDay, AttendanceStatus, Classroom } from '@/types'
 import { entryHasContent, getAttendanceIcon, getAttendanceLabel } from '@/lib/attendance'
 import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
 import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
+import { fetchStudentClassrooms, invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
 import { getTodayInToronto } from '@/lib/timezone'
 
 interface HistoryEntry {
@@ -34,14 +35,13 @@ export default function HistoryPage() {
   useEffect(() => {
     async function loadClassrooms() {
       try {
-        const response = await fetch('/api/student/classrooms')
-        const data = await response.json()
+        const nextClassrooms = await fetchStudentClassrooms()
 
-        setClassrooms(data.classrooms || [])
+        setClassrooms(nextClassrooms)
 
         // Auto-select first classroom
-        if (data.classrooms && data.classrooms.length > 0) {
-          setSelectedClassroom(data.classrooms[0])
+        if (nextClassrooms.length > 0) {
+          setSelectedClassroom(nextClassrooms[0])
         }
       } catch (err) {
         console.error('Error loading classrooms:', err)
@@ -140,7 +140,8 @@ export default function HistoryPage() {
       }
 
       // Add to list and select
-      setClassrooms([data.classroom, ...classrooms])
+      invalidateStudentClassrooms()
+      setClassrooms((current) => [data.classroom, ...current.filter((classroom) => classroom.id !== data.classroom.id)])
       setSelectedClassroom(data.classroom)
       setJoinCode('')
       setShowJoinFlow(false)

--- a/src/lib/student-classrooms-client.ts
+++ b/src/lib/student-classrooms-client.ts
@@ -1,0 +1,48 @@
+import type { Classroom } from '@/types'
+import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+
+type StudentClassroomsResponse = {
+  classrooms?: Classroom[]
+}
+
+export const STUDENT_CLASSROOMS_CACHE_PREFIX = 'student-classrooms:'
+const STUDENT_CLASSROOMS_CACHE_TTL_MS = 20_000
+
+async function getStudentClassroomsCacheKey(): Promise<string | null> {
+  const response = await fetch('/api/auth/me', { cache: 'no-store' })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok || typeof data.user?.id !== 'string') {
+    return null
+  }
+  return `${STUDENT_CLASSROOMS_CACHE_PREFIX}${data.user.id}:list`
+}
+
+async function fetchStudentClassroomsFromApi(): Promise<StudentClassroomsResponse> {
+  const response = await fetch('/api/student/classrooms')
+  const data = await response.json().catch(() => ({ classrooms: [] }))
+  if (!response.ok) {
+    const message = typeof data.error === 'string' ? data.error : 'Failed to load classrooms'
+    throw new Error(message)
+  }
+  return data
+}
+
+export async function fetchStudentClassrooms(): Promise<Classroom[]> {
+  const cacheKey = await getStudentClassroomsCacheKey()
+  if (!cacheKey) {
+    const data = await fetchStudentClassroomsFromApi()
+    return data.classrooms || []
+  }
+
+  const data = await fetchJSONWithCache<StudentClassroomsResponse>(
+    cacheKey,
+    fetchStudentClassroomsFromApi,
+    STUDENT_CLASSROOMS_CACHE_TTL_MS,
+  )
+
+  return data.classrooms || []
+}
+
+export function invalidateStudentClassrooms() {
+  invalidateCachedJSONMatching(STUDENT_CLASSROOMS_CACHE_PREFIX)
+}

--- a/tests/components/JoinClassroomPage.test.tsx
+++ b/tests/components/JoinClassroomPage.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import JoinClassroomPage from '@/app/join/[code]/page'
+import { invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
+
+const push = vi.hoisted(() => vi.fn())
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ code: 'ABC123' }),
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div>Loading...</div>,
+}))
+
+vi.mock('@/lib/student-classrooms-client', () => ({
+  invalidateStudentClassrooms: vi.fn(),
+}))
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
+describe('JoinClassroomPage', () => {
+  beforeEach(() => {
+    push.mockClear()
+    vi.mocked(invalidateStudentClassrooms).mockClear()
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(
+      jsonResponse({ classroom: { id: 'classroom-1' } })
+    )) as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    cleanup()
+  })
+
+  it('invalidates student classroom caches after joining by link', async () => {
+    render(<JoinClassroomPage />)
+
+    await waitFor(() => {
+      expect(invalidateStudentClassrooms).toHaveBeenCalledOnce()
+    })
+    expect(push).toHaveBeenCalledWith('/classrooms/classroom-1?tab=today')
+  })
+})

--- a/tests/components/StudentHistoryPage.test.tsx
+++ b/tests/components/StudentHistoryPage.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import HistoryPage from '@/app/student/history/page'
+import { fetchClassDaysForClassroom } from '@/lib/class-days-client'
+import { fetchStudentClassrooms, invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
+import { fetchStudentEntriesForClassroom } from '@/lib/student-entries-client'
+import type { Classroom } from '@/types'
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <div>Loading...</div>,
+}))
+
+vi.mock('@/lib/timezone', () => ({
+  getTodayInToronto: () => '2025-05-10',
+}))
+
+vi.mock('@/lib/class-days-client', () => ({
+  fetchClassDaysForClassroom: vi.fn(),
+}))
+
+vi.mock('@/lib/student-classrooms-client', () => ({
+  fetchStudentClassrooms: vi.fn(),
+  invalidateStudentClassrooms: vi.fn(),
+}))
+
+vi.mock('@/lib/student-entries-client', () => ({
+  fetchStudentEntriesForClassroom: vi.fn(),
+}))
+
+const classroom: Classroom = {
+  id: 'classroom-1',
+  teacher_id: 'teacher-1',
+  title: 'History Class',
+  class_code: 'ABC123',
+  term_label: null,
+  allow_enrollment: true,
+  start_date: null,
+  end_date: null,
+  lesson_plan_visibility: 'hidden',
+  archived_at: null,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    vi.mocked(fetchClassDaysForClassroom).mockResolvedValue([
+      { id: 'day-1', classroom_id: classroom.id, date: '2025-05-09', prompt_text: null, is_class_day: true },
+    ])
+    vi.mocked(fetchStudentEntriesForClassroom).mockResolvedValue([])
+    vi.mocked(fetchStudentClassrooms).mockResolvedValue([classroom])
+    vi.mocked(invalidateStudentClassrooms).mockClear()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    cleanup()
+  })
+
+  it('loads student classrooms through the shared cached client', async () => {
+    render(<HistoryPage />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('History Class')).toHaveLength(2)
+    })
+    expect(screen.getByText('My Classes')).toBeInTheDocument()
+    expect(fetchStudentClassrooms).toHaveBeenCalledOnce()
+    expect(fetchClassDaysForClassroom).toHaveBeenCalledWith(classroom.id)
+    expect(fetchStudentEntriesForClassroom).toHaveBeenCalledWith(classroom.id)
+  })
+
+  it('invalidates cached student classrooms after joining a class from the empty state', async () => {
+    const joinedClassroom = { ...classroom, id: 'classroom-2', title: 'Joined Class', class_code: 'JOIN42' }
+    vi.mocked(fetchStudentClassrooms).mockResolvedValue([])
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/student/classrooms/join') {
+        return Promise.resolve(jsonResponse({ classroom: joinedClassroom }))
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    }) as any)
+
+    render(<HistoryPage />)
+
+    expect(await screen.findByText('No Classes Yet')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /class code/i }), {
+      target: { value: 'join42' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Join Class' }))
+
+    await waitFor(() => {
+      expect(invalidateStudentClassrooms).toHaveBeenCalledOnce()
+    })
+    await waitFor(() => {
+      expect(screen.getAllByText('Joined Class')).toHaveLength(2)
+    })
+    expect(fetchClassDaysForClassroom).toHaveBeenCalledWith(joinedClassroom.id)
+  })
+})

--- a/tests/unit/student-classrooms-client.test.ts
+++ b/tests/unit/student-classrooms-client.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchStudentClassrooms, invalidateStudentClassrooms } from '@/lib/student-classrooms-client'
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
+describe('student classrooms client', () => {
+  afterEach(() => {
+    invalidateStudentClassrooms()
+    vi.unstubAllGlobals()
+  })
+
+  it('reuses cached classroom lists for the verified current student', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'student-1' } }))
+      .mockResolvedValueOnce(jsonResponse({ classrooms: [{ id: 'classroom-1' }] }))
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'student-1' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchStudentClassrooms()).resolves.toEqual([{ id: 'classroom-1' }])
+    await expect(fetchStudentClassrooms()).resolves.toEqual([{ id: 'classroom-1' }])
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/student/classrooms')
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/auth/me', { cache: 'no-store' })
+  })
+
+  it('bypasses shared caching when the current user id cannot be verified', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ error: 'Temporary auth failure' }, false))
+      .mockResolvedValueOnce(jsonResponse({ classrooms: [{ id: 'student-a-classroom' }] }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Temporary auth failure' }, false))
+      .mockResolvedValueOnce(jsonResponse({ classrooms: [{ id: 'student-b-classroom' }] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchStudentClassrooms()).resolves.toEqual([{ id: 'student-a-classroom' }])
+    await expect(fetchStudentClassrooms()).resolves.toEqual([{ id: 'student-b-classroom' }])
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/student/classrooms')
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/student/classrooms')
+  })
+})


### PR DESCRIPTION
## Summary
- add a student classrooms client that scopes /api/student/classrooms cache entries by verified /api/auth/me user id
- route /student/history classroom list reads through the shared cache helper
- invalidate student classroom caches after joining from /student/history and /join/[code]
- add unit/component coverage for cache reuse, auth-scope bypass, history-page reads, and join invalidation

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/unit/request-cache.test.ts
- pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/components/StudentHistoryTab.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/api/student/classrooms.test.ts tests/api/student/classrooms-join.test.ts tests/api/student/classrooms-id.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- pnpm test