### PR TITLE
[codex] Add student exam reload-resume e2e

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,19 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — UI sidebar guidance cleanup
-
-**Completed:**
-- Updated `docs/core/design.md` so the classroom shell treats `RightSidebar` as optional route-level chrome, not a default details pane.
-- Clarified the teacher work-surface canon: assignments/quizzes/tests should use integrated `TeacherWorkspaceSplit` inspectors only when active work justifies side-by-side panes.
-- Promoted the teacher workspace split audit language from proposed extraction to the current structural primitive and discouraged external right-sidebar substitutes for teacher work surfaces.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/layout-config.test.ts -- --runInBand`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
 ## 2026-05-31 — Composite widget audit relevance
 
 **Completed:**
@@ -964,3 +951,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm build`
 - `pnpm test`
+
+## 2026-06-07 — Student exam reload-resume e2e coverage
+
+**Completed:**
+- Added a focused Playwright student exam-mode flow that starts an open-response test, waits for draft autosave, reloads the browser, reopens the test, and verifies the draft resumes.
+- Asserted reload telemetry is recorded as route-exit activity while window/full-screen exit telemetry remains unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed until `pnpm install` restored `node_modules`; rerun via `bash scripts/verify-env.sh` passed)
+- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop -g "resumes an in-progress"`
+- `pnpm lint`

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -301,6 +301,68 @@ test.describe('student exam mode', () => {
     }
   })
 
+  test('resumes an in-progress test after browser reload and classifies the exit as a route exit', async ({ browser, page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const classroom = await withTeacherPage(browser, async (teacherPage) => {
+        const shared = await findSharedClassroom(page, teacherPage)
+        const testRecord = await createActiveOpenResponseTest(teacherPage, shared.id, testTitle)
+        testId = testRecord.id
+        return shared
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      const splitShell = page.locator('[data-testid="student-test-split-container"]')
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+      const responseBox = page.locator('textarea[placeholder="Write your response..."]')
+      await expect(responseBox).toBeVisible()
+      await responseBox.fill('Draft resumes after a browser reload.')
+      await expect(page.getByText('Unsaved changes')).toBeVisible()
+      await expect(page.getByText('Saved', { exact: true })).toBeVisible({ timeout: 20_000 })
+
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+      await expect(responseBox).toBeVisible()
+      await expect(responseBox).toHaveValue('Draft resumes after a browser reload.')
+
+      await expect.poll(async () => {
+        if (!testId) return { routeExitAttempts: 0, windowUnmaximizeAttempts: -1 }
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return {
+          routeExitAttempts: detail.focus_summary?.route_exit_attempts ?? 0,
+          windowUnmaximizeAttempts: detail.focus_summary?.window_unmaximize_attempts ?? 0,
+        }
+      }).toEqual(expect.objectContaining({
+        routeExitAttempts: expect.any(Number),
+        windowUnmaximizeAttempts: 0,
+      }))
+      await expect.poll(async () => {
+        if (!testId) return 0
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return detail.focus_summary?.route_exit_attempts ?? 0
+      }).toBeGreaterThanOrEqual(1)
+    } finally {
+      await cleanupTest(browser, testId)
+    }
+  })
+
   test('records restored away focus without hiding the open-response draft', async ({ browser, page }) => {
     test.setTimeout(90_000)
     let testId: string | null = null


### PR DESCRIPTION
## Selected flow
Student exam mode: browser reload/resume for an in-progress open-response test. This was chosen because student exam mode is the top coverage priority and the existing spec covered locks, route-exit blocking, and focus restoration, but did not isolate browser reload as a resume path with telemetry classification.

## Risk profile
exam-mode

## Tests added or updated
- Added `resumes an in-progress test after browser reload and classifies the exit as a route exit` in `e2e/student-exam-mode.spec.ts`.
- The flow creates an active open-response test through existing teacher APIs, starts it as the seeded student, waits for autosave, reloads the browser, reopens the test, verifies draft preservation, and checks route-exit vs window/full-screen telemetry.

## Commands run
- `pnpm install` to restore missing `node_modules` in this worktree.
- `bash .codex/skills/pika-session-start/scripts/session_start.sh` initially failed because dependencies were missing.
- `bash scripts/verify-env.sh` passed after install: 316 Vitest files / 2,765 tests.
- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop -g "resumes an in-progress"` failed once while tightening the autosave wait, then passed.
- `pnpm lint` passed.
- `git diff --check` passed.
- `node scripts/trim-session-log.mjs` and `node scripts/trim-session-log.mjs --check` passed after rerunning the check serially.

## Seeded-data assumptions
Requires the existing e2e auth seed state: `teacher@example.com` and `student1@example.com` with password `test1234`, plus at least one shared classroom between them. The test creates and deletes its own test record.

## Residual coverage gaps
Teacher exam-mode scheduling/visibility telemetry and assignment release/submission flows remain for future weekly runs.