### PR TITLE
[codex] Add assessment draft helper aliases

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -720,3 +720,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm build`
 - `pnpm vitest run --sequence.concurrent=false` (303 files / 2684 tests)
+
+## 2026-06-13 — Legacy quiz server draft helper names
+
+**Completed:**
+- Added assessment-named primary draft helpers in `src/lib/server/assessment-drafts.ts`: `AssessmentDraftContent`, `AssessmentDraftQuestion`, `validateAssessmentDraftContent`, `buildAssessmentDraftContentFromRows`, and `syncAssessmentQuestionsFromDraft`.
+- Kept legacy `QuizDraft*`, `validateQuizDraftContent`, `buildQuizDraftContentFromRows`, and `syncQuizQuestionsFromDraft` exports as compatibility aliases.
+- Updated internal markdown/course-blueprint typing and assessment draft unit tests to prefer assessment-named helpers.
+- Did not change database tables, persisted `quiz_id` fields, route payload shapes, migrations, RPCs, or storage paths.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/assessment-drafts.test.ts tests/lib/quiz-markdown.test.ts tests/lib/server/course-blueprints.test.ts tests/lib/server/course-sites.test.ts`
+- `pnpm lint`
+- `git diff --check`

--- a/src/lib/quiz-markdown.ts
+++ b/src/lib/quiz-markdown.ts
@@ -1,5 +1,5 @@
 import { validateQuizOptions } from '@/lib/assessments'
-import type { QuizDraftContent, QuizDraftQuestion } from '@/lib/server/assessment-drafts'
+import type { AssessmentDraftContent, AssessmentDraftQuestion } from '@/lib/server/assessment-drafts'
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -22,7 +22,7 @@ export interface QuizMarkdownParseOptions {
 }
 
 export interface QuizMarkdownParseResult {
-  draftContent: QuizDraftContent | null
+  draftContent: AssessmentDraftContent | null
   errors: string[]
 }
 
