### PR TITLE
Guard quiz individual response reloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,24 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — AI grading egress sanitization
-
-**Completed:**
-- Added shared AI sanitization utilities for direct identifier redaction, roster-aware initials reuse, provider pseudonym refs, and egress allow-list validation.
-- Kept log summary APIs compatible while routing their redaction helpers through the shared sanitizer.
-- Sanitized assignment grading prompt fields, artifact metadata, and generated feedback, and added `store: false` to assignment grading OpenAI requests.
-- Sanitized test grading prompt fields, answer references, student responses, and generated feedback, added `store: false`, and changed batch grading to send pseudonymous provider refs mapped back locally.
-- Documented the AI grading egress contract for the upcoming GradeX adapter.
-
-**Validation:**
-- `pnpm test tests/unit/ai-sanitization.test.ts tests/unit/log-summary.test.ts tests/unit/ai-grading.test.ts tests/unit/ai-test-grading.test.ts tests/lib/ai-test-grading.test.ts`
-- `pnpm test tests/api/teacher/assignments-auto-grade.test.ts tests/api/teacher/assignment-auto-grade-runs.test.ts tests/api/teacher/tests-ai-suggest.test.ts tests/api/teacher/tests-auto-grade.test.ts tests/api/teacher/test-auto-grade-runs.test.ts tests/lib/test-ai-grading-runs.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
-- `pnpm lint`
-- `pnpm test` (one unrelated `StudentAssignmentsTab` modal test failed during the full run; rerunning that file passed)
-- `pnpm test tests/components/StudentAssignmentsTab.test.tsx`
-- `pnpm build`
-- `git diff --check`
-
 ## 2026-05-31 — Upload image route standardization
 
 **Completed:**
@@ -958,3 +940,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
 - Headless Playwright check: Daily → Classwork → assignment detail → Back returned to Classwork summary.
 - `pnpm test -- tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx` (ran the full suite due script argument handling; only failed the pre-existing `TeacherGradebookTab.test.tsx` timeout)
+
+## 2026-06-08 — Quiz individual responses freshness audit
+
+**Completed:**
+- Scoped `QuizIndividualResponses` loaded responders, questions, stats, load errors, and grading notices to the active assessment scope.
+- Added request-id guards so stale individual-response result loads cannot overwrite after selected quiz/test id, API base, or assessment type changes.
+- Guarded save/clear/suggest completion paths so old assessment grading callbacks cannot repaint notices or trigger parent refreshes after a selection switch.
+- Added direct component coverage for stale result response overwrites and already-loaded old responses being hidden immediately on quiz switches.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/QuizIndividualResponses.test.tsx tests/components/QuizDetailPanel.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx`
+- `pnpm test`

--- a/src/components/QuizIndividualResponses.tsx
+++ b/src/components/QuizIndividualResponses.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { getQuizExitCount } from '@/lib/quizzes'
 import { Button, Input } from '@/ui'
@@ -51,6 +51,21 @@ interface TestStats {
   ungraded_open_responses?: number
 }
 
