### PR TITLE
[codex] Read test grading payloads by current key

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,25 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Student assessment freshness audit
-
-**Completed:**
-- Routed `StudentQuizzesTab` list reads through `fetchJSONWithCache` with zero-TTL in-flight dedupe and force-refresh keys after submit/back refreshes.
-- Added list and detail request guards so stale student quiz/test list or selected-detail responses cannot repaint after classroom/type changes or newer reads.
-- Reset selected assessment state when the classroom or assessment type changes.
-- Added `StudentQuizResults` request guards and payload reset so stale result responses cannot win after `quizId` changes.
-- Added component coverage for stale list, detail, and result response races.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/unit/request-cache.test.ts`
-- `pnpm vitest run tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/components/StudentQuizForm.test.tsx tests/api/student/quizzes.test.ts tests/api/student/quizzes-id.test.ts tests/api/student/quizzes-results.test.ts tests/api/student/quizzes-respond.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-respond.test.ts tests/api/student/tests-session-status.test.ts tests/api/student/tests-focus-events.test.ts tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm test`
-
 ## 2026-06-06 — Quiz detail freshness audit
 
 **Completed:**
@@ -694,6 +675,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/quiz-markdown.test.ts tests/unit/assessment-drafts.test.ts tests/components/TestDetailPanel.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+- `git diff --check`
+
+## 2026-06-13 — Legacy quiz grading payload reader
+
+**Completed:**
+- Normalized `TestStudentGradingPanel` results payloads into a canonical `test` field.
+- Used the shared Tests API reader so current `test` payloads are preferred while legacy `quiz` payloads still work as fallback.
+- Updated grading panel fixtures to use the current `test` key and added explicit legacy `quiz` fallback coverage.
+- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/components/TestStudentGradingPanel.test.tsx tests/lib/test-api-contract.test.ts`
 - `pnpm lint`
 - `pnpm test`
 - `git diff --check`

--- a/src/components/TestStudentGradingPanel.tsx
+++ b/src/components/TestStudentGradingPanel.tsx
@@ -11,6 +11,7 @@ import {
   TEACHER_TEST_GRADING_ROW_UPDATED_EVENT,
   type TeacherTestGradingRowUpdatedEventDetail,
 } from '@/lib/events'
+import { readTestFromPayload } from '@/lib/test-api-contract'
 import type { TestFocusSummary } from '@/types'
 
 interface TestQuestionInfo {
@@ -51,13 +52,20 @@ interface TestStudentRow {
   focus_summary: TestFocusSummary | null
 }
 
+interface TestResultSummary {
+  id: string
+  title: string
+}
+
 interface TestResultsPayload {
-  quiz: {
-    id: string
-    title: string
-  }
+  test: TestResultSummary
   questions: TestQuestionInfo[]
   students: TestStudentRow[]
+}
+
+type TestResultsResponsePayload = Omit<TestResultsPayload, 'test'> & {
+  test?: TestResultSummary | null
+  quiz?: TestResultSummary | null
 }
 
 interface GradeDraft {
@@ -153,6 +161,17 @@ function computeStudentGradingMetrics(
   }
 }
 
+function normalizeTestResultsPayload(data: TestResultsResponsePayload): TestResultsPayload {
+  const test = readTestFromPayload<TestResultSummary>(data)
+  if (!test) throw new Error('Failed to load test results')
+
+  return {
+    test,
+    questions: data.questions,
+    students: data.students,
+  }
+}
+
 interface Props {
   testId: string
   selectedStudentId: string | null
@@ -229,7 +248,7 @@ export function TestStudentGradingPanel({
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Failed to load test results')
 
-      const payload = data as TestResultsPayload
+      const payload = normalizeTestResultsPayload(data as TestResultsResponsePayload)
       setResults(payload)
 
       const nextDrafts: Record<string, GradeDraft> = {}

--- a/tests/components/TestStudentGradingPanel.test.tsx
+++ b/tests/components/TestStudentGradingPanel.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/ui', () => ({
 
 function makeResultsPayload(score: number | null, feedback: string | null) {
   return {
-    quiz: { id: 'test-1', title: 'Unit Test' },
+    test: { id: 'test-1', title: 'Unit Test' },
     questions: [
       {
         id: 'q-open-1',
@@ -71,7 +71,7 @@ function makeMixedResultsPayload(
   const selectedOption = options.selectedOption ?? 1
   const correctOption = options.correctOption ?? 1
   return {
-    quiz: { id: 'test-1', title: 'Unit Test' },
+    test: { id: 'test-1', title: 'Unit Test' },
     questions: [
       {
         id: 'q-mc-1',
@@ -247,6 +247,30 @@ describe('TestStudentGradingPanel save-all grading', () => {
       String(input).endsWith('/api/teacher/tests/test-1/results')
     )
     expect(resultsCalls).toHaveLength(1)
+  })
+
+  it('accepts legacy quiz result payloads as a compatibility fallback', async () => {
+    const legacyPayload = makeResultsPayload(3, 'Legacy feedback') as ReturnType<typeof makeResultsPayload> & {
+      quiz?: { id: string; title: string }
+      test?: { id: string; title: string }
+    }
+    legacyPayload.quiz = legacyPayload.test
+    delete legacyPayload.test
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => legacyPayload,
+    })
+
+    render(
+      <TestStudentGradingPanel
+        testId="test-1"
+        selectedStudentId="student-1"
+      />
+    )
+
+    await screen.findByDisplayValue('3')
+    expect(screen.getByDisplayValue('Legacy feedback')).toBeInTheDocument()
   })
 
   it('renders score inputs for MC and open questions and saves MC overrides', async () => {


### PR DESCRIPTION
## Summary
- normalize `TestStudentGradingPanel` result payloads into a canonical `test` field
- use the shared Tests API reader so current `test` keys are preferred with legacy `quiz` fallback
- update grading panel fixtures to use `test` and add explicit legacy `quiz` fallback coverage

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm exec tsc --noEmit`
- `pnpm test tests/components/TestStudentGradingPanel.test.tsx tests/lib/test-api-contract.test.ts`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

## Notes
- No API response shape, schema, migration, RPC, storage path, or persisted `quiz_id` changes.