### PR TITLE
[codex] Rename student tests payload types

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,24 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Quiz detail freshness audit
-
-**Completed:**
-- Added request-scope guards to `QuizDetailPanel` draft, test-document detail, and results loads so stale responses cannot repaint after selected assessment, classroom, route base, or assessment-type changes.
-- Reset result payload and invalidated in-flight load/save revisions when the selected assessment scope changes.
-- Added save contexts so pending debounced saves can still persist their original assessment without applying stale draft state to the currently selected panel.
-- Added component coverage for stale draft, test-detail document, results, same-id assessment-type switch, selected-assessment save-response races, and pending debounced save persistence across assessment switches.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx tests/components/QuizResultsView.test.tsx tests/components/TeacherQuizzesTab.test.tsx tests/components/TeacherTestsTab.test.tsx tests/api/teacher/quizzes-results.test.ts tests/api/teacher/tests-results.test.ts tests/unit/request-cache.test.ts`
-- `git diff --check`
-- `pnpm lint`
-- `pnpm build`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm test`
-- `pnpm vitest run tests/components/QuizDetailPanel.test.tsx`
-
 ## 2026-06-06 — Survey detail freshness audit
 
 **Completed:**
@@ -691,6 +673,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/components/TestStudentGradingPanel.test.tsx tests/lib/test-api-contract.test.ts`
+- `pnpm lint`
+- `pnpm test`
+- `git diff --check`
+
+## 2026-06-13 — Student Tests payload type names
+
+**Completed:**
+- Renamed local `StudentTestsTab` response type aliases so current `test` and `tests` payload fields are primary.
+- Collapsed duplicated session-status test/quiz summary shapes into one current `StudentTestSessionStatusSummary`.
+- Kept legacy `quiz` and `quizzes` fields in the local types as documented compatibility fallbacks.
+- Did not change runtime behavior, API response shapes, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/components/StudentTestsTab.test.tsx tests/lib/test-api-contract.test.ts`
 - `pnpm lint`
 - `pnpm test`
 - `git diff --check`

--- a/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentTestsTab.tsx
@@ -57,34 +57,32 @@ interface RemoteClosureNotice {
   description: string
 }
 
+interface StudentTestSessionStatusSummary {
+  id: string
+  status: 'draft' | 'active' | 'closed'
+  assessment_type: 'test'
+  student_status: StudentTestStatus
+  returned_at: string | null
+}
+
 interface StudentTestSessionStatusResponse {
-  test?: {
-    id: string
-    status: 'draft' | 'active' | 'closed'
-    assessment_type: 'test'
-    student_status: StudentTestStatus
-    returned_at: string | null
-  }
-  quiz?: {
-    id: string
-    status: 'draft' | 'active' | 'closed'
-    assessment_type: 'test'
-    student_status: StudentTestStatus
-    returned_at: string | null
-  }
+  test?: StudentTestSessionStatusSummary
+  quiz?: StudentTestSessionStatusSummary
   student_status: StudentTestStatus
   returned_at: string | null
   can_continue: boolean
   message: string | null
 }
 
-interface StudentAssessmentListResponse {
+interface StudentTestListResponse {
   tests?: StudentTestView[]
+  /** Legacy compatibility key emitted during the Tests contract transition. */
   quizzes?: StudentTestView[]
 }
 
-interface StudentAssessmentDetailResponse {
+interface StudentTestDetailResponse {
   test?: StudentTestView
+  /** Legacy compatibility key emitted during the Tests contract transition. */
   quiz?: StudentTestView
   questions?: TestAssessmentQuestion[]
   student_responses?: Record<string, number | TestResponseDraftValue>
@@ -376,7 +374,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
     setLoading(true)
     try {
       const query = new URLSearchParams({ classroom_id: classroomId })
-      const data = await fetchJSONWithCache<StudentAssessmentListResponse>(
+      const data = await fetchJSONWithCache<StudentTestListResponse>(
         options.forceRefresh
           ? `student-assessments:${viewAssessmentType}:${classroomId}:refresh:${requestId}`
           : `student-assessments:${viewAssessmentType}:${classroomId}`,
@@ -484,7 +482,7 @@ export function StudentTestsTab({ classroom, isActive = true }: Props) {
     try {
       // Bypass fetchJSONWithCache for selected detail freshness; request ids guard stale responses.
       const res = await fetch(`${basePath}/${testId}`)
-      const data = await res.json() as StudentAssessmentDetailResponse
+      const data = await res.json() as StudentTestDetailResponse
       if (
         detailRequestIdRef.current !== requestId ||
         selectedTestIdRef.current !== testId ||


### PR DESCRIPTION
## Summary
- rename local `StudentTestsTab` response types around current `test` and `tests` payload fields
- collapse duplicated session-status test/quiz summary shape into `StudentTestSessionStatusSummary`
- keep legacy `quiz`/`quizzes` fields documented as compatibility fallbacks

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm exec tsc --noEmit`
- `pnpm test tests/components/StudentTestsTab.test.tsx tests/lib/test-api-contract.test.ts`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

## Notes
- Type-only cleanup. No runtime behavior, API response shape, schema, migration, RPC, storage path, or persisted `quiz_id` changes.