### PR TITLE
[codex] Centralize test assessment type names

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -670,6 +670,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Refactored the parser into explicit typed and legacy coercion helpers without changing behavior, and added unit coverage for fallback object shapes, CRLF normalization, and required non-blank open responses.
 - Verified with `bash scripts/verify-env.sh` and `pnpm test` (full Vitest suite: 302 files, 2671 tests).
 - PR: https://github.com/codepetca/pika/pull/779
+
 ## 2026-06-12 — Legacy quiz API compatibility contract helper
 
 **Completed:**
@@ -734,3 +735,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm build`
 - `pnpm vitest run --sequence.concurrent=false` (303 files / 2674 tests)
+
+## 2026-06-13 — Legacy quiz type contract cleanup
+
+**Completed:**
+- Inverted the shared assessment type definitions so active `TestAssessment*`, `StudentTest*`, and `TestFocus*` names are canonical in `src/types/index.ts`.
+- Kept legacy `Quiz*` type exports as compatibility aliases/interfaces for DB-shaped and older contract code.
+- Updated assessment utilities and server access helpers to consume canonical Test/Assessment type names while preserving legacy exports and response shapes.
+- Moved the active TeacherTestsTab component test from `QuizWithStats` to `TestAssessmentWithStats`.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm test` (303 files / 2678 tests)
+- `git diff --check`

--- a/src/lib/assessments.ts
+++ b/src/lib/assessments.ts
@@ -6,23 +6,23 @@
  */
 
 import type {
-  Quiz,
-  QuizAssessmentType,
-  QuizFocusEventType,
-  QuizFocusSummary,
-  QuizQuestion,
-  QuizResponse,
-  QuizWithStats,
-  QuizStatus,
-  StudentQuizStatus,
-  QuizResultsAggregate,
+  TestAssessment,
+  TestAssessmentQuestion,
+  TestAssessmentResponse,
+  TestAssessmentStatus,
+  TestAssessmentType,
+  TestAssessmentWithStats,
+  TestFocusEventType,
+  TestFocusSummary,
+  TestResultsAggregate,
+  StudentTestStatus,
 } from '@/types'
 
 /**
  * Get human-readable label for quiz status
  */
