### PR TITLE
[codex] Clean up legacy quiz test contracts

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,19 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Snapshot gallery hardening phase-1 second pass
-
-**Completed:**
-- Added `requireSnapshotGalleryAccess()` in `src/lib/auth.ts` to gate snapshot endpoints to non-production teachers by default and allow production access only for `SNAPSHOT_GALLERY_ADMIN_EMAILS` allowlist entries.
-- Replaced `requireAuth()` with snapshot-specific access check in `src/app/api/snapshots/list/route.ts` and `src/app/api/snapshots/[filename]/route.ts`.
-- Updated snapshot API tests to mock and verify the new auth path.
-- Added unit coverage for snapshot-gallery access gating in `tests/unit/auth.test.ts`.
-- Added production admin allowlist env variable and clarified gallery security docs in `.env.example` and `docs/snapshot-gallery.md`.
-
-**Validation:**
-- `pnpm test tests/unit/auth.test.ts tests/api/snapshots-list.test.ts tests/api/snapshots-filename.test.ts`
-- `pnpm lint`
-
 ## 2026-06-01 — Snapshot gallery production restriction finalized
 
 **Completed:**
@@ -965,3 +952,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx`
 - GitHub PR #760 checks: `Test & Build`, `Check UI Import Policy`, `Check No dark: Classes in App Code`, Vercel status all passed.
+
+## 2026-06-09 — Legacy quiz contract transition
+
+**Completed:**
+- Created `codex/legacy-quiz-contract-cleanup` from `origin/main`.
+- Audited remaining internal `quiz` / `quizzes` references across migrations, API payloads, shared types, server/lib code, UI wrappers, tests, and docs.
+- Added dual `test`/`tests` plus legacy `quiz`/`quizzes` response keys to active `/api/*/tests` endpoints.
+- Updated active test clients to prefer `test`/`tests` response keys with legacy fallback.
+- Added test-named type aliases and `@/lib/tests` helper exports, then migrated active test routes/components to those names.
+- Removed unused one-line legacy UI wrappers (`Quiz*`, `StudentQuiz*`, `StudentQuizzesTab`) and updated architecture/UI guidance.
+- Left production schema, migrations, legacy DB tables, gradebook legacy fields, and blueprint schema compatibility unchanged.
+
+**Validation:**
+- `pnpm exec tsc --noEmit`
+- `pnpm vitest run tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx`
+- `pnpm lint`
+- `pnpm build`
+- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
+- `pnpm test` (301 files / 2655 tests)

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -51,7 +51,7 @@ src/
 │   └── classrooms/[classroomId]/  # classroom detail page with ~19 tabs
 │       └── ClassroomPageClient.tsx # ~1500 LOC god component (gradual decomposition ongoing)
 ├── components/                    # Feature components and modals
-│   ├── QuizDetailPanel.tsx        # Legacy-named test editor/viewer (draft mode)
+│   ├── TestDetailPanel.tsx        # Test editor/viewer (draft mode)
 │   ├── AssignmentModal.tsx        # Assignment editor (~900 LOC, scheduling)
 │   ├── TestStudentGradingPanel.tsx # Per-student test grading
 │   └── ...
@@ -166,10 +166,10 @@ const data = await fetch(`/api/teacher/gradebook?...`).then(r => r.json())
 Use raw `fetch()` only for one-off mutations (POST/PATCH/DELETE) or when freshness is critical.
 
 ### Assessments Pattern
-Pika exposes **tests** as the active assessment surface. Quiz product routes and tabs have been removed,
-but some test internals still use legacy quiz-named helpers and compatibility response keys.
+Pika exposes **tests** as the active assessment surface. Quiz product routes and tabs have been removed.
+Some database history and compatibility response keys still retain legacy quiz naming during the contract transition.
 
-- **Test status**: `getStudentTestStatus()` from `@/lib/quizzes` — uses `returned_at` field
+- **Test status**: `getStudentTestStatus()` from `@/lib/tests` — uses `returned_at` field
 - **Draft editing**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`
 - **Scheduling**: `combineScheduleDateTimeToIso()` / `isScheduleIsoInFuture()` from `@/lib/scheduling`
 - **AI grading** (tests only): `src/lib/ai-test-grading.ts` — reference answer SHA-256 cached per question

--- a/docs/guidance/ui/audit-teacher-work-surfaces.md
+++ b/docs/guidance/ui/audit-teacher-work-surfaces.md
@@ -67,7 +67,7 @@ These should remain composed feature patterns even if they use shared primitives
 | --- | --- | --- | --- | --- |
 | Teacher assignment summary list and selection flow | `TeacherClassroomView` | stable | keep composed | now |
 | Teacher assignment focused workspace and student inspection | `TeacherClassroomView`, `TeacherStudentWorkPanel` | stable | keep composed, feed split extraction | now |
-| Teacher test authoring composition | `TeacherTestsTab`, `QuizDetailPanel` | experimental | keep composed | now |
+| Teacher test authoring composition | `TeacherTestsTab`, `TestDetailPanel` | experimental | keep composed | now |
 | Teacher grading workspace composition | `TeacherTestsTab`, `TestStudentGradingPanel` | experimental | keep composed | now |
 
 ## Feature-Local Behavior

--- a/src/app/api/student/tests/[id]/focus-events/route.ts
+++ b/src/app/api/student/tests/[id]/focus-events/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
-import { summarizeQuizFocusEvents } from '@/lib/quizzes'
+import { summarizeTestFocusEvents } from '@/lib/tests'
 import {
   assertStudentCanAccessTest,
   getEffectiveStudentTestAccess,
@@ -9,12 +9,12 @@ import {
 import { getServiceRoleClient } from '@/lib/supabase'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
-import type { QuizFocusEventType } from '@/types'
+import type { TestFocusEventType } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-const ALLOWED_EVENT_TYPES: QuizFocusEventType[] = [
+const ALLOWED_EVENT_TYPES: TestFocusEventType[] = [
   'away_start',
   'away_end',
   'route_exit_attempt',
@@ -27,7 +27,7 @@ export const POST = withErrorHandler('PostStudentTestFocusEvent', async (request
   const { id: testId } = await context.params
   const body = await request.json()
 
-  const eventType = body?.event_type as QuizFocusEventType | undefined
+  const eventType = body?.event_type as TestFocusEventType | undefined
   const sessionId = String(body?.session_id || '').trim()
 
   if (!eventType || !ALLOWED_EVENT_TYPES.includes(eventType)) {
@@ -146,6 +146,6 @@ export const POST = withErrorHandler('PostStudentTestFocusEvent', async (request
 
   return NextResponse.json({
     success: true,
-    focus_summary: summarizeQuizFocusEvents(events || []),
+    focus_summary: summarizeTestFocusEvents(events || []),
   })
 })

--- a/src/app/api/student/tests/[id]/history/route.ts
+++ b/src/app/api/student/tests/[id]/history/route.ts
@@ -11,7 +11,7 @@ import {
 import { getServiceRoleClient } from '@/lib/supabase'
 import { withErrorHandler } from '@/lib/api-handler'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
-import type { QuizStatus } from '@/types'
+import type { TestAssessmentStatus } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -32,7 +32,7 @@ export const GET = withErrorHandler('GetStudentTestHistory', async (request, con
   const supabase = getServiceRoleClient()
 
   let studentId = user.id
-  let studentTestStatus: QuizStatus = 'draft'
+  let studentTestStatus: TestAssessmentStatus = 'draft'
 
   if (user.role === 'teacher') {
     if (!requestedStudentId) {

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { aggregateResults, canStudentViewTestResults } from '@/lib/quizzes'
+import { aggregateTestResults, canStudentViewTestResults } from '@/lib/tests'
 import {
   assertStudentCanAccessTest,
   getEffectiveStudentTestAccess,
@@ -13,7 +13,7 @@ import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import { withErrorHandler } from '@/lib/api-handler'
-import type { QuizQuestion, QuizResponse } from '@/types'
+import type { TestAssessmentQuestion, TestAssessmentResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -325,11 +325,11 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
       student_id: response.student_id,
       selected_option: response.selected_option,
       submitted_at: response.submitted_at,
-    } satisfies QuizResponse]
+    } satisfies TestAssessmentResponse]
   })
 
-  const aggregated = aggregateResults(
-    multipleChoiceQuestions as QuizQuestion[],
+  const aggregated = aggregateTestResults(
+    multipleChoiceQuestions as TestAssessmentQuestion[],
     multipleChoiceResponses
   )
 
@@ -391,15 +391,18 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
   const earnedPoints = questionResults.reduce((acc, question) => acc + (question.score ?? 0), 0)
   const percent = possiblePoints > 0 ? (earnedPoints / possiblePoints) * 100 : 0
 
+  const responseTest = {
+    id: test.id,
+    title: test.title,
+    status: test.status,
+    returned_at: attempt?.returned_at || null,
+    access_state: accessState.access_state,
+    effective_access: accessState.effective_access,
+  }
+
   return NextResponse.json({
-    quiz: {
-      id: test.id,
-      title: test.title,
-      status: test.status,
-      returned_at: attempt?.returned_at || null,
-      access_state: accessState.access_state,
-      effective_access: accessState.effective_access,
-    },
+    test: responseTest,
+    quiz: responseTest,
     results: aggregated,
     my_responses: myResponses,
     question_results: questionResults,

--- a/src/app/api/student/tests/[id]/route.ts
+++ b/src/app/api/student/tests/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { getStudentTestStatus, summarizeQuizFocusEvents } from '@/lib/quizzes'
+import { getStudentTestStatus, summarizeTestFocusEvents } from '@/lib/tests'
 import {
   assertStudentCanAccessTest,
   getEffectiveStudentTestAccess,
@@ -172,26 +172,29 @@ export const GET = withErrorHandler('GetStudentTest', async (request, context) =
     .eq('student_id', user.id)
     .order('occurred_at', { ascending: true })
 
+  const responseTest = {
+    id: test.id,
+    classroom_id: test.classroom_id,
+    title: test.title,
+    assessment_type: 'test' as const,
+    status: test.status,
+    show_results: test.show_results,
+    documents: normalizeTestDocuments(test.documents),
+    position: test.position,
+    student_status: studentStatus,
+    returned_at: attempt?.returned_at || null,
+    access_state: accessState.access_state,
+    effective_access: accessState.effective_access,
+    created_at: test.created_at,
+    updated_at: test.updated_at,
+  }
+
   return NextResponse.json({
-    quiz: {
-      id: test.id,
-      classroom_id: test.classroom_id,
-      title: test.title,
-      assessment_type: 'test' as const,
-      status: test.status,
-      show_results: test.show_results,
-      documents: normalizeTestDocuments(test.documents),
-      position: test.position,
-      student_status: studentStatus,
-      returned_at: attempt?.returned_at || null,
-      access_state: accessState.access_state,
-      effective_access: accessState.effective_access,
-      created_at: test.created_at,
-      updated_at: test.updated_at,
-    },
+    test: responseTest,
+    quiz: responseTest,
     questions: questions || [],
     student_status: studentStatus,
     student_responses: studentResponses,
-    focus_summary: summarizeQuizFocusEvents(focusEvents || []),
+    focus_summary: summarizeTestFocusEvents(focusEvents || []),
   })
 })

--- a/src/app/api/student/tests/[id]/session-status/route.ts
+++ b/src/app/api/student/tests/[id]/session-status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { getStudentTestStatus } from '@/lib/quizzes'
+import { getStudentTestStatus } from '@/lib/tests'
 import {
   assertStudentCanAccessTest,
   getEffectiveStudentTestAccess,
@@ -134,16 +134,19 @@ export const GET = withErrorHandler('GetStudentTestSessionStatus', async (_reque
         : getStudentTestStatus(test, hasSubmitted, attempt?.returned_at)
   const canContinue = accessState.can_start_or_continue
 
+  const responseTest = {
+    id: test.id,
+    status: test.status,
+    assessment_type: 'test' as const,
+    student_status: studentStatus,
+    returned_at: attempt?.returned_at || null,
+    access_state: accessState.access_state,
+    effective_access: accessState.effective_access,
+  }
+
   return NextResponse.json({
-    quiz: {
-      id: test.id,
-      status: test.status,
-      assessment_type: 'test' as const,
-      student_status: studentStatus,
-      returned_at: attempt?.returned_at || null,
-      access_state: accessState.access_state,
-      effective_access: accessState.effective_access,
-    },
+    test: responseTest,
+    quiz: responseTest,
     student_status: studentStatus,
     returned_at: attempt?.returned_at || null,
     can_continue: canContinue,

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -8,7 +8,7 @@ import {
   isMissingTestAttemptReturnColumnsError,
   isMissingTestStudentAvailabilityError,
 } from '@/lib/server/tests'
-import { getStudentTestStatus } from '@/lib/quizzes'
+import { getStudentTestStatus } from '@/lib/tests'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -47,7 +47,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
 
   if (activeError) {
     if (activeError.code === 'PGRST205') {
-      return NextResponse.json({ quizzes: [], migration_required: true })
+      return NextResponse.json({ tests: [], quizzes: [], migration_required: true })
     }
     console.error('Error fetching active tests:', activeError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -245,6 +245,6 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
     }
   })
 
-  // Keep response key as `quizzes` for current UI component compatibility.
-  return NextResponse.json({ quizzes: testsWithStatus })
+  // Keep legacy `quizzes` key during the tests API contract transition.
+  return NextResponse.json({ tests: testsWithStatus, quizzes: testsWithStatus })
 })

--- a/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
@@ -53,12 +53,15 @@ export const POST = withErrorHandler('SyncTeacherTestDocument', async (_request,
     (currentDoc) => currentDoc.id === docId
   )
 
+  const responseTest = {
+    ...test,
+    documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+    assessment_type: 'test',
+  }
+
   return NextResponse.json({
     doc: syncedDoc,
-    quiz: {
-      ...test,
-      documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
-      assessment_type: 'test',
-    },
+    test: responseTest,
+    quiz: responseTest,
   })
 })

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { aggregateResults, summarizeQuizFocusEvents } from '@/lib/quizzes'
+import { aggregateTestResults, summarizeTestFocusEvents } from '@/lib/tests'
 import {
   assertTeacherOwnsTest,
   getEffectiveStudentTestAccess,
@@ -13,7 +13,12 @@ import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { loadChunkedRows } from '@/lib/server/query-chunks'
 import { getActiveTestAiGradingRunSummary } from '@/lib/server/test-ai-grading-runs'
 import { normalizeTestResponses } from '@/lib/test-attempts'
-import type { QuizFocusSummary, QuizQuestion, QuizResponse, TestStudentAvailabilityState } from '@/types'
+import type {
+  TestAssessmentQuestion,
+  TestAssessmentResponse,
+  TestFocusSummary,
+  TestStudentAvailabilityState,
+} from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
 
 export const dynamic = 'force-dynamic'
@@ -454,7 +459,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     }
   }
 
-  const focusSummaryByStudent = new Map<string, QuizFocusSummary>()
+  const focusSummaryByStudent = new Map<string, TestFocusSummary>()
   if (classroomStudentIds.length > 0) {
     const { rows: focusEvents, error: focusEventsError } = await loadFocusEvents(supabase, testId, classroomStudentIds)
     if (focusEventsError) {
@@ -470,7 +475,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     }
 
     for (const [studentId, events] of grouped) {
-      focusSummaryByStudent.set(studentId, summarizeQuizFocusEvents(events))
+      focusSummaryByStudent.set(studentId, summarizeTestFocusEvents(events))
     }
   }
 
@@ -607,11 +612,11 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
       student_id: response.student_id,
       selected_option: response.selected_option,
       submitted_at: response.submitted_at,
-    } satisfies QuizResponse]
+    } satisfies TestAssessmentResponse]
   })
 
-  const aggregated = aggregateResults(
-    multipleChoiceQuestions as QuizQuestion[],
+  const aggregated = aggregateTestResults(
+    multipleChoiceQuestions as TestAssessmentQuestion[],
     multipleChoiceResponses
   )
 
@@ -633,14 +638,17 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
     }
   }
 
+  const responseTest = {
+    id: test.id,
+    title: test.title,
+    assessment_type: 'test' as const,
+    status: test.status,
+    show_results: test.show_results,
+  }
+
   return NextResponse.json({
-    quiz: {
-      id: test.id,
-      title: test.title,
-      assessment_type: 'test' as const,
-      status: test.status,
-      show_results: test.show_results,
-    },
+    test: responseTest,
+    quiz: responseTest,
     questions: (questions || []).map((q) => ({
       id: q.id,
       question_type: q.question_type === 'open_response' ? 'open_response' : 'multiple_choice',

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
-import { canActivateQuiz } from '@/lib/quizzes'
+import { canActivateTest } from '@/lib/tests'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
 import { normalizeTestDocuments, validateTestDocumentsPayload } from '@/lib/test-documents'
@@ -98,22 +98,25 @@ export const GET = withErrorHandler('GetTestById', async (_request, context) => 
     }
   }
 
+  const responseTest = {
+    id: test.id,
+    classroom_id: test.classroom_id,
+    title,
+    assessment_type: 'test' as const,
+    status: test.status,
+    show_results: showResults,
+    documents: normalizeTestDocuments(test.documents),
+    position: test.position,
+    points_possible: test.points_possible,
+    include_in_final: test.include_in_final,
+    created_by: test.created_by,
+    created_at: test.created_at,
+    updated_at: test.updated_at,
+  }
+
   return NextResponse.json({
-    quiz: {
-      id: test.id,
-      classroom_id: test.classroom_id,
-      title,
-      assessment_type: 'test' as const,
-      status: test.status,
-      show_results: showResults,
-      documents: normalizeTestDocuments(test.documents),
-      position: test.position,
-      points_possible: test.points_possible,
-      include_in_final: test.include_in_final,
-      created_by: test.created_by,
-      created_at: test.created_at,
-      updated_at: test.updated_at,
-    },
+    test: responseTest,
+    quiz: responseTest,
     questions: responseQuestions,
     classroom: test.classrooms,
   })
@@ -199,7 +202,7 @@ export const PATCH = withErrorHandler('PatchUpdateTest', async (request, context
     }
 
     const questionList = questions || []
-    const activation = canActivateQuiz(existing, questionList.length)
+    const activation = canActivateTest(existing, questionList.length)
     if (!activation.valid) {
       return NextResponse.json({ error: activation.error }, { status: 400 })
     }
@@ -330,12 +333,15 @@ export const PATCH = withErrorHandler('PatchUpdateTest', async (request, context
     }
   }
 
+  const responseTest = {
+    ...test,
+    documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+    assessment_type: 'test',
+  }
+
   return NextResponse.json({
-    quiz: {
-      ...test,
-      documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
-      assessment_type: 'test',
-    },
+    test: responseTest,
+    quiz: responseTest,
   })
 })
 

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -135,7 +135,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
   if (testsError) {
     if (testsError.code === 'PGRST205') {
-      return NextResponse.json({ quizzes: [], migration_required: true })
+      return NextResponse.json({ tests: [], quizzes: [], migration_required: true })
     }
     console.error('Error fetching tests:', testsError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -315,8 +315,8 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
     }
   })
 
-  // Keep response key as `quizzes` for current UI component compatibility.
-  return NextResponse.json({ quizzes: testsWithStats })
+  // Keep legacy `quizzes` key during the tests API contract transition.
+  return NextResponse.json({ tests: testsWithStats, quizzes: testsWithStats })
 })
 
 // POST /api/teacher/tests - Create a new test
@@ -409,13 +409,16 @@ export const POST = withErrorHandler('CreateTeacherTest', async (request) => {
     return NextResponse.json({ error: 'Failed to create test draft' }, { status: 500 })
   }
 
+  const responseTest = {
+    ...test,
+    documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
+    assessment_type: 'test',
+  }
+
   return NextResponse.json(
     {
-      quiz: {
-        ...test,
-        documents: normalizeTestDocuments((test as { documents?: unknown }).documents),
-        assessment_type: 'test',
-      },
+      test: responseTest,
+      quiz: responseTest,
     },
     { status: 201 }
   )

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -55,7 +55,7 @@ import type {
   LessonPlan,
   TiptapContent,
   Assignment,
-  QuizWithStats,
+  TestAssessmentWithStats,
 } from '@/types'
 
 interface UserInfo {
@@ -591,9 +591,9 @@ function ClassroomPageContent({
   const [calendarSidebarState, setCalendarSidebarState] = useState<CalendarSidebarState | null>(null)
 
   // State for selected assessment (teacher tests tab)
-  const [selectedQuiz, setSelectedQuiz] = useState<QuizWithStats | null>(null)
+  const [selectedQuiz, setSelectedQuiz] = useState<TestAssessmentWithStats | null>(null)
   const [pendingAssessmentDelete, setPendingAssessmentDelete] = useState<{
-    quiz: QuizWithStats
+    quiz: TestAssessmentWithStats
     responsesCount: number
   } | null>(null)
   const [isDeletingAssessment, setIsDeletingAssessment] = useState(false)
@@ -603,7 +603,7 @@ function ClassroomPageContent({
   } | null>(null)
   const [testsTabClickToken, setTestsTabClickToken] = useState(0)
 
-  const handleSelectQuiz = useCallback((quiz: QuizWithStats | null) => {
+  const handleSelectQuiz = useCallback((quiz: TestAssessmentWithStats | null) => {
     setSelectedQuiz(quiz)
   }, [])
 

--- a/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentQuizzesTab.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { StudentTestsTab as StudentQuizzesTab } from './StudentTestsTab'

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -7,10 +7,10 @@ import { Spinner } from '@/components/Spinner'
 import { PageContent, PageLayout, PageStack } from '@/components/PageLayout'
 import { TestTextDocumentViewer } from '@/components/TestTextDocumentViewer'
 import {
-  getQuizExitCount,
-  getQuizStatusBadgeClass,
-  QUIZ_EXIT_BURST_WINDOW_MS,
-} from '@/lib/quizzes'
+  getTestExitCount,
+  getTestStatusBadgeClass,
+  TEST_EXIT_BURST_WINDOW_MS,
+} from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { StudentTestForm } from '@/components/StudentTestForm'
 import { StudentTestResults } from '@/components/StudentTestResults'
@@ -22,17 +22,17 @@ import {
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import type {
   Classroom,
-  QuizAssessmentType,
-  QuizFocusSummary,
-  QuizQuestion,
-  StudentQuizStatus,
-  StudentQuizView,
+  TestAssessmentType,
+  TestFocusSummary,
+  TestAssessmentQuestion,
+  StudentTestStatus,
+  StudentTestView,
   TestResponseDraftValue,
 } from '@/types'
 
 interface Props {
   classroom: Classroom
-  assessmentType: QuizAssessmentType
+  assessmentType: TestAssessmentType
   isActive?: boolean
 }
 
@@ -57,29 +57,38 @@ interface RemoteClosureNotice {
 }
 
 interface StudentTestSessionStatusResponse {
-  quiz: {
+  test?: {
     id: string
     status: 'draft' | 'active' | 'closed'
     assessment_type: 'test'
-    student_status: StudentQuizStatus
+    student_status: StudentTestStatus
     returned_at: string | null
   }
-  student_status: StudentQuizStatus
+  quiz?: {
+    id: string
+    status: 'draft' | 'active' | 'closed'
+    assessment_type: 'test'
+    student_status: StudentTestStatus
+    returned_at: string | null
+  }
+  student_status: StudentTestStatus
   returned_at: string | null
   can_continue: boolean
   message: string | null
 }
 
 interface StudentAssessmentListResponse {
-  quizzes?: StudentQuizView[]
+  tests?: StudentTestView[]
+  quizzes?: StudentTestView[]
 }
 
 interface StudentAssessmentDetailResponse {
-  quiz: StudentQuizView
-  questions?: QuizQuestion[]
+  test?: StudentTestView
+  quiz?: StudentTestView
+  questions?: TestAssessmentQuestion[]
   student_responses?: Record<string, number | TestResponseDraftValue>
-  student_status?: StudentQuizStatus
-  focus_summary?: QuizFocusSummary | null
+  student_status?: StudentTestStatus
+  focus_summary?: TestFocusSummary | null
 }
 
 type FullscreenCapableElement = HTMLElement & {
@@ -106,7 +115,7 @@ function formatPointsTotal(points: number): string {
   return `${formatted} ${unit} total`
 }
 
-function formatTestOverviewLabel(questions: QuizQuestion[]): string {
+function formatTestOverviewLabel(questions: TestAssessmentQuestion[]): string {
   const questionCount = questions.length
   const totalPoints = questions.reduce((sum, question) => {
     const points = Number(question.points ?? 0)
@@ -200,7 +209,7 @@ function getExamWindowComplianceSnapshot(): ExamWindowComplianceSnapshot {
   }
 }
 
-function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
+function extractAllowedDocLinks(questions: TestAssessmentQuestion[]): AllowedDocItem[] {
   const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
   const plainUrlPattern = /\bhttps?:\/\/[^\s)]+/g
   const linksByUrl = new Map<string, AllowedDocItem>()
@@ -226,7 +235,7 @@ function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
 }
 
 function getRemoteClosureDescription(
-  studentStatus: StudentQuizStatus | 'unavailable',
+  studentStatus: StudentTestStatus | 'unavailable',
   message?: string | null
 ): string {
   if (message?.trim()) return message
@@ -241,13 +250,13 @@ function getRemoteClosureDescription(
 
 export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const notifications = useStudentNotifications()
-  const [quizzes, setQuizzes] = useState<StudentQuizView[]>([])
+  const [quizzes, setQuizzes] = useState<StudentTestView[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedQuizId, setSelectedQuizId] = useState<string | null>(null)
-  const [focusSummary, setFocusSummary] = useState<QuizFocusSummary | null>(null)
+  const [focusSummary, setFocusSummary] = useState<TestFocusSummary | null>(null)
   const [selectedQuiz, setSelectedQuiz] = useState<{
-    quiz: StudentQuizView
-    questions: QuizQuestion[]
+    quiz: StudentTestView
+    questions: TestAssessmentQuestion[]
     studentResponses: Record<string, number | TestResponseDraftValue>
   } | null>(null)
   const [startedTestId, setStartedTestId] = useState<string | null>(null)
@@ -276,7 +285,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const sessionStatusInFlightRef = useRef(false)
   const listRequestIdRef = useRef(0)
   const detailRequestIdRef = useRef(0)
-  const assessmentType: QuizAssessmentType = 'test'
+  const assessmentType: TestAssessmentType = 'test'
   const currentScopeRef = useRef({ classroomId: classroom.id, assessmentType })
   const isTestsView = true
   const apiBasePath = '/api/student/tests'
@@ -384,7 +393,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
       ) {
         return
       }
-      setQuizzes(data.quizzes || [])
+      setQuizzes(data.tests || data.quizzes || [])
     } catch (err) {
       if (
         listRequestIdRef.current === requestId &&
@@ -422,7 +431,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   }, [assessmentType, classroom.id])
 
   const handleRemoteTestClosure = useCallback((options?: {
-    studentStatus?: StudentQuizStatus
+    studentStatus?: StudentTestStatus
     message?: string | null
   }) => {
     clearPendingNonCompliantTimeout()
@@ -483,14 +492,17 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
       ) {
         return
       }
+      const responseTest = data.test ?? data.quiz
       const listQuiz = quizzes.find((quiz) => quiz.id === quizId)
-      const studentStatus = data.student_status ?? data.quiz?.student_status ?? listQuiz?.student_status ?? 'not_started'
+      const nextQuiz = responseTest ?? listQuiz
+      if (!nextQuiz) throw new Error('Test not found')
+      const studentStatus = data.student_status ?? responseTest?.student_status ?? listQuiz?.student_status ?? 'not_started'
       setSelectedQuiz({
-        quiz: { ...data.quiz, student_status: studentStatus },
+        quiz: { ...nextQuiz, student_status: studentStatus },
         questions: data.questions || [],
         studentResponses: data.student_responses || {},
       })
-      setFocusSummary((data.focus_summary as QuizFocusSummary | null) || null)
+      setFocusSummary((data.focus_summary as TestFocusSummary | null) || null)
     } catch (err) {
       if (
         detailRequestIdRef.current === requestId &&
@@ -583,7 +595,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
 
       const data = await res.json().catch(() => ({}))
       if (res.ok && data?.focus_summary) {
-        setFocusSummary(data.focus_summary as QuizFocusSummary)
+        setFocusSummary(data.focus_summary as TestFocusSummary)
       }
     } catch (err) {
       console.error('Error posting quiz focus event:', err)
@@ -937,7 +949,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
 
   useEffect(() => {
     if (!isTestsView) return
-    const exitsCount = getQuizExitCount(focusSummary)
+    const exitsCount = getTestExitCount(focusSummary)
     const awayTotalSeconds = Math.max(0, focusSummary?.away_total_seconds ?? 0)
 
     window.dispatchEvent(
@@ -1084,7 +1096,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
-        findIntentUntilRef.current = Date.now() + QUIZ_EXIT_BURST_WINDOW_MS
+        findIntentUntilRef.current = Date.now() + TEST_EXIT_BURST_WINDOW_MS
         findSuppressionUntilRef.current = 0
       }
     }
@@ -1204,7 +1216,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                         Returned
                       </span>
                     ) : quiz.status === 'closed' ? (
-                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('closed')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getTestStatusBadgeClass('closed')}`}>
                         Closed
                       </span>
                     ) : quiz.student_status === 'responded' ? (
@@ -1212,7 +1224,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                         Submitted
                       </span>
                     ) : (
-                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('active')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getTestStatusBadgeClass('active')}`}>
                         New
                       </span>
                     )}
@@ -1220,7 +1232,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                 ) : (
                   <>
                     {quiz.student_status === 'not_started' && (
-                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getQuizStatusBadgeClass('active')}`}>
+                      <span className={`rounded-badge px-2.5 py-1 text-xs font-semibold ${getTestStatusBadgeClass('active')}`}>
                         New
                       </span>
                     )}
@@ -1257,7 +1269,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
   const showCurrentTestInfoPanel = hasSelectedQuiz && focusEnabled
   const showDocPanel = showCurrentTestInfoPanel && activeDoc !== null
   const awayDurationLabel = formatDuration(focusSummary?.away_total_seconds ?? 0)
-  const exitsCount = getQuizExitCount(focusSummary)
+  const exitsCount = getTestExitCount(focusSummary)
   const awayCount = focusSummary?.away_count ?? 0
   const routeExitAttempts = focusSummary?.route_exit_attempts ?? 0
   const windowUnmaximizeAttempts = focusSummary?.window_unmaximize_attempts ?? 0
@@ -1649,8 +1661,8 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                           : selectedQuiz?.quiz.student_status === 'responded'
                             ? 'bg-surface-2 text-text-muted'
                             : selectedQuiz?.quiz.status === 'closed'
-                              ? getQuizStatusBadgeClass('closed')
-                              : getQuizStatusBadgeClass('active'),
+                              ? getTestStatusBadgeClass('closed')
+                              : getTestStatusBadgeClass('active'),
                       ].join(' ')}
                     >
                       {selectedQuiz?.quiz.student_status === 'can_view_results'

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -45,7 +45,7 @@ import {
 } from '@/lib/events'
 import { getDisplayAssessmentTitle } from '@/lib/assessment-titles'
 import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
-import { getQuizExitCount } from '@/lib/quizzes'
+import { getTestExitCount } from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
 import { compareByNameFields } from '@/lib/table-sort'
@@ -56,9 +56,9 @@ import type {
   AssessmentEditorSummaryUpdate,
   AssessmentWorkspaceSummaryPatch,
   Classroom,
-  Quiz,
-  QuizFocusSummary,
-  QuizWithStats,
+  TestAssessment,
+  TestFocusSummary,
+  TestAssessmentWithStats,
   TestAiGradingRunSummary,
 } from '@/types'
 
@@ -69,7 +69,7 @@ interface Props {
   selectedTestMode?: WorkspaceTab | null
   selectedTestStudentId?: string | null
   updateSearchParams?: UpdateSearchParamsFn
-  onSelectTest?: (test: QuizWithStats | null) => void
+  onSelectTest?: (test: TestAssessmentWithStats | null) => void
   onTestGradingDataRefresh?: () => void
   onTestGradingContextChange?: (context: {
     mode: 'authoring' | 'grading'
@@ -108,7 +108,7 @@ interface TestGradingStudentRow {
   access_state?: 'open' | 'closed' | null
   effective_access?: 'open' | 'closed'
   access_source?: 'test' | 'student'
-  focus_summary: QuizFocusSummary | null
+  focus_summary: TestFocusSummary | null
 }
 
 interface TestGradingQuestionSummary {
@@ -126,7 +126,7 @@ type TestGradingSortColumn = 'first_name' | 'last_name'
 const GRADING_POLL_INTERVAL_MS = 15_000
 
 function getTestGradingExitCount(student: TestGradingStudentRow): number {
-  return getQuizExitCount(student.focus_summary)
+  return getTestExitCount(student.focus_summary)
 }
 
 function TestWorkspacePaneFrame({ children }: { children: ReactNode }) {
@@ -167,7 +167,7 @@ function getSortableNameParts(student: TestGradingStudentRow): { firstName: stri
 
 function getEffectiveTestAccess(
   student: Pick<TestGradingStudentRow, 'effective_access'>,
-  testStatus: Quiz['status'] | null | undefined,
+  testStatus: TestAssessment['status'] | null | undefined,
 ): 'open' | 'closed' {
   return student.effective_access || (testStatus === 'active' ? 'open' : 'closed')
 }
@@ -253,7 +253,7 @@ function formatTestAiGradingRunMessage(run: TestAiGradingRunSummary): {
   }
 }
 
-function withDefaultTestStats(test: Quiz): QuizWithStats {
+function withDefaultTestStats(test: TestAssessment): TestAssessmentWithStats {
   return {
     ...test,
     assessment_type: 'test',
@@ -265,15 +265,15 @@ function withDefaultTestStats(test: Quiz): QuizWithStats {
       open_access: 0,
       closed_access: 0,
       questions_count: 0,
-      ...((test as Partial<QuizWithStats>).stats ?? {}),
+      ...((test as Partial<TestAssessmentWithStats>).stats ?? {}),
     },
   }
 }
 
 function applyTestSummaryPatchToTest(
-  test: QuizWithStats,
+  test: TestAssessmentWithStats,
   update: AssessmentWorkspaceSummaryPatch
-): QuizWithStats {
+): TestAssessmentWithStats {
   return {
     ...test,
     title: typeof update.title === 'string' ? update.title : test.title,
@@ -322,7 +322,7 @@ export function TeacherTestsTab({
   const selectedTestIdRef = useRef<string | null>(null)
   const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(null)
 
-  const [tests, setTests] = useState<QuizWithStats[]>([])
+  const [tests, setTests] = useState<TestAssessmentWithStats[]>([])
   const { showMessage } = useAppMessage()
   const [loading, setLoading] = useState(true)
   const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('grading')
@@ -336,14 +336,14 @@ export function TeacherTestsTab({
   const [testEditModalView, setTestEditModalView] = useState<TestEditModalView>('edit')
   const [testEditTitlePortalTarget, setTestEditTitlePortalTarget] = useState<HTMLDivElement | null>(null)
   const [, setTestEditSaveStatus] = useState<TestEditSaveStatus>('saved')
-  const [pendingDeleteTest, setPendingDeleteTest] = useState<QuizWithStats | null>(null)
+  const [pendingDeleteTest, setPendingDeleteTest] = useState<TestAssessmentWithStats | null>(null)
   const [isDeletingTest, setIsDeletingTest] = useState(false)
 
   const [gradingStudents, setGradingStudents] = useState<TestGradingStudentRow[]>([])
   const [unreviewedExitCounts, setUnreviewedExitCounts] = useState<Record<string, number>>({})
   const [exitAlertStudentId, setExitAlertStudentId] = useState<string | null>(null)
   const [gradingQuestions, setGradingQuestions] = useState<TestGradingQuestionSummary[]>([])
-  const [gradingServerTestStatus, setGradingServerTestStatus] = useState<Quiz['status'] | null>(null)
+  const [gradingServerTestStatus, setGradingServerTestStatus] = useState<TestAssessment['status'] | null>(null)
   const [gradingServerTestId, setGradingServerTestId] = useState<string | null>(null)
   const [testAiGradingRun, setTestAiGradingRun] = useState<TestAiGradingRunSummary | null>(null)
   const [gradingLoading, setGradingLoading] = useState(false)
@@ -727,7 +727,7 @@ export function TeacherTestsTab({
     setLoading(true)
     try {
       const query = new URLSearchParams({ classroom_id: classroom.id })
-      const data = await fetchJSONWithCache<{ tests?: QuizWithStats[]; quizzes?: QuizWithStats[] }>(
+      const data = await fetchJSONWithCache<{ tests?: TestAssessmentWithStats[]; quizzes?: TestAssessmentWithStats[] }>(
         `teacher-tests:${classroom.id}`,
         async () => {
           const response = await fetch(`${apiBasePath}?${query.toString()}`)
@@ -737,7 +737,7 @@ export function TeacherTestsTab({
         },
         0,
       )
-      const loadedTests = (data.tests || data.quizzes || []) as QuizWithStats[]
+      const loadedTests = (data.tests || data.quizzes || []) as TestAssessmentWithStats[]
       const currentSelectedTestId = selectedTestIdRef.current
       const currentDraftSummary = selectedTestDraftSummaryRef.current
       setTests(
@@ -809,9 +809,10 @@ export function TeacherTestsTab({
       if (isStaleRequest()) return
       if (!ok) throw new Error(data.error || 'Failed to load test results')
 
+      const responseTest = data?.test ?? data?.quiz
       const nextStatus =
-        data?.quiz?.status === 'draft' || data?.quiz?.status === 'active' || data?.quiz?.status === 'closed'
-          ? (data.quiz.status as Quiz['status'])
+        responseTest?.status === 'draft' || responseTest?.status === 'active' || responseTest?.status === 'closed'
+          ? (responseTest.status as TestAssessment['status'])
           : null
 
       setGradingServerTestStatus(nextStatus)
@@ -1263,7 +1264,7 @@ export function TeacherTestsTab({
     }
   }, [activeTestAiRun, classroom.id, clearBatchSelection, hasActiveTestAiRun, loadGradingRows, onTestGradingDataRefresh, showMessage])
 
-  function handleOpenTest(test: QuizWithStats) {
+  function handleOpenTest(test: TestAssessmentWithStats) {
     navigateTestWorkspace({ testId: test.id, mode: 'grading', studentId: null })
     setGradingError('')
     setGradingWarning('')
@@ -1271,7 +1272,7 @@ export function TeacherTestsTab({
     clearBatchSelection()
   }
 
-  function handleEditTest(test: QuizWithStats) {
+  function handleEditTest(test: TestAssessmentWithStats) {
     navigateTestWorkspace({ testId: test.id, mode: 'authoring', studentId: null })
     setGradingError('')
     setGradingWarning('')
@@ -1312,7 +1313,7 @@ export function TeacherTestsTab({
       if (!response.ok) {
         throw new Error(data.error || 'Failed to create test')
       }
-      handleTestCreated(data.quiz as Quiz)
+      handleTestCreated((data.test ?? data.quiz) as TestAssessment)
     } catch (error: any) {
       showMessage({ text: error?.message || 'Failed to create test', tone: 'warning' })
     } finally {
@@ -1320,7 +1321,7 @@ export function TeacherTestsTab({
     }
   }
 
-  function handleTestCreated(test: Quiz) {
+  function handleTestCreated(test: TestAssessment) {
     const createdTest = withDefaultTestStats(test)
 
     setTestEditMode(false)
@@ -1689,19 +1690,20 @@ export function TeacherTestsTab({
         throw new Error(data.error || 'Failed to update test')
       }
 
+      const responseTest = data?.test ?? data?.quiz
       const nextStatus =
-        data?.test?.status === 'draft' || data?.test?.status === 'active' || data?.test?.status === 'closed'
-          ? data.test.status
+        responseTest?.status === 'draft' || responseTest?.status === 'active' || responseTest?.status === 'closed'
+          ? responseTest.status
           : payload.status === 'draft' || payload.status === 'active' || payload.status === 'closed'
             ? payload.status
             : undefined
 
       applyTestSummaryPatch(selectedTestId, {
         status: nextStatus,
-        title: typeof data?.test?.title === 'string' ? data.test.title : undefined,
-        show_results: typeof data?.test?.show_results === 'boolean' ? data.test.show_results : undefined,
+        title: typeof responseTest?.title === 'string' ? responseTest.title : undefined,
+        show_results: typeof responseTest?.show_results === 'boolean' ? responseTest.show_results : undefined,
         questions_count:
-          typeof data?.test?.stats?.questions_count === 'number' ? data.test.stats.questions_count : undefined,
+          typeof responseTest?.stats?.questions_count === 'number' ? responseTest.stats.questions_count : undefined,
       })
 
       if (nextStatus) {

--- a/src/components/QuizDetailPanel.tsx
+++ b/src/components/QuizDetailPanel.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { TestDetailPanel as QuizDetailPanel } from './TestDetailPanel'

--- a/src/components/QuizIndividualResponses.tsx
+++ b/src/components/QuizIndividualResponses.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { TestIndividualResponses as QuizIndividualResponses } from './TestIndividualResponses'

--- a/src/components/QuizQuestionEditor.tsx
+++ b/src/components/QuizQuestionEditor.tsx
@@ -1,5 +1,0 @@
-'use client'
-
-export {
-  TestMultipleChoiceQuestionEditor as QuizQuestionEditor,
-} from './TestMultipleChoiceQuestionEditor'

--- a/src/components/QuizResultsView.tsx
+++ b/src/components/QuizResultsView.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { TestResultsView as QuizResultsView } from './TestResultsView'

--- a/src/components/StudentQuizForm.tsx
+++ b/src/components/StudentQuizForm.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { StudentTestForm as StudentQuizForm } from './StudentTestForm'

--- a/src/components/StudentQuizResults.tsx
+++ b/src/components/StudentQuizResults.tsx
@@ -1,3 +1,0 @@
-'use client'
-
-export { StudentTestResults as StudentQuizResults } from './StudentTestResults'

--- a/src/components/StudentTestForm.tsx
+++ b/src/components/StudentTestForm.tsx
@@ -15,16 +15,16 @@ import {
   isQuestionFlagged,
   toggleFlaggedQuestion,
 } from '@/lib/flag-questions'
-import type { QuizAssessmentType, QuizQuestion, TestResponseDraftValue } from '@/types'
+import type { TestAssessmentType, TestAssessmentQuestion, TestResponseDraftValue } from '@/types'
 
 interface Props {
   quizId: string
-  questions: QuizQuestion[]
+  questions: TestAssessmentQuestion[]
   initialResponses?: Record<string, number | TestResponseDraftValue> | TestResponses
   enableDraftAutosave?: boolean
   previewMode?: boolean
   isInteractionLocked?: boolean
-  assessmentType?: QuizAssessmentType
+  assessmentType?: TestAssessmentType
   apiBasePath?: string
   onAvailabilityLoss?: () => void
   onSubmitted: () => void

--- a/src/components/StudentTestResults.tsx
+++ b/src/components/StudentTestResults.tsx
@@ -8,8 +8,8 @@ import {
   normalizeMultipleChoiceOptionIndex,
 } from '@/components/MultipleChoiceOptionReview'
 import type {
-  QuizAssessmentType,
-  QuizResultsAggregate,
+  TestAssessmentType,
+  TestResultsAggregate,
   TestResponseDraftValue,
 } from '@/types'
 
@@ -38,7 +38,7 @@ interface TestResultSummary {
 }
 
 interface ResultsPayload {
-  results?: QuizResultsAggregate[]
+  results?: TestResultsAggregate[]
   question_results?: TestQuestionResult[]
   summary?: TestResultSummary
 }
@@ -54,7 +54,7 @@ function selectedOptionFromResponse(
 interface Props {
   quizId: string
   myResponses: Record<string, number | TestResponseDraftValue>
-  assessmentType?: QuizAssessmentType
+  assessmentType?: TestAssessmentType
   apiBasePath?: string
   showSubmissionBanner?: boolean
 }

--- a/src/components/TeacherTestCard.tsx
+++ b/src/components/TeacherTestCard.tsx
@@ -6,14 +6,14 @@ import { ExternalLink, GripVertical, Lock, Trash2, Unlock } from 'lucide-react'
 import { TeacherWorkItemCardFrame } from '@/components/teacher-work-surface/TeacherWorkItemCardFrame'
 import {
   getAssessmentStatusLabel,
-  getQuizStatusBadgeClass,
+  getTestStatusBadgeClass,
   getTeacherTestListDisplayStatus,
-} from '@/lib/quizzes'
+} from '@/lib/tests'
 import { Button, Tooltip } from '@/ui'
-import type { QuizWithStats } from '@/types'
+import type { TestAssessmentWithStats } from '@/types'
 
 interface TeacherTestCardProps {
-  test: QuizWithStats
+  test: TestAssessmentWithStats
   isReadOnly: boolean
   isDragDisabled?: boolean
   editMode: boolean
@@ -52,7 +52,7 @@ export function TeacherTestCard({
   const isDraft = test.status === 'draft'
   const displayStatus = getTeacherTestListDisplayStatus(test)
   const statusLabel = getAssessmentStatusLabel(displayStatus, 'test')
-  const statusBadgeClass = getQuizStatusBadgeClass(displayStatus)
+  const statusBadgeClass = getTestStatusBadgeClass(displayStatus)
   const totalStudents = test.stats.total_students || 0
   const submittedCount = test.stats.submitted ?? test.stats.responded ?? 0
   const openAccessCount = test.stats.open_access ?? (test.status === 'active' ? totalStudents : 0)

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -8,7 +8,7 @@ import { StudentTestForm } from '@/components/StudentTestForm'
 import { TestTextDocumentViewer } from '@/components/TestTextDocumentViewer'
 import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
-import type { QuizQuestion, TestDocument } from '@/types'
+import type { TestAssessmentQuestion, TestDocument } from '@/types'
 
 interface Props {
   classroomId: string
@@ -42,7 +42,7 @@ function isWindowNearMaximized(): boolean {
   return widthRatio >= 0.96 && heightRatio >= 0.9
 }
 
-function extractAllowedDocLinks(questions: QuizQuestion[]): AllowedDocItem[] {
+function extractAllowedDocLinks(questions: TestAssessmentQuestion[]): AllowedDocItem[] {
   const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
   const plainUrlPattern = /\bhttps?:\/\/[^\s)]+/g
   const linksByUrl = new Map<string, AllowedDocItem>()
@@ -75,7 +75,7 @@ export function TeacherTestPreviewPage({
   onClose,
 }: Props) {
   const [title, setTitle] = useState('Test Preview')
-  const [questions, setQuestions] = useState<QuizQuestion[]>([])
+  const [questions, setQuestions] = useState<TestAssessmentQuestion[]>([])
   const [documents, setDocuments] = useState<TestDocument[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -217,9 +217,10 @@ export function TeacherTestPreviewPage({
         throw new Error(data?.error || 'Failed to load preview')
       }
 
-      setTitle(data?.quiz?.title || 'Test Preview')
-      setQuestions((data?.questions || []) as QuizQuestion[])
-      setDocuments(normalizeTestDocuments(data?.quiz?.documents))
+      const responseTest = data?.test ?? data?.quiz
+      setTitle(responseTest?.title || 'Test Preview')
+      setQuestions((data?.questions || []) as TestAssessmentQuestion[])
+      setDocuments(normalizeTestDocuments(responseTest?.documents))
     } catch (err: any) {
       setError(err?.message || 'Failed to load preview')
     } finally {
@@ -277,7 +278,8 @@ export function TeacherTestPreviewPage({
           return
         }
 
-        setDocuments(normalizeTestDocuments(data?.quiz?.documents))
+        const responseTest = data?.test ?? data?.quiz
+        setDocuments(normalizeTestDocuments(responseTest?.documents))
       } catch (error) {
         if (!isCancelled) {
           console.error(`Auto-sync failed for ${staleDoc.title}:`, error)

--- a/src/components/TestDetailPanel.tsx
+++ b/src/components/TestDetailPanel.tsx
@@ -24,7 +24,7 @@ import { Spinner } from '@/components/Spinner'
 import { useRefRect } from '@/hooks/use-element-rect'
 import { useWindowSize } from '@/hooks/use-window-size'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
-import { canEditQuizQuestions } from '@/lib/quizzes'
+import { canEditTestQuestions } from '@/lib/tests'
 import { TestMultipleChoiceQuestionEditor } from '@/components/TestMultipleChoiceQuestionEditor'
 import { TestQuestionEditor } from '@/components/TestQuestionEditor'
 import { TestDocumentsEditor } from '@/components/TestDocumentsEditor'
@@ -43,14 +43,14 @@ import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
 import type {
   AssessmentEditorSummaryUpdate,
   JsonPatchOperation,
-  QuizQuestion,
-  QuizWithStats,
-  QuizResultsAggregate,
+  TestAssessmentQuestion,
+  TestAssessmentWithStats,
+  TestResultsAggregate,
   TestDocument,
 } from '@/types'
 
 interface Props {
-  quiz: QuizWithStats
+  quiz: TestAssessmentWithStats
   classroomId: string
   apiBasePath?: string
   onQuizUpdate: (update?: AssessmentEditorSummaryUpdate) => void
@@ -72,7 +72,7 @@ interface Props {
 type AssessmentEditorDraft = {
   title: string
   show_results: boolean
-  questions: QuizQuestion[]
+  questions: TestAssessmentQuestion[]
   source_format?: 'markdown'
   source_markdown?: string
 }
@@ -81,7 +81,7 @@ type AssessmentRequestScope = {
   quizId: string
   classroomId: string
   apiBasePath: string
-  assessmentType: QuizWithStats['assessment_type']
+  assessmentType: TestAssessmentWithStats['assessment_type']
   isTestsView: boolean
 }
 
@@ -168,11 +168,11 @@ export function TestDetailPanel({
   const isTestsView = quiz.assessment_type === 'test' || apiBasePath.includes('/tests')
   const { showMarkdown } = useMarkdownPreference()
   const questionLayout = assessmentQuestionLayout ?? testQuestionLayout
-  const [questions, setQuestions] = useState<QuizQuestion[]>([])
+  const [questions, setQuestions] = useState<TestAssessmentQuestion[]>([])
   const [documents, setDocuments] = useState<TestDocument[]>(
     () => normalizeTestDocuments((quiz as { documents?: unknown }).documents)
   )
-  const [results, setResults] = useState<QuizResultsAggregate[] | null>(null)
+  const [results, setResults] = useState<TestResultsAggregate[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [viewMode, setViewMode] = useState<AssessmentViewMode>(() => 'questions')
   const [isDocumentsCardExpanded, setIsDocumentsCardExpanded] = useState(true)
@@ -196,7 +196,7 @@ export function TestDetailPanel({
   )
   const [conflictDraft, setConflictDraft] = useState<{
     version: number
-    content: { title: string; show_results: boolean; questions: QuizQuestion[] }
+    content: { title: string; show_results: boolean; questions: TestAssessmentQuestion[] }
   } | null>(null)
 
   const [editTitle, setEditTitle] = useState(quiz.title)
@@ -333,11 +333,11 @@ export function TestDetailPanel({
     return previewWindow
   }, [])
 
-  const normalizeQuestionPositions = useCallback((nextQuestions: QuizQuestion[]): QuizQuestion[] => {
+  const normalizeQuestionPositions = useCallback((nextQuestions: TestAssessmentQuestion[]): TestAssessmentQuestion[] => {
     return nextQuestions.map((question, index) => ({ ...question, position: index }))
   }, [])
 
-  const normalizeDraftQuestions = useCallback((rawQuestions: unknown[]): QuizQuestion[] => {
+  const normalizeDraftQuestions = useCallback((rawQuestions: unknown[]): TestAssessmentQuestion[] => {
     return normalizeQuestionPositions(
       (rawQuestions || []).map((rawQuestion, index) => {
         const question = (rawQuestion || {}) as Record<string, unknown>
@@ -517,7 +517,7 @@ export function TestDetailPanel({
     })
   }, [documents, draftShowResults, editTitle, isTestsView, questions])
   const hasResponses = quiz.stats.responded > 0
-  const isEditable = canEditQuizQuestions(quiz, hasResponses)
+  const isEditable = canEditTestQuestions(quiz, hasResponses)
   const usesMarkdownOnlyQuestions = questionLayout === 'markdown-only'
   const isMarkdownSurfaceEnabled = showMarkdown || usesMarkdownOnlyQuestions
   const hasPendingMarkdownImport = isMarkdownSurfaceEnabled && markdownDirty
@@ -770,7 +770,7 @@ export function TestDetailPanel({
           }
 
           const serverDraft = data?.draft as
-            | { version: number; content: { title: string; show_results: boolean; questions: QuizQuestion[] } }
+            | { version: number; content: { title: string; show_results: boolean; questions: TestAssessmentQuestion[] } }
             | undefined
           if (serverDraft) {
             setConflictDraft({
@@ -946,7 +946,8 @@ export function TestDetailPanel({
         if (detailRes?.ok) {
           const detailData = await detailRes.json()
           if (!isCurrentLoadRequest(requestId, scope)) return
-          setDocuments(normalizeTestDocuments(detailData?.quiz?.documents))
+          const responseTest = detailData?.test ?? detailData?.quiz
+          setDocuments(normalizeTestDocuments(responseTest?.documents))
         }
       }
 
@@ -1014,7 +1015,8 @@ export function TestDetailPanel({
           return
         }
 
-        setDocuments(normalizeTestDocuments(data?.quiz?.documents))
+        const responseTest = data?.test ?? data?.quiz
+        setDocuments(normalizeTestDocuments(responseTest?.documents))
       } catch (error) {
         if (!isCancelled) {
           console.error(`Auto-sync failed for ${staleDoc.title}:`, error)
@@ -1165,7 +1167,7 @@ export function TestDetailPanel({
   function handleAddQuestion(questionType: 'multiple_choice' | 'open_response' = 'multiple_choice') {
     if (!isEditable) return
 
-    const nextQuestion: QuizQuestion = isTestsView
+    const nextQuestion: TestAssessmentQuestion = isTestsView
       ? questionType === 'open_response'
         ? {
             id: crypto.randomUUID(),
@@ -1231,7 +1233,7 @@ export function TestDetailPanel({
     handleAddQuestion(questionType)
   }
 
-  function handleQuestionChange(updatedQuestion: QuizQuestion, options?: { force?: boolean }) {
+  function handleQuestionChange(updatedQuestion: TestAssessmentQuestion, options?: { force?: boolean }) {
     const nextQuestions = normalizeQuestionPositions(
       questions.map((question) =>
         question.id === updatedQuestion.id ? { ...updatedQuestion } : question
@@ -1280,7 +1282,7 @@ export function TestDetailPanel({
 
     const sourceQuestion = questions[sourceIndex]
     const now = new Date().toISOString()
-    const duplicatedQuestion: QuizQuestion = {
+    const duplicatedQuestion: TestAssessmentQuestion = {
       ...sourceQuestion,
       id: crypto.randomUUID(),
       options: [...sourceQuestion.options],
@@ -1725,7 +1727,7 @@ export function TestDetailPanel({
       )}
       <textarea
         data-testid={isTestsView ? 'test-markdown-editor' : 'quiz-markdown-editor'}
-        aria-label={isTestsView ? 'Test markdown editor' : 'Quiz markdown editor'}
+        aria-label={isTestsView ? 'Test markdown editor' : 'Assessment markdown editor'}
         value={markdownContent}
         readOnly={!isMarkdownEditable}
         onChange={(event) => handleMarkdownChange(event.target.value)}
@@ -1850,7 +1852,7 @@ export function TestDetailPanel({
     </div>
   )
 
-  const titleLabel = isTestsView ? 'Test' : 'Quiz'
+  const titleLabel = isTestsView ? 'Test' : 'Assessment'
   const titleGeneratedLabel = generatedTitleLabel ?? (isTestsView ? 'Untitled Test' : 'Untitled')
   const renderEditableTitle = ({
     className,
@@ -2278,7 +2280,7 @@ export function TestDetailPanel({
 }
 
 /** Read-only preview of the quiz as students see it */
