### PR TITLE
Rename assessment server access contract

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -687,3 +687,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
 - `pnpm lint`
+
+## 2026-06-14 — Legacy quiz server access names
+
+**Completed:**
+- Exported the assessment access result type from `src/lib/server/assessments.ts` as `AssessmentAccessResult`.
+- Updated assessment access not-found errors from quiz wording to assessment wording.
+- Updated server access unit tests to exercise assessment-named helpers as the primary path.
+- Kept legacy `assertTeacherOwnsQuiz`, `assertStudentCanAccessQuiz`, and `quiz` result fields covered as compatibility aliases.
+- Did not change API response shapes, database tables, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/server-access.test.ts`
+- `pnpm lint`
+- `pnpm test`

--- a/src/lib/server/assessments.ts
+++ b/src/lib/server/assessments.ts
@@ -23,7 +23,7 @@ export type AssessmentAccessRecord = {
 
 export type QuizAccessRecord = AssessmentAccessRecord
 
-type AccessResult<T> =
+export type AssessmentAccessResult<T> =
   | { ok: true; assessment: T; quiz: T }
   | { ok: false; status: number; error: string }
 
@@ -34,7 +34,7 @@ type AssessmentVisibilityRecord = {
 
 type QuizVisibilityRecord = AssessmentVisibilityRecord
 
-function assessmentAccessSuccess<T>(assessment: T): AccessResult<T> {
+function assessmentAccessSuccess<T>(assessment: T): AssessmentAccessResult<T> {
   return {
     ok: true,
     assessment,
@@ -65,7 +65,7 @@ export async function assertTeacherOwnsAssessment(
   teacherId: string,
   assessmentId: string,
   opts?: { checkArchived?: boolean }
-): Promise<AccessResult<AssessmentAccessRecord>> {
+): Promise<AssessmentAccessResult<AssessmentAccessRecord>> {
   const supabase = getServiceRoleClient()
   const { data: assessment, error } = await supabase
     .from('quizzes')
@@ -81,7 +81,7 @@ export async function assertTeacherOwnsAssessment(
     .single()
 
   if (error || !assessment) {
-    return { ok: false, status: 404, error: 'Quiz not found' }
+    return { ok: false, status: 404, error: 'Assessment not found' }
   }
 
   if (assessment.classrooms.teacher_id !== teacherId) {
@@ -100,7 +100,7 @@ export const assertTeacherOwnsQuiz = assertTeacherOwnsAssessment
 export async function assertStudentCanAccessAssessment(
   studentId: string,
   assessmentId: string
-): Promise<AccessResult<AssessmentAccessRecord>> {
+): Promise<AssessmentAccessResult<AssessmentAccessRecord>> {
   const supabase = getServiceRoleClient()
   const { data: assessment, error } = await supabase
     .from('quizzes')
@@ -116,7 +116,7 @@ export async function assertStudentCanAccessAssessment(
     .single()
 
   if (error || !assessment) {
-    return { ok: false, status: 404, error: 'Quiz not found' }
+    return { ok: false, status: 404, error: 'Assessment not found' }
   }
 
   if (assessment.classrooms.archived_at) {

--- a/tests/unit/server-access.test.ts
+++ b/tests/unit/server-access.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   assertStudentCanAccessAssessment,
   assertStudentCanAccessQuiz,
+  assertTeacherOwnsAssessment,
   assertTeacherOwnsQuiz,
 } from '@/lib/server/assessments'
 import {
@@ -171,7 +172,7 @@ describe('server access helpers', () => {
   })
 
   describe('assessment access', () => {
-    it('returns 403 when the teacher requests archived quiz access with archived checks enabled', async () => {
+    it('returns 403 when the teacher requests archived assessment access with archived checks enabled', async () => {
       mockSupabaseClient.from.mockImplementation((table: string) => {
         expect(table).toBe('quizzes')
         return createSingleSelectResult({
@@ -196,67 +197,27 @@ describe('server access helpers', () => {
         })
       })
 
-      await expect(assertTeacherOwnsQuiz('teacher-1', 'quiz-1', { checkArchived: true })).resolves.toEqual({
+      await expect(assertTeacherOwnsAssessment('teacher-1', 'quiz-1', { checkArchived: true })).resolves.toEqual({
         ok: false,
         status: 403,
         error: 'Classroom is archived',
       })
     })
 
-    it('returns 404 when the quiz does not exist for a student', async () => {
+    it('returns 404 when the assessment does not exist for a student', async () => {
       mockSupabaseClient.from.mockImplementation((table: string) => {
         expect(table).toBe('quizzes')
         return createSingleSelectResult({ data: null, error: { code: 'PGRST116' } })
       })
 
-      await expect(assertStudentCanAccessQuiz('student-1', 'quiz-1')).resolves.toEqual({
+      await expect(assertStudentCanAccessAssessment('student-1', 'quiz-1')).resolves.toEqual({
         ok: false,
         status: 404,
-        error: 'Quiz not found',
+        error: 'Assessment not found',
       })
     })
 
-    it('returns the quiz when the student is enrolled in an active classroom', async () => {
-      mockSupabaseClient.from.mockImplementation((table: string) => {
-        if (table === 'quizzes') {
-          return createSingleSelectResult({
-            data: {
-              id: 'quiz-1',
-              classroom_id: 'classroom-1',
-              status: 'active',
-              opens_at: null,
-              title: 'Quiz 1',
-              show_results: false,
-              position: 0,
-              created_by: 'teacher-1',
-              created_at: '2026-03-01T00:00:00.000Z',
-              updated_at: '2026-03-01T00:00:00.000Z',
-              classrooms: {
-                id: 'classroom-1',
-                teacher_id: 'teacher-1',
-                archived_at: null,
-              },
-            },
-            error: null,
-          })
-        }
-
-        expect(table).toBe('classroom_enrollments')
-        return createSingleSelectResult({ data: { id: 'enrollment-1' }, error: null })
-      })
-
-      const result = await assertStudentCanAccessQuiz('student-1', 'quiz-1')
-
-      expect(result.ok).toBe(true)
-      if (result.ok) {
-        expect(result.assessment).toBe(result.quiz)
-        expect(result.assessment.id).toBe('quiz-1')
-        expect(result.quiz.id).toBe('quiz-1')
-        expect(result.quiz.classrooms.archived_at).toBeNull()
-      }
-    })
-
-    it('supports the canonical assessment access helper with the legacy quiz table contract', async () => {
+    it('returns the assessment when the student is enrolled in an active classroom', async () => {
       mockSupabaseClient.from.mockImplementation((table: string) => {
         if (table === 'quizzes') {
           return createSingleSelectResult({
@@ -291,7 +252,51 @@ describe('server access helpers', () => {
       if (result.ok) {
         expect(result.assessment).toBe(result.quiz)
         expect(result.assessment.id).toBe('quiz-1')
+        expect(result.quiz.id).toBe('quiz-1')
+        expect(result.quiz.classrooms.archived_at).toBeNull()
       }
+    })
+
+    it('keeps legacy quiz access aliases wired to the assessment contract', async () => {
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === 'quizzes') {
+          return createSingleSelectResult({
+            data: {
+              id: 'quiz-1',
+              classroom_id: 'classroom-1',
+              status: 'active',
+              opens_at: null,
+              title: 'Quiz 1',
+              show_results: false,
+              position: 0,
+              created_by: 'teacher-1',
+              created_at: '2026-03-01T00:00:00.000Z',
+              updated_at: '2026-03-01T00:00:00.000Z',
+              classrooms: {
+                id: 'classroom-1',
+                teacher_id: 'teacher-1',
+                archived_at: null,
+              },
+            },
+            error: null,
+          })
+        }
+
+        expect(table).toBe('classroom_enrollments')
+        return createSingleSelectResult({ data: { id: 'enrollment-1' }, error: null })
+      })
+
+      const result = await assertStudentCanAccessQuiz('student-1', 'quiz-1')
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.assessment).toBe(result.quiz)
+        expect(result.assessment.id).toBe('quiz-1')
+      }
+
+      await expect(assertTeacherOwnsQuiz('teacher-1', 'quiz-1')).resolves.toMatchObject({
+        ok: true,
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- export the assessment server access result type as `AssessmentAccessResult`
- switch assessment access not-found copy from quiz wording to assessment wording
- update server access tests to use assessment helpers as the primary path while keeping legacy quiz alias coverage

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/unit/server-access.test.ts
- pnpm lint
- pnpm test

## Risk
- runtime-platform: low. The only runtime behavior change is the internal assessment helper 404 text from `Quiz not found` to `Assessment not found`; no schema/API response shape changes.