-export function getQuizStatusLabel(status: QuizStatus): string {
-  const labels: Record<QuizStatus, string> = {
+export function getQuizStatusLabel(status: TestAssessmentStatus): string {
+  const labels: Record<TestAssessmentStatus, string> = {
     draft: 'Draft',
     active: 'Active',
     closed: 'Closed',
@@ -31,18 +31,18 @@ export function getQuizStatusLabel(status: QuizStatus): string {
 }
 
 export function getAssessmentStatusLabel(
-  status: QuizStatus,
-  assessmentType: QuizAssessmentType
+  status: TestAssessmentStatus,
+  assessmentType: TestAssessmentType
 ): string {
   if (assessmentType === 'test' && status === 'active') return 'Open'
   return getQuizStatusLabel(status)
 }
 
 export function getTeacherTestListDisplayStatus(
-  test: Pick<Quiz, 'status'> & {
-    stats?: Partial<QuizWithStats['stats']> | null
+  test: Pick<TestAssessment, 'status'> & {
+    stats?: Partial<TestAssessmentWithStats['stats']> | null
   }
-): QuizStatus {
+): TestAssessmentStatus {
   if (test.status !== 'active') return test.status
 
   const totalStudents = toNonNegativeCount(test.stats?.total_students)
@@ -71,8 +71,8 @@ function toNonNegativeCount(value: unknown): number | null {
 /**
  * Get badge CSS classes for quiz status
  */
-export function getQuizStatusBadgeClass(status: QuizStatus): string {
-  const classes: Record<QuizStatus, string> = {
+export function getQuizStatusBadgeClass(status: TestAssessmentStatus): string {
+  const classes: Record<TestAssessmentStatus, string> = {
     draft: 'bg-surface-2 text-text-muted',
     active: 'bg-success-bg text-success',
     closed: 'bg-danger-bg text-danger',
@@ -80,14 +80,19 @@ export function getQuizStatusBadgeClass(status: QuizStatus): string {
   return classes[status]
 }
 
-export function getQuizAssessmentType(quiz: { assessment_type?: QuizAssessmentType | null }): QuizAssessmentType {
+export function getQuizAssessmentType(
+  quiz: { assessment_type?: TestAssessmentType | null }
+): TestAssessmentType {
   return quiz.assessment_type === 'test' ? 'test' : 'quiz'
 }
 
 /**
  * Check if a student can respond to a quiz
  */
-export function canStudentRespond(quiz: Pick<Quiz, 'status'>, hasResponded: boolean): boolean {
+export function canStudentRespond(
+  quiz: Pick<TestAssessment, 'status'>,
+  hasResponded: boolean
+): boolean {
   return quiz.status === 'active' && !hasResponded
 }
 
@@ -95,7 +100,7 @@ export function canStudentRespond(quiz: Pick<Quiz, 'status'>, hasResponded: bool
  * Check if a student can view quiz results
  */
 export function canStudentViewResults(
-  quiz: Pick<Quiz, 'show_results' | 'status'>,
+  quiz: Pick<TestAssessment, 'show_results' | 'status'>,
   hasResponded: boolean
 ): boolean {
   return quiz.show_results && quiz.status === 'closed' && hasResponded
@@ -106,7 +111,7 @@ export function canStudentViewResults(
  * Tests are released when work has been explicitly returned by the teacher.
  */
 export function canStudentViewTestResults(
-  test: Pick<Quiz, 'status'>,
+  test: Pick<TestAssessment, 'status'>,
   hasResponded: boolean,
   returnedAt: string | null | undefined | boolean
 ): boolean {
@@ -122,10 +127,10 @@ export function canStudentViewTestResults(
  * Both wrappers below delegate here; call this directly when you have a mixed-type assessment.
  */
 export function getStudentAssessmentStatus(
-  assessment: Pick<Quiz, 'status'> & { show_results?: boolean | null },
+  assessment: Pick<TestAssessment, 'status'> & { show_results?: boolean | null },
   hasResponded: boolean,
   opts?: { returnedAt?: string | null | boolean }
-): StudentQuizStatus {
+): StudentTestStatus {
   if (!hasResponded) return 'not_started'
   if (assessment.status === 'closed') {
     if (opts?.returnedAt) return 'can_view_results'
@@ -139,9 +144,9 @@ export function getStudentAssessmentStatus(
  * Results become visible when the quiz is closed and show_results is enabled.
  */
 export function getStudentQuizStatus(
-  quiz: Pick<Quiz, 'show_results' | 'status'>,
+  quiz: Pick<TestAssessment, 'show_results' | 'status'>,
   hasResponded: boolean
-): StudentQuizStatus {
+): StudentTestStatus {
   return getStudentAssessmentStatus(quiz, hasResponded)
 }
 
@@ -150,10 +155,10 @@ export function getStudentQuizStatus(
  * Tests become viewable once the teacher returns the submitted work.
  */
 export function getStudentTestStatus(
-  test: Pick<Quiz, 'status'>,
+  test: Pick<TestAssessment, 'status'>,
   hasResponded: boolean,
   returnedAt: string | null | undefined | boolean
-): StudentQuizStatus {
+): StudentTestStatus {
   return getStudentAssessmentStatus(test, hasResponded, { returnedAt })
 }
 
@@ -162,7 +167,7 @@ export function getStudentTestStatus(
  * Policy: teachers can edit question sets at any stage.
  */
 export function canEditQuizQuestions(
-  _quiz: Pick<Quiz, 'status'>,
+  _quiz: Pick<TestAssessment, 'status'>,
   _hasResponses: boolean
 ): boolean {
   return true
@@ -172,9 +177,9 @@ export function canEditQuizQuestions(
  * Aggregate quiz responses into per-question results
  */
 export function aggregateResults(
-  questions: QuizQuestion[],
-  responses: QuizResponse[]
-): QuizResultsAggregate[] {
+  questions: TestAssessmentQuestion[],
+  responses: TestAssessmentResponse[]
+): TestResultsAggregate[] {
   return questions.map((q) => {
     const questionResponses = responses.filter((r) => r.question_id === q.id)
     const counts = q.options.map((_, idx) =>
@@ -207,7 +212,7 @@ export function validateQuizOptions(options: string[]): { valid: boolean; error?
  * Check if a quiz can be activated (draft → active)
  */
 export function canActivateQuiz(
-  quiz: Pick<Quiz, 'status'>,
+  quiz: Pick<TestAssessment, 'status'>,
   questionsCount: number
 ): { valid: boolean; error?: string } {
   if (quiz.status !== 'draft') {
@@ -220,7 +225,7 @@ export function canActivateQuiz(
 }
 
 type FocusEventLike = {
-  event_type: QuizFocusEventType
+  event_type: TestFocusEventType
   occurred_at: string
 }
 
@@ -229,7 +234,7 @@ export const QUIZ_EXIT_BURST_WINDOW_MS = 2000
 type QuizExitSummaryLike = ({
   exit_count?: number | null
 } & Pick<
-  QuizFocusSummary,
+  TestFocusSummary,
   'away_count' | 'route_exit_attempts' | 'window_unmaximize_attempts'
 >) | null | undefined
 
@@ -251,7 +256,7 @@ export function getQuizExitCount(summary: QuizExitSummaryLike): number {
   return awayCount + routeExitAttempts + windowUnmaximizeAttempts
 }
 
-export function emptyQuizFocusSummary(): QuizFocusSummary {
+export function emptyQuizFocusSummary(): TestFocusSummary {
   return {
     exit_count: 0,
     away_count: 0,
@@ -263,7 +268,7 @@ export function emptyQuizFocusSummary(): QuizFocusSummary {
   }
 }
 
-export function summarizeQuizFocusEvents(events: FocusEventLike[]): QuizFocusSummary {
+export function summarizeQuizFocusEvents(events: FocusEventLike[]): TestFocusSummary {
   if (!events.length) return emptyQuizFocusSummary()
 
   const sorted = [...events].sort(

--- a/src/lib/server/assessments.ts
+++ b/src/lib/server/assessments.ts
@@ -1,12 +1,12 @@
 import { getServiceRoleClient } from '@/lib/supabase'
 import { isVisibleAtNow } from '@/lib/scheduling'
-import type { QuizAssessmentType, QuizStatus } from '@/types'
+import type { TestAssessmentStatus, TestAssessmentType } from '@/types'
 
-export type QuizAccessRecord = {
+export type AssessmentAccessRecord = {
   id: string
   classroom_id: string
-  assessment_type?: QuizAssessmentType | null
-  status: QuizStatus
+  assessment_type?: TestAssessmentType | null
+  status: TestAssessmentStatus
   opens_at: string | null
   title: string
   show_results: boolean
@@ -21,18 +21,18 @@ export type QuizAccessRecord = {
   }
 }
 
-export type AssessmentAccessRecord = QuizAccessRecord
+export type QuizAccessRecord = AssessmentAccessRecord
 
 type AccessResult<T> =
   | { ok: true; assessment: T; quiz: T }
   | { ok: false; status: number; error: string }
 
-type QuizVisibilityRecord = {
-  status: QuizStatus
+type AssessmentVisibilityRecord = {
+  status: TestAssessmentStatus
   opens_at: string | null
 }
 
-type AssessmentVisibilityRecord = QuizVisibilityRecord
+type QuizVisibilityRecord = AssessmentVisibilityRecord
 
 function assessmentAccessSuccess<T>(assessment: T): AccessResult<T> {
   return {
@@ -65,7 +65,7 @@ export async function assertTeacherOwnsAssessment(
   teacherId: string,
   assessmentId: string,
   opts?: { checkArchived?: boolean }
-): Promise<AccessResult<QuizAccessRecord>> {
+): Promise<AccessResult<AssessmentAccessRecord>> {
   const supabase = getServiceRoleClient()
   const { data: assessment, error } = await supabase
     .from('quizzes')
@@ -92,7 +92,7 @@ export async function assertTeacherOwnsAssessment(
     return { ok: false, status: 403, error: 'Classroom is archived' }
   }
 
-  return assessmentAccessSuccess(assessment as QuizAccessRecord)
+  return assessmentAccessSuccess(assessment as AssessmentAccessRecord)
 }
 
 export const assertTeacherOwnsQuiz = assertTeacherOwnsAssessment
@@ -100,7 +100,7 @@ export const assertTeacherOwnsQuiz = assertTeacherOwnsAssessment
 export async function assertStudentCanAccessAssessment(
   studentId: string,
   assessmentId: string
-): Promise<AccessResult<QuizAccessRecord>> {
+): Promise<AccessResult<AssessmentAccessRecord>> {
   const supabase = getServiceRoleClient()
   const { data: assessment, error } = await supabase
     .from('quizzes')
@@ -134,7 +134,7 @@ export async function assertStudentCanAccessAssessment(
     return { ok: false, status: 403, error: 'Not enrolled in this classroom' }
   }
 
-  return assessmentAccessSuccess(assessment as QuizAccessRecord)
+  return assessmentAccessSuccess(assessment as AssessmentAccessRecord)
 }
 
 export const assertStudentCanAccessQuiz = assertStudentCanAccessAssessment

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -716,7 +716,7 @@ export interface CourseBlueprintAssignment {
 export interface CourseBlueprintAssessment {
   id: string
   course_blueprint_id: string
-  assessment_type: QuizAssessmentType
+  assessment_type: TestAssessmentType
   title: string
   content: Record<string, unknown>
   documents: TestDocument[]
@@ -766,13 +766,13 @@ export interface CreateClassroomFromBlueprintInput {
   end_date?: string
 }
 
-// Quiz types
-export type QuizStatus = 'draft' | 'active' | 'closed'
-export type QuizAssessmentType = 'quiz' | 'test'
+// Assessment/Test types
+export type TestAssessmentStatus = 'draft' | 'active' | 'closed'
+export type TestAssessmentType = 'quiz' | 'test'
 export type SurveyStatus = 'draft' | 'active' | 'closed'
 export type SurveyQuestionType = 'multiple_choice' | 'short_text' | 'link'
 export type TestStudentAvailabilityState = 'open' | 'closed'
-export type QuizFocusEventType =
+export type TestFocusEventType =
   | 'away_start'
   | 'away_end'
   | 'route_exit_attempt'
@@ -792,7 +792,7 @@ export interface TestDocument {
 }
 export type TestAiGradingBasis = 'teacher_key' | 'generated_reference'
 
-export interface QuizFocusSummary {
+export interface TestFocusSummary {
   exit_count: number
   away_count: number
   away_total_seconds: number
@@ -884,12 +884,12 @@ export interface SurveyQuestionResult {
   total_responses: number
 }
 
-export interface Quiz {
+export interface TestAssessment {
   id: string
   classroom_id: string
   title: string
-  assessment_type: QuizAssessmentType
-  status: QuizStatus
+  assessment_type: TestAssessmentType
+  status: TestAssessmentStatus
   opens_at: string | null
   show_results: boolean
   documents?: TestDocument[]
@@ -902,7 +902,7 @@ export interface Quiz {
   updated_at: string
 }
 
-export interface QuizQuestion {
+export interface TestAssessmentQuestion {
   id: string
   quiz_id: string
   question_text: string
@@ -919,7 +919,7 @@ export interface QuizQuestion {
   updated_at: string
 }
 
-export interface QuizResponse {
+export interface TestAssessmentResponse {
   id: string
   quiz_id: string
   question_id: string
@@ -1002,12 +1002,12 @@ export interface TestAttemptHistoryEntry {
   created_at: string
 }
 
-// Extended quiz types for UI
-export interface QuizWithQuestions extends Quiz {
-  questions: QuizQuestion[]
+// Extended assessment types for UI
+export interface TestAssessmentWithQuestions extends TestAssessment {
+  questions: TestAssessmentQuestion[]
 }
 
-export interface QuizWithStats extends Quiz {
+export interface TestAssessmentWithStats extends TestAssessment {
   stats: {
     total_students: number
     responded: number
@@ -1025,18 +1025,18 @@ export interface AssessmentEditorSummaryUpdate {
 }
 
 export interface AssessmentWorkspaceSummaryPatch extends Partial<AssessmentEditorSummaryUpdate> {
-  status?: QuizStatus
+  status?: TestAssessmentStatus
 }
 
-export type StudentQuizStatus = 'not_started' | 'responded' | 'can_view_results'
+export type StudentTestStatus = 'not_started' | 'responded' | 'can_view_results'
 
-export interface StudentQuizView extends Quiz {
-  student_status: StudentQuizStatus
-  questions?: QuizQuestion[]
-  focus_summary?: QuizFocusSummary | null
+export interface StudentTestView extends TestAssessment {
+  student_status: StudentTestStatus
+  questions?: TestAssessmentQuestion[]
+  focus_summary?: TestFocusSummary | null
 }
 
-export interface QuizResultsAggregate {
+export interface TestResultsAggregate {
   question_id: string
   question_text: string
   options: string[]
@@ -1044,20 +1044,20 @@ export interface QuizResultsAggregate {
   total_responses: number
 }
 
-// Test-facing aliases for the active assessment surface. Legacy Quiz* names
-// remain exported during the API/type contract transition.
-export type TestAssessmentStatus = QuizStatus
-export type TestAssessmentType = QuizAssessmentType
-export type TestAssessment = Quiz
-export type TestAssessmentQuestion = QuizQuestion
-export type TestAssessmentResponse = QuizResponse
-export type TestAssessmentWithQuestions = QuizWithQuestions
-export type TestAssessmentWithStats = QuizWithStats
-export type StudentTestStatus = StudentQuizStatus
-export type StudentTestView = StudentQuizView
-export type TestResultsAggregate = QuizResultsAggregate
-export type TestFocusEventType = QuizFocusEventType
-export type TestFocusSummary = QuizFocusSummary
+// Legacy quiz-facing aliases remain exported while database/API compatibility
+// fields still use quiz-shaped names during the Tests transition.
+export type QuizStatus = TestAssessmentStatus
+export type QuizAssessmentType = TestAssessmentType
+export type QuizFocusEventType = TestFocusEventType
+export interface QuizFocusSummary extends TestFocusSummary {}
+export interface Quiz extends TestAssessment {}
+export interface QuizQuestion extends TestAssessmentQuestion {}
+export interface QuizResponse extends TestAssessmentResponse {}
+export interface QuizWithQuestions extends TestAssessmentWithQuestions {}
+export interface QuizWithStats extends TestAssessmentWithStats {}
+export type StudentQuizStatus = StudentTestStatus
+export interface StudentQuizView extends StudentTestView {}
+export type QuizResultsAggregate = TestResultsAggregate
 
 // Log summary types
 export interface LogSummaryActionItem {

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -6,7 +6,7 @@ import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
 import { TEACHER_TESTS_UPDATED_EVENT, TEACHER_TEST_GRADING_ROW_UPDATED_EVENT } from '@/lib/events'
 import { createMockClassroom, createMockTest } from '../helpers/mocks'
-import type { Classroom, QuizWithStats } from '@/types'
+import type { Classroom, TestAssessmentWithStats } from '@/types'
 
 const { setOpenMock } = vi.hoisted(() => ({
   setOpenMock: vi.fn(),
@@ -35,7 +35,7 @@ vi.mock('@/components/TestDetailPanel', () => ({
     titlePortalTarget,
     generatedTitleLabel,
   }: {
-    test?: QuizWithStats
+    test?: TestAssessmentWithStats
     testQuestionLayout?: string
     showPreviewButton?: boolean
     showResultsTab?: boolean
@@ -175,7 +175,7 @@ function Wrapper({ children }: { children: ReactNode }) {
   )
 }
 
-function makeTest(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
+function makeTest(overrides: Partial<TestAssessmentWithStats> = {}): TestAssessmentWithStats {
   const base = createMockTest({
     assessment_type: 'test',
     status: 'draft',
@@ -186,7 +186,7 @@ function makeTest(overrides: Partial<QuizWithStats> = {}): QuizWithStats {
     assessment_type: 'test',
     stats: { total_students: 10, responded: 5, questions_count: 3 },
     ...overrides,
-  } as QuizWithStats
+  } as TestAssessmentWithStats
 }
 
 function listFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
@@ -232,7 +232,7 @@ function makeResultsResponse(overrides?: {
   quizTitle?: string
   students?: Array<Record<string, unknown>>
   questions?: Array<Record<string, unknown>>
-  quizStatus?: QuizWithStats['status']
+  quizStatus?: TestAssessmentWithStats['status']
   activeRun?: Record<string, unknown> | null
 }) {
   return {
@@ -277,7 +277,7 @@ describe('TeacherTestsTab', () => {
     vi.restoreAllMocks()
   })
 
-  function mockTestsResponse(tests: QuizWithStats[] = []) {
+  function mockTestsResponse(tests: TestAssessmentWithStats[] = []) {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ tests }),
@@ -294,7 +294,7 @@ describe('TeacherTestsTab', () => {
       updater: (params: URLSearchParams) => void,
       options?: { replace?: boolean },
     ) => void
-    onSelectTest?: (test: QuizWithStats | null) => void
+    onSelectTest?: (test: TestAssessmentWithStats | null) => void
     onRequestTestPreview?: (preview: { testId: string; title: string }) => void
     onRequestDelete?: () => void
     onTestGradingContextChange?: (context: {


### PR DESCRIPTION
## Summary
- make TestAssessment*, StudentTest*, and TestFocus* the canonical shared type definitions
- keep legacy Quiz* exports as compatibility aliases/interfaces for DB-shaped and older contract code
- update assessment helpers, server access helper typings, and active TeacherTestsTab test usage to consume canonical names

## Scope notes
- no schema, migration, RPC, storage, or API payload shape changes
- legacy quiz response keys and DB-shaped quiz_id fields are intentionally preserved

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx
- pnpm test (303 files / 2678 tests)
- git diff --check