### PR TITLE
Guard teacher calendar loads by classroom

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,63 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Teacher calendar cache audit
-
-**Completed:**
-- Routed `/teacher/calendar` classroom list reads through `fetchJSONWithCache` with a shared teacher-classrooms cache key.
-- Reused the shared class-days client for cached class-day reads instead of raw page-level GETs.
-- Invalidated classroom and class-day caches after calendar generation, class-day toggles, classroom creation, and classroom deletion.
-- Added component coverage for cached classroom/class-day loads plus generation and toggle invalidation behavior.
-- Addressed PR review feedback by moving classroom-list caching to a shared teacher-classrooms client, invalidating it from cross-route classroom mutations, and guarding `/teacher/calendar` against stale overlapping class-day responses.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx`
-- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/CreateClassroomModal.test.tsx tests/contexts/ClassDaysContext.test.tsx tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
-## 2026-06-06 — Teacher dashboard cache audit
-
-**Completed:**
-- Routed `/teacher/dashboard` classroom and attendance reads through shared `fetchJSONWithCache` helpers.
-- Scoped the shared teacher-classrooms cache key by the active `/api/auth/me` user id and switched classroom-list invalidation to a prefix clear.
-- Kept teacher dashboard entry-detail reads fresh instead of caching them because student entry edits have no teacher-side invalidation path.
-- Invalidated dashboard attendance caches after roster upload, classroom creation, and classroom deletion.
-- Added request-generation guards so stale attendance responses cannot repaint the dashboard after switching classrooms or after a roster-upload refresh.
-- Added component coverage for cache usage, roster-upload invalidation, fresh entry-detail reads, and stale attendance responses.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/TeacherDashboardPage.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/components/TeacherDashboardPage.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherDashboardPage.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-
-## 2026-06-06 — Teacher blueprints cache audit
-
-**Completed:**
-- Routed `/teacher/blueprints` list and detail reads through a verified-user-scoped `fetchJSONWithCache` helper.
-- Bypassed blueprint caching when `/api/auth/me` cannot verify a user id.
-- Invalidated blueprint caches after metadata, content, planned-site, import, AI, merge, and create mutations.
-- Addressed PR review feedback by also invalidating blueprint caches after course-package imports and blueprint instantiation from `CreateClassroomModal`.
-- Added request-generation guards so stale blueprint detail responses cannot overwrite the active selection.
-- Added component/unit coverage for scoped cache keys, stale detail responses, mutation invalidation, modal import/instantiate invalidation, and auth-scope cache bypass.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed on pre-existing blueprint component fixture gap)
-- `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/api/teacher/course-blueprints-route.test.ts tests/api/teacher/course-blueprint-publication-routes.test.ts tests/api/teacher/course-blueprint-instantiate.test.ts tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
 ## 2026-06-06 — Student classrooms cache audit
 
 **Completed:**
@@ -707,6 +650,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test` (303 files / 2676 tests)
 - `git diff --check`
+
 ## 2026-06-13 — Student Today stale classroom load guard
 
 **Completed:**
@@ -751,3 +695,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
 - `pnpm test` (303 files / 2678 tests)
 - `git diff --check`
+## 2026-06-13 — Teacher lesson calendar stale classroom load guard
+
+**Completed:**
+- Continued the systems/UI audit client freshness track after PR #780.
+- Guarded teacher lesson calendar lesson-plan, assignment, announcement, and markdown async loads so late responses from a previous classroom cannot update the current classroom view.
+- Tagged loaded lesson plans, assignments, and announcements with the classroom id they belong to, so previously loaded classroom data is hidden while the next classroom loads.
+- Added regression coverage for both late stale responses after a classroom change and immediate hiding of previous-classroom data while the next classroom is pending.
+- Addressed subagent PR review feedback by clearing/reloading open markdown sidebar content when the classroom changes and blocking saves while markdown content is not associated with the current classroom.
+- Guarded late autosave PUT responses before they can retag or mutate visible lesson-plan state after the teacher switches classrooms.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2682 tests)
+- Subagent PR review found stale open-sidebar markdown and late autosave response gaps.
+- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx` (after review fixes; 8 tests)
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2684 tests)

--- a/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherLessonCalendarTab.tsx
@@ -63,12 +63,18 @@ export function TeacherLessonCalendarTab({
   onNavigateToAnnouncements = () => {},
 }: Props) {
   const [lessonPlans, setLessonPlans] = useState<LessonPlan[]>([])
-  const lessonPlansRef = useRef(lessonPlans)
-  lessonPlansRef.current = lessonPlans
+  const [lessonPlansClassroomId, setLessonPlansClassroomId] = useState(classroom.id)
+  const visibleLessonPlans = lessonPlansClassroomId === classroom.id ? lessonPlans : []
+  const lessonPlansRef = useRef(visibleLessonPlans)
+  lessonPlansRef.current = visibleLessonPlans
   // Track last-seen markdown per date to suppress duplicate autosave emissions.
   const lastSeenContentRef = useRef<Map<string, string>>(new Map())
   const [assignments, setAssignments] = useState<Assignment[]>([])
+  const [assignmentsClassroomId, setAssignmentsClassroomId] = useState(classroom.id)
+  const visibleAssignments = assignmentsClassroomId === classroom.id ? assignments : []
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [announcementsClassroomId, setAnnouncementsClassroomId] = useState(classroom.id)
+  const visibleAnnouncements = announcementsClassroomId === classroom.id ? announcements : []
   const classDays = useClassDays(classroom.id)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -82,9 +88,13 @@ export function TeacherLessonCalendarTab({
   }, [classroom.id])
   const [currentDate, setCurrentDate] = useState(new Date())
   const [markdownContent, setMarkdownContent] = useState('')
+  const [markdownContentClassroomId, setMarkdownContentClassroomId] = useState('')
+  const visibleMarkdownContent = markdownContentClassroomId === classroom.id ? markdownContent : ''
   const [markdownError, setMarkdownError] = useState<string | null>(null)
   const [bulkSaving, setBulkSaving] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
 
   const { toggle: toggleSidebar, isOpen: isSidebarOpen, setOpen: setSidebarOpen } = useRightSidebar()
   const { showMarkdown } = useMarkdownPreference()
@@ -102,6 +112,7 @@ export function TeacherLessonCalendarTab({
     const normalized = normalizeLessonPlanMarkdown(contentMarkdown)
     const now = new Date().toISOString()
 
+    setLessonPlansClassroomId(classroom.id)
     setLessonPlans((prev) => {
       const existing = prev.find((plan) => plan.date === date)
 
@@ -145,40 +156,60 @@ export function TeacherLessonCalendarTab({
 
   // Fetch all lesson plans for the term once
   useEffect(() => {
+    let cancelled = false
+    const requestedClassroomId = classroom.id
+    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
+
     async function loadLessonPlans() {
       setLoading(true)
       try {
-        const plans = await fetchTeacherLessonPlansForRange(classroom.id, fetchRange.start, fetchRange.end)
+        const plans = await fetchTeacherLessonPlansForRange(requestedClassroomId, fetchRange.start, fetchRange.end)
+        if (!isCurrentLoad()) return
         // Seed last-seen content so Tiptap normalization doesn't trigger saves
         lastSeenContentRef.current.clear()
         for (const plan of plans) {
           lastSeenContentRef.current.set(plan.date, plan.content_markdown ?? '')
         }
+        setLessonPlansClassroomId(requestedClassroomId)
         setLessonPlans(plans)
       } catch (err) {
+        if (!isCurrentLoad()) return
         console.error('Error loading lesson plans:', err)
       } finally {
-        setLoading(false)
+        if (isCurrentLoad()) {
+          setLoading(false)
+        }
       }
     }
     loadLessonPlans()
+
+    return () => {
+      cancelled = true
+    }
   }, [classroom.id, fetchRange.start, fetchRange.end, refreshKey])
 
   // Fetch assignments for the classroom
   useEffect(() => {
+    let cancelled = false
+    const requestedClassroomId = classroom.id
+    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
+
     async function loadAssignments() {
       try {
         const data = await fetchJSONWithCache<{ assignments?: Assignment[] }>(
-          `teacher-assignments:${classroom.id}`,
+          `teacher-assignments:${requestedClassroomId}`,
           async () => {
-            const res = await fetch(`/api/teacher/assignments?classroom_id=${classroom.id}`)
+            const res = await fetch(`/api/teacher/assignments?classroom_id=${requestedClassroomId}`)
             if (!res.ok) throw new Error('Failed to load assignments')
             return res.json()
           },
           20_000,
         )
+        if (!isCurrentLoad()) return
+        setAssignmentsClassroomId(requestedClassroomId)
         setAssignments(data.assignments || [])
       } catch (err) {
+        if (!isCurrentLoad()) return
         console.error('Error loading assignments:', err)
       }
     }
@@ -194,44 +225,59 @@ export function TeacherLessonCalendarTab({
     }
     window.addEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
     return () => {
+      cancelled = true
       window.removeEventListener(TEACHER_ASSIGNMENTS_UPDATED_EVENT, handleAssignmentsUpdated)
     }
   }, [classroom.id])
 
   // Fetch announcements for the classroom
   useEffect(() => {
+    let cancelled = false
+    const requestedClassroomId = classroom.id
+    const isCurrentLoad = () => !cancelled && currentClassroomIdRef.current === requestedClassroomId
+
     async function loadAnnouncements() {
       try {
         const data = await fetchJSONWithCache<{ announcements?: Announcement[] }>(
-          `teacher-announcements:${classroom.id}`,
+          `teacher-announcements:${requestedClassroomId}`,
           async () => {
-            const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
+            const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/announcements`)
             if (!res.ok) throw new Error('Failed to load announcements')
             return res.json()
           },
           20_000,
         )
+        if (!isCurrentLoad()) return
+        setAnnouncementsClassroomId(requestedClassroomId)
         setAnnouncements(data.announcements || [])
       } catch (err) {
+        if (!isCurrentLoad()) return
         console.error('Error loading announcements:', err)
       }
     }
     loadAnnouncements()
+
+    return () => {
+      cancelled = true
+    }
   }, [classroom.id])
 
   // Save a single lesson plan
   const saveLessonPlan = useCallback(
     async (date: string, contentMarkdown: string) => {
+      const requestedClassroomId = classroom.id
       try {
-        const res = await fetch(`/api/teacher/classrooms/${classroom.id}/lesson-plans/${date}`, {
+        const res = await fetch(`/api/teacher/classrooms/${requestedClassroomId}/lesson-plans/${date}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ content_markdown: contentMarkdown }),
         })
         if (res.ok) {
           const data = await res.json()
-          invalidateTeacherLessonPlansForClassroom(classroom.id)
+          invalidateTeacherLessonPlansForClassroom(requestedClassroomId)
           needsRefreshRef.current = true
+          if (currentClassroomIdRef.current !== requestedClassroomId) return
+          setLessonPlansClassroomId(requestedClassroomId)
           setLessonPlans((prev) => {
             if (!data.lesson_plan) {
               return prev.filter((plan) => plan.date !== date)
@@ -337,24 +383,46 @@ export function TeacherLessonCalendarTab({
 
   // Fetch and generate markdown content
   const loadMarkdownContent = useCallback(async () => {
+    const requestedClassroomId = classroom.id
+    const isCurrentLoad = () => currentClassroomIdRef.current === requestedClassroomId
+
     setLoading(true)
     setMarkdownError(null)
     try {
       const start = classroom.start_date || fetchRange.start
       const end = classroom.end_date || fetchRange.end
-      const cachedPlans = await fetchTeacherLessonPlansForRange(classroom.id, start, end)
-      const plans = applyPendingLessonPlanChanges(cachedPlans, pendingChangesRef.current, classroom.id)
+      const cachedPlans = await fetchTeacherLessonPlansForRange(requestedClassroomId, start, end)
+      if (!isCurrentLoad()) return
+      const plans = applyPendingLessonPlanChanges(cachedPlans, pendingChangesRef.current, requestedClassroomId)
       const markdown = lessonPlansToMarkdown(classroom, plans, start, end)
+      setMarkdownContentClassroomId(requestedClassroomId)
       setMarkdownContent(markdown)
       markdownContentRef.current = markdown
       needsRefreshRef.current = false
     } catch (err) {
+      if (!isCurrentLoad()) return
       console.error('Error loading lesson plans:', err)
       setMarkdownError(err instanceof Error ? err.message : 'Failed to load lesson plans')
     } finally {
-      setLoading(false)
+      if (isCurrentLoad()) {
+        setLoading(false)
+      }
     }
   }, [classroom, fetchRange])
+
+  const previousMarkdownClassroomIdRef = useRef(classroom.id)
+  useEffect(() => {
+    if (previousMarkdownClassroomIdRef.current === classroom.id) return
+    previousMarkdownClassroomIdRef.current = classroom.id
+    markdownContentRef.current = ''
+    setMarkdownContent('')
+    setMarkdownContentClassroomId('')
+    setMarkdownError(null)
+    needsRefreshRef.current = true
+    if (showMarkdown && isSidebarOpen) {
+      loadMarkdownContent()
+    }
+  }, [classroom.id, isSidebarOpen, loadMarkdownContent, showMarkdown])
 
   // Handle markdown panel toggle - just toggle, effect handles loading
   const handleMarkdownToggle = useCallback(() => {
@@ -366,6 +434,7 @@ export function TeacherLessonCalendarTab({
   const handleMarkdownChange = useCallback((content: string) => {
     // Always update ref immediately so save has latest content
     markdownContentRef.current = content
+    setMarkdownContentClassroomId(classroom.id)
 
     // Debounce state update to reduce parent re-renders
     if (markdownSyncTimeoutRef.current) {
@@ -374,7 +443,7 @@ export function TeacherLessonCalendarTab({
     markdownSyncTimeoutRef.current = setTimeout(() => {
       setMarkdownContent(content)
     }, MARKDOWN_SYNC_DEBOUNCE_MS)
-  }, [])
+  }, [classroom.id])
 
   // Load markdown content when sidebar opens (handles both button click and keyboard shortcut)
   useEffect(() => {
@@ -395,6 +464,10 @@ export function TeacherLessonCalendarTab({
   // Handle markdown save
   const handleMarkdownSave = useCallback(async () => {
     setMarkdownError(null)
+    if (markdownContentClassroomId !== classroom.id) {
+      setMarkdownError('Lesson plans are still loading')
+      return
+    }
     setBulkSaving(true)
 
     try {
@@ -439,7 +512,7 @@ export function TeacherLessonCalendarTab({
     } finally {
       setBulkSaving(false)
     }
-  }, [classroom, setSidebarOpen])
+  }, [classroom, markdownContentClassroomId, setSidebarOpen])
 
   // Handle assignment click - navigate to assignments tab with assignment selected
   const handleAssignmentClick = useCallback(
@@ -489,7 +562,7 @@ export function TeacherLessonCalendarTab({
   useEffect(() => {
     if (showMarkdown && isSidebarOpen) {
       onSidebarStateChange?.({
-        markdownContent,
+        markdownContent: visibleMarkdownContent,
         markdownError,
         bulkSaving,
         onMarkdownChange: handleMarkdownChange,
@@ -498,9 +571,9 @@ export function TeacherLessonCalendarTab({
     } else {
       onSidebarStateChange?.(null)
     }
-  }, [showMarkdown, isSidebarOpen, markdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
+  }, [showMarkdown, isSidebarOpen, visibleMarkdownContent, markdownError, bulkSaving, onSidebarStateChange, handleMarkdownSave, handleMarkdownChange])
 
-  if (loading && lessonPlans.length === 0) {
+  if (loading && visibleLessonPlans.length === 0) {
     return (
       <PageLayout bleedX={false}>
         <PageContent>
@@ -542,9 +615,9 @@ export function TeacherLessonCalendarTab({
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}
-            lessonPlans={lessonPlans}
-            assignments={assignments}
-            announcements={announcements}
+            lessonPlans={visibleLessonPlans}
+            assignments={visibleAssignments}
+            announcements={visibleAnnouncements}
             classDays={classDays}
             viewMode={viewMode}
             currentDate={currentDate}

--- a/tests/components/TeacherLessonCalendarTab.test.tsx
+++ b/tests/components/TeacherLessonCalendarTab.test.tsx
@@ -43,8 +43,14 @@ vi.mock('@/contexts/MarkdownPreferenceContext', () => ({
 }))
 
 vi.mock('@/components/LessonCalendar', () => ({
-  LessonCalendar: ({ lessonPlans, onContentChange }: any) => (
-    <div data-testid="lesson-calendar" data-lesson-count={lessonPlans.length}>
+  LessonCalendar: ({ lessonPlans, assignments, announcements, onContentChange }: any) => (
+    <div
+      data-testid="lesson-calendar"
+      data-lesson-count={lessonPlans.length}
+      data-lesson-classrooms={lessonPlans.map((plan: LessonPlan) => plan.classroom_id).join(',')}
+      data-assignment-classrooms={assignments.map((assignment: any) => assignment.classroom_id).join(',')}
+      data-announcement-classrooms={announcements.map((announcement: any) => announcement.classroom_id).join(',')}
+    >
       <button type="button" onClick={() => onContentChange?.('2025-01-06', 'Updated lesson')}>
         Edit lesson
       </button>
@@ -64,6 +70,16 @@ function lessonPlan(overrides: Partial<LessonPlan> = {}): LessonPlan {
     updated_at: '2025-01-01T00:00:00Z',
     ...overrides,
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -126,6 +142,367 @@ describe('TeacherLessonCalendarTab', () => {
     expect(urls.filter((url) => url.includes('/lesson-plans?'))).toHaveLength(1)
     expect(urls.filter((url) => url.includes('/assignments'))).toHaveLength(1)
     expect(urls.filter((url) => url.includes('/announcements'))).toHaveLength(1)
+  })
+
+  it('ignores stale classroom-scoped loads after the classroom changes', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const firstLessonPlansRequest = deferred<any>()
+    const firstAssignmentsRequest = deferred<any>()
+    const firstAnnouncementsRequest = deferred<any>()
+    const secondLessonPlansRequest = deferred<any>()
+    const secondAssignmentsRequest = deferred<any>()
+    const secondAnnouncementsRequest = deferred<any>()
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans`)) {
+        return firstLessonPlansRequest.promise
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/lesson-plans`)) {
+        return secondLessonPlansRequest.promise
+      }
+      if (url.includes(`classroom_id=${classroom.id}`)) {
+        return firstAssignmentsRequest.promise
+      }
+      if (url.includes(`classroom_id=${secondClassroom.id}`)) {
+        return secondAssignmentsRequest.promise
+      }
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/announcements`)) {
+        return firstAnnouncementsRequest.promise
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/announcements`)) {
+        return secondAnnouncementsRequest.promise
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    view.rerender(<TeacherLessonCalendarTab classroom={secondClassroom} />)
+
+    secondLessonPlansRequest.resolve({
+      ok: true,
+      json: async () => ({
+        lesson_plans: [lessonPlan({ id: 'lesson-2', classroom_id: secondClassroom.id })],
+      }),
+    })
+    secondAssignmentsRequest.resolve({
+      ok: true,
+      json: async () => ({ assignments: [{ id: 'assignment-2', classroom_id: secondClassroom.id }] }),
+    })
+    secondAnnouncementsRequest.resolve({
+      ok: true,
+      json: async () => ({ announcements: [{ id: 'announcement-2', classroom_id: secondClassroom.id }] }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', secondClassroom.id)
+    })
+
+    firstLessonPlansRequest.resolve({
+      ok: true,
+      json: async () => ({
+        lesson_plans: [lessonPlan({ id: 'lesson-1', classroom_id: classroom.id })],
+      }),
+    })
+    firstAssignmentsRequest.resolve({
+      ok: true,
+      json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
+    })
+    firstAnnouncementsRequest.resolve({
+      ok: true,
+      json: async () => ({ announcements: [{ id: 'announcement-1', classroom_id: classroom.id }] }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', secondClassroom.id)
+    })
+  })
+
+  it('hides previous classroom data while the next classroom loads', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const secondLessonPlansRequest = deferred<any>()
+    const secondAssignmentsRequest = deferred<any>()
+    const secondAnnouncementsRequest = deferred<any>()
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            lesson_plans: [lessonPlan({ id: 'lesson-1', classroom_id: classroom.id })],
+          }),
+        })
+      }
+      if (url.includes(`classroom_id=${classroom.id}`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/announcements`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ announcements: [{ id: 'announcement-1', classroom_id: classroom.id }] }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/lesson-plans`)) {
+        return secondLessonPlansRequest.promise
+      }
+      if (url.includes(`classroom_id=${secondClassroom.id}`)) {
+        return secondAssignmentsRequest.promise
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/announcements`)) {
+        return secondAnnouncementsRequest.promise
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', classroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', classroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', classroom.id)
+    })
+
+    view.rerender(<TeacherLessonCalendarTab classroom={secondClassroom} />)
+
+    expect(screen.queryByTestId('lesson-calendar')).not.toBeInTheDocument()
+
+    secondLessonPlansRequest.resolve({
+      ok: true,
+      json: async () => ({
+        lesson_plans: [lessonPlan({ id: 'lesson-2', classroom_id: secondClassroom.id })],
+      }),
+    })
+    secondAssignmentsRequest.resolve({
+      ok: true,
+      json: async () => ({ assignments: [{ id: 'assignment-2', classroom_id: secondClassroom.id }] }),
+    })
+    secondAnnouncementsRequest.resolve({
+      ok: true,
+      json: async () => ({ announcements: [{ id: 'announcement-2', classroom_id: secondClassroom.id }] }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', secondClassroom.id)
+    })
+  })
+
+  it('clears open markdown sidebar content on classroom change and blocks saving until reloaded', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const secondLessonPlansRequest = deferred<any>()
+    let latestSidebarState: CalendarSidebarState | null = null
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        throw new Error(`Unexpected save: ${url}`)
+      }
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            lesson_plans: [lessonPlan({ id: 'lesson-1', classroom_id: classroom.id })],
+          }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/lesson-plans`)) {
+        return secondLessonPlansRequest.promise
+      }
+      if (url.includes('assignments')) return Promise.resolve({ ok: true, json: async () => ({ assignments: [] }) })
+      if (url.includes('announcements')) return Promise.resolve({ ok: true, json: async () => ({ announcements: [] }) })
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    sidebarState.isOpen = true
+    const view = render(
+      <TeacherLessonCalendarTab
+        classroom={classroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toContain('Original lesson')
+    })
+
+    view.rerender(
+      <TeacherLessonCalendarTab
+        classroom={secondClassroom}
+        onSidebarStateChange={(state) => {
+          latestSidebarState = state
+        }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toBe('')
+    })
+
+    await act(async () => {
+      latestSidebarState?.onSave()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownError).toBe('Lesson plans are still loading')
+    })
+
+    secondLessonPlansRequest.resolve({
+      ok: true,
+      json: async () => ({
+        lesson_plans: [
+          lessonPlan({
+            id: 'lesson-2',
+            classroom_id: secondClassroom.id,
+            content_markdown: 'Second classroom lesson',
+          }),
+        ],
+      }),
+    })
+
+    await waitFor(() => {
+      expect(latestSidebarState?.markdownContent).toContain('Second classroom lesson')
+    })
+  })
+
+  it('ignores late autosave responses after the classroom changes', async () => {
+    const secondClassroom = createMockClassroom({
+      id: 'classroom-2',
+      start_date: '2025-01-01',
+      end_date: '2025-06-30',
+    })
+    const firstAutosaveRequest = deferred<any>()
+
+    invalidateTeacherLessonPlansForClassroom(secondClassroom.id)
+    invalidateCachedJSON(`teacher-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`teacher-announcements:${secondClassroom.id}`)
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`) && init?.method === 'PUT') {
+        return firstAutosaveRequest.promise
+      }
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            lesson_plans: [lessonPlan({ id: 'lesson-1', classroom_id: classroom.id })],
+          }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/lesson-plans`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            lesson_plans: [lessonPlan({ id: 'lesson-2', classroom_id: secondClassroom.id })],
+          }),
+        })
+      }
+      if (url.includes(`classroom_id=${classroom.id}`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ assignments: [{ id: 'assignment-1', classroom_id: classroom.id }] }),
+        })
+      }
+      if (url.includes(`classroom_id=${secondClassroom.id}`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ assignments: [{ id: 'assignment-2', classroom_id: secondClassroom.id }] }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${classroom.id}/announcements`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ announcements: [{ id: 'announcement-1', classroom_id: classroom.id }] }),
+        })
+      }
+      if (url.includes(`/api/teacher/classrooms/${secondClassroom.id}/announcements`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ announcements: [{ id: 'announcement-2', classroom_id: secondClassroom.id }] }),
+        })
+      }
+      throw new Error(`Unhandled fetch: ${url}`)
+    })
+
+    const view = render(<TeacherLessonCalendarTab classroom={classroom} />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', classroom.id)
+    })
+
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit lesson' }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    vi.useRealTimers()
+
+    expect(fetchMock.mock.calls.some(([url, init]) =>
+      String(url).includes(`/api/teacher/classrooms/${classroom.id}/lesson-plans/2025-01-06`) &&
+      init?.method === 'PUT'
+    )).toBe(true)
+
+    view.rerender(<TeacherLessonCalendarTab classroom={secondClassroom} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', secondClassroom.id)
+    })
+
+    firstAutosaveRequest.resolve({
+      ok: true,
+      json: async () => ({
+        lesson_plan: lessonPlan({
+          id: 'lesson-1',
+          classroom_id: classroom.id,
+          content_markdown: 'Late saved lesson',
+        }),
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-lesson-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-assignment-classrooms', secondClassroom.id)
+      expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-classrooms', secondClassroom.id)
+    })
   })
 
   it('invalidates cached teacher lesson plans after an autosaved edit', async () => {


### PR DESCRIPTION
## Summary
- Guard teacher lesson calendar lesson-plan, assignment, announcement, and markdown async loads with current classroom checks.
- Tag loaded lesson plans, assignments, and announcements by classroom id so previous-classroom data is hidden while the next classroom loads.
- Clear/reload open markdown sidebar content on classroom changes, and block saves while markdown content is not associated with the current classroom.
- Guard late autosave PUT responses before they can mutate visible state after a classroom switch.
- Add regression coverage for late stale responses, hiding previous-classroom data during route changes, open-sidebar markdown switching, and late autosave completion.

## Review
- Subagent review found stale open-sidebar markdown and late autosave response gaps; both are fixed in the updated commit.

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm build
- pnpm vitest run --sequence.concurrent=false (303 files / 2684 tests)