-function QuizPreview({ questions, isTestsView }: { questions: QuizQuestion[]; isTestsView: boolean }) {
+function QuizPreview({ questions, isTestsView }: { questions: TestAssessmentQuestion[]; isTestsView: boolean }) {
   const [selected, setSelected] = useState<Record<string, number | string>>({})
 
   if (questions.length === 0) {

--- a/src/components/TestDocumentsEditor.tsx
+++ b/src/components/TestDocumentsEditor.tsx
@@ -156,7 +156,8 @@ export function TestDocumentsEditor({
         throw new Error(data.error || 'Failed to save documents')
       }
 
-      const normalized = normalizeTestDocuments(data.quiz?.documents || nextDocs)
+      const responseTest = data.test ?? data.quiz
+      const normalized = normalizeTestDocuments(responseTest?.documents || nextDocs)
       setLocalDocs(normalized)
       onDocumentsChange?.(normalized)
       return normalized
@@ -188,7 +189,8 @@ export function TestDocumentsEditor({
         throw new Error(data.error || 'Failed to sync document')
       }
 
-      const normalized = normalizeTestDocuments(data.quiz?.documents || localDocs)
+      const responseTest = data.test ?? data.quiz
+      const normalized = normalizeTestDocuments(responseTest?.documents || localDocs)
       setLocalDocs(normalized)
       onDocumentsChange?.(normalized)
       return normalized

--- a/src/components/TestIndividualResponses.tsx
+++ b/src/components/TestIndividualResponses.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { getQuizExitCount } from '@/lib/quizzes'
+import { getTestExitCount } from '@/lib/tests'
 import { Button, Input } from '@/ui'
-import type { QuizFocusSummary } from '@/types'
+import type { TestFocusSummary } from '@/types'
 
 interface QuestionInfo {
   id: string
@@ -30,7 +30,7 @@ interface Responder {
   name: string | null
   email: string
   answers: Record<string, number | TestAnswerDetail>
-  focus_summary: QuizFocusSummary | null
+  focus_summary: TestFocusSummary | null
 }
 
 interface Props {
@@ -355,7 +355,7 @@ export function TestIndividualResponses({
             </button>
             {student.focus_summary && (
               <p className="ml-4 mt-0.5 text-xs text-text-muted">
-                Exits: {getQuizExitCount(student.focus_summary)} · Away time:{' '}
+                Exits: {getTestExitCount(student.focus_summary)} · Away time:{' '}
                 {formatDuration(student.focus_summary.away_total_seconds)}
               </p>
             )}

--- a/src/components/TestMultipleChoiceQuestionEditor.tsx
+++ b/src/components/TestMultipleChoiceQuestionEditor.tsx
@@ -6,14 +6,14 @@ import { CSS } from '@dnd-kit/utilities'
 import { Plus, Trash2, GripVertical } from 'lucide-react'
 import { Button, Input } from '@/ui'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
-import { MAX_QUIZ_OPTIONS, validateQuizOptions } from '@/lib/quizzes'
-import type { QuizQuestion } from '@/types'
+import { MAX_TEST_OPTIONS, validateTestOptions } from '@/lib/tests'
+import type { TestAssessmentQuestion } from '@/types'
 
 interface Props {
-  question: QuizQuestion
+  question: TestAssessmentQuestion
   questionNumber: number
   isEditable: boolean
-  onChange: (question: QuizQuestion) => void
+  onChange: (question: TestAssessmentQuestion) => void
   onDelete: (questionId: string) => void
 }
 
@@ -68,7 +68,7 @@ export function TestMultipleChoiceQuestionEditor({
     }
 
     const cleanedOptions = currentOptions.map((option) => option.trim()).filter(Boolean)
-    const optionsValidation = validateQuizOptions(cleanedOptions)
+    const optionsValidation = validateTestOptions(cleanedOptions)
     if (!optionsValidation.valid) {
       setError(optionsValidation.error || 'Invalid options')
       return
@@ -96,7 +96,7 @@ export function TestMultipleChoiceQuestionEditor({
   }
 
   function handleAddOption() {
-    if (!isEditable || options.length >= MAX_QUIZ_OPTIONS) return
+    if (!isEditable || options.length >= MAX_TEST_OPTIONS) return
     const nextOptions = [...options, '']
     setOptions(nextOptions)
     justAddedOption.current = true
@@ -204,7 +204,7 @@ export function TestMultipleChoiceQuestionEditor({
             ))}
           </div>
 
-          {isEditable && options.length < MAX_QUIZ_OPTIONS && (
+          {isEditable && options.length < MAX_TEST_OPTIONS && (
             <button
               type="button"
               onClick={handleAddOption}

--- a/src/components/TestQuestionEditor.tsx
+++ b/src/components/TestQuestionEditor.tsx
@@ -7,14 +7,14 @@ import { ChevronDown, ChevronRight, Copy, GripVertical, Plus, Trash2 } from 'luc
 import { Button, Input } from '@/ui'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 import { defaultPointsForQuestionType } from '@/lib/test-questions'
-import { MAX_QUIZ_OPTIONS } from '@/lib/quizzes'
-import type { QuizQuestion, TestQuestionType } from '@/types'
+import { MAX_TEST_OPTIONS } from '@/lib/tests'
+import type { TestAssessmentQuestion, TestQuestionType } from '@/types'
 
 interface Props {
-  question: QuizQuestion
+  question: TestAssessmentQuestion
   questionNumber: number
   isEditable: boolean
-  onChange: (question: QuizQuestion, options?: { force?: boolean }) => void
+  onChange: (question: TestAssessmentQuestion, options?: { force?: boolean }) => void
   onDelete: (questionId: string) => void
   onDuplicate?: (questionId: string) => void
   variant?: 'card' | 'detail' | 'accordion'
@@ -44,7 +44,7 @@ function summarizeHeaderLine(questionText: string | null | undefined): string {
   return flattened || 'Untitled question'
 }
 
-function toLocalState(question: QuizQuestion): LocalQuestionState {
+function toLocalState(question: TestAssessmentQuestion): LocalQuestionState {
   const questionType = question.question_type === 'open_response' ? 'open_response' : 'multiple_choice'
   return {
     question_type: questionType,
@@ -154,8 +154,8 @@ export function TestQuestionEditor({
         setError('At least 2 options are required')
         return
       }
-      if (nextOptions.length > MAX_QUIZ_OPTIONS) {
-        setError(`Maximum ${MAX_QUIZ_OPTIONS} options allowed`)
+      if (nextOptions.length > MAX_TEST_OPTIONS) {
+        setError(`Maximum ${MAX_TEST_OPTIONS} options allowed`)
         return
       }
       if (nextOptions.some((option) => !option)) {
@@ -265,7 +265,7 @@ export function TestQuestionEditor({
           </div>
         )
       })}
-      {isEditable && state.options.length < MAX_QUIZ_OPTIONS ? (
+      {isEditable && state.options.length < MAX_TEST_OPTIONS ? (
         <Button type="button" variant="secondary" size="sm" onClick={addOption} className="gap-1.5">
           <Plus className="h-4 w-4" />
           Option

--- a/src/components/TestResultsView.tsx
+++ b/src/components/TestResultsView.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import type { QuizResultsAggregate } from '@/types'
+import type { TestResultsAggregate } from '@/types'
 import { QuestionMarkdown } from '@/components/QuestionMarkdown'
 
 interface Props {
-  results: QuizResultsAggregate[] | null
+  results: TestResultsAggregate[] | null
 }
 
 export function TestResultsView({ results }: Props) {

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -11,7 +11,7 @@ import {
   TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
   type TeacherTestGradingRowUpdatedEventDetail,
 } from '@/lib/events'
-import type { QuizFocusSummary } from '@/types'
+import type { TestFocusSummary } from '@/types'
 
 interface TestQuestionInfo {
   id: string
@@ -48,7 +48,7 @@ interface TestStudentRow {
   graded_open_responses: number
   ungraded_open_responses: number
   answers: TestAnswersByQuestion
-  focus_summary: QuizFocusSummary | null
+  focus_summary: TestFocusSummary | null
 }
 
 interface TestResultsPayload {

--- a/src/hooks/useDraftMode.ts
+++ b/src/hooks/useDraftMode.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/lib/test-questions'
-import type { JsonPatchOperation, QuizQuestion } from '@/types'
+import type { JsonPatchOperation, TestAssessmentQuestion } from '@/types'
 
 const AUTOSAVE_DEBOUNCE_MS = 3_000
 const AUTOSAVE_MIN_INTERVAL_MS = 10_000
@@ -11,7 +11,7 @@ const AUTOSAVE_MIN_INTERVAL_MS = 10_000
 export type DraftContent = {
   title: string
   show_results: boolean
-  questions: QuizQuestion[]
+  questions: TestAssessmentQuestion[]
 }
 
 export type DraftSaveStatus = 'saved' | 'saving' | 'unsaved'
@@ -31,7 +31,7 @@ interface UseDraftModeOptions {
   /** Called with a human-readable error message; called with '' to clear. */
   onError: (msg: string) => void
   /** Called whenever the server provides a canonical question list (on load or conflict). */
-  onQuestionsChange: (questions: QuizQuestion[]) => void
+  onQuestionsChange: (questions: TestAssessmentQuestion[]) => void
 }
 
 export interface UseDraftModeReturn {
@@ -54,7 +54,7 @@ export interface UseDraftModeReturn {
   saveDraft: (nextDraft: DraftContent, options?: { forceFull?: boolean }) => Promise<void>
   scheduleSave: (nextDraft: DraftContent, options?: { force?: boolean }) => void
   scheduleAutosave: (nextDraft: DraftContent) => void
-  handleTitleSave: (questions: QuizQuestion[]) => Promise<void>
+  handleTitleSave: (questions: TestAssessmentQuestion[]) => Promise<void>
 }
 
 /**
@@ -111,9 +111,9 @@ export function useDraftMode({
     setConflictDraft(null)
   }, [quizId, quizTitle])
 
-  /** Normalise raw question data from the server into the QuizQuestion shape. */
+  /** Normalise raw question data from the server into the TestAssessmentQuestion shape. */
   const normalizeDraftQuestions = useCallback(
-    (rawQuestions: unknown[]): QuizQuestion[] => {
+    (rawQuestions: unknown[]): TestAssessmentQuestion[] => {
       return (rawQuestions || []).map((rawQuestion, index) => {
         const question = (rawQuestion || {}) as Record<string, unknown>
         const questionType =
@@ -155,7 +155,7 @@ export function useDraftMode({
           position: index,
           created_at: String(question.created_at || new Date().toISOString()),
           updated_at: String(question.updated_at || new Date().toISOString()),
-        } as QuizQuestion
+        } as TestAssessmentQuestion
       })
     },
     [quizId]
@@ -243,7 +243,7 @@ export function useDraftMode({
           const serverDraft = data?.draft as
             | {
                 version: number
-                content: { title: string; show_results: boolean; questions: QuizQuestion[] }
+                content: { title: string; show_results: boolean; questions: TestAssessmentQuestion[] }
               }
             | undefined
           if (serverDraft) {
@@ -335,7 +335,7 @@ export function useDraftMode({
   )
 
   const handleTitleSave = useCallback(
-    async (questions: QuizQuestion[]) => {
+    async (questions: TestAssessmentQuestion[]) => {
       const trimmed = editTitle.trim()
       const fallbackTitle =
         (pendingDraftRef.current?.title ||

--- a/src/lib/server/tests.ts
+++ b/src/lib/server/tests.ts
@@ -1,6 +1,6 @@
 import { getServiceRoleClient } from '@/lib/supabase'
 import { validateClassroomStudentIds } from '@/lib/server/classroom-enrollment-validation'
-import type { QuizStatus, TestStudentAvailabilityState } from '@/types'
+import type { TestAssessmentStatus, TestStudentAvailabilityState } from '@/types'
 
 type PostgrestErrorLike = {
   code?: string
@@ -19,7 +19,7 @@ function getPostgrestErrorText(error: PostgrestErrorLike): string {
 export type TestAccessRecord = {
   id: string
   classroom_id: string
-  status: QuizStatus
+  status: TestAssessmentStatus
   title: string
   show_results: boolean
   documents?: unknown
@@ -60,7 +60,7 @@ export type EffectiveStudentTestAccess = {
 }
 
 export function getEffectiveStudentTestAccess(params: {
-  testStatus: QuizStatus
+  testStatus: TestAssessmentStatus
   accessState?: TestStudentAvailabilityState | null
   hasSubmitted?: boolean
   returnedAt?: string | null

--- a/src/lib/test-questions.ts
+++ b/src/lib/test-questions.ts
@@ -1,4 +1,4 @@
-import { MAX_QUIZ_OPTIONS } from '@/lib/quizzes'
+import { MAX_TEST_OPTIONS } from '@/lib/tests'
 import { DEFAULT_OPEN_RESPONSE_MAX_CHARS } from '@/lib/test-attempts'
 import type { TestQuestionType } from '@/types'
 
@@ -147,8 +147,8 @@ export function validateTestQuestionCreate(
   if (normalizedOptions.length < 2) {
     return { valid: false, error: 'At least 2 options are required' }
   }
-  if (normalizedOptions.length > MAX_QUIZ_OPTIONS) {
-    return { valid: false, error: `Maximum ${MAX_QUIZ_OPTIONS} options allowed` }
+  if (normalizedOptions.length > MAX_TEST_OPTIONS) {
+    return { valid: false, error: `Maximum ${MAX_TEST_OPTIONS} options allowed` }
   }
 
   const rawCorrectOption = input.correct_option
@@ -249,8 +249,8 @@ export function validateTestQuestionUpdate(
   if (nextOptions.length < 2) {
     return { valid: false, error: 'At least 2 options are required' }
   }
-  if (nextOptions.length > MAX_QUIZ_OPTIONS) {
-    return { valid: false, error: `Maximum ${MAX_QUIZ_OPTIONS} options allowed` }
+  if (nextOptions.length > MAX_TEST_OPTIONS) {
+    return { valid: false, error: `Maximum ${MAX_TEST_OPTIONS} options allowed` }
   }
 
   const currentCorrectOption =

--- a/src/lib/tests.ts
+++ b/src/lib/tests.ts
@@ -1,0 +1,16 @@
+export {
+  getAssessmentStatusLabel,
+  getQuizStatusBadgeClass as getTestStatusBadgeClass,
+  getTeacherTestListDisplayStatus,
+  canStudentViewTestResults,
+  getStudentTestStatus,
+  canEditQuizQuestions as canEditTestQuestions,
+  aggregateResults as aggregateTestResults,
+  MAX_QUIZ_OPTIONS as MAX_TEST_OPTIONS,
+  validateQuizOptions as validateTestOptions,
+  canActivateQuiz as canActivateTest,
+  QUIZ_EXIT_BURST_WINDOW_MS as TEST_EXIT_BURST_WINDOW_MS,
+  getQuizExitCount as getTestExitCount,
+  emptyQuizFocusSummary as emptyTestFocusSummary,
+  summarizeQuizFocusEvents as summarizeTestFocusEvents,
+} from '@/lib/quizzes'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1044,6 +1044,21 @@ export interface QuizResultsAggregate {
   total_responses: number
 }
 
+// Test-facing aliases for the active assessment surface. Legacy Quiz* names
+// remain exported during the API/type contract transition.
+export type TestAssessmentStatus = QuizStatus
+export type TestAssessmentType = QuizAssessmentType
+export type TestAssessment = Quiz
+export type TestAssessmentQuestion = QuizQuestion
+export type TestAssessmentResponse = QuizResponse
+export type TestAssessmentWithQuestions = QuizWithQuestions
+export type TestAssessmentWithStats = QuizWithStats
+export type StudentTestStatus = StudentQuizStatus
+export type StudentTestView = StudentQuizView
+export type TestResultsAggregate = QuizResultsAggregate
+export type TestFocusEventType = QuizFocusEventType
+export type TestFocusSummary = QuizFocusSummary
+
 // Log summary types
 export interface LogSummaryActionItem {
   text: string

--- a/tests/api/student/tests-id.test.ts
+++ b/tests/api/student/tests-id.test.ts
@@ -226,8 +226,9 @@ describe('GET /api/student/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quiz.id).toBe('test-1')
-    expect(data.quiz.returned_at).toBeNull()
+    expect(data.test).toEqual(data.quiz)
+    expect(data.test.id).toBe('test-1')
+    expect(data.test.returned_at).toBeNull()
     expect(questionSelectColumns).not.toContain('correct_option')
     expect(questionSelectColumns).not.toContain('answer_key')
     expect(data.questions[0].correct_option).toBeUndefined()

--- a/tests/api/student/tests-results.test.ts
+++ b/tests/api/student/tests-results.test.ts
@@ -434,8 +434,9 @@ describe('GET /api/student/tests/[id]/results', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quiz.id).toBe('test-1')
-    expect(data.quiz.returned_at).toBe('2026-03-05T11:00:00.000Z')
+    expect(data.test).toEqual(data.quiz)
+    expect(data.test.id).toBe('test-1')
+    expect(data.test.returned_at).toBe('2026-03-05T11:00:00.000Z')
     expect(data.summary.earned_points).toBe(4)
     expect(data.question_results[0].sample_solution).toContain('println')
     expect(data.results[0]).toEqual(

--- a/tests/api/student/tests-route.test.ts
+++ b/tests/api/student/tests-route.test.ts
@@ -170,8 +170,9 @@ describe('GET /api/student/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(1)
-    expect(data.quizzes[0].id).toBe('test-1')
+    expect(data.tests).toEqual(data.quizzes)
+    expect(data.tests).toHaveLength(1)
+    expect(data.tests[0].id).toBe('test-1')
   })
 
   it('computes test student_status from returned state for closed responded tests', async () => {

--- a/tests/api/student/tests-session-status.test.ts
+++ b/tests/api/student/tests-session-status.test.ts
@@ -291,8 +291,9 @@ describe('GET /api/student/tests/[id]/session-status', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(data.test).toEqual(data.quiz)
     expect(data.can_continue).toBe(false)
-    expect(data.effective_access ?? data.quiz.effective_access).toBe('closed')
+    expect(data.effective_access ?? data.test.effective_access).toBe('closed')
     expect(data.message).toContain('saved draft is preserved')
   })
 })

--- a/tests/api/teacher/tests-id-route.test.ts
+++ b/tests/api/teacher/tests-id-route.test.ts
@@ -133,8 +133,9 @@ describe('PATCH /api/teacher/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quiz.title).toBe('Closed Test')
-    expect(data.quiz.show_results).toBe(false)
+    expect(data.test).toEqual(data.quiz)
+    expect(data.test.title).toBe('Closed Test')
+    expect(data.test.show_results).toBe(false)
     expect(data.questions[0].question_text).toBe('Canonical question text')
     expect(data.questions[0].sample_solution).toBe('canonical sample solution')
   })

--- a/tests/api/teacher/tests-route.test.ts
+++ b/tests/api/teacher/tests-route.test.ts
@@ -185,7 +185,8 @@ describe('GET /api/teacher/tests', () => {
       { column: 'position', ascending: false },
       { column: 'created_at', ascending: false },
     ])
-    expect((data.quizzes as Array<{ id: string }>).map((quiz) => quiz.id)).toEqual(['test-2', 'test-1'])
+    expect(data.tests).toEqual(data.quizzes)
+    expect((data.tests as Array<{ id: string }>).map((test) => test.id)).toEqual(['test-2', 'test-1'])
   })
 
   it('returns 500 when reading test responses fails', async () => {
@@ -751,8 +752,9 @@ describe('POST /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(201)
-    expect(data.quiz.position).toBe(3)
-    expect(data.quiz.title).toBe('New Test')
+    expect(data.test).toEqual(data.quiz)
+    expect(data.test.position).toBe(3)
+    expect(data.test.title).toBe('New Test')
     expect(assessmentDraftInsertSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         assessment_type: 'test',


### PR DESCRIPTION
## Summary

- Add dual `test`/`tests` response keys to active `/api/*/tests` routes while preserving legacy `quiz`/`quizzes` keys for compatibility.
- Add test-facing type aliases and `@/lib/tests` helper exports, then migrate active test routes/components/hooks to those names.
- Remove unused one-line legacy UI wrappers and update architecture/UI guidance to reflect the Tests surface.

## Impact

This advances the internal Tests naming transition without changing production schema, migrations, database table names, storage/RPC names, or existing legacy payload keys. Existing consumers that still read `quiz`/`quizzes` should continue to work during the transition, while active clients can read `test`/`tests` first.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (301 files / 2655 tests)
- `node scripts/trim-session-log.mjs --check`