### PR TITLE
[codex] Add assessment markdown helper aliases

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,59 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Student classrooms cache audit
-
-**Completed:**
-- Added a verified-user-scoped `student-classrooms` client for `/api/student/classrooms` repeated reads.
-- Routed `/student/history` classroom list reads through the shared cache helper.
-- Invalidated student classroom caches after joining from `/student/history` and `/join/[code]`.
-- Added coverage for scoped list caching, auth-scope cache bypass, history-page cache usage, and join invalidation.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/unit/student-classrooms-client.test.ts tests/components/StudentHistoryPage.test.tsx tests/components/JoinClassroomPage.test.tsx tests/components/StudentHistoryTab.test.tsx tests/components/StudentClassroomsIndex.test.tsx tests/api/student/classrooms.test.ts tests/api/student/classrooms-join.test.ts tests/api/student/classrooms-id.test.ts tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
-## 2026-06-06 — Teacher classroom index cache audit
-
-**Completed:**
-- Extended the shared teacher-classrooms client to cache active and archived classroom lists separately.
-- Routed `TeacherClassroomsIndex` active refresh and archived-list loads through the shared helper instead of raw list fetches.
-- Preserved prefix invalidation after archive, restore, delete, reorder, and create flows.
-- Added coverage for separate active/archived cache keys and archived-view helper usage.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/unit/teacher-classrooms-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/components/CreateClassroomModal.test.tsx tests/components/TeacherSettingsTab.test.tsx tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-
-## 2026-06-06 — Classroom blueprint modal cache audit
-
-**Completed:**
-- Routed `CreateClassroomModal` blueprint list loads through the shared `fetchTeacherBlueprints` cache helper instead of a raw `/api/teacher/course-blueprints` fetch.
-- Kept import and instantiate mutation paths raw and preserved blueprint/classroom cache invalidation after successful mutations.
-- Added a stale-load guard so a closed/reopened modal cannot have a prior blueprint list response wipe the current options.
-- Addressed PR review feedback by bumping the list-load generation after blueprint imports so pending open-time list loads cannot erase imported options.
-- Updated modal coverage for cached list loading, empty blueprint lists, mutation fetches, stale close/reopen responses, and import-while-list-load-is-pending races.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/components/CreateClassroomModal.test.tsx tests/components/TeacherBlueprintsPage.test.tsx tests/unit/teacher-blueprints-client.test.ts tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherCalendarPage.test.tsx tests/components/TeacherDashboardPage.test.tsx tests/unit/teacher-classrooms-client.test.ts tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-
 ## 2026-06-06 — Teacher quiz list freshness audit
 
 **Completed:**
@@ -695,6 +642,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
 - `pnpm test` (303 files / 2678 tests)
 - `git diff --check`
+
 ## 2026-06-13 — Teacher lesson calendar stale classroom load guard
 
 **Completed:**