+interface ResponsesDataState {
+  scope: string
+  responders: Responder[]
+  questions: QuestionInfo[]
+  stats: TestStats | null
+}
+
+interface ScopedMessageState {
+  scope: string
+  message: string
+}
+
+const EMPTY_RESPONDERS: Responder[] = []
+const EMPTY_QUESTIONS: QuestionInfo[] = []
+
 function formatDuration(totalSeconds: number): string {
   const safe = Math.max(0, Math.round(totalSeconds))
   const minutes = Math.floor(safe / 60)
@@ -70,30 +85,49 @@ export function QuizIndividualResponses({
   onUpdated,
 }: Props) {
   const isTestsView = assessmentType === 'test'
-  const [responders, setResponders] = useState<Responder[]>([])
-  const [questions, setQuestions] = useState<QuestionInfo[]>([])
+  const scope = `${assessmentType}:${apiBasePath}:${quizId}`
+  const [dataState, setDataState] = useState<ResponsesDataState | null>(null)
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+  const [errorState, setErrorState] = useState<ScopedMessageState | null>(null)
   const [expandedStudent, setExpandedStudent] = useState<string | null>(null)
-  const [stats, setStats] = useState<TestStats | null>(null)
   const [gradeDrafts, setGradeDrafts] = useState<Record<string, GradeDraft>>({})
   const [savingResponseId, setSavingResponseId] = useState<string | null>(null)
   const [suggestingResponseId, setSuggestingResponseId] = useState<string | null>(null)
-  const [gradingError, setGradingError] = useState('')
-  const [gradingMessage, setGradingMessage] = useState('')
+  const [gradingErrorState, setGradingErrorState] = useState<ScopedMessageState | null>(null)
+  const [gradingMessageState, setGradingMessageState] = useState<ScopedMessageState | null>(null)
+  const loadRequestIdRef = useRef(0)
+  const currentScopeRef = useRef(scope)
+  currentScopeRef.current = scope
+
+  const activeData = dataState?.scope === scope ? dataState : null
+  const responders = activeData?.responders ?? EMPTY_RESPONDERS
+  const questions = activeData?.questions ?? EMPTY_QUESTIONS
+  const stats = activeData?.stats ?? null
+  const error = errorState?.scope === scope ? errorState.message : ''
+  const gradingError = gradingErrorState?.scope === scope ? gradingErrorState.message : ''
+  const gradingMessage = gradingMessageState?.scope === scope ? gradingMessageState.message : ''
 
   const load = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1
+    loadRequestIdRef.current = requestId
+    const requestedScope = scope
+    if (currentScopeRef.current !== requestedScope) return
     setLoading(true)
-    setError('')
+    setErrorState(null)
     try {
+      // Bypass fetchJSONWithCache for selected assessment responses freshness; request ids guard stale responses.
       const res = await fetch(`${apiBasePath}/${quizId}/results`)
       const data = await res.json()
+      if (loadRequestIdRef.current !== requestId || currentScopeRef.current !== requestedScope) return
       if (!res.ok) throw new Error(data.error || 'Failed to load')
 
       const nextResponders = data.responders || []
-      setResponders(nextResponders)
-      setQuestions(data.questions || [])
-      setStats((data.stats as TestStats | null) || null)
+      setDataState({
+        scope: requestedScope,
+        responders: nextResponders,
+        questions: data.questions || [],
+        stats: (data.stats as TestStats | null) || null,
+      })
 
       if (isTestsView) {
         const nextDrafts: Record<string, GradeDraft> = {}
@@ -108,13 +142,22 @@ export function QuizIndividualResponses({
           }
         }
         setGradeDrafts(nextDrafts)
+      } else {
+        setGradeDrafts({})
       }
     } catch (loadError: any) {
-      setError(loadError.message || 'Failed to load responses')
+      if (loadRequestIdRef.current === requestId && currentScopeRef.current === requestedScope) {
+        setErrorState({
+          scope: requestedScope,
+          message: loadError.message || 'Failed to load responses',
+        })
+      }
     } finally {
-      setLoading(false)
+      if (loadRequestIdRef.current === requestId && currentScopeRef.current === requestedScope) {
+        setLoading(false)
+      }
     }
-  }, [apiBasePath, isTestsView, quizId])
+  }, [apiBasePath, isTestsView, quizId, scope])
 
   useEffect(() => {
     void load()
@@ -139,41 +182,57 @@ export function QuizIndividualResponses({
   async function handleSuggestGrade(
     responseId: string
   ) {
-    setGradingError('')
-    setGradingMessage('')
+    const operationScope = scope
+    setGradingErrorState(null)
+    setGradingMessageState(null)
     setSuggestingResponseId(responseId)
     try {
       const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}/ai-suggest`, {
         method: 'POST',
       })
       const data = await res.json()
+      if (currentScopeRef.current !== operationScope) return
       if (!res.ok) throw new Error(data.error || 'Failed to generate AI suggestion')
 
       updateDraft(responseId, {
         score: data.suggestion?.score != null ? String(data.suggestion.score) : '',
         feedback: data.suggestion?.feedback || '',
       })
-      setGradingMessage('AI suggestion loaded. Review before saving.')
+      setGradingMessageState({
+        scope: operationScope,
+        message: 'AI suggestion loaded. Review before saving.',
+      })
     } catch (suggestError: any) {
-      setGradingError(suggestError.message || 'Failed to generate AI suggestion')
+      if (currentScopeRef.current === operationScope) {
+        setGradingErrorState({
+          scope: operationScope,
+          message: suggestError.message || 'Failed to generate AI suggestion',
+        })
+      }
     }
     finally {
-      setSuggestingResponseId(null)
+      if (currentScopeRef.current === operationScope) {
+        setSuggestingResponseId(null)
+      }
     }
   }
 
   async function handleSaveGrade(responseId: string, maxPoints: number) {
+    const operationScope = scope
     const draft = gradeDrafts[responseId]
     if (!draft) return
 
     const score = Number(draft.score)
     if (!Number.isFinite(score) || score < 0 || score > maxPoints) {
-      setGradingError(`Score must be between 0 and ${maxPoints}`)
+      setGradingErrorState({
+        scope: operationScope,
+        message: `Score must be between 0 and ${maxPoints}`,
+      })
       return
     }
 
-    setGradingError('')
-    setGradingMessage('')
+    setGradingErrorState(null)
+    setGradingMessageState(null)
     setSavingResponseId(responseId)
     try {
       const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}`, {
@@ -185,21 +244,32 @@ export function QuizIndividualResponses({
         }),
       })
       const data = await res.json()
+      if (currentScopeRef.current !== operationScope) return
       if (!res.ok) throw new Error(data.error || 'Failed to save grade')
 
-      setGradingMessage('Grade saved.')
+      setGradingMessageState({ scope: operationScope, message: 'Grade saved.' })
       await load()
-      onUpdated?.()
+      if (currentScopeRef.current === operationScope) {
+        onUpdated?.()
+      }
     } catch (saveError: any) {
-      setGradingError(saveError.message || 'Failed to save grade')
+      if (currentScopeRef.current === operationScope) {
+        setGradingErrorState({
+          scope: operationScope,
+          message: saveError.message || 'Failed to save grade',
+        })
+      }
     } finally {
-      setSavingResponseId(null)
+      if (currentScopeRef.current === operationScope) {
+        setSavingResponseId(null)
+      }
     }
   }
 
   async function handleClearGrade(responseId: string) {
-    setGradingError('')
-    setGradingMessage('')
+    const operationScope = scope
+    setGradingErrorState(null)
+    setGradingMessageState(null)
     setSavingResponseId(responseId)
     try {
       const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}`, {
@@ -208,19 +278,29 @@ export function QuizIndividualResponses({
         body: JSON.stringify({ clear_grade: true }),
       })
       const data = await res.json()
+      if (currentScopeRef.current !== operationScope) return
       if (!res.ok) throw new Error(data.error || 'Failed to clear grade')
 
-      setGradingMessage('Grade cleared.')
+      setGradingMessageState({ scope: operationScope, message: 'Grade cleared.' })
       await load()
-      onUpdated?.()
+      if (currentScopeRef.current === operationScope) {
+        onUpdated?.()
+      }
     } catch (clearError: any) {
-      setGradingError(clearError.message || 'Failed to clear grade')
+      if (currentScopeRef.current === operationScope) {
+        setGradingErrorState({
+          scope: operationScope,
+          message: clearError.message || 'Failed to clear grade',
+        })
+      }
     } finally {
-      setSavingResponseId(null)
+      if (currentScopeRef.current === operationScope) {
+        setSavingResponseId(null)
+      }
     }
   }
 
-  if (loading) {
+  if (loading || (!activeData && !error)) {
     return (
       <div className="flex justify-center py-4">
         <Spinner />

--- a/tests/components/QuizIndividualResponses.test.tsx
+++ b/tests/components/QuizIndividualResponses.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import type { ReactNode } from 'react'
+import { QuizIndividualResponses } from '@/components/QuizIndividualResponses'
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+function quizResultsPayload(quizId: string, studentName: string) {
+  return {
+    questions: [{
+      id: `${quizId}-question`,
+      question_text: `${quizId} question`,
+      question_type: 'multiple_choice',
+      options: ['A', 'B'],
+    }],
+    responders: [{
+      student_id: `${quizId}-student`,
+      name: studentName,
+      email: `${quizId}@example.com`,
+      answers: { [`${quizId}-question`]: 1 },
+      focus_summary: null,
+    }],
+  }
+}
+
+function createMountedRoot() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  return {
+    render: (node: ReactNode) => root.render(node),
+    cleanup: () => {
+      root.unmount()
+      host.remove()
+    },
+  }
+}
+
+describe('QuizIndividualResponses', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('ignores stale result responses after selected quiz changes', async () => {
+    const staleResults = createDeferred<Response>()
+    const currentResults = createDeferred<Response>()
+    const fetchMock = vi.fn((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/quizzes/quiz-stale/results')) return staleResults.promise
+      if (href.endsWith('/api/teacher/quizzes/quiz-current/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<QuizIndividualResponses quizId="quiz-stale" />)
+
+    await act(async () => {
+      rerender(<QuizIndividualResponses quizId="quiz-current" />)
+    })
+
+    await act(async () => {
+      currentResults.resolve(jsonResponse(quizResultsPayload('quiz-current', 'Current Student')))
+      await currentResults.promise
+    })
+
+    expect(await screen.findByText('Current Student')).toBeInTheDocument()
+
+    await act(async () => {
+      staleResults.resolve(jsonResponse(quizResultsPayload('quiz-stale', 'Stale Student')))
+      await staleResults.promise
+    })
+
+    expect(screen.getByText('Current Student')).toBeInTheDocument()
+    expect(screen.queryByText('Stale Student')).not.toBeInTheDocument()
+  })
+
+  it('hides loaded responses immediately when selected quiz changes', async () => {
+    const currentResults = createDeferred<Response>()
+    const fetchMock = vi.fn((url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith('/api/teacher/quizzes/quiz-stale/results')) {
+        return Promise.resolve(jsonResponse(quizResultsPayload('quiz-stale', 'Already Loaded Student')))
+      }
+      if (href.endsWith('/api/teacher/quizzes/quiz-current/results')) return currentResults.promise
+      throw new Error(`Unexpected fetch: ${href}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mounted = createMountedRoot()
+    try {
+      await act(async () => {
+        mounted.render(<QuizIndividualResponses quizId="quiz-stale" />)
+      })
+
+      expect(await screen.findByText('Already Loaded Student')).toBeInTheDocument()
+
+      flushSync(() => {
+        mounted.render(<QuizIndividualResponses quizId="quiz-current" />)
+      })
+
+      expect(screen.queryByText('Already Loaded Student')).not.toBeInTheDocument()
+
+      await act(async () => {
+        currentResults.resolve(jsonResponse(quizResultsPayload('quiz-current', 'Current Loaded Student')))
+        await currentResults.promise
+      })
+
+      expect(await screen.findByText('Current Loaded Student')).toBeInTheDocument()
+    } finally {
+      mounted.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Scope QuizIndividualResponses loaded data, errors, and grading notices to the active assessment selection
- Add request-id guards for individual response result loads and stale grading callbacks
- Add direct component tests for stale response overwrites and immediate hiding after quiz switches

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/QuizIndividualResponses.test.tsx tests/components/QuizDetailPanel.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm build
- pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx
- pnpm test

Note: an earlier full test run launched in parallel with build/lint had unrelated contention failures in StudentAssignmentsTab and TeacherGradebookTab; both files passed in isolation, and the later sequential full suite passed.