### PR TITLE
Rename draft hook assessment options

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -683,3 +683,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `gh run watch 27520948663 --repo codepetca/pika --interval 15 --exit-status`
 - `gh pr merge 795 --repo codepetca/pika --merge --delete-branch`
 - `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
+## 2026-06-14 — Draft hook assessment option names
+
+**Completed:**
+- Renamed the primary `useDraftMode` options from `quizId`/`quizTitle` to `assessmentId`/`assessmentTitle`.
+- Kept legacy `quizId`/`quizTitle` option aliases for compatibility and added focused test coverage for them.
+- Updated hook comments, examples, and tests to use assessment/test wording by default.
+- Left DB-shaped `quiz_id` question fields and draft route contracts unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/hooks/useDraftMode.test.ts`
+- `pnpm lint`
+- `pnpm test`

--- a/src/hooks/useDraftMode.ts
+++ b/src/hooks/useDraftMode.ts
@@ -21,12 +21,14 @@ export type ConflictDraft = {
   content: DraftContent
 } | null
 
-interface UseDraftModeOptions {
-  quizId: string
-  quizTitle: string
+type DraftModeAssessmentIdentity =
+  | { assessmentId: string; assessmentTitle: string; quizId?: string; quizTitle?: string }
+  | { assessmentId?: string; assessmentTitle?: string; quizId: string; quizTitle: string }
+
+type UseDraftModeOptions = DraftModeAssessmentIdentity & {
   showResults: boolean
   apiBasePath: string
-  /** Called after a successful save so the parent can refresh quiz metadata. */
+  /** Called after a successful save so the parent can refresh assessment metadata. */
   onUpdate: () => void
   /** Called with a human-readable error message; called with '' to clear. */
   onError: (msg: string) => void
@@ -58,7 +60,7 @@ export interface UseDraftModeReturn {
 }
 
 /**
- * Manages draft autosave state for quiz/test editors.
+ * Manages draft autosave state for assessment editors.
  *
  * Isolated concerns: debounced autosave, throttled saves, JSON-Patch
  * diffing, 409 conflict detection, and inline title editing.
@@ -66,26 +68,31 @@ export interface UseDraftModeReturn {
  * @example
  * ```tsx
  * const draft = useDraftMode({
- *   quizId: quiz.id,
- *   quizTitle: quiz.title,
- *   showResults: quiz.show_results,
+ *   assessmentId: test.id,
+ *   assessmentTitle: test.title,
+ *   showResults: test.show_results,
  *   apiBasePath,
- *   onUpdate: onQuizUpdate,
+ *   onUpdate: onTestUpdate,
  *   onError: setError,
  *   onQuestionsChange: setQuestions,
  * })
  * ```
  */
-export function useDraftMode({
-  quizId,
-  quizTitle,
-  showResults,
-  apiBasePath,
-  onUpdate,
-  onError,
-  onQuestionsChange,
-}: UseDraftModeOptions): UseDraftModeReturn {
-  const [editTitle, setEditTitle] = useState(quizTitle)
+export function useDraftMode(options: UseDraftModeOptions): UseDraftModeReturn {
+  const {
+    showResults,
+    apiBasePath,
+    onUpdate,
+    onError,
+    onQuestionsChange,
+  } = options
+  const assessmentId = options.assessmentId ?? options.quizId
+  const assessmentTitle = options.assessmentTitle ?? options.quizTitle
+  if (!assessmentId || !assessmentTitle) {
+    throw new Error('useDraftMode requires assessmentId/assessmentTitle')
+  }
+
+  const [editTitle, setEditTitle] = useState(assessmentTitle)
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [savingTitle, setSavingTitle] = useState(false)
   const [saveStatus, setSaveStatus] = useState<DraftSaveStatus>('saved')
@@ -104,12 +111,12 @@ export function useDraftMode({
     saveStatusRef.current = saveStatus
   }, [saveStatus])
 
-  // Reset title/conflict state when a different quiz is selected
+  // Reset title/conflict state when a different assessment is selected
   useEffect(() => {
-    setEditTitle(quizTitle)
+    setEditTitle(assessmentTitle)
     setIsEditingTitle(false)
     setConflictDraft(null)
-  }, [quizId, quizTitle])
+  }, [assessmentId, assessmentTitle])
 
   /** Normalise raw question data from the server into the TestAssessmentQuestion shape. */
   const normalizeDraftQuestions = useCallback(
@@ -120,7 +127,7 @@ export function useDraftMode({
           question.question_type === 'open_response' ? 'open_response' : 'multiple_choice'
         return {
           id: String(question.id || crypto.randomUUID()),
-          quiz_id: quizId,
+          quiz_id: assessmentId,
           question_text: String(question.question_text || ''),
           options: Array.isArray(question.options)
             ? question.options.map((o) => String(o))
@@ -158,7 +165,7 @@ export function useDraftMode({
         } as TestAssessmentQuestion
       })
     },
-    [quizId]
+    [assessmentId]
   )
 
   const applyServerDraft = useCallback(
@@ -171,7 +178,7 @@ export function useDraftMode({
       if (!draft?.content) return
 
       const nextTitle =
-        typeof draft.content.title === 'string' ? draft.content.title : quizTitle
+        typeof draft.content.title === 'string' ? draft.content.title : assessmentTitle
       const nextShowResults =
         typeof draft.content.show_results === 'boolean' ? draft.content.show_results : showResults
       const nextQuestions = normalizeDraftQuestions(draft.content.questions || [])
@@ -190,7 +197,7 @@ export function useDraftMode({
       onError('')
       setConflictDraft(null)
     },
-    [normalizeDraftQuestions, onError, onQuestionsChange, quizTitle, showResults]
+    [normalizeDraftQuestions, onError, onQuestionsChange, assessmentTitle, showResults]
   )
 
   const saveDraft = useCallback(
@@ -232,7 +239,7 @@ export function useDraftMode({
       }
 
       try {
-        const response = await fetch(`${apiBasePath}/${quizId}/draft`, {
+        const response = await fetch(`${apiBasePath}/${assessmentId}/draft`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -285,7 +292,7 @@ export function useDraftMode({
         onError(saveError instanceof Error ? saveError.message : 'Failed to save draft')
       }
     },
-    [apiBasePath, applyServerDraft, normalizeDraftQuestions, onError, onUpdate, quizId]
+    [apiBasePath, applyServerDraft, normalizeDraftQuestions, onError, onUpdate, assessmentId]
   )
 
   const scheduleSave = useCallback(
@@ -343,10 +350,10 @@ export function useDraftMode({
             try {
               return (JSON.parse(lastSavedDraftRef.current) as { title?: string })?.title
             } catch {
-              return quizTitle
+              return assessmentTitle
             }
           })()) ||
-        quizTitle
+        assessmentTitle
 
       if (!trimmed) {
         setEditTitle(fallbackTitle)
@@ -365,7 +372,7 @@ export function useDraftMode({
       onError('')
       scheduleSave(nextDraft, { force: true })
     },
-    [editTitle, onError, quizTitle, scheduleSave, showResults]
+    [assessmentTitle, editTitle, onError, scheduleSave, showResults]
   )
 
   // Flush pending unsaved draft on unmount (e.g. navigating away mid-edit)

--- a/tests/hooks/useDraftMode.test.ts
+++ b/tests/hooks/useDraftMode.test.ts
@@ -7,8 +7,8 @@ import type { TestAssessmentQuestion } from '@/types'
 
 function makeOptions(overrides: Partial<Parameters<typeof useDraftMode>[0]> = {}) {
   return {
-    quizId: 'quiz-1',
-    quizTitle: 'Test Quiz',
+    assessmentId: 'test-1',
+    assessmentTitle: 'Test Assessment',
     showResults: false,
     apiBasePath: '/api/teacher/tests',
     onUpdate: vi.fn(),
@@ -21,7 +21,7 @@ function makeOptions(overrides: Partial<Parameters<typeof useDraftMode>[0]> = {}
 function makeQuestion(overrides: Partial<TestAssessmentQuestion> = {}): TestAssessmentQuestion {
   return {
     id: 'q-1',
-    quiz_id: 'quiz-1',
+    quiz_id: 'test-1',
     question_text: 'What is 2+2?',
     question_type: 'multiple_choice',
     options: ['1', '2', '4', '5'],
@@ -42,9 +42,51 @@ describe('useDraftMode', () => {
   })
 
   describe('initial state', () => {
-    it('initialises editTitle from quizTitle', () => {
-      const { result } = renderHook(() => useDraftMode(makeOptions({ quizTitle: 'My Quiz' })))
-      expect(result.current.editTitle).toBe('My Quiz')
+    it('initialises editTitle from assessmentTitle', () => {
+      const { result } = renderHook(() =>
+        useDraftMode(makeOptions({ assessmentTitle: 'My Test' }))
+      )
+      expect(result.current.editTitle).toBe('My Test')
+    })
+
+    it('accepts legacy quizId and quizTitle option aliases', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ version: 2 }),
+      })
+      vi.stubGlobal('fetch', fetchSpy)
+
+      const { result } = renderHook(() =>
+        useDraftMode({
+          quizId: 'legacy-test-1',
+          quizTitle: 'Legacy Test',
+          showResults: false,
+          apiBasePath: '/api/teacher/tests',
+          onUpdate: vi.fn(),
+          onError: vi.fn(),
+          onQuestionsChange: vi.fn(),
+        })
+      )
+
+      expect(result.current.editTitle).toBe('Legacy Test')
+
+      await act(async () => {
+        await result.current.saveDraft({
+          title: 'Updated Title',
+          show_results: false,
+          questions: [],
+        })
+      })
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/api/teacher/tests/legacy-test-1/draft'),
+          expect.objectContaining({ method: 'PATCH' })
+        )
+      })
+
+      vi.unstubAllGlobals()
     })
 
     it('initialises saveStatus as "saved"', () => {
@@ -72,7 +114,7 @@ describe('useDraftMode', () => {
     it('resets title and clears conflict when given a canonical draft', () => {
       const onQuestionsChange = vi.fn()
       const { result } = renderHook(() =>
-        useDraftMode(makeOptions({ quizTitle: 'Old Title', onQuestionsChange }))
+        useDraftMode(makeOptions({ assessmentTitle: 'Old Title', onQuestionsChange }))
       )
 
       act(() => {
@@ -90,7 +132,7 @@ describe('useDraftMode', () => {
     it('does nothing when draft is null', () => {
       const onQuestionsChange = vi.fn()
       const { result } = renderHook(() =>
-        useDraftMode(makeOptions({ quizTitle: 'Original', onQuestionsChange }))
+        useDraftMode(makeOptions({ assessmentTitle: 'Original', onQuestionsChange }))
       )
 
       act(() => {
@@ -123,7 +165,7 @@ describe('useDraftMode', () => {
 
       await waitFor(() => {
         expect(fetchSpy).toHaveBeenCalledWith(
-          expect.stringContaining('/api/teacher/tests/quiz-1/draft'),
+          expect.stringContaining('/api/teacher/tests/test-1/draft'),
           expect.objectContaining({ method: 'PATCH' })
         )
       })
@@ -182,11 +224,12 @@ describe('useDraftMode', () => {
     })
   })
 
-  describe('title changes on quizId change', () => {
-    it('resets editTitle when quizId changes', () => {
+  describe('title changes on assessmentId change', () => {
+    it('resets editTitle when assessmentId changes', () => {
       const { result, rerender } = renderHook(
-        ({ quizId, quizTitle }) => useDraftMode(makeOptions({ quizId, quizTitle })),
-        { initialProps: { quizId: 'quiz-1', quizTitle: 'Quiz One' } }
+        ({ assessmentId, assessmentTitle }) =>
+          useDraftMode(makeOptions({ assessmentId, assessmentTitle })),
+        { initialProps: { assessmentId: 'test-1', assessmentTitle: 'Test One' } }
       )
 
       act(() => {
@@ -194,9 +237,9 @@ describe('useDraftMode', () => {
       })
       expect(result.current.editTitle).toBe('Modified Title')
 
-      rerender({ quizId: 'quiz-2', quizTitle: 'Quiz Two' })
+      rerender({ assessmentId: 'test-2', assessmentTitle: 'Test Two' })
 
-      expect(result.current.editTitle).toBe('Quiz Two')
+      expect(result.current.editTitle).toBe('Test Two')
     })
   })
 
@@ -211,7 +254,7 @@ describe('useDraftMode', () => {
 
       const onUpdate = vi.fn()
       const { result } = renderHook(() =>
-        useDraftMode(makeOptions({ quizTitle: 'Old', onUpdate }))
+        useDraftMode(makeOptions({ assessmentTitle: 'Old', onUpdate }))
       )
 
       act(() => {


### PR DESCRIPTION
## Summary
- rename useDraftMode's primary options to assessmentId/assessmentTitle
- keep legacy quizId/quizTitle option aliases for compatibility
- update hook tests to default to assessment/test wording and cover legacy aliases explicitly

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/hooks/useDraftMode.test.ts
- pnpm lint
- pnpm test

## Notes
- No schema, migration, API route, response-shape, or persisted quiz_id changes.