### PR TITLE
Guard teacher quiz list reloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,20 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Assignment list stats pagination
-
-**Completed:**
-- Routed teacher assignment list stats reads through the shared chunked/paged Supabase loader.
-- Preserved the legacy fallback for databases without `assignment_docs.teacher_cleared_at`.
-- Added a dense 2,500-row stats regression so list stats cannot silently stop at Supabase's default page.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/teacher/assignments.test.ts tests/unit/query-chunks.test.ts -- --runInBand`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-05-31 — Student entries broad-read cap
 
 **Completed:**
@@ -956,3 +942,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `pnpm test`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-06 — Teacher quiz list freshness audit
+
+**Completed:**
+- Routed `TeacherQuizzesTab` list reads through `fetchJSONWithCache` with a zero TTL for in-flight GET dedupe.
+- Added request-id and classroom guards so stale quiz list responses cannot repaint after classroom changes or newer reloads.
+- Addressed PR review feedback by forcing mutation/update-triggered reloads to use one-off cache keys so they cannot attach to older pending passive reads.
+- Addressed follow-up review feedback by letting quiz cards rely on the global quiz-update event instead of also calling a parent forced reload.
+- Added component coverage for stale classroom-switch list responses and creation-while-initial-load-is-pending races while preserving existing mount, update-event, creation, selection, and delete behavior.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizCard.test.tsx tests/components/QuizModal.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-route.test.ts tests/api/teacher/quizzes-id.test.ts tests/api/teacher/quizzes-results.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherQuizzesTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Code, Plus, Trash2 } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { QuizModal } from '@/components/QuizModal'
@@ -10,6 +10,7 @@ import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWo
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { fetchJSONWithCache } from '@/lib/request-cache'
 import { Button, DialogPanel, EmptyState, Tooltip } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
@@ -46,6 +47,9 @@ export function TeacherQuizzesTab({
 }: Props) {
   const apiBasePath = '/api/teacher/quizzes'
   const isReadOnly = !!classroom.archived_at
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
 
   const [quizzes, setQuizzes] = useState<QuizWithStats[]>([])
   const [loading, setLoading] = useState(true)
@@ -123,17 +127,36 @@ export function TeacherQuizzesTab({
     navigateQuizWorkspace(null, options)
   }, [navigateQuizWorkspace])
 
-  const loadQuizzes = useCallback(async () => {
+  const loadQuizzes = useCallback(async (options: { forceRefresh?: boolean } = {}) => {
+    const classroomId = classroom.id
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
     setLoading(true)
     try {
-      const query = new URLSearchParams({ classroom_id: classroom.id })
-      const response = await fetch(`${apiBasePath}?${query.toString()}`)
-      const data = await response.json()
+      const query = new URLSearchParams({ classroom_id: classroomId })
+      const data = await fetchJSONWithCache<{ quizzes?: QuizWithStats[] }>(
+        options.forceRefresh
+          ? `teacher-quizzes:${classroomId}:refresh:${requestId}`
+          : `teacher-quizzes:${classroomId}`,
+        async () => {
+          // fetchJSONWithCache wraps this repeated GET; force refreshes use one-off keys.
+          const response = await fetch(`${apiBasePath}?${query.toString()}`)
+          const payload = await response.json()
+          if (!response.ok) throw new Error(payload.error || 'Failed to load quizzes')
+          return payload
+        },
+        0,
+      )
+      if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroomId) return
       setQuizzes(data.quizzes || [])
     } catch (error) {
-      console.error('Error loading quizzes:', error)
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        console.error('Error loading quizzes:', error)
+      }
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === classroomId) {
+        setLoading(false)
+      }
     }
   }, [classroom.id])
 
@@ -145,7 +168,7 @@ export function TeacherQuizzesTab({
     function handleQuizzesUpdated(event: Event) {
       const detail = (event as CustomEvent<{ classroomId?: string }>).detail
       if (!detail || detail.classroomId !== classroom.id) return
-      void loadQuizzes()
+      void loadQuizzes({ forceRefresh: true })
     }
 
     window.addEventListener(TEACHER_QUIZZES_UPDATED_EVENT, handleQuizzesUpdated)
@@ -274,9 +297,7 @@ export function TeacherQuizzesTab({
           isSelected={selectedQuizId === quiz.id}
           isReadOnly={isReadOnly}
           onSelect={() => handleCardSelect(quiz)}
-          onQuizUpdate={() => {
-            void loadQuizzes()
-          }}
+          onQuizUpdate={() => undefined}
         />
       ))}
     </TeacherWorkItemList>
@@ -294,7 +315,7 @@ export function TeacherQuizzesTab({
           applyQuizSummaryPatch(selectedQuizWorkspace.id, update)
           return
         }
-        void loadQuizzes()
+        void loadQuizzes({ forceRefresh: true })
       }}
       onRequestDelete={onRequestDelete}
       showInlineDeleteAction={false}

--- a/tests/components/TeacherQuizzesTab.test.tsx
+++ b/tests/components/TeacherQuizzesTab.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import { TeacherQuizzesTab } from '@/app/classrooms/[classroomId]/TeacherQuizzesTab'
 import { TooltipProvider } from '@/ui'
 import { TEACHER_QUIZZES_UPDATED_EVENT } from '@/lib/events'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 import { createMockClassroom, createMockQuiz } from '../helpers/mocks'
 import type { QuizAssessmentType, QuizWithStats } from '@/types'
 
@@ -83,6 +84,23 @@ function listFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   )
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response
+}
+
 describe('TeacherQuizzesTab', () => {
   const classroom = createMockClassroom()
   let fetchMock: ReturnType<typeof vi.fn>
@@ -94,6 +112,7 @@ describe('TeacherQuizzesTab', () => {
   })
 
   afterEach(() => {
+    invalidateCachedJSONMatching('teacher-quizzes:')
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -136,6 +155,48 @@ describe('TeacherQuizzesTab', () => {
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/quizzes?classroom_id=')
   })
 
+  it('ignores stale quiz list responses after classroom changes', async () => {
+    const firstLoad = createDeferred<Response>()
+    const secondLoad = createDeferred<Response>()
+    const firstClassroom = createMockClassroom({ id: 'classroom-a', title: 'Classroom A' })
+    const secondClassroom = createMockClassroom({ id: 'classroom-b', title: 'Classroom B' })
+    fetchMock
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise)
+
+    const view = render(
+      <TeacherQuizzesTab classroom={firstClassroom} assessmentType="quiz" />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    view.rerender(<TeacherQuizzesTab classroom={secondClassroom} assessmentType="quiz" />)
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(2)
+    })
+
+    await act(async () => {
+      secondLoad.resolve(jsonResponse({
+        quizzes: [makeQuiz({ id: 'quiz-current', title: 'Current Classroom Quiz' })],
+      }))
+    })
+
+    expect(await screen.findByText('Current Classroom Quiz')).toBeInTheDocument()
+
+    await act(async () => {
+      firstLoad.resolve(jsonResponse({
+        quizzes: [makeQuiz({ id: 'quiz-stale', title: 'Stale Classroom Quiz' })],
+      }))
+    })
+
+    expect(screen.getByText('Current Classroom Quiz')).toBeInTheDocument()
+    expect(screen.queryByText('Stale Classroom Quiz')).not.toBeInTheDocument()
+  })
+
   it('fetches quizzes once when update event fires (not twice)', async () => {
     mockQuizzesResponse([])
     renderTab()
@@ -175,6 +236,47 @@ describe('TeacherQuizzesTab', () => {
     await waitFor(() => {
       expect(listFetchCalls(fetchMock)).toHaveLength(2)
     })
+  })
+
+  it('forces a fresh quiz list reload after creation while the initial load is pending', async () => {
+    const initialLoad = createDeferred<Response>()
+    const postCreateLoad = createDeferred<Response>()
+    fetchMock
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockReturnValueOnce(postCreateLoad.promise)
+
+    renderTab()
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    fireEvent.click(screen.getByTestId('mock-quiz-save'))
+
+    await waitFor(() => {
+      expect(listFetchCalls(fetchMock)).toHaveLength(2)
+    })
+
+    await act(async () => {
+      postCreateLoad.resolve(jsonResponse({
+        quizzes: [makeQuiz({ id: 'created-quiz-id', title: 'Created Quiz' })],
+      }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('mock-quiz-detail').some((item) =>
+        item.textContent?.includes('Detail for Created Quiz')
+      )).toBe(true)
+    })
+
+    await act(async () => {
+      initialLoad.resolve(jsonResponse({ quizzes: [] }))
+    })
+
+    expect(screen.getAllByTestId('mock-quiz-detail').some((item) =>
+      item.textContent?.includes('Detail for Created Quiz')
+    )).toBe(true)
   })
 
   it('renders quiz mode with the quiz API and primary action', async () => {


### PR DESCRIPTION
## Summary
- route TeacherQuizzesTab list reads through fetchJSONWithCache with zero TTL for in-flight GET dedupe
- add request-id and classroom guards before applying quiz list or loading-state updates
- add coverage for stale quiz list responses after classroom changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/unit/request-cache.test.ts
- pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizCard.test.tsx tests/components/QuizModal.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-route.test.ts tests/api/teacher/quizzes-id.test.ts tests/api/teacher/quizzes-results.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test