### PR TITLE
[codex] Harden skill progression workflow

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -665,3 +665,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `git diff --check`
+## 2026-06-12 — Skill progression workflow hardening
+
+**Completed:**
+- Added a new UI acceptance brief guide so non-trivial UI work records the target surface, reference, roles, viewports, themes, states, primary signal, and out-of-scope treatments before coding.
+- Added schema rollout and component refactor checklists to make migration/query-shape PRs and large TSX extraction PRs declare rollout risk, fallback expectations, and shared-component boundaries up front.
+- Updated AI routing, session-start, issue-worker, agent-role, UI canon, and UI verification guidance so the acceptance brief plus role/viewport/theme/state verification matrix are part of the default workflow.
+- Added explicit specialist-skill trigger guidance for `product-design:get-context`, `pika-ui-verify`, `supabase:supabase-postgres-best-practices`, and `vercel:react-best-practices`.
+
+**Validation:**
+- Reviewed diffs for `docs/ai-instructions.md`, `.codex/prompts/session-start.md`, `docs/guides/ai-ui-testing.md`, `.codex/prompts/ui-verify.md`, `.codex/skills/pika-ui-verify/SKILL.md`, `docs/core/agents.md`, `docs/issue-worker.md`, and the new guidance docs.
+- `node scripts/trim-session-log.mjs`
+- `node scripts/trim-session-log.mjs --check`

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -21,10 +21,14 @@ Manual fallback:
 6. Read `.ai/SESSION-LOG.md` only if recent handoff context is needed; use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 7. Load only the task-specific docs routed by `docs/ai-instructions.md`.
    - For UI work, include a UI guidance declaration.
+   - For UI work, record a brief acceptance target using `docs/guidance/ui/change-brief.md`.
    - Record: stable guidance followed
    - Record: experimental guidance introduced: yes/no
    - Record: human promotion needed: yes/no
+   - For migration/query-shape work, read `docs/guidance/schema-rollout-checklist.md`.
+   - For large TSX refactors or shared shell extraction, read `docs/guidance/component-refactor-checklist.md`.
    - For non-trivial work, declare risk profile: `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform`.
    - If any risk profile applies, read `docs/guidance/dev-flow-risk-checklists.md`.
+   - When available in the current session, prefer `product-design:get-context`, `pika-ui-verify`, `supabase:supabase-postgres-best-practices`, and `vercel:react-best-practices` at their matching trigger points.
 8. If `$ARGUMENTS` is an issue number, run `gh issue view $ARGUMENTS --json number,title,body,labels`.
 9. State the task, propose the approach, and wait for approval before coding.

--- a/.codex/prompts/ui-verify.md
+++ b/.codex/prompts/ui-verify.md
@@ -10,6 +10,9 @@ bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "$ARGUMENTS"
 ```
 
 After screenshots are captured:
-1. Review the teacher and student views.
-2. Check layout, spacing, typography, responsiveness, and missing states.
-3. If anything looks off, fix the code and repeat the verification.
+1. Review the teacher and student views, or explicitly record why one role is not applicable.
+2. Check desktop and mobile coverage.
+3. Check light and dark mode when the surface supports both.
+4. Check the relevant visual states: default, hover, focus, open, selected, loading, empty, drag, or edit.
+5. Check layout, spacing, typography, responsiveness, and whether the intended primary signal is clear without extra chrome.
+6. If anything looks off, fix the code and repeat the verification.

--- a/.codex/skills/pika-ui-verify/SKILL.md
+++ b/.codex/skills/pika-ui-verify/SKILL.md
@@ -7,7 +7,7 @@ description: Visual verification of Pika UI changes using Playwright screenshots
 
 ## Overview
 
-Takes Playwright screenshots of a given Pika page from both teacher and student perspectives, then prompts visual review.
+Takes Playwright screenshots of a given Pika page from both teacher and student perspectives, then prompts visual review against an explicit role, viewport, theme, and state matrix.
 
 ## Workflow
 
@@ -17,20 +17,29 @@ Takes Playwright screenshots of a given Pika page from both teacher and student 
    bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/abc123"
    ```
 3. Review screenshots in `/tmp/pika-*.png`.
-4. If issues found: fix code and re-run.
-5. Report "Visual verification passed" when all views look correct.
+4. Verify the relevant matrix entries:
+   - teacher and student, or declare one `n/a`
+   - desktop and mobile
+   - light and dark when supported
+   - affected states such as hover, open, selected, loading, empty, drag, or edit
+5. If issues found: fix code and re-run.
+6. Report "Visual verification passed" only after the matrix is covered.
 
 ## What Gets Checked
 
 - Desktop teacher view (1440×900)
+- Mobile teacher view (390×844) when the change affects teacher mobile layouts
+- Desktop student view when the change affects student desktop layouts
 - Mobile student view (390×844)
 - No layout overflow or broken elements
 - Text legibility
 - Dark mode (if applicable — semantic tokens only)
+- The intended visual signal without extra decorative treatments
 
 ## Guardrails
 
 - Run BOTH roles — never skip student or teacher.
+- Cover the affected states intentionally — do not assume the default screen proves hover/open/selected behavior.
 - Iterate until verified — don't commit unverified UI changes.
 - See `docs/guides/ai-ui-testing.md` for detailed patterns.
 

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -22,8 +22,10 @@ After the startup set above, load task-specific docs:
 | Task | Read next |
 |---|---|
 | Any non-trivial code change | [`docs/core/architecture.md`](./core/architecture.md) |
-| UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
+| UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guidance/ui/change-brief.md`](./guidance/ui/change-brief.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
 | Teacher assignments or tests work-surface shell/layout work | [`docs/guidance/ui/teacher-work-surfaces.md`](./guidance/ui/teacher-work-surfaces.md), [`docs/guidance/assignment-ux-language.md`](./guidance/assignment-ux-language.md), [`docs/guidance/ui/audit-teacher-work-surfaces.md`](./guidance/ui/audit-teacher-work-surfaces.md) |
+| Migrations, Supabase query-shape changes, or rollout compatibility work | [`docs/guidance/schema-rollout-checklist.md`](./guidance/schema-rollout-checklist.md) |
+| Large TSX refactors or shared shell/component extractions | [`docs/guidance/component-refactor-checklist.md`](./guidance/component-refactor-checklist.md) |
 | TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
 | Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |
 | Workspace state, grading runs, exam mode, or runtime platform risk | [`docs/guidance/dev-flow-risk-checklists.md`](./guidance/dev-flow-risk-checklists.md) |
@@ -66,6 +68,15 @@ Inspect or modify source only after the startup set and task-routed docs are loa
 | Merge `main` into `production` | `/merge-main-into-production` | `.codex/prompts/merge-main-into-production.md` |
 
 UI changes require Playwright final verification before commit. Chrome plugin checks are supplemental. See [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md).
+
+## Specialist Skill Triggers
+
+When the tooling is available in the current agent session, prefer these skills at the trigger points below:
+
+- `product-design:get-context` before non-trivial UI or UX work so the acceptance brief is explicit before coding
+- `pika-ui-verify` before closing any UI change so the role, viewport, theme, and state matrix is actually checked
+- `supabase:supabase-postgres-best-practices` before migration or Supabase query-shape PRs
+- `vercel:react-best-practices` before opening large TSX refactors or shared shell/component extraction PRs
 
 ## Source Of Truth Order
 

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -61,7 +61,7 @@ Adopt a specialized agent role based on your task type. All agents must first re
 
 **Focus**: Database schema, migrations, RLS policies
 
-**Also read**: `architecture.md`, `project-context.md`, existing migrations in `/supabase/migrations/`
+**Also read**: `architecture.md`, `project-context.md`, `docs/guidance/schema-rollout-checklist.md`, existing migrations in `/supabase/migrations/`
 
 **Responsibilities**: Design tables and relationships. Write Supabase migrations (SQL). Implement RLS policies. Ensure proper indexing. Document schema changes.
 
@@ -73,7 +73,7 @@ Adopt a specialized agent role based on your task type. All agents must first re
 
 **Focus**: Code quality without behavior changes
 
-**Also read**: `architecture.md`, `design.md`, `tests.md`
+**Also read**: `architecture.md`, `design.md`, `tests.md`, `docs/guidance/component-refactor-checklist.md`
 
 **Responsibilities**: Improve clarity. Extract duplicated code. Improve naming. Ensure all tests pass after changes. Remove dead code.
 
@@ -85,9 +85,9 @@ Adopt a specialized agent role based on your task type. All agents must first re
 
 **Focus**: User interface and experience
 
-**Also read**: `design.md`, `architecture.md`, `guides/ai-ui-testing.md`
+**Also read**: `design.md`, `architecture.md`, `docs/guidance/ui/change-brief.md`, `guides/ai-ui-testing.md`
 
-**Responsibilities**: Implement UI following design.md. Mobile-first responsive design. Keep components thin. Tailwind CSS only. WCAG 2.1 accessibility. **Visually verify all changes** using `/ui-verify` (Claude) or `.codex/prompts/ui-verify.md` (Codex).
+**Responsibilities**: Implement UI following design.md. Lock the acceptance target before coding. Mobile-first responsive design. Keep components thin. Tailwind CSS only. WCAG 2.1 accessibility. **Visually verify all changes** using `/ui-verify` (Claude) or `.codex/prompts/ui-verify.md` (Codex).
 
 **Must NOT**: Add business logic to components. Use component libraries. Skip mobile responsiveness. Ignore accessibility. Commit UI changes without visual verification.
 

--- a/docs/guidance/component-refactor-checklist.md
+++ b/docs/guidance/component-refactor-checklist.md
@@ -1,0 +1,38 @@
+# Component Refactor Checklist
+
+Use this before large TSX refactors, shared shell extraction, or cross-surface UI consolidation.
+
+## Triggers
+
+Read this when any of these are true:
+
+- a TSX file is becoming a large shared surface
+- a new component extracts behavior used by multiple classroom tabs or roles
+- a refactor touches layout, state coordination, and business behavior in the same change
+- the work is presented as structural, not a redesign
+
+## Structure Checks
+
+- Name the component boundary in one sentence
+- Keep business logic in `src/lib/*`, server helpers, or existing data modules
+- Prefer passing derived display data over domain-specific live state when possible
+- Stop if the shared component starts requiring domain-only props from one surface
+- Keep query/routing/mutation behavior outside pure shell components unless the shell already owns it
+
+## PR-Scale Checks
+
+- If a component grows large, explain why it is still a coherent unit
+- If a shared component replaces repeated markup, list the repeated structure it owns
+- List visible behavior that must remain unchanged if this is a structural refactor
+- Add focused regression tests for the extracted shell contract, not only the parent surface
+
+## Review Prompt
+
+Before opening the PR, answer:
+
+```text
+Is this a shell extraction, a behavior extraction, or both?
+What business logic stayed out of the shared component?
+Which parent-level tests prove the refactor did not redesign the surface?
+Which component-level tests prove the new shared contract?
+```

--- a/docs/guidance/schema-rollout-checklist.md
+++ b/docs/guidance/schema-rollout-checklist.md
@@ -1,0 +1,46 @@
+# Schema And Query Rollout Checklist
+
+Use this checklist for migrations, Supabase query-shape changes, compatibility shims, and any PR that changes stored fields or API payload shaping.
+
+## Read This When
+
+- adding or editing a migration
+- changing a Supabase `select(...)` shape
+- introducing a new persisted field
+- adding a fallback for pre-migration or partially rolled-out environments
+- changing a teacher or student API response contract
+
+## Pre-Change Checks
+
+- Name the rollout risk: schema mismatch, query widening, backfill correctness, payload drift, or compatibility window
+- Prefer explicit column lists over `select('*')`
+- Confirm browser-side Supabase access is not being added
+- Confirm writes stay in server routes with existing auth helpers
+- Identify whether reads must tolerate both pre-migration and post-migration schemas during rollout
+
+## Migration Checklist
+
+- Backfill is deterministic and scoped correctly
+- Constraints/defaults match the intended application behavior
+- Migration numbering does not collide with `origin/main`
+- Any compatibility window is documented in the PR notes
+- AI does not apply migrations locally; humans do
+
+## Query And Payload Checklist
+
+- Narrow the select list to rendered or returned fields
+- Avoid accidentally exposing extra columns while adding a new field
+- Keep teacher/student response shaping explicit when rollout fallbacks exist
+- Add a regression for the fallback path when a new column is unavailable
+- Add a regression for the steady-state path when the column is present
+
+## Review Prompt
+
+Before opening the PR, answer:
+
+```text
+What widened?
+What fallback exists?
+What breaks if the migration has not been applied yet?
+Which regression proves the intended payload shape?
+```

--- a/docs/guidance/ui/README.md
+++ b/docs/guidance/ui/README.md
@@ -24,9 +24,10 @@ When a task affects UI, styling, layout, or interaction flow, read in this order
 1. [`docs/core/design.md`](/docs/core/design.md)
 2. [`src/ui/README.md`](/src/ui/README.md)
 3. [`docs/guidance/ui/stable.md`](/docs/guidance/ui/stable.md)
-4. Family-specific canon docs in this folder when the task targets a governed slice
-5. Relevant experimental, legacy, and open-question docs in this folder only if they materially affect the task
-6. [`docs/guidance/ui/composite-widget-accessibility.md`](/docs/guidance/ui/composite-widget-accessibility.md) when the task changes composite interactions or ARIA semantics
+4. [`docs/guidance/ui/change-brief.md`](/docs/guidance/ui/change-brief.md)
+5. Family-specific canon docs in this folder when the task targets a governed slice
+6. Relevant experimental, legacy, and open-question docs in this folder only if they materially affect the task
+7. [`docs/guidance/ui/composite-widget-accessibility.md`](/docs/guidance/ui/composite-widget-accessibility.md) when the task changes composite interactions or ARIA semantics
 
 The stable file is the default. Experimental and legacy docs are context, not overrides.
 
@@ -54,6 +55,7 @@ This is intentionally smaller than the full app.
 When a task touches UI/UX, the implementation plan or issue note should declare:
 
 - guidance read
+- acceptance target captured
 - stable guidance followed
 - experimental guidance introduced: yes/no
 - experimental draft file updated or created, if any

--- a/docs/guidance/ui/change-brief.md
+++ b/docs/guidance/ui/change-brief.md
@@ -1,0 +1,54 @@
+# UI Change Brief
+
+Use this brief before starting any non-trivial UI or UX change. The goal is to lock the acceptance target early enough to avoid post-PR visual churn.
+
+If the task is small but still user-visible, answer this briefly in the plan or PR notes.
+
+## Required Brief
+
+Record these items before coding:
+
+- Surface: page, tab, modal, menu, card, or shell being changed
+- Reference: existing Pika surface or governed canon that the new work should resemble
+- Affected roles: teacher, student, unauthenticated, or not-applicable
+- Required viewports: desktop, mobile, or both
+- Required themes: light, dark, or both
+- Key interaction states: default, hover, focus, open, selected, loading, empty, edit, drag, or any state that materially changes visuals
+- Primary signal: the one visual cue that should do the work, such as accent edge, gradient, icon, or elevation
+- Must not add: visual treatments or extra UI elements that are explicitly out of scope
+- Composite widget accessibility review needed: yes/no
+
+## Recommended Acceptance Language
+
+Use compact language like:
+
+```text
+This is a refinement of the existing teacher work-surface pattern, not a redesign.
+
+Primary signal: the pencil options menu and primary action button grouping.
+Must not add: extra marker dots, decorative subtitles, or duplicate selection chrome.
+
+Verify teacher and student where applicable, desktop and mobile, light and dark, plus hover/open/selected states.
+```
+
+## Verification Matrix
+
+Before marking UI work complete, confirm each relevant row:
+
+| Dimension | Required declaration |
+|---|---|
+| Role | `teacher`, `student`, or `n/a` |
+| Viewport | `desktop`, `mobile`, or `both` |
+| Theme | `light`, `dark`, or `both` |
+| States | Explicit list of affected visual states |
+
+Do not leave this implicit in screenshots alone. If a dimension is not relevant, say why.
+
+## Escalation Rule
+
+Stop and seek human judgment before continuing when:
+
+- the brief cannot name a clear reference surface
+- the primary signal changes mid-implementation
+- the work introduces a new visual pattern that does not fit stable guidance
+- multiple acceptable treatments remain and the difference is product judgment rather than implementation quality

--- a/docs/guides/ai-ui-testing.md
+++ b/docs/guides/ai-ui-testing.md
@@ -10,6 +10,8 @@ This guide explains how to use Playwright for AI-assisted UI verification in Pik
 2. Check **BOTH** teacher and student views (if applicable)
 3. Iterate on aesthetics/styling until it looks good
 
+Before coding non-trivial UI work, record the acceptance target from [`docs/guidance/ui/change-brief.md`](/docs/guidance/ui/change-brief.md). The strongest recent failure mode has been visual churn after the first implementation, not missing screenshots.
+
 ## Tooling Policy
 
 Playwright is the required path for final UI/UX verification. Use Playwright for E2E tests, `pnpm e2e:verify` scenarios, reproducible screenshots, teacher/student auth-state checks, and artifacts that another agent or CI can rerun.
@@ -162,31 +164,44 @@ If you want a looser “same family, not exact clone” direction for future wor
 
 When implementing UI changes:
 
-### Step 1: Make the change
+### Step 1: Lock the acceptance target
+Record the affected roles, viewports, themes, key visual states, primary signal, and any explicitly out-of-scope treatments.
+
+### Step 2: Make the change
 Edit the component/page code.
 
-### Step 2: Take screenshot
+### Step 3: Take screenshot
 ```bash
 npx playwright screenshot http://localhost:3000/<page> /tmp/check.png \
   --load-storage .auth/teacher.json --viewport-size 1440,900
 ```
 
-### Step 3: View and assess
+### Step 4: View and assess
 Use Read tool to view `/tmp/check.png`. Check:
 - Spacing and alignment
 - Colors and typography
 - Overall aesthetics
+- Whether the intended primary signal is actually doing the work
+- Whether any out-of-scope treatment leaked in
 
-### Step 4: Iterate
+### Step 5: Iterate
 If something looks off:
 1. Edit the code
 2. Take another screenshot
 3. Repeat until satisfied
 
-### Step 5: Check both roles
-Verify both teacher and student views look correct.
+### Step 6: Check the verification matrix
+Verify the relevant combinations explicitly:
 
-### Step 6: Commit
+- teacher and student roles, or record why one is `n/a`
+- desktop and mobile
+- light and dark when the surface supports both
+- affected visual states such as default, hover, focus, open, selected, loading, empty, drag, or edit
+
+### Step 7: Check both roles
+Verify both teacher and student views look correct when both roles are affected.
+
+### Step 8: Commit
 Only commit once the UI looks correct in both views.
 
 ## Best Practices
@@ -196,12 +211,15 @@ Only commit once the UI looks correct in both views.
 - Any styling/CSS changes
 - New UI features
 - Layout changes
+- Shared shell or modal refactors that can change visuals without changing intent
 
 ### Tips
 - Use `--full-page` for long scrollable content
 - Use `--wait-for-selector` if content loads dynamically
 - Check both light and dark mode if applicable
 - Standard viewport is 1440x900
+- For mobile, use a narrow viewport such as `390x844`
+- If hover/open/selected states matter, capture them intentionally rather than inferring from the default screen
 
 ## Troubleshooting
 

--- a/docs/issue-worker.md
+++ b/docs/issue-worker.md
@@ -12,8 +12,10 @@ gh issue view <number> --json number,title,body,labels,comments
 2. Read `.ai/CURRENT.md`
 3. Read `docs/ai-instructions.md` and load only the task-specific docs it routes you to.
 3. Check `.ai/features.json` for any referenced feature IDs.
-4. If the issue affects UI/UX, read `docs/guidance/ui/README.md` and `docs/guidance/ui/stable.md`.
+4. If the issue affects UI/UX, read `docs/guidance/ui/README.md`, `docs/guidance/ui/stable.md`, and `docs/guidance/ui/change-brief.md`.
 5. If the issue affects teacher assignments or teacher tests, also read `docs/guidance/ui/teacher-work-surfaces.md` and `docs/guidance/ui/audit-teacher-work-surfaces.md`.
+6. If the issue affects migrations or Supabase query shape, read `docs/guidance/schema-rollout-checklist.md`.
+7. If the issue is a large TSX refactor or shared shell extraction, read `docs/guidance/component-refactor-checklist.md`.
 
 ## 3) Branch & PR Setup
 - Create or open a dedicated worktree using `docs/dev-workflow.md`.
@@ -27,11 +29,22 @@ Produce a short plan:
 
 If the issue affects UI/UX, add a **UI guidance declaration**:
 - guidance read
+- acceptance target captured from `docs/guidance/ui/change-brief.md`
 - stable guidance followed
 - teacher work-surface canon followed: yes/no/not-applicable
 - experimental guidance introduced: yes/no
 - experimental draft file created or updated, if any
 - human promotion needed: yes/no
+
+If the issue affects migrations or Supabase query shape, add a **rollout declaration**:
+- rollout risk named
+- fallback needed before migration applied: yes/no
+- explicit payload shape regression planned: yes/no
+
+If the issue is a large TSX refactor or shared shell extraction, add a **component refactor declaration**:
+- shell extraction, behavior extraction, or both
+- business logic kept out of shared component: yes/no
+- focused shared-component regression planned: yes/no
 
 Do not proceed until the user approves the plan.
 
@@ -48,7 +61,7 @@ Do not proceed until the user approves the plan.
 
 ## 6) AI UI Verification (MANDATORY for UI Changes)
 - Use `docs/guides/ai-ui-testing.md` or `.codex/prompts/ui-verify.md`.
-- Check the affected teacher and student views when both roles are impacted.
+- Check the role, viewport, theme, and state matrix explicitly.
 - Iterate on the UI until the verified screenshots are acceptable.
 
 ## 7) Update AI Continuity Layer


### PR DESCRIPTION
## Summary
- add a required UI acceptance brief for non-trivial UI work
- add rollout and component-refactor checklists for migration/query and large TSX PRs
- wire the new guidance into startup, routing, issue-worker, agent-role, and UI verification docs

## Validation
- reviewed the docs diff locally for consistency across prompts, skills, and guidance
- `node scripts/trim-session-log.mjs`
- `node scripts/trim-session-log.mjs --check`

## Notes
- This is a workflow/docs change only; no runtime app code changed.
- Self-review completed: no blocking findings in the current diff.
