### PR TITLE
Guard student assessment reloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,21 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Student entries broad-read cap
-
-**Completed:**
-- Added a default cap for broad `/api/student/entries` reads that span all active classrooms.
-- Preserved classroom-scoped no-limit history behavior so attendance history surfaces do not mark older entries absent.
-- Added API coverage for broad default limiting, explicit broad limit capping, classroom-scoped no-limit behavior, and explicit classroom limits.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/api/student/entries.test.ts -- --runInBand`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
 ## 2026-05-31 — Teacher test authoring URL mode
 
 **Completed:**
@@ -956,6 +941,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/unit/request-cache.test.ts`
 - `pnpm vitest run tests/components/TeacherQuizzesTab.test.tsx tests/components/QuizCard.test.tsx tests/components/QuizModal.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-route.test.ts tests/api/teacher/quizzes-id.test.ts tests/api/teacher/quizzes-results.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+
+## 2026-06-06 — Student assessment freshness audit
+
+**Completed:**
+- Routed `StudentQuizzesTab` list reads through `fetchJSONWithCache` with zero-TTL in-flight dedupe and force-refresh keys after submit/back refreshes.
+- Added list and detail request guards so stale student quiz/test list or selected-detail responses cannot repaint after classroom/type changes or newer reads.
+- Reset selected assessment state when the classroom or assessment type changes.
+- Added `StudentQuizResults` request guards and payload reset so stale result responses cannot win after `quizId` changes.
+- Added component coverage for stale list, detail, and result response races.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/components/StudentQuizForm.test.tsx tests/api/student/quizzes.test.ts tests/api/student/quizzes-id.test.ts tests/api/student/quizzes-results.test.ts tests/api/student/quizzes-respond.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-respond.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-focus-events.test.ts tests/unit/request-cache.test.ts`
 - `git diff --check`
 - `pnpm lint`
 - `pnpm build`

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -11,6 +11,7 @@ import {
   getQuizStatusBadgeClass,
   QUIZ_EXIT_BURST_WINDOW_MS,
 } from '@/lib/quizzes'
+import { fetchJSONWithCache } from '@/lib/request-cache'
 import { StudentQuizForm } from '@/components/StudentQuizForm'
 import { StudentQuizResults } from '@/components/StudentQuizResults'
 import { Button, ConfirmDialog, EmptyState } from '@/ui'
@@ -67,6 +68,18 @@ interface StudentTestSessionStatusResponse {
   returned_at: string | null
   can_continue: boolean
   message: string | null
+}
+
+interface StudentAssessmentListResponse {
+  quizzes?: StudentQuizView[]
+}
+
+interface StudentAssessmentDetailResponse {
+  quiz: StudentQuizView
+  questions?: QuizQuestion[]
+  student_responses?: Record<string, number | TestResponseDraftValue>
+  student_status?: StudentQuizStatus
+  focus_summary?: QuizFocusSummary | null
 }
 
 type FullscreenCapableElement = HTMLElement & {
@@ -261,8 +274,12 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   const findSuppressionUntilRef = useRef(0)
   const docsInteractionSuppressionUntilRef = useRef(0)
   const sessionStatusInFlightRef = useRef(false)
+  const listRequestIdRef = useRef(0)
+  const detailRequestIdRef = useRef(0)
+  const currentScopeRef = useRef({ classroomId: classroom.id, assessmentType })
   const isTestsView = assessmentType === 'test'
   const apiBasePath = isTestsView ? '/api/student/tests' : '/api/student/quizzes'
+  currentScopeRef.current = { classroomId: classroom.id, assessmentType }
   const focusEnabled = useMemo(() => {
     if (!selectedQuiz) return false
     const hasSubmitted = selectedQuiz.quiz.student_status !== 'not_started'
@@ -339,23 +356,69 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     }
   }, [clearPendingNonCompliantTimeout])
 