@@ -734,4 +682,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/unit/assessment-drafts.test.ts tests/lib/quiz-markdown.test.ts tests/lib/server/course-blueprints.test.ts tests/lib/server/course-sites.test.ts`
 - `pnpm lint`
+- `git diff --check`
+
+## 2026-06-13 — Legacy quiz markdown helper aliases
+
+**Completed:**
+- Added assessment-named markdown helper exports in `src/lib/quiz-markdown.ts`: `assessmentToMarkdown`, `markdownToAssessment`, and `AssessmentMarkdown*` types.
+- Kept `quizToMarkdown`, `markdownToQuiz`, and `QuizMarkdown*` exports as compatibility aliases.
+- Updated active `TestDetailPanel` markdown editing code to import and call the assessment-named helpers.
+- Expanded markdown unit coverage for the new helper names and alias compatibility.
+- Did not change markdown format text, route payloads, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `pnpm test tests/lib/quiz-markdown.test.ts tests/components/TestDetailPanel.test.tsx tests/unit/assessment-drafts.test.ts`
 - `git diff --check`

--- a/src/components/TestDetailPanel.tsx
+++ b/src/components/TestDetailPanel.tsx
@@ -39,7 +39,7 @@ import { isLinkDocumentSnapshotStale, normalizeTestDocuments } from '@/lib/test-
 import { isGeneratedAssessmentTitle } from '@/lib/assessment-titles'
 import { createJsonPatch, shouldStoreSnapshot } from '@/lib/json-patch'
 import { readTestFromPayload } from '@/lib/test-api-contract'
-import { markdownToQuiz, quizToMarkdown } from '@/lib/quiz-markdown'
+import { assessmentToMarkdown, markdownToAssessment } from '@/lib/quiz-markdown'
 import { markdownToTest, testToMarkdown } from '@/lib/test-markdown'
 import type {
   AssessmentEditorSummaryUpdate,
@@ -427,7 +427,7 @@ export function TestDetailPanel({
                 questions: nextQuestions,
                 documents: documentsRef.current,
               })
-            : quizToMarkdown({
+            : assessmentToMarkdown({
                 title: nextTitle,
                 show_results: nextShowResults,
                 questions: nextQuestions,
@@ -526,7 +526,7 @@ export function TestDetailPanel({
       })
     }
 
-    return quizToMarkdown({
+    return assessmentToMarkdown({
       title: editTitle,
       show_results: draftShowResults,
       questions,
@@ -712,7 +712,7 @@ export function TestDetailPanel({
                       questions: nextDraft.questions,
                       documents: options?.documents ?? documents,
                     })
-                  : quizToMarkdown({
+                  : assessmentToMarkdown({
                       title: nextDraft.title,
                       show_results: nextDraft.show_results,
                       questions: nextDraft.questions,
@@ -1548,7 +1548,7 @@ export function TestDetailPanel({
       return
     }
 
-    const parsed = markdownToQuiz(markdownContent, {
+    const parsed = markdownToAssessment(markdownContent, {
       defaultShowResults: draftShowResults,
       existingQuestions: questions.map((question) => ({ id: question.id })),
     })
@@ -1580,7 +1580,7 @@ export function TestDetailPanel({
       questions: nextQuestions,
     }
 
-    const nextDerivedMarkdown = quizToMarkdown({
+    const nextDerivedMarkdown = assessmentToMarkdown({
       title: parsed.draftContent.title,
       show_results: parsed.draftContent.show_results,
       questions: nextQuestions,

--- a/src/lib/quiz-markdown.ts
+++ b/src/lib/quiz-markdown.ts
@@ -6,7 +6,7 @@ const UUID_RE =
 
 const FIELD_KEYS = new Set(['id', 'prompt', 'options', 'show results', 'title'])
 
-export interface QuizMarkdownSerializeInput {
+export interface AssessmentMarkdownSerializeInput {
   title: string
   show_results: boolean
   questions: Array<{
@@ -16,15 +16,21 @@ export interface QuizMarkdownSerializeInput {
   }>
 }
 
-export interface QuizMarkdownParseOptions {
+export type QuizMarkdownSerializeInput = AssessmentMarkdownSerializeInput
+
+export interface AssessmentMarkdownParseOptions {
   defaultShowResults?: boolean
   existingQuestions?: Array<{ id: string }>
 }
 
-export interface QuizMarkdownParseResult {
+export type QuizMarkdownParseOptions = AssessmentMarkdownParseOptions
+
+export interface AssessmentMarkdownParseResult {
   draftContent: AssessmentDraftContent | null
   errors: string[]
 }
+
+export type QuizMarkdownParseResult = AssessmentMarkdownParseResult
 
 function normalizeLineEndings(markdown: string): string[] {
   return markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n')
@@ -139,7 +145,7 @@ function splitQuestionBlocks(lines: string[]): Array<{ heading: string; lines: s
 function parseQuestionBlock(
   blockLines: string[],
   index: number,
-  options: QuizMarkdownParseOptions,
+  options: AssessmentMarkdownParseOptions,
   errors: string[]
 ): AssessmentDraftQuestion | null {
   let id: string | undefined
@@ -199,7 +205,7 @@ function parseQuestionBlock(
   }
 }
 
-export function quizToMarkdown(input: QuizMarkdownSerializeInput): string {
+export function assessmentToMarkdown(input: AssessmentMarkdownSerializeInput): string {
   const lines: string[] = [
     '# Quiz',
     `Title: ${input.title}`,
@@ -218,10 +224,12 @@ export function quizToMarkdown(input: QuizMarkdownSerializeInput): string {
   return `${lines.join('\n').trimEnd()}\n`
 }
 
-export function markdownToQuiz(
+export const quizToMarkdown = assessmentToMarkdown
+
+export function markdownToAssessment(
   markdown: string,
-  options: QuizMarkdownParseOptions = {}
-): QuizMarkdownParseResult {
+  options: AssessmentMarkdownParseOptions = {}
+): AssessmentMarkdownParseResult {
   const lines = normalizeLineEndings(markdown)
   const errors: string[] = []
   let title = ''
@@ -272,3 +280,5 @@ export function markdownToQuiz(
     errors: [],
   }
 }
+
+export const markdownToQuiz = markdownToAssessment

--- a/tests/lib/quiz-markdown.test.ts
+++ b/tests/lib/quiz-markdown.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
-import { markdownToQuiz, quizToMarkdown } from '@/lib/quiz-markdown'
+import {
+  assessmentToMarkdown,
+  markdownToAssessment,
+  markdownToQuiz,
+  quizToMarkdown,
+} from '@/lib/quiz-markdown'
 
-describe('quizToMarkdown', () => {
-  it('serializes a quiz draft into markdown', () => {
-    const markdown = quizToMarkdown({
+describe('assessmentToMarkdown', () => {
+  it('serializes assessment draft content into markdown', () => {
+    const markdown = assessmentToMarkdown({
       title: 'Intro Quiz',
       show_results: false,
       questions: [
@@ -22,8 +27,8 @@ describe('quizToMarkdown', () => {
   })
 })
 
-describe('markdownToQuiz', () => {
-  it('parses quiz markdown into draft content', () => {
+describe('markdownToAssessment', () => {
+  it('parses assessment markdown into draft content', () => {
     const markdown = `# Quiz
 Title: Intro Quiz
 Show Results: true
