### PR TITLE
[codex] Add API auth boundary coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,23 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz TestDetailPanel internal rename pass
-
-**Completed:**
-- Created `codex/legacy-quiz-test-detail-internals` from merged `origin/main`.
-- Renamed `TestDetailPanel` component-local runtime internals from legacy quiz names to test/assessment names:
-  resolved assessment object, update notifier, request scope `testId`, defaults ref, loaded-draft guard, and detail load callback.
-- Preserved public compatibility props (`quiz`, `onQuizUpdate`), API response fallback (`data.quiz`), legacy markdown helpers, inactive legacy quiz-mode UI fallbacks, and DB-shaped `quiz_id` fields.
-- Did not touch database schema, migrations, RPCs, storage paths, API payload contracts, or production compatibility response keys.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2659 tests before edits)
-- `pnpm vitest run tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
-- `pnpm test` (301 files / 2659 tests)
-
 ## 2026-06-10 — Legacy quiz TestDetailPanel fixture cleanup pass
 
 **Completed:**
@@ -785,3 +768,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Gradient-only follow-up: `pnpm lint`
 - Gradient-only follow-up: `pnpm build`
 - Gradient-only visual verification: `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms` and `E2E_BASE_URL=http://localhost:3002 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms/ddb6fbe4-66b3-46cf-9efa-21cb4f2a5218`; computed-style check confirmed card/header borders are neutral while gradients remain.
+
+## 2026-06-13 — API auth-boundary negative coverage
+
+**Completed:**
+- Continued the systems/UI audit program with the API authorization-boundary slice.
+- Added negative teacher ownership and student enrollment coverage for legacy `GET /api/teacher/class-days`.
+- Added matching negative coverage for canonical `GET /api/classrooms/[classroomId]/class-days`.
+- Added teacher-side `GET /api/student/tests/[id]/history` coverage for non-owned tests and students outside the test classroom.
+- Confirmed the existing routes already block these paths before downstream class-day/history data reads; no production route changes were needed.
+
+**Validation:**
+- `pnpm vitest run tests/api/teacher/class-days.test.ts tests/api/classrooms-class-days.test.ts tests/api/student/tests-history.test.ts` (18 tests)
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `pnpm vitest run --sequence.concurrent=false` (303 files / 2690 tests)

--- a/tests/api/classrooms-class-days.test.ts
+++ b/tests/api/classrooms-class-days.test.ts
@@ -62,6 +62,48 @@ describe('classroom class-days route', () => {
     expect(data.class_days).toEqual([{ date: '2026-03-17' }])
   })
 
+  it('blocks teachers from reading class days for classrooms they do not own', async () => {
+    const { assertTeacherOwnsClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherOwnsClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+    const { fetchClassDaysForClassroom } = await import('@/lib/server/class-days')
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/classrooms/classroom-2/class-days'),
+      { params: Promise.resolve({ classroomId: 'classroom-2' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Forbidden')
+    expect(fetchClassDaysForClassroom).not.toHaveBeenCalled()
+  })
+
+  it('blocks students from reading class days for classrooms they cannot access', async () => {
+    const { requireAuth } = await import('@/lib/auth')
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    const { fetchClassDaysForClassroom } = await import('@/lib/server/class-days')
+    ;(requireAuth as any).mockResolvedValueOnce({ id: 'student-1', role: 'student' })
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Not enrolled in this classroom',
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/classrooms/classroom-2/class-days'),
+      { params: Promise.resolve({ classroomId: 'classroom-2' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Not enrolled in this classroom')
+    expect(fetchClassDaysForClassroom).not.toHaveBeenCalled()
+  })
+
   it('generates initial class days for teachers', async () => {
     const response = await POST(
       new NextRequest('http://localhost:3000/api/classrooms/classroom-1/class-days', {

--- a/tests/api/student/tests-history.test.ts
+++ b/tests/api/student/tests-history.test.ts
@@ -225,6 +225,57 @@ describe('GET /api/student/tests/[id]/history', () => {
     expect(data.error).toBe('student_id is required')
   })
 
+  it('blocks teacher history reads for tests they do not own', async () => {
+    const { requireAuth } = await import('@/lib/auth')
+    ;(requireAuth as any).mockResolvedValueOnce({
+      id: 'teacher-2',
+      email: 'teacher2@example.com',
+      role: 'teacher',
+    })
+    vi.mocked(serverTests.assertTeacherOwnsTest).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    } as any)
+    ;(mockSupabaseClient.from as any) = vi.fn()
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history?student_id=student-1'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Forbidden')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('blocks teacher history reads for students outside the test classroom', async () => {
+    const { requireAuth } = await import('@/lib/auth')
+    ;(requireAuth as any).mockResolvedValueOnce({
+      id: 'teacher-1',
+      email: 'teacher@example.com',
+      role: 'teacher',
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn((table: string) => {
+      if (table === 'classroom_enrollments') {
+        return mockSingle({ data: null, error: null })
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/student/tests/test-1/history?student_id=student-2'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Not enrolled in this classroom')
+    expect(mockSupabaseClient.from).toHaveBeenCalledTimes(1)
+    expect(mockSupabaseClient.from).toHaveBeenCalledWith('classroom_enrollments')
+  })
+
   it('keeps teacher-owned history access independent from student availability state', async () => {
     const { requireAuth } = await import('@/lib/auth')
     ;(requireAuth as any).mockResolvedValueOnce({

--- a/tests/api/teacher/class-days.test.ts
+++ b/tests/api/teacher/class-days.test.ts
@@ -52,4 +52,42 @@ describe('GET /api/teacher/class-days', () => {
     const response = await GET(request)
     expect(response.status).toBe(200)
   })
+
+  it('blocks teachers from reading class days for classrooms they do not own', async () => {
+    const { assertTeacherOwnsClassroom } = await import('@/lib/server/classrooms')
+    ;(assertTeacherOwnsClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Forbidden',
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn()
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/class-days?classroom_id=c2')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Forbidden')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
+
+  it('blocks students from reading class days for classrooms they cannot access', async () => {
+    const { requireAuth } = await import('@/lib/auth')
+    const { assertStudentCanAccessClassroom } = await import('@/lib/server/classrooms')
+    ;(requireAuth as any).mockResolvedValueOnce({ id: 'student-1', role: 'student' })
+    ;(assertStudentCanAccessClassroom as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: 'Not enrolled in this classroom',
+    })
+    ;(mockSupabaseClient.from as any) = vi.fn()
+
+    const request = new NextRequest('http://localhost:3000/api/teacher/class-days?classroom_id=c2')
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('Not enrolled in this classroom')
+    expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- add negative ownership/enrollment tests for legacy `GET /api/teacher/class-days`
- add matching negative tests for canonical `GET /api/classrooms/[classroomId]/class-days`
- add teacher-side `GET /api/student/tests/[id]/history` boundary coverage for non-owned tests and students outside the test classroom

## Impact
This is test-only coverage for API authorization boundaries found during the systems/UI audit. The existing routes already deny these paths before downstream data reads, so no production route changes were needed.

## Validation
- `pnpm vitest run tests/api/teacher/class-days.test.ts tests/api/classrooms-class-days.test.ts tests/api/student/tests-history.test.ts`
- `git diff --check`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm build`
- `pnpm vitest run --sequence.concurrent=false`