### PR TITLE
[codex] Migrate test prop component tests

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -8,23 +8,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-01 — Joining row copy refinement
-
-**Completed:**
-- Restored brief row-level copy for joining controls while keeping the tooltip concise.
-- Added an X marker inside the off-side toggle thumb.
-- Linked the roster-mode row copy to the classroom roster tab.
-- Added focused coverage for the visible joining copy and roster link.
-
-**Validation:**
-- `pnpm test tests/components/TeacherSettingsTab.test.tsx`
-- `pnpm test tests/components/TeacherSettingsTab.test.tsx tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `pnpm build`
-- `git diff --check`
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- Visual verification: Settings desktop/mobile/student screenshots via `pika-ui-verify`; checked the Disallow/X off state and restored the classroom to allowed.
-
 ## 2026-06-01 — Roster join row wording
 
 **Completed:**
@@ -980,3 +963,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm vitest run tests/components/StudentTestsTab.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
 - `pnpm lint`
+
+## 2026-06-09 — Legacy quiz component test prop migration pass
+
+**Completed:**
+- Created `codex/legacy-quiz-test-prop-tests` from merged `origin/main`.
+- Migrated direct component tests for `StudentTestForm`, `StudentTestResults`, `TestIndividualResponses`, and `TestDetailPanel` to active `testId`, `test`, and `onTestUpdate` props.
+- Added narrow compatibility assertions for legacy `quizId`, `quiz`, and `onQuizUpdate` aliases so fallback support remains intentional.
+- Updated the `TeacherTestsTab` mock of `TestDetailPanel` to model the active test-named prop contract instead of accepting legacy aliases.
+- Did not touch production runtime code, database schema, migrations, RPCs, storage paths, API payload keys, or DB-shaped `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests before edits)
+- `pnpm vitest run tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
+- `pnpm test` (301 files / 2659 tests)

--- a/tests/components/StudentTestForm.test.tsx
+++ b/tests/components/StudentTestForm.test.tsx
@@ -15,12 +15,37 @@ describe('StudentTestForm preview mode', () => {
     localStorage.clear()
   })
 
+  it('accepts legacy quizId as a compatibility alias', () => {
+    render(
+      <StudentTestForm
+        quizId="legacy-test-id"
+        questions={[
+          createMockQuizQuestion({
+            id: 'q1',
+            question_text: 'Which option is correct?',
+            options: ['A', 'B'],
+            question_type: 'multiple_choice',
+            position: 0,
+          }),
+        ]}
+        assessmentType="test"
+        previewMode
+        onSubmitted={vi.fn()}
+      />
+    )
+
+    const titleArea = screen.getByText('Q1').closest('[data-question-title-id="q1"]')!
+    fireEvent.click(titleArea)
+
+    expect(JSON.parse(localStorage.getItem('pika:flagged-questions:legacy-test-id') || '[]')).toContain('q1')
+  })
+
   it('simulates submit without saving data', async () => {
     const onSubmitted = vi.fn()
 
     render(
       <StudentTestForm
-        quizId="test-preview-id"
+        testId="test-preview-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -51,7 +76,7 @@ describe('StudentTestForm preview mode', () => {
   it('labels open-response textboxes for assistive technology', () => {
     render(
       <StudentTestForm
-        quizId="test-open-response-label-id"
+        testId="test-open-response-label-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -74,7 +99,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-flag-id"
+        testId="test-flag-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -117,7 +142,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-warning-id"
+        testId="test-warning-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -154,7 +179,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-footer-id"
+        testId="test-footer-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -199,7 +224,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-radio-position-id"
+        testId="test-radio-position-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -229,7 +254,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-markdown-options-id"
+        testId="test-markdown-options-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',
@@ -264,7 +289,7 @@ describe('StudentTestForm preview mode', () => {
 
     render(
       <StudentTestForm
-        quizId="test-closed-id"
+        testId="test-closed-id"
         questions={[
           createMockQuizQuestion({
             id: 'q1',

--- a/tests/components/StudentTestResults.test.tsx
+++ b/tests/components/StudentTestResults.test.tsx
@@ -25,12 +25,26 @@ describe('StudentTestResults', () => {
     return { ok: true, json: async () => body } as Response
   }
 
+  it('accepts legacy quizId as a compatibility alias', async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [] }),
+    })
+
+    render(<StudentTestResults quizId="legacy-test-id" myResponses={{}} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/student/tests/legacy-test-id/results')
+    })
+  })
+
   it('shows loading spinner initially', () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockReturnValue(new Promise(() => {})) // never resolves
 
     const { container } = render(
-      <StudentTestResults quizId="quiz-1" myResponses={{}} />
+      <StudentTestResults testId="quiz-1" myResponses={{}} />
     )
 
     // Spinner renders an svg or loading element
@@ -44,7 +58,7 @@ describe('StudentTestResults', () => {
       json: async () => ({ error: 'Quiz not found' }),
     })
 
-    render(<StudentTestResults quizId="quiz-1" myResponses={{}} />)
+    render(<StudentTestResults testId="quiz-1" myResponses={{}} />)
 
     await waitFor(() => {
       expect(screen.getByText('Quiz not found')).toBeInTheDocument()
@@ -58,7 +72,7 @@ describe('StudentTestResults', () => {
       json: async () => ({ results: [] }),
     })
 
-    render(<StudentTestResults quizId="quiz-1" myResponses={{}} />)
+    render(<StudentTestResults testId="quiz-1" myResponses={{}} />)
 
     await waitFor(() => {
       expect(screen.getByText('No results available.')).toBeInTheDocument()
@@ -97,7 +111,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        quizId="quiz-1"
+        testId="quiz-1"
         myResponses={{ q1: 1 }}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -144,7 +158,7 @@ describe('StudentTestResults', () => {
 
     const { container } = render(
       <StudentTestResults
-        quizId="quiz-1"
+        testId="quiz-1"
         myResponses={{ q1: 0 }}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -205,7 +219,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        quizId="quiz-1"
+        testId="quiz-1"
         myResponses={{}}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -255,7 +269,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        quizId="quiz-1"
+        testId="quiz-1"
         myResponses={{}}
         assessmentType="test"
         apiBasePath="/api/student/tests"

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -24,7 +24,6 @@ vi.mock('@/lib/gradebook-cache', () => ({
 vi.mock('@/components/TestDetailPanel', () => ({
   TestDetailPanel: ({
     test,
-    quiz,
     testQuestionLayout,
     showPreviewButton,
     showResultsTab,
@@ -33,12 +32,10 @@ vi.mock('@/components/TestDetailPanel', () => ({
     onRequestTestPreview,
     onDraftSummaryChange,
     onTestUpdate,
-    onQuizUpdate,
     titlePortalTarget,
     generatedTitleLabel,
   }: {
     test?: QuizWithStats
-    quiz?: QuizWithStats
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
@@ -55,20 +52,14 @@ vi.mock('@/components/TestDetailPanel', () => ({
       show_results: boolean
       questions_count: number
     }) => void
-    onQuizUpdate?: (update?: {
-      title: string
-      show_results: boolean
-      questions_count: number
-    }) => void
     titlePortalTarget?: HTMLElement | null
     generatedTitleLabel?: string
   }) => {
-    const selectedTest = test ?? quiz
-    if (!selectedTest) throw new Error('Mock TestDetailPanel requires test')
+    if (!test) throw new Error('Mock TestDetailPanel requires test')
     const [pendingMarkdown, setPendingMarkdown] = useState(false)
-    const displayedTitle = /^Untitled(?:\s+\d{4}-\d{2}-\d{2}(?:\s+\d{2}:\d{2}:\d{2})?)?$/.test(selectedTest.title)
+    const displayedTitle = /^Untitled(?:\s+\d{4}-\d{2}-\d{2}(?:\s+\d{2}:\d{2}:\d{2})?)?$/.test(test.title)
       ? generatedTitleLabel || 'Untitled'
-      : selectedTest.title
+      : test.title
 
     return (
       <>
@@ -86,12 +77,12 @@ vi.mock('@/components/TestDetailPanel', () => ({
           data-show-preview={String(showPreviewButton)}
           data-show-results={String(showResultsTab)}
         >
-          Detail for {selectedTest.title}
+          Detail for {test.title}
           {showPreviewButton ? (
             <button
               type="button"
               disabled={pendingMarkdown}
-              onClick={() => onRequestTestPreview?.({ testId: selectedTest.id, title: selectedTest.title })}
+              onClick={() => onRequestTestPreview?.({ testId: test.id, title: test.title })}
             >
               Preview
             </button>
@@ -124,7 +115,7 @@ vi.mock('@/components/TestDetailPanel', () => ({
             type="button"
             onClick={() =>
               onDraftSummaryChange?.({
-                title: `${selectedTest.title} Draft`,
+                title: `${test.title} Draft`,
                 show_results: false,
                 questions_count: 0,
               })
@@ -135,8 +126,8 @@ vi.mock('@/components/TestDetailPanel', () => ({
           <button
             type="button"
             onClick={() =>
-              (onTestUpdate ?? onQuizUpdate)?.({
-                title: `${selectedTest.title} Updated`,
+              onTestUpdate?.({
+                title: `${test.title} Updated`,
                 show_results: false,
                 questions_count: 0,
               })

--- a/tests/components/TestDetailPanel.test.tsx
+++ b/tests/components/TestDetailPanel.test.tsx
@@ -116,6 +116,25 @@ describe('TestDetailPanel', () => {
     return fetchMock
   }
 
+  it('accepts legacy quiz and onQuizUpdate as compatibility aliases', async () => {
+    mockFetchForTest(sampleQuestions)
+    const legacyTest = makeTestWithStats({ title: 'Legacy Alias Test' })
+    const legacyOnQuizUpdate = vi.fn()
+
+    render(
+      <TestDetailPanel
+        quiz={legacyTest}
+        classroomId="classroom-1"
+        onQuizUpdate={legacyOnQuizUpdate}
+      />,
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Legacy Alias Test')).toBeInTheDocument()
+    })
+  })
+
   it('ignores stale draft responses after selected assessment changes', async () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     const staleDraft = createDeferred<Response>()
@@ -142,7 +161,7 @@ describe('TestDetailPanel', () => {
     const staleQuiz = makeTestWithStats({ id: 'quiz-stale', title: 'Stale Quiz' })
     const currentQuiz = makeTestWithStats({ id: 'quiz-current', title: 'Current Quiz' })
     const { rerender } = render(
-      <TestDetailPanel quiz={staleQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
+      <TestDetailPanel test={staleQuiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />,
       { wrapper: Wrapper }
     )
 
@@ -151,7 +170,7 @@ describe('TestDetailPanel', () => {
     })
 
     rerender(
-      <TestDetailPanel quiz={currentQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />
+      <TestDetailPanel test={currentQuiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />
     )
 
     await waitFor(() => {
@@ -240,11 +259,10 @@ describe('TestDetailPanel', () => {
       assessment_type: 'test',
     })
     const { rerender } = render(
-      <TestDetailPanel
-        quiz={staleTest}
+      <TestDetailPanel test={staleTest}
         classroomId="classroom-1"
         apiBasePath="/api/teacher/tests"
-        onQuizUpdate={vi.fn()}
+        onTestUpdate={vi.fn()}
       />,
       { wrapper: Wrapper }
     )
@@ -254,11 +272,10 @@ describe('TestDetailPanel', () => {
     })
 
     rerender(
-      <TestDetailPanel
-        quiz={currentTest}
+      <TestDetailPanel test={currentTest}
         classroomId="classroom-1"
         apiBasePath="/api/teacher/tests"
-        onQuizUpdate={vi.fn()}
+        onTestUpdate={vi.fn()}
       />
     )
 
@@ -333,7 +350,7 @@ describe('TestDetailPanel', () => {
       assessment_type: 'test',
     })
     const { rerender } = render(
-      <TestDetailPanel quiz={sameIdQuiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />,
+      <TestDetailPanel test={sameIdQuiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />,
       { wrapper: Wrapper }
     )
 
@@ -342,7 +359,7 @@ describe('TestDetailPanel', () => {
     })
 
     rerender(
-      <TestDetailPanel quiz={sameIdTest} classroomId="classroom-1" onQuizUpdate={vi.fn()} />
+      <TestDetailPanel test={sameIdTest} classroomId="classroom-1" onTestUpdate={vi.fn()} />
     )
 
     await waitFor(() => {
@@ -413,7 +430,7 @@ describe('TestDetailPanel', () => {
       mockFetchForTest(sampleQuestions)
       const quiz = makeTestWithStats()
 
-      render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+      render(<TestDetailPanel test={quiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />, { wrapper: Wrapper })
 
       await waitFor(() => {
         expect(screen.getByText('Questions (2)')).toBeInTheDocument()
@@ -453,11 +470,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -502,11 +518,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -555,11 +570,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           showPreviewButton={false}
           showResultsTab={false}
         />,
@@ -614,11 +628,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -765,11 +778,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="editor-only"
           showPreviewButton={false}
           showResultsTab={false}
@@ -824,11 +836,10 @@ describe('TestDetailPanel', () => {
         return (
           <>
             <div data-testid="test-modal-title-target" ref={setTitleTarget} />
-            <TestDetailPanel
-              quiz={testQuiz}
+            <TestDetailPanel test={testQuiz}
               classroomId="classroom-1"
               apiBasePath="/api/teacher/tests"
-              onQuizUpdate={vi.fn()}
+              onTestUpdate={vi.fn()}
               testQuestionLayout="editor-only"
               showPreviewButton={false}
               showResultsTab={false}
@@ -878,11 +889,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="markdown-only"
           showPreviewButton={false}
           showResultsTab={false}
@@ -933,11 +943,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1061,11 +1070,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1122,11 +1130,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           onDraftSummaryChange={onDraftSummaryChange}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
@@ -1208,13 +1215,12 @@ describe('TestDetailPanel', () => {
         stats: { total_students: 25, responded: 0, questions_count: 0 },
       })
 
-      const onQuizUpdateInitial = vi.fn()
+      const onTestUpdateInitial = vi.fn()
       const { rerender } = render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={onQuizUpdateInitial}
+          onTestUpdate={onTestUpdateInitial}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1229,13 +1235,12 @@ describe('TestDetailPanel', () => {
         expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
       })
 
-      const onQuizUpdateNext = vi.fn()
+      const onTestUpdateNext = vi.fn()
       rerender(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={onQuizUpdateNext}
+          onTestUpdate={onTestUpdateNext}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1311,11 +1316,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           onSaveStatusChange={onSaveStatusChange}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
@@ -1431,11 +1435,10 @@ describe('TestDetailPanel', () => {
       })
 
       const { rerender } = render(
-        <TestDetailPanel
-          quiz={staleTest}
+        <TestDetailPanel test={staleTest}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1456,11 +1459,10 @@ describe('TestDetailPanel', () => {
       vi.useRealTimers()
 
       rerender(
-        <TestDetailPanel
-          quiz={currentTest}
+        <TestDetailPanel test={currentTest}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1558,11 +1560,10 @@ describe('TestDetailPanel', () => {
       })
 
       const { rerender } = render(
-        <TestDetailPanel
-          quiz={staleTest}
+        <TestDetailPanel test={staleTest}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1577,11 +1578,10 @@ describe('TestDetailPanel', () => {
       expect(fetchMock.mock.calls.filter((call: any[]) => call[1]?.method === 'PATCH')).toHaveLength(0)
 
       rerender(
-        <TestDetailPanel
-          quiz={currentTest}
+        <TestDetailPanel test={currentTest}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1633,11 +1633,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1696,11 +1695,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1758,11 +1756,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -1821,11 +1818,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           onPendingMarkdownImportChange={onPendingMarkdownImportChange}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
@@ -1895,11 +1891,10 @@ describe('TestDetailPanel', () => {
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="summary-detail"
           showPreviewButton={false}
           showResultsTab={false}
@@ -2040,11 +2035,10 @@ _None_
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2125,11 +2119,10 @@ _None_
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           onRequestTestPreview={onRequestTestPreview}
         />,
         { wrapper: Wrapper }
@@ -2214,11 +2207,10 @@ Correct Option: 2
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2277,11 +2269,10 @@ Correct Option: 2
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
           testQuestionLayout="markdown-only"
         />,
         { wrapper: Wrapper }
@@ -2295,7 +2286,7 @@ Correct Option: 2
 
     it('applies valid markdown and saves through draft endpoint', async () => {
       const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
-      const onQuizUpdate = vi.fn()
+      const onTestUpdate = vi.fn()
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
@@ -2361,11 +2352,10 @@ Correct Option: 2
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={onQuizUpdate}
+          onTestUpdate={onTestUpdate}
         />,
         { wrapper: Wrapper }
       )
@@ -2427,7 +2417,7 @@ _None_
       expect(body.content.show_results).toBe(true)
       expect(body.content.questions).toHaveLength(2)
       expect(body.documents).toEqual([])
-      expect(onQuizUpdate).toHaveBeenLastCalledWith({
+      expect(onTestUpdate).toHaveBeenLastCalledWith({
         title: 'Markdown Test Updated',
         show_results: true,
         questions_count: 2,
@@ -2465,11 +2455,10 @@ _None_
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2533,11 +2522,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2558,7 +2546,7 @@ Prompt:
       mockFetchForTest(sampleQuestions)
       const quiz = makeTestWithStats({ title: 'My Cool Test' })
 
-      render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+      render(<TestDetailPanel test={quiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />, { wrapper: Wrapper })
 
       await waitFor(() => {
         expect(screen.getByText('My Cool Test')).toBeInTheDocument()
@@ -2573,7 +2561,7 @@ Prompt:
       mockFetchForTest([])
       const quiz = makeTestWithStats()
 
-      render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+      render(<TestDetailPanel test={quiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />, { wrapper: Wrapper })
 
       await waitFor(() => {
         expect(screen.queryByText('Quiz must have at least 1 question')).not.toBeInTheDocument()
@@ -2597,11 +2585,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2648,11 +2635,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2717,11 +2703,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2788,11 +2773,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -2889,11 +2873,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -3010,11 +2993,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -3115,11 +3097,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -3208,11 +3189,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -3280,11 +3260,10 @@ Prompt:
       })
 
       render(
-        <TestDetailPanel
-          quiz={testQuiz}
+        <TestDetailPanel test={testQuiz}
           classroomId="classroom-1"
           apiBasePath="/api/teacher/tests"
-          onQuizUpdate={vi.fn()}
+          onTestUpdate={vi.fn()}
         />,
         { wrapper: Wrapper }
       )
@@ -3307,7 +3286,7 @@ Prompt:
       const fetchMock = mockFetchForTest(sampleQuestions)
       const quiz = makeTestWithStats({ title: 'Old Title' })
 
-      render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+      render(<TestDetailPanel test={quiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />, { wrapper: Wrapper })
 
       await waitFor(() => {
         expect(screen.getByText('Old Title')).toBeInTheDocument()
@@ -3340,7 +3319,7 @@ Prompt:
       mockFetchForTest(sampleQuestions)
       const quiz = makeTestWithStats({ title: 'Original' })
 
-      render(<TestDetailPanel quiz={quiz} classroomId="classroom-1" onQuizUpdate={vi.fn()} />, { wrapper: Wrapper })
+      render(<TestDetailPanel test={quiz} classroomId="classroom-1" onTestUpdate={vi.fn()} />, { wrapper: Wrapper })
 
       await waitFor(() => {
         expect(screen.getByText('Original')).toBeInTheDocument()

--- a/tests/components/TestIndividualResponses.test.tsx
+++ b/tests/components/TestIndividualResponses.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
 import type { ReactNode } from 'react'
@@ -56,6 +56,20 @@ describe('TestIndividualResponses', () => {
     vi.restoreAllMocks()
   })
 
+  it('accepts legacy quizId as a compatibility alias', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({
+      questions: [],
+      responders: [],
+    })))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TestIndividualResponses quizId="legacy-test-id" />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests/legacy-test-id/results')
+    })
+  })
+
   it('ignores stale result responses after selected quiz changes', async () => {
     const staleResults = createDeferred<Response>()
     const currentResults = createDeferred<Response>()
@@ -67,10 +81,10 @@ describe('TestIndividualResponses', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { rerender } = render(<TestIndividualResponses quizId="quiz-stale" />)
+    const { rerender } = render(<TestIndividualResponses testId="quiz-stale" />)
 
     await act(async () => {
-      rerender(<TestIndividualResponses quizId="quiz-current" />)
+      rerender(<TestIndividualResponses testId="quiz-current" />)
     })
 
     await act(async () => {
@@ -104,13 +118,13 @@ describe('TestIndividualResponses', () => {
     const mounted = createMountedRoot()
     try {
       await act(async () => {
-        mounted.render(<TestIndividualResponses quizId="quiz-stale" />)
+        mounted.render(<TestIndividualResponses testId="quiz-stale" />)
       })
 
       expect(await screen.findByText('Already Loaded Student')).toBeInTheDocument()
 
       flushSync(() => {
-        mounted.render(<TestIndividualResponses quizId="quiz-current" />)
+        mounted.render(<TestIndividualResponses testId="quiz-current" />)
       })
 
       expect(screen.queryByText('Already Loaded Student')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- migrate direct component tests to the active `testId`, `test`, and `onTestUpdate` props
- add narrow compatibility assertions for legacy `quizId`, `quiz`, and `onQuizUpdate` aliases
- update the `TeacherTestsTab` `TestDetailPanel` mock to model the active test-named prop contract

## Impact
This is a tests-only cleanup pass. It does not change production runtime code, database schema, migrations, RPCs, storage paths, API payloads, or DB-shaped `quiz_id` fields.

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (pre-edit full suite, 301 files / 2655 tests)
- `pnpm vitest run tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
- `pnpm test` (301 files / 2659 tests)