-  const loadQuizzes = useCallback(async () => {
+  const loadQuizzes = useCallback(async (options: { forceRefresh?: boolean } = {}) => {
+    const classroomId = classroom.id
+    const viewAssessmentType = assessmentType
+    const basePath = apiBasePath
+    const requestId = listRequestIdRef.current + 1
+    listRequestIdRef.current = requestId
     setLoading(true)
     try {
-      const query = new URLSearchParams({ classroom_id: classroom.id })
-      const res = await fetch(`${apiBasePath}?${query.toString()}`)
-      const data = await res.json()
+      const query = new URLSearchParams({ classroom_id: classroomId })
+      const data = await fetchJSONWithCache<StudentAssessmentListResponse>(
+        options.forceRefresh
+          ? `student-assessments:${viewAssessmentType}:${classroomId}:refresh:${requestId}`
+          : `student-assessments:${viewAssessmentType}:${classroomId}`,
+        async () => {
+          // fetchJSONWithCache wraps this repeated GET; force refreshes use one-off keys.
+          const res = await fetch(`${basePath}?${query.toString()}`)
+          return res.json()
+        },
+        0,
+      )
+      if (
+        listRequestIdRef.current !== requestId ||
+        currentScopeRef.current.classroomId !== classroomId ||
+        currentScopeRef.current.assessmentType !== viewAssessmentType
+      ) {
+        return
+      }
       setQuizzes(data.quizzes || [])
     } catch (err) {
-      console.error('Error loading quizzes:', err)
+      if (
+        listRequestIdRef.current === requestId &&
+        currentScopeRef.current.classroomId === classroomId &&
+        currentScopeRef.current.assessmentType === viewAssessmentType
+      ) {
+        console.error('Error loading quizzes:', err)
+      }
     } finally {
-      setLoading(false)
+      if (
+        listRequestIdRef.current === requestId &&
+        currentScopeRef.current.classroomId === classroomId &&
+        currentScopeRef.current.assessmentType === viewAssessmentType
+      ) {
+        setLoading(false)
+      }
     }
-  }, [apiBasePath, classroom.id])
+  }, [apiBasePath, assessmentType, classroom.id])
 
   useEffect(() => {
     loadQuizzes()
   }, [loadQuizzes])
