### PR TITLE
Cache blueprint list in classroom modal

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,26 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — SplitButton menu focus
-
-**Completed:**
-- Hardened the shared `SplitButton` menu with focus-on-open, arrow/Home/End navigation over enabled items, and focus restoration to the opener on Escape, outside close, and item selection.
-- Added semantic component coverage for disabled-item skipping, wraparound keyboard movement, Escape close behavior, and selection focus restoration.
-- Addressed review follow-ups so parent rerenders from menu focus/hover do not reset keyboard focus, existing modal actions still restore focus normally, and `DialogPanel` moves focus into modal dialogs even when they open after async menu work.
-- Verified the teacher tests tab visually after the shared primitive change.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/ui/SplitButton.test.tsx`
-- `pnpm test tests/ui/SplitButton.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm test tests/ui/SplitButton.test.tsx tests/ui/Dialog.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm test tests/ui/Dialog.test.tsx tests/ui/SplitButton.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/AssignmentModal.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomView.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `E2E_BASE_URL=http://localhost:3022 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`
-
 ## 2026-05-31 — Assignment list stats pagination
 
 **Completed:**
@@ -957,3 +937,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-06-06 — Classroom blueprint modal cache audit
+
+**Completed:**
+- Routed `CreateClassroomModal` blueprint list loads through the shared `fetchTeacherBlueprints` cache helper instead of a raw `/api/teacher/course-blueprints` fetch.
+- Kept import and instantiate mutation paths raw and preserved blueprint/classroom cache invalidation after successful mutations.
+- Added a stale-load guard so a closed/reopened modal cannot have a prior blueprint list response wipe the current options.
+- Addressed PR review feedback by bumping the list-load generation after blueprint imports so pending open-time list loads cannot erase imported options.
+- Updated modal coverage for cached list loading, empty blueprint lists, mutation fetches, stale close/reopen responses, and import-while-list-load-is-pending races.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/unit/teacher-classrooms-client.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `pnpm test`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/components/CreateClassroomModal.tsx
+++ b/src/components/CreateClassroomModal.tsx
@@ -5,7 +5,7 @@ import { Input, Button, DialogPanel, FormField, SplitButton } from '@/ui'
 import { format } from 'date-fns'
 import type { CourseBlueprint } from '@/types'
 import { invalidateTeacherClassrooms } from '@/lib/teacher-classrooms-client'
