### PR TITLE
Cache teacher classroom index reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — PageActionBar mobile menu focus
-
-**Completed:**
-- Added explicit focus management for the shared `PageActionBar` mobile overflow menu.
-- Connected the overflow trigger to its menu with `aria-controls`.
-- Moved focus to the first enabled menu item on open, added arrow/Home/End menu navigation, and restored focus to the trigger on Escape, outside close, and item selection.
-- Added component coverage for trigger/menu relationships, focus movement, keyboard navigation, and focus restoration.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/PageActionBar.test.tsx tests/ui/SplitButton.test.tsx`
-- `pnpm lint`
-- `pnpm exec tsc --noEmit --pretty false`
-- `pnpm test`
-- `pnpm build`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3021 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh teacher/dashboard`
-- Manual Playwright mobile menu check: focus moved from `Course blueprints` to `Open classroom` with ArrowDown, Escape returned focus to `Open actions menu`, and the menu closed.
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-page-actionbar-menu-mobile-viewport.png`, `/tmp/pika-page-actionbar-menu-mobile-keyboard.png`
-
 ## 2026-05-31 — SplitButton menu focus
 
 **Completed:**
@@ -956,6 +936,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/unit/request-cache.test.ts`
 - `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/components/StudentHistoryTab.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/api/student/classrooms.test.ts tests/api/student/classrooms-join.test.ts tests/api/student/classrooms-id.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+
+## 2026-06-06 — Teacher classroom index cache audit
+
+**Completed:**
+- Extended the shared teacher-classrooms client to cache active and archived classroom lists separately.
+- Routed `TeacherClassroomsIndex` active refresh and archived-list loads through the shared helper instead of raw list fetches.
+- Preserved prefix invalidation after archive, restore, delete, reorder, and create flows.
+- Added coverage for separate active/archived cache keys and archived-view helper usage.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/unit/request-cache.test.ts`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`

--- a/src/app/classrooms/TeacherClassroomsIndex.tsx
+++ b/src/app/classrooms/TeacherClassroomsIndex.tsx
@@ -28,7 +28,7 @@ import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { ClassroomRowGhost, SortableClassroomRow } from '@/components/SortableClassroomRow'
 import type { Classroom } from '@/types'
-import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
+import { fetchTeacherClassrooms, invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 
 interface Props {
   initialClassrooms: Classroom[]
@@ -85,12 +85,8 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
     setIsLoadingArchived(true)
     setError('')
     try {
-      const res = await fetch('/api/teacher/classrooms?archived=true')
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        throw new Error(data.error || 'Failed to load archived classrooms')
-      }
-      setArchivedClassrooms(data.classrooms || [])
+      const classrooms = await fetchTeacherClassrooms({ archived: true })
+      setArchivedClassrooms(classrooms)
     } catch (err: any) {
       setError(err.message || 'Failed to load archived classrooms')
     } finally {
@@ -100,11 +96,8 @@ export function TeacherClassroomsIndex({ initialClassrooms }: Props) {
 
   const refreshActiveClassrooms = useCallback(async () => {
     try {
-      const res = await fetch('/api/teacher/classrooms')
-      const data = await res.json().catch(() => ({}))
-      if (res.ok && data.classrooms) {
-        setActiveClassrooms(data.classrooms)
-      }
+      const classrooms = await fetchTeacherClassrooms()
+      setActiveClassrooms(classrooms)
     } catch {
       // Ignore; the page still has server-rendered data.
     }

--- a/src/lib/teacher-classrooms-client.ts
+++ b/src/lib/teacher-classrooms-client.ts
@@ -5,21 +5,29 @@ type TeacherClassroomsResponse = {
   classrooms?: Classroom[]
 }
 
+type TeacherClassroomsOptions = {
+  archived?: boolean
+}
+
 export const TEACHER_CLASSROOMS_CACHE_PREFIX = 'teacher-classrooms:'
 const TEACHER_CLASSROOMS_CACHE_TTL_MS = 20_000
 
-async function getTeacherClassroomsCacheKey(): Promise<string | null> {
+function getTeacherClassroomsListSegment(options: TeacherClassroomsOptions = {}) {
+  return options.archived ? 'archived-list' : 'active-list'
+}
+
+async function getTeacherClassroomsCacheKey(options: TeacherClassroomsOptions = {}): Promise<string | null> {
   const response = await fetch('/api/auth/me', { cache: 'no-store' })
   const data = await response.json().catch(() => ({}))
   if (!response.ok || typeof data.user?.id !== 'string') {
     return null
   }
   const userId = data.user.id
-  return `${TEACHER_CLASSROOMS_CACHE_PREFIX}${userId}:list`
+  return `${TEACHER_CLASSROOMS_CACHE_PREFIX}${userId}:${getTeacherClassroomsListSegment(options)}`
 }
 
-async function fetchTeacherClassroomsFromApi(): Promise<TeacherClassroomsResponse> {
-  const response = await fetch('/api/teacher/classrooms')
+async function fetchTeacherClassroomsFromApi(options: TeacherClassroomsOptions = {}): Promise<TeacherClassroomsResponse> {
+  const response = await fetch(options.archived ? '/api/teacher/classrooms?archived=true' : '/api/teacher/classrooms')
   const data = await response.json().catch(() => ({ classrooms: [] }))
   if (!response.ok) {
     const message = typeof data.error === 'string' ? data.error : 'Failed to load classrooms'
@@ -28,16 +36,16 @@ async function fetchTeacherClassroomsFromApi(): Promise<TeacherClassroomsRespons
   return data
 }
 
-export async function fetchTeacherClassrooms(): Promise<Classroom[]> {
-  const cacheKey = await getTeacherClassroomsCacheKey()
+export async function fetchTeacherClassrooms(options: TeacherClassroomsOptions = {}): Promise<Classroom[]> {
+  const cacheKey = await getTeacherClassroomsCacheKey(options)
   if (!cacheKey) {
-    const data = await fetchTeacherClassroomsFromApi()
+    const data = await fetchTeacherClassroomsFromApi(options)
     return data.classrooms || []
   }
 
   const data = await fetchJSONWithCache<TeacherClassroomsResponse>(
     cacheKey,
-    fetchTeacherClassroomsFromApi,
+    () => fetchTeacherClassroomsFromApi(options),
     TEACHER_CLASSROOMS_CACHE_TTL_MS,
   )
 

--- a/tests/components/TeacherCalendarPage.test.tsx
+++ b/tests/components/TeacherCalendarPage.test.tsx
@@ -151,7 +151,7 @@ describe('Teacher calendar page', () => {
 
     expect(await screen.findByText('Create Calendar')).toBeInTheDocument()
     expect(fetchJSONWithCache).toHaveBeenCalledWith(
-      'teacher-classrooms:teacher-1:list',
+      'teacher-classrooms:teacher-1:active-list',
       expect.any(Function),
       20_000,
     )

--- a/tests/components/TeacherClassroomsIndex.test.tsx
+++ b/tests/components/TeacherClassroomsIndex.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { TeacherClassroomsIndex } from '@/app/classrooms/TeacherClassroomsIndex'
+import { fetchTeacherClassrooms } from '@/lib/teacher-classrooms-client'
 import { TooltipProvider } from '@/ui'
 import { createMockClassroom } from '../helpers/mocks'
 import type { Classroom } from '@/types'
@@ -10,6 +11,11 @@ const push = vi.hoisted(() => vi.fn())
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
   usePathname: () => '/classrooms',
+}))
+
+vi.mock('@/lib/teacher-classrooms-client', () => ({
+  fetchTeacherClassrooms: vi.fn(),
+  invalidateTeacherClassrooms: vi.fn(),
 }))
 
 function renderTeacherClassroomsIndex(initialClassrooms: Classroom[]) {
@@ -26,6 +32,7 @@ describe('TeacherClassroomsIndex', () => {
   beforeEach(() => {
     fetchMock = vi.fn()
     push.mockReset()
+    vi.mocked(fetchTeacherClassrooms).mockResolvedValue([])
     vi.stubGlobal('fetch', fetchMock)
   })
 
@@ -51,12 +58,9 @@ describe('TeacherClassroomsIndex', () => {
   })
 
   it('never shows the create button in archived view', async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        classrooms: [createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' })],
-      }),
-    })
+    vi.mocked(fetchTeacherClassrooms).mockResolvedValueOnce([
+      createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' }),
+    ])
 
     renderTeacherClassroomsIndex([])
 
@@ -64,6 +68,7 @@ describe('TeacherClassroomsIndex', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Archived' }))
 
     expect(await screen.findByRole('button', { name: /^Archived/ })).toBeInTheDocument()
+    expect(fetchTeacherClassrooms).toHaveBeenCalledWith({ archived: true })
     expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
   })
 
@@ -120,12 +125,9 @@ describe('TeacherClassroomsIndex', () => {
   })
 
   it('returns to active view when edit mode is turned off from archived view', async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        classrooms: [createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' })],
-      }),
-    })
+    vi.mocked(fetchTeacherClassrooms).mockResolvedValueOnce([
+      createMockClassroom({ id: 'archived-1', title: 'Archived', archived_at: '2026-04-01T12:00:00Z' }),
+    ])
 
     renderTeacherClassroomsIndex([])
 

--- a/tests/components/TeacherDashboardPage.test.tsx
+++ b/tests/components/TeacherDashboardPage.test.tsx
@@ -206,7 +206,7 @@ describe('Teacher dashboard page', () => {
 
     expect(await screen.findByText('student@example.com')).toBeInTheDocument()
     expect(fetchJSONWithCache).toHaveBeenCalledWith(
-      'teacher-classrooms:teacher-1:list',
+      'teacher-classrooms:teacher-1:active-list',
       expect.any(Function),
       20_000,
     )

--- a/tests/unit/teacher-classrooms-client.test.ts
+++ b/tests/unit/teacher-classrooms-client.test.ts
@@ -14,6 +14,30 @@ describe('teacher classrooms client', () => {
     vi.unstubAllGlobals()
   })
 
+  it('caches active and archived classroom lists separately for the verified teacher', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'teacher-1' } }))
+      .mockResolvedValueOnce(jsonResponse({ classrooms: [{ id: 'active-class' }] }))
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'teacher-1' } }))
+      .mockResolvedValueOnce(jsonResponse({ classrooms: [{ id: 'archived-class' }] }))
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'teacher-1' } }))
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 'teacher-1' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchTeacherClassrooms()).resolves.toEqual([{ id: 'active-class' }])
+    await expect(fetchTeacherClassrooms({ archived: true })).resolves.toEqual([{ id: 'archived-class' }])
+    await expect(fetchTeacherClassrooms()).resolves.toEqual([{ id: 'active-class' }])
+    await expect(fetchTeacherClassrooms({ archived: true })).resolves.toEqual([{ id: 'archived-class' }])
+
+    expect(fetchMock).toHaveBeenCalledTimes(6)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/teacher/classrooms')
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/teacher/classrooms?archived=true')
+    expect(fetchMock).toHaveBeenNthCalledWith(5, '/api/auth/me', { cache: 'no-store' })
+    expect(fetchMock).toHaveBeenNthCalledWith(6, '/api/auth/me', { cache: 'no-store' })
+  })
+
   it('bypasses shared caching when the current user id cannot be verified', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({ error: 'Temporary auth failure' }, false))


### PR DESCRIPTION
## Summary
- extend the shared teacher classrooms client with separate active and archived list cache keys
- route classroom index active refresh and archived view loads through the shared helper
- preserve prefix invalidation after classroom mutations and update affected cache key coverage

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/unit/request-cache.test.ts
- pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- pnpm test