### PR TITLE
[codex] Adopt test names in active tests contracts

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,18 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Snapshot gallery production restriction finalized
-
-**Completed:**
-- Updated `requireSnapshotGalleryAccess()` to be strictly non-production only (no production allowlist fallback).
-- Removed `SNAPSHOT_GALLERY_ADMIN_EMAILS` from `.env.example`.
-- Updated snapshot gallery docs to reflect production-blocked policy.
-- Adjusted `requireSnapshotGalleryAccess` unit tests accordingly (`tests/unit/auth.test.ts`).
-
-**Validation:**
-- `pnpm test tests/unit/auth.test.ts tests/api/snapshots-list.test.ts tests/api/snapshots-filename.test.ts`
-- `pnpm lint`
-
 ## 2026-06-01 — Open join classroom access mode
 
 **Completed:**
@@ -972,3 +960,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
 - `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
 - `pnpm test` (301 files / 2655 tests)
+
+## 2026-06-09 — Legacy quiz internal test naming pass
+
+**Completed:**
+- Merged PR #762 (`Clean up legacy quiz test contracts`) into `main`.
+- Created `codex/legacy-quiz-internal-test-names` from the merged `origin/main`.
+- Continued the safe internal naming transition by moving active `/tests` route/test type imports to `Test*` aliases.
+- Updated active `/api/*/tests` assertions and the return-visibility integration test to read `test`/`tests` first while preserving explicit legacy `quiz`/`quizzes` equality checks.
+- Added test-named mock factories (`createMockTest`, `createMockTestQuestion`, `createMockTestResponse`) over the legacy DB-shaped contracts.
+- Migrated `TestDetailPanel` component test fixtures to test-named aliases/helpers without changing the component prop contract or schema-shaped `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm vitest run tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts tests/api/integration/test-return-visibility-flow.test.ts tests/components/TestResultsView.test.tsx tests/components/TestDetailPanel.test.tsx tests/hooks/useDraftMode.test.ts tests/components/StudentTestsTab.test.tsx`
+- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -12,7 +12,7 @@ import { getStudentTestStatus } from '@/lib/tests'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
-import type { Quiz } from '@/types'
+import type { TestAssessment } from '@/types'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -218,7 +218,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
 
   const allTests = [...visibleActiveTests, ...visibleClosedTests]
 
-  const testsWithStatus = allTests.map((test: Quiz) => {
+  const testsWithStatus = allTests.map((test: TestAssessment) => {
     const hasResponded = respondedTestIds.has(test.id)
     const isReturned = returnedTestIds.has(test.id)
     const access = getEffectiveStudentTestAccess({

--- a/tests/api/integration/test-return-visibility-flow.test.ts
+++ b/tests/api/integration/test-return-visibility-flow.test.ts
@@ -451,7 +451,7 @@ describe('Test Return Visibility Integration', () => {
     )
     const listBeforeData = await listBefore.json()
     expect(listBefore.status).toBe(200)
-    expect(listBeforeData.quizzes[0].student_status).toBe('responded')
+    expect(listBeforeData.tests[0].student_status).toBe('responded')
 
     const detailBefore = await getStudentTestDetail(
       new NextRequest('http://localhost:3000/api/student/tests/test-1'),
@@ -488,7 +488,7 @@ describe('Test Return Visibility Integration', () => {
     )
     const listAfterData = await listAfter.json()
     expect(listAfter.status).toBe(200)
-    expect(listAfterData.quizzes[0].student_status).toBe('can_view_results')
+    expect(listAfterData.tests[0].student_status).toBe('can_view_results')
 
     const detailAfter = await getStudentTestDetail(
       new NextRequest('http://localhost:3000/api/student/tests/test-1'),
@@ -497,7 +497,7 @@ describe('Test Return Visibility Integration', () => {
     const detailAfterData = await detailAfter.json()
     expect(detailAfter.status).toBe(200)
     expect(detailAfterData.student_status).toBe('can_view_results')
-    expect(detailAfterData.quiz.returned_at).not.toBeNull()
+    expect(detailAfterData.test.returned_at).not.toBeNull()
 
     const resultsAfter = await getStudentTestResults(
       new NextRequest('http://localhost:3000/api/student/tests/test-1/results'),
@@ -505,7 +505,7 @@ describe('Test Return Visibility Integration', () => {
     )
     const resultsAfterData = await resultsAfter.json()
     expect(resultsAfter.status).toBe(200)
-    expect(resultsAfterData.quiz.returned_at).not.toBeNull()
+    expect(resultsAfterData.test.returned_at).not.toBeNull()
     expect(resultsAfterData.summary.earned_points).toBe(4)
   })
 
@@ -549,7 +549,7 @@ describe('Test Return Visibility Integration', () => {
     )
     const listAfterData = await listAfter.json()
     expect(listAfter.status).toBe(200)
-    expect(listAfterData.quizzes[0].student_status).toBe('can_view_results')
+    expect(listAfterData.tests[0].student_status).toBe('can_view_results')
 
     const detailAfter = await getStudentTestDetail(
       new NextRequest('http://localhost:3000/api/student/tests/test-1'),

--- a/tests/api/student/tests-id.test.ts
+++ b/tests/api/student/tests-id.test.ts
@@ -300,7 +300,7 @@ describe('GET /api/student/tests/[id]', () => {
 
     expect(response.status).toBe(200)
     expect(data.student_status).toBe('responded')
-    expect(data.quiz.student_status).toBe('responded')
+    expect(data.test.student_status).toBe('responded')
   })
 
   it('returns student_status=can_view_results when closed test has been returned', async () => {
@@ -372,7 +372,7 @@ describe('GET /api/student/tests/[id]', () => {
 
     expect(response.status).toBe(200)
     expect(data.student_status).toBe('can_view_results')
-    expect(data.quiz.student_status).toBe('can_view_results')
+    expect(data.test.student_status).toBe('can_view_results')
   })
 
   it('does not expose closed test when only placeholder graded rows exist', async () => {

--- a/tests/api/student/tests-route.test.ts
+++ b/tests/api/student/tests-route.test.ts
@@ -268,9 +268,9 @@ describe('GET /api/student/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(2)
+    expect(data.tests).toHaveLength(2)
     const byId = Object.fromEntries(
-      (data.quizzes as Array<{ id: string; student_status: string }>).map((quiz) => [quiz.id, quiz.student_status])
+      (data.tests as Array<{ id: string; student_status: string }>).map((test) => [test.id, test.student_status])
     )
     expect(byId['test-closed-returned']).toBe('can_view_results')
     expect(byId['test-closed-responded']).toBe('responded')
@@ -354,8 +354,8 @@ describe('GET /api/student/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(1)
-    expect(data.quizzes[0]).toMatchObject({
+    expect(data.tests).toHaveLength(1)
+    expect(data.tests[0]).toMatchObject({
       id: 'test-closed-opened',
       student_status: 'not_started',
       access_state: 'open',
@@ -486,7 +486,7 @@ describe('GET /api/student/tests', () => {
       { status: 'active', column: 'position', ascending: false },
       { status: 'closed', column: 'position', ascending: false },
     ])
-    expect((data.quizzes as Array<{ id: string }>).map((quiz) => quiz.id)).toEqual([
+    expect((data.tests as Array<{ id: string }>).map((test) => test.id)).toEqual([
       'test-active-new',
       'test-active-old',
       'test-closed-new',
@@ -562,6 +562,6 @@ describe('GET /api/student/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(0)
+    expect(data.tests).toHaveLength(0)
   })
 })

--- a/tests/api/teacher/tests-id-route.test.ts
+++ b/tests/api/teacher/tests-id-route.test.ts
@@ -249,7 +249,7 @@ describe('PATCH /api/teacher/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quiz.status).toBe('active')
+    expect(data.test.status).toBe('active')
   })
 
   it('updates test documents when payload is valid', async () => {
@@ -312,7 +312,7 @@ describe('PATCH /api/teacher/tests/[id]', () => {
         documents,
       })
     )
-    expect(data.quiz.documents).toEqual(documents)
+    expect(data.test.documents).toEqual(documents)
   })
 
   it('returns 400 for invalid test documents payload', async () => {
@@ -408,7 +408,7 @@ describe('PATCH /api/teacher/tests/[id]', () => {
         documents,
       })
     )
-    expect(data.quiz.documents).toEqual(documents)
+    expect(data.test.documents).toEqual(documents)
   })
 
   it('finalizes draft attempts when closing an active test', async () => {
@@ -449,7 +449,7 @@ describe('PATCH /api/teacher/tests/[id]', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quiz.status).toBe('closed')
+    expect(data.test.status).toBe('closed')
     expect(mockSupabaseClient.rpc).toHaveBeenCalledWith('close_test_for_grading_atomic', {
       p_test_id: 'test-1',
       p_closed_by: 'teacher-1',

--- a/tests/api/teacher/tests-route.test.ts
+++ b/tests/api/teacher/tests-route.test.ts
@@ -359,8 +359,8 @@ describe('GET /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(1)
-    expect(data.quizzes[0].stats.responded).toBe(0)
+    expect(data.tests).toHaveLength(1)
+    expect(data.tests[0].stats.responded).toBe(0)
   })
 
   it('counts only currently enrolled students as respondents', async () => {
@@ -462,12 +462,12 @@ describe('GET /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(1)
-    expect(data.quizzes[0].stats.total_students).toBe(2)
-    expect(data.quizzes[0].stats.responded).toBe(2)
-    expect(data.quizzes[0].stats.submitted).toBe(1)
-    expect(data.quizzes[0].stats.open_access).toBe(1)
-    expect(data.quizzes[0].stats.closed_access).toBe(1)
+    expect(data.tests).toHaveLength(1)
+    expect(data.tests[0].stats.total_students).toBe(2)
+    expect(data.tests[0].stats.responded).toBe(2)
+    expect(data.tests[0].stats.submitted).toBe(1)
+    expect(data.tests[0].stats.open_access).toBe(1)
+    expect(data.tests[0].stats.closed_access).toBe(1)
     expect(scopedInCalls).toContainEqual({
       table: 'test_attempts',
       column: 'student_id',
@@ -564,8 +564,8 @@ describe('GET /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes).toHaveLength(51)
-    expect(data.quizzes[0].stats).toEqual({
+    expect(data.tests).toHaveLength(51)
+    expect(data.tests[0].stats).toEqual({
       total_students: 51,
       responded: 2,
       submitted: 1,
@@ -674,12 +674,12 @@ describe('GET /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.quizzes[0].title).toBe('Draft Overlay Title')
-    expect(data.quizzes[0].show_results).toBe(true)
-    expect(data.quizzes[0].stats.questions_count).toBe(0)
-    expect(data.quizzes[1].title).toBe('Closed Test')
-    expect(data.quizzes[1].show_results).toBe(false)
-    expect(data.quizzes[1].stats.questions_count).toBe(2)
+    expect(data.tests[0].title).toBe('Draft Overlay Title')
+    expect(data.tests[0].show_results).toBe(true)
+    expect(data.tests[0].stats.questions_count).toBe(0)
+    expect(data.tests[1].title).toBe('Closed Test')
+    expect(data.tests[1].show_results).toBe(false)
+    expect(data.tests[1].stats.questions_count).toBe(2)
   })
 })
 
@@ -834,11 +834,11 @@ describe('POST /api/teacher/tests', () => {
     const data = await response.json()
 
     expect(response.status).toBe(201)
-    expect(data.quiz.title).toMatch(/^Untitled \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+    expect(data.test.title).toMatch(/^Untitled \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
     expect(assessmentDraftInsertSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.objectContaining({
-          title: data.quiz.title,
+          title: data.test.title,
         }),
       })
     )

--- a/tests/components/StudentTestsTab.test.tsx
+++ b/tests/components/StudentTestsTab.test.tsx
@@ -6,7 +6,7 @@ import {
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
 } from '@/lib/events'
 import { invalidateCachedJSONMatching } from '@/lib/request-cache'
-import type { QuizFocusSummary } from '@/types'
+import type { TestFocusSummary } from '@/types'
 import { createMockClassroom } from '../helpers/mocks'
 
 describe('StudentTestsTab exam mode', () => {
@@ -280,7 +280,7 @@ describe('StudentTestsTab exam mode', () => {
     return splitContainer instanceof HTMLDivElement ? splitContainer : null
   }
 
-  function makeFocusSummary(overrides: Partial<QuizFocusSummary> = {}): QuizFocusSummary {
+  function makeFocusSummary(overrides: Partial<TestFocusSummary> = {}): TestFocusSummary {
     return {
       exit_count: 0,
       away_count: 0,

--- a/tests/components/TestDetailPanel.test.tsx
+++ b/tests/components/TestDetailPanel.test.tsx
@@ -3,29 +3,29 @@ import { act, render, screen, fireEvent, waitFor, within } from '@testing-librar
 import { useState, type ReactNode } from 'react'
 import { TestDetailPanel } from '@/components/TestDetailPanel'
 import { TooltipProvider } from '@/ui'
-import { createMockQuiz, createMockQuizQuestion } from '../helpers/mocks'
-import type { QuizWithStats, QuizQuestion, QuizResultsAggregate } from '@/types'
+import { createMockTest, createMockTestQuestion } from '../helpers/mocks'
+import type { TestAssessmentWithStats, TestAssessmentQuestion, TestResultsAggregate } from '@/types'
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <TooltipProvider>{children}</TooltipProvider>
 }
 
-function makeQuizWithStats(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
-  const base = createMockQuiz(overrides)
+function makeTestWithStats(overrides: Partial<TestAssessmentWithStats> = {}): TestAssessmentWithStats {
+  const base = createMockTest(overrides)
   return {
     ...base,
     stats: { total_students: 25, responded: 0, questions_count: 2 },
     ...overrides,
-  } as QuizWithStats
+  } as TestAssessmentWithStats
 }
 
-const sampleQuestions: QuizQuestion[] = [
-  createMockQuizQuestion({ id: 'q1', question_text: 'Favorite color?', options: ['Red', 'Blue', 'Green'], position: 0 }),
-  createMockQuizQuestion({ id: 'q2', question_text: 'Favorite animal?', options: ['Cat', 'Dog'], position: 1 }),
+const sampleQuestions: TestAssessmentQuestion[] = [
+  createMockTestQuestion({ id: 'q1', question_text: 'Favorite color?', options: ['Red', 'Blue', 'Green'], position: 0 }),
+  createMockTestQuestion({ id: 'q2', question_text: 'Favorite animal?', options: ['Cat', 'Dog'], position: 1 }),
 ]
 
-const summaryDetailQuestions: QuizQuestion[] = [
-  createMockQuizQuestion({
+const summaryDetailQuestions: TestAssessmentQuestion[] = [
+  createMockTestQuestion({
     id: 'sq1',
     assessment_type: 'test',
     question_type: 'open_response',
@@ -38,7 +38,7 @@ const summaryDetailQuestions: QuizQuestion[] = [
     response_monospace: true,
     position: 0,
   }),
-  createMockQuizQuestion({
+  createMockTestQuestion({
     id: 'sq2',
     assessment_type: 'test',
     question_type: 'multiple_choice',
@@ -78,9 +78,9 @@ describe('TestDetailPanel', () => {
     return { ok: true, json: async () => body } as Response
   }
 
-  function mockFetchForQuiz(
-    questions: QuizQuestion[],
-    results?: QuizResultsAggregate[],
+  function mockFetchForTest(
+    questions: TestAssessmentQuestion[],
+    results?: TestResultsAggregate[],
     draftOverrides?: {
       title?: string
       show_results?: boolean
@@ -120,13 +120,13 @@ describe('TestDetailPanel', () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     const staleDraft = createDeferred<Response>()
     const currentDraft = createDeferred<Response>()
-    const staleQuestion = createMockQuizQuestion({
+    const staleQuestion = createMockTestQuestion({
       id: 'q-stale',
       quiz_id: 'quiz-stale',
       question_text: 'Stale draft question',
       position: 0,
     })
-    const currentQuestion = createMockQuizQuestion({
+    const currentQuestion = createMockTestQuestion({
       id: 'q-current',
       quiz_id: 'quiz-current',
       question_text: 'Current draft question',
@@ -139,8 +139,8 @@ describe('TestDetailPanel', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     })
 
-    const staleQuiz = makeQuizWithStats({ id: 'quiz-stale', title: 'Stale Quiz' })
-    const currentQuiz = makeQuizWithStats({ id: 'quiz-current', title: 'Current Quiz' })
+    const staleQuiz = makeTestWithStats({ id: 'quiz-stale', title: 'Stale Quiz' })
+    const currentQuiz = makeTestWithStats({ id: 'quiz-current', title: 'Current Quiz' })
     const { rerender } = render(
       <TestDetailPanel quiz={staleQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
       { wrapper: Wrapper }
@@ -229,12 +229,12 @@ describe('TestDetailPanel', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     })
 
-    const staleTest = makeQuizWithStats({
+    const staleTest = makeTestWithStats({
       id: 'test-stale',
       title: 'Stale Test',
       assessment_type: 'test',
     })
-    const currentTest = makeQuizWithStats({
+    const currentTest = makeTestWithStats({
       id: 'test-current',
       title: 'Current Test',
       assessment_type: 'test',
@@ -322,12 +322,12 @@ describe('TestDetailPanel', () => {
       throw new Error(`Unexpected fetch: ${url}`)
     })
 
-    const sameIdQuiz = makeQuizWithStats({
+    const sameIdQuiz = makeTestWithStats({
       id: 'assessment-1',
       title: 'Same Id Quiz',
       assessment_type: 'quiz',
     })
-    const sameIdTest = makeQuizWithStats({
+    const sameIdTest = makeTestWithStats({
       id: 'assessment-1',
       title: 'Same Id Test',
       assessment_type: 'test',
@@ -357,7 +357,7 @@ describe('TestDetailPanel', () => {
             title: 'Same Id Test',
             show_results: true,
             questions: [
-              createMockQuizQuestion({
+              createMockTestQuestion({
                 id: 'q-current-test',
                 quiz_id: 'assessment-1',
                 assessment_type: 'test',
@@ -390,7 +390,7 @@ describe('TestDetailPanel', () => {
             title: 'Same Id Quiz',
             show_results: true,
             questions: [
-              createMockQuizQuestion({
+              createMockTestQuestion({
                 id: 'q-stale-quiz',
                 quiz_id: 'assessment-1',
                 question_text: 'Stale same-id quiz question',
@@ -410,8 +410,8 @@ describe('TestDetailPanel', () => {
   })
 
   describe('tabs', () => {    it('shows question count in Questions tab', async () => {
-      mockFetchForQuiz(sampleQuestions)
-      const quiz = makeQuizWithStats()
+      mockFetchForTest(sampleQuestions)
+      const quiz = makeTestWithStats()
 
       render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
 
@@ -447,7 +447,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Docs Test',
       })
@@ -496,7 +496,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Docs Tab Order Test',
       })
@@ -548,7 +548,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Accessible Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -607,7 +607,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Two Pane Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -758,7 +758,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Editor Modal Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -813,7 +813,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Untitled 2026-05-14 10:45:00',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -871,7 +871,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Modal Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -926,7 +926,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Resizable Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1054,7 +1054,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Empty Markdown Import Test',
         stats: { total_students: 25, responded: 0, questions_count: 0 },
@@ -1115,7 +1115,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Two Pane Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1200,7 +1200,7 @@ describe('TestDetailPanel', () => {
         throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         id: 'quiz-race-test',
         assessment_type: 'test',
         title: 'Race Test',
@@ -1302,7 +1302,7 @@ describe('TestDetailPanel', () => {
         throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         id: 'quiz-stale-save-test',
         assessment_type: 'test',
         title: 'Stale Save Test',
@@ -1351,7 +1351,7 @@ describe('TestDetailPanel', () => {
               content: {
                 title: 'Stale Save Test',
                 show_results: false,
-                questions: [createMockQuizQuestion({ id: 'saved-q1' })],
+                questions: [createMockTestQuestion({ id: 'saved-q1' })],
               },
             },
           }),
@@ -1366,7 +1366,7 @@ describe('TestDetailPanel', () => {
     it('ignores stale save responses after selected assessment changes', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
       const staleSave = createDeferred<Response>()
-      const currentQuestion = createMockQuizQuestion({
+      const currentQuestion = createMockTestQuestion({
         id: 'q-current-save-scope',
         assessment_type: 'test',
         question_type: 'open_response',
@@ -1415,14 +1415,14 @@ describe('TestDetailPanel', () => {
         throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
       })
 
-      const staleTest = makeQuizWithStats({
+      const staleTest = makeTestWithStats({
         id: 'test-save-stale',
         assessment_type: 'test',
         title: 'Stale Save Test',
         show_results: false,
         stats: { total_students: 25, responded: 0, questions_count: 0 },
       })
-      const currentTest = makeQuizWithStats({
+      const currentTest = makeTestWithStats({
         id: 'test-save-current',
         assessment_type: 'test',
         title: 'Current Save Test',
@@ -1477,7 +1477,7 @@ describe('TestDetailPanel', () => {
               title: 'Stale Save Test',
               show_results: false,
               questions: [
-                createMockQuizQuestion({
+                createMockTestQuestion({
                   id: 'q-stale-save-scope',
                   assessment_type: 'test',
                   question_type: 'multiple_choice',
@@ -1542,14 +1542,14 @@ describe('TestDetailPanel', () => {
         throw new Error(`Unexpected fetch: ${url} ${options?.method || 'GET'}`)
       })
 
-      const staleTest = makeQuizWithStats({
+      const staleTest = makeTestWithStats({
         id: 'test-pending-save',
         assessment_type: 'test',
         title: 'Pending Save Test',
         show_results: false,
         stats: { total_students: 25, responded: 0, questions_count: 0 },
       })
-      const currentTest = makeQuizWithStats({
+      const currentTest = makeTestWithStats({
         id: 'test-pending-current',
         assessment_type: 'test',
         title: 'Pending Current Test',
@@ -1626,7 +1626,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Duplicate Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1689,7 +1689,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Split Button Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1751,7 +1751,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Mirror Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1814,7 +1814,7 @@ describe('TestDetailPanel', () => {
         }),
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Pending Markdown Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -1888,7 +1888,7 @@ describe('TestDetailPanel', () => {
         })
         .mockImplementationOnce(() => patchPromise as unknown as Promise<Response>)
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Apply Timing Test',
         stats: { total_students: 25, responded: 0, questions_count: 2 },
@@ -2033,7 +2033,7 @@ _None_
       } as unknown as Window
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => fakePreviewWindow)
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         id: 'test-preview-action-id',
         assessment_type: 'test',
         title: 'Preview Action Test',
@@ -2118,7 +2118,7 @@ _None_
       const onRequestTestPreview = vi.fn()
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         id: 'test-inline-preview-id',
         assessment_type: 'test',
         title: 'Inline Preview Test',
@@ -2208,7 +2208,7 @@ Correct Option: 2
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Test',
       })
@@ -2271,7 +2271,7 @@ Correct Option: 2
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Creation Test',
       })
@@ -2355,7 +2355,7 @@ Correct Option: 2
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Test',
       })
@@ -2459,7 +2459,7 @@ _None_
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Test',
       })
@@ -2527,7 +2527,7 @@ Prompt:
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Markdown Test',
       })
@@ -2555,8 +2555,8 @@ Prompt:
 
   describe('Questions tab', () => {
     it('shows test title that is click-to-edit', async () => {
-      mockFetchForQuiz(sampleQuestions)
-      const quiz = makeQuizWithStats({ title: 'My Cool Test' })
+      mockFetchForTest(sampleQuestions)
+      const quiz = makeTestWithStats({ title: 'My Cool Test' })
 
       render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
 
@@ -2570,8 +2570,8 @@ Prompt:
     })
 
     it('does not show activation warning label when no questions', async () => {
-      mockFetchForQuiz([])
-      const quiz = makeQuizWithStats()
+      mockFetchForTest([])
+      const quiz = makeTestWithStats()
 
       render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
 
@@ -2581,7 +2581,7 @@ Prompt:
     })
 
     it('in tests authoring, question type is fixed and open-response char limit is hidden', async () => {
-      const testQuestion = createMockQuizQuestion({
+      const testQuestion = createMockTestQuestion({
         id: 'test-q1',
         question_type: 'open_response',
         question_text: 'Explain your reasoning',
@@ -2590,8 +2590,8 @@ Prompt:
         response_max_chars: 5000,
         answer_key: null,
       })
-      mockFetchForQuiz([testQuestion])
-      const testQuiz = makeQuizWithStats({
+      mockFetchForTest([testQuestion])
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Mixed Format Test',
       })
@@ -2632,7 +2632,7 @@ Prompt:
     })
 
     it('keeps answer key collapsed by default and expands on click', async () => {
-      const testQuestion = createMockQuizQuestion({
+      const testQuestion = createMockTestQuestion({
         id: 'test-q-open',
         question_type: 'open_response',
         question_text: 'Explain photosynthesis.',
@@ -2641,8 +2641,8 @@ Prompt:
         response_max_chars: 5000,
         answer_key: null,
       })
-      mockFetchForQuiz([testQuestion])
-      const testQuiz = makeQuizWithStats({
+      mockFetchForTest([testQuestion])
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Open Response Test',
       })
@@ -2678,7 +2678,7 @@ Prompt:
           ok: true,
           json: async () => ({
             questions: [
-              createMockQuizQuestion({
+              createMockTestQuestion({
                 id: 'test-q-save',
                 question_type: 'open_response',
                 question_text: 'Explain inertia.',
@@ -2698,7 +2698,7 @@ Prompt:
           ok: true,
           json: async () => ({
             questions: [
-              createMockQuizQuestion({
+              createMockTestQuestion({
                 id: 'test-q-save',
                 question_type: 'open_response',
                 question_text: 'Explain inertia.',
@@ -2711,7 +2711,7 @@ Prompt:
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Save Answer Key Test',
       })
@@ -2782,7 +2782,7 @@ Prompt:
           json: async () => ({}),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Draft Test',
       })
@@ -2838,7 +2838,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+        if (url === '/api/teacher/tests/test-1' && (!options?.method || options.method === 'GET')) {
           return {
             ok: true,
             json: async () => ({
@@ -2847,7 +2847,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1' && options?.method === 'PATCH') {
+        if (url === '/api/teacher/tests/test-1' && options?.method === 'PATCH') {
           const body = JSON.parse(String(options.body))
           return {
             ok: true,
@@ -2883,7 +2883,7 @@ Prompt:
         throw new Error(`Unexpected fetch call: ${url}`)
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Doc Save Test',
       })
@@ -2959,7 +2959,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+        if (url === '/api/teacher/tests/test-1' && (!options?.method || options.method === 'GET')) {
           return {
             ok: true,
             json: async () => ({
@@ -2980,7 +2980,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && options?.method === 'POST') {
+        if (url === '/api/teacher/tests/test-1/documents/doc-1/sync' && options?.method === 'POST') {
           return {
             ok: true,
             json: async () => ({
@@ -3004,7 +3004,7 @@ Prompt:
         throw new Error(`Unexpected fetch call: ${url}`)
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Doc Refresh Test',
       })
@@ -3031,7 +3031,7 @@ Prompt:
 
       expect(
         fetchMock.mock.calls.some(
-          (call: any[]) => call[0] === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && call[1]?.method === 'POST'
+          (call: any[]) => call[0] === '/api/teacher/tests/test-1/documents/doc-1/sync' && call[1]?.method === 'POST'
         )
       ).toBe(false)
 
@@ -3039,7 +3039,7 @@ Prompt:
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
-          '/api/teacher/tests/quiz-1/documents/doc-1/sync',
+          '/api/teacher/tests/test-1/documents/doc-1/sync',
           expect.objectContaining({ method: 'POST' })
         )
       })
@@ -3064,7 +3064,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1' && (!options?.method || options.method === 'GET')) {
+        if (url === '/api/teacher/tests/test-1' && (!options?.method || options.method === 'GET')) {
           return {
             ok: true,
             json: async () => ({
@@ -3085,7 +3085,7 @@ Prompt:
           }
         }
 
-        if (url === '/api/teacher/tests/quiz-1/documents/doc-1/sync' && options?.method === 'POST') {
+        if (url === '/api/teacher/tests/test-1/documents/doc-1/sync' && options?.method === 'POST') {
           return {
             ok: true,
             json: async () => ({
@@ -3109,7 +3109,7 @@ Prompt:
         throw new Error(`Unexpected fetch call: ${url}`)
       })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Doc Auto Sync Test',
       })
@@ -3130,7 +3130,7 @@ Prompt:
 
       await waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
-          '/api/teacher/tests/quiz-1/documents/doc-1/sync',
+          '/api/teacher/tests/test-1/documents/doc-1/sync',
           expect.objectContaining({ method: 'POST' })
         )
       })
@@ -3202,7 +3202,7 @@ Prompt:
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Doc Text Save Test',
       })
@@ -3274,7 +3274,7 @@ Prompt:
           }),
         })
 
-      const testQuiz = makeQuizWithStats({
+      const testQuiz = makeTestWithStats({
         assessment_type: 'test',
         title: 'Doc Upload Modal Test',
       })
@@ -3304,8 +3304,8 @@ Prompt:
 
   describe('title editing', () => {
     it('saves title on Enter key', async () => {
-      const fetchMock = mockFetchForQuiz(sampleQuestions)
-      const quiz = makeQuizWithStats({ title: 'Old Title' })
+      const fetchMock = mockFetchForTest(sampleQuestions)
+      const quiz = makeTestWithStats({ title: 'Old Title' })
 
       render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
 
@@ -3337,8 +3337,8 @@ Prompt:
     })
 
     it('cancels edit on Escape key', async () => {
-      mockFetchForQuiz(sampleQuestions)
-      const quiz = makeQuizWithStats({ title: 'Original' })
+      mockFetchForTest(sampleQuestions)
+      const quiz = makeTestWithStats({ title: 'Original' })
 
       render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
 

--- a/tests/components/TestResultsView.test.tsx
+++ b/tests/components/TestResultsView.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { TestResultsView } from '@/components/TestResultsView'
-import type { QuizResultsAggregate } from '@/types'
+import type { TestResultsAggregate } from '@/types'
 
-const sampleResults: QuizResultsAggregate[] = [
+const sampleResults: TestResultsAggregate[] = [
   {
     question_id: 'q1',
     question_text: 'What is the capital of France?',
@@ -84,7 +84,7 @@ describe('TestResultsView', () => {
   })
 
   it('handles single response correctly', () => {
-    const single: QuizResultsAggregate[] = [
+    const single: TestResultsAggregate[] = [
       {
         question_id: 'q1',
         question_text: 'Yes or no?',

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -14,6 +14,9 @@ import type {
   Quiz,
   QuizQuestion,
   QuizResponse,
+  TestAssessment,
+  TestAssessmentQuestion,
+  TestAssessmentResponse,
 } from '@/types'
 
 // ============================================================================
@@ -259,3 +262,37 @@ export const createMockQuizResponse = (overrides: Partial<QuizResponse> = {}): Q
   submitted_at: '2024-10-15T14:30:00Z',
   ...overrides,
 })
+
+/**
+ * Create a mock test with default or custom values.
+ * The shape aliases the legacy quiz table contract while using the active surface name.
+ */
+export const createMockTest = (overrides: Partial<TestAssessment> = {}): TestAssessment =>
+  createMockQuiz({
+    id: 'test-1',
+    title: 'Test Assessment',
+    assessment_type: 'test',
+    ...overrides,
+  })
+
+/**
+ * Create a mock test question with default or custom values.
+ */
+export const createMockTestQuestion = (
+  overrides: Partial<TestAssessmentQuestion> = {}
+): TestAssessmentQuestion =>
+  createMockQuizQuestion({
+    quiz_id: 'test-1',
+    ...overrides,
+  })
+
+/**
+ * Create a mock test response with default or custom values.
+ */
+export const createMockTestResponse = (
+  overrides: Partial<TestAssessmentResponse> = {}
+): TestAssessmentResponse =>
+  createMockQuizResponse({
+    quiz_id: 'test-1',
+    ...overrides,
+  })

--- a/tests/hooks/useDraftMode.test.ts
+++ b/tests/hooks/useDraftMode.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { useDraftMode } from '@/hooks/useDraftMode'
-import type { QuizQuestion } from '@/types'
+import type { TestAssessmentQuestion } from '@/types'
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -18,7 +18,7 @@ function makeOptions(overrides: Partial<Parameters<typeof useDraftMode>[0]> = {}
   }
 }
 
-function makeQuestion(overrides: Partial<QuizQuestion> = {}): QuizQuestion {
+function makeQuestion(overrides: Partial<TestAssessmentQuestion> = {}): TestAssessmentQuestion {
   return {
     id: 'q-1',
     quiz_id: 'quiz-1',


### PR DESCRIPTION
## Summary

- Move safe active `/tests` route/test type imports from legacy `Quiz*` names to `Test*` aliases.
- Update active `/api/*/tests` assertions and the return-visibility integration test to read `test`/`tests` first while keeping explicit legacy `quiz`/`quizzes` equality checks.
- Add test-named mock factories over the existing legacy DB-shaped contracts and migrate `TestDetailPanel` fixtures to those helpers.

## Impact

This continues the Tests naming transition after #762 without changing schema, migrations, DB-shaped fields such as `quiz_id`, or legacy compatibility response keys.

## Validation

- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm vitest run tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts tests/api/integration/test-return-visibility-flow.test.ts tests/components/TestResultsView.test.tsx tests/components/TestDetailPanel.test.tsx tests/hooks/useDraftMode.test.ts tests/components/StudentTestsTab.test.tsx`
- `node scripts/trim-session-log.mjs --check`