+
+  useEffect(() => {
+    detailRequestIdRef.current += 1
+    selectedQuizIdRef.current = null
+    setSelectedQuizId(null)
+    setSelectedQuiz(null)
+    setFocusSummary(null)
+    setStartedTestId(null)
+    setShowStartTestConfirm(false)
+    setPendingStartTestId(null)
+    setActiveDoc(null)
+    setRemoteClosureNotice(null)
+  }, [assessmentType, classroom.id])
 
   const handleRemoteTestClosure = useCallback((options?: {
     studentStatus?: StudentQuizStatus
@@ -389,6 +452,12 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   }, [clearPendingNonCompliantTimeout])
 
   async function handleSelectQuiz(quizId: string) {
+    const classroomId = classroom.id
+    const viewAssessmentType = assessmentType
+    const basePath = apiBasePath
+    const requestId = detailRequestIdRef.current + 1
+    detailRequestIdRef.current = requestId
+    selectedQuizIdRef.current = quizId
     setSelectedQuizId(quizId)
     setLoadingQuiz(true)
     setActiveDoc(null)
@@ -402,8 +471,17 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     docsInteractionSuppressionUntilRef.current = 0
 
     try {
-      const res = await fetch(`${apiBasePath}/${quizId}`)
-      const data = await res.json()
+      // Bypass fetchJSONWithCache for selected detail freshness; request ids guard stale responses.
+      const res = await fetch(`${basePath}/${quizId}`)
+      const data = await res.json() as StudentAssessmentDetailResponse
+      if (
+        detailRequestIdRef.current !== requestId ||
+        selectedQuizIdRef.current !== quizId ||
+        currentScopeRef.current.classroomId !== classroomId ||
+        currentScopeRef.current.assessmentType !== viewAssessmentType
+      ) {
+        return
+      }
       const listQuiz = quizzes.find((quiz) => quiz.id === quizId)
       const studentStatus = data.student_status ?? data.quiz?.student_status ?? listQuiz?.student_status ?? 'not_started'
       setSelectedQuiz({
@@ -413,9 +491,23 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
       })
       setFocusSummary((data.focus_summary as QuizFocusSummary | null) || null)
     } catch (err) {
-      console.error('Error loading quiz:', err)
+      if (
+        detailRequestIdRef.current === requestId &&
+        selectedQuizIdRef.current === quizId &&
+        currentScopeRef.current.classroomId === classroomId &&
+        currentScopeRef.current.assessmentType === viewAssessmentType
+      ) {
+        console.error('Error loading quiz:', err)
+      }
     } finally {
-      setLoadingQuiz(false)
+      if (
+        detailRequestIdRef.current === requestId &&
+        selectedQuizIdRef.current === quizId &&
+        currentScopeRef.current.classroomId === classroomId &&
+        currentScopeRef.current.assessmentType === viewAssessmentType
+      ) {
+        setLoadingQuiz(false)
+      }
     }
   }
 
@@ -428,6 +520,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
 
     sessionStatusInFlightRef.current = true
     try {
+      // Bypass fetchJSONWithCache for active exam session freshness.
       const res = await fetch(`${apiBasePath}/${quizId}/session-status`, {
         cache: 'no-store',
       })
@@ -771,7 +864,9 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
   ])
 
   const performBackToAssessmentList = useCallback(() => {
+    detailRequestIdRef.current += 1
     clearPendingNonCompliantTimeout()
+    selectedQuizIdRef.current = null
     setSelectedQuizId(null)
     setSelectedQuiz(null)
     setStartedTestId(null)
@@ -790,7 +885,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     findIntentUntilRef.current = 0
     findSuppressionUntilRef.current = 0
     docsInteractionSuppressionUntilRef.current = 0
-    loadQuizzes() // Refresh list to get updated status
+    loadQuizzes({ forceRefresh: true }) // Refresh list to get updated status
   }, [applyWindowComplianceSnapshot, clearPendingNonCompliantTimeout, loadQuizzes])
 
   function handleBack() {
@@ -802,7 +897,7 @@ export function StudentQuizzesTab({ classroom, assessmentType, isActive = true }
     if (isTestsView) {
       notifications?.decrementActiveTestsCount()
     }
-    void loadQuizzes()
+    void loadQuizzes({ forceRefresh: true })
 
     // Reload selected assessment details to get updated status/feedback.
     if (selectedQuizIdRef.current) {

--- a/src/components/StudentQuizResults.tsx
+++ b/src/components/StudentQuizResults.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import {
@@ -69,22 +69,35 @@ export function StudentQuizResults({
   const [payload, setPayload] = useState<ResultsPayload | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const requestIdRef = useRef(0)
   const isTestsView =
     assessmentType === 'test' || apiBasePath.includes('/tests')
 
   useEffect(() => {
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+    setLoading(true)
+    setError('')
+    setPayload(null)
+
     async function loadResults() {
       try {
+        // Bypass fetchJSONWithCache so returned results always follow the selected quizId.
         const res = await fetch(`${apiBasePath}/${quizId}/results`)
         const data = await res.json()
+        if (requestIdRef.current !== requestId) return
         if (!res.ok) {
           throw new Error(data.error || 'Failed to load results')
         }
         setPayload(data as ResultsPayload)
       } catch (err: any) {
-        setError(err.message || 'Failed to load results')
+        if (requestIdRef.current === requestId) {
+          setError(err.message || 'Failed to load results')
+        }
       } finally {
-        setLoading(false)
+        if (requestIdRef.current === requestId) {
+          setLoading(false)
+        }
       }
     }
     loadResults()

--- a/tests/components/StudentQuizResults.test.tsx
+++ b/tests/components/StudentQuizResults.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import { StudentQuizResults } from '@/components/StudentQuizResults'
 import type { QuizResultsAggregate } from '@/types'
 
@@ -28,6 +28,20 @@ describe('StudentQuizResults', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve
+      reject = promiseReject
+    })
+    return { promise, resolve, reject }
+  }
+
+  function jsonResponse(body: unknown): Response {
+    return { ok: true, json: async () => body } as Response
+  }
 
   it('shows loading spinner initially', () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
@@ -86,6 +100,65 @@ describe('StudentQuizResults', () => {
     // Check options and percentages
     expect(screen.getByText('London')).toBeInTheDocument()
     expect(screen.getByText('15 (75%)')).toBeInTheDocument() // Paris
+  })
+
+  it('resets and ignores stale result responses when quizId changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleResults = createDeferred<Response>()
+    const currentResults = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/api/student/quizzes/quiz-1/results')) return staleResults.promise
+      if (url.endsWith('/api/student/quizzes/quiz-2/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const { rerender } = render(
+      <StudentQuizResults quizId="quiz-1" myResponses={{}} />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/quizzes/quiz-1/results')
+    })
+
+    rerender(<StudentQuizResults quizId="quiz-2" myResponses={{}} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/quizzes/quiz-2/results')
+    })
+
+    await act(async () => {
+      currentResults.resolve(jsonResponse({
+        results: [{
+          question_id: 'q-current',
+          question_text: 'Current result question',
+          options: ['A', 'B'],
+          counts: [1, 0],
+          total_responses: 1,
+        }],
+      }))
+      await currentResults.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Current result question')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      staleResults.resolve(jsonResponse({
+        results: [{
+          question_id: 'q-stale',
+          question_text: 'Stale result question',
+          options: ['A', 'B'],
+          counts: [0, 1],
+          total_responses: 1,
+        }],
+      }))
+      await staleResults.promise
+    })
+
+    expect(screen.getByText('Current result question')).toBeInTheDocument()
+    expect(screen.queryByText('Stale result question')).not.toBeInTheDocument()
   })
 
   it('highlights the student\'s own answer', async () => {

--- a/tests/components/StudentQuizzesTab.test.tsx
+++ b/tests/components/StudentQuizzesTab.test.tsx
@@ -5,6 +5,7 @@ import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
 } from '@/lib/events'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 import type { QuizFocusSummary } from '@/types'
 import { createMockClassroom } from '../helpers/mocks'
 
@@ -39,9 +40,24 @@ describe('StudentQuizzesTab exam mode', () => {
       configurable: true,
       value: 768,
     })
+    invalidateCachedJSONMatching('student-assessments:')
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve
+      reject = promiseReject
+    })
+    return { promise, resolve, reject }
+  }
+
+  function jsonResponse(body: unknown): Response {
+    return { ok: true, json: async () => body } as Response
+  }
 
   function queueTestList() {
     fetchMock.mockResolvedValueOnce({
@@ -91,6 +107,160 @@ describe('StudentQuizzesTab exam mode', () => {
       }),
     })
   }
