### PR TITLE
Guard Student Today loads by classroom

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,25 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Gradebook action consistency audit
-
-**Completed:**
-- Split the Gradebook floating action controls so score-display mode has its own secondary SplitButton and selected-student email actions only appear after a student selection.
-- Removed the actionable `Email (0)` empty state from the Gradebook tab to match roster-tab behavior.
-- Renamed the Gradebook settings toggle to `Gradebook column controls` in ARIA/title/tooltip text so the action describes the column editor.
-- Updated Gradebook component tests for the split score/email menus, selected-email visibility, and column-controls semantics.
-- Addressed PR review feedback by covering the score-display SplitButton primary action, not only the dropdown radio path.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/6d20a5cb-c497-4dc1-ac74-0637068c8a7f?tab=gradebook'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
-- Manual Playwright screenshots for selected-email desktop, selected-email mobile, and selected-email dark mode.
-- `git diff --check`
-- `pnpm vitest run tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-06-06 — Teacher calendar cache audit
 
 **Completed:**
@@ -725,3 +706,31 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test` (303 files / 2676 tests)
 - `git diff --check`
+## 2026-06-13 — Student Today stale classroom load guard
+
+**Completed:**
+- Reestablished the systems/UI audit goal and continued the active client freshness slice.
+- Guarded `StudentTodayTab` entry and lesson-plan async responses by request id and classroom id so late responses from a previous classroom cannot overwrite the current classroom view.
+- Passed the loaded classroom id through `onLessonPlanLoad` and made `ClassroomPageClient` ignore stale lesson-plan updates.
+- Added regression coverage for switching from classroom A to classroom B before classroom A's entries and lesson plan resolve.
+- Updated the adjacent `ClassroomPageClientAssignmentsEditMode` mock to use the new lesson-plan callback contract.
+- Addressed subagent PR review feedback by storing the Today sidebar lesson plan with its classroom id so classroom route changes synchronously hide stale previous-classroom plan content.
+- Added parent-level regression coverage for clearing the Student Today sidebar plan when the classroom route changes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx`
+- `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2673 tests)
+- Subagent PR review found one P2 stale sidebar display gap.
+- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx` (after review fix; 32 tests)
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2674 tests)

--- a/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
+++ b/src/app/classrooms/[classroomId]/ClassroomPageClient.tsx
@@ -327,7 +327,7 @@ function StudentTodayWorkspace({
   lastClassLessonPlan: LessonPlan | null
   lastClassDate: string | null
   lastClassLoading: boolean
-  onLessonPlanLoad: (plan: LessonPlan | null) => void
+  onLessonPlanLoad: (plan: LessonPlan | null, classroomId: string) => void
 }) {
   const [planPaneWidth, setPlanPaneWidth] = useState(34)
 
@@ -582,7 +582,13 @@ function ClassroomPageContent({
   const [selectedAssignment, setSelectedAssignment] = useState<SelectedAssignmentInstructions | null>(null)
 
   // State for today's lesson plan (student today tab)
-  const [todayLessonPlan, setTodayLessonPlan] = useState<LessonPlan | null>(null)
+  const [todayLessonPlanState, setTodayLessonPlanState] = useState<{
+    classroomId: string
+    plan: LessonPlan | null
+  }>({ classroomId: classroom.id, plan: null })
+  const todayLessonPlan = todayLessonPlanState.classroomId === classroom.id
+    ? todayLessonPlanState.plan
+    : null
   const [lastClassLessonPlan, setLastClassLessonPlan] = useState<LessonPlan | null>(null)
   const [lastClassLessonPlanDate, setLastClassLessonPlanDate] = useState<string | null>(null)
   const [lastClassLessonPlanLoading, setLastClassLessonPlanLoading] = useState(false)
@@ -647,9 +653,10 @@ function ClassroomPageContent({
     setSelectedAssignment(assignment)
   }, [])
 
-  const handleSetLessonPlan = useCallback((plan: LessonPlan | null) => {
-    setTodayLessonPlan(plan)
-  }, [])
+  const handleSetLessonPlan = useCallback((plan: LessonPlan | null, loadedClassroomId: string) => {
+    if (loadedClassroomId !== classroom.id) return
+    setTodayLessonPlanState({ classroomId: loadedClassroomId, plan })
+  }, [classroom.id])
 
   useEffect(() => {
     if (isTeacher || activeTab !== 'today') return

--- a/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTodayTab.tsx
@@ -62,7 +62,7 @@ function resolveEntryContent(entry: Entry | null): TiptapContent {
 interface StudentTodayTabProps {
   classroom: Classroom
   layout?: 'page' | 'pane'
-  onLessonPlanLoad?: (plan: LessonPlan | null) => void
+  onLessonPlanLoad?: (plan: LessonPlan | null, classroomId: string) => void
 }
 
 export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }: StudentTodayTabProps) {
@@ -97,9 +97,20 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
   const entryVersionRef = useRef(1)
   const todayRef = useRef('')
   const hasLocalEditSinceLoadRef = useRef(false)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
 
   useEffect(() => {
     async function load() {
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
+      const requestedClassroomId = classroom.id
+      const isCurrentLoad = () => (
+        loadRequestIdRef.current === requestId &&
+        currentClassroomIdRef.current === requestedClassroomId
+      )
+
       setLoading(true)
       try {
         const todayDate = getTodayInToronto()
@@ -130,19 +141,23 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
           20_000,
         )
           .then(data => {
+            if (!isCurrentLoad()) return
             const plans = data.lesson_plans || data.lessonPlans || []
             const todayPlan = plans.find((p: LessonPlan) => p.date === todayDate) || null
-            onLessonPlanLoad?.(todayPlan)
+            onLessonPlanLoad?.(todayPlan, requestedClassroomId)
           })
           .catch(err => {
+            if (!isCurrentLoad()) return
             console.error('Error loading lesson plan:', err)
-            onLessonPlanLoad?.(null)
+            onLessonPlanLoad?.(null, requestedClassroomId)
           })
 
         const applyEntryState = (todayEntry: Entry | null) => {
+          if (!isCurrentLoad()) return
+
           const loadedContent = resolveEntryContent(todayEntry)
           const draftContent = safeSessionGetJson<TiptapContent>(
-            getDailyLogDraftKey(classroom.id, todayDate)
+            getDailyLogDraftKey(requestedClassroomId, todayDate)
           )
           if (
             draftContent &&
@@ -173,16 +188,19 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
         }
 
         if (Array.isArray(cached)) {
+          if (!isCurrentLoad()) return
           setHistoryEntries(cached)
           const todayEntry = cached.find((e: Entry) => e.date === todayDate) || null
           applyEntryState(todayEntry)
           setLoading(false)
         }
 
-        const entriesPromise = fetchStudentEntriesForClassroom(classroom.id, { limit: historyLimit })
+        const entriesPromise = fetchStudentEntriesForClassroom(requestedClassroomId, { limit: historyLimit })
           .then(entries => {
+            if (!isCurrentLoad()) return
             if (hasLocalEditSinceLoadRef.current) {
               setHistoryEntries(prev => {
+                if (!isCurrentLoad()) return prev
                 const currentTodayEntry = prev.find((e: Entry) => e.date === todayDate) || null
                 const next = currentTodayEntry
                   ? upsertEntryIntoHistory(entries, currentTodayEntry, historyLimit)
@@ -202,13 +220,16 @@ export function StudentTodayTab({ classroom, layout = 'page', onLessonPlanLoad }
       } catch (err) {
         console.error('Error loading today tab:', err)
       } finally {
-        setLoading(false)
+        if (loadRequestIdRef.current === requestId && currentClassroomIdRef.current === requestedClassroomId) {
+          setLoading(false)
+        }
       }
     }
 
     load()
 
     return () => {
+      loadRequestIdRef.current += 1
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current)
       }

--- a/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
+++ b/tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
@@ -205,11 +205,12 @@ vi.mock('@/app/classrooms/[classroomId]/StudentTodayTab', async () => {
   const React = await import('react')
 
   return {
-    StudentTodayTab: ({ onLessonPlanLoad }: any) => {
+    StudentTodayTab: ({ classroom, onLessonPlanLoad }: any) => {
       React.useEffect(() => {
+        if (classroom?.id !== 'classroom-1') return
         onLessonPlanLoad?.({
           id: 'today-plan',
-          classroom_id: 'classroom-1',
+          classroom_id: classroom.id,
           date: '2026-05-12',
           content: {
             type: 'doc',
@@ -223,8 +224,8 @@ vi.mock('@/app/classrooms/[classroomId]/StudentTodayTab', async () => {
           content_markdown: null,
           created_at: '2026-05-12T00:00:00Z',
           updated_at: '2026-05-12T00:00:00Z',
-        })
-      }, [onLessonPlanLoad])
+        }, classroom.id)
+      }, [classroom?.id, onLessonPlanLoad])
 
       return <div />
     },
@@ -335,14 +336,19 @@ function renderClient(options?: {
   )
 }
 
-function renderStudentClient(options?: { initialTab?: string; initialSearchParams?: Record<string, string | undefined> }) {
+function renderStudentClient(options?: {
+  classroom?: Classroom
+  initialTab?: string
+  initialSearchParams?: Record<string, string | undefined>
+}) {
+  const targetClassroom = options?.classroom ?? classroom
   const initialTab = options?.initialTab ?? 'today'
   const initialSearchParams = options?.initialSearchParams ?? { tab: initialTab }
 
   return render(
     <MarkdownPreferenceProvider>
       <ClassroomPageClient
-        classroom={classroom}
+        classroom={targetClassroom}
         user={{ id: 'student-1', email: 'student1@example.com', role: 'student' }}
         teacherClassrooms={[]}
         initialTab={initialTab}
@@ -487,6 +493,31 @@ describe('ClassroomPageClient assignment edit-mode markdown gating', () => {
     expect(screen.getByRole('heading', { name: 'Yesterday' })).toBeInTheDocument()
     expect(screen.getByText('Mon May 11')).toBeInTheDocument()
     expect(await screen.findByText('Last class calendar entry')).toBeInTheDocument()
+  })
+
+  it('clears the student today sidebar plan when the classroom route changes', async () => {
+    const secondClassroom = { ...classroom, id: 'classroom-2', title: 'Chemistry' }
+    window.history.replaceState({}, '', '/classrooms/classroom-1?tab=today')
+
+    const view = renderStudentClient({ classroom, initialTab: 'today', initialSearchParams: { tab: 'today' } })
+
+    expect(await screen.findByText('Today calendar entry')).toBeInTheDocument()
+
+    window.history.replaceState({}, '', '/classrooms/classroom-2?tab=today')
+    view.rerender(
+      <MarkdownPreferenceProvider>
+        <ClassroomPageClient
+          classroom={secondClassroom}
+          user={{ id: 'student-1', email: 'student1@example.com', role: 'student' }}
+          teacherClassrooms={[]}
+          initialTab="today"
+          initialSearchParams={{ tab: 'today' }}
+        />
+      </MarkdownPreferenceProvider>,
+    )
+
+    expect(screen.queryByText('Today calendar entry')).not.toBeInTheDocument()
+    expect(screen.getByText('No lesson plan for today.')).toBeInTheDocument()
   })
 
   it('falls back from the legacy quizzes tab to the default teacher tab', async () => {

--- a/tests/components/StudentTodayTabHistory.test.tsx
+++ b/tests/components/StudentTodayTabHistory.test.tsx
@@ -100,6 +100,12 @@ const classroom: Classroom = {
   updated_at: '2025-01-01T00:00:00Z',
 }
 
+const secondClassroom: Classroom = {
+  ...classroom,
+  id: 'c2',
+  title: 'Second Class',
+}
+
 const entries: Entry[] = [
   {
     id: 'e1',
@@ -229,6 +235,99 @@ describe('StudentTodayTab history section', () => {
 
     expect(await screen.findByText('No past logs yet')).toBeInTheDocument()
     expect(screen.queryByText('Tue Dec 16')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale entry and lesson-plan responses after classroom changes', async () => {
+    const firstEntriesRequest = deferred<any>()
+    const firstLessonPlanRequest = deferred<any>()
+    const secondEntriesRequest = deferred<any>()
+    const secondLessonPlanRequest = deferred<any>()
+    const lessonPlanLoads: Array<{ classroomId: string; title: string | null }> = []
+    const firstEntries: Entry[] = [
+      {
+        ...entries[0],
+        id: 'first-today-entry',
+        classroom_id: classroom.id,
+        text: 'Classroom A today log.',
+      },
+    ]
+    const secondEntries: Entry[] = [
+      {
+        ...entries[0],
+        id: 'second-today-entry',
+        classroom_id: secondClassroom.id,
+        text: 'Classroom B today log.',
+      },
+    ]
+    const firstLessonPlan = {
+      id: 'first-plan',
+      classroom_id: classroom.id,
+      date: '2025-12-16',
+      title: 'Classroom A plan',
+      content: null,
+      created_at: '2025-12-16T01:00:00Z',
+      updated_at: '2025-12-16T01:00:00Z',
+    }
+    const secondLessonPlan = {
+      ...firstLessonPlan,
+      id: 'second-plan',
+      classroom_id: secondClassroom.id,
+      title: 'Classroom B plan',
+    }
+    const fetchMock = vi.fn((input: RequestInfo) => {
+      const url = String(input)
+      if (url.startsWith(`/api/student/entries?classroom_id=${classroom.id}&limit=12`)) {
+        return firstEntriesRequest.promise
+      }
+      if (url.startsWith(`/api/student/entries?classroom_id=${secondClassroom.id}&limit=12`)) {
+        return secondEntriesRequest.promise
+      }
+      if (url.includes(`/api/student/classrooms/${classroom.id}/lesson-plans`)) {
+        return firstLessonPlanRequest.promise
+      }
+      if (url.includes(`/api/student/classrooms/${secondClassroom.id}/lesson-plans`)) {
+        return secondLessonPlanRequest.promise
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const view = render(
+      <StudentTodayTab
+        classroom={classroom}
+        onLessonPlanLoad={(plan, classroomId) => {
+          lessonPlanLoads.push({ classroomId, title: plan?.title ?? null })
+        }}
+      />,
+    )
+
+    view.rerender(
+      <StudentTodayTab
+        classroom={secondClassroom}
+        onLessonPlanLoad={(plan, classroomId) => {
+          lessonPlanLoads.push({ classroomId, title: plan?.title ?? null })
+        }}
+      />,
+    )
+
+    secondLessonPlanRequest.resolve(await mockJson({ lesson_plans: [secondLessonPlan] }))
+    secondEntriesRequest.resolve(await mockJson({ entries: secondEntries }))
+
+    expect(await screen.findByDisplayValue('Classroom B today log.')).toBeInTheDocument()
+    expect(lessonPlanLoads).toEqual([
+      { classroomId: secondClassroom.id, title: 'Classroom B plan' },
+    ])
+
+    firstLessonPlanRequest.resolve(await mockJson({ lesson_plans: [firstLessonPlan] }))
+    firstEntriesRequest.resolve(await mockJson({ entries: firstEntries }))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Classroom B today log.')).toBeInTheDocument()
+    })
+    expect(screen.queryByDisplayValue('Classroom A today log.')).not.toBeInTheDocument()
+    expect(lessonPlanLoads).toEqual([
+      { classroomId: secondClassroom.id, title: 'Classroom B plan' },
+    ])
   })
 
   it('keeps an empty new entry marked saved', async () => {


### PR DESCRIPTION
## Summary
- Guard Student Today entry and lesson-plan async loads with request/classroom identity so stale classroom responses are ignored after navigation.
- Pass the loaded classroom id through the Today lesson-plan callback and ignore stale parent updates.
- Store the Today sidebar lesson plan with its classroom id so route changes synchronously hide previous-classroom plan content.
- Add regression coverage for resolving classroom A after switching to classroom B and for clearing the parent sidebar plan on classroom route changes.

## Review
- Subagent review found one P2 stale sidebar display gap; fixed in the updated commit.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx
- pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
- pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm build
- pnpm vitest run --sequence.concurrent=false (303 files / 2674 tests)
