### PR TITLE
[codex] Centralize legacy quiz Tests API contract

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,17 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-05 — Teacher attendance freshness guards
-
-**Completed:**
-- Added request-generation guards to `TeacherAttendanceTab` so stale classroom/date log responses cannot repaint the active teacher daily view after a classroom switch or date change.
-- Reset teacher attendance local state on classroom changes so date/selection/loading state reinitializes against the next classroom instead of carrying the prior classroom forward.
-- Added matching request-generation guards to `LogSummary` and created regression tests covering stale classroom summary responses plus stale teacher-log responses after a classroom switch.
-
-**Validation:**
-- `git diff --check`
-- `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` (fails in this worktree: `vitest` command unavailable because dependencies are not installed)
-
 ## 2026-06-06 — Gradebook action consistency audit
 
 **Completed:**
@@ -693,3 +682,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 - Rebased `codex/action-cluster-classwork` onto `origin/main` and resolved the `TeacherTestsTab.test.tsx` helper import conflict by keeping `createMockTest` plus the branch's `Classroom` typing.
 - Verified the rebased branch with `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/TeacherTestsTab.test.tsx` and `pnpm exec tsc --noEmit --pretty false`.
+
+## 2026-06-12 — Legacy quiz API compatibility contract helper
+
+**Completed:**
+- Created `codex/legacy-quiz-contract-compat` from current `origin/main`.
+- Inventoried remaining `quiz` / `quizzes` references and separated persisted/database contracts from active Tests API compatibility aliases.
+- Added `src/lib/test-api-contract.ts` to centralize the active Tests API `{ test, quiz }` and `{ tests, quizzes }` compatibility payloads.
+- Updated student and teacher Tests API routes to use the shared compatibility helper without changing response shape.
+- Added canonical `assessment` success data to `src/lib/server/assessments.ts` while preserving the legacy `quiz` alias.
+- Trimmed redundant `docs/ai-instructions.md` wording after the rebased `origin/main` startup-doc changes exceeded the enforced default startup context budget.
+- Did not touch production schema, migrations, RPCs, storage paths, gradebook contracts, course blueprint contracts, or DB-shaped `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/unit/server-access.test.ts tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
+- `pnpm test` (303 files / 2672 tests)
+- `git diff --check`

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -1,12 +1,9 @@
 # AI Instructions for Pika
 
-This file is the AI routing layer for the repo. Use it after `.ai/START-HERE.md`.
-
-For worktree creation, cleanup, and shared `.env.local` setup, use [`docs/dev-workflow.md`](./dev-workflow.md). Do not duplicate those setup steps elsewhere.
+Routing layer for repo agents. Use it after `.ai/START-HERE.md`.
+Worktree creation, cleanup, and shared `.env.local` setup live in [`docs/dev-workflow.md`](./dev-workflow.md).
 
 ## Default Startup Context
-
-Read these files at the start of every session:
 
 1. [`.ai/START-HERE.md`](../.ai/START-HERE.md)
 2. [`.ai/CURRENT.md`](../.ai/CURRENT.md)
@@ -17,15 +14,15 @@ Do not tail `.ai/JOURNAL-ARCHIVE.md` by default. Use `.ai/SESSION-LOG.md` only f
 
 ## Load Only The Docs You Need
 
-After the startup set above, load task-specific docs:
+After startup, load only task-specific docs:
 
 | Task | Read next |
 |---|---|
 | Any non-trivial code change | [`docs/core/architecture.md`](./core/architecture.md) |
-| UI or UX work | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guidance/ui/change-brief.md`](./guidance/ui/change-brief.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
-| Teacher assignments or tests work-surface shell/layout work | [`docs/guidance/ui/teacher-work-surfaces.md`](./guidance/ui/teacher-work-surfaces.md), [`docs/guidance/assignment-ux-language.md`](./guidance/assignment-ux-language.md), [`docs/guidance/ui/audit-teacher-work-surfaces.md`](./guidance/ui/audit-teacher-work-surfaces.md) |
-| Migrations, Supabase query-shape changes, or rollout compatibility work | [`docs/guidance/schema-rollout-checklist.md`](./guidance/schema-rollout-checklist.md) |
-| Large TSX refactors or shared shell/component extractions | [`docs/guidance/component-refactor-checklist.md`](./guidance/component-refactor-checklist.md) |
+| UI/UX | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guidance/ui/change-brief.md`](./guidance/ui/change-brief.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
+| Teacher assignments/tests shell/layout | [`docs/guidance/ui/teacher-work-surfaces.md`](./guidance/ui/teacher-work-surfaces.md), [`docs/guidance/assignment-ux-language.md`](./guidance/assignment-ux-language.md), [`docs/guidance/ui/audit-teacher-work-surfaces.md`](./guidance/ui/audit-teacher-work-surfaces.md) |
+| Migrations, Supabase query-shape, rollout compatibility | [`docs/guidance/schema-rollout-checklist.md`](./guidance/schema-rollout-checklist.md) |
+| Large TSX/shared shell refactors | [`docs/guidance/component-refactor-checklist.md`](./guidance/component-refactor-checklist.md) |
 | TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
 | Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |
 | Workspace state, grading runs, exam mode, or runtime platform risk | [`docs/guidance/dev-flow-risk-checklists.md`](./guidance/dev-flow-risk-checklists.md) |
@@ -35,23 +32,23 @@ After the startup set above, load task-specific docs:
 | Course blueprint package import/export | [`docs/guidance/course-blueprint-packages.md`](./guidance/course-blueprint-packages.md) |
 | Feature-specific behavior | `docs/guidance/*.md` or the closest focused spec |
 
-Inspect or modify source only after the startup set and task-routed docs are loaded.
+Inspect or edit source only after startup and routed docs.
 
 ## Repo Invariants
 
 - Platform: Next.js App Router, Supabase, Tailwind CSS, Vitest, Vercel
-- Vercel cron guardrail: on the Hobby plan, cron schedules must run at most once per day; do not add sub-daily repo-managed Vercel cron jobs
+- Vercel cron: Hobby plan schedules must run at most once per day
 - Timezone: all deadline and attendance logic uses `America/Toronto`
-- Auth: current runtime uses email verification codes plus password login; upcoming WorkOS AuthKit work must map WorkOS users to `public.users.workos_user_id` while preserving local `public.users.id` UUIDs
-- Supabase access: app authorization belongs in server routes via `requireAuth()` / `requireRole()` and the service-role client; do not add new browser-side Supabase table/RPC access without explicit review
+- Auth: email verification codes plus password login; WorkOS must map to `public.users.workos_user_id` while preserving local UUIDs
+- Supabase access: authorize in server routes via `requireAuth()` / `requireRole()` and service-role client; no new browser-side table/RPC access without review
 - Architecture: keep business logic out of UI components; prefer `src/lib/*` and server-side modules
 - API routes: use `withErrorHandler` from `@/lib/api-handler`
 - Repeated client-side reads: use `fetchJSONWithCache` from `@/lib/request-cache`
 - Tiptap content parsing: import `parseContentField` from `@/lib/tiptap-content`
 - UI primitives: import from `@/ui`; use semantic tokens in app code instead of raw `dark:` classes
 - Migrations: AI may create or edit migration files, but humans apply them manually
-- Workflow: use a worktree for non-trivial work; include `Model recommendation: <model> - <reason>`, append `.ai/SESSION-LOG.md`, and run `node scripts/trim-session-log.mjs`
-- Risk profile: for non-trivial work, declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform` in the plan
+- Workflow: use a worktree; include `Model recommendation: <model> - <reason>`; append `.ai/SESSION-LOG.md`; run `node scripts/trim-session-log.mjs`
+- Risk profile: declare `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform`
 
 ## Prompt And Skill Map
 

--- a/src/app/api/student/tests/[id]/results/route.ts
+++ b/src/app/api/student/tests/[id]/results/route.ts
@@ -13,6 +13,7 @@ import { getClassroomStudentIds } from '@/lib/server/classrooms'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { chunkValues, loadPagedRows } from '@/lib/server/query-chunks'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 import type { TestAssessmentQuestion, TestAssessmentResponse } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -401,8 +402,7 @@ export const GET = withErrorHandler('GetStudentTestResults', async (request, con
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
     results: aggregated,
     my_responses: myResponses,
     question_results: questionResults,

--- a/src/app/api/student/tests/[id]/route.ts
+++ b/src/app/api/student/tests/[id]/route.ts
@@ -13,6 +13,7 @@ import { normalizeTestResponses, type TestResponses } from '@/lib/test-attempts'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -190,8 +191,7 @@ export const GET = withErrorHandler('GetStudentTest', async (request, context) =
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
     questions: questions || [],
     student_status: studentStatus,
     student_responses: studentResponses,

--- a/src/app/api/student/tests/[id]/session-status/route.ts
+++ b/src/app/api/student/tests/[id]/session-status/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/server/tests'
 import { hasAnyMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -145,8 +146,7 @@ export const GET = withErrorHandler('GetStudentTestSessionStatus', async (_reque
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
     student_status: studentStatus,
     returned_at: attempt?.returned_at || null,
     can_continue: canContinue,

--- a/src/app/api/student/tests/route.ts
+++ b/src/app/api/student/tests/route.ts
@@ -12,6 +12,7 @@ import { getStudentTestStatus } from '@/lib/tests'
 import { normalizeTestDocuments } from '@/lib/test-documents'
 import { hasMeaningfulTestResponse } from '@/lib/test-responses'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizListKey } from '@/lib/test-api-contract'
 import type { TestAssessment } from '@/types'
 
 export const dynamic = 'force-dynamic'
@@ -47,7 +48,7 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
 
   if (activeError) {
     if (activeError.code === 'PGRST205') {
-      return NextResponse.json({ tests: [], quizzes: [], migration_required: true })
+      return NextResponse.json({ ...withLegacyQuizListKey([]), migration_required: true })
     }
     console.error('Error fetching active tests:', activeError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -245,6 +246,5 @@ export const GET = withErrorHandler('GetStudentTests', async (request, context) 
     }
   })
 
-  // Keep legacy `quizzes` key during the tests API contract transition.
-  return NextResponse.json({ tests: testsWithStatus, quizzes: testsWithStatus })
+  return NextResponse.json(withLegacyQuizListKey(testsWithStatus))
 })

--- a/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
+++ b/src/app/api/teacher/tests/[id]/documents/[docId]/sync/route.ts
@@ -5,6 +5,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
 import { clearTestDocumentSnapshot, normalizeTestDocuments } from '@/lib/test-documents'
 import { findTestDocument, syncExternalLinkTestDocument } from '@/lib/server/test-document-snapshots'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 
@@ -61,7 +62,6 @@ export const POST = withErrorHandler('SyncTeacherTestDocument', async (_request,
 
   return NextResponse.json({
     doc: syncedDoc,
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
   })
 })

--- a/src/app/api/teacher/tests/[id]/results/route.ts
+++ b/src/app/api/teacher/tests/[id]/results/route.ts
@@ -20,6 +20,7 @@ import type {
   TestStudentAvailabilityState,
 } from '@/types'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -647,8 +648,7 @@ export const GET = withErrorHandler('GetTeacherTestResults', async (request, con
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
     questions: (questions || []).map((q) => ({
       id: q.id,
       question_type: q.question_type === 'open_response' ? 'open_response' : 'multiple_choice',

--- a/src/app/api/teacher/tests/[id]/route.ts
+++ b/src/app/api/teacher/tests/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   type TestDraftContent,
 } from '@/lib/server/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
+import { withLegacyQuizKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -115,8 +116,7 @@ export const GET = withErrorHandler('GetTestById', async (_request, context) => 
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
     questions: responseQuestions,
     classroom: test.classrooms,
   })
@@ -340,8 +340,7 @@ export const PATCH = withErrorHandler('PatchUpdateTest', async (request, context
   }
 
   return NextResponse.json({
-    test: responseTest,
-    quiz: responseTest,
+    ...withLegacyQuizKey(responseTest),
   })
 })
 

--- a/src/app/api/teacher/tests/route.ts
+++ b/src/app/api/teacher/tests/route.ts
@@ -23,6 +23,7 @@ import { withErrorHandler } from '@/lib/api-handler'
 import { getFallbackAssessmentTitle } from '@/lib/assessment-titles'
 import type { TestStudentAvailabilityState } from '@/types'
 import { chunkValues, loadChunkedRows } from '@/lib/server/query-chunks'
+import { withLegacyQuizKey, withLegacyQuizListKey } from '@/lib/test-api-contract'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -135,7 +136,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
 
   if (testsError) {
     if (testsError.code === 'PGRST205') {
-      return NextResponse.json({ tests: [], quizzes: [], migration_required: true })
+      return NextResponse.json({ ...withLegacyQuizListKey([]), migration_required: true })
     }
     console.error('Error fetching tests:', testsError)
     return NextResponse.json({ error: 'Failed to fetch tests' }, { status: 500 })
@@ -315,8 +316,7 @@ export const GET = withErrorHandler('GetTeacherTests', async (request) => {
     }
   })
 
-  // Keep legacy `quizzes` key during the tests API contract transition.
-  return NextResponse.json({ tests: testsWithStats, quizzes: testsWithStats })
+  return NextResponse.json(withLegacyQuizListKey(testsWithStats))
 })
 
 // POST /api/teacher/tests - Create a new test
@@ -417,8 +417,7 @@ export const POST = withErrorHandler('CreateTeacherTest', async (request) => {
 
   return NextResponse.json(
     {
-      test: responseTest,
-      quiz: responseTest,
+      ...withLegacyQuizKey(responseTest),
     },
     { status: 201 }
   )

--- a/src/lib/server/assessments.ts
+++ b/src/lib/server/assessments.ts
@@ -24,7 +24,7 @@ export type QuizAccessRecord = {
 export type AssessmentAccessRecord = QuizAccessRecord
 
 type AccessResult<T> =
-  | { ok: true; quiz: T }
+  | { ok: true; assessment: T; quiz: T }
   | { ok: false; status: number; error: string }
 
 type QuizVisibilityRecord = {
@@ -33,6 +33,14 @@ type QuizVisibilityRecord = {
 }
 
 type AssessmentVisibilityRecord = QuizVisibilityRecord
+
+function assessmentAccessSuccess<T>(assessment: T): AccessResult<T> {
+  return {
+    ok: true,
+    assessment,
+    quiz: assessment,
+  }
+}
 
 export function isAssessmentVisibleToStudents(
   assessment: AssessmentVisibilityRecord,
@@ -84,7 +92,7 @@ export async function assertTeacherOwnsAssessment(
     return { ok: false, status: 403, error: 'Classroom is archived' }
   }
 
-  return { ok: true, quiz: assessment as QuizAccessRecord }
+  return assessmentAccessSuccess(assessment as QuizAccessRecord)
 }
 
 export const assertTeacherOwnsQuiz = assertTeacherOwnsAssessment
@@ -126,7 +134,7 @@ export async function assertStudentCanAccessAssessment(
     return { ok: false, status: 403, error: 'Not enrolled in this classroom' }
   }
 
-  return { ok: true, quiz: assessment as QuizAccessRecord }
+  return assessmentAccessSuccess(assessment as QuizAccessRecord)
 }
 
 export const assertStudentCanAccessQuiz = assertStudentCanAccessAssessment

--- a/src/lib/test-api-contract.ts
+++ b/src/lib/test-api-contract.ts
@@ -1,0 +1,17 @@
+/**
+ * Tests are the active product surface, but these routes still emit legacy
+ * quiz-shaped keys for older clients during the contract transition.
+ */
+export function withLegacyQuizListKey<T>(tests: T[]): { tests: T[]; quizzes: T[] } {
+  return {
+    tests,
+    quizzes: tests,
+  }
+}
+
+export function withLegacyQuizKey<T>(test: T): { test: T; quiz: T } {
+  return {
+    test,
+    quiz: test,
+  }
+}

--- a/tests/lib/test-api-contract.test.ts
+++ b/tests/lib/test-api-contract.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { withLegacyQuizKey, withLegacyQuizListKey } from '@/lib/test-api-contract'
+
+describe('test API compatibility contract', () => {
+  it('mirrors the current tests list under the legacy quizzes key', () => {
+    const tests = [{ id: 'test-1' }, { id: 'test-2' }]
+
+    const payload = withLegacyQuizListKey(tests)
+
+    expect(payload).toEqual({ tests, quizzes: tests })
+    expect(payload.quizzes).toBe(payload.tests)
+  })
+
+  it('mirrors the current test detail under the legacy quiz key', () => {
+    const test = { id: 'test-1' }
+
+    const payload = withLegacyQuizKey(test)
+
+    expect(payload).toEqual({ test, quiz: test })
+    expect(payload.quiz).toBe(payload.test)
+  })
+})

--- a/tests/unit/server-access.test.ts
+++ b/tests/unit/server-access.test.ts
@@ -6,6 +6,7 @@ import {
   getClassroomStudentIds,
 } from '@/lib/server/classrooms'
 import {
+  assertStudentCanAccessAssessment,
   assertStudentCanAccessQuiz,
   assertTeacherOwnsQuiz,
 } from '@/lib/server/assessments'
@@ -169,7 +170,7 @@ describe('server access helpers', () => {
     })
   })
 
-  describe('quiz access', () => {
+  describe('assessment access', () => {
     it('returns 403 when the teacher requests archived quiz access with archived checks enabled', async () => {
       mockSupabaseClient.from.mockImplementation((table: string) => {
         expect(table).toBe('quizzes')
@@ -248,8 +249,48 @@ describe('server access helpers', () => {
 
       expect(result.ok).toBe(true)
       if (result.ok) {
+        expect(result.assessment).toBe(result.quiz)
+        expect(result.assessment.id).toBe('quiz-1')
         expect(result.quiz.id).toBe('quiz-1')
         expect(result.quiz.classrooms.archived_at).toBeNull()
+      }
+    })
+
+    it('supports the canonical assessment access helper with the legacy quiz table contract', async () => {
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'quizzes') {
+          return createSingleSelectResult({
+            data: {
+              id: 'quiz-1',
+              classroom_id: 'classroom-1',
+              status: 'active',
+              opens_at: null,
+              title: 'Quiz 1',
+              show_results: false,
+              position: 0,
+              created_by: 'teacher-1',
+              created_at: '2026-03-01T00:00:00.000Z',
+              updated_at: '2026-03-01T00:00:00.000Z',
+              classrooms: {
+                id: 'classroom-1',
+                teacher_id: 'teacher-1',
+                archived_at: null,
+              },
+            },
+            error: null,
+          })
+        }
+
+        expect(table).toBe('classroom_enrollments')
+        return createSingleSelectResult({ data: { id: 'enrollment-1' }, error: null })
+      })
+
+      const result = await assertStudentCanAccessAssessment('student-1', 'quiz-1')
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.assessment).toBe(result.quiz)
+        expect(result.assessment.id).toBe('quiz-1')
       }
     })
   })


### PR DESCRIPTION
## Summary
- Centralize active Tests API legacy `quiz` / `quizzes` response aliases in `src/lib/test-api-contract.ts`
- Update student and teacher Tests API routes to use the shared helper without changing payload shape
- Add canonical `assessment` success data to server assessment access helpers while preserving the legacy `quiz` alias
- Trim `docs/ai-instructions.md` so the required startup context remains under the enforced budget after recent main changes

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/unit/server-access.test.ts tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
- `pnpm test` (303 files / 2672 tests)

## Self-review
- No production schema, migrations, RPCs, storage paths, gradebook contracts, course blueprint contracts, or DB-shaped `quiz_id` fields changed.
- API response compatibility is preserved: current and legacy keys still point to the same object/array.
