### PR TITLE
Rename arbitrary quiz fixture wording

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,26 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz contract transition
-
-**Completed:**
-- Created `codex/legacy-quiz-contract-cleanup` from `origin/main`.
-- Audited remaining internal `quiz` / `quizzes` references across migrations, API payloads, shared types, server/lib code, UI wrappers, tests, and docs.
-- Added dual `test`/`tests` plus legacy `quiz`/`quizzes` response keys to active `/api/*/tests` endpoints.
-- Updated active test clients to prefer `test`/`tests` response keys with legacy fallback.
-- Added test-named type aliases and `@/lib/tests` helper exports, then migrated active test routes/components to those names.
-- Removed unused one-line legacy UI wrappers (`Quiz*`, `StudentQuiz*`, `StudentQuizzesTab`) and updated architecture/UI guidance.
-- Left production schema, migrations, legacy DB tables, gradebook legacy fields, and blueprint schema compatibility unchanged.
-
-**Validation:**
-- `pnpm exec tsc --noEmit`
-- `pnpm vitest run tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
-- `pnpm test` (301 files / 2655 tests)
-
 ## 2026-06-09 — Roster summary pane removal
 
 **Completed:**
@@ -680,4 +660,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/components/TestIndividualResponses.test.tsx`
 - `pnpm lint`
+- `pnpm test`
+
+## 2026-06-14 — Arbitrary quiz fixture wording cleanup
+
+**Completed:**
+- Renamed arbitrary announcement and lesson-calendar fixture copy from Quiz wording to Test wording.
+- Updated the generic dev-flow risk checklist example from quiz status to test status.
+- Left schema, API compatibility keys, gradebook category fields, and legacy alias coverage unchanged.
+- No production schema or runtime contract changes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/api/teacher/announcements.test.ts tests/unit/announcements.test.ts tests/components/LessonCalendar.test.tsx tests/components/LessonDayCell.test.tsx`
+- `pnpm lint`
+- `pnpm test` (first run hit unrelated component timeout failures; failed files passed on isolated rerun)
 - `pnpm test`

--- a/docs/guidance/dev-flow-risk-checklists.md
+++ b/docs/guidance/dev-flow-risk-checklists.md
@@ -33,7 +33,7 @@ Do not move business logic, data loading, selection state, grading behavior, rou
 
 The migrated assignment UI should look and behave the same after the refactor. Any visible difference must be explicitly listed and justified before continuing.
 
-Stop and reassess if the new shell API starts needing domain-specific props such as assignment status, quiz status, grading state, AI run state, student selection, rubric state, or return behavior.
+Stop and reassess if the new shell API starts needing domain-specific props such as assignment status, test status, grading state, AI run state, student selection, rubric state, or return behavior.
 ```
 
 ## Async Grading

--- a/tests/api/teacher/announcements.test.ts
+++ b/tests/api/teacher/announcements.test.ts
@@ -122,7 +122,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
     const mockAnnouncement = {
       id: 'a-1',
       classroom_id: 'c-1',
-      title: 'Quiz reminder',
+      title: 'Test reminder',
       content: 'Test Content',
       created_by: 'teacher-1',
       created_at: '2025-01-15T12:00:00Z',
@@ -143,7 +143,7 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
       'http://localhost:3000/api/teacher/classrooms/c-1/announcements',
       {
         method: 'POST',
-        body: JSON.stringify({ title: '  Quiz reminder  ', content: 'Test Content' }),
+        body: JSON.stringify({ title: '  Test reminder  ', content: 'Test Content' }),
       }
     )
     const response = await POST(request, { params: Promise.resolve({ id: 'c-1' }) })
@@ -151,11 +151,11 @@ describe('POST /api/teacher/classrooms/[id]/announcements', () => {
 
     const data = await response.json()
     expect(data.announcement.id).toBe('a-1')
-    expect(data.announcement.title).toBe('Quiz reminder')
+    expect(data.announcement.title).toBe('Test reminder')
     expect(data.announcement.content).toBe('Test Content')
     expect(insert).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Quiz reminder',
+        title: 'Test reminder',
         content: 'Test Content',
       }),
     )

--- a/tests/components/LessonCalendar.test.tsx
+++ b/tests/components/LessonCalendar.test.tsx
@@ -27,9 +27,9 @@ const mockClassroom: Classroom = {
 const mondayAssignment: Assignment = {
   id: 'assignment-1',
   classroom_id: 'cls-123',
-  title: 'Week 11 quiz',
-  description: 'Quiz instructions',
-  instructions_markdown: 'Quiz instructions',
+  title: 'Week 11 test',
+  description: 'Test instructions',
+  instructions_markdown: 'Test instructions',
   rich_instructions: null,
   due_at: '2026-03-16T16:00:00.000Z',
   position: 0,
@@ -195,7 +195,7 @@ describe('LessonCalendar', () => {
     const dialog = screen.getByRole('dialog', { name: /monday, march 16, 2026/i })
 
     expect(dialog).toBeInTheDocument()
-    expect(within(dialog).getByText('Week 11 quiz')).toBeInTheDocument()
+    expect(within(dialog).getByText('Week 11 test')).toBeInTheDocument()
   })
 
   it('renders announcement markdown in the focused day dialog', () => {

--- a/tests/components/LessonDayCell.test.tsx
+++ b/tests/components/LessonDayCell.test.tsx
@@ -43,7 +43,7 @@ const markdownAnnouncement: Announcement = {
   content: 'Read the [course outline](https://example.com/outline) before class.',
 }
 
-const titledAnnouncementTitle = 'Quiz reminder with a very long title that should truncate in the calendar'
+const titledAnnouncementTitle = 'Test reminder with a very long title that should truncate in the calendar'
 
 const titledAnnouncement: Announcement = {
   ...longAnnouncement,

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('announcement helpers', () => {
   it('normalizes blank announcement titles to null', () => {
-    expect(normalizeAnnouncementTitle('  Quiz reminder  ')).toBe('Quiz reminder')
+    expect(normalizeAnnouncementTitle('  Test reminder  ')).toBe('Test reminder')
     expect(normalizeAnnouncementTitle('   ')).toBeNull()
     expect(normalizeAnnouncementTitle(null)).toBeNull()
   })


### PR DESCRIPTION
## Summary
- rename arbitrary announcement/calendar fixture copy from Quiz wording to Test wording
- update the generic dev-flow risk checklist example from quiz status to test status
- leave schema, API compatibility keys, gradebook category fields, and legacy alias coverage unchanged

## Validation
- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
- `pnpm exec tsc --noEmit`
- `pnpm test tests/api/teacher/announcements.test.ts tests/unit/announcements.test.ts tests/components/LessonCalendar.test.tsx tests/components/LessonDayCell.test.tsx`
- `pnpm lint`
- `pnpm test` (first run hit unrelated component timeout failures; failed files passed on isolated rerun)
- `pnpm test`
