### PR TITLE
Guard survey detail reloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,24 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Teacher assignment passive sidebar removal
-
-**Completed:**
-- Disabled the external right sidebar for teacher assignment summary and workspace route keys.
-- Stopped rendering the classroom route's passive assignment sidebar fallback for teacher assignments.
-- Added coverage so teacher assignments match the tests work-surface rule: no external sidebar until an integrated workspace inspector is active.
-- Fixed review feedback so disabled right-sidebar routes clear stale mobile right-drawer state.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/layout-config.test.ts tests/components/ThreePanelProvider.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx -- --runInBand --testTimeout=10000`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `E2E_BASE_URL=http://localhost:3025 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- Reviewed screenshots: `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-teacher-assignments-loaded.png`
-
 ## 2026-05-31 — UI sidebar guidance cleanup
 
 **Completed:**
@@ -964,3 +946,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm vitest run tests/components/QuizDetailPanel.test.tsx`
+
+## 2026-06-06 — Survey detail freshness audit
+
+**Completed:**
+- Added request-id and selected-survey guards to teacher survey authoring detail loads, teacher survey results loads, and student survey detail/results loads.
+- Scoped already-loaded teacher/student survey detail and result payloads to the active selected survey so old survey content is hidden immediately on selection changes.
+- Reset student survey result payloads while a new selected survey or result request is loading.
+- Kept selected survey detail/results reads raw for freshness and guarded stale responses explicitly.
+- Added component coverage for stale teacher survey detail/results responses, stale student survey detail/results responses, and already-loaded old detail/results after survey switches.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm test`

--- a/src/components/surveys/StudentSurveyPanel.tsx
+++ b/src/components/surveys/StudentSurveyPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ExternalLink, Pencil } from 'lucide-react'
 import { Button, Card, Input } from '@/ui'
 import { FloatingActionCluster } from '@/components/FloatingActionCluster'