-import { invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
+import { fetchTeacherBlueprints, invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
 
 type WizardStep = 'name' | 'blueprint' | 'calendar'
 type CalendarMode = 'preset' | 'custom'
@@ -30,6 +30,7 @@ export function CreateClassroomModal({
   const startMonthId = useId()
   const endMonthId = useId()
   const importInputRef = useRef<HTMLInputElement | null>(null)
+  const blueprintLoadGenerationRef = useRef(0)
 
   const [step, setStep] = useState<WizardStep>('name')
   const [title, setTitle] = useState('')
@@ -52,12 +53,21 @@ export function CreateClassroomModal({
 
   useEffect(() => {
     if (!isOpen) return
+    let isCurrent = true
+    const loadGeneration = blueprintLoadGenerationRef.current + 1
+    blueprintLoadGenerationRef.current = loadGeneration
     setCreationMode(initialBlueprintId ? 'blueprint' : 'blank')
     setSelectedBlueprintId(initialBlueprintId || '')
-    fetch('/api/teacher/course-blueprints')
-      .then((response) => response.json().catch(() => ({})))
-      .then((data) => setAvailableBlueprints((data.blueprints || []) as CourseBlueprint[]))
-      .catch(() => setAvailableBlueprints([]))
+    fetchTeacherBlueprints()
+      .then((blueprints) => {
+        if (isCurrent && blueprintLoadGenerationRef.current === loadGeneration) setAvailableBlueprints(blueprints)
+      })
+      .catch(() => {
+        if (isCurrent && blueprintLoadGenerationRef.current === loadGeneration) setAvailableBlueprints([])
+      })
+    return () => {
+      isCurrent = false
+    }
   }, [initialBlueprintId, isOpen])
 
   function getSemesterYears() {
@@ -144,6 +154,7 @@ export function CreateClassroomModal({
 
       const blueprint = data.blueprint as CourseBlueprint
       invalidateTeacherBlueprints()
+      blueprintLoadGenerationRef.current += 1
       setAvailableBlueprints((current) => {
         const withoutImported = current.filter((item) => item.id !== blueprint.id)
         return [blueprint, ...withoutImported]

--- a/tests/components/CreateClassroomModal.test.tsx
+++ b/tests/components/CreateClassroomModal.test.tsx
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { CreateClassroomModal } from '@/components/CreateClassroomModal'
-import { invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
+import { fetchTeacherBlueprints, invalidateTeacherBlueprints } from '@/lib/teacher-blueprints-client'
 import type { CourseBlueprint } from '@/types'
 
 vi.mock('@/lib/teacher-blueprints-client', () => ({
+  fetchTeacherBlueprints: vi.fn(),
   invalidateTeacherBlueprints: vi.fn(),
 }))
 
@@ -40,6 +41,16 @@ const mockBlueprint: CourseBlueprint = {
   updated_at: '2026-04-21T12:00:00Z',
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
 describe('CreateClassroomModal', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
@@ -48,7 +59,9 @@ describe('CreateClassroomModal', () => {
       ok: true,
       json: async () => ({ blueprints: [mockBlueprint] }),
     })
+    vi.mocked(fetchTeacherBlueprints).mockResolvedValue([mockBlueprint])
     vi.stubGlobal('fetch', fetchMock)
+    vi.mocked(fetchTeacherBlueprints).mockClear()
     vi.mocked(invalidateTeacherBlueprints).mockClear()
   })
 
@@ -89,7 +102,7 @@ describe('CreateClassroomModal', () => {
     renderModal()
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/course-blueprints')
+      expect(fetchTeacherBlueprints).toHaveBeenCalledOnce()
     })
 
     fireEvent.change(getClassroomNameInput(), {
@@ -122,16 +135,80 @@ describe('CreateClassroomModal', () => {
   })
 
   it('switches to file loading when no saved blueprints exist', async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ blueprints: [] }),
-    })
+    vi.mocked(fetchTeacherBlueprints).mockResolvedValueOnce([])
 
     renderModal()
     await openBlueprintSourceStep()
 
     expect(screen.getByRole('combobox', { name: /course blueprint/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+  })
+
+  it('ignores stale blueprint loads after closing and reopening', async () => {
+    const firstLoad = createDeferred<CourseBlueprint[]>()
+    const secondLoad = createDeferred<CourseBlueprint[]>()
+    vi.mocked(fetchTeacherBlueprints)
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise)
+
+    const props = { onClose: vi.fn(), onSuccess: vi.fn() }
+    const view = render(<CreateClassroomModal isOpen {...props} />)
+
+    expect(fetchTeacherBlueprints).toHaveBeenCalledOnce()
+    view.rerender(<CreateClassroomModal isOpen={false} {...props} />)
+    view.rerender(<CreateClassroomModal isOpen {...props} />)
+    expect(fetchTeacherBlueprints).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      secondLoad.resolve([mockBlueprint])
+    })
+
+    await openBlueprintSourceStep()
+    expect(await screen.findByRole('option', { name: mockBlueprint.title })).toBeInTheDocument()
+
+    await act(async () => {
+      firstLoad.resolve([])
+    })
+    expect(screen.getByRole('option', { name: mockBlueprint.title })).toBeInTheDocument()
+  })
+
+  it('keeps an imported blueprint when the initial blueprint load resolves late', async () => {
+    const initialLoad = createDeferred<CourseBlueprint[]>()
+    vi.mocked(fetchTeacherBlueprints).mockReturnValueOnce(initialLoad.promise)
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/teacher/course-blueprints/import') {
+        return {
+          ok: true,
+          json: async () => ({ blueprint: mockBlueprint }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    renderModal()
+    await openBlueprintSourceStep()
+
+    const fileInput = screen.getByLabelText('Import course package file')
+    const file = new File(['bundle'], 'course-package.tar', { type: 'application/x-tar' })
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: async () => new TextEncoder().encode('bundle').buffer,
+    })
+
+    fireEvent.change(getBlueprintSelect(), { target: { value: '__choose-file__' } })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(getBlueprintSelect()).toHaveValue(mockBlueprint.id)
+    })
+
+    await act(async () => {
+      initialLoad.resolve([])
+    })
+
+    expect(getBlueprintSelect()).toHaveValue(mockBlueprint.id)
+    expect(screen.getByRole('option', { name: mockBlueprint.title })).toBeInTheDocument()
   })
 
   it('loads a blueprint file in the source step before moving to calendar', async () => {
@@ -144,11 +221,9 @@ describe('CreateClassroomModal', () => {
         }
       }
 
-      return {
-        ok: true,
-        json: async () => ({ blueprints: [] }),
-      }
+      throw new Error(`Unexpected fetch: ${url}`)
     })
+    vi.mocked(fetchTeacherBlueprints).mockResolvedValueOnce([])
 
     renderModal()
     await openBlueprintSourceStep()
@@ -178,12 +253,6 @@ describe('CreateClassroomModal', () => {
     fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       const method = init?.method || 'GET'
-      if (url === '/api/teacher/course-blueprints' && method === 'GET') {
-        return {
-          ok: true,
-          json: async () => ({ blueprints: [mockBlueprint] }),
-        }
-      }
       if (url === `/api/teacher/course-blueprints/${mockBlueprint.id}/instantiate` && method === 'POST') {
         return {
           ok: true,


### PR DESCRIPTION
## Summary
- route CreateClassroomModal blueprint list loads through the shared fetchTeacherBlueprints cache helper
- guard modal blueprint list loads so stale close/reopen responses cannot replace current options
- keep import and instantiate mutation paths raw while preserving cache invalidation after success

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts
- pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/unit/teacher-classrooms-client.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- pnpm test
- bash .codex/skills/pika-audit/scripts/audit.sh