### PR TITLE
chore(workflow): add orient-only session start

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,42 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-04 — Resource sidebar freshness audit
-
-**Completed:**
-- Added a shared client helper for teacher and student classroom resource reads, cache keys, and cross-role invalidation after teacher saves.
-- Made teacher and student resource sidebars ignore stale responses from older classroom reads and only render content for the classroom that actually finished loading.
-- Added sidebar regressions for hiding stale teacher/student resources during classroom switches and invalidating student resource cache after a teacher save.
-- Addressed PR review feedback by scoping pending teacher resource autosave drafts and save completions to their classroom id so blur/unload saves and stale in-flight saves cannot corrupt the newly selected classroom state.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx`
-- `pnpm vitest run tests/components/ClassResourcesSidebar.test.tsx tests/components/ResourcesTab.test.tsx tests/api/teacher/resources.test.ts tests/api/student/resources.test.ts`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
-## 2026-06-04 — Classwork materials freshness audit
-
-**Completed:**
-- Made the student assignments/materials/surveys tab reset loaded state on classroom changes, hide previous classroom classwork while the next classroom loads, and ignore stale classwork responses.
-- Guarded teacher classwork summary loads and rendered teacher classwork only from data loaded for the current classroom so older assignment/material/survey/class-day reads cannot overwrite or remain interactive under a new classroom shell.
-- Added component regressions for active student classroom switches, stale teacher classwork load completion after switching classrooms, and hiding already-loaded teacher classwork while the next classroom loads.
-- Addressed PR review feedback by requiring the selected teacher assignment workspace to belong to the currently loaded classroom before loading details, exposing workspace props, or accepting stale detail completions.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm vitest run tests/api/teacher/materials.test.ts tests/api/student/materials.test.ts tests/components/StudentAssignmentsTab.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
 ## 2026-06-04 — Classroom shell freshness audit
 
 **Completed:**
@@ -664,6 +628,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
 - `E2E_BASE_URL=http://localhost:3001 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=91d01b50-807d-43ac-a5db-018c9645ac94&testMode=grading&testStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
 - Playwright desktop forced-scroll check: right pane scroll node `rightDeltaPx: 0` while vertically overflowing (`scrollHeight 956`, `clientHeight 504`).
+
 ## 2026-06-10 — Legacy quiz utility alias pass
 
 **Completed:**
@@ -682,3 +647,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm vitest run tests/components/AssignmentModal.test.tsx` (reran after one unrelated full-suite timing failure)
 - `pnpm test` (301 files / 2662 tests)
+
+## 2026-06-12 — Startup orient-only mode and fast verify-env
+
+**Completed:**
+- Added `--orient-only` / `--read-only` support to `.codex/skills/pika-session-start/scripts/session_start.sh` so report-only and docs-only runs can load startup context without mutating `.env.local` or running `verify-env.sh`.
+- Changed `scripts/verify-env.sh` so the default path stops after environment and dependency checks; test execution now requires `--tests` or `--full`.
+- Updated startup guidance in `.ai/START-HERE.md`, `.codex/prompts/session-start.md`, `.claude/commands/session-start.md`, `AGENTS.md`, and the `pika-session-start` skill to document the read-only startup path and the new verify-env modes.
+- Extended `tests/unit/ai-startup-docs.test.ts` to lock the non-mutating orient-only behavior, the fast default `verify-env.sh` path, and the startup-doc references.
+
+**Validation:**
+- `pnpm install --frozen-lockfile`
+- `bash scripts/verify-env.sh --help`
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh --help`
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`
+- `bash scripts/verify-env.sh`
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `git diff --check`

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -21,7 +21,8 @@
 [ ] Plan before coding: task, model, approach, approval
 ```
 
-Do not code if verification fails. Read `.ai/SESSION-LOG.md` only for recent handoff context; `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+Do not code if verification fails. Use `.ai/SESSION-LOG.md` only for recent handoff; use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
+For docs-only or review work, use `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`.
 
 ---
 

--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -15,6 +15,7 @@ Steps:
    - Ensure `.env.local` symlinks to `$HOME/Repos/.env/pika/.env.local`.
    - Run: `bash scripts/verify-env.sh`
    - If verify-env.sh fails: STOP — report the failure.
+   - For report-only, docs-only, or review work, use `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only` instead so startup stays read-only.
 
 2) Recover recent context
    - Run: `git log --oneline -10`

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -7,6 +7,11 @@ Preferred path:
 bash .codex/skills/pika-session-start/scripts/session_start.sh
 ```
 
