### PR TITLE
[codex] Add teacher exam access e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,24 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-06 — Survey detail freshness audit
-
-**Completed:**
-- Added request-id and selected-survey guards to teacher survey authoring detail loads, teacher survey results loads, and student survey detail/results loads.
-- Scoped already-loaded teacher/student survey detail and result payloads to the active selected survey so old survey content is hidden immediately on selection changes.
-- Reset student survey result payloads while a new selected survey or result request is loading.
-- Kept selected survey detail/results reads raw for freshness and guarded stale responses explicitly.
-- Added component coverage for stale teacher survey detail/results responses, stale student survey detail/results responses, and already-loaded old detail/results after survey switches.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/TeacherSurveyWorkspace.test.tsx tests/components/TeacherSurveyResultsPane.test.tsx tests/components/StudentSurveyPanel.test.tsx`
-- `git diff --check`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm build`
-- `pnpm test`
-
 ## 2026-06-07 — Student exam reload-resume e2e coverage
 
 **Completed:**
@@ -692,3 +674,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `pnpm test`
 - `git diff --check`
+
+## 2026-06-14 — Teacher exam access lifecycle e2e
+
+**Completed:**
+- Added a focused Playwright teacher exam-mode flow covering draft test activation, opening all student access, closing all student access, and summary card open/closed access counts.
+- The spec creates a single open-response draft test through existing teacher API routes, selects a seeded classroom with enrolled students, drives lifecycle transitions through the teacher grading workspace UI, and deletes its test record in cleanup.
+- Risk profile: exam-mode.
+- Model recommendation: GPT-5 Codex - e2e coverage task with repo-specific Playwright and API setup.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
+- `pnpm lint`

--- a/e2e/teacher-exam-mode.spec.ts
+++ b/e2e/teacher-exam-mode.spec.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type Page } from '@playwright/test'
+
+const TEACHER_STORAGE = '.auth/teacher.json'
+
+interface ClassroomRecord {
+  id: string
+  title?: string | null
+}
+
+interface AssessmentRecord {
+  id: string
+  title: string
+}
+
+interface AssessmentDraftRecord {
+  version: number
+  content: {
+    title: string
+    show_results: boolean
+    questions: unknown[]
+  }
+}
+
+interface TestResultsRecord {
+  test?: {
+    status?: 'draft' | 'active' | 'closed'
+  }
+  quiz?: {
+    status?: 'draft' | 'active' | 'closed'
+  }
+  students?: Array<{
+    student_id: string
+    effective_access?: 'open' | 'closed'
+  }>
+}
+
+function uniqueTitle(): string {
+  return `Teacher Exam Mode E2E ${Date.now()}`
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function loadJson<T>(page: Page, path: string): Promise<T> {
+  return page.evaluate(async (apiPath) => {
+    const response = await fetch(apiPath)
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data?.error || `Failed to load ${apiPath}: ${response.status}`)
+    }
+    return data
+  }, path) as Promise<T>
+}
+
+async function sendJson<T>(
+  page: Page,
+  method: 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  return page.evaluate(async ({ apiPath, payload, requestMethod }) => {
+    const response = await fetch(apiPath, {
+      method: requestMethod,
+      headers: payload ? { 'Content-Type': 'application/json' } : undefined,
+      body: payload ? JSON.stringify(payload) : undefined,
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data?.error || `Failed to ${requestMethod} ${apiPath}: ${response.status}`)
+    }
+    return data
+  }, { apiPath: path, payload: body, requestMethod: method }) as Promise<T>
+}
+
+async function createDraftOpenResponseTest(
+  page: Page,
+  classroomId: string,
+  title: string,
+): Promise<AssessmentRecord> {
+  const created = await sendJson<{ quiz: AssessmentRecord }>(page, 'POST', '/api/teacher/tests', {
+    classroom_id: classroomId,
+    title,
+  })
+
+  const testRecord = created.quiz
+  const draft = await loadJson<{ draft: AssessmentDraftRecord }>(
+    page,
+    `/api/teacher/tests/${testRecord.id}/draft`,
+  )
+
+  await sendJson(page, 'PATCH', `/api/teacher/tests/${testRecord.id}/draft`, {
+    version: draft.draft.version,
+    content: {
+      ...draft.draft.content,
+      title,
+      show_results: false,
+      questions: [
+        {
+          id: randomUUID(),
+          question_type: 'open_response',
+          question_text: 'Explain how closing exam access affects student test availability.',
+          options: [],
+          correct_option: null,
+          answer_key: 'Closed access should block further test taking while preserving work for grading.',
+          sample_solution: null,
+          points: 5,
+          response_max_chars: 2000,
+          response_monospace: false,
+        },
+      ],
+    },
+  })
+
+  return testRecord
+}
+
+async function createDraftTestInClassroomWithStudents(page: Page, title: string): Promise<{
+  classroom: ClassroomRecord
+  testRecord: AssessmentRecord
+  studentCount: number
+}> {
+  const data = await loadJson<{ classrooms?: ClassroomRecord[] }>(page, '/api/teacher/classrooms')
+  const classrooms = data.classrooms || []
+
+  for (const classroom of classrooms) {
+    const testRecord = await createDraftOpenResponseTest(page, classroom.id, title)
+    const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testRecord.id}/results`)
+    const studentCount = results.students?.length || 0
+
+    if (studentCount > 0) {
+      return { classroom, testRecord, studentCount }
+    }
+
+    await sendJson(page, 'DELETE', `/api/teacher/tests/${testRecord.id}`).catch(() => undefined)
+  }
+
+  expect(
+    classrooms.length,
+    'Seed a teacher classroom with at least one enrolled student before running teacher exam-mode e2e tests.',
+  ).toBeGreaterThan(0)
+  throw new Error('No seeded teacher classroom has enrolled students.')
+}
+
+async function cleanupTest(page: Page, testId: string | null): Promise<void> {
+  if (!testId) return
+  await sendJson(page, 'DELETE', `/api/teacher/tests/${testId}`).catch(() => undefined)
+}
+
+function getResultsStatus(results: TestResultsRecord): 'draft' | 'active' | 'closed' | undefined {
+  return results.test?.status ?? results.quiz?.status
+}
+
+test.describe('teacher exam mode', () => {
+  test.use({ storageState: TEACHER_STORAGE })
+
+  test('activates a draft test and closes all student access from the grading workspace', async ({ page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const { classroom, testRecord, studentCount } = await createDraftTestInClassroomWithStudents(page, testTitle)
+      testId = testRecord.id
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      const testButton = page.getByRole('button', { name: new RegExp(`^${escapeRegExp(testTitle)}$`) })
+      await expect(testButton).toBeVisible({ timeout: 15_000 })
+
+      const testCard = testButton.locator('xpath=ancestor::div[contains(@class, "rounded-card")][1]')
+      await expect(testCard.getByText('Draft', { exact: true })).toBeVisible()
+      await expect(testCard.getByLabel('0 open')).toBeVisible()
+      await expect(testCard.getByLabel(`${studentCount} closed`)).toBeVisible()
+
+      await testButton.click()
+      await expect(page.locator('[data-test-grading-student-row]').first()).toBeVisible({ timeout: 15_000 })
+
+      await page.getByRole('button', { name: 'Open All' }).click()
+      await expect(page.getByText('Activate test?')).toBeVisible()
+      await page.getByRole('button', { name: 'Activate' }).click()
+
+      await expect.poll(async () => {
+        const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testRecord.id}/results`)
+        return getResultsStatus(results)
+      }).toBe('active')
+
+      await expect(page.getByRole('button', { name: 'Open All' })).toBeVisible()
+      await page.getByRole('button', { name: 'Open All' }).click()
+      await expect(page.getByText(`Open access for ${studentCount} student(s)?`)).toBeVisible()
+      await page.getByRole('button', { name: 'Open Access', exact: true }).click()
+
+      await expect.poll(async () => {
+        const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testRecord.id}/results`)
+        const students = results.students || []
+        return {
+          studentCount: students.length,
+          openCount: students.filter((student) => student.effective_access === 'open').length,
+        }
+      }).toEqual({ studentCount, openCount: studentCount })
+      await expect(page.getByRole('button', { name: 'Close All' })).toBeVisible()
+      await expect(page.locator('[data-test-grading-student-row]').first().getByRole('button', {
+        name: /Access open.*Close access/,
+      })).toBeVisible()
+
+      await page.getByRole('button', { name: 'Close All' }).click()
+      await expect(page.getByText(`Close access for ${studentCount} student(s)?`)).toBeVisible()
+      await page.getByRole('button', { name: 'Close Access', exact: true }).click()
+
+      await expect.poll(async () => {
+        const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testRecord.id}/results`)
+        const students = results.students || []
+        return {
+          studentCount: students.length,
+          closedCount: students.filter((student) => student.effective_access === 'closed').length,
+        }
+      }).toEqual({ studentCount, closedCount: studentCount })
+      await expect(page.getByRole('button', { name: 'Open All' })).toBeVisible()
+      await expect(page.locator('[data-test-grading-student-row]').first().getByRole('button', {
+        name: /Access closed for this student\. Open access/,
+      })).toBeVisible()
+
+      await page.getByRole('link', { name: 'Tests' }).click()
+      await expect(testCard.getByText('Closed', { exact: true })).toBeVisible()
+      await expect(testCard.getByLabel('0 open')).toBeVisible()
+      await expect(testCard.getByLabel(`${studentCount} closed`)).toBeVisible()
+    } finally {
+      await cleanupTest(page, testId)
+    }
+  })
+})


### PR DESCRIPTION
## Selected flow
Teacher exam mode: draft test activation, opening all student access, closing all student access, and summary-card open/closed access counts from the teacher grading workspace.

Chosen because the existing student exam-mode spec already covers draft preservation, route exits, reload resume, window/focus lock behavior, and focus telemetry. Teacher exam-mode lifecycle/access coverage was the next highest-priority bounded gap.

## Risk profile
Exam-mode.

## Tests added or updated
- Added `e2e/teacher-exam-mode.spec.ts`.
- The spec creates one open-response draft test through existing teacher API routes, selects a seeded teacher classroom with enrolled students, drives activation/open/close access through the UI, verifies API-backed access state, verifies summary card counts, and deletes the test in cleanup.
- Updated `.ai/SESSION-LOG.md` and trimmed it with the repo script.

## Commands run
- `bash scripts/verify-env.sh`
- `pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
- `pnpm lint`
- `node scripts/trim-session-log.mjs`
- `node scripts/trim-session-log.mjs --check`
- `git diff --check`

## Seeded-data assumptions
- `E2E_TEACHER_EMAIL` / default `teacher@example.com` can log in.
- The teacher has at least one active classroom with one or more enrolled students.
- The test creates and deletes its own assessment record; no static test fixture is required.

## Residual coverage gaps
- Scheduled/open/closed date-window behavior is still not covered by e2e.
- Teacher grading visibility after submitted student work is not covered here.
- Teacher telemetry review of focus/away, fullscreen/window exits, and route exits remains covered primarily through student-side event generation, not a teacher review workflow.
