### PR TITLE
Rename teacher tests payload types

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,31 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-07 — Student exam reload-resume e2e coverage
-
-**Completed:**
-- Added a focused Playwright student exam-mode flow that starts an open-response test, waits for draft autosave, reloads the browser, reopens the test, and verifies the draft resumes.
-- Asserted reload telemetry is recorded as route-exit activity while window/full-screen exit telemetry remains unchanged.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (initially failed until `pnpm install` restored `node_modules`; rerun via `bash scripts/verify-env.sh` passed)
-- `pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop -g "resumes an in-progress"`
-- `pnpm lint`
-
-## 2026-06-08 — Classroom sidebar history tightening
-
-**Completed:**
-- Changed first-level classroom sidebar navigation to replace the current history entry instead of pushing a lateral tab entry.
-- Changed the Classwork sidebar reset path to clear selected assignment state with replace for both teacher and student nav.
-- Added regression coverage for generic sidebar tab replacement and the Classwork selection-clear replace behavior while preserving existing in-tab workspace push coverage.
-
-**Validation:**
-- `pnpm exec vitest run tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-- Headless Playwright check: Daily → Classwork → assignment detail → Back returned to Classwork summary.
-- `pnpm test -- tests/components/NavItems.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherQuizzesTab.test.tsx` (ran the full suite due script argument handling; only failed the pre-existing `TeacherGradebookTab.test.tsx` timeout)
-
 ## 2026-06-08 — Quiz individual responses freshness audit
 
 **Completed:**
@@ -715,3 +690,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm exec playwright test e2e/student-exam-mode.spec.ts -g "keeps a transient away restoration" --project=chromium-desktop`
 - `pnpm lint`
+## 2026-06-14 — Teacher Tests payload type names
+
+**Completed:**
+- Added current-key local response types in `TeacherTestsTab` for teacher test list and results payloads.
+- Kept legacy `quiz` and `quizzes` fields documented as compatibility fallbacks in those local types.
+- Updated `TeacherTestsTab` component fixtures so current `test` results and create payloads are the default.
+- Added explicit legacy `quiz` results-payload fallback coverage.
+- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `pnpm test`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -122,6 +122,28 @@ interface TestGradingQuestionSummary {
   responseMonospace: boolean
 }
 
+type TeacherTestListResponse = {
+  tests?: TestAssessmentWithStats[]
+  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
+  quizzes?: TestAssessmentWithStats[]
+}
+
+type TeacherTestResultsQuestionResponse = {
+  id: string
+  question_type?: unknown
+  response_monospace?: unknown
+}
+
+type TeacherTestResultsResponse = {
+  test?: TestAssessment | null
+  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
+  quiz?: TestAssessment | null
+  students?: TestGradingStudentRow[]
+  questions?: TeacherTestResultsQuestionResponse[]
+  active_ai_grading_run?: TestAiGradingRunSummary | null
+  error?: string
+}
+
 type WorkspaceState = 'list' | 'selected'
 type WorkspaceTab = 'authoring' | 'grading'
 type TestEditModalView = 'edit' | 'markdown'
@@ -732,7 +754,7 @@ export function TeacherTestsTab({
     setLoading(true)
     try {
       const query = new URLSearchParams({ classroom_id: classroom.id })
-      const data = await fetchJSONWithCache<{ tests?: TestAssessmentWithStats[]; quizzes?: TestAssessmentWithStats[] }>(
+      const data = await fetchJSONWithCache<TeacherTestListResponse>(
         `teacher-tests:${classroom.id}`,
         async () => {
           const response = await fetch(`${apiBasePath}?${query.toString()}`)
@@ -803,7 +825,7 @@ export function TeacherTestsTab({
     }
     setGradingError('')
     try {
-      const { ok, data } = await fetchJSONWithCache<{ ok: boolean; data: any }>(
+      const { ok, data } = await fetchJSONWithCache<{ ok: boolean; data: TeacherTestResultsResponse }>(
         `teacher-test-results:${requestedTestId}:${requestId}`,
         async () => {
           const response = await fetch(`${apiBasePath}/${requestedTestId}/results`, { cache: 'no-store' })
@@ -835,7 +857,7 @@ export function TeacherTestsTab({
       setGradingStudents(nextStudents)
       setGradingQuestions(
         Array.isArray(data.questions)
-          ? data.questions.map((question: any) => ({
+          ? data.questions.map((question) => ({
               id: String(question.id),
               questionType:
                 question.question_type === 'open_response' ? 'open_response' : 'multiple_choice',

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -228,22 +228,25 @@ function makeGradingStudent(overrides: Record<string, unknown> = {}) {
 }
 
 function makeResultsResponse(overrides?: {
-  quizId?: string
-  quizTitle?: string
+  testId?: string
+  testTitle?: string
   students?: Array<Record<string, unknown>>
   questions?: Array<Record<string, unknown>>
-  quizStatus?: TestAssessmentWithStats['status']
+  testStatus?: TestAssessmentWithStats['status']
   activeRun?: Record<string, unknown> | null
+  legacyQuizKey?: boolean
 }) {
+  const testSummary = {
+    id: overrides?.testId ?? 'test-1',
+    title: overrides?.testTitle ?? 'Unit Test',
+    status: overrides?.testStatus ?? 'active',
+    grading_finalized_at: null,
+  }
+
   return {
     ok: true,
     json: async () => ({
-      quiz: {
-        id: overrides?.quizId ?? 'test-1',
-        title: overrides?.quizTitle ?? 'Unit Test',
-        status: overrides?.quizStatus ?? 'active',
-        grading_finalized_at: null,
-      },
+      [overrides?.legacyQuizKey ? 'quiz' : 'test']: testSummary,
       questions:
         overrides?.questions ?? [
           {
@@ -396,6 +399,17 @@ describe('TeacherTestsTab', () => {
     )
   })
 
+  it('reads legacy quiz-keyed test results payloads as a compatibility fallback', async () => {
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ legacyQuizKey: true }))
+    renderTab()
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close All' })).toBeInTheDocument()
+  })
+
   it('opens the edit modal from the selected test edit button', async () => {
     const updateSearchParams = vi.fn((updater: (params: URLSearchParams) => void) => {
       const params = new URLSearchParams('tab=tests')
@@ -496,7 +510,7 @@ describe('TeacherTestsTab', () => {
 
   it('disables status actions while markdown edits are pending in the edit modal', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
     renderTab()
 
     await openEditModalFromSelectedTest()
@@ -540,7 +554,7 @@ describe('TeacherTestsTab', () => {
   it('delegates preview from the test edit modal', async () => {
     const onRequestTestPreview = vi.fn()
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
     renderTab({ onRequestTestPreview })
 
     await openEditModalFromSelectedTest()
@@ -560,7 +574,7 @@ describe('TeacherTestsTab', () => {
 
   it('updates the selected test header and activation state immediately from modal draft changes', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
@@ -583,7 +597,7 @@ describe('TeacherTestsTab', () => {
 
   it('keeps the selected workspace mounted and updates saved test metadata after autosave', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
     const onSelectTest = vi.fn()
     renderTab({ onSelectTest })
 
@@ -616,7 +630,7 @@ describe('TeacherTestsTab', () => {
       if (url === '/api/teacher/tests' && init?.method === 'POST') {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ quiz: createdTest }),
+          json: async () => ({ test: createdTest }),
         })
       }
       if (typeof url === 'string' && url.includes('/api/teacher/tests?classroom_id=')) {
@@ -627,9 +641,9 @@ describe('TeacherTestsTab', () => {
       }
       if (url === '/api/teacher/tests/created-test-id/results') {
         return Promise.resolve(makeResultsResponse({
-          quizId: 'created-test-id',
-          quizTitle: 'Untitled 2026-05-14 10:45:00',
-          quizStatus: 'draft',
+          testId: 'created-test-id',
+          testTitle: 'Untitled 2026-05-14 10:45:00',
+          testStatus: 'draft',
           students: [],
         }))
       }
@@ -654,7 +668,7 @@ describe('TeacherTestsTab', () => {
 
   it('updates the tests list from edit modal draft title changes', async () => {
     mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })])
-    fetchMock.mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
     const view = renderTab({ testsTabClickToken: 0 })
 
     expect(await openEditModalFromSelectedTest()).toHaveTextContent('Detail for Unit Test')
@@ -681,7 +695,7 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'draft' })] }),
       })
-      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'draft' }))
+      .mockResolvedValueOnce(makeResultsResponse({ testStatus: 'draft' }))
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -736,7 +750,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'active',
+        testStatus: 'active',
         students: [
           {
             student_id: 'student-1',
@@ -763,7 +777,7 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ updated_count: 1, skipped_count: 0, state: 'open' }),
       })
-      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'active' }))
+      .mockResolvedValueOnce(makeResultsResponse({ testStatus: 'active' }))
 
     renderTab()
 
@@ -808,13 +822,13 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
       })
-      .mockResolvedValueOnce(makeResultsResponse({ quizStatus: 'active' }))
+      .mockResolvedValueOnce(makeResultsResponse({ testStatus: 'active' }))
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ updated_count: 1, skipped_count: 0, state: 'closed' }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'active',
+        testStatus: 'active',
         students: [
           {
             student_id: 'student-1',
@@ -1687,7 +1701,7 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'active' })] }),
       })
-      .mockResolvedValue(makeResultsResponse({ quizStatus: 'closed' }))
+      .mockResolvedValue(makeResultsResponse({ testStatus: 'closed' }))
 
     renderTab()
 
@@ -1786,7 +1800,7 @@ describe('TeacherTestsTab', () => {
         ok: true,
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
       })
-      .mockResolvedValue(makeResultsResponse({ quizStatus: 'active' }))
+      .mockResolvedValue(makeResultsResponse({ testStatus: 'active' }))
 
     renderTab()
 
@@ -1845,8 +1859,8 @@ describe('TeacherTestsTab', () => {
     await act(async () => {
       resolveSecondResults?.(
         makeResultsResponse({
-          quizId: 'test-2',
-          quizTitle: 'Unit Test B',
+          testId: 'test-2',
+          testTitle: 'Unit Test B',
           students: [
             {
               student_id: 'student-2',
@@ -1875,8 +1889,8 @@ describe('TeacherTestsTab', () => {
     await act(async () => {
       resolveFirstResults?.(
         makeResultsResponse({
-          quizId: 'test-1',
-          quizTitle: 'Unit Test A',
+          testId: 'test-1',
+          testTitle: 'Unit Test A',
           students: [
             {
               student_id: 'student-1',
@@ -2103,7 +2117,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'closed',
+        testStatus: 'closed',
         students: [
           {
             student_id: 'student-1',
@@ -2150,7 +2164,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ unsubmitted_count: 1, skipped_count: 0 }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'closed',
+        testStatus: 'closed',
         students: [
           {
             student_id: 'student-1',
@@ -2252,7 +2266,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test', status: 'closed' })] }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'closed',
+        testStatus: 'closed',
         students: [
           {
             student_id: 'student-1',
@@ -2280,7 +2294,7 @@ describe('TeacherTestsTab', () => {
         json: async () => ({ unsubmitted_count: 1, skipped_count: 0 }),
       })
       .mockResolvedValueOnce(makeResultsResponse({
-        quizStatus: 'closed',
+        testStatus: 'closed',
         students: [
           {
             student_id: 'student-1',


### PR DESCRIPTION
## Summary
- add current-key local TeacherTestsTab response types for test list and results payloads
- keep legacy `quiz`/`quizzes` keys documented as compatibility fallbacks
- update TeacherTestsTab fixtures to default to current `test` payloads and add explicit legacy `quiz` fallback coverage

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/components/TeacherTestsTab.test.tsx
- pnpm lint
- pnpm test

## Risk
- runtime-platform: low. This is type/test cleanup around existing shared payload readers; no route payload shape, schema, migration, RPC, storage, or persisted `quiz_id` change.