@@ -116,37 +116,61 @@ export function StudentSurveyPanel({
 }: StudentSurveyPanelProps) {
   const [detail, setDetail] = useState<SurveyDetailPayload | null>(null)
   const [responses, setResponses] = useState<Record<string, SurveyResponseValue>>({})
-  const [results, setResults] = useState<SurveyResultsPayload | null>(null)
+  const [resultsState, setResultsState] = useState<{ surveyId: string; payload: SurveyResultsPayload } | null>(null)
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [isEditingResponse, setIsEditingResponse] = useState(false)
   const [error, setError] = useState('')
+  const detailRequestIdRef = useRef(0)
+  const resultsRequestIdRef = useRef(0)
+  const currentSurveyIdRef = useRef(surveyId)
+  currentSurveyIdRef.current = surveyId
+  const activeDetail = detail?.survey?.id === surveyId ? detail : null
+  const results = resultsState?.surveyId === surveyId ? resultsState.payload : null
 
   const loadSurvey = useCallback(async () => {
+    const requestId = detailRequestIdRef.current + 1
+    detailRequestIdRef.current = requestId
+    const requestedSurveyId = surveyId
     setLoading(true)
     setError('')
+    setResultsState(null)
     try {
+      // Bypass fetchJSONWithCache for selected survey freshness; request ids guard stale responses.
       const response = await fetch(`/api/student/surveys/${surveyId}`)
       const data = await response.json()
+      if (detailRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load survey')
       setDetail(data)
       setResponses(data.student_responses || {})
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load survey')
-      setDetail(null)
+      if (detailRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setError(err instanceof Error ? err.message : 'Failed to load survey')
+        setDetail(null)
+      }
     } finally {
-      setLoading(false)
+      if (detailRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setLoading(false)
+      }
     }
   }, [surveyId])
 
   const loadResults = useCallback(async () => {
+    const requestId = resultsRequestIdRef.current + 1
+    resultsRequestIdRef.current = requestId
+    const requestedSurveyId = surveyId
+    setResultsState(null)
     try {
+      // Bypass fetchJSONWithCache for selected survey results freshness; request ids guard stale responses.
       const response = await fetch(`/api/student/surveys/${surveyId}/results`)
       const data = await response.json()
+      if (resultsRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load results')
-      setResults(data)
+      setResultsState({ surveyId: requestedSurveyId, payload: data })
     } catch {
-      setResults(null)
+      if (resultsRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setResultsState(null)
+      }
     }
   }, [surveyId])
 
@@ -155,29 +179,29 @@ export function StudentSurveyPanel({
   }, [loadSurvey])
 
   useEffect(() => {
-    if (detail?.survey && canStudentViewSurveyResults(detail.survey)) {
+    if (activeDetail?.survey && canStudentViewSurveyResults(activeDetail.survey)) {
       void loadResults()
     } else {
-      setResults(null)
+      setResultsState(null)
     }
-  }, [detail?.survey, loadResults])
+  }, [activeDetail?.survey, loadResults])
 
   useEffect(() => {
-    const survey = detail?.survey
+    const survey = activeDetail?.survey
     if (!survey) return
     setIsEditingResponse(!canStudentViewSurveyResults(survey))
-  }, [detail?.survey])
+  }, [activeDetail?.survey])
 
   const canRespond = useMemo(() => {
-    if (!detail) return false
-    if (detail.survey.status !== 'active') return false
-    const hasSubmitted = detail.has_submitted ?? Object.keys(detail.student_responses || {}).length > 0
-    return !hasSubmitted || detail.survey.dynamic_responses
-  }, [detail])
+    if (!activeDetail) return false
+    if (activeDetail.survey.status !== 'active') return false
+    const hasSubmitted = activeDetail.has_submitted ?? Object.keys(activeDetail.student_responses || {}).length > 0
+    return !hasSubmitted || activeDetail.survey.dynamic_responses
+  }, [activeDetail])
 
   const allAnswered = useMemo(() => {
-    if (!detail) return false
-    return detail.questions.every((question) => {
+    if (!activeDetail) return false
+    return activeDetail.questions.every((question) => {
       const response = responses[question.id]
       if (!response) return false
       if (question.question_type === 'multiple_choice') {
@@ -185,10 +209,10 @@ export function StudentSurveyPanel({
       }
       return response.question_type !== 'multiple_choice' && response.response_text.trim().length > 0
     })
-  }, [detail, responses])
+  }, [activeDetail, responses])
 
   async function submitResponses() {
-    if (!detail) return
+    if (!activeDetail) return
     setSubmitting(true)
     setError('')
     try {
@@ -201,8 +225,8 @@ export function StudentSurveyPanel({
       if (!response.ok) throw new Error(data.error || 'Failed to submit responses')
       onCompleted?.()
       await loadSurvey()
-      if (canStudentViewSurveyResults(detail.survey)) await loadResults()
-      if (canStudentViewSurveyResults(detail.survey)) setIsEditingResponse(false)
+      if (canStudentViewSurveyResults(activeDetail.survey)) await loadResults()
+      if (canStudentViewSurveyResults(activeDetail.survey)) setIsEditingResponse(false)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to submit responses')
     } finally {
@@ -210,7 +234,7 @@ export function StudentSurveyPanel({
     }
   }
 
-  if (loading) {
+  if (loading || (detail !== null && !activeDetail)) {
     return (
       <Card tone="panel" padding="lg">
         <div className="flex justify-center py-8">
@@ -220,7 +244,7 @@ export function StudentSurveyPanel({
     )
   }
 
-  if (!detail) {
+  if (!activeDetail) {
     return (
       <Card tone="panel" padding="lg">
         <p className="text-sm text-danger">{error || 'Survey unavailable'}</p>
@@ -228,8 +252,8 @@ export function StudentSurveyPanel({
     )
   }
 
-  const { survey, questions } = detail
-  const hasSubmitted = detail.has_submitted ?? Object.keys(detail.student_responses || {}).length > 0
+  const { survey, questions } = activeDetail
+  const hasSubmitted = activeDetail.has_submitted ?? Object.keys(activeDetail.student_responses || {}).length > 0
   const canViewResults = canStudentViewSurveyResults(survey)
   const showResponseForm = isEditingResponse || !canViewResults
   const showResults = canViewResults

--- a/src/components/surveys/TeacherSurveyResultsPane.tsx
+++ b/src/components/surveys/TeacherSurveyResultsPane.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { BarChart3 } from 'lucide-react'
 import { Card } from '@/ui'
 import { Spinner } from '@/components/Spinner'
@@ -20,20 +20,34 @@ interface TeacherSurveyResultsPaneProps {
 }
 
 export function TeacherSurveyResultsPane({ survey }: TeacherSurveyResultsPaneProps) {
-  const [payload, setPayload] = useState<SurveyResultsPayload | null>(null)
+  const [payloadState, setPayloadState] = useState<{ surveyId: string; payload: SurveyResultsPayload } | null>(null)
   const [error, setError] = useState('')
+  const loadRequestIdRef = useRef(0)
+  const currentSurveyIdRef = useRef(survey.id)
+  currentSurveyIdRef.current = survey.id
+  const payload = payloadState?.surveyId === survey.id ? payloadState.payload : null
 
   const loadResults = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
+    const requestedSurveyId = survey.id
     setError('')
-    setPayload(null)
+    setPayloadState(null)
     try {
+      // Bypass fetchJSONWithCache for selected survey results freshness; request ids guard stale responses.
       const response = await fetch(`/api/teacher/surveys/${survey.id}/results`)
       const data = await response.json()
+      if (loadRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load survey results')
-      setPayload(data)
+      setPayloadState({ surveyId: requestedSurveyId, payload: data })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load survey results')
-      setPayload({ results: [], stats: { responded: 0, total_students: survey.stats.total_students || 0 } })
+      if (loadRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setError(err instanceof Error ? err.message : 'Failed to load survey results')
+        setPayloadState({
+          surveyId: requestedSurveyId,
+          payload: { results: [], stats: { responded: 0, total_students: survey.stats.total_students || 0 } },
+        })
+      }
     }
   }, [survey.id, survey.stats.total_students])
 

--- a/src/components/surveys/TeacherSurveyWorkspace.tsx
+++ b/src/components/surveys/TeacherSurveyWorkspace.tsx
@@ -480,13 +480,17 @@ export function TeacherSurveyWorkspace({
   const [surveyMarkdownInfo, setSurveyMarkdownInfo] = useState('')
   const onSurveyUpdatedRef = useRef(onSurveyUpdated)
   const consumedInitialEditModeRef = useRef<string | null>(null)
+  const loadRequestIdRef = useRef(0)
+  const currentSurveyIdRef = useRef(surveyId)
+  currentSurveyIdRef.current = surveyId
 
   useEffect(() => {
     onSurveyUpdatedRef.current = onSurveyUpdated
   }, [onSurveyUpdated])
 
-  const survey = detail?.survey ?? null
-  const questions = useMemo(() => detail?.questions ?? [], [detail?.questions])
+  const activeDetail = detail?.survey?.id === surveyId ? detail : null
+  const survey = activeDetail?.survey ?? null
+  const questions = useMemo(() => activeDetail?.questions ?? [], [activeDetail?.questions])
   const statusClassName = survey ? getSurveyStatusBadgeClass(survey.status) : ''
   const currentSurveyMarkdown = useMemo(
     () => (survey ? surveyToMarkdown({ survey, questions }) : ''),
@@ -494,19 +498,28 @@ export function TeacherSurveyWorkspace({
   )
 
   const loadSurvey = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
+    const requestedSurveyId = surveyId
     setLoading(true)
     setError('')
     try {
+      // Bypass fetchJSONWithCache for selected survey freshness; request ids guard stale responses.
       const response = await fetch(`/api/teacher/surveys/${surveyId}`)
       const data = await response.json()
+      if (loadRequestIdRef.current !== requestId || currentSurveyIdRef.current !== requestedSurveyId) return
       if (!response.ok) throw new Error(data.error || 'Failed to load survey')
       setDetail({ survey: data.survey, questions: data.questions || [] })
       onSurveyUpdatedRef.current(data.survey)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load survey')
-      setDetail(null)
+      if (loadRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setError(err instanceof Error ? err.message : 'Failed to load survey')
+        setDetail(null)
+      }
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId && currentSurveyIdRef.current === requestedSurveyId) {
+        setLoading(false)
+      }
     }
   }, [surveyId])
 
@@ -758,7 +771,7 @@ export function TeacherSurveyWorkspace({
     }
   }
 
-  if (loading) {
+  if (loading || (detail !== null && !activeDetail)) {
     return (
       <div className="flex flex-1 items-center justify-center py-12">
         <Spinner />

--- a/tests/components/StudentSurveyPanel.test.tsx
+++ b/tests/components/StudentSurveyPanel.test.tsx
@@ -1,6 +1,82 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import type { ReactNode } from 'react'
 import { StudentSurveyPanel } from '@/components/surveys/StudentSurveyPanel'
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+function surveyDetailPayload(surveyId: string, title: string, questionText: string) {
+  return {
+    survey: {
+      id: surveyId,
+      classroom_id: 'classroom-1',
+      title,
+      status: 'active',
+      opens_at: null,
+      show_results: true,
+      dynamic_responses: false,
+      position: 0,
+      student_status: 'can_view_results',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+    questions: [{
+      id: `${surveyId}-question`,
+      survey_id: surveyId,
+      question_type: 'multiple_choice',
+      question_text: questionText,
+      options: ['A', 'B'],
+      response_max_chars: 500,
+      position: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    }],
+    student_status: 'can_view_results',
+    has_submitted: false,
+    student_responses: {},
+  }
+}
+
+function surveyResultsPayload(questionId: string, questionText: string) {
+  return {
+    results: [{
+      question_id: questionId,
+      question_type: 'multiple_choice',
+      question_text: questionText,
+      options: ['A', 'B'],
+      counts: [1, 0],
+      responses: [],
+      total_responses: 1,
+    }],
+  }
+}
+
+function createMountedRoot() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  return {
+    render: (node: ReactNode) => root.render(node),
+    cleanup: () => {
+      root.unmount()
+      host.remove()
+    },
+  }
+}
 
 describe('StudentSurveyPanel', () => {
   beforeEach(() => {
@@ -110,5 +186,159 @@ describe('StudentSurveyPanel', () => {
     expect(screen.getByRole('button', { name: 'View results' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Share your project link response' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'What did you build? response' })).toBeInTheDocument()
+  })
+
+  it('ignores stale detail responses after selected survey changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleDetail = createDeferred<Response>()
+    const currentDetail = createDeferred<Response>()
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/student/surveys/survey-stale')) return staleDetail.promise
+      if (href.endsWith('/api/student/surveys/survey-current')) return currentDetail.promise
+      if (href.endsWith('/api/student/surveys/survey-current/results')) {
+        return Promise.resolve(jsonResponse(surveyResultsPayload('current-result', 'Current result question')))
+      }
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+
+    const { rerender } = render(<StudentSurveyPanel surveyId="survey-stale" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/surveys/survey-stale')
+    })
+
+    rerender(<StudentSurveyPanel surveyId="survey-current" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/surveys/survey-current')
+    })
+
+    await act(async () => {
+      currentDetail.resolve(jsonResponse(surveyDetailPayload(
+        'survey-current',
+        'Current Student Survey',
+        'Current student question',
+      )))
+      await currentDetail.promise
+    })
+
+    expect(await screen.findByRole('heading', { name: 'Current Student Survey' })).toBeInTheDocument()
+
+    await act(async () => {
+      staleDetail.resolve(jsonResponse(surveyDetailPayload(
+        'survey-stale',
+        'Stale Student Survey',
+        'Stale student question',
+      )))
+      await staleDetail.promise
+    })
+
+    expect(screen.getByRole('heading', { name: 'Current Student Survey' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Stale Student Survey' })).not.toBeInTheDocument()
+  })
+
+  it('ignores stale result responses after selected survey changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const staleResults = createDeferred<Response>()
+    const currentResults = createDeferred<Response>()
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/student/surveys/survey-stale/results')) return staleResults.promise
+      if (href.endsWith('/api/student/surveys/survey-current/results')) return currentResults.promise
+      if (href.endsWith('/api/student/surveys/survey-stale')) {
+        return Promise.resolve(jsonResponse(surveyDetailPayload(
+          'survey-stale',
+          'Stale Student Survey',
+          'Stale student question',
+        )))
+      }
+      if (href.endsWith('/api/student/surveys/survey-current')) {
+        return Promise.resolve(jsonResponse(surveyDetailPayload(
+          'survey-current',
+          'Current Student Survey',
+          'Current student question',
+        )))
+      }
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+
+    const { rerender } = render(<StudentSurveyPanel surveyId="survey-stale" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/surveys/survey-stale/results')
+    })
+
+    rerender(<StudentSurveyPanel surveyId="survey-current" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/surveys/survey-current/results')
+    })
+
+    await act(async () => {
+      currentResults.resolve(jsonResponse(surveyResultsPayload('current-result', 'Current result question')))
+      await currentResults.promise
+    })
+
+    expect(await screen.findByText('Current result question')).toBeInTheDocument()
+
+    await act(async () => {
+      staleResults.resolve(jsonResponse(surveyResultsPayload('stale-result', 'Stale result question')))
+      await staleResults.promise
+    })
+
+    expect(screen.getByText('Current result question')).toBeInTheDocument()
+    expect(screen.queryByText('Stale result question')).not.toBeInTheDocument()
+  })
+
+  it('hides loaded results immediately when selected survey changes', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    const currentResults = createDeferred<Response>()
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/student/surveys/survey-stale/results')) {
+        return Promise.resolve(jsonResponse(surveyResultsPayload('stale-result', 'Already loaded stale result')))
+      }
+      if (href.endsWith('/api/student/surveys/survey-current/results')) return currentResults.promise
+      if (href.endsWith('/api/student/surveys/survey-stale')) {
+        return Promise.resolve(jsonResponse(surveyDetailPayload(
+          'survey-stale',
+          'Stale Student Survey',
+          'Stale student question',
+        )))
+      }
+      if (href.endsWith('/api/student/surveys/survey-current')) {
+        return Promise.resolve(jsonResponse(surveyDetailPayload(
+          'survey-current',
+          'Current Student Survey',
+          'Current student question',
+        )))
+      }
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+
+    const mounted = createMountedRoot()
+    try {
+      await act(async () => {
+        mounted.render(<StudentSurveyPanel surveyId="survey-stale" />)
+      })
+
+      expect(await screen.findByText('Already loaded stale result')).toBeInTheDocument()
+
+      flushSync(() => {
+        mounted.render(<StudentSurveyPanel surveyId="survey-current" />)
+      })
+
+      expect(screen.queryByText('Already loaded stale result')).not.toBeInTheDocument()
+
+      await act(async () => {
+        currentResults.resolve(jsonResponse(surveyResultsPayload('current-result', 'Current loaded result')))
+        await currentResults.promise
+      })
+
+      expect(await screen.findByText('Current loaded result')).toBeInTheDocument()
+    } finally {
+      mounted.cleanup()
+    }
   })
 })

--- a/tests/components/TeacherSurveyResultsPane.test.tsx
+++ b/tests/components/TeacherSurveyResultsPane.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import type { ReactNode } from 'react'
 import { TeacherSurveyResultsPane } from '@/components/surveys/TeacherSurveyResultsPane'
 import type { SurveyWithStats } from '@/types'
 
@@ -18,6 +21,33 @@ function makeSurvey(overrides: Partial<SurveyWithStats> = {}): SurveyWithStats {
     updated_at: '2026-01-01T00:00:00.000Z',
     stats: { total_students: 2, responded: 0, questions_count: 1 },
     ...overrides,
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+function createMountedRoot() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  return {
+    render: (node: ReactNode) => root.render(node),
+    cleanup: () => {
+      root.unmount()
+      host.remove()
+    },
   }
 }
 
@@ -57,5 +87,131 @@ describe('TeacherSurveyResultsPane', () => {
       expect(screen.getAllByText('50%')).toHaveLength(2)
     })
     expect(screen.queryByText('1 (50%)')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale result responses after selected survey changes', async () => {
+    const staleResults = createDeferred<Response>()
+    const currentResults = createDeferred<Response>()
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/surveys/survey-stale/results')) return staleResults.promise
+      if (href.endsWith('/api/teacher/surveys/survey-current/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    }))
+
+    const { rerender } = render(
+      <TeacherSurveyResultsPane survey={makeSurvey({ id: 'survey-stale', title: 'Stale Survey' })} />
+    )
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/teacher/surveys/survey-stale/results')
+    })
+
+    rerender(
+      <TeacherSurveyResultsPane survey={makeSurvey({ id: 'survey-current', title: 'Current Survey' })} />
+    )
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/teacher/surveys/survey-current/results')
+    })
+
+    await act(async () => {
+      currentResults.resolve(jsonResponse({
+        stats: { total_students: 2, responded: 1 },
+        results: [{
+          question_id: 'question-current',
+          question_type: 'multiple_choice',
+          question_text: 'Current results question',
+          options: ['A', 'B'],
+          counts: [1, 0],
+          responses: [],
+          total_responses: 1,
+        }],
+      }))
+      await currentResults.promise
+    })
+
+    expect(await screen.findByText('Current results question')).toBeInTheDocument()
+
+    await act(async () => {
+      staleResults.resolve(jsonResponse({
+        stats: { total_students: 2, responded: 1 },
+        results: [{
+          question_id: 'question-stale',
+          question_type: 'multiple_choice',
+          question_text: 'Stale results question',
+          options: ['A', 'B'],
+          counts: [0, 1],
+          responses: [],
+          total_responses: 1,
+        }],
+      }))
+      await staleResults.promise
+    })
+
+    expect(screen.getByText('Current results question')).toBeInTheDocument()
+    expect(screen.queryByText('Stale results question')).not.toBeInTheDocument()
+  })
+
+  it('hides loaded results immediately when selected survey changes', async () => {
+    const currentResults = createDeferred<Response>()
+    vi.stubGlobal('fetch', vi.fn((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/surveys/survey-stale/results')) {
+        return Promise.resolve(jsonResponse({
+          stats: { total_students: 2, responded: 1 },
+          results: [{
+            question_id: 'question-stale',
+            question_type: 'multiple_choice',
+            question_text: 'Already loaded stale question',
+            options: ['A', 'B'],
+            counts: [0, 1],
+            responses: [],
+            total_responses: 1,
+          }],
+        }))
+      }
+      if (href.endsWith('/api/teacher/surveys/survey-current/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    }))
+
+    const mounted = createMountedRoot()
+    try {
+      await act(async () => {
+        mounted.render(
+          <TeacherSurveyResultsPane survey={makeSurvey({ id: 'survey-stale', title: 'Stale Survey' })} />
+        )
+      })
+
+      expect(await screen.findByText('Already loaded stale question')).toBeInTheDocument()
+
+      flushSync(() => {
+        mounted.render(
+          <TeacherSurveyResultsPane survey={makeSurvey({ id: 'survey-current', title: 'Current Survey' })} />
+        )
+      })
+
+      expect(screen.queryByText('Already loaded stale question')).not.toBeInTheDocument()
+
+      await act(async () => {
+        currentResults.resolve(jsonResponse({
+          stats: { total_students: 2, responded: 1 },
+          results: [{
+            question_id: 'question-current',
+            question_type: 'multiple_choice',
+            question_text: 'Current loaded question',
+            options: ['A', 'B'],
+            counts: [1, 0],
+            responses: [],
+            total_responses: 1,
+          }],
+        }))
+        await currentResults.promise
+      })
+
+      expect(await screen.findByText('Current loaded question')).toBeInTheDocument()
+    } finally {
+      mounted.cleanup()
+    }
   })
 })

--- a/tests/components/TeacherSurveyWorkspace.test.tsx
+++ b/tests/components/TeacherSurveyWorkspace.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import type { ReactNode } from 'react'
 import { TeacherSurveyWorkspace } from '@/components/surveys/TeacherSurveyWorkspace'
 import type { Survey } from '@/types'
 
@@ -17,6 +20,33 @@ function makeSurvey(overrides: Partial<Survey> = {}): Survey {
     created_at: '2026-01-01T00:00:00.000Z',
     updated_at: '2026-01-01T00:00:00.000Z',
     ...overrides,
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+function createMountedRoot() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  return {
+    render: (node: ReactNode) => root.render(node),
+    cleanup: () => {
+      root.unmount()
+      host.remove()
+    },
   }
 }
 
@@ -50,6 +80,168 @@ describe('TeacherSurveyWorkspace', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+  })
+
+  it('ignores stale detail responses after selected survey changes', async () => {
+    const staleDetail = createDeferred<Response>()
+    const currentDetail = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/surveys/survey-stale')) return staleDetail.promise
+      if (href.endsWith('/api/teacher/surveys/survey-current')) return currentDetail.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+
+    const { rerender } = render(
+      <TeacherSurveyWorkspace
+        classroomId="classroom-1"
+        surveyId="survey-stale"
+        onBack={vi.fn()}
+        onSurveyUpdated={vi.fn()}
+        onSurveyDeleted={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/surveys/survey-stale')
+    })
+
+    rerender(
+      <TeacherSurveyWorkspace
+        classroomId="classroom-1"
+        surveyId="survey-current"
+        onBack={vi.fn()}
+        onSurveyUpdated={vi.fn()}
+        onSurveyDeleted={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/surveys/survey-current')
+    })
+
+    await act(async () => {
+      currentDetail.resolve(jsonResponse({
+        survey: makeSurvey({ id: 'survey-current', title: 'Current Survey' }),
+        questions: [{
+          id: 'question-current',
+          survey_id: 'survey-current',
+          question_type: 'short_text',
+          question_text: 'Current survey question',
+          options: [],
+          response_max_chars: 1200,
+          position: 0,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        }],
+      }))
+      await currentDetail.promise
+    })
+
+    expect(await screen.findByRole('button', { name: 'Edit survey title' })).toHaveTextContent('Current Survey')
+    expect(screen.getByDisplayValue('Current survey question')).toBeInTheDocument()
+
+    await act(async () => {
+      staleDetail.resolve(jsonResponse({
+        survey: makeSurvey({ id: 'survey-stale', title: 'Stale Survey' }),
+        questions: [{
+          id: 'question-stale',
+          survey_id: 'survey-stale',
+          question_type: 'short_text',
+          question_text: 'Stale survey question',
+          options: [],
+          response_max_chars: 1200,
+          position: 0,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        }],
+      }))
+      await staleDetail.promise
+    })
+
+    expect(screen.getByRole('button', { name: 'Edit survey title' })).toHaveTextContent('Current Survey')
+    expect(screen.getByDisplayValue('Current survey question')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('Stale survey question')).not.toBeInTheDocument()
+  })
+
+  it('hides loaded detail immediately when selected survey changes', async () => {
+    const currentDetail = createDeferred<Response>()
+
+    fetchMock.mockImplementation((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/surveys/survey-stale')) {
+        return Promise.resolve(jsonResponse({
+          survey: makeSurvey({ id: 'survey-stale', title: 'Already Loaded Stale Survey' }),
+          questions: [{
+            id: 'question-stale',
+            survey_id: 'survey-stale',
+            question_type: 'short_text',
+            question_text: 'Already loaded stale question',
+            options: [],
+            response_max_chars: 1200,
+            position: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          }],
+        }))
+      }
+      if (href.endsWith('/api/teacher/surveys/survey-current')) return currentDetail.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+
+    const mounted = createMountedRoot()
+    try {
+      await act(async () => {
+        mounted.render(
+          <TeacherSurveyWorkspace
+            classroomId="classroom-1"
+            surveyId="survey-stale"
+            onBack={vi.fn()}
+            onSurveyUpdated={vi.fn()}
+            onSurveyDeleted={vi.fn()}
+          />
+        )
+      })
+
+      expect(await screen.findByDisplayValue('Already loaded stale question')).toBeInTheDocument()
+
+      flushSync(() => {
+        mounted.render(
+          <TeacherSurveyWorkspace
+            classroomId="classroom-1"
+            surveyId="survey-current"
+            onBack={vi.fn()}
+            onSurveyUpdated={vi.fn()}
+            onSurveyDeleted={vi.fn()}
+          />
+        )
+      })
+
+      expect(screen.queryByDisplayValue('Already loaded stale question')).not.toBeInTheDocument()
+
+      await act(async () => {
+        currentDetail.resolve(jsonResponse({
+          survey: makeSurvey({ id: 'survey-current', title: 'Current Survey' }),
+          questions: [{
+            id: 'question-current',
+            survey_id: 'survey-current',
+            question_type: 'short_text',
+            question_text: 'Current loaded question',
+            options: [],
+            response_max_chars: 1200,
+            position: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          }],
+        }))
+        await currentDetail.promise
+      })
+
+      expect(await screen.findByDisplayValue('Current loaded question')).toBeInTheDocument()
+    } finally {
+      mounted.cleanup()
+    }
   })
 
   it('honors an explicit markdown authoring mode', async () => {


### PR DESCRIPTION
## Summary
- add selected-survey request guards for teacher survey authoring detail, teacher results, and student detail/results loads
- reset student result payloads while a new selected survey/results load is in progress
- cover stale survey detail/results races in teacher and student component tests

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm build
- pnpm test