### PR TITLE
[codex] Add transient exam focus e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -703,3 +703,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/server-access.test.ts`
 - `pnpm lint`
 - `pnpm test`
+
+## 2026-06-13 — Student exam-mode transient focus e2e
+
+**Completed:**
+- Added a focused Playwright e2e case covering transient blur/focus restoration during an active student exam.
+- Verified the open-response draft stays visible, exam lock overlays do not appear, and focus telemetry records a zero-second away restoration.
+- Reused the existing exam-mode API setup and cleanup helpers; no schema, app logic, or seeded data changes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "keeps a transient away restoration" --project=chromium-desktop`
+- `pnpm lint`

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -424,4 +424,63 @@ test.describe('student exam mode', () => {
       await cleanupTest(browser, testId)
     }
   })
+
+  test('keeps a transient away restoration visible and preserves the draft response', async ({ browser, page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const classroom = await withTeacherPage(browser, async (teacherPage) => {
+        const shared = await findSharedClassroom(page, teacherPage)
+        const testRecord = await createActiveOpenResponseTest(teacherPage, shared.id, testTitle)
+        testId = testRecord.id
+        return shared
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      const splitShell = page.locator('[data-testid="student-test-split-container"]')
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+      const responseBox = page.locator('textarea[placeholder="Write your response..."]')
+      await expect(responseBox).toBeVisible()
+      await responseBox.fill('Draft remains visible through a transient away restoration.')
+      await expect(page.getByText('Saved')).toBeVisible({ timeout: 20_000 })
+
+      await page.evaluate(() => {
+        window.dispatchEvent(new Event('blur'))
+        window.dispatchEvent(new Event('focus'))
+      })
+
+      await expect(page.locator('[data-testid="exam-content-obscurer"]')).toHaveCount(0)
+      await expect(page.locator('[data-testid="exam-interaction-blocker"]')).toHaveCount(0)
+      await expect(responseBox).toBeVisible()
+      await expect(responseBox).toHaveValue('Draft remains visible through a transient away restoration.')
+
+      await expect.poll(async () => {
+        if (!testId) return { awayCount: 0, awayTotalSeconds: -1 }
+        const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
+        return {
+          awayCount: detail.focus_summary?.away_count ?? 0,
+          awayTotalSeconds: detail.focus_summary?.away_total_seconds ?? -1,
+        }
+      }).toEqual({
+        awayCount: 1,
+        awayTotalSeconds: 0,
+      })
+      await expect(
+        page.locator('[data-testid="student-test-documents-pane"]').getByLabel(/Away\/focus 1/)
+      ).toBeVisible()
+    } finally {
+      await cleanupTest(browser, testId)
+    }
+  })
 })


### PR DESCRIPTION
## Selected flow

Student exam mode: transient away/focus restoration during an active open-response test.

Chosen because student exam mode is the top automation priority and the existing spec already covered sustained away/focus loss, sustained window loss, reload resume, and route-exit blocking. The remaining bounded gap was the short blur/focus path where the draft should remain visible and telemetry should distinguish a zero-second away restoration from lock-worthy noncompliance.

## Risk profile

exam-mode

This touches only Playwright coverage. It verifies draft preservation, lock overlay absence, and focus telemetry during active test-taking.

## Tests added or updated

- Updated `e2e/student-exam-mode.spec.ts`
- Added `keeps a transient away restoration visible and preserves the draft response`

## Commands run

- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm install` (existing lockfile only; needed because `node_modules` was missing before startup verification could pass)
- `pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "keeps a transient away restoration" --project=chromium-desktop`
- `pnpm lint`
- `node scripts/trim-session-log.mjs`
- `git diff --check`

## Seeded-data assumptions

Uses the existing e2e auth setup defaults and assumes the seeded teacher and student auth users share at least one classroom. The test creates and deletes its own active open-response test through existing API routes.

## Residual coverage gaps

Teacher-side exam-mode telemetry visibility still has limited e2e coverage, especially scheduled/open/closed transitions and row-level distinctions between route exits, focus/away events, and window/full-screen exits.
