### PR TITLE
Update teacher work-surface docs for tests

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-08 — Legacy quiz UI naming cleanup
-
-**Completed:**
-- Created `codex/legacy-quiz-naming-cleanup` from `origin/main` after PR #758.
-- Renamed remaining legacy quiz-named UI component implementations and component tests to test-named files.
-- Left old `Quiz*`/`StudentQuizzesTab` files as thin compatibility wrappers around the new `Test*` implementations.
-- Updated active app imports and component test mocks to use the new test-named modules.
-- Preserved database/type/API compatibility names such as `quizzes`, `QuizQuestion`, and `quiz` response payload keys for a later contract-level pass.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestResultsView.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm lint`
-- `pnpm test` (301 files / 2655 tests)
-- `pnpm build`
-
 ## 2026-06-09 — Main to production release sync
 
 **Completed:**
@@ -679,4 +663,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/server-assessments.test.ts tests/components/StudentTestResults.test.tsx tests/lib/flag-questions.test.ts`
 - `pnpm lint`
 - `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
+- `pnpm test`
+
+## 2026-06-14 — Teacher work-surface docs test wording
+
+**Completed:**
+- Updated stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests.
+- Removed active teacher quiz authoring/state-machine references from the canon.
+- Updated the work-surface audit and stable guidance index to match the active Tests product surface.
+- Left the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
+- `pnpm lint`
 - `pnpm test`

--- a/docs/guidance/ui/audit-teacher-work-surfaces.md
+++ b/docs/guidance/ui/audit-teacher-work-surfaces.md
@@ -103,7 +103,7 @@ These are present or recently present patterns that should not be treated as reu
 | --- | --- | --- | --- | --- |
 | Passive split shells that reserve empty detail space before selection | tests/quizzes shell paths | legacy drift | mark legacy, avoid copying | now |
 | Mode controls that visually outrank content lists | tests authoring/grading toggle states | legacy drift | reduce or localize | now |
-| Divergent card systems with incompatible metadata density | assignments vs quizzes/tests cards | experimental drift | converge before extracting | later |
+| Divergent card systems with incompatible metadata density | assignments vs tests cards | experimental drift | converge before extracting | later |
 
 ## Extraction Roadmap
 
@@ -131,7 +131,7 @@ Required API shape:
 
 Non-goals:
 
-- no assignment, quiz, or test business logic
+- no assignment or test business logic
 - no grading logic
 - no routing/query management beyond what a layout primitive strictly needs
 
@@ -140,11 +140,11 @@ Adoption rule:
 - teacher assignments and teacher tests may use it where the current workspace state truly matches
   active primary-plus-inspector work
 - do not enable the classroom route's external `RightSidebar` as a substitute for the workspace split
-  in teacher assignment, quiz, or test summary/workspace states
+  in teacher assignment or test summary/workspace states
 
 ### Later: teacher work-item card convergence
 
-Assignments and quizzes/tests both need compact work-item cards, but they have not converged far enough yet to justify one primitive.
+Assignments and tests both need compact work-item cards, but they have not converged far enough yet to justify one primitive.
 
 Promotion criteria before extraction:
 
@@ -155,7 +155,7 @@ Promotion criteria before extraction:
 
 ### Never for now: full assessment mega-shell
 
-Do not introduce a generic assessment framework that tries to own assignments, quizzes, and tests in one abstraction. The family is aligned at the structural level, not at the business-logic level.
+Do not introduce a generic assessment framework that tries to own assignments and tests in one abstraction. The family is aligned at the structural level, not at the business-logic level.
 
 ## Review Checklist
 

--- a/docs/guidance/ui/stable.md
+++ b/docs/guidance/ui/stable.md
@@ -91,6 +91,6 @@ Source grounding:
 ## Stable Guidance Limits
 
 - This file is intentionally narrow. It does not try to canonize the entire app.
-- Teacher assignments/quizzes/tests family rules live in [`teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md).
+- Teacher assignments/tests family rules live in [`teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md).
 - If a current pattern exists in code but is not listed here, do not assume it is stable.
 - Use an experimental draft when you want to propose reuse beyond the current stable rules.

--- a/docs/guidance/ui/teacher-work-surfaces.md
+++ b/docs/guidance/ui/teacher-work-surfaces.md
@@ -184,8 +184,8 @@ shared shell and split primitives instead of building feature-local layout and
 resize code.
 
 Use this composition as the default selected-workspace template for assignments,
-quizzes, tests, and nearby teacher work tabs when the workflow has an active
-primary pane plus an active inspector/detail pane:
+tests, and nearby teacher work tabs when the workflow has an active primary pane
+plus an active inspector/detail pane:
 
 ```tsx
 <TeacherWorkSurfaceShell
@@ -431,16 +431,15 @@ For this teacher work-surface family:
   - shared page-shell pieces already in use
   - stable empty/list/detail containers where structure truly matches
   - the teacher resizable split workspace container derived from assignments
-  - shared teacher work-item card variants only if assignments/quizzes/tests converge
+  - shared teacher work-item card variants only if assignments/tests converge
 - should remain composed patterns:
   - teacher assignment summary
   - teacher assignment workspace
-  - teacher quiz authoring composition
   - teacher test authoring composition
   - grading workspace composition
 - should remain feature-local:
   - grading behavior
-  - quiz/test state machines
+  - test state machines
   - assessment-specific domain controls
   - authoring rules and validation logic
 
@@ -471,7 +470,7 @@ Every teacher work-surface pattern should be classified as one of:
 
 Promotion flow:
 
-1. a pattern changes in assignments, quizzes, or tests
+1. a pattern changes in assignments or tests
 2. it is recorded as local or experimental
 3. if it proves better or reusable, this canon and the audit are updated
 4. only then does it become stable or a primitive candidate
@@ -480,7 +479,7 @@ The weekly promotion-review automation should be used to surface promotion candi
 
 ## Change Protocol
 
-Any meaningful teacher assignments/quizzes/tests UX change should update this canon when it changes:
+Any meaningful teacher assignments/tests UX change should update this canon when it changes:
 
 - the interaction ladder
 - shell structure
@@ -494,4 +493,4 @@ When updating this file, explicitly note whether the pattern is:
 
 - assignment-led and already stable
 - experimental and under review
-- promoted from quizzes/tests because it is now the better family pattern
+- promoted from tests because it is now the better family pattern


### PR DESCRIPTION
## Summary
- update stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests
- remove active teacher quiz authoring/state-machine references from the canon
- update the work-surface audit and stable guidance index to match the active Tests product surface

## Notes
- leaves the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying
- docs-only; no code, schema, API, or compatibility contract changes

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts
- pnpm lint
- pnpm test
