### PR TITLE
[codex] Standardize classroom FAB subshell actions

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-05-31 — Student history cache reuse
-
-**Completed:**
-- Added a shared student entries client helper that caches `/api/student/entries` reads by classroom and optional limit.
-- Routed classroom student history and standalone student history class-day/entry reads through shared cached helpers.
-- Routed the today tab’s entry history refresh through the shared student entries cache and invalidated classroom entry caches after successful saves.
-- Added component coverage proving student history remounts reuse cached class days and entries, plus save invalidation coverage in today-tab history tests.
-- Addressed PR review feedback by clearing stale history rows after failed reloads, cancelling stale history requests after classroom changes, and invalidating/updating entry caches on save conflicts without caching partial conflict payloads as full history rows.
-- Spawned new read-only audit tracks for accessibility/mobile consistency, API standardization, classroom action surfaces, and client caching/freshness.
-
-**Validation:**
-- `pnpm vitest run tests/components/StudentHistoryTab.test.tsx tests/components/StudentTodayTabHistory.test.tsx`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-05-31 — Gradebook cache invalidation after grading
 
 **Completed:**
@@ -957,3 +940,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
 - `pnpm lint`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
+
+## 2026-06-08 — FAB subshell standardization
+
+**Completed:**
+- Added a standardized `floatingAction` split-button slot to `TeacherWorkSurfaceActionBar`.
+- Migrated teacher Classwork, Tests, Gradebook, Roster, and Announcements FAB clusters to one split action per first-level tab/workspace, moving secondary toggles/actions into the split menu.
+- Consolidated selected-assignment pane switching, survey visibility/edit actions, gradebook score display/column/email actions, roster CSV/remove/email actions, and announcement creation into standardized split menus.
+- Left Calendar/Attendance unchanged because their FAB controls are date/view navigation rather than action menus.
+- Deferred product quiz removal to a later pass; Tests remain in scope.
+
+**Validation:**
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm build`
+- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
+- Visual verification screenshots for teacher Classwork, Tests, Gradebook, Roster, Announcements, plus student Classwork sanity check.

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -414,18 +414,27 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       {!isReadOnly && (
         <TeacherWorkSurfaceActionBar
           testId="announcements-actionbar-center"
-          center={
-            <Button
-              type="button"
-              variant="primary"
-              onClick={() => setIsCreating(true)}
-              disabled={isCreating || saving}
-              aria-label="New announcement"
-            >
-              <Plus className="h-4 w-4" aria-hidden="true" />
-              <span>New</span>
-            </Button>
-          }
+          floatingAction={{
+            label: (
+              <span className="inline-flex items-center gap-1.5">
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                <span>New</span>
+              </span>
+            ),
+            onPrimaryClick: () => setIsCreating(true),
+            options: [
+              {
+                id: 'announcement',
+                label: 'Announcement',
+                onSelect: () => setIsCreating(true),
+              },
+            ],
+            disabled: isCreating || saving,
+            variant: 'primary',
+            toggleAriaLabel: 'Announcement actions',
+            menuPlacement: 'down',
+            primaryButtonProps: { 'aria-label': 'New announcement' },
+          }}
           centerPlacement="floating"
         />
       )}

--- a/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherClassroomView.tsx
@@ -19,7 +19,6 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import {
-  BarChart3,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -37,7 +36,7 @@ import {
   Trash2,
   Unlock,
 } from 'lucide-react'
-import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, ContentDialog, DialogPanel, FormField, Input, SplitButton, Tooltip, useAppMessage, useOverlayMessage, type SplitButtonOption } from '@/ui'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { Spinner } from '@/components/Spinner'
@@ -59,7 +58,6 @@ import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/T
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TeacherWorkItemList } from '@/components/teacher-work-surface/TeacherWorkItemList'
 import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
-import { TeacherEditModeControls } from '@/components/teacher-work-surface/TeacherEditModeControls'
 import { RichTextEditor } from '@/components/editor'
 import {
   ACTIONBAR_ICON_BUTTON_CLASSNAME,
@@ -77,7 +75,6 @@ import {
   getAssignmentSplitPaneViewSessionKey,
   getAssignmentWorkspaceStudentCookieName,
   getDefaultAssignmentSplitPaneView,
-  getNextAssignmentSplitPaneView,
   parseAssignmentSplitPaneView,
   parseAssignmentWorkspaceStudentId,
   type AssignmentSplitPaneView,
@@ -194,24 +191,6 @@ function AssignmentSplitPaneIcon({
   }
 
   return <FileText className="h-4 w-4" aria-hidden="true" />
-}
-
-function HiddenResultsIcon() {
-  return (
-    <span className="relative inline-flex h-4 w-4 items-center justify-center" aria-hidden="true">
-      <BarChart3 className="h-4 w-4" />
-      <span className="absolute h-0.5 w-5 rotate-45 rounded-full bg-current" />
-    </span>
-  )
-}
-
-function surveyStateButtonClassName(isOn: boolean) {
-  return [
-    'h-10 w-10 p-0',
-    isOn
-      ? 'border-success bg-success-bg text-success hover:bg-success-bg-hover'
-      : 'border-danger bg-danger-bg text-danger hover:bg-danger-bg-hover',
-  ].join(' ')
 }
 
 function TeacherMaterialCard({
@@ -1986,9 +1965,7 @@ export function TeacherClassroomView({
     return currentStudentRows[0]?.student_id ?? null
   }, [classroom.id, currentStudentRows, selectedStudentId, selection])
 
-  const handleCycleSplitPaneView = useCallback(() => {
-    const nextView = getNextAssignmentSplitPaneView(splitPaneView)
-
+  const handleSelectSplitPaneView = useCallback((nextView: AssignmentSplitPaneView) => {
     if (nextView !== 'students-grading') {
       const nextStudentId = resolveDetailsStudentId()
       if (!nextStudentId) return
@@ -2001,7 +1978,6 @@ export function TeacherClassroomView({
     resolveDetailsStudentId,
     setPersistedSplitPaneView,
     setSelectedStudentAndNavigate,
-    splitPaneView,
   ])
 
   useEffect(() => {
@@ -2215,12 +2191,42 @@ export function TeacherClassroomView({
     </div>
   )
 
+  const splitPaneViewIndicator = ASSIGNMENT_SPLIT_PANE_VIEW_INDICATORS[splitPaneView]
+
+  const assignmentPaneOptions: SplitButtonOption[] = (Object.keys(ASSIGNMENT_SPLIT_PANE_VIEW_LABELS) as AssignmentSplitPaneView[]).map((view) => ({
+    id: `pane-${view}`,
+    label: ASSIGNMENT_SPLIT_PANE_VIEW_LABELS[view],
+    checked: splitPaneView === view,
+    onSelect: () => handleSelectSplitPaneView(view),
+    disabled: !canCycleSplitPaneView,
+  }))
+
   const classPaneActions = (
     <Tooltip content={`Grade${workspaceActionLabelSuffix}`}>
       <span className="inline-flex">
         <SplitButton
           label={
-            <span className="inline-flex items-center gap-2">
+            <span className="inline-flex items-center gap-2 whitespace-nowrap">
+              <span
+                className="inline-flex items-center gap-1.5"
+                data-testid="assignment-split-pane-indicator"
+                data-view-index={splitPaneViewIndicator.index}
+                data-view-icon={splitPaneViewIndicator.icon}
+                aria-hidden="true"
+              >
+                <span
+                  className="min-w-3 text-center text-xs font-semibold tabular-nums"
+                  data-testid="assignment-split-pane-index"
+                >
+                  {splitPaneViewIndicator.index}
+                </span>
+                <span
+                  className="inline-flex"
+                  data-testid="assignment-split-pane-icon"
+                >
+                  <AssignmentSplitPaneIcon pane={splitPaneViewIndicator.icon} />
+                </span>
+              </span>
               <Check className="h-4 w-4" aria-hidden="true" />
               <span>AI Grade</span>
             </span>
@@ -2229,6 +2235,7 @@ export function TeacherClassroomView({
             void handleBatchAutoGrade()
           }}
           options={[
+            ...assignmentPaneOptions,
             {
               id: 'edit-assignment',
               label: (
@@ -2243,6 +2250,7 @@ export function TeacherClassroomView({
                 }
               },
               disabled: !canEditAssignment,
+              dividerBefore: true,
             },
             {
               id: 'delete-assignment',
@@ -2365,66 +2373,11 @@ export function TeacherClassroomView({
     </div>
   ) : null
 
-  const assignmentSummaryEditControls = (
-    <TeacherEditModeControls
-      active={assignmentEditMode}
-      onActiveChange={setAssignmentEditMode}
-      disabled={isReadOnly}
-      variant="secondary"
-    />
-  )
-
-  const splitPaneViewLabel = ASSIGNMENT_SPLIT_PANE_VIEW_LABELS[splitPaneView]
-  const nextSplitPaneView = getNextAssignmentSplitPaneView(splitPaneView)
-  const nextSplitPaneViewLabel = ASSIGNMENT_SPLIT_PANE_VIEW_LABELS[nextSplitPaneView]
-  const splitPaneViewIndicator = ASSIGNMENT_SPLIT_PANE_VIEW_INDICATORS[splitPaneView]
-
   const assignmentWorkspaceControls = selection.mode === 'assignment' ? (
     <div
       data-testid="assignment-workspace-actionbar-center"
       className="relative flex min-w-0 items-center justify-center gap-2"
     >
-      <Tooltip
-        content={
-          canCycleSplitPaneView
-            ? `Current: ${splitPaneViewLabel}. Next: ${nextSplitPaneViewLabel}.`
-            : 'No students available for split views yet.'
-        }
-      >
-        <span className="inline-flex">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="inline-flex min-w-0 items-center gap-1.5"
-            onClick={handleCycleSplitPaneView}
-            disabled={!canCycleSplitPaneView}
-            aria-label={`Assignment panes: ${splitPaneViewLabel}. Switch to ${nextSplitPaneViewLabel}.`}
-          >
-            <span
-              className="inline-flex items-center gap-1.5"
-              data-testid="assignment-split-pane-indicator"
-              data-view-index={splitPaneViewIndicator.index}
-              data-view-icon={splitPaneViewIndicator.icon}
-            >
-              <span
-                className="min-w-3 text-center text-xs font-semibold tabular-nums"
-                data-testid="assignment-split-pane-index"
-                aria-hidden="true"
-              >
-                {splitPaneViewIndicator.index}
-              </span>
-              <span
-                className="inline-flex"
-                data-testid="assignment-split-pane-icon"
-              >
-                <AssignmentSplitPaneIcon pane={splitPaneViewIndicator.icon} />
-              </span>
-            </span>
-            <span className="sr-only">{splitPaneViewLabel}</span>
-          </Button>
-        </span>
-      </Tooltip>
       {classPaneActions}
       {workspaceStatus}
     </div>
@@ -2445,71 +2398,104 @@ export function TeacherClassroomView({
         }
       >
         <span className="inline-flex">
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className={surveyStateButtonClassName(selectedSurvey.status === 'active')}
-            aria-label={selectedSurvey.status === 'active' ? 'Close poll' : 'Open poll'}
-            aria-pressed={selectedSurvey.status === 'active'}
-            onClick={() => {
+          <SplitButton
+            label={
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                {selectedSurvey.status === 'active' ? (
+                  <Unlock className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Lock className="h-4 w-4" aria-hidden="true" />
+                )}
+                <span>{selectedSurvey.status === 'active' ? 'Close poll' : 'Open poll'}</span>
+              </span>
+            }
+            onPrimaryClick={() => {
               void patchSelectedSurvey({
                 status: selectedSurvey.status === 'active' ? 'closed' : 'active',
               })
             }}
+            options={[
+              {
+                id: 'open-poll',
+                label: 'Open poll',
+                checked: selectedSurvey.status === 'active',
+                onSelect: () => {
+                  void patchSelectedSurvey({ status: 'active' })
+                },
+                disabled:
+                  isReadOnly ||
+                  surveyActionBusy ||
+                  isDeletingSurvey ||
+                  selectedSurvey.status === 'active' ||
+                  selectedSurvey.stats.questions_count === 0,
+              },
+              {
+                id: 'close-poll',
+                label: 'Close poll',
+                checked: selectedSurvey.status !== 'active',
+                onSelect: () => {
+                  void patchSelectedSurvey({ status: 'closed' })
+                },
+                disabled:
+                  isReadOnly ||
+                  surveyActionBusy ||
+                  isDeletingSurvey ||
+                  selectedSurvey.status !== 'active',
+              },
+              {
+                id: 'show-results',
+                label: 'Show results',
+                checked: selectedSurvey.show_results,
+                onSelect: () => {
+                  void patchSelectedSurvey({ show_results: true })
+                },
+                disabled: isReadOnly || surveyActionBusy || isDeletingSurvey || selectedSurvey.show_results,
+              },
+              {
+                id: 'hide-results',
+                label: 'Hide results',
+                checked: !selectedSurvey.show_results,
+                onSelect: () => {
+                  void patchSelectedSurvey({ show_results: false })
+                },
+                disabled: isReadOnly || surveyActionBusy || isDeletingSurvey || !selectedSurvey.show_results,
+              },
+              {
+                id: 'edit-survey',
+                label: (
+                  <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                    <Pencil className="h-4 w-4" aria-hidden="true" />
+                    <span>Edit survey</span>
+                  </span>
+                ),
+                onSelect: () => {
+                  setCreatedSurveyEditorIntent({ surveyId: selectedSurvey.id, editMode: 'edit' })
+                  openSurveyModal(selectedSurvey.id)
+                },
+                disabled: isReadOnly || surveyActionBusy || isDeletingSurvey,
+                dividerBefore: true,
+              },
+            ]}
+            size="sm"
+            variant="secondary"
             disabled={
               isReadOnly ||
               surveyActionBusy ||
-              isDeletingSurvey ||
-              (selectedSurvey.status === 'draft' && selectedSurvey.stats.questions_count === 0)
+              isDeletingSurvey
             }
-          >
-            {selectedSurvey.status === 'active' ? (
-              <Unlock className="h-4 w-4" aria-hidden="true" />
-            ) : (
-              <Lock className="h-4 w-4" aria-hidden="true" />
-            )}
-          </Button>
-        </span>
-      </Tooltip>
-      <Tooltip content={selectedSurvey.show_results ? 'Hide results' : 'Show results'}>
-        <span className="inline-flex">
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className={surveyStateButtonClassName(selectedSurvey.show_results)}
-            aria-label={selectedSurvey.show_results ? 'Hide results' : 'Show results'}
-            aria-pressed={selectedSurvey.show_results}
-            onClick={() => {
-              void patchSelectedSurvey({ show_results: !selectedSurvey.show_results })
+            className="inline-flex"
+            toggleAriaLabel="More survey actions"
+            menuPlacement="down"
+            primaryButtonProps={{
+              'aria-label': selectedSurvey.status === 'active' ? 'Close poll' : 'Open poll',
+              'aria-pressed': selectedSurvey.status === 'active',
+              disabled:
+                isReadOnly ||
+                surveyActionBusy ||
+                isDeletingSurvey ||
+                (selectedSurvey.status === 'draft' && selectedSurvey.stats.questions_count === 0),
             }}
-            disabled={isReadOnly || surveyActionBusy || isDeletingSurvey}
-          >
-            {selectedSurvey.show_results ? (
-              <BarChart3 className="h-4 w-4" aria-hidden="true" />
-            ) : (
-              <HiddenResultsIcon />
-            )}
-          </Button>
-        </span>
-      </Tooltip>
-      <Tooltip content="Edit survey">
-        <span className="inline-flex">
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            className="h-10 w-10 p-0"
-            aria-label="Edit survey"
-            onClick={() => {
-              setCreatedSurveyEditorIntent({ surveyId: selectedSurvey.id, editMode: 'edit' })
-              openSurveyModal(selectedSurvey.id)
-            }}
-            disabled={isReadOnly || surveyActionBusy || isDeletingSurvey}
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-          </Button>
+          />
         </span>
       </Tooltip>
     </div>
@@ -2519,63 +2505,67 @@ export function TeacherClassroomView({
     selection.mode === 'summary' ? (
       <TeacherWorkSurfaceActionBar
         testId="assignment-summary-actionbar-center"
-        center={
-          <div className="flex items-center justify-center gap-1.5">
-            <Tooltip content="Create a new assignment">
-              <span className="inline-flex">
-                <SplitButton
-                  label={
-                    <span className="inline-flex items-center gap-1.5">
-                      <Plus className="h-4 w-4" aria-hidden="true" />
-                      <span>New</span>
-                    </span>
-                  }
-                  onPrimaryClick={() => setIsCreateModalOpen(true)}
-                  options={[
-                    {
-                      id: 'assignment',
-                      label: 'Assignment',
-                      onSelect: () => setIsCreateModalOpen(true),
-                    },
-                    {
-                      id: 'material',
-                      label: 'Material',
-                      onSelect: () => {
-                        setEditMaterial(null)
-                        setIsMaterialModalOpen(true)
-                      },
-                    },
-                    {
-                      id: 'survey',
-                      label: 'Survey',
-                      onSelect: () => setIsSurveyCreateModalOpen(true),
-                    },
-                    ...(showMarkdownEditorOption
-                      ? [
-                          {
-                            id: 'edit-markdown',
-                            label: (
-                              <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                                <FileText className="h-4 w-4" aria-hidden="true" />
-                                <span>Edit Markdown</span>
-                              </span>
-                            ),
-                            onSelect: () => onOpenMarkdownEditor?.(),
-                            disabled: !onOpenMarkdownEditor || isReadOnly,
-                          },
-                        ]
-                      : []),
-                  ]}
-                  disabled={isReadOnly}
-                  toggleAriaLabel="Choose classwork type"
-                  menuPlacement="down"
-                  primaryButtonProps={{ 'aria-label': 'New assignment' }}
-                />
-              </span>
-            </Tooltip>
-            {assignmentSummaryEditControls}
-          </div>
-        }
+        floatingAction={{
+          label: (
+            <span className="inline-flex items-center gap-1.5">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span>New</span>
+            </span>
+          ),
+          onPrimaryClick: () => setIsCreateModalOpen(true),
+          options: [
+            {
+              id: 'assignment',
+              label: 'Assignment',
+              onSelect: () => setIsCreateModalOpen(true),
+            },
+            {
+              id: 'material',
+              label: 'Material',
+              onSelect: () => {
+                setEditMaterial(null)
+                setIsMaterialModalOpen(true)
+              },
+            },
+            {
+              id: 'survey',
+              label: 'Survey',
+              onSelect: () => setIsSurveyCreateModalOpen(true),
+            },
+            {
+              id: 'edit-classwork-list',
+              label: (
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
+                  <span>Edit list controls</span>
+                </span>
+              ),
+              checked: assignmentEditMode,
+              onSelect: () => setAssignmentEditMode(!assignmentEditMode),
+              disabled: isReadOnly,
+              dividerBefore: true,
+            },
+            ...(showMarkdownEditorOption
+              ? [
+                  {
+                    id: 'edit-markdown',
+                    label: (
+                      <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                        <FileText className="h-4 w-4" aria-hidden="true" />
+                        <span>Edit Markdown</span>
+                      </span>
+                    ),
+                    onSelect: () => onOpenMarkdownEditor?.(),
+                    disabled: !onOpenMarkdownEditor || isReadOnly,
+                  },
+                ]
+              : []),
+          ],
+          disabled: isReadOnly,
+          toggleAriaLabel: 'Choose classwork action',
+          menuPlacement: 'down',
+          primaryButtonProps: { 'aria-label': 'New assignment' },
+        }}
         centerPlacement="floating"
       />
     ) : (

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -10,7 +10,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type Ref,
 } from 'react'
-import { ChevronDown, ChevronUp, Copy, Mail, Settings, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, Copy, ListFilter, Mail, Settings, X } from 'lucide-react'
 import type {
   GradebookAssessmentCell,
   GradebookAssessmentColumn,
@@ -18,12 +18,8 @@ import type {
   GradebookStudentSummary,
 } from '@/types'
 import {
-  Button,
   Input,
-  SegmentedControl,
-  SplitButton,
   Tooltip,
-  type SegmentedControlOption,
   type SplitButtonOption,
   useAppMessage,
 } from '@/ui'
@@ -1664,14 +1660,18 @@ export function TeacherGradebookTab({
   }
 
   const isSettingsActive = columnEditorOpen
-  const scoreDisplayOptions: Array<SegmentedControlOption<ScoreDisplayMode>> = [
+  const scoreDisplayOptions: SplitButtonOption[] = [
     {
-      value: 'percent',
-      label: 'Scores: %',
+      id: 'score-display-percent',
+      label: 'Show %',
+      checked: scoreDisplayMode === 'percent',
+      onSelect: () => handleScoreDisplayModeChange('percent'),
     },
     {
-      value: 'raw',
-      label: 'Scores: Raw',
+      id: 'score-display-raw',
+      label: 'Show Raw',
+      checked: scoreDisplayMode === 'raw',
+      onSelect: () => handleScoreDisplayModeChange('raw'),
     },
   ]
   const selectedEmailOptions: SplitButtonOption[] = [
@@ -1696,53 +1696,54 @@ export function TeacherGradebookTab({
       onSelect: () => openOutlook(selectedStudentEmails),
     },
   ]
+  const gradebookActionOptions: SplitButtonOption[] = [
+    ...scoreDisplayOptions,
+    {
+      id: 'column-controls',
+      label: (
+        <span className="inline-flex items-center gap-2 whitespace-nowrap">
+          <Settings className="h-4 w-4" aria-hidden="true" />
+          <span>Column controls</span>
+        </span>
+      ),
+      checked: isSettingsActive,
+      onSelect: () => handleSettingsActiveChange(!isSettingsActive),
+      dividerBefore: true,
+    },
+    ...(selectedStudentEmails.length > 0
+      ? selectedEmailOptions.map((option, index) => ({
+          ...option,
+          dividerBefore: index === 0 ? true : option.dividerBefore,
+        }))
+      : []),
+  ]
+  const nextScoreDisplayMode: ScoreDisplayMode = scoreDisplayMode === 'percent' ? 'raw' : 'percent'
+  const scoreDisplayLabel = scoreDisplayMode === 'percent' ? 'Scores: %' : 'Scores: Raw'
+  const hasSelectedEmailActions = selectedStudentEmails.length > 0
+
   const actionBar = (
     <TeacherWorkSurfaceActionBar
-      center={
-        <div className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-1.5">
-          <SegmentedControl<ScoreDisplayMode>
-            ariaLabel="Gradebook score display"
-            value={scoreDisplayMode}
-            options={scoreDisplayOptions}
-            onChange={handleScoreDisplayModeChange}
-            className="h-9"
-          />
-          {selectedStudentEmails.length > 0 ? (
-            <SplitButton
-              label={
-                <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <Mail className="h-4 w-4" aria-hidden="true" />
-                  <span>Email ({selectedStudentEmails.length})</span>
-                </span>
-              }
-              onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
-              options={selectedEmailOptions}
-              size="sm"
-              toggleAriaLabel="Gradebook email actions"
-              menuPlacement="down"
-            />
-          ) : null}
-          <Tooltip content={isSettingsActive ? 'Hide gradebook column controls' : 'Show gradebook column controls'}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label="Gradebook column controls"
-              aria-pressed={isSettingsActive}
-              title="Gradebook column controls"
-              className={[
-                'h-9 w-9 px-0',
-                isSettingsActive
-                  ? 'border-primary/40 bg-info-bg text-primary shadow-inner hover:bg-info-bg-hover hover:text-primary'
-                  : '',
-              ].join(' ')}
-              onClick={() => handleSettingsActiveChange(!isSettingsActive)}
-            >
-              <Settings className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          </Tooltip>
-        </div>
-      }
+      floatingAction={{
+        label: hasSelectedEmailActions ? (
+          <span className="inline-flex items-center gap-2 whitespace-nowrap">
+            <Mail className="h-4 w-4" aria-hidden="true" />
+            <span>Email ({selectedStudentEmails.length})</span>
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-2 whitespace-nowrap">
+            <ListFilter className="h-4 w-4" aria-hidden="true" />
+            <span>{scoreDisplayLabel}</span>
+          </span>
+        ),
+        onPrimaryClick: hasSelectedEmailActions
+          ? () => openDefaultEmail(selectedStudentEmails)
+          : () => handleScoreDisplayModeChange(nextScoreDisplayMode),
+        options: gradebookActionOptions,
+        variant: hasSelectedEmailActions ? 'primary' : 'secondary',
+        size: 'sm',
+        toggleAriaLabel: 'Gradebook actions',
+        menuPlacement: 'down',
+      }}
       centerPlacement="floating"
     />
   )

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { ConfirmDialog, SplitButton, type SplitButtonOption, useAppMessage } from '@/ui'
+import { ConfirmDialog, type SplitButtonOption, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
@@ -505,41 +505,30 @@ export function TeacherRosterTab({ classroom }: Props) {
       },
     )
   }
+  const combinedRosterActionOptions: SplitButtonOption[] = [
+    ...rosterActionOptions,
+    ...(someSelected
+      ? selectedEmailOptions.map((option, index) => ({
+          ...option,
+          dividerBefore: index === 0 ? true : option.dividerBefore,
+        }))
+      : []),
+  ]
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
-      center={
-        <div className="flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-1.5">
-          <SplitButton
-            label="+ Students"
-            onPrimaryClick={() => {
-              if (isReadOnly || isRosterLoading) return
-              setAddModalOpen(true)
-            }}
-            options={rosterActionOptions}
-            disabled={isReadOnly || isRosterLoading}
-            size="sm"
-            toggleAriaLabel="Roster actions"
-            menuPlacement="down"
-          />
-          {someSelected ? (
-            <SplitButton
-              label={
-                <span className="inline-flex items-center gap-2 whitespace-nowrap">
-                  <Mail className="h-4 w-4" aria-hidden="true" />
-                  <span>Email ({selectedStudentEmails.length})</span>
-                </span>
-              }
-              onPrimaryClick={() => openDefaultEmail(selectedStudentEmails)}
-              options={selectedEmailOptions}
-              disabled={selectedStudentEmails.length === 0}
-              size="sm"
-              toggleAriaLabel="Roster email actions"
-              menuPlacement="down"
-            />
-          ) : null}
-        </div>
-      }
+      floatingAction={{
+        label: '+ Students',
+        onPrimaryClick: () => {
+          if (isReadOnly || isRosterLoading) return
+          setAddModalOpen(true)
+        },
+        options: combinedRosterActionOptions,
+        disabled: isReadOnly || isRosterLoading,
+        size: 'sm',
+        toggleAriaLabel: 'Roster actions',
+        menuPlacement: 'down',
+      }}
       centerPlacement="floating"
     />
   )

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -51,7 +51,7 @@ import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
-import { Button, ConfirmDialog, DialogPanel, EmptyState, RefreshingIndicator, Select, SplitButton, Tooltip, useAppMessage, useOverlayMessage } from '@/ui'
+import { Button, ConfirmDialog, DialogPanel, EmptyState, RefreshingIndicator, Select, Tooltip, useAppMessage, useOverlayMessage, type SplitButtonProps } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
   AssessmentWorkspaceSummaryPatch,
@@ -2269,16 +2269,15 @@ export function TeacherTestsTab({
     </div>
   )
 
-  const selectedTestActions = selectedTestWorkspace ? (
-    <SplitButton
-      label={
+  const selectedTestAction: SplitButtonProps | null = selectedTestWorkspace ? {
+      label: (
         <span className="inline-flex items-center gap-2">
           {getAccessActionIcon(accessPrimaryState)}
           <span>{getAccessActionLabel(accessPrimaryState, accessPrimaryScope, accessPrimaryCount)}</span>
         </span>
-      }
-      onPrimaryClick={() => handleAccessAction(accessPrimaryState)}
-      options={[
+      ),
+      onPrimaryClick: () => handleAccessAction(accessPrimaryState),
+      options: [
         {
           id: `${accessAlternateState}-${accessPrimaryScope.toLowerCase()}`,
           label: (
@@ -2401,18 +2400,17 @@ export function TeacherTestsTab({
             isCombinedTestActionsBusy,
           destructive: true,
         },
-      ]}
-      variant="secondary"
-      size="sm"
-      className="inline-flex"
-      toggleAriaLabel="More test actions"
-      menuPlacement="down"
-      primaryButtonProps={{
+      ],
+      variant: 'secondary',
+      size: 'sm',
+      className: 'inline-flex',
+      toggleAriaLabel: 'More test actions',
+      menuPlacement: 'down',
+      primaryButtonProps: {
         'aria-label': getAccessActionLabel(accessPrimaryState, accessPrimaryScope, accessPrimaryCount),
         disabled: isAccessActionDisabled,
-      }}
-    />
-  ) : null
+      },
+    } : null
 
   const workspaceModeStatus =
     selectedWorkspaceTab === 'grading' && selectedStudentId && testGradingSaveState.status !== 'idle' ? (
@@ -2433,13 +2431,6 @@ export function TeacherTestsTab({
             : 'Unsaved'}
       </span>
     ) : null
-
-  const selectedWorkspaceControls = workspaceState === 'selected' ? (
-    <div className="flex min-w-0 flex-wrap items-center justify-center gap-2 sm:gap-3">
-      {selectedTestActions}
-      {workspaceModeStatus}
-    </div>
-  ) : null
 
   const activeTestGradingMessage =
     workspaceState === 'selected' && selectedWorkspaceTab === 'grading'
@@ -2494,46 +2485,48 @@ export function TeacherTestsTab({
 
   const primaryContent = workspaceState === 'selected' ? (
     <TeacherWorkSurfaceActionBar
-      center={selectedWorkspaceControls}
+      floatingAction={selectedTestAction ?? undefined}
+      floatingActionStatus={workspaceModeStatus}
       centerPlacement="floating"
     />
   ) : (
     <TeacherWorkSurfaceActionBar
-      center={
-        <div className="flex items-center justify-center gap-1.5">
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            className="gap-1.5"
-            onClick={handleNewTest}
-            disabled={isReadOnly || isCreatingTest || loading}
-          >
+      floatingAction={{
+        label: (
+          <span className="inline-flex items-center gap-1.5">
             <Plus className="h-4 w-4" aria-hidden="true" />
             <span>{isCreatingTest ? 'Creating...' : 'New'}</span>
-          </Button>
-          <Tooltip content={testEditMode ? 'Hide test list controls' : 'Show test list controls'}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label="Test list settings"
-              title="Test list settings"
-              aria-pressed={testEditMode}
-              className={[
-                'h-9 w-9 px-0',
-                testEditMode
-                  ? 'border-primary/40 bg-info-bg text-primary shadow-inner hover:bg-info-bg-hover hover:text-primary'
-                  : '',
-              ].join(' ')}
-              onClick={() => setTestEditMode((prev) => !prev)}
-              disabled={isReadOnly}
-            >
-              <Settings className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          </Tooltip>
-        </div>
-      }
+          </span>
+        ),
+        onPrimaryClick: handleNewTest,
+        options: [
+          {
+            id: 'new-test',
+            label: 'Test',
+            onSelect: handleNewTest,
+            disabled: isReadOnly || isCreatingTest || loading,
+          },
+          {
+            id: 'test-list-controls',
+            label: (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <Settings className="h-4 w-4" aria-hidden="true" />
+                <span>List controls</span>
+              </span>
+            ),
+            checked: testEditMode,
+            onSelect: () => setTestEditMode((prev) => !prev),
+            disabled: isReadOnly,
+            dividerBefore: true,
+          },
+        ],
+        disabled: isReadOnly || isCreatingTest || loading,
+        variant: 'primary',
+        size: 'sm',
+        toggleAriaLabel: 'More test actions',
+        menuPlacement: 'down',
+        primaryButtonProps: { 'aria-label': 'New test' },
+      }}
       centerPlacement="floating"
     />
   )

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
@@ -2,11 +2,14 @@
 
 import type { ReactNode } from 'react'
 import { FloatingActionCluster } from '@/components/FloatingActionCluster'
+import { SplitButton, type SplitButtonProps } from '@/ui'
 import { cn } from '@/ui/utils'
 
 interface TeacherWorkSurfaceActionBarProps {
   label?: ReactNode
   center?: ReactNode
+  floatingAction?: SplitButtonProps
+  floatingActionStatus?: ReactNode
   trailing?: ReactNode
   className?: string
   labelClassName?: string
@@ -33,6 +36,8 @@ export function TeacherWorkSurfaceFloatingActionCluster({
 export function TeacherWorkSurfaceActionBar({
   label,
   center,
+  floatingAction,
+  floatingActionStatus,
   trailing,
   className,
   labelClassName,
@@ -42,6 +47,12 @@ export function TeacherWorkSurfaceActionBar({
   testId,
 }: TeacherWorkSurfaceActionBarProps) {
   const isCenterFloating = centerPlacement === 'floating'
+  const resolvedCenter = floatingAction ? (
+    <div className="flex max-w-[calc(100vw-2rem)] items-center justify-center gap-2">
+      <SplitButton {...floatingAction} />
+      {floatingActionStatus}
+    </div>
+  ) : center
 
   return (
     <div
@@ -54,14 +65,14 @@ export function TeacherWorkSurfaceActionBar({
       <div className={cn('min-w-0 max-w-full overflow-hidden justify-self-start text-sm font-semibold text-text-default', labelClassName)}>
         {label}
       </div>
-      {center ? (
+      {resolvedCenter ? (
         isCenterFloating ? (
           <TeacherWorkSurfaceFloatingActionCluster className={centerClassName}>
-            {center}
+            {resolvedCenter}
           </TeacherWorkSurfaceFloatingActionCluster>
         ) : (
           <div className={cn('min-w-0 justify-self-center', centerClassName)}>
-            {center}
+            {resolvedCenter}
           </div>
         )
       ) : (

--- a/tests/components/TeacherClassroomView.test.tsx
+++ b/tests/components/TeacherClassroomView.test.tsx
@@ -115,6 +115,7 @@ vi.mock('@/ui', () => ({
           type="button"
           onClick={option.onSelect}
           disabled={option.disabled}
+          aria-pressed={option.checked}
           onMouseEnter={() => option.onHoverChange?.(true)}
           onMouseLeave={() => option.onHoverChange?.(false)}
           onFocus={() => option.onHoverChange?.(true)}
@@ -937,14 +938,14 @@ describe('TeacherClassroomView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit Markdown' }))
     expect(onOpenMarkdownEditor).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
 
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: 'Edit Markdown' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
     expect(onEditModeChange).toHaveBeenLastCalledWith(true)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
   })
@@ -961,14 +962,14 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
+    expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByRole('button', { name: 'Open assignment code editor' })).not.toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'false')
     })
   })
 
@@ -987,7 +988,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
     fireEvent.click(screen.getByRole('button', { name: 'Assignment One' }))
 
     expect(screen.getByRole('dialog')).toHaveTextContent('Editing Assignment One')
@@ -1025,7 +1026,7 @@ describe('TeacherClassroomView', () => {
       materialButton.compareDocumentPosition(assignmentButton) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
     expect(screen.getByRole('button', { name: 'Drag to reorder material' })).toBeInTheDocument()
     expect(materialButton.querySelector('.border-l-2')).not.toBeInTheDocument()
     expect(materialButton.closest('.bg-info-bg')).not.toHaveClass('border-primary/40')
@@ -1074,10 +1075,10 @@ describe('TeacherClassroomView', () => {
     expect(screen.getByTestId('mock-survey-results-pane')).toHaveTextContent('Survey results survey-1')
     expect(screen.getByTestId('survey-workspace-actionbar-center').parentElement).toHaveClass('fixed')
     expect(screen.getByRole('button', { name: 'Edit survey' })).toBeInTheDocument()
-    const closePollButton = screen.getByRole('button', { name: 'Close poll' })
+    const closePollButton = screen.getAllByRole('button', { name: 'Close poll' })[0]
     const hideResultsButton = screen.getByRole('button', { name: 'Hide results' })
-    expect(closePollButton).toHaveClass('bg-success-bg', 'text-success')
-    expect(hideResultsButton).toHaveClass('bg-success-bg', 'text-success')
+    expect(closePollButton).toHaveAttribute('aria-pressed', 'true')
+    expect(hideResultsButton).toHaveAttribute('aria-pressed', 'false')
     expect(screen.queryByRole('button', { name: 'Lock responses' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Delete survey' })).not.toBeInTheDocument()
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
@@ -1100,7 +1101,8 @@ describe('TeacherClassroomView', () => {
       )
     })
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Show results' })).toHaveClass('bg-danger-bg', 'text-danger')
+      expect(screen.getByRole('button', { name: 'Show results' })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByRole('button', { name: 'Hide results' })).toHaveAttribute('aria-pressed', 'true')
     })
 
     const { params } = applySearchParamsUpdate(updateSearchParams.mock.calls[0])
@@ -1142,9 +1144,9 @@ describe('TeacherClassroomView', () => {
     )
 
     expect(await screen.findByTestId('mock-survey-results-pane')).toHaveTextContent('Survey results survey-1')
-    const openPollButton = screen.getByRole('button', { name: 'Open poll' })
+    const openPollButton = screen.getAllByRole('button', { name: 'Open poll' })[0]
     expect(openPollButton).toBeDisabled()
-    expect(openPollButton).toHaveClass('bg-danger-bg', 'text-danger')
+    expect(openPollButton).toHaveAttribute('aria-pressed', 'false')
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(screen.queryByTestId('teacher-work-panel')).not.toBeInTheDocument()
   })
@@ -1177,13 +1179,14 @@ describe('TeacherClassroomView', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Draft Survey' }))
 
-    expect(screen.getByRole('button', { name: 'Open poll' })).toBeDisabled()
+    expect(screen.getAllByRole('button', { name: 'Open poll' })[0]).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit survey' })).not.toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit survey' }))
     fireEvent.click(screen.getByRole('button', { name: 'Mock add survey question' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Open poll' })).not.toBeDisabled()
+      expect(screen.getAllByRole('button', { name: 'Open poll' })[0]).not.toBeDisabled()
     })
   })
 
@@ -1266,8 +1269,8 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
+    expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'true')
 
     fireEvent.click(screen.getByRole('button', { name: 'New assignment' }))
     expect(screen.getByRole('dialog')).toHaveTextContent('New Assignment')
@@ -1275,7 +1278,7 @@ describe('TeacherClassroomView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close assignment modal' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'false')
     })
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
@@ -1318,8 +1321,8 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByRole('button', { name: 'Assignment One' })).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit list controls' }))
+    expect(screen.getByRole('button', { name: 'Edit list controls' })).toHaveAttribute('aria-pressed', 'true')
 
     rerender(
       <TeacherClassroomView
@@ -1330,7 +1333,7 @@ describe('TeacherClassroomView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Edit list controls' })).not.toBeInTheDocument()
     })
     expect(onEditModeChange).toHaveBeenLastCalledWith(false)
   })
@@ -1718,9 +1721,8 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    expect(screen.getByRole('button', {
-      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
-    })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Students + grading' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Content + grading' })).toHaveAttribute('aria-pressed', 'false')
     expectAssignmentSplitPaneIndicator({
       index: '1',
       icon: 'grading',
@@ -1734,7 +1736,7 @@ describe('TeacherClassroomView', () => {
     expect(screen.getAllByRole('button', { name: /AI Grade/i })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Return/i })).toHaveLength(1)
     expect(screen.getByTestId('assignment-workspace-actionbar-center').parentElement).toHaveClass('fixed')
-    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit list controls' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Edit assignment' })).not.toBeInTheDocument()
 
     expect(screen.getByRole('button', { name: 'Edit Assignment' })).toBeInTheDocument()
@@ -2139,9 +2141,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('button', {
-      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
-    }))
+    fireEvent.click(screen.getByRole('button', { name: 'Content + grading' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('content-grading')
@@ -2159,9 +2159,8 @@ describe('TeacherClassroomView', () => {
       inspectorCollapsed: false,
       inspectorWidth: 61,
     })
-    expect(screen.getByRole('button', {
-      name: 'Assignment panes: Content + grading. Switch to Students + content.',
-    })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Content + grading' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Students + content' })).toHaveAttribute('aria-pressed', 'false')
     expectAssignmentSplitPaneIndicator({
       index: '2',
       icon: 'content',
@@ -2209,7 +2208,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Content + grading' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('content-grading')
@@ -2222,7 +2221,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('teacher-work-panel')).toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Students + content' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-content')
@@ -2236,7 +2235,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('assignment-right-pane')).not.toHaveTextContent('grading:assignment-1:student-1')
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Assignment panes:/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Students + grading' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-grading')
@@ -2294,9 +2293,7 @@ describe('TeacherClassroomView', () => {
       expect(screen.getByTestId('assignment-right-pane')).toHaveTextContent('work:assignment-1:student-1')
       expect(screen.getByTestId('assignment-right-pane')).not.toHaveTextContent('grading:assignment-1:student-1')
     })
-    expect(screen.getByRole('button', {
-      name: 'Assignment panes: Students + content. Switch to Students + grading.',
-    })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Students + content' })).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('keeps the students and grading view active when clicking a student row', async () => {
@@ -2362,9 +2359,7 @@ describe('TeacherClassroomView', () => {
     })
 
     expect(screen.getByTestId('assignment-split-pane-view')).toHaveTextContent('students-grading')
-    expect(screen.getByRole('button', {
-      name: 'Assignment panes: Students + grading. Switch to Content + grading.',
-    })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Students + grading' })).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('restores the class-pane scroll position after selecting a lower student row', async () => {

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -186,6 +186,19 @@ describe('TeacherGradebookTab', () => {
     )
   }
 
+  function openGradebookActions() {
+    const existingMenu = screen.queryByRole('menu')
+    if (existingMenu) return existingMenu
+
+    fireEvent.click(screen.getByRole('button', { name: 'Gradebook actions' }))
+    return screen.getByRole('menu')
+  }
+
+  function toggleGradebookColumnControls() {
+    const menu = openGradebookActions()
+    fireEvent.click(within(menu).getByRole('menuitemradio', { name: 'Column controls' }))
+  }
+
   it('renders the assessment matrix and delegates settings navigation', async () => {
     const onSectionChange = vi.fn()
 
@@ -215,41 +228,45 @@ describe('TeacherGradebookTab', () => {
     fireEvent.keyDown(firstResize, { key: 'ArrowRight' })
     expect(firstResize).toHaveAttribute('aria-valuenow', '104')
     expect(screen.queryByRole('button', { name: 'Email (0)' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Gradebook score display actions' })).not.toBeInTheDocument()
-    const scoreDisplayControl = screen.getByRole('group', { name: 'Gradebook score display' })
-    expect(within(scoreDisplayControl).getByRole('button', { name: 'Scores: %' })).toHaveAttribute('aria-pressed', 'true')
-    expect(within(scoreDisplayControl).getByRole('button', { name: 'Scores: Raw' })).toHaveAttribute('aria-pressed', 'false')
-    fireEvent.click(within(scoreDisplayControl).getByRole('button', { name: 'Scores: Raw' }))
-    expect(within(scoreDisplayControl).getByRole('button', { name: 'Scores: Raw' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Gradebook actions' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scores: %' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Scores: %' }))
+    expect(screen.getByRole('button', { name: 'Scores: Raw' })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Ada Lovelace.*8\/10 10\/10 9\/10 85\.0%/ })).toBeInTheDocument()
-    fireEvent.click(within(scoreDisplayControl).getByRole('button', { name: 'Scores: %' }))
-    expect(within(scoreDisplayControl).getByRole('button', { name: 'Scores: %' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Scores: Raw' }))
+    expect(screen.getByRole('button', { name: 'Scores: %' })).toBeInTheDocument()
+    let gradebookMenu = openGradebookActions()
+    const percentToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })
+    const rawToggle = within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })
+    expect(percentToggle).toHaveAttribute('aria-checked', 'true')
+    expect(rawToggle).toHaveAttribute('aria-checked', 'false')
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Copy emails (0)' })).not.toBeInTheDocument()
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Gmail' })).not.toBeInTheDocument()
+    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Outlook' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Summary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Gradebook view' })).not.toBeInTheDocument()
 
-    fireEvent.click(within(scoreDisplayControl).getByRole('button', { name: 'Scores: Raw' }))
-    expect(within(scoreDisplayControl).getByRole('button', { name: 'Scores: Raw' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' }))
     expect(screen.getByRole('row', { name: /Ada Lovelace.*8\/10 10\/10 9\/10 85\.0%/ })).toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Avg.*7\/10 10\/10 8\.5\/10 77\.5%/ })).toBeInTheDocument()
-    fireEvent.click(within(scoreDisplayControl).getByRole('button', { name: 'Scores: %' }))
+    gradebookMenu = openGradebookActions()
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'false')
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(within(gradebookMenu).getByRole('menuitemradio', { name: 'Show %' }))
     expect(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ })).toBeInTheDocument()
 
     const adaSelect = screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })
     fireEvent.click(adaSelect)
     expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook email actions' }))
-    const gradebookMenu = screen.getByRole('menu')
-    expect(within(gradebookMenu).queryByRole('separator')).not.toBeInTheDocument()
-    expect(within(gradebookMenu).queryByRole('menuitemradio', { name: 'Show %' })).not.toBeInTheDocument()
-    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Scores: %' })).not.toBeInTheDocument()
-    expect(within(gradebookMenu).queryByRole('menuitem', { name: 'Scores: Raw' })).not.toBeInTheDocument()
+    gradebookMenu = openGradebookActions()
+    expect(within(gradebookMenu).queryByRole('menuitemradio', { name: 'Show %' })).toBeInTheDocument()
     fireEvent.click(within(gradebookMenu).getByRole('menuitem', { name: 'Copy emails (1)' }))
     await waitFor(() => {
       expect(clipboardWriteText).toHaveBeenCalledWith('ada@example.com')
     })
     fireEvent.click(adaSelect)
-    expect(screen.getByRole('button', { name: 'Gradebook column controls' })).toHaveAttribute('aria-pressed', 'false')
+    gradebookMenu = openGradebookActions()
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
 
     fireEvent.click(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ }))
     const detailPanel = screen.getByRole('region', { name: 'Ada Lovelace assessment details' })
@@ -272,9 +289,7 @@ describe('TeacherGradebookTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'First' }))
     expect(screen.getAllByRole('row')[1]).toHaveTextContent(/AdaLovelace/)
 
-    const settingsToggle = screen.getByRole('button', { name: 'Gradebook column controls' })
-    expect(settingsToggle).toHaveAttribute('aria-pressed', 'false')
-    fireEvent.click(settingsToggle)
+    toggleGradebookColumnControls()
 
     expect(onSectionChange).toHaveBeenCalledWith('settings')
     expect(screen.queryByRole('checkbox', { name: 'Use category weights' })).not.toBeInTheDocument()
@@ -331,7 +346,7 @@ describe('TeacherGradebookTab', () => {
     expect(avgRowToggle).not.toBeChecked()
     expect(screen.getByRole('row', { name: /Avg.*70%.*100%.*85%/ })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
+    toggleGradebookColumnControls()
     expect(screen.queryByRole('row', { name: /Avg/ })).not.toBeInTheDocument()
     expect(screen.getByRole('row', { name: /Med/ })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Last' })).not.toBeInTheDocument()
@@ -351,11 +366,12 @@ describe('TeacherGradebookTab', () => {
         </TooltipProvider>
       </AppMessageProvider>,
     )
-    expect(screen.getByRole('button', { name: 'Gradebook column controls' })).toHaveAttribute('aria-pressed', 'true')
+    gradebookMenu = openGradebookActions()
+    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'true')
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
     })
-  })
+  }, 10_000)
 
   it('color codes grade text by percentage band', async () => {
     const response = gradebookResponse()
@@ -410,13 +426,13 @@ describe('TeacherGradebookTab', () => {
 
     expect(await screen.findByText('Ada')).toBeInTheDocument()
 
-    const floatingCluster = screen.getByRole('group', { name: 'Gradebook score display' }).closest('.fixed')
+    const floatingCluster = screen.getByRole('button', { name: 'Gradebook actions' }).closest('.fixed')
     expect(floatingCluster).toHaveClass('fixed', 'z-40')
     expect(floatingCluster?.className).not.toContain('z-[70]')
     expect(screen.getByRole('columnheader', { name: 'First' })).toHaveClass('z-30')
     expect(screen.getByRole('columnheader', { name: 'Final' })).toHaveClass('z-20', 'md:z-30')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
+    toggleGradebookColumnControls()
     expect(screen.getByRole('columnheader', { name: 'Visible' })).toHaveClass('z-30')
   })
 
@@ -430,16 +446,15 @@ describe('TeacherGradebookTab', () => {
     fireEvent.click(adaSelect)
     expect(screen.getByRole('button', { name: 'Email (1)' })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
+    toggleGradebookColumnControls()
 
     expect(onSectionChange).toHaveBeenCalledWith('settings')
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Email (0)' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Gradebook email actions' })).not.toBeInTheDocument()
-    expect(screen.getByRole('group', { name: 'Gradebook score display' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Gradebook actions' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Gradebook column controls' }))
+    toggleGradebookColumnControls()
 
     expect(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' })).not.toBeChecked()
     expect(screen.queryByRole('button', { name: 'Email (1)' })).not.toBeInTheDocument()

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -297,15 +297,11 @@ describe('TeacherRosterTab', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Grace Hopper' }))
 
     expect(screen.getByRole('button', { name: '+ Students' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Email \(2\)/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Email \(2\)/ })).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Roster actions' }))
     expect(screen.getByRole('menuitem', { name: '+ CSV' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Remove students' })).toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: /Gmail/ })).not.toBeInTheDocument()
-
-    await user.keyboard('{Escape}')
-    await user.click(screen.getByRole('button', { name: 'Roster email actions' }))
     expect(screen.getByRole('menuitem', { name: 'Copy emails (2)' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Gmail' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Outlook' })).toBeInTheDocument()

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -327,13 +327,19 @@ describe('TeacherTestsTab', () => {
     return screen.findByTestId('mock-test-detail')
   }
 
+  function toggleTestListControls() {
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'List controls' }))
+  }
+
   it('renders the tests list by default with no selected workspace', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
     renderTab()
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Test list settings' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New test' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.getByRole('menuitemradio', { name: 'List controls' })).toHaveAttribute('aria-checked', 'false')
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
@@ -607,7 +613,7 @@ describe('TeacherTestsTab', () => {
       return Promise.reject(new Error(`Unexpected fetch ${String(url)}`))
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    fireEvent.click(screen.getByRole('button', { name: 'New test' }))
 
     expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Untitled 2026-05-14 10:45:00')
     const dialog = screen.getByRole('dialog')
@@ -929,17 +935,16 @@ describe('TeacherTestsTab', () => {
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Delete Unit Test' })).not.toBeInTheDocument()
-    const settingsButton = screen.getByRole('button', { name: 'Test list settings' })
-    expect(settingsButton).toHaveAttribute('aria-pressed', 'false')
-    fireEvent.click(settingsButton)
+    toggleTestListControls()
 
     expect(screen.getByRole('button', { name: 'Drag to reorder Unit Test' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Delete Unit Test' })).toBeInTheDocument()
-    expect(settingsButton).toHaveAttribute('aria-pressed', 'true')
-    fireEvent.click(settingsButton)
+    fireEvent.click(screen.getByRole('button', { name: 'More test actions' }))
+    expect(screen.getByRole('menuitemradio', { name: 'List controls' })).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'List controls' }))
     expect(screen.queryByRole('button', { name: 'Drag to reorder Unit Test' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
+    toggleTestListControls()
     view.rerender(
       <TeacherTestsTab
         classroom={classroom}
@@ -959,7 +964,7 @@ describe('TeacherTestsTab', () => {
     renderTab()
 
     expect(await screen.findByText('Unit Test')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
+    toggleTestListControls()
 
     expect(screen.getByRole('button', { name: 'Drag to reorder Unit Test' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Delete Unit Test' })).toBeInTheDocument()
@@ -981,7 +986,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ tests: [] }),
       })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Test list settings' }))
+    toggleTestListControls()
     fireEvent.click(screen.getByRole('button', { name: 'Delete Unit Test' }))
     expect(await screen.findByText('Delete test?')).toBeInTheDocument()
     fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))


### PR DESCRIPTION
## Summary
- Add a standardized `floatingAction` split-button slot to `TeacherWorkSurfaceActionBar`.
- Migrate teacher Classwork, Tests, Gradebook, Roster, and Announcements to one split action in the FAB cluster.
- Move secondary controls into split menus for classwork list controls, assignment pane selection, survey state/results/editing, gradebook score/column/email actions, roster CSV/remove/email actions, and announcement creation.

## Notes
- Calendar and Attendance are intentionally unchanged because their FAB controls are date/view navigation rather than action menus.
- Product-facing quiz removal is deferred to a separate pass.
- During review, fixed the empty-draft survey case so a disabled primary `Open poll` action does not disable the secondary `Edit survey` action.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
- `pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx`
- `pnpm build`
- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
- `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments"`
- Manual visual review of loaded teacher Classwork, Tests, Gradebook, Roster, and Announcements screenshots.
