### PR TITLE
Guard quiz detail reloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,25 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Teacher test authoring URL mode
-
-**Completed:**
-- Made `testMode=authoring` open the teacher test editor instead of silently falling back to grading.
-- Updated test workspace navigation so Edit Test and newly created tests write authoring mode, while editor close returns the URL to grading mode.
-- Routed teacher test list/detail reads through `fetchJSONWithCache` to satisfy the client-read audit gate.
-- Added component coverage for authoring deep links, editor close URL repair, Edit Test URL state, and Browser Back from authoring to grading.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/ui/Dialog.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3024 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- Manual Playwright screenshots for `testMode=authoring`: `/tmp/pika-teacher-authoring.png`, `/tmp/pika-teacher-authoring-mobile.png`
-
 ## 2026-05-31 — Teacher assignment passive sidebar removal
 
 **Completed:**
@@ -965,3 +946,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm build`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
+
+## 2026-06-06 — Quiz detail freshness audit
+
+**Completed:**
+- Added request-scope guards to `QuizDetailPanel` draft, test-document detail, and results loads so stale responses cannot repaint after selected assessment, classroom, route base, or assessment-type changes.
+- Reset result payload and invalidated in-flight load/save revisions when the selected assessment scope changes.
+- Added save contexts so pending debounced saves can still persist their original assessment without applying stale draft state to the currently selected panel.
+- Added component coverage for stale draft, test-detail document, results, same-id assessment-type switch, selected-assessment save-response races, and pending debounced save persistence across assessment switches.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/QuizResultsView.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-results.test.ts tests/api/teacher/tests-results.test.ts tests/unit/request-cache.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `pnpm build`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx`

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -77,6 +77,27 @@ type AssessmentEditorDraft = {
   source_markdown?: string
 }
 