+
+  it('ignores stale assessment list responses after classroom changes', async () => {
+    const firstClassroom = createMockClassroom({ id: 'classroom-a', title: 'Classroom A' })
+    const secondClassroom = createMockClassroom({ id: 'classroom-b', title: 'Classroom B' })
+    const firstList = createDeferred<Response>()
+    const secondList = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/student/quizzes?classroom_id=classroom-a')) return firstList.promise
+      if (url.includes('/api/student/quizzes?classroom_id=classroom-b')) return secondList.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const { rerender } = render(
+      <StudentQuizzesTab classroom={firstClassroom} assessmentType="quiz" />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/quizzes?classroom_id=classroom-a')
+    })
+
+    rerender(<StudentQuizzesTab classroom={secondClassroom} assessmentType="quiz" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/quizzes?classroom_id=classroom-b')
+    })
+
+    await act(async () => {
+      secondList.resolve(jsonResponse({
+        quizzes: [{
+          id: 'quiz-current',
+          title: 'Current Classroom Quiz',
+          assessment_type: 'quiz',
+          status: 'active',
+          show_results: false,
+          position: 0,
+          student_status: 'not_started',
+        }],
+      }))
+      await secondList.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Classroom Quiz')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      firstList.resolve(jsonResponse({
+        quizzes: [{
+          id: 'quiz-stale',
+          title: 'Stale Classroom Quiz',
+          assessment_type: 'quiz',
+          status: 'active',
+          show_results: false,
+          position: 0,
+          student_status: 'not_started',
+        }],
+      }))
+      await firstList.promise
+    })
+
+    expect(screen.getByText('Current Classroom Quiz')).toBeInTheDocument()
+    expect(screen.queryByText('Stale Classroom Quiz')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale assessment detail responses after classroom changes', async () => {
+    const firstClassroom = createMockClassroom({ id: 'classroom-a', title: 'Classroom A' })
+    const secondClassroom = createMockClassroom({ id: 'classroom-b', title: 'Classroom B' })
+    const firstDetail = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/api/student/quizzes?classroom_id=classroom-a')) {
+        return Promise.resolve(jsonResponse({
+          quizzes: [{
+            id: 'quiz-old',
+            title: 'Older Quiz',
+            assessment_type: 'quiz',
+            status: 'active',
+            show_results: false,
+            position: 0,
+            student_status: 'not_started',
+          }],
+        }))
+      }
+      if (url.includes('/api/student/quizzes?classroom_id=classroom-b')) {
+        return Promise.resolve(jsonResponse({
+          quizzes: [{
+            id: 'quiz-current',
+            title: 'Current Classroom Quiz',
+            assessment_type: 'quiz',
+            status: 'active',
+            show_results: false,
+            position: 0,
+            student_status: 'not_started',
+          }],
+        }))
+      }
+      if (url.endsWith('/api/student/quizzes/quiz-old')) return firstDetail.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const { rerender } = render(
+      <StudentQuizzesTab classroom={firstClassroom} assessmentType="quiz" />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Older Quiz')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Older Quiz'))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/quizzes/quiz-old')
+    })
+
+    rerender(<StudentQuizzesTab classroom={secondClassroom} assessmentType="quiz" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Classroom Quiz')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      firstDetail.resolve(jsonResponse({
+        quiz: {
+          id: 'quiz-old',
+          title: 'Older Quiz',
+          assessment_type: 'quiz',
+          status: 'active',
+          show_results: false,
+          position: 0,
+          student_status: 'not_started',
+        },
+        student_status: 'not_started',
+        questions: [
+          {
+            id: 'q-stale',
+            quiz_id: 'quiz-old',
+            question_text: 'Stale detail question',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            points: 1,
+            response_max_chars: 5000,
+            position: 0,
+          },
+        ],
+        student_responses: {},
+        focus_summary: null,
+      }))
+      await firstDetail.promise
+    })
+
+    expect(screen.getByText('Current Classroom Quiz')).toBeInTheDocument()
+    expect(screen.queryByText('Stale detail question')).not.toBeInTheDocument()
+  })
 
   function getSplitContainer(container: HTMLElement): HTMLDivElement {
     const splitContainer = container.querySelector(


### PR DESCRIPTION
## Summary
- guard student quiz/test list loads with cache dedupe, request ids, and classroom/type scope checks
- guard selected assessment detail loads and reset selection on classroom/type changes
- reset and guard student result payloads when quizId changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/unit/request-cache.test.ts
- pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/components/StudentQuizForm.test.tsx tests/api/student/quizzes.test.ts tests/api/student/quizzes-id.test.ts tests/api/student/quizzes-results.test.ts tests/api/student/quizzes-respond.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-respond.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-focus-events.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test