### PR TITLE
Add test prop aliases

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,19 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Joining tooltip copy consolidation
-
-**Completed:**
-- Moved the allow-new-students and join-mode explanatory copy into the `Joining` info tooltip.
-- Left the Settings rows as compact `Allow / Disallow` and `Roster / Open` toggles.
-
-**Validation:**
-- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
-- `pnpm test tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`.
-
 ## 2026-06-01 — Joining row copy refinement
 
 **Completed:**
@@ -976,4 +963,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
 - `pnpm exec tsc --noEmit`
 - `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+
+## 2026-06-09 — Legacy quiz component prop alias pass
+
+**Completed:**
+- Created `codex/legacy-quiz-prop-aliases` from merged `origin/main`.
+- Added test-named component prop aliases while preserving legacy compatibility props:
+  `testId` for `StudentTestForm`, `StudentTestResults`, and `TestIndividualResponses`; `test`/`onTestUpdate` for `TestDetailPanel`.
+- Migrated active app callers in `StudentTestsTab`, `TeacherTestsTab`, `TeacherTestPreviewPage`, and `TestDetailPanel` to test-named props.
+- Left legacy `quizId`, `quiz`, and `onQuizUpdate` props supported for existing tests/hidden callers.
+- Did not touch database schema, migrations, RPCs, storage paths, API payload keys, or DB-shaped `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
+- `pnpm exec tsc --noEmit`
+- `pnpm vitest run tests/components/StudentTestsTab.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
 - `pnpm lint`

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -1550,7 +1550,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                           </Button>
                         ) : hasResponded && selectedTest.test.student_status === 'can_view_results' ? (
                           <StudentTestResults
-                            quizId={selectedTestId!}
+                            testId={selectedTestId!}
                             myResponses={selectedTest.studentResponses}
                             assessmentType={assessmentType}
                             apiBasePath={apiBasePath}
@@ -1571,7 +1571,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                           </div>
                         ) : (
                           <StudentTestForm
-                            quizId={selectedTestId!}
+                            testId={selectedTestId!}
                             questions={selectedTest.questions}
                             initialResponses={selectedTest.studentResponses}
                             enableDraftAutosave
@@ -1710,7 +1710,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                     </div>
                   ) : hasResponded && selectedTest.test.student_status === 'can_view_results' ? (
                     <StudentTestResults
-                      quizId={selectedTestId!}
+                      testId={selectedTestId!}
                       myResponses={selectedTest.studentResponses}
                       assessmentType={assessmentType}
                       apiBasePath={apiBasePath}
@@ -1731,7 +1731,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
                     </div>
                   ) : (
                     <StudentTestForm
-                      quizId={selectedTestId!}
+                      testId={selectedTestId!}
                       questions={selectedTest.questions}
                       initialResponses={selectedTest.studentResponses}
                       enableDraftAutosave

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -2718,11 +2718,11 @@ export function TeacherTestsTab({
         <div className="min-h-0 flex-1 overflow-hidden">
           {selectedTestWorkspace ? (
             <TestDetailPanel
-              quiz={selectedTestWorkspace}
+              test={selectedTestWorkspace}
               classroomId={classroom.id}
               apiBasePath={apiBasePath}
               onDraftSummaryChange={handleSelectedTestDraftSummaryChange}
-              onQuizUpdate={(update) => {
+              onTestUpdate={(update) => {
                 if (update) {
                   applySelectedTestDraftSummary(update)
                   return

--- a/src/components/StudentTestForm.tsx
+++ b/src/components/StudentTestForm.tsx
@@ -18,7 +18,8 @@ import {
 import type { TestAssessmentType, TestAssessmentQuestion, TestResponseDraftValue } from '@/types'
 
 interface Props {
-  quizId: string
+  testId?: string
+  quizId?: string
   questions: TestAssessmentQuestion[]
   initialResponses?: Record<string, number | TestResponseDraftValue> | TestResponses
   enableDraftAutosave?: boolean
@@ -43,6 +44,7 @@ function isAssessmentAvailabilityError(message: string): boolean {
 }
 
 export function StudentTestForm({
+  testId: testIdProp,
   quizId,
   questions,
   initialResponses,
@@ -54,6 +56,12 @@ export function StudentTestForm({
   onAvailabilityLoss,
   onSubmitted,
 }: Props) {
+  const resolvedTestId = testIdProp ?? quizId
+  if (!resolvedTestId) {
+    throw new Error('StudentTestForm requires testId')
+  }
+  const testId: string = resolvedTestId
+
   const OPEN_RESPONSE_TAB_INDENT = '\t'
   const OPEN_RESPONSE_TAB_SIZE = 4
   const AUTOSAVE_DEBOUNCE_MS = 5000
@@ -137,25 +145,25 @@ export function StudentTestForm({
     pendingResponsesRef.current = normalized
     lastSavedResponsesRef.current = JSON.stringify(normalized)
     setSaveStatus('saved')
-  }, [initialResponses, quizId])
+  }, [initialResponses, testId])
 
   // Load and monitor flagged questions from localStorage
   useEffect(() => {
     const loadFlaggedQuestions = () => {
-      const flagged = getFlaggedQuestions(quizId)
+      const flagged = getFlaggedQuestions(testId)
       setFlaggedQuestions(flagged)
     }
     loadFlaggedQuestions()
 
     // Set up storage event listener for changes in other tabs
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === `pika:flagged-questions:${quizId}`) {
+      if (e.key === `pika:flagged-questions:${testId}`) {
         loadFlaggedQuestions()
       }
     }
     window.addEventListener('storage', handleStorageChange)
     return () => window.removeEventListener('storage', handleStorageChange)
-  }, [quizId])
+  }, [testId])
 
   const saveDraft = useCallback(async (
     draftResponses: TestResponses,
@@ -174,7 +182,7 @@ export function StudentTestForm({
     lastSaveAttemptAtRef.current = Date.now()
 
     try {
-      const res = await fetch(`${apiBasePath}/${quizId}/attempt`, {
+      const res = await fetch(`${apiBasePath}/${testId}/attempt`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -196,7 +204,7 @@ export function StudentTestForm({
       }
       setSaveStatus('unsaved')
     }
-  }, [apiBasePath, onAvailabilityLoss, quizId, shouldAutosave])
+  }, [apiBasePath, onAvailabilityLoss, testId, shouldAutosave])
 
   useEffect(() => {
     return () => {
@@ -409,7 +417,7 @@ export function StudentTestForm({
         await saveDraft(responses, { trigger: 'blur', force: true })
       }
 
-      const res = await fetch(`${apiBasePath}/${quizId}/respond`, {
+      const res = await fetch(`${apiBasePath}/${testId}/respond`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -421,7 +429,7 @@ export function StudentTestForm({
         throw new Error(data.error || 'Failed to submit response')
       }
       // Clear flagged questions on successful submission
-      clearFlaggedQuestions(quizId)
+      clearFlaggedQuestions(testId)
       setFlaggedQuestions([])
       onSubmitted()
     } catch (err: any) {
@@ -438,8 +446,8 @@ export function StudentTestForm({
   }
 
   function handleToggleFlagged(questionId: string) {
-    const newState = toggleFlaggedQuestion(quizId, questionId)
-    const updated = getFlaggedQuestions(quizId)
+    const newState = toggleFlaggedQuestion(testId, questionId)
+    const updated = getFlaggedQuestions(testId)
     setFlaggedQuestions(updated)
   }
 
@@ -455,7 +463,7 @@ export function StudentTestForm({
                   response?.question_type === 'open_response' ? response.response_text : ''
                 const selectedOption =
                   response?.question_type === 'multiple_choice' ? response.selected_option : null
-                const isFlagged = isQuestionFlagged(quizId, question.id)
+                const isFlagged = isQuestionFlagged(testId, question.id)
 
                 return (
                   <>

--- a/src/components/StudentTestResults.tsx
+++ b/src/components/StudentTestResults.tsx
@@ -52,7 +52,8 @@ function selectedOptionFromResponse(
 }
 
 interface Props {
-  quizId: string
+  testId?: string
+  quizId?: string
   myResponses: Record<string, number | TestResponseDraftValue>
   assessmentType?: TestAssessmentType
   apiBasePath?: string
@@ -60,12 +61,19 @@ interface Props {
 }
 
 export function StudentTestResults({
+  testId: testIdProp,
   quizId,
   myResponses,
   assessmentType,
   apiBasePath = '/api/student/tests',
   showSubmissionBanner = true,
 }: Props) {
+  const resolvedTestId = testIdProp ?? quizId
+  if (!resolvedTestId) {
+    throw new Error('StudentTestResults requires testId')
+  }
+  const testId: string = resolvedTestId
+
   const [payload, setPayload] = useState<ResultsPayload | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -82,8 +90,8 @@ export function StudentTestResults({
 
     async function loadResults() {
       try {
-        // Bypass fetchJSONWithCache so returned results always follow the selected quizId.
-        const res = await fetch(`${apiBasePath}/${quizId}/results`)
+        // Bypass fetchJSONWithCache so returned results always follow the selected testId.
+        const res = await fetch(`${apiBasePath}/${testId}/results`)
         const data = await res.json()
         if (requestIdRef.current !== requestId) return
         if (!res.ok) {
@@ -101,7 +109,7 @@ export function StudentTestResults({
       }
     }
     loadResults()
-  }, [apiBasePath, quizId])
+  }, [apiBasePath, testId])
 
   if (loading) {
     return (

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -522,7 +522,7 @@ export function TeacherTestPreviewPage({
               <h2 className="text-xl font-bold text-text-default">{title}</h2>
               {questions.length > 0 ? (
                 <StudentTestForm
-                  quizId={testId}
+                  testId={testId}
                   questions={questions}
                   assessmentType="test"
                   previewMode

--- a/src/components/TestDetailPanel.tsx
+++ b/src/components/TestDetailPanel.tsx
@@ -50,10 +50,12 @@ import type {
 } from '@/types'
 
 interface Props {
-  quiz: TestAssessmentWithStats
+  test?: TestAssessmentWithStats
+  quiz?: TestAssessmentWithStats
   classroomId: string
   apiBasePath?: string
-  onQuizUpdate: (update?: AssessmentEditorSummaryUpdate) => void
+  onTestUpdate?: (update?: AssessmentEditorSummaryUpdate) => void
+  onQuizUpdate?: (update?: AssessmentEditorSummaryUpdate) => void
   onDraftSummaryChange?: (update: AssessmentEditorSummaryUpdate) => void
   onRequestDelete?: () => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
@@ -145,10 +147,12 @@ function summarizeDraftContent(
 }
 
 export function TestDetailPanel({
-  quiz,
+  test,
+  quiz: legacyQuiz,
   classroomId,
   apiBasePath = '/api/teacher/tests',
-  onQuizUpdate,
+  onTestUpdate,
+  onQuizUpdate: legacyOnQuizUpdate,
   onDraftSummaryChange,
   onRequestDelete,
   onRequestTestPreview,
@@ -163,6 +167,17 @@ export function TestDetailPanel({
   titlePortalTarget = null,
   generatedTitleLabel,
 }: Props) {
+  const resolvedTest = test ?? legacyQuiz
+  const resolvedOnTestUpdate = onTestUpdate ?? legacyOnQuizUpdate
+  if (!resolvedTest) {
+    throw new Error('TestDetailPanel requires test')
+  }
+  if (!resolvedOnTestUpdate) {
+    throw new Error('TestDetailPanel requires onTestUpdate')
+  }
+  const quiz: TestAssessmentWithStats = resolvedTest
+  const onQuizUpdate: (update?: AssessmentEditorSummaryUpdate) => void = resolvedOnTestUpdate
+
   const AUTOSAVE_DEBOUNCE_MS = 3000
   const AUTOSAVE_MIN_INTERVAL_MS = 10_000
   const isTestsView = quiz.assessment_type === 'test' || apiBasePath.includes('/tests')
@@ -2260,7 +2275,7 @@ export function TestDetailPanel({
             {hasResponses && !isTestsView && (
               <div className="pt-4 border-t border-border">
                 <TestIndividualResponses
-                  quizId={quiz.id}
+                  testId={quiz.id}
                   apiBasePath={apiBasePath}
                   assessmentType={isTestsView ? 'test' : 'quiz'}
                   onUpdated={loadQuizDetails}

--- a/src/components/TestIndividualResponses.tsx
+++ b/src/components/TestIndividualResponses.tsx
@@ -34,7 +34,8 @@ interface Responder {
 }
 
 interface Props {
-  quizId: string
+  testId?: string
+  quizId?: string
   apiBasePath?: string
   assessmentType?: 'quiz' | 'test'
   onUpdated?: () => void
@@ -79,13 +80,20 @@ function toTestAnswerDetail(answer: number | TestAnswerDetail | undefined): Test
 }
 
 export function TestIndividualResponses({
+  testId: testIdProp,
   quizId,
   apiBasePath = '/api/teacher/tests',
   assessmentType = 'test',
   onUpdated,
 }: Props) {
+  const resolvedTestId = testIdProp ?? quizId
+  if (!resolvedTestId) {
+    throw new Error('TestIndividualResponses requires testId')
+  }
+  const testId: string = resolvedTestId
+
   const isTestsView = assessmentType === 'test'
-  const scope = `${assessmentType}:${apiBasePath}:${quizId}`
+  const scope = `${assessmentType}:${apiBasePath}:${testId}`
   const [dataState, setDataState] = useState<ResponsesDataState | null>(null)
   const [loading, setLoading] = useState(true)
   const [errorState, setErrorState] = useState<ScopedMessageState | null>(null)
@@ -116,7 +124,7 @@ export function TestIndividualResponses({
     setErrorState(null)
     try {
       // Bypass fetchJSONWithCache for selected assessment responses freshness; request ids guard stale responses.
-      const res = await fetch(`${apiBasePath}/${quizId}/results`)
+      const res = await fetch(`${apiBasePath}/${testId}/results`)
       const data = await res.json()
       if (loadRequestIdRef.current !== requestId || currentScopeRef.current !== requestedScope) return
       if (!res.ok) throw new Error(data.error || 'Failed to load')
@@ -157,7 +165,7 @@ export function TestIndividualResponses({
         setLoading(false)
       }
     }
-  }, [apiBasePath, isTestsView, quizId, scope])
+  }, [apiBasePath, isTestsView, testId, scope])
 
   useEffect(() => {
     void load()
@@ -187,7 +195,7 @@ export function TestIndividualResponses({
     setGradingMessageState(null)
     setSuggestingResponseId(responseId)
     try {
-      const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}/ai-suggest`, {
+      const res = await fetch(`${apiBasePath}/${testId}/responses/${responseId}/ai-suggest`, {
         method: 'POST',
       })
       const data = await res.json()
@@ -235,7 +243,7 @@ export function TestIndividualResponses({
     setGradingMessageState(null)
     setSavingResponseId(responseId)
     try {
-      const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}`, {
+      const res = await fetch(`${apiBasePath}/${testId}/responses/${responseId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -272,7 +280,7 @@ export function TestIndividualResponses({
     setGradingMessageState(null)
     setSavingResponseId(responseId)
     try {
-      const res = await fetch(`${apiBasePath}/${quizId}/responses/${responseId}`, {
+      const res = await fetch(`${apiBasePath}/${testId}/responses/${responseId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ clear_grade: true }),

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/lib/gradebook-cache', () => ({
 
 vi.mock('@/components/TestDetailPanel', () => ({
   TestDetailPanel: ({
+    test,
     quiz,
     testQuestionLayout,
     showPreviewButton,
@@ -31,11 +32,13 @@ vi.mock('@/components/TestDetailPanel', () => ({
     onSaveStatusChange,
     onRequestTestPreview,
     onDraftSummaryChange,
+    onTestUpdate,
     onQuizUpdate,
     titlePortalTarget,
     generatedTitleLabel,
   }: {
-    quiz: QuizWithStats
+    test?: QuizWithStats
+    quiz?: QuizWithStats
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
@@ -43,6 +46,11 @@ vi.mock('@/components/TestDetailPanel', () => ({
     onSaveStatusChange?: (status: 'saved' | 'saving' | 'unsaved') => void
     onRequestTestPreview?: (preview: { testId: string; title: string }) => void
     onDraftSummaryChange?: (update: {
+      title: string
+      show_results: boolean
+      questions_count: number
+    }) => void
+    onTestUpdate?: (update?: {
       title: string
       show_results: boolean
       questions_count: number
@@ -55,10 +63,12 @@ vi.mock('@/components/TestDetailPanel', () => ({
     titlePortalTarget?: HTMLElement | null
     generatedTitleLabel?: string
   }) => {
+    const selectedTest = test ?? quiz
+    if (!selectedTest) throw new Error('Mock TestDetailPanel requires test')
     const [pendingMarkdown, setPendingMarkdown] = useState(false)
-    const displayedTitle = /^Untitled(?:\s+\d{4}-\d{2}-\d{2}(?:\s+\d{2}:\d{2}:\d{2})?)?$/.test(quiz.title)
+    const displayedTitle = /^Untitled(?:\s+\d{4}-\d{2}-\d{2}(?:\s+\d{2}:\d{2}:\d{2})?)?$/.test(selectedTest.title)
       ? generatedTitleLabel || 'Untitled'
-      : quiz.title
+      : selectedTest.title
 
     return (
       <>
@@ -76,12 +86,12 @@ vi.mock('@/components/TestDetailPanel', () => ({
           data-show-preview={String(showPreviewButton)}
           data-show-results={String(showResultsTab)}
         >
-          Detail for {quiz.title}
+          Detail for {selectedTest.title}
           {showPreviewButton ? (
             <button
               type="button"
               disabled={pendingMarkdown}
-              onClick={() => onRequestTestPreview?.({ testId: quiz.id, title: quiz.title })}
+              onClick={() => onRequestTestPreview?.({ testId: selectedTest.id, title: selectedTest.title })}
             >
               Preview
             </button>
@@ -114,7 +124,7 @@ vi.mock('@/components/TestDetailPanel', () => ({
             type="button"
             onClick={() =>
               onDraftSummaryChange?.({
-                title: `${quiz.title} Draft`,
+                title: `${selectedTest.title} Draft`,
                 show_results: false,
                 questions_count: 0,
               })
@@ -125,8 +135,8 @@ vi.mock('@/components/TestDetailPanel', () => ({
           <button
             type="button"
             onClick={() =>
-              onQuizUpdate?.({
-                title: `${quiz.title} Updated`,
+              (onTestUpdate ?? onQuizUpdate)?.({
+                title: `${selectedTest.title} Updated`,
                 show_results: false,
                 questions_count: 0,
               })


### PR DESCRIPTION
## Summary
- Add test-named prop aliases while preserving legacy compatibility props:
  - StudentTestForm, StudentTestResults, TestIndividualResponses: testId with quizId fallback.
  - TestDetailPanel: test/onTestUpdate with quiz/onQuizUpdate fallback.
- Migrate active app callers to test-named props.
- Keep legacy prop support for tests and hidden/internal callers.

## Risk
- Risk profile: workspace-state, exam-mode.
- Compatibility-first prop aliasing only; no layout, schema, migration, RPC, storage, API payload, or DB-shaped quiz_id changes.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh (includes pnpm test, 301 files / 2655 tests)
- pnpm exec tsc --noEmit
- pnpm vitest run tests/components/StudentTestsTab.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
- pnpm lint