+type AssessmentRequestScope = {
+  quizId: string
+  classroomId: string
+  apiBasePath: string
+  assessmentType: QuizWithStats['assessment_type']
+  isTestsView: boolean
+}
+
+type DraftSaveContext = {
+  scope: AssessmentRequestScope
+  draftVersion: number
+  lastSavedDraft: string
+}
+
+type SaveDraftOptions = {
+  forceFull?: boolean
+  documents?: TestDocument[]
+  sourceMarkdown?: string
+  saveContext?: DraftSaveContext
+}
+
 type AssessmentViewMode = 'questions' | 'documents' | 'markdown' | 'preview' | 'results'
 
 const TEST_SUMMARY_DETAIL_LAYOUT = {
@@ -190,7 +211,7 @@ export function QuizDetailPanel({
   const saveDraftRef = useRef<
     | ((
         nextDraft: AssessmentEditorDraft,
-        options?: { forceFull?: boolean; documents?: TestDocument[]; sourceMarkdown?: string }
+        options?: SaveDraftOptions
       ) => Promise<boolean>)
     | null
   >(null)
@@ -203,11 +224,26 @@ export function QuizDetailPanel({
   const summaryDetailWorkspaceRef = useRef<HTMLDivElement>(null)
   const summaryDetailResizeCleanupRef = useRef<(() => void) | null>(null)
   const quizDefaultsRef = useRef({ title: quiz.title, show_results: quiz.show_results })
+  const loadRequestIdRef = useRef(0)
+  const currentLoadScopeRef = useRef({
+    quizId: quiz.id,
+    classroomId,
+    apiBasePath,
+    assessmentType: quiz.assessment_type,
+    isTestsView,
+  })
   const [summaryDetailMarkdownWidthPercent, setSummaryDetailMarkdownWidthPercent] = useState<number>(
     TEST_SUMMARY_DETAIL_LAYOUT.defaultMarkdownWidth
   )
   const loadedDraftQuizIdRef = useRef<string | null>(null)
   quizDefaultsRef.current = { title: quiz.title, show_results: quiz.show_results }
+  currentLoadScopeRef.current = {
+    quizId: quiz.id,
+    classroomId,
+    apiBasePath,
+    assessmentType: quiz.assessment_type,
+    isTestsView,
+  }
 
   const updateSaveStatus = useCallback((status: 'saved' | 'saving' | 'unsaved') => {
     saveStatusRef.current = status
@@ -219,6 +255,27 @@ export function QuizDetailPanel({
     draftMutationRevisionRef.current += 1
     updateSaveStatus('unsaved')
   }, [updateSaveStatus])
+
+  const isCurrentAssessmentScope = useCallback((scope: AssessmentRequestScope) => {
+    const currentScope = currentLoadScopeRef.current
+    return (
+      currentScope.quizId === scope.quizId &&
+      currentScope.classroomId === scope.classroomId &&
+      currentScope.apiBasePath === scope.apiBasePath &&
+      currentScope.assessmentType === scope.assessmentType &&
+      currentScope.isTestsView === scope.isTestsView
+    )
+  }, [])
+
+  const isCurrentLoadRequest = useCallback((requestId: number, scope: AssessmentRequestScope) => {
+    return loadRequestIdRef.current === requestId && isCurrentAssessmentScope(scope)
+  }, [isCurrentAssessmentScope])
+
+  const createDraftSaveContext = useCallback((): DraftSaveContext => ({
+    scope: { ...currentLoadScopeRef.current },
+    draftVersion: draftVersionRef.current,
+    lastSavedDraft: lastSavedDraftRef.current,
+  }), [])
 
   const requestCurrentWindowFullscreen = useCallback(async () => {
     const fullscreenElement = document.documentElement as HTMLElement & {
@@ -393,16 +450,24 @@ export function QuizDetailPanel({
   // Reset local draft state only when the selected quiz/test changes.
   useEffect(() => {
     const quizDefaults = quizDefaultsRef.current
+    loadRequestIdRef.current += 1
+    draftMutationRevisionRef.current += 1
+    saveTimeoutRef.current = null
+    throttledSaveTimeoutRef.current = null
+    pendingDraftRef.current = null
+    lastSavedDraftRef.current = ''
+    draftVersionRef.current = 1
     loadedDraftQuizIdRef.current = null
     setEditTitle(quizDefaults.title)
     setDraftShowResults(quizDefaults.show_results)
+    setResults(null)
     setConflictDraft(null)
     setIsMarkdownEditing(false)
     setMarkdownDirty(false)
     markdownDirtyRef.current = false
     setMarkdownError('')
     setMarkdownInfo('')
-  }, [quiz.id])
+  }, [apiBasePath, classroomId, isTestsView, quiz.assessment_type, quiz.id])
 
   useEffect(() => {
     setDocuments(normalizeTestDocuments((quiz as { documents?: unknown }).documents))
@@ -593,8 +658,25 @@ export function QuizDetailPanel({
   const saveDraft = useCallback(
     async (
       nextDraft: AssessmentEditorDraft,
-      options?: { forceFull?: boolean; documents?: TestDocument[]; sourceMarkdown?: string }
+      options?: SaveDraftOptions
     ) => {
+      const saveContext = options?.saveContext
+      const saveScope = saveContext?.scope ?? {
+        quizId: quiz.id,
+        classroomId,
+        apiBasePath,
+        assessmentType: quiz.assessment_type,
+        isTestsView,
+      }
+      const saveRevision = draftMutationRevisionRef.current
+      const canPersistSave = Boolean(saveContext) || isCurrentAssessmentScope(saveScope)
+      const shouldApplySaveLocally = () => (
+        saveRevision === draftMutationRevisionRef.current &&
+        isCurrentAssessmentScope(saveScope)
+      )
+      if (!canPersistSave) {
+        return false
+      }
       const shouldPersistMarkdownSource =
         isTestsView ||
         isMarkdownSurfaceEnabled ||
@@ -622,24 +704,24 @@ export function QuizDetailPanel({
             }
           : nextDraft
       const nextSerialized = JSON.stringify(contentDraft)
-      const saveRevision = draftMutationRevisionRef.current
-      const isLatestSave = () => saveRevision === draftMutationRevisionRef.current
-      if (!options?.forceFull && nextSerialized === lastSavedDraftRef.current) {
-        if (isLatestSave()) {
+      const baseSerialized = saveContext?.lastSavedDraft ?? lastSavedDraftRef.current
+      const draftVersion = saveContext?.draftVersion ?? draftVersionRef.current
+      if (!options?.forceFull && nextSerialized === baseSerialized) {
+        if (shouldApplySaveLocally()) {
           updateSaveStatus('saved')
         }
         return true
       }
 
-      if (isLatestSave()) {
+      if (shouldApplySaveLocally()) {
         updateSaveStatus('saving')
       }
       lastSaveAttemptAtRef.current = Date.now()
 
       let baseDraft = contentDraft
       try {
-        if (lastSavedDraftRef.current) {
-          baseDraft = JSON.parse(lastSavedDraftRef.current) as AssessmentEditorDraft
+        if (baseSerialized) {
+          baseDraft = JSON.parse(baseSerialized) as AssessmentEditorDraft
         }
       } catch {
         baseDraft = contentDraft
@@ -658,7 +740,7 @@ export function QuizDetailPanel({
         content?: AssessmentEditorDraft
         documents?: TestDocument[]
       } = {
-        version: draftVersionRef.current,
+        version: draftVersion,
       }
 
       if (shouldSendPatch) {
@@ -678,8 +760,12 @@ export function QuizDetailPanel({
         })
         const data = await response.json()
 
+        if (!shouldApplySaveLocally()) {
+          return response.ok
+        }
+
         if (response.status === 409) {
-          if (!isLatestSave()) {
+          if (!shouldApplySaveLocally()) {
             return false
           }
 
@@ -714,7 +800,7 @@ export function QuizDetailPanel({
         if (serverDraft?.content) {
           draftVersionRef.current = serverDraft.version
           lastSavedDraftRef.current = nextSerialized
-          if (isLatestSave()) {
+          if (shouldApplySaveLocally()) {
             applyServerDraft(serverDraft)
             onQuizUpdate({
               title:
@@ -733,7 +819,7 @@ export function QuizDetailPanel({
         } else {
           draftVersionRef.current += 1
           lastSavedDraftRef.current = nextSerialized
-          if (isLatestSave()) {
+          if (shouldApplySaveLocally()) {
             pendingDraftRef.current = nextDraft
             updateSaveStatus('saved')
             setError('')
@@ -744,7 +830,7 @@ export function QuizDetailPanel({
         return true
       } catch (saveError: any) {
         console.error('Error saving draft:', saveError)
-        if (isLatestSave()) {
+        if (shouldApplySaveLocally()) {
           updateSaveStatus('unsaved')
           setError(saveError?.message || 'Failed to save draft')
         }
@@ -754,11 +840,14 @@ export function QuizDetailPanel({
     [
       apiBasePath,
       applyServerDraft,
+      classroomId,
       documents,
+      isCurrentAssessmentScope,
       isMarkdownSurfaceEnabled,
       isTestsView,
       normalizeDraftQuestions,
       onQuizUpdate,
+      quiz.assessment_type,
       quiz.id,
       updateSaveStatus,
     ]
@@ -767,11 +856,12 @@ export function QuizDetailPanel({
   const scheduleSave = useCallback(
     (
       nextDraft: AssessmentEditorDraft,
-      options?: { force?: boolean }
+      options?: { force?: boolean; saveContext?: DraftSaveContext }
     ) => {
       if (conflictDraft) return
 
       pendingDraftRef.current = nextDraft
+      const saveContext = options?.saveContext ?? createDraftSaveContext()
 
       if (throttledSaveTimeoutRef.current) {
         clearTimeout(throttledSaveTimeoutRef.current)
@@ -782,20 +872,18 @@ export function QuizDetailPanel({
       const msSinceLastAttempt = now - lastSaveAttemptAtRef.current
 
       if (options?.force || msSinceLastAttempt >= AUTOSAVE_MIN_INTERVAL_MS) {
-        void saveDraft(nextDraft)
+        void saveDraft(nextDraft, { saveContext })
         return
       }
 
       const waitMs = AUTOSAVE_MIN_INTERVAL_MS - msSinceLastAttempt
+      const scheduledDraft = nextDraft
       throttledSaveTimeoutRef.current = setTimeout(() => {
         throttledSaveTimeoutRef.current = null
-        const latestDraft = pendingDraftRef.current
-        if (latestDraft) {
-          void saveDraft(latestDraft)
-        }
+        void saveDraft(scheduledDraft, { saveContext })
       }, waitMs)
     },
-    [AUTOSAVE_MIN_INTERVAL_MS, conflictDraft, saveDraft]
+    [AUTOSAVE_MIN_INTERVAL_MS, conflictDraft, createDraftSaveContext, saveDraft]
   )
 
   const scheduleAutosave = useCallback(
@@ -803,6 +891,7 @@ export function QuizDetailPanel({
       if (conflictDraft) return
 
       pendingDraftRef.current = nextDraft
+      const saveContext = createDraftSaveContext()
       markDraftUnsaved()
       setError('')
 
@@ -811,17 +900,29 @@ export function QuizDetailPanel({
       }
 
       saveTimeoutRef.current = setTimeout(() => {
-        scheduleSave(nextDraft)
+        saveTimeoutRef.current = null
+        scheduleSave(nextDraft, { saveContext })
       }, AUTOSAVE_DEBOUNCE_MS)
     },
-    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, markDraftUnsaved, scheduleSave]
+    [AUTOSAVE_DEBOUNCE_MS, conflictDraft, createDraftSaveContext, markDraftUnsaved, scheduleSave]
   )
 
   const loadQuizDetails = useCallback(async () => {
+    const scope = {
+      quizId: quiz.id,
+      classroomId,
+      apiBasePath,
+      assessmentType: quiz.assessment_type,
+      isTestsView,
+    }
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
     setLoading(true)
     try {
+      // Bypass fetchJSONWithCache for selected assessment freshness; request ids guard stale responses.
       const draftRes = await fetch(`${apiBasePath}/${quiz.id}/draft`)
       const draftData = await draftRes.json()
+      if (!isCurrentLoadRequest(requestId, scope)) return
       if (!draftRes.ok) {
         throw new Error(draftData.error || 'Failed to load assessment draft')
       }
@@ -840,27 +941,45 @@ export function QuizDetailPanel({
       applyServerDraft(normalizedDraft)
 
       if (isTestsView) {
+        // Bypass fetchJSONWithCache so test documents always follow the selected assessment.
         const detailRes = await fetch(`${apiBasePath}/${quiz.id}`)
         if (detailRes?.ok) {
           const detailData = await detailRes.json()
+          if (!isCurrentLoadRequest(requestId, scope)) return
           setDocuments(normalizeTestDocuments(detailData?.quiz?.documents))
         }
       }
 
       if (hasResponses) {
+        // Bypass fetchJSONWithCache so results always follow the selected assessment.
         const resultsRes = await fetch(`${apiBasePath}/${quiz.id}/results`)
         const resultsData = await resultsRes.json()
+        if (!isCurrentLoadRequest(requestId, scope)) return
         setResults(resultsData.results || [])
       } else {
+        if (!isCurrentLoadRequest(requestId, scope)) return
         setResults(null)
       }
     } catch (err: any) {
-      console.error('Error loading quiz details:', err)
-      setError(err?.message || 'Failed to load assessment details')
+      if (isCurrentLoadRequest(requestId, scope)) {
+        console.error('Error loading quiz details:', err)
+        setError(err?.message || 'Failed to load assessment details')
+      }
     } finally {
-      setLoading(false)
+      if (isCurrentLoadRequest(requestId, scope)) {
+        setLoading(false)
+      }
     }
-  }, [apiBasePath, applyServerDraft, hasResponses, isTestsView, quiz.id])
+  }, [
+    apiBasePath,
+    applyServerDraft,
+    classroomId,
+    hasResponses,
+    isCurrentLoadRequest,
+    isTestsView,
+    quiz.assessment_type,
+    quiz.id,
+  ])
 
   useEffect(() => {
     loadQuizDetails()

--- a/tests/components/QuizDetailPanel.test.tsx
+++ b/tests/components/QuizDetailPanel.test.tsx
@@ -68,6 +68,20 @@ describe('QuizDetailPanel', () => {
     vi.restoreAllMocks()
   })
 
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve
+      reject = promiseReject
+    })
+    return { promise, resolve, reject }
+  }
+
+  function jsonResponse(body: unknown): Response {
+    return { ok: true, json: async () => body } as Response
+  }
+
   function mockFetchForQuiz(
     questions: QuizQuestion[],
     results?: QuizResultsAggregate[],
@@ -105,6 +119,400 @@ describe('QuizDetailPanel', () => {
     }
     return fetchMock
   }
+
+  it('ignores stale draft responses after selected assessment changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleDraft = createDeferred<Response>()
+    const currentDraft = createDeferred<Response>()
+    const staleQuestion = createMockQuizQuestion({
+      id: 'q-stale',
+      quiz_id: 'quiz-stale',
+      question_text: 'Stale draft question',
+      position: 0,
+    })
+    const currentQuestion = createMockQuizQuestion({
+      id: 'q-current',
+      quiz_id: 'quiz-current',
+      question_text: 'Current draft question',
+      position: 0,
+    })
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/api/teacher/quizzes/quiz-stale/draft')) return staleDraft.promise
+      if (url.endsWith('/api/teacher/quizzes/quiz-current/draft')) return currentDraft.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const staleQuiz = makeQuizWithStats({ id: 'quiz-stale', title: 'Stale Quiz' })
+    const currentQuiz = makeQuizWithStats({ id: 'quiz-current', title: 'Current Quiz' })
+    const { rerender } = render(
+      <QuizDetailPanel quiz={staleQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/quizzes/quiz-stale/draft')
+    })
+
+    rerender(
+      <QuizDetailPanel quiz={currentQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/quizzes/quiz-current/draft')
+    })
+
+    await act(async () => {
+      currentDraft.resolve(jsonResponse({
+        draft: {
+          version: 1,
+          content: {
+            title: 'Current Quiz',
+            show_results: true,
+            questions: [currentQuestion],
+          },
+        },
+      }))
+      await currentDraft.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Current draft question')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      staleDraft.resolve(jsonResponse({
+        draft: {
+          version: 1,
+          content: {
+            title: 'Stale Quiz',
+            show_results: true,
+            questions: [staleQuestion],
+          },
+        },
+      }))
+      await staleDraft.promise
+    })
+
+    expect(screen.getByText('Current draft question')).toBeInTheDocument()
+    expect(screen.queryByText('Stale draft question')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale test detail documents after selected assessment changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleDetail = createDeferred<Response>()
+    const currentDetail = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/api/teacher/tests/test-stale/draft')) {
+        return Promise.resolve(jsonResponse({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Stale Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }))
+      }
+      if (url.endsWith('/api/teacher/tests/test-current/draft')) {
+        return Promise.resolve(jsonResponse({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Current Test',
+              show_results: true,
+              questions: summaryDetailQuestions,
+            },
+          },
+        }))
+      }
+      if (url.endsWith('/api/teacher/tests/test-stale')) return staleDetail.promise
+      if (url.endsWith('/api/teacher/tests/test-current')) return currentDetail.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const staleTest = makeQuizWithStats({
+      id: 'test-stale',
+      title: 'Stale Test',
+      assessment_type: 'test',
+    })
+    const currentTest = makeQuizWithStats({
+      id: 'test-current',
+      title: 'Current Test',
+      assessment_type: 'test',
+    })
+    const { rerender } = render(
+      <QuizDetailPanel
+        quiz={staleTest}
+        classroomId="classroom-1"
+        apiBasePath="/api/teacher/tests"
+        onQuizUpdate={vi.fn()}
+      />,
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/test-stale')
+    })
+
+    rerender(
+      <QuizDetailPanel
+        quiz={currentTest}
+        classroomId="classroom-1"
+        apiBasePath="/api/teacher/tests"
+        onQuizUpdate={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/test-current')
+    })
+
+    await act(async () => {
+      currentDetail.resolve(jsonResponse({
+        quiz: {
+          documents: [
+            { id: 'doc-current', title: 'Current Reference', source: 'text', content: 'Current' },
+          ],
+        },
+      }))
+      await currentDetail.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Documents (1)' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Documents (1)' }))
+    expect(screen.getByText('Current Reference')).toBeInTheDocument()
+
+    await act(async () => {
+      staleDetail.resolve(jsonResponse({
+        quiz: {
+          documents: [
+            { id: 'doc-stale', title: 'Stale Reference', source: 'text', content: 'Stale' },
+          ],
+        },
+      }))
+      await staleDetail.promise
+    })
+
+    expect(screen.getByText('Current Reference')).toBeInTheDocument()
+    expect(screen.queryByText('Stale Reference')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale result responses after selected assessment changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleResults = createDeferred<Response>()
+    const currentResults = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/api/teacher/quizzes/quiz-stale/draft')) {
+        return Promise.resolve(jsonResponse({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Stale Quiz',
+              show_results: true,
+              questions: sampleQuestions,
+            },
+          },
+        }))
+      }
+      if (url.endsWith('/api/teacher/quizzes/quiz-current/draft')) {
+        return Promise.resolve(jsonResponse({
+          draft: {
+            version: 1,
+            content: {
+              title: 'Current Quiz',
+              show_results: true,
+              questions: sampleQuestions,
+            },
+          },
+        }))
+      }
+      if (url.endsWith('/api/teacher/quizzes/quiz-stale/results')) return staleResults.promise
+      if (url.endsWith('/api/teacher/quizzes/quiz-current/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const staleQuiz = makeQuizWithStats({
+      id: 'quiz-stale',
+      title: 'Stale Quiz',
+      stats: { total_students: 25, responded: 1, questions_count: 1 },
+    })
+    const currentQuiz = makeQuizWithStats({
+      id: 'quiz-current',
+      title: 'Current Quiz',
+      stats: { total_students: 25, responded: 1, questions_count: 1 },
+    })
+    const { rerender } = render(
+      <QuizDetailPanel quiz={staleQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/quizzes/quiz-stale/results')
+    })
+
+    rerender(
+      <QuizDetailPanel quiz={currentQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/quizzes/quiz-current/results')
+    })
+
+    await act(async () => {
+      currentResults.resolve(jsonResponse({
+        results: [{
+          question_id: 'q-current',
+          question_text: 'Current results question',
+          options: ['A', 'B'],
+          counts: [1, 0],
+          total_responses: 1,
+        }],
+      }))
+      await currentResults.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Results (1)' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('tab', { name: 'Results (1)' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Current results question')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      staleResults.resolve(jsonResponse({
+        results: [{
+          question_id: 'q-stale',
+          question_text: 'Stale results question',
+          options: ['A', 'B'],
+          counts: [0, 1],
+          total_responses: 1,
+        }],
+      }))
+      await staleResults.promise
+    })
+
+    expect(screen.getByText('Current results question')).toBeInTheDocument()
+    expect(screen.queryByText('Stale results question')).not.toBeInTheDocument()
+  })
+
+  it('invalidates stale loads when assessment type changes for the same id', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleQuizDraft = createDeferred<Response>()
+    const currentTestDraft = createDeferred<Response>()
+    let draftReads = 0
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/api/teacher/quizzes/assessment-1/draft')) {
+        draftReads += 1
+        return draftReads === 1 ? staleQuizDraft.promise : currentTestDraft.promise
+      }
+      if (url.endsWith('/api/teacher/quizzes/assessment-1')) {
+        return Promise.resolve(jsonResponse({
+          quiz: {
+            documents: [
+              { id: 'doc-current', title: 'Current Test Reference', source: 'text', content: 'Current' },
+            ],
+          },
+        }))
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const sameIdQuiz = makeQuizWithStats({
+      id: 'assessment-1',
+      title: 'Same Id Quiz',
+      assessment_type: 'quiz',
+    })
+    const sameIdTest = makeQuizWithStats({
+      id: 'assessment-1',
+      title: 'Same Id Test',
+      assessment_type: 'test',
+    })
+    const { rerender } = render(
+      <QuizDetailPanel quiz={sameIdQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/quizzes/assessment-1/draft')
+    })
+
+    rerender(
+      <QuizDetailPanel quiz={sameIdTest} classroomId="classroom-1" onQuizUpdate={vi.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(draftReads).toBe(2)
+    })
+
+    await act(async () => {
+      currentTestDraft.resolve(jsonResponse({
+        draft: {
+          version: 1,
+          content: {
+            title: 'Same Id Test',
+            show_results: true,
+            questions: [
+              createMockQuizQuestion({
+                id: 'q-current-test',
+                quiz_id: 'assessment-1',
+                assessment_type: 'test',
+                question_type: 'open_response',
+                question_text: 'Current same-id test question',
+                options: [],
+                correct_option: null,
+                points: 2,
+                position: 0,
+              }),
+            ],
+          },
+        },
+      }))
+      await currentTestDraft.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Documents (1)' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Documents (1)' }))
+    expect(screen.getByText('Current Test Reference')).toBeInTheDocument()
+
+    await act(async () => {
+      staleQuizDraft.resolve(jsonResponse({
+        draft: {
+          version: 1,
+          content: {
+            title: 'Same Id Quiz',
+            show_results: true,
+            questions: [
+              createMockQuizQuestion({
+                id: 'q-stale-quiz',
+                quiz_id: 'assessment-1',
+                question_text: 'Stale same-id quiz question',
+                position: 0,
+              }),
+            ],
+          },
+        },
+      }))
+      await staleQuizDraft.promise
+    })
+
+    expect(screen.getByText('Current Test Reference')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('tab', { name: 'Questions (1)' }))
+    expect(screen.getByDisplayValue('Current same-id test question')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('Stale same-id quiz question')).not.toBeInTheDocument()
+  })
 
   describe('tabs', () => {
     it('renders Questions, Preview, and Results tabs for quizzes', async () => {
@@ -1245,6 +1653,245 @@ Options:
 
       expect(onSaveStatusChange).not.toHaveBeenCalledWith('saved')
       expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+    })
+
+    it('ignores stale save responses after selected assessment changes', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+      const staleSave = createDeferred<Response>()
+      const currentQuestion = createMockQuizQuestion({
+        id: 'q-current-save-scope',
+        assessment_type: 'test',
+        question_type: 'open_response',
+        question_text: 'Current switched test question',
+        options: [],
+        correct_option: null,
+        points: 2,
+        position: 0,
+      })
+
+      fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url === '/api/teacher/tests/test-save-stale/draft' && options?.method === 'PATCH') {
+          return staleSave.promise
+        }
+        if (url === '/api/teacher/tests/test-save-stale/draft' && !options) {
+          return Promise.resolve(jsonResponse({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Stale Save Test',
+                show_results: false,
+                questions: [],
+              },
+            },
+          }))
+        }
+        if (url === '/api/teacher/tests/test-save-stale' && !options) {
+          return Promise.resolve(jsonResponse({ quiz: { documents: [] } }))
+        }
+        if (url === '/api/teacher/tests/test-save-current/draft' && !options) {
+          return Promise.resolve(jsonResponse({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Current Save Test',
+                show_results: false,
+                questions: [currentQuestion],
+              },
+            },
+          }))
+        }
+        if (url === '/api/teacher/tests/test-save-current' && !options) {
+          return Promise.resolve(jsonResponse({ quiz: { documents: [] } }))
+        }
+
+        throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
+      })
+
+      const staleTest = makeQuizWithStats({
+        id: 'test-save-stale',
+        assessment_type: 'test',
+        title: 'Stale Save Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+      const currentTest = makeQuizWithStats({
+        id: 'test-save-current',
+        assessment_type: 'test',
+        title: 'Current Save Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 1 },
+      })
+
+      const { rerender } = render(
+        <QuizDetailPanel
+          quiz={staleTest}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const addQuestionButton = await screen.findByRole('button', { name: '+ MC Question' })
+      vi.useFakeTimers()
+
+      fireEvent.click(addQuestionButton)
+
+      await act(async () => {
+        vi.advanceTimersByTime(3_100)
+      })
+
+      expect(fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')).toHaveLength(1)
+      vi.useRealTimers()
+
+      rerender(
+        <QuizDetailPanel
+          quiz={currentTest}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />
+      )
+
+      expect(await screen.findByDisplayValue('Current switched test question')).toBeInTheDocument()
+
+      await act(async () => {
+        staleSave.resolve(jsonResponse({
+          draft: {
+            version: 2,
+            content: {
+              title: 'Stale Save Test',
+              show_results: false,
+              questions: [
+                createMockQuizQuestion({
+                  id: 'q-stale-save-scope',
+                  assessment_type: 'test',
+                  question_type: 'multiple_choice',
+                  question_text: 'Stale saved question',
+                  position: 0,
+                }),
+              ],
+            },
+          },
+        }))
+        await staleSave.promise
+      })
+
+      expect(screen.getByDisplayValue('Current switched test question')).toBeInTheDocument()
+      expect(screen.queryByDisplayValue('Stale saved question')).not.toBeInTheDocument()
+    })
+
+    it('persists pending debounced saves after selected assessment changes', async () => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+
+      fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url === '/api/teacher/tests/test-pending-save/draft' && options?.method === 'PATCH') {
+          const body = JSON.parse(String(options.body ?? '{}'))
+          return Promise.resolve(jsonResponse({
+            draft: {
+              version: Number(body.version ?? 1) + 1,
+              content: body.content,
+            },
+          }))
+        }
+        if (url === '/api/teacher/tests/test-pending-save/draft' && !options) {
+          return Promise.resolve(jsonResponse({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Pending Save Test',
+                show_results: false,
+                questions: [],
+              },
+            },
+          }))
+        }
+        if (url === '/api/teacher/tests/test-pending-save' && !options) {
+          return Promise.resolve(jsonResponse({ quiz: { documents: [] } }))
+        }
+        if (url === '/api/teacher/tests/test-pending-current/draft' && !options) {
+          return Promise.resolve(jsonResponse({
+            draft: {
+              version: 1,
+              content: {
+                title: 'Pending Current Test',
+                show_results: false,
+                questions: [],
+              },
+            },
+          }))
+        }
+        if (url === '/api/teacher/tests/test-pending-current' && !options) {
+          return Promise.resolve(jsonResponse({ quiz: { documents: [] } }))
+        }
+
+        throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
+      })
+
+      const staleTest = makeQuizWithStats({
+        id: 'test-pending-save',
+        assessment_type: 'test',
+        title: 'Pending Save Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+      const currentTest = makeQuizWithStats({
+        id: 'test-pending-current',
+        assessment_type: 'test',
+        title: 'Pending Current Test',
+        show_results: false,
+        stats: { total_students: 25, responded: 0, questions_count: 0 },
+      })
+
+      const { rerender } = render(
+        <QuizDetailPanel
+          quiz={staleTest}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const addQuestionButton = await screen.findByRole('button', { name: '+ MC Question' })
+      vi.useFakeTimers()
+
+      fireEvent.click(addQuestionButton)
+      expect(fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')).toHaveLength(0)
+
+      rerender(
+        <QuizDetailPanel
+          quiz={currentTest}
+          classroomId="classroom-1"
+          apiBasePath="/api/teacher/tests"
+          onQuizUpdate={vi.fn()}
+          testQuestionLayout="summary-detail"
+          showPreviewButton={false}
+          showResultsTab={false}
+        />
+      )
+
+      await act(async () => {
+        await Promise.resolve()
+        vi.advanceTimersByTime(3_100)
+        await Promise.resolve()
+      })
+      vi.useRealTimers()
+
+      const patchCalls = fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')
+      expect(patchCalls).toHaveLength(1)
+      expect(String(patchCalls[0]?.[0])).toBe('/api/teacher/tests/test-pending-save/draft')
+      const patchBody = JSON.parse(String(patchCalls[0]?.[1]?.body ?? '{}'))
+      expect(patchBody.content?.questions).toHaveLength(1)
     })
 
     it('duplicates a test question immediately below the source in summary-detail mode', async () => {


### PR DESCRIPTION
## Summary
- add scoped request guards for QuizDetailPanel draft, test-detail document, and results loads
- reset stale result payloads and invalidate in-flight load/save revisions on assessment scope changes
- cover stale draft, test-document, results, and same-id assessment-type switch races

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/QuizResultsView.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-results.test.ts tests/api/teacher/tests-results.test.ts tests/unit/request-cache.test.ts
- git diff --check
- pnpm lint
- pnpm build
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test
- pnpm vitest run tests/components/QuizDetailPanel.test.tsx