### PR TITLE
[codex] Fix duplicate assignment return comments

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,19 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Gradex egress sanitization alignment
-
-**Completed:**
-- Refactored the Gradex assignment payload builder to require Pika's standard AI sanitization context.
-- Routed Gradex assignment title, instructions, and submission text through `sanitizeAiText` before Gradex payload construction.
-- Kept Gradex-specific pseudonymous refs and local mappings while preserving extra raw-token hardening for Pika DB identifiers and bare `www.` URLs.
-- Strengthened Gradex adapter tests for roster-name initials, required sanitization context, raw identifier exclusion, and Gradex-owned provider/model settings.
-
-**Validation:**
-- `pnpm test tests/lib/gradex-assignment-payload.test.ts tests/unit/ai-sanitization.test.ts tests/unit/ai-grading.test.ts tests/lib/assignment-ai-grading-runs.test.ts`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-
 ## 2026-06-01 — Snapshot gallery hardening phase-1 second pass
 
 **Completed:**
@@ -885,6 +872,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test` (one unrelated `StudentHistoryPage` concurrency failure; isolated rerun passed)
 - `pnpm vitest run tests/components/StudentHistoryPage.test.tsx`
 - `pnpm vitest run --sequence.concurrent=false`
+
+## 2026-06-09 — Assignment returned-comment duplication fix
+
+**Completed:**
+- Stopped assignment AI grading from copying previously returned `feedback` into each new AI feedback result.
+- Made the full assignment return route clear `teacher_feedback_draft` and AI suggestion fields after comments are sent as returned feedback.
+- Added return-route coverage for clearing the comment draft and AI suggestion state.
+- Fixed the stale teacher calendar component test by pinning `getTodayInToronto`; the test was clicking a past disabled date after June 8.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (failed on reproducible baseline `tests/components/TeacherCalendarPage.test.tsx` class-day toggle assertion before this branch's edits)
+- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts`
+- `pnpm vitest run tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts`
+- `pnpm test`
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`
 
 ## 2026-06-08 — Assignment AI grading pane refresh
 

--- a/src/app/api/teacher/assignments/[id]/return/route.ts
+++ b/src/app/api/teacher/assignments/[id]/return/route.ts
@@ -140,6 +140,11 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
         teacher_cleared_at: now,
         returned_at: now,
         feedback_returned_at: now,
+        teacher_feedback_draft: null,
+        teacher_feedback_draft_updated_at: null,
+        ai_feedback_suggestion: null,
+        ai_feedback_suggested_at: null,
+        ai_feedback_model: null,
       },
     })
 
@@ -153,6 +158,11 @@ export const POST = withErrorHandler('PostTeacherAssignmentReturn', async (reque
           is_submitted: false,
           returned_at: now,
           feedback_returned_at: now,
+          teacher_feedback_draft: null,
+          teacher_feedback_draft_updated_at: null,
+          ai_feedback_suggestion: null,
+          ai_feedback_suggested_at: null,
+          ai_feedback_model: null,
         },
       })
     }

--- a/src/lib/ai-grading.ts
+++ b/src/lib/ai-grading.ts
@@ -430,7 +430,7 @@ async function callAssignmentGradingApi(opts: {
   }
 }
 
-function parseAssignmentGradingResponse(outputText: string, previousFeedback?: string | null) {
+function parseAssignmentGradingResponse(outputText: string) {
   let jsonText = outputText
   const codeBlockMatch = outputText.match(/```(?:json)?\s*([\s\S]*?)```/)
   if (codeBlockMatch) {
@@ -469,10 +469,6 @@ function parseAssignmentGradingResponse(outputText: string, previousFeedback?: s
     })
   }
 
-  if (previousFeedback) {
-    feedback = `${previousFeedback}\n\n--- Resubmission ---\n\n${feedback}`
-  }
-
   return {
     score_completion: sc,
     score_thinking: st,
@@ -486,7 +482,6 @@ export async function gradeStudentWork(opts: {
   instructions: string
   studentWork: TiptapContent
   submissionArtifacts?: AssignmentArtifact[]
-  previousFeedback?: string | null
   requestTimeoutMs?: number
   telemetry?: AssignmentGradingTelemetryContext
   sanitizationContext?: AiSanitizationContext | null
@@ -515,7 +510,7 @@ export async function gradeStudentWork(opts: {
       requestTimeoutMs: opts.requestTimeoutMs,
     })
     const usage = extractOpenAIResponseUsage(payload)
-    const parsed = parseAssignmentGradingResponse(outputText, opts.previousFeedback)
+    const parsed = parseAssignmentGradingResponse(outputText)
 
     logAiPromptTelemetry({
       feature: opts.telemetry?.feature ?? 'assignment_auto_grade',

--- a/src/lib/server/assignment-ai-grading-runs.ts
+++ b/src/lib/server/assignment-ai-grading-runs.ts
@@ -361,7 +361,6 @@ export async function gradeAssignmentDocWithAi({
     instructions: getAssignmentInstructionsText(assignment),
     studentWork,
     submissionArtifacts,
-    previousFeedback: assignmentDoc.feedback,
     requestTimeoutMs,
     sanitizationContext: resolvedSanitizationContext,
     telemetry: {

--- a/tests/api/teacher/assignments-id-return.test.ts
+++ b/tests/api/teacher/assignments-id-return.test.ts
@@ -383,6 +383,11 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
         is_submitted: false,
         returned_at: expect.any(String),
         feedback_returned_at: expect.any(String),
+        teacher_feedback_draft: null,
+        teacher_feedback_draft_updated_at: null,
+        ai_feedback_suggestion: null,
+        ai_feedback_suggested_at: null,
+        ai_feedback_model: null,
       }),
     ]))
     expect(
@@ -527,6 +532,11 @@ describe('POST /api/teacher/assignments/[id]/return', () => {
         returned_at: expect.any(String),
         feedback_returned_at: expect.any(String),
         teacher_cleared_at: expect.any(String),
+        teacher_feedback_draft: null,
+        teacher_feedback_draft_updated_at: null,
+        ai_feedback_suggestion: null,
+        ai_feedback_suggested_at: null,
+        ai_feedback_model: null,
       }),
     )
     expect(appendAssignmentFeedbackEntry).toHaveBeenCalledWith(

--- a/tests/components/TeacherCalendarPage.test.tsx
+++ b/tests/components/TeacherCalendarPage.test.tsx
@@ -36,6 +36,10 @@ vi.mock('@/lib/request-cache', () => ({
   prefetchJSON: vi.fn(),
 }))
 
+vi.mock('@/lib/timezone', () => ({
+  getTodayInToronto: () => '2026-06-01',
+}))
+
 function renderCalendarPage() {
   return render(
     <TooltipProvider>


### PR DESCRIPTION
## Summary

Fixes duplicate returned assignment comments when teachers use AI grading after comments have already been returned or deleted.

Also fixes the stale teacher calendar component test that was clicking a now-disabled past date.

## Root cause

Assignment AI grading was copying `assignment_docs.feedback` into every new AI grading result as prior feedback, separated by `--- Resubmission ---`. That field can outlive visible feedback history entries, so deleted/previous comments could be reintroduced above the new AI feedback.

The full assignment return endpoint also marked comments as returned but left `teacher_feedback_draft` and AI suggestion fields populated, so the comment textbox could reload stale sent comments.

The calendar test used `2026-06-08` as the toggle target while the calendar intentionally disables dates before today. Once the current date moved past June 8, the test clicked a disabled button and no `PATCH` was sent.

## Changes

- Stop AI assignment grading from prepending prior `assignment_docs.feedback` to new AI feedback.
- Clear `teacher_feedback_draft`, draft timestamp, and AI suggestion fields when returning assignment work.
- Add API-route coverage that returned work clears the comment draft and AI suggestion state.
- Pin `getTodayInToronto()` in the teacher calendar page test so its June 8 fixture remains toggleable.
- Update the session log and keep it trimmed to the latest 60 entries.

## Validation

- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/api/teacher/assignments-id-return.test.ts tests/api/teacher/assignments-id-feedback-return.test.ts tests/unit/ai-grading.test.ts tests/api/teacher/assignments-auto-grade.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `git diff --check`

## Notes

Existing rows that already persisted duplicated text in `assignment_docs.feedback` or feedback history will not be automatically rewritten by this PR.