@@ -37,7 +42,7 @@ Options:
 - Practice
 - Submit`
 
-    const result = markdownToQuiz(markdown)
+    const result = markdownToAssessment(markdown)
 
     expect(result.errors).toEqual([])
     expect(result.draftContent).toMatchObject({
@@ -65,11 +70,16 @@ Prompt:
 Options:
 - Only one`
 
-    const result = markdownToQuiz(markdown)
+    const result = markdownToAssessment(markdown)
 
     expect(result.draftContent).toBeNull()
     expect(result.errors).toContain('Question 1: Prompt is required')
     expect(result.errors).toContain('Question 1: At least 2 options required')
     expect(result.errors).toContain('Title is required')
+  })
+
+  it('keeps legacy quiz markdown exports as compatibility aliases', () => {
+    expect(quizToMarkdown).toBe(assessmentToMarkdown)
+    expect(markdownToQuiz).toBe(markdownToAssessment)
   })
 })


### PR DESCRIPTION
## Summary
- add assessment-named markdown helper exports for assessment draft markdown
- keep quizToMarkdown, markdownToQuiz, and QuizMarkdown* as compatibility aliases
- update active TestDetailPanel markdown editing code to call the assessment-named helpers

## Scope notes
- no markdown format, route payload, schema, migration, RPC, storage, or persisted quiz_id changes
- legacy quiz markdown exports remain available for older callers

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test tests/lib/quiz-markdown.test.ts tests/components/TestDetailPanel.test.tsx tests/unit/assessment-drafts.test.ts
- pnpm test (303 files / 2686 tests)
- git diff --check