+For report-only, docs-only, or review work:
+```bash
+bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only
+```
+
 Manual fallback:
 1. Resolve the repo root with `git rev-parse --show-toplevel` and verify it is not `$HOME/Repos/pika` for branch work.
 2. Ensure `.env.local` symlinks to `$HOME/Repos/.env/pika/.env.local`.

--- a/.codex/skills/pika-session-start/SKILL.md
+++ b/.codex/skills/pika-session-start/SKILL.md
@@ -15,6 +15,10 @@ Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with 
    ```bash
    bash .codex/skills/pika-session-start/scripts/session_start.sh
    ```
+   For report-only, docs-only, or review work, use:
+   ```bash
+   bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only
+   ```
 2. Review the output — confirm worktree, branch, `.ai/CURRENT.md`, and feature status.
 3. If an issue number is provided, load it with `gh issue view <number>`.
 4. Propose implementation plan before writing any code.
@@ -23,7 +27,8 @@ Automates the `.ai/START-HERE.md` ritual to ensure every AI session begins with 
 
 - Run from the current Pika worktree root, not the hub checkout.
 - STOP if the resolved repo root equals `$HOME/Repos/pika` (the hub).
-- The script creates a missing `.env.local` symlink to `$HOME/Repos/.env/pika/.env.local` before verification.
+- The default script path creates a missing `.env.local` symlink to `$HOME/Repos/.env/pika/.env.local` before verification.
+- `--orient-only` / `--read-only` keeps startup non-mutating and skips `verify-env.sh`; use it only for report-only, docs-only, or review work.
 - STOP if `verify-env.sh` fails.
 - Do NOT write any code until a plan is approved.
 - Use the resolved repo root consistently for git commands and file paths.

--- a/.codex/skills/pika-session-start/scripts/session_start.sh
+++ b/.codex/skills/pika-session-start/scripts/session_start.sh
@@ -5,6 +5,27 @@ set -euo pipefail
 PASS="\033[0;32m✅\033[0m"
 FAIL="\033[0;31m❌\033[0m"
 INFO="\033[0;34mℹ️ \033[0m"
