### PR TITLE
Rename assessment draft sync errors

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,36 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-08 — Assignment AI grading pane refresh
-
-**Completed:**
-- Refreshed the mounted selected-student assignment grading pane when a background assignment AI grading run completes, avoiding a full page refresh.
-- Applied the same pane refresh to the legacy synchronous batch auto-grade path.
-- Added classroom-view coverage that asserts a mounted grading pane receives a refresh-key bump after background AI grading completion.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (worktree rerun failed in baseline verification only: `LoginClient.test.tsx` two failures and `crypto.test.ts` password hash timeout; prior hub startup run failed different unrelated tests)
-- `pnpm vitest run tests/components/TeacherClassroomView.test.tsx`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
-
-## 2026-06-08 — FAB subshell standardization
-
-**Completed:**
-- Added a standardized `floatingAction` split-button slot to `TeacherWorkSurfaceActionBar`.
-- Migrated teacher Classwork, Tests, Gradebook, Roster, and Announcements FAB clusters to one split action per first-level tab/workspace, moving secondary toggles/actions into the split menu.
-- Consolidated selected-assignment pane switching, survey visibility/edit actions, gradebook score display/column/email actions, roster CSV/remove/email actions, and announcement creation into standardized split menus.
-- Left Calendar/Attendance unchanged because their FAB controls are date/view navigation rather than action menus.
-- Deferred product quiz removal to a later pass; Tests remain in scope.
-
-**Validation:**
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm exec vitest run tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm build`
-- `E2E_BASE_URL=http://localhost:3001 pnpm e2e:auth`
-- Visual verification screenshots for teacher Classwork, Tests, Gradebook, Roster, Announcements, plus student Classwork sanity check.
-
 ## 2026-06-08 — Product quiz removal
 
 **Completed:**
@@ -683,6 +653,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `gh run watch 27520948663 --repo codepetca/pika --interval 15 --exit-status`
 - `gh pr merge 795 --repo codepetca/pika --merge --delete-branch`
 - `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
+
 ## 2026-06-14 — Draft hook assessment option names
 
 **Completed:**
@@ -695,5 +666,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/hooks/useDraftMode.test.ts`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-14 — Assessment draft sync error wording
+
+**Completed:**
+- Renamed `syncAssessmentQuestionsFromDraft` failure messages from quiz-question wording to assessment-question wording.
+- Updated nearby generic assessment draft helper comments to avoid quiz/test route wording.
+- Updated the focused unit assertion for the renamed insert failure message.
+- Left compatibility exports, `AssessmentDraftType = 'quiz' | 'test'`, `quiz_questions`, `quiz_id`, route contracts, and persisted payload shapes unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/assessment-drafts.test.ts`
 - `pnpm lint`
 - `pnpm test`

--- a/src/lib/server/assessment-drafts.ts
+++ b/src/lib/server/assessment-drafts.ts
@@ -481,10 +481,10 @@ export async function syncAssessmentQuestionsFromDraft(
       position,
     }),
     errorMessages: {
-      load: 'Failed to load quiz questions for sync',
-      update: 'Failed to update synced quiz question',
-      insert: 'Failed to insert synced quiz question',
-      delete: 'Failed to delete removed quiz question',
+      load: 'Failed to load assessment questions for sync',
+      update: 'Failed to update synced assessment question',
+      insert: 'Failed to insert synced assessment question',
+      delete: 'Failed to delete removed assessment question',
     },
   })
 }
@@ -606,7 +606,7 @@ async function syncAssessmentQuestionRowsFromDraft<TQuestion extends { id: strin
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Generic helpers shared by quiz/test draft routes
+// Generic helpers shared by assessment draft routes
 // ────────────────────────────────────────────────────────────────────────────
 
 export type EnsureDraftConfig<TContent> = {
@@ -634,7 +634,7 @@ export type EnsureDraftConfig<TContent> = {
 
 /**
  * Ensures an assessment draft exists and is valid; creates/repairs it if not.
- * Shared by quiz and test draft routes to eliminate duplication.
+ * Shared by assessment draft routes to eliminate duplication.
  */
 export async function ensureAssessmentDraft<TContent>(
   supabase: SupabaseLike,
@@ -721,7 +721,7 @@ export async function ensureAssessmentDraft<TContent>(
 
 /**
  * Sync title and show_results from a saved draft back to the parent assessment table.
- * Used after PATCH in quiz/test draft routes.
+ * Used after PATCH in assessment draft routes.
  */
 export async function syncAssessmentMetadataFromDraft(
   supabase: SupabaseLike,

--- a/tests/unit/assessment-drafts.test.ts
+++ b/tests/unit/assessment-drafts.test.ts
@@ -477,7 +477,7 @@ describe('assessment drafts', () => {
     ).resolves.toEqual({
       ok: false,
       status: 500,
-      error: 'Failed to insert synced quiz question',
+      error: 'Failed to insert synced assessment question',
     })
   })
 


### PR DESCRIPTION
## Summary
- rename assessment draft sync failure messages from quiz-question wording to assessment-question wording
- update generic assessment-draft helper comments to avoid quiz/test route wording
- update the focused unit assertion for the renamed insert failure

## Compatibility
- no schema, migration, route, payload, helper alias, table, or column changes
- `AssessmentDraftType = 'quiz' | 'test'`, `quiz_questions`, and `quiz_id` remain unchanged

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/unit/assessment-drafts.test.ts
- pnpm lint
- pnpm test
