### PR TITLE
[codex] Refresh assignment AI grading pane

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Student lesson calendar cache reuse
-
-**Completed:**
-- Routed student lesson calendar assignment reads through the shared `student-assignments:<classroomId>` cache key.
-- Routed student lesson calendar announcement reads through the shared `student-announcements:<classroomId>` cache key.
-- Routed student lesson calendar lesson-plan reads through a range-specific `student-lesson-plans:<classroomId>:<start>:<end>` cache key.
-- Added remount coverage proving the calendar reuses cached lesson plans, assignments, and announcements.
-- Addressed review feedback by isolating per-endpoint load failures and strengthening remount coverage to wait for completed cached data.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts -- --runInBand`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-05-31 — Student history cache reuse
 
 **Completed:**
@@ -961,3 +944,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test` (one unrelated `StudentHistoryPage` concurrency failure; isolated rerun passed)
 - `pnpm vitest run tests/components/StudentHistoryPage.test.tsx`
 - `pnpm vitest run --sequence.concurrent=false`
+
+## 2026-06-08 — Assignment AI grading pane refresh
+
+**Completed:**
+- Refreshed the mounted selected-student assignment grading pane when a background assignment AI grading run completes, avoiding a full page refresh.
+- Applied the same pane refresh to the legacy synchronous batch auto-grade path.
+- Added classroom-view coverage that asserts a mounted grading pane receives a refresh-key bump after background AI grading completion.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (worktree rerun failed in baseline verification only: `LoginClient.test.tsx` two failures and `crypto.test.ts` password hash timeout; prior hub startup run failed different unrelated tests)
+- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -1585,6 +1585,9 @@ export function TeacherClassroomView({
     const message = formatAssignmentAiGradingRunMessage(activeAssignmentAiRun)
     batchClearSelection()
     setRefreshCounter((count) => count + 1)
+    if (selectedStudentId) {
+      setGradeSelectedRefreshCounter((count) => count + 1)
+    }
 
     if (message.error) {
       setError(message.error)
@@ -1593,7 +1596,7 @@ export function TeacherClassroomView({
       setInfo(message.info)
       setError('')
     }
-  }, [activeAssignmentAiRun, batchClearSelection, hasActiveAssignmentAiRun])
+  }, [activeAssignmentAiRun, batchClearSelection, hasActiveAssignmentAiRun, selectedStudentId])
 
   async function handleBatchAutoGrade() {
     if (!selectedAssignmentData || batchSelectedCount === 0) return
@@ -1628,6 +1631,9 @@ export function TeacherClassroomView({
       batchClearSelection()
       // Reload assignment data to refresh statuses/grades
       setRefreshCounter((c) => c + 1)
+      if (selectedStudentId) {
+        setGradeSelectedRefreshCounter((c) => c + 1)
+      }
     } catch (err: any) {
       setError(err.message || 'Auto-grade failed')
     } finally {

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -243,6 +243,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
     splitPaneView = 'students-grading',
     studentHeader,
     inspectorWidth,
+    refreshKey = 0,
     onLayoutChange,
     onDetailsMetaChange,
     onGradeTemplateChange,
@@ -276,6 +277,7 @@ vi.mock('@/components/TeacherStudentWorkPanel', () => ({
         <div
           data-testid="teacher-work-panel"
           data-highlighted-sections={highlightedInspectorSections.join(',')}
+          data-refresh-key={refreshKey}
         >
           <div data-testid="assignment-split-pane-view">{splitPaneView}</div>
           <div data-testid="assignment-workspace-inspector-width">{inspectorWidth}</div>
@@ -2676,6 +2678,7 @@ describe('TeacherClassroomView', () => {
     await waitFor(() => {
       expect(mockShowMessage).toHaveBeenCalledWith({ text: 'Graded 1', tone: 'info' })
     })
+    expect(screen.getByTestId('teacher-work-panel')).toHaveAttribute('data-refresh-key', '1')
   })
 
   it('shows only unique true errors in the completion message and treats empty work as missing', async () => {


### PR DESCRIPTION
## Summary

Refresh the mounted selected-student assignment grading pane when assignment AI grading completes.

## Root Cause

Background assignment AI grading completion refreshed the assignment detail roster data, but the already-mounted `TeacherStudentWorkPanel` only reloads its selected student document when its `refreshKey` changes. That meant the roster/status could update while the grade/comments pane stayed stale until the teacher manually refreshed the page.

## Changes

- Bump the selected-student pane refresh key when a background assignment AI grading run completes.
- Apply the same pane refresh to the legacy synchronous batch auto-grade response path.
- Add classroom-view regression coverage that verifies a mounted grading pane receives the refresh key bump after background AI grading completes.
- Update and trim the AI session log.

## Validation

- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`

Note: `bash .codex/skills/pika-session-start/scripts/session_start.sh` ran full baseline verification and failed on unrelated flaky/baseline tests (`LoginClient.test.tsx` two failures and `crypto.test.ts` password hash timeout). The focused classroom-view suite and lint passed after the patch.