+ORIENT_ONLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --orient-only|--read-only)
+      ORIENT_ONLY=1
+      ;;
+    -h|--help)
+      echo "Usage: bash .codex/skills/pika-session-start/scripts/session_start.sh [--orient-only]"
+      echo ""
+      echo "Default: verify worktree, repair .env.local when missing, run verify-env.sh, and render startup docs."
+      echo "  --orient-only, --read-only: render startup context without mutating .env.local or running verify-env.sh."
+      exit 0
+      ;;
+    *)
+      echo -e "${FAIL} Unknown argument: $arg"
+      echo "   Run with --help for usage."
+      exit 1
+      ;;
+  esac
+done
 
 print_required_doc() {
   local label="$1"
@@ -88,13 +109,18 @@ echo -e "${PASS} Worktree = $WORKTREE"
 # ── 2. Verify environment ───────────────────────────
 echo ""
 echo "── 2. Environment check"
-ensure_env_symlink "$WORKTREE"
-if [[ -f "$WORKTREE/scripts/verify-env.sh" ]]; then
-  bash "$WORKTREE/scripts/verify-env.sh" && \
-    echo -e "${PASS} verify-env.sh passed" || \
-    { echo -e "${FAIL} verify-env.sh failed. Fix before proceeding."; exit 1; }
+if [[ "$ORIENT_ONLY" -eq 1 ]]; then
+  echo -e "${INFO} Orient-only mode: skipping .env.local repair and verify-env.sh."
+  echo "   Use the default session-start path before editing code."
 else
-  echo -e "${INFO} verify-env.sh not found, skipping"
+  ensure_env_symlink "$WORKTREE"
+  if [[ -f "$WORKTREE/scripts/verify-env.sh" ]]; then
+    bash "$WORKTREE/scripts/verify-env.sh" && \
+      echo -e "${PASS} verify-env.sh passed" || \
+      { echo -e "${FAIL} verify-env.sh failed. Fix before proceeding."; exit 1; }
+  else
+    echo -e "${INFO} verify-env.sh not found, skipping"
+  fi
 fi
 
 # ── 3. Git context ──────────────────────────────────
@@ -142,9 +168,17 @@ echo -e "${INFO} The required startup docs were rendered above."
 echo -e "${INFO} Load only the task-specific docs routed by docs/ai-instructions.md before coding."
 echo -e "${INFO} Use .ai/SESSION-LOG.md only for recent handoff context."
 echo -e "${INFO} Use .ai/JOURNAL-ARCHIVE.md only for historical investigation."
+if [[ "$ORIENT_ONLY" -eq 1 ]]; then
+  echo -e "${INFO} Orient-only mode is for report-only, docs-only, or review work."
+fi
 
 echo ""
 echo "╔══════════════════════════════════════════════╗"
-echo "║  Session ready. State your task and wait    ║"
-echo "║  for plan approval before writing code.     ║"
+if [[ "$ORIENT_ONLY" -eq 1 ]]; then
+  echo "║   Context loaded for read-only work. Use    ║"
+  echo "║   full session-start before editing code.   ║"
+else
+  echo "║  Session ready. State your task and wait    ║"
+  echo "║  for plan approval before writing code.     ║"
+fi
 echo "╚══════════════════════════════════════════════╝"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Use `docs/guides/ai-ui-testing.md` and `.codex/prompts/ui-verify.md` for the act
 - Testing: Vitest + React Testing Library
 
 ## Core Commands
-- Verify: `bash scripts/verify-env.sh` (optional: `--full`)
+- Verify: `bash scripts/verify-env.sh` (optional: `--tests` or `--full`)
 - Tests: `pnpm test` (watch: `pnpm test:watch`)
 - Lint: `pnpm lint`
 - Build: `pnpm build`

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -13,7 +13,7 @@ Read these files at the start of every session:
 3. [`.ai/features.json`](../.ai/features.json)
 4. [`docs/ai-instructions.md`](./ai-instructions.md)
 
-Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff context; after each append, immediately run `node scripts/trim-session-log.mjs`.
+Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only for recent handoff; after each append, run `node scripts/trim-session-log.mjs`.
 
 ## Load Only The Docs You Need
 
@@ -33,7 +33,7 @@ After the startup set above, load task-specific docs:
 | Course blueprint package import/export | [`docs/guidance/course-blueprint-packages.md`](./guidance/course-blueprint-packages.md) |
 | Feature-specific behavior | `docs/guidance/*.md` or the closest focused spec |
 
-Inspect or modify source only after the startup set and the docs required by your task are loaded.
+Inspect or modify source only after the startup set and task-routed docs are loaded.
 
 ## Repo Invariants
 
@@ -48,7 +48,7 @@ Inspect or modify source only after the startup set and the docs required by you
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: use worktree for non-trivial work; plan/discuss with `Model recommendation: <model> - <reason>` (`5.3-spark` low-risk; else `5.5 medium|high|extra high`), append `.ai/SESSION-LOG.md`, and immediately run `node scripts/trim-session-log.mjs`
+- Workflow: use a worktree for non-trivial work; include `Model recommendation: <model> - <reason>`, append `.ai/SESSION-LOG.md`, and run `node scripts/trim-session-log.mjs`
 - Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
 
 ## Prompt And Command Map

--- a/scripts/verify-env.sh
+++ b/scripts/verify-env.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 MODE="${1:-}"
 
 if [[ "$MODE" == "-h" || "$MODE" == "--help" ]]; then
-  echo "Usage: bash scripts/verify-env.sh [--full]"
+  echo "Usage: bash scripts/verify-env.sh [--tests|--full]"
   echo ""
-  echo "Default: fast checks (node, .ai layer, tests)."
-  echo "  --full: also run lint + build (slower)."
+  echo "Default: fast checks (node, package manager, AI continuity layer, features.json, dependencies)."
+  echo "  --tests: also run pnpm/npm test."
+  echo "  --full: run tests + lint + build."
   exit 0
 fi
 
@@ -79,9 +80,11 @@ if [[ ! -d "node_modules" ]]; then
 fi
 echo "✅ Dependencies installed"
 
-echo "Running tests..."
-"${PM_CMD[@]}" test
-echo "✅ Tests passing"
+if [[ "$MODE" == "--tests" || "$MODE" == "--full" ]]; then
+  echo "Running tests..."
+  "${PM_CMD[@]}" test
+  echo "✅ Tests passing"
+fi
 
 if [[ "$MODE" == "--full" ]]; then
   echo "Running lint..."

--- a/tests/unit/ai-startup-docs.test.ts
+++ b/tests/unit/ai-startup-docs.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -51,6 +51,29 @@ function makeFixtureWorktree() {
 function commitAll(repoRoot: string, message: string) {
   execFileSync('git', ['add', '.'], { cwd: repoRoot })
   execFileSync('git', ['commit', '-m', message], { cwd: repoRoot })
+}
+
+function makeVerifyEnvFixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'pika-verify-env-'))
+
+  mkdirSync(join(repoRoot, '.ai'), { recursive: true })
+  mkdirSync(join(repoRoot, 'node_modules'), { recursive: true })
+
+  writeFileSync(
+    join(repoRoot, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'verify-env-fixture',
+        private: true,
+        packageManager: 'npm@10.0.0',
+      },
+      null,
+      2,
+    ),
+  )
+  writeFileSync(join(repoRoot, '.ai/features.json'), '{\n  "features": []\n}\n')
+
+  return repoRoot
 }
 
 const requiredStartupFiles = [
@@ -107,6 +130,7 @@ describe('AI startup docs', () => {
     for (const file of requiredStartupFiles) {
       expect(prompt).toContain(file)
     }
+    expect(prompt).toContain('--orient-only')
   })
 
   it('documents both named and app-managed Codex worktree locations', () => {
@@ -146,6 +170,14 @@ describe('AI startup docs', () => {
 
     for (const file of files) {
       expect(readRepoFile(file)).toContain('detached HEAD')
+    }
+  })
+
+  it('documents orient-only startup for read-only work', () => {
+    const files = ['.ai/START-HERE.md', '.claude/commands/session-start.md', '.codex/prompts/session-start.md']
+
+    for (const file of files) {
+      expect(readRepoFile(file)).toContain('--orient-only')
     }
   })
 
@@ -234,6 +266,38 @@ describe('AI startup docs', () => {
     }
   })
 
+  it('keeps orient-only session-start non-mutating', () => {
+    const repoRoot = makeFixtureWorktree()
+    const canonicalEnv = join(repoRoot, 'Repos/.env/pika/.env.local')
+    const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
+
+    mkdirSync(dirname(canonicalEnv), { recursive: true })
+    writeFileSync(canonicalEnv, 'SESSION_SECRET=fixture-secret-with-at-least-32-characters\n')
+    writeFileSync(
+      join(repoRoot, 'scripts/verify-env.sh'),
+      '#!/usr/bin/env bash\ntouch verify-env-ran\nexit 1\n',
+      { mode: 0o755 },
+    )
+
+    try {
+      const output = execFileSync('bash', [scriptPath, '--orient-only'], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: repoRoot,
+        },
+        encoding: 'utf8',
+      })
+
+      expect(output).toContain('Orient-only mode: skipping .env.local repair and verify-env.sh.')
+      expect(output).toContain('Context loaded for read-only work.')
+      expect(existsSync(join(repoRoot, '.env.local'))).toBe(false)
+      expect(existsSync(join(repoRoot, 'verify-env-ran'))).toBe(false)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
   it('reports detached HEAD state during automated session-start', () => {
     const repoRoot = makeFixtureWorktree()
     const scriptPath = resolve(testDir, '../../.codex/skills/pika-session-start/scripts/session_start.sh')
@@ -278,6 +342,24 @@ describe('AI startup docs', () => {
       expect(`${result.stdout}\n${result.stderr}`).toContain('Current repo is the hub')
     } finally {
       rmSync(homeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps verify-env fast by default', () => {
+    const repoRoot = makeVerifyEnvFixture()
+    const scriptPath = resolve(testDir, '../../scripts/verify-env.sh')
+
+    try {
+      const output = execFileSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+
+      expect(output).toContain('✅ Dependencies installed')
+      expect(output).not.toContain('Running tests...')
+      expect(output).toContain('Environment verified. Ready for development.')
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- add `--orient-only` / `--read-only` support to the Pika session-start script for docs-only and review work
- make `scripts/verify-env.sh` fast by default, with explicit `--tests` and `--full` modes for heavier validation
- update startup docs/prompts and add regression coverage for the read-only startup path and fast verify-env default

## Validation
- `pnpm install --frozen-lockfile`
- `bash scripts/verify-env.sh --help`
- `bash .codex/skills/pika-session-start/scripts/session_start.sh --help`
- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
- `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`
- `bash scripts/verify-env.sh`
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `node scripts/trim-session-log.mjs --check`
- `git diff --check`

## Review notes
- self-review found no blocking defects in the patch
- `.ai/SESSION-LOG.md` was updated and re-trimmed as required by the repo workflow
