### PR TITLE
[codex] Tighten classroom sidebar history

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,24 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Composite widget audit relevance
-
-**Completed:**
-- Tightened the `missing-a11y-tests` audit guardrail so composite-widget changes require a changed semantic test that matches or references the changed component.
-- Kept the allowed test locations scoped to `tests/components`, `tests/ui`, or `tests/integration`.
-- Added fixture coverage for the bypass case where an unrelated component test changed beside a composite-widget component.
-- Addressed review feedback by making the no-changed-test path report `missing-a11y-tests` cleanly on Bash 3.2 and by avoiding loose content-reference matches for generic stems such as `button`.
-- Addressed follow-up review feedback by matching generic component stems against changed test filenames case-insensitively, with a `button.tsx` / `Button.test.tsx` regression fixture.
-- Tightened that follow-up so generic stems require exact changed test filename matches, avoiding false positives such as `page.tsx` passing through `PageActionBar.test.tsx`.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts -- --runInBand`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-
 ## 2026-06-01 — AI grading egress sanitization
 
 **Completed:**
@@ -962,3 +944,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed until `pnpm install` restored `node_modules`; rerun via `bash scripts/verify-env.sh` passed)
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop -g "resumes an in-progress"`
 - `pnpm lint`
+
+## 2026-06-08 — Classroom sidebar history tightening
+
+**Completed:**
+- Changed first-level classroom sidebar navigation to replace the current history entry instead of pushing a lateral tab entry.
+- Changed the Classwork sidebar reset path to clear selected assignment state with replace for both teacher and student nav.
+- Added regression coverage for generic sidebar tab replacement and the Classwork selection-clear replace behavior while preserving existing in-tab workspace push coverage.
+
+**Validation:**
+- `pnpm exec vitest run tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+- Headless Playwright check: Daily → Classwork → assignment detail → Back returned to Classwork summary.
+- `pnpm test -- tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx` (ran the full suite due script argument handling; only failed the pre-existing `TeacherGradebookTab.test.tsx` timeout)

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -1034,7 +1034,7 @@ function ClassroomPageContent({
           params.delete('testStudentId')
         }
         params.delete('quizId')
-      })
+      }, { replace: true })
       window.requestAnimationFrame(() => {
         markClassroomTabSwitchReady(tab)
       })

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -158,7 +158,7 @@ export function NavItems({
         params.delete('assignmentId')
       }
       params.delete('assignmentStudentId')
-    })
+    }, { replace: true })
     window.dispatchEvent(
       new CustomEvent(TEACHER_ASSIGNMENTS_SELECTION_EVENT, {
         detail: { classroomId, value },
@@ -175,7 +175,7 @@ export function NavItems({
         params.delete('assignmentId')
       }
       params.delete('assignmentStudentId')
-    })
+    }, { replace: true })
   }
 
   function onNavigate() {

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -88,7 +88,22 @@ vi.mock('@/components/layout', async () => {
     ThreePanelShell: ({ children }: any) => <div>{children}</div>,
     LeftSidebar: ({ children }: any) => <div>{children}</div>,
     MainContent: ({ children }: any) => <main>{children}</main>,
-    NavItems: () => <nav />,
+    NavItems: ({ onTabChange }: any) => (
+      <nav>
+        <button type="button" onClick={() => onTabChange('attendance')}>
+          Go Daily
+        </button>
+        <button type="button" onClick={() => onTabChange('assignments')}>
+          Go Classwork
+        </button>
+        <button type="button" onClick={() => onTabChange('tests')}>
+          Go Tests
+        </button>
+        <button type="button" onClick={() => onTabChange('resources')}>
+          Go Syllabus
+        </button>
+      </nav>
+    ),
     RightSidebar: ({ children, headerActions, title }: any) => {
       const { isRightOpen, setRightOpen } = useLayoutContext()
       if (!isRightOpen) return null
@@ -362,6 +377,19 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
       markdown: '## Assignment One',
       hasRichContent: false,
     })
+  })
+
+  it('replaces history when sidebar navigation changes first-level tabs', () => {
+    renderClient()
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+    const pushStateSpy = vi.spyOn(window.history, 'pushState')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go Syllabus' }))
+
+    expect(pushStateSpy).not.toHaveBeenCalled()
+    expect(replaceStateSpy).toHaveBeenCalled()
+    const lastReplaceCall = replaceStateSpy.mock.calls.at(-1)
+    expect(lastReplaceCall?.[2]).toBe('/classrooms/classroom-1?tab=resources')
   })
 
   it('opens assignment markdown from the assignments FAB dropdown and closes it from the modal', async () => {

--- a/tests/components/NavItems.test.tsx
+++ b/tests/components/NavItems.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { NavItems } from '@/components/layout/NavItems'
 
@@ -162,5 +162,29 @@ describe('NavItems notification dots', () => {
     expect(screen.queryByRole('link', { name: 'Quizzes' })).toBeNull()
     expect(container.querySelector('[data-new-activity-dot="true"]')).toBeNull()
     expect(screen.queryByRole('link', { name: /new activity/i })).toBeNull()
+  })
+
+  it('clears classwork selection with replace when the sidebar tab is clicked', () => {
+    const onTabChange = vi.fn()
+    const updateSearchParams = vi.fn()
+    render(
+      <NavItems
+        classroomId="classroom-1"
+        role="teacher"
+        activeTab="assignments"
+        onTabChange={onTabChange}
+        updateSearchParams={updateSearchParams}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Classwork' }))
+
+    expect(onTabChange).toHaveBeenCalledWith('assignments')
+    expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), { replace: true })
+    const params = new URLSearchParams('tab=assignments&assignmentId=assignment-1&assignmentStudentId=student-1')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('tab')).toBe('assignments')
+    expect(params.get('assignmentId')).toBeNull()
+    expect(params.get('assignmentStudentId')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Tightens classroom shell navigation so first-level sidebar/rail tab clicks replace the current history entry instead of pushing lateral tab entries. This keeps browser Back focused on meaningful in-tab depth, so flows like Daily -> Classwork -> assignment detail return to Classwork summary instead of stepping back through Daily.

## Changes

- Changed classroom sidebar tab changes to call the existing guarded route updater with `{ replace: true }`.
- Changed the special Classwork reset path in `NavItems` to clear selected assignment/student params with replace for teacher and student nav.
- Added regression coverage for generic sidebar replacement and Classwork selection reset replacement.
- Preserved existing in-tab workspace push behavior for assignments/tests.

## Validation

- `pnpm exec vitest run tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Headless Playwright check: Daily -> Classwork -> assignment detail -> Back returned to Classwork summary

Note: `pnpm test -- ...` accidentally ran the full suite because of script argument handling; the only failure was the pre-existing `TeacherGradebookTab.test.tsx` timeout.