@@ -141,7 +141,7 @@ function parseQuestionBlock(
   index: number,
   options: QuizMarkdownParseOptions,
   errors: string[]
-): QuizDraftQuestion | null {
+): AssessmentDraftQuestion | null {
   let id: string | undefined
   let prompt = ''
   let choices: string[] = []
@@ -253,7 +253,7 @@ export function markdownToQuiz(
   const questionBlocks = splitQuestionBlocks(lines)
   const questions = questionBlocks
     .map((block, questionIndex) => parseQuestionBlock(block.lines, questionIndex, options, errors))
-    .filter((question): question is QuizDraftQuestion => Boolean(question))
+    .filter((question): question is AssessmentDraftQuestion => Boolean(question))
 
   if (questions.length === 0) errors.push('At least one question is required')
 

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -10,11 +10,13 @@ const UUID_RE =
 
 export type AssessmentDraftType = 'quiz' | 'test'
 
-export type QuizDraftQuestion = {
+export type AssessmentDraftQuestion = {
   id: string
   question_text: string
   options: string[]
 }
+
+export type QuizDraftQuestion = AssessmentDraftQuestion
 
 export type TestDraftQuestion = {
   id: string
@@ -29,13 +31,15 @@ export type TestDraftQuestion = {
   response_monospace: boolean
 }
 
-export type QuizDraftContent = {
+export type AssessmentDraftContent = {
   title: string
   show_results: boolean
-  questions: QuizDraftQuestion[]
+  questions: AssessmentDraftQuestion[]
   source_format?: 'markdown'
   source_markdown?: string
 }
+
+export type QuizDraftContent = AssessmentDraftContent
 
 export type TestDraftContent = {
   title: string
@@ -132,7 +136,9 @@ export function isMissingAssessmentDraftsError(error: {
   return error.code === 'PGRST205' || error.code === '42P01' || combined.includes('table')
 }
 
-export function validateQuizDraftContent(input: unknown): ValidationResult<QuizDraftContent> {
+export function validateAssessmentDraftContent(
+  input: unknown
+): ValidationResult<AssessmentDraftContent> {
   if (!isRecord(input)) return { valid: false, error: 'Invalid draft content' }
 
   const title = parseTitle(input.title)
@@ -147,7 +153,7 @@ export function validateQuizDraftContent(input: unknown): ValidationResult<QuizD
     return { valid: false, error: 'questions must be an array' }
   }
 
-  const questions: QuizDraftQuestion[] = []
+  const questions: AssessmentDraftQuestion[] = []
 
   for (let index = 0; index < input.questions.length; index += 1) {
     const rawQuestion = input.questions[index]
@@ -200,6 +206,8 @@ export function validateQuizDraftContent(input: unknown): ValidationResult<QuizD
     },
   }
 }
+
+export const validateQuizDraftContent = validateAssessmentDraftContent
 
 export function validateTestDraftContent(
   input: unknown,
@@ -290,14 +298,14 @@ export function buildNextDraftContent<TContent extends object>(
   return { ok: true, content: validation.value }
 }
 
-export function buildQuizDraftContentFromRows(
-  quiz: { title: string; show_results: boolean },
+export function buildAssessmentDraftContentFromRows(
+  assessment: { title: string; show_results: boolean },
   rows: unknown[]
-): QuizDraftContent {
+): AssessmentDraftContent {
   const questions = rows as Array<{ id: string; question_text: string; options: unknown }>
   return {
-    title: quiz.title,
-    show_results: quiz.show_results,
+    title: assessment.title,
+    show_results: assessment.show_results,
     questions: (questions || []).map((question) => {
       const options = parseStringArray(question.options) || []
       return {
@@ -308,6 +316,8 @@ export function buildQuizDraftContentFromRows(
     }),
   }
 }
+
+export const buildQuizDraftContentFromRows = buildAssessmentDraftContentFromRows
 
 type TestQuestionRow = {
   id: string
@@ -448,15 +458,15 @@ export async function updateAssessmentDraft<TContent>(
   }
 }
 
-export async function syncQuizQuestionsFromDraft(
+export async function syncAssessmentQuestionsFromDraft(
   supabase: SupabaseLike,
-  quizId: string,
-  content: QuizDraftContent
+  assessmentId: string,
+  content: AssessmentDraftContent
 ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
   return syncAssessmentQuestionRowsFromDraft(supabase, {
     table: 'quiz_questions',
     foreignKey: 'quiz_id',
-    parentId: quizId,
+    parentId: assessmentId,
     questions: content.questions,
     buildUpdatePayload: (question, position) => ({
       question_text: question.question_text,
@@ -465,7 +475,7 @@ export async function syncQuizQuestionsFromDraft(
     }),
     buildInsertPayload: (question, position) => ({
       id: question.id,
-      quiz_id: quizId,
+      quiz_id: assessmentId,
       question_text: question.question_text,
       options: question.options,
       position,
@@ -478,6 +488,8 @@ export async function syncQuizQuestionsFromDraft(
     },
   })
 }
+
+export const syncQuizQuestionsFromDraft = syncAssessmentQuestionsFromDraft
 
 export async function syncTestQuestionsFromDraft(
   supabase: SupabaseLike,

--- a/src/lib/server/course-blueprints.ts
+++ b/src/lib/server/course-blueprints.ts
@@ -32,7 +32,7 @@ import type {
   LinkedBlueprintClassroom,
   TestDocument,
 } from '@/types'
-import type { QuizDraftContent, TestDraftContent } from '@/lib/server/assessment-drafts'
+import type { AssessmentDraftContent, TestDraftContent } from '@/lib/server/assessment-drafts'
 import { isMissingAssessmentDraftsError } from '@/lib/server/assessment-drafts'
 import { normalizeAssignmentSubmissionRequirementDrafts } from '@/lib/assignment-submission-requirements'
 
@@ -107,7 +107,7 @@ async function maybeInsertAssessmentDraft(
   classroomId: string,
   assessmentId: string,
   teacherId: string,
-  content: QuizDraftContent | TestDraftContent
+  content: AssessmentDraftContent | TestDraftContent
 ) {
   const { error } = await supabase
     .from('assessment_drafts')
@@ -433,7 +433,7 @@ export async function syncCourseBlueprintAssessments(
     id?: string
     assessment_type: 'test'
     title: string
-    content: QuizDraftContent | TestDraftContent
+    content: AssessmentDraftContent | TestDraftContent
     documents: TestDocument[]
     position: number
   }>,

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  buildAssessmentDraftContentFromRows,
   buildNextDraftContent,
   buildQuizDraftContentFromRows,
   buildTestDraftContentFromRows,
   createAssessmentDraft,
   getAssessmentDraftByType,
   isMissingAssessmentDraftsError,
+  syncAssessmentQuestionsFromDraft,
   syncQuizQuestionsFromDraft,
   syncTestQuestionsFromDraft,
   updateAssessmentDraft,
+  validateAssessmentDraftContent,
   validateQuizDraftContent,
   validateTestDraftContent,
 } from '@/lib/server/assessment-drafts'
@@ -19,9 +22,9 @@ const TEST_ID_1 = '33333333-3333-4333-8333-333333333333'
 const TEST_ID_2 = '44444444-4444-4444-8444-444444444444'
 
 describe('assessment drafts', () => {
-  it('validates and normalizes quiz draft content', () => {
+  it('validates and normalizes assessment draft content', () => {
     expect(
-      validateQuizDraftContent({
+      validateAssessmentDraftContent({
         title: '  Quiz Draft  ',
         show_results: true,
         questions: [
@@ -48,9 +51,9 @@ describe('assessment drafts', () => {
     })
   })
 
-  it('rejects duplicate quiz question ids', () => {
+  it('rejects duplicate assessment question ids', () => {
     expect(
-      validateQuizDraftContent({
+      validateAssessmentDraftContent({
         title: 'Quiz Draft',
         show_results: false,
         questions: [
@@ -173,7 +176,7 @@ describe('assessment drafts', () => {
       {
         patch: [{ op: 'replace', path: '/title', value: 'Updated title' }],
       },
-      validateQuizDraftContent
+      validateAssessmentDraftContent
     )
 
     expect(result).toEqual({
@@ -196,7 +199,7 @@ describe('assessment drafts', () => {
       {
         patch: [{ op: 'replace', path: '/missing', value: 'Updated title' }],
       },
-      validateQuizDraftContent
+      validateAssessmentDraftContent
     )
 
     expect(result).toEqual({
@@ -208,7 +211,7 @@ describe('assessment drafts', () => {
 
   it('builds draft content from persisted quiz and test rows', () => {
     expect(
-      buildQuizDraftContentFromRows(
+      buildAssessmentDraftContentFromRows(
         { title: 'Quiz', show_results: true },
         [{ id: QUIZ_ID_1, question_text: 'Prompt', options: ['One', '', 'Two'] }]
       )
@@ -273,6 +276,12 @@ describe('assessment drafts', () => {
     ).toBe(true)
 
     expect(isMissingAssessmentDraftsError({ code: '42703', message: 'column missing' })).toBe(false)
+  })
+
+  it('keeps legacy quiz helper exports as compatibility aliases', () => {
+    expect(validateQuizDraftContent).toBe(validateAssessmentDraftContent)
+    expect(buildQuizDraftContentFromRows).toBe(buildAssessmentDraftContentFromRows)
+    expect(syncQuizQuestionsFromDraft).toBe(syncAssessmentQuestionsFromDraft)
   })
 
   it('wraps draft fetch/create/update operations and normalizes thrown errors', async () => {
@@ -382,7 +391,7 @@ describe('assessment drafts', () => {
     })
   })
 
-  it('syncs quiz questions by updating existing rows, inserting new rows, and deleting removed rows', async () => {
+  it('syncs assessment questions by updating existing rows, inserting new rows, and deleting removed rows', async () => {
     const updates: Array<Record<string, unknown>> = []
     const inserts: Array<Record<string, unknown>> = []
     const deletes: Array<string> = []
@@ -419,7 +428,7 @@ describe('assessment drafts', () => {
     }
 
     await expect(
-      syncQuizQuestionsFromDraft(supabase, 'quiz-1', {
+      syncAssessmentQuestionsFromDraft(supabase, 'quiz-1', {
         title: 'Quiz',
         show_results: false,
         questions: [
@@ -442,7 +451,7 @@ describe('assessment drafts', () => {
     expect(deletes).toEqual([QUIZ_ID_2])
   })
 
-  it('returns a 500 error when syncing quiz questions fails during insert', async () => {
+  it('returns a 500 error when syncing assessment questions fails during insert', async () => {
     const supabase = {
       from: vi.fn((_table: string) => ({
         select: vi.fn(() => ({
@@ -458,7 +467,7 @@ describe('assessment drafts', () => {
     }
 
     await expect(
-      syncQuizQuestionsFromDraft(supabase, 'quiz-1', {
+      syncAssessmentQuestionsFromDraft(supabase, 'quiz-1', {
         title: 'Quiz',
         show_results: false,
         questions: [


### PR DESCRIPTION
## Summary
- add assessment-named primary helpers for legacy-compatible draft content in assessment-drafts
- keep the existing QuizDraft* helper exports as identity compatibility aliases
- update markdown/course-blueprint typings and assessment draft tests to prefer assessment helper names

## Scope notes
- no schema, migration, RPC, storage, or API payload changes
- persisted quiz_id fields and legacy quiz helper exports remain intact

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/unit/assessment-drafts.test.ts tests/lib/quiz-markdown.test.ts tests/lib/server/course-blueprints.test.ts tests/lib/server/course-sites.test.ts
- pnpm lint
- pnpm test (303 files / 2681 tests)
- git diff --check