### PR TITLE
Rename teacher test UI state

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,19 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Open join settings toggle polish
-
-**Completed:**
-- Replaced the Settings join checkbox and right-aligned segmented control with matching left-aligned two-choice toggles.
-- Updated the toggle states so `Allow`/`Roster` sit on the left and `Disallow`/`Open` sit on the right.
-
-**Validation:**
-- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
-
 ## 2026-06-01 — Joining tooltip copy consolidation
 
 **Completed:**
@@ -974,4 +961,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm vitest run tests/components/StudentTestsTab.test.tsx`
 - `pnpm vitest run tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx`
+- `pnpm lint`
+
+## 2026-06-09 — Legacy quiz teacher Tests state naming pass
+
+**Completed:**
+- Created `codex/legacy-quiz-teacher-state-names` from merged `origin/main`.
+- Renamed `ClassroomPageClient` teacher Tests parent state from `selectedQuiz`/`handleSelectQuiz` to `selectedTest`/`handleSelectTest`.
+- Renamed the local pending-delete object key from `quiz` to `test` for active Tests deletion state.
+- Preserved legacy `quizId` query cleanup and existing child component/API compatibility contracts.
+- Did not touch database schema, migrations, RPCs, storage paths, or production API route contracts.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherTestsTab.test.tsx`
 - `pnpm lint`

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -590,10 +590,10 @@ function ClassroomPageContent({
   // State for calendar sidebar (teacher calendar tab)
   const [calendarSidebarState, setCalendarSidebarState] = useState<CalendarSidebarState | null>(null)
 
-  // State for selected assessment (teacher tests tab)
-  const [selectedQuiz, setSelectedQuiz] = useState<TestAssessmentWithStats | null>(null)
+  // State for selected test (teacher tests tab)
+  const [selectedTest, setSelectedTest] = useState<TestAssessmentWithStats | null>(null)
   const [pendingAssessmentDelete, setPendingAssessmentDelete] = useState<{
-    quiz: TestAssessmentWithStats
+    test: TestAssessmentWithStats
     responsesCount: number
   } | null>(null)
   const [isDeletingAssessment, setIsDeletingAssessment] = useState(false)
@@ -603,13 +603,13 @@ function ClassroomPageContent({
   } | null>(null)
   const [testsTabClickToken, setTestsTabClickToken] = useState(0)
 
-  const handleSelectQuiz = useCallback((quiz: TestAssessmentWithStats | null) => {
-    setSelectedQuiz(quiz)
+  const handleSelectTest = useCallback((test: TestAssessmentWithStats | null) => {
+    setSelectedTest(test)
   }, [])
 
   useEffect(() => {
     if (activeTab === 'tests') {
-      setSelectedQuiz(null)
+      setSelectedTest(null)
     }
   }, [activeTab])
 
@@ -621,10 +621,10 @@ function ClassroomPageContent({
 
   useEffect(() => {
     if (!teacherTestPreview) return
-    if (!selectedQuiz) return
-    if (selectedQuiz.id === teacherTestPreview.testId) return
+    if (!selectedTest) return
+    if (selectedTest.id === teacherTestPreview.testId) return
     setTeacherTestPreview(null)
-  }, [selectedQuiz, teacherTestPreview])
+  }, [selectedTest, teacherTestPreview])
 
   // State for markdown editing (teacher assignments tab - summary view only)
   const [assignmentViewMode, setAssignmentViewMode] = useState<AssignmentViewMode>('summary')
@@ -1097,26 +1097,26 @@ function ClassroomPageContent({
     hasActiveTeacherSplitPanes || hasTeacherViewportGrid || (!isTeacher && activeTab === 'today')
 
   async function handleRequestAssessmentDelete() {
-    if (!selectedQuiz) return
+    if (!selectedTest) return
 
     try {
       const data = await fetchJSONWithCache<{ stats?: { responded?: number } }>(
-        `teacher-assessment-results:${assessmentLabel}:${selectedQuiz.id}`,
+        `teacher-assessment-results:${assessmentLabel}:${selectedTest.id}`,
         async () => {
-          const res = await fetch(`${assessmentApiBasePath}/${selectedQuiz.id}/results`)
+          const res = await fetch(`${assessmentApiBasePath}/${selectedTest.id}/results`)
           if (!res.ok) throw new Error('Failed to load assessment results')
           return res.json()
         },
         0,
       )
       setPendingAssessmentDelete({
-        quiz: selectedQuiz,
+        test: selectedTest,
         responsesCount: Number(data?.stats?.responded || 0),
       })
     } catch {
       setPendingAssessmentDelete({
-        quiz: selectedQuiz,
-        responsesCount: Number(selectedQuiz.stats.responded || 0),
+        test: selectedTest,
+        responsesCount: Number(selectedTest.stats.responded || 0),
       })
     }
   }
@@ -1129,13 +1129,13 @@ function ClassroomPageContent({
 
     setIsDeletingAssessment(true)
     try {
-      const res = await fetch(`${deleteApiBasePath}/${pendingAssessmentDelete.quiz.id}`, { method: 'DELETE' })
+      const res = await fetch(`${deleteApiBasePath}/${pendingAssessmentDelete.test.id}`, { method: 'DELETE' })
       if (!res.ok) {
         const data = await res.json()
         throw new Error(data.error || `Failed to delete ${deleteLabel}`)
       }
 
-      setSelectedQuiz(null)
+      setSelectedTest(null)
       navigateInClassroom((params) => {
         params.delete('testId')
         params.delete('testMode')
@@ -1258,7 +1258,7 @@ function ClassroomPageContent({
                         selectedTestMode={testModeParam}
                         selectedTestStudentId={testStudentIdParam}
                         updateSearchParams={navigateInClassroom}
-                        onSelectTest={handleSelectQuiz}
+                        onSelectTest={handleSelectTest}
                         onRequestTestPreview={setTeacherTestPreview}
                         onRequestDelete={() => {
                           void handleRequestAssessmentDelete()


### PR DESCRIPTION
## Summary
- Rename ClassroomPageClient teacher Tests parent state from selectedQuiz/handleSelectQuiz to selectedTest/handleSelectTest.
- Rename the local pending-delete state key from quiz to test for active Tests deletion state.
- Preserve legacy quizId query cleanup and existing child component/API compatibility contracts.

## Risk
- Risk profile: workspace-state.
- This is a structural naming refactor only; no UI layout, schema, migration, RPC, storage, or API route contract changes.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh (includes pnpm test, 301 files / 2655 tests)
- pnpm exec tsc --noEmit
- pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherTestsTab.test.tsx
- pnpm lint