### PR TITLE
Rename current test fixture wording

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,25 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-08 — Product quiz removal
-
-**Completed:**
-- Removed teacher and student `/api/*/quizzes` product routes, quiz override route, teacher quiz tab, quiz card/modal components, and matching route/component tests.
-- Made the student assessment tab and shared legacy-named quiz components operate against tests by default while preserving test database compatibility.
-- Removed quizzes from gradebook output, course blueprint package import/export, blueprint AI targets, classroom blueprint source loading, and course-site grading summaries.
-- Renamed the teacher assessment update browser event from the old quiz name to a tests-specific event.
-- Updated AI routing, architecture, course blueprint package, and teacher work-surface docs so quizzes are no longer described as an active product surface.
-- PR self-review tightened remaining blueprint and actual-site paths so legacy quiz assessments are not cloned or rendered.
-
-**Validation:**
-- `pnpm lint`
-- `pnpm test --run tests/components/TeacherTestsTab.test.tsx tests/components/QuizDetailPanel.test.tsx tests/components/StudentQuizzesTab.test.tsx tests/components/StudentQuizResults.test.tsx tests/components/StudentQuizForm.test.tsx`
-- `pnpm test` (301 files / 2655 tests)
-- Post-review focused checks for blueprint/test paths and isolated `StudentHistoryPage` flake rerun.
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests"`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=gradebook"`
-
 ## 2026-06-08 — Legacy quiz UI naming cleanup
 
 **Completed:**
@@ -682,4 +663,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/unit/assessment-drafts.test.ts`
 - `pnpm lint`
+- `pnpm test`
+
+## 2026-06-14 — Current test fixture wording cleanup
+
+**Completed:**
+- Renamed server assessment visibility unit-test descriptions and locals from quiz wording to assessment wording.
+- Updated `StudentTestResults` current-surface test fixtures to use `test-1` and `Test not found` while preserving the explicit legacy `quizId` alias test.
+- Updated the flagged-question helper file comment from test/quiz taking to test taking.
+- Did not change runtime behavior, schema, API payloads, compatibility aliases, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/server-assessments.test.ts tests/components/StudentTestResults.test.tsx tests/lib/flag-questions.test.ts`
+- `pnpm lint`
+- `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
 - `pnpm test`

--- a/src/lib/flag-questions.ts
+++ b/src/lib/flag-questions.ts
@@ -1,5 +1,5 @@
 /**
- * Utilities for managing flagged questions during test/quiz taking.
+ * Utilities for managing flagged questions during test taking.
  * Flagged questions are stored client-side in localStorage, keyed by test ID.
  */
 

--- a/tests/components/StudentTestResults.test.tsx
+++ b/tests/components/StudentTestResults.test.tsx
@@ -44,7 +44,7 @@ describe('StudentTestResults', () => {
     fetchMock.mockReturnValue(new Promise(() => {})) // never resolves
 
     const { container } = render(
-      <StudentTestResults testId="quiz-1" myResponses={{}} />
+      <StudentTestResults testId="test-1" myResponses={{}} />
     )
 
     // Spinner renders an svg or loading element
@@ -55,13 +55,13 @@ describe('StudentTestResults', () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>
     fetchMock.mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ error: 'Quiz not found' }),
+      json: async () => ({ error: 'Test not found' }),
     })
 
-    render(<StudentTestResults testId="quiz-1" myResponses={{}} />)
+    render(<StudentTestResults testId="test-1" myResponses={{}} />)
 
     await waitFor(() => {
-      expect(screen.getByText('Quiz not found')).toBeInTheDocument()
+      expect(screen.getByText('Test not found')).toBeInTheDocument()
     })
   })
 
@@ -72,7 +72,7 @@ describe('StudentTestResults', () => {
       json: async () => ({ results: [] }),
     })
 
-    render(<StudentTestResults testId="quiz-1" myResponses={{}} />)
+    render(<StudentTestResults testId="test-1" myResponses={{}} />)
 
     await waitFor(() => {
       expect(screen.getByText('No results available.')).toBeInTheDocument()
@@ -111,7 +111,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        testId="quiz-1"
+        testId="test-1"
         myResponses={{ q1: 1 }}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -158,7 +158,7 @@ describe('StudentTestResults', () => {
 
     const { container } = render(
       <StudentTestResults
-        testId="quiz-1"
+        testId="test-1"
         myResponses={{ q1: 0 }}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -219,7 +219,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        testId="quiz-1"
+        testId="test-1"
         myResponses={{}}
         assessmentType="test"
         apiBasePath="/api/student/tests"
@@ -269,7 +269,7 @@ describe('StudentTestResults', () => {
 
     render(
       <StudentTestResults
-        testId="quiz-1"
+        testId="test-1"
         myResponses={{}}
         assessmentType="test"
         apiBasePath="/api/student/tests"

--- a/tests/unit/server-assessments.test.ts
+++ b/tests/unit/server-assessments.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, it } from 'vitest'
 import { hasAssessmentOpened, isAssessmentVisibleToStudents } from '@/lib/server/assessments'
 
 describe('assessment scheduling visibility helpers', () => {
-  it('treats active quizzes with null opens_at as open/visible', () => {
-    const quiz = { status: 'active' as const, opens_at: null }
-    expect(isAssessmentVisibleToStudents(quiz)).toBe(true)
-    expect(hasAssessmentOpened(quiz)).toBe(true)
+  it('treats active assessments with null opens_at as open/visible', () => {
+    const assessment = { status: 'active' as const, opens_at: null }
+    expect(isAssessmentVisibleToStudents(assessment)).toBe(true)
+    expect(hasAssessmentOpened(assessment)).toBe(true)
   })
 
-  it('hides active quizzes scheduled in the future', () => {
+  it('hides active assessments scheduled in the future', () => {
     const now = new Date('2026-03-01T12:00:00.000Z')
-    const quiz = { status: 'active' as const, opens_at: '2026-03-01T13:00:00.000Z' }
-    expect(isAssessmentVisibleToStudents(quiz, now)).toBe(false)
-    expect(hasAssessmentOpened(quiz, now)).toBe(false)
+    const assessment = { status: 'active' as const, opens_at: '2026-03-01T13:00:00.000Z' }
+    expect(isAssessmentVisibleToStudents(assessment, now)).toBe(false)
+    expect(hasAssessmentOpened(assessment, now)).toBe(false)
   })
 
-  it('shows active quizzes scheduled in the past', () => {
+  it('shows active assessments scheduled in the past', () => {
     const now = new Date('2026-03-01T12:00:00.000Z')
-    const quiz = { status: 'active' as const, opens_at: '2026-03-01T11:59:59.000Z' }
-    expect(isAssessmentVisibleToStudents(quiz, now)).toBe(true)
-    expect(hasAssessmentOpened(quiz, now)).toBe(true)
+    const assessment = { status: 'active' as const, opens_at: '2026-03-01T11:59:59.000Z' }
+    expect(isAssessmentVisibleToStudents(assessment, now)).toBe(true)
+    expect(hasAssessmentOpened(assessment, now)).toBe(true)
   })
 
-  it('never marks non-active quizzes as visible/open', () => {
+  it('never marks non-active assessments as visible/open', () => {
     const now = new Date('2026-03-01T12:00:00.000Z')
     expect(isAssessmentVisibleToStudents({ status: 'draft', opens_at: null }, now)).toBe(false)
     expect(isAssessmentVisibleToStudents({ status: 'closed', opens_at: null }, now)).toBe(false)


### PR DESCRIPTION
## Summary
- rename server assessment visibility unit-test descriptions and locals from quiz wording to assessment wording
- update StudentTestResults current-surface fixtures to use test ids and test error text
- update the flagged-question helper comment to test-only wording

## Compatibility
- preserved the explicit legacy quizId alias test
- no runtime behavior, schema, API payload, compatibility alias, or persisted quiz_id changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm exec tsc --noEmit
- pnpm test tests/unit/server-assessments.test.ts tests/components/StudentTestResults.test.tsx tests/lib/flag-questions.test.ts
- pnpm lint
- pnpm test (first run hit an unrelated StudentLessonCalendarTab timeout; isolated rerun passed)
- pnpm test
