### PR TITLE
Refactor test response normalization

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,17 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-05 — Teacher attendance freshness guards
-
-**Completed:**
-- Added request-generation guards to `TeacherAttendanceTab` so stale classroom/date log responses cannot repaint the active teacher daily view after a classroom switch or date change.
-- Reset teacher attendance local state on classroom changes so date/selection/loading state reinitializes against the next classroom instead of carrying the prior classroom forward.
-- Added matching request-generation guards to `LogSummary` and created regression tests covering stale classroom summary responses plus stale teacher-log responses after a classroom switch.
-
-**Validation:**
-- `git diff --check`
-- `pnpm vitest run tests/components/TeacherAttendanceTab.test.tsx tests/components/LogSummary.test.tsx` (fails in this worktree: `vitest` command unavailable because dependencies are not installed)
-
 ## 2026-06-06 — Gradebook action consistency audit
 
 **Completed:**
@@ -693,3 +682,10 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 - Rebased `codex/action-cluster-classwork` onto `origin/main` and resolved the `TeacherTestsTab.test.tsx` helper import conflict by keeping `createMockTest` plus the branch's `Classroom` typing.
 - Verified the rebased branch with `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/TeacherTestsTab.test.tsx` and `pnpm exec tsc --noEmit --pretty false`.
+
+## 2026-06-13 — Weekly Simplification: Test Response Normalization
+
+- Selected the student test-taking response normalization path in `src/lib/test-attempts.ts` as the hotspot because it handled several legacy payload shapes with duplicated coercion branches used by both form and API routes.
+- Refactored the parser into explicit typed and legacy coercion helpers without changing behavior, and added unit coverage for fallback object shapes, CRLF normalization, and required non-blank open responses.
+- Verified with `bash scripts/verify-env.sh` and `pnpm test` (full Vitest suite: 302 files, 2671 tests).
+- PR: pending

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -688,4 +688,4 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Selected the student test-taking response normalization path in `src/lib/test-attempts.ts` as the hotspot because it handled several legacy payload shapes with duplicated coercion branches used by both form and API routes.
 - Refactored the parser into explicit typed and legacy coercion helpers without changing behavior, and added unit coverage for fallback object shapes, CRLF normalization, and required non-blank open responses.
 - Verified with `bash scripts/verify-env.sh` and `pnpm test` (full Vitest suite: 302 files, 2671 tests).
-- PR: pending
+- PR: https://github.com/codepetca/pika/pull/779

--- a/src/lib/test-attempts.ts
+++ b/src/lib/test-attempts.ts
@@ -15,65 +15,63 @@ function normalizeOpenResponseText(raw: string): string {
   return raw.replace(/\r\n/g, '\n')
 }
 
-function parseResponseValue(raw: unknown): TestResponseDraftValue | null {
-  if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0) {
-    return {
-      question_type: 'multiple_choice',
-      selected_option: raw,
-    }
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function toMultipleChoiceResponse(selectedOption: number): TestResponseDraftValue {
+  return {
+    question_type: 'multiple_choice',
+    selected_option: selectedOption,
   }
+}
 
-  if (typeof raw === 'string') {
-    return {
-      question_type: 'open_response',
-      response_text: normalizeOpenResponseText(raw),
-    }
+function toOpenResponse(responseText: string): TestResponseDraftValue {
+  return {
+    question_type: 'open_response',
+    response_text: normalizeOpenResponseText(responseText),
   }
+}
 
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
-
-  const rawRecord = raw as Record<string, unknown>
+function parseTypedResponseValue(rawRecord: Record<string, unknown>): TestResponseDraftValue | null {
   if (
     rawRecord.question_type === 'multiple_choice' &&
-    typeof rawRecord.selected_option === 'number' &&
-    Number.isInteger(rawRecord.selected_option) &&
-    rawRecord.selected_option >= 0
+    isNonNegativeInteger(rawRecord.selected_option)
   ) {
-    return {
-      question_type: 'multiple_choice',
-      selected_option: rawRecord.selected_option,
-    }
+    return toMultipleChoiceResponse(rawRecord.selected_option)
   }
 
   if (
     rawRecord.question_type === 'open_response' &&
     typeof rawRecord.response_text === 'string'
   ) {
-    return {
-      question_type: 'open_response',
-      response_text: normalizeOpenResponseText(rawRecord.response_text),
-    }
-  }
-
-  if (
-    typeof rawRecord.selected_option === 'number' &&
-    Number.isInteger(rawRecord.selected_option) &&
-    rawRecord.selected_option >= 0
-  ) {
-    return {
-      question_type: 'multiple_choice',
-      selected_option: rawRecord.selected_option,
-    }
-  }
-
-  if (typeof rawRecord.response_text === 'string') {
-    return {
-      question_type: 'open_response',
-      response_text: normalizeOpenResponseText(rawRecord.response_text),
-    }
+    return toOpenResponse(rawRecord.response_text)
   }
 
   return null
+}
+
+function parseLegacyResponseValue(rawRecord: Record<string, unknown>): TestResponseDraftValue | null {
+  if (isNonNegativeInteger(rawRecord.selected_option)) {
+    return toMultipleChoiceResponse(rawRecord.selected_option)
+  }
+
+  if (typeof rawRecord.response_text === 'string') {
+    return toOpenResponse(rawRecord.response_text)
+  }
+
+  return null
+}
+
+function parseResponseValue(raw: unknown): TestResponseDraftValue | null {
+  if (isNonNegativeInteger(raw)) return toMultipleChoiceResponse(raw)
+
+  if (typeof raw === 'string') return toOpenResponse(raw)
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+
+  const rawRecord = raw as Record<string, unknown>
+  return parseTypedResponseValue(rawRecord) ?? parseLegacyResponseValue(rawRecord)
 }
 
 function getQuestionType(question: QuestionOptionSet): TestQuestionType {

--- a/tests/unit/test-attempts.test.ts
+++ b/tests/unit/test-attempts.test.ts
@@ -32,6 +32,45 @@ describe('test-attempts utilities', () => {
     })
   })
 
+  it('preserves legacy object response shapes and normalizes open-response newlines', () => {
+    const result = normalizeTestResponses({
+      'q-3': {
+        response_text: 'Line 1\r\nLine 2',
+      },
+      'q-1': {
+        question_type: 'multiple_choice',
+        selected_option: 2,
+      },
+      'q-2': {
+        question_type: 'unknown',
+        selected_option: 1,
+      },
+      'q-4': {
+        question_type: 'multiple_choice',
+        response_text: 'fallback text',
+      },
+    })
+
+    expect(result).toEqual({
+      'q-1': {
+        question_type: 'multiple_choice',
+        selected_option: 2,
+      },
+      'q-2': {
+        question_type: 'multiple_choice',
+        selected_option: 1,
+      },
+      'q-3': {
+        question_type: 'open_response',
+        response_text: 'Line 1\nLine 2',
+      },
+      'q-4': {
+        question_type: 'open_response',
+        response_text: 'fallback text',
+      },
+    })
+  })
+
   it('validates response option ranges and question ids', () => {
     const questions = [
       { id: 'q-1', question_type: 'multiple_choice' as const, options: ['A', 'B'] },
@@ -66,6 +105,25 @@ describe('test-attempts utilities', () => {
     expect(
       validateTestResponsesAgainstQuestions(
         { 'q-1': { question_type: 'multiple_choice', selected_option: 0 } },
+        questions,
+        { requireAllQuestions: true }
+      )
+    ).toEqual({ valid: false, error: 'All questions must be answered' })
+  })
+
+  it('requires non-blank open responses when all questions must be answered', () => {
+    const questions = [
+      { id: 'q-1', question_type: 'open_response' as const, options: [], response_max_chars: 50 },
+    ]
+
+    expect(
+      validateTestResponsesAgainstQuestions(
+        {
+          'q-1': {
+            question_type: 'open_response',
+            response_text: '   ',
+          },
+        },
         questions,
         { requireAllQuestions: true }
       )


### PR DESCRIPTION
## Summary
- selected hotspot: `src/lib/test-attempts.ts` response normalization used by the student test-taking form and test attempt/respond routes
- why chosen: it handled multiple legacy payload shapes with duplicated coercion branches, which made this exam-adjacent path harder to reason about and easier to regress
- risk profile: `none`
- behavior preserved: existing numeric, string, typed-object, and legacy object response shapes still normalize the same way; no product behavior changes intended
- tests added/updated: `tests/unit/test-attempts.test.ts` now covers legacy object fallbacks, CRLF normalization, and required non-blank open responses
- commands run: `bash scripts/verify-env.sh`, `pnpm test`
- residual risks/follow-up intentionally left out: this keeps the current compatibility behavior even for oddly mixed object payloads; broader API payload tightening was intentionally left out of scope
