### PR TITLE
[codex] Centralize legacy quiz client readers

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,25 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Gradebook action consistency audit
-
-**Completed:**
-- Split the Gradebook floating action controls so score-display mode has its own secondary SplitButton and selected-student email actions only appear after a student selection.
-- Removed the actionable `Email (0)` empty state from the Gradebook tab to match roster-tab behavior.
-- Renamed the Gradebook settings toggle to `Gradebook column controls` in ARIA/title/tooltip text so the action describes the column editor.
-- Updated Gradebook component tests for the split score/email menus, selected-email visibility, and column-controls semantics.
-- Addressed PR review feedback by covering the score-display SplitButton primary action, not only the dropdown radio path.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/6d20a5cb-c497-4dc1-ac74-0637068c8a7f?tab=gradebook'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook'`
-- Manual Playwright screenshots for selected-email desktop, selected-email mobile, and selected-email dark mode.
-- `git diff --check`
-- `pnpm vitest run tests/components/TeacherGradebookTab.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-
 ## 2026-06-06 — Teacher calendar cache audit
 
 **Completed:**
@@ -701,4 +682,21 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
 - `pnpm test` (303 files / 2672 tests)
+- `git diff --check`
+
+## 2026-06-13 — Legacy quiz client response readers
+
+**Completed:**
+- Created `codex/legacy-quiz-client-readers` from current `origin/main`.
+- Added `readTestFromPayload` and `readTestsFromPayload` to `src/lib/test-api-contract.ts` so active client code reads current Tests API keys first and legacy quiz keys only as compatibility fallback.
+- Replaced scattered `data.test ?? data.quiz` and `data.tests || data.quizzes || []` reads in teacher/student Tests UI, test document sync flows, the teacher preview page, and the assessment URL-state e2e helper.
+- Expanded `tests/lib/test-api-contract.test.ts` to cover current-key preference, legacy fallback, and empty payload behavior.
+- Did not change server payloads, schema, migrations, RPCs, storage paths, gradebook contracts, course blueprint contracts, or DB-shaped `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test` (303 files / 2676 tests)
 - `git diff --check`

--- a/e2e/teacher-assessment-url-state.spec.ts
+++ b/e2e/teacher-assessment-url-state.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { readTestsFromPayload } from '../src/lib/test-api-contract'
 
 const TEACHER_STORAGE = '.auth/teacher.json'
 
@@ -58,7 +59,7 @@ async function loadTeacherTestWithStudent(page: Page, classroomId: string): Prom
     page,
     `/api/teacher/tests?classroom_id=${encodeURIComponent(classroomId)}`,
   )
-  const tests = data.tests || data.quizzes || []
+  const tests = readTestsFromPayload<AssessmentRecord>(data)
   const preferredTests = [
     ...tests.filter((candidate) => Number(candidate.stats?.responded || 0) > 0),
     ...tests.filter((candidate) => Number(candidate.stats?.responded || 0) <= 0),

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -15,6 +15,7 @@ import { fetchJSONWithCache } from '@/lib/request-cache'
 import { StudentTestForm } from '@/components/StudentTestForm'
 import { StudentTestResults } from '@/components/StudentTestResults'
 import { Button, ConfirmDialog, EmptyState } from '@/ui'
+import { readTestFromPayload, readTestsFromPayload } from '@/lib/test-api-contract'
 import {
   STUDENT_TEST_EXAM_MODE_CHANGE_EVENT,
   STUDENT_TEST_ROUTE_EXIT_ATTEMPT_EVENT,
@@ -393,7 +394,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
       ) {
         return
       }
-      setTests(data.tests || data.quizzes || [])
+      setTests(readTestsFromPayload(data))
     } catch (err) {
       if (
         listRequestIdRef.current === requestId &&
@@ -492,7 +493,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
       ) {
         return
       }
-      const responseTest = data.test ?? data.quiz
+      const responseTest = readTestFromPayload<StudentTestView>(data)
       const listTest = tests.find((test) => test.id === testId)
       const nextTest = responseTest ?? listTest
       if (!nextTest) throw new Error('Test not found')

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -52,6 +52,7 @@ import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { getTestExitCount } from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
+import { readTestFromPayload, readTestsFromPayload } from '@/lib/test-api-contract'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
@@ -741,7 +742,7 @@ export function TeacherTestsTab({
         },
         0,
       )
-      const loadedTests = (data.tests || data.quizzes || []) as TestAssessmentWithStats[]
+      const loadedTests = readTestsFromPayload<TestAssessmentWithStats>(data)
       const currentSelectedTestId = selectedTestIdRef.current
       const currentDraftSummary = selectedTestDraftSummaryRef.current
       setTests(
@@ -813,7 +814,7 @@ export function TeacherTestsTab({
       if (isStaleRequest()) return
       if (!ok) throw new Error(data.error || 'Failed to load test results')
 
-      const responseTest = data?.test ?? data?.quiz
+      const responseTest = readTestFromPayload<TestAssessment>(data)
       const nextStatus =
         responseTest?.status === 'draft' || responseTest?.status === 'active' || responseTest?.status === 'closed'
           ? (responseTest.status as TestAssessment['status'])
@@ -1317,7 +1318,11 @@ export function TeacherTestsTab({
       if (!response.ok) {
         throw new Error(data.error || 'Failed to create test')
       }
-      handleTestCreated((data.test ?? data.quiz) as TestAssessment)
+      const createdTest = readTestFromPayload<TestAssessment>(data)
+      if (!createdTest) {
+        throw new Error('Failed to create test')
+      }
+      handleTestCreated(createdTest)
     } catch (error: any) {
       showMessage({ text: error?.message || 'Failed to create test', tone: 'warning' })
     } finally {
@@ -1694,7 +1699,7 @@ export function TeacherTestsTab({
         throw new Error(data.error || 'Failed to update test')
       }
 
-      const responseTest = data?.test ?? data?.quiz
+      const responseTest = readTestFromPayload<TestAssessmentWithStats>(data)
       const nextStatus =
         responseTest?.status === 'draft' || responseTest?.status === 'active' || responseTest?.status === 'closed'
           ? responseTest.status

--- a/src/components/TeacherTestPreviewPage.tsx
+++ b/src/components/TeacherTestPreviewPage.tsx
@@ -8,6 +8,7 @@ import { StudentTestForm } from '@/components/StudentTestForm'
 import { TestTextDocumentViewer } from '@/components/TestTextDocumentViewer'
 import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
+import { readTestFromPayload } from '@/lib/test-api-contract'
 import type { TestAssessmentQuestion, TestDocument } from '@/types'
 
 interface Props {
@@ -217,7 +218,7 @@ export function TeacherTestPreviewPage({
         throw new Error(data?.error || 'Failed to load preview')
       }
 
-      const responseTest = data?.test ?? data?.quiz
+      const responseTest = readTestFromPayload<{ title?: string; documents?: unknown }>(data)
       setTitle(responseTest?.title || 'Test Preview')
       setQuestions((data?.questions || []) as TestAssessmentQuestion[])
       setDocuments(normalizeTestDocuments(responseTest?.documents))
@@ -278,7 +279,7 @@ export function TeacherTestPreviewPage({
           return
         }
 
-        const responseTest = data?.test ?? data?.quiz
+        const responseTest = readTestFromPayload<{ documents?: unknown }>(data)
         setDocuments(normalizeTestDocuments(responseTest?.documents))
       } catch (error) {
         if (!isCancelled) {

--- a/src/components/TestDetailPanel.tsx
+++ b/src/components/TestDetailPanel.tsx
@@ -38,6 +38,7 @@ import { DEFAULT_MULTIPLE_CHOICE_POINTS, DEFAULT_OPEN_RESPONSE_POINTS } from '@/
 import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-documents'
 import { isGeneratedAssessmentTitle } from '@/lib/assessment-titles'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
+import { readTestFromPayload } from '@/lib/test-api-contract'
 import { markdownToQuiz, quizToMarkdown } from '@/lib/quiz-markdown'
 import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
 import type {
@@ -961,7 +962,7 @@ export function TestDetailPanel({
         if (detailRes?.ok) {
           const detailData = await detailRes.json()
           if (!isCurrentLoadRequest(requestId, scope)) return
-          const responseTest = detailData?.test ?? detailData?.quiz
+          const responseTest = readTestFromPayload<{ documents?: unknown }>(detailData)
           setDocuments(normalizeTestDocuments(responseTest?.documents))
         }
       }
@@ -1030,7 +1031,7 @@ export function TestDetailPanel({
           return
         }
 
-        const responseTest = data?.test ?? data?.quiz
+        const responseTest = readTestFromPayload<{ documents?: unknown }>(data)
         setDocuments(normalizeTestDocuments(responseTest?.documents))
       } catch (error) {
         if (!isCancelled) {

--- a/src/components/TestDocumentsEditor.tsx
+++ b/src/components/TestDocumentsEditor.tsx
@@ -11,6 +11,7 @@ import {
   normalizeTestDocuments,
   isValidHttpUrl,
 } from '@/lib/test-documents'
+import { readTestFromPayload } from '@/lib/test-api-contract'
 import type { TestDocument } from '@/types'
 
 interface Props {
@@ -156,7 +157,7 @@ export function TestDocumentsEditor({
         throw new Error(data.error || 'Failed to save documents')
       }
 
-      const responseTest = data.test ?? data.quiz
+      const responseTest = readTestFromPayload<{ documents?: unknown }>(data)
       const normalized = normalizeTestDocuments(responseTest?.documents || nextDocs)
       setLocalDocs(normalized)
       onDocumentsChange?.(normalized)
@@ -189,7 +190,7 @@ export function TestDocumentsEditor({
         throw new Error(data.error || 'Failed to sync document')
       }
 
-      const responseTest = data.test ?? data.quiz
+      const responseTest = readTestFromPayload<{ documents?: unknown }>(data)
       const normalized = normalizeTestDocuments(responseTest?.documents || localDocs)
       setLocalDocs(normalized)
       onDocumentsChange?.(normalized)

--- a/src/lib/test-api-contract.ts
+++ b/src/lib/test-api-contract.ts
@@ -15,3 +15,21 @@ export function withLegacyQuizKey<T>(test: T): { test: T; quiz: T } {
     quiz: test,
   }
 }
+
+type TestApiListPayload<T> = {
+  tests?: T[] | null
+  quizzes?: T[] | null
+}
+
+type TestApiDetailPayload<T> = {
+  test?: T | null
+  quiz?: T | null
+}
+
+export function readTestsFromPayload<T>(payload: TestApiListPayload<T> | null | undefined): T[] {
+  return payload?.tests ?? payload?.quizzes ?? []
+}
+
+export function readTestFromPayload<T>(payload: TestApiDetailPayload<T> | null | undefined): T | undefined {
+  return payload?.test ?? payload?.quiz ?? undefined
+}

--- a/tests/lib/test-api-contract.test.ts
+++ b/tests/lib/test-api-contract.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { withLegacyQuizKey, withLegacyQuizListKey } from '@/lib/test-api-contract'
+import {
+  readTestFromPayload,
+  readTestsFromPayload,
+  withLegacyQuizKey,
+  withLegacyQuizListKey,
+} from '@/lib/test-api-contract'
 
 describe('test API compatibility contract', () => {
   it('mirrors the current tests list under the legacy quizzes key', () => {
@@ -18,5 +23,33 @@ describe('test API compatibility contract', () => {
 
     expect(payload).toEqual({ test, quiz: test })
     expect(payload.quiz).toBe(payload.test)
+  })
+
+  it('reads the current tests list before the legacy quizzes key', () => {
+    const currentTests = [{ id: 'test-current' }]
+    const legacyTests = [{ id: 'test-legacy' }]
+
+    expect(readTestsFromPayload({ tests: currentTests, quizzes: legacyTests })).toBe(currentTests)
+  })
+
+  it('falls back to the legacy quizzes key for older list payloads', () => {
+    const legacyTests = [{ id: 'test-legacy' }]
+
+    expect(readTestsFromPayload({ quizzes: legacyTests })).toBe(legacyTests)
+    expect(readTestsFromPayload(null)).toEqual([])
+  })
+
+  it('reads the current test detail before the legacy quiz key', () => {
+    const currentTest = { id: 'test-current' }
+    const legacyTest = { id: 'test-legacy' }
+
+    expect(readTestFromPayload({ test: currentTest, quiz: legacyTest })).toBe(currentTest)
+  })
+
+  it('falls back to the legacy quiz key for older detail payloads', () => {
+    const legacyTest = { id: 'test-legacy' }
+
+    expect(readTestFromPayload({ quiz: legacyTest })).toBe(legacyTest)
+    expect(readTestFromPayload(undefined)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Add shared Tests API client readers for current `test` / `tests` keys with legacy `quiz` / `quizzes` fallback
- Replace scattered client fallback expressions in teacher/student Tests UI, document sync flows, teacher preview, and the assessment URL-state e2e helper
- Extend `test-api-contract` coverage for current-key preference, legacy fallback, and empty payload behavior

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test` (303 files / 2676 tests)
- `git diff --check`

## Notes
- No server payloads, schema, migrations, RPCs, storage paths, gradebook/course-blueprint contracts, or DB-shaped `quiz_id` fields changed.
