### PR TITLE
Document remaining legacy quiz contracts

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz student Tests state naming pass
-
-**Completed:**
-- Created `codex/legacy-quiz-ui-state-names` from the merged `origin/main`.
-- Renamed active `StudentTestsTab` local state, refs, handlers, and selected-detail object keys from quiz-oriented names to test-oriented names.
-- Preserved legacy API compatibility response keys (`quiz`, `quizzes`) and existing child component `quizId` prop contracts.
-- Did not touch database schema, migrations, RPCs, storage paths, or production API route contracts.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm vitest run tests/components/StudentTestsTab.test.tsx`
-- `pnpm vitest run tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx`
-- `pnpm lint`
-
 ## 2026-06-09 — Legacy quiz teacher Tests state naming pass
 
 **Completed:**
@@ -672,5 +657,19 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm exec tsc --noEmit`
 - `pnpm test tests/components/TestDetailPanel.test.tsx`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-16 — Legacy quiz contract cleanup plan
+
+**Completed:**
+- Added `docs/guidance/legacy-quiz-contract-cleanup.md` to inventory remaining internal `quiz` / `quizzes` references by category.
+- Documented what can still be safely renamed versus what requires payload, gradebook, course package, or schema migration planning.
+- Added routing from `docs/ai-instructions.md` and the architecture assessments section so future passes load the cleanup guide.
+- No production schema, API payload, or runtime behavior changes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/course-blueprint-package-docs.test.ts`
 - `pnpm lint`
 - `pnpm test`

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -22,6 +22,7 @@ After startup, load only task-specific docs:
 | UI/UX | [`docs/core/design.md`](./core/design.md), [`docs/guidance/ui/README.md`](./guidance/ui/README.md), [`docs/guidance/ui/stable.md`](./guidance/ui/stable.md), [`docs/guidance/ui/change-brief.md`](./guidance/ui/change-brief.md), [`docs/guides/ai-ui-testing.md`](./guides/ai-ui-testing.md) |
 | Teacher assignments/tests shell/layout | [`docs/guidance/ui/teacher-work-surfaces.md`](./guidance/ui/teacher-work-surfaces.md), [`docs/guidance/assignment-ux-language.md`](./guidance/assignment-ux-language.md), [`docs/guidance/ui/audit-teacher-work-surfaces.md`](./guidance/ui/audit-teacher-work-surfaces.md) |
 | Migrations, Supabase query-shape, rollout compatibility | [`docs/guidance/schema-rollout-checklist.md`](./guidance/schema-rollout-checklist.md) |
+| Legacy quiz/tests contract cleanup | [`docs/guidance/legacy-quiz-contract-cleanup.md`](./guidance/legacy-quiz-contract-cleanup.md), [`docs/guidance/schema-rollout-checklist.md`](./guidance/schema-rollout-checklist.md) |
 | Large TSX/shared shell refactors | [`docs/guidance/component-refactor-checklist.md`](./guidance/component-refactor-checklist.md) |
 | TDD, coverage, or test design | [`docs/core/tests.md`](./core/tests.md) |
 | Setup, runtime, or deployment questions | [`docs/core/project-context.md`](./core/project-context.md) |

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -168,6 +168,8 @@ Use raw `fetch()` only for one-off mutations (POST/PATCH/DELETE) or when freshne
 ### Assessments Pattern
 Pika exposes **tests** as the active assessment surface. Quiz product routes and tabs have been removed.
 Some database history and compatibility response keys still retain legacy quiz naming during the contract transition.
+Before changing remaining `quiz` / `quizzes` names, load
+[`docs/guidance/legacy-quiz-contract-cleanup.md`](../guidance/legacy-quiz-contract-cleanup.md).
 
 - **Test status**: `getStudentTestStatus()` from `@/lib/tests` — uses `returned_at` field
 - **Draft editing**: unified `assessment_drafts` table + JSON Patch via `@/lib/server/assessment-drafts`

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -1,0 +1,214 @@
+# Legacy Quiz Contract Cleanup
+
+Use this guide when auditing or changing remaining internal `quiz` / `quizzes`
+names after the product surface moved to **Tests**.
+
+The current product contract is:
+
+- User-facing navigation, labels, and active routes should say **Tests**.
+- Legacy quiz routes/tabs are removed from the product surface.
+- Some database tables, payload aliases, TypeScript aliases, package fields, and
+  tests intentionally still use `quiz` names while compatibility is maintained.
+- AI agents may create migration files after approval, but humans apply
+  migrations manually.
+
+## Current Inventory
+
+### Database, Migrations, RPC, And Storage
+
+Retain until an approved schema migration exists:
+
+- Legacy quiz tables and columns referenced by server routes and tests:
+  `quizzes`, `quiz_questions`, `quiz_responses`, `quiz_student_scores`,
+  `quiz_id`, and quiz update functions/policies.
+- Historical migrations that created or hardened quiz tables, indexes, and RLS.
+- `assessment_drafts.assessment_type = 'quiz' | 'test'`, because historical or
+  imported drafts may still carry `quiz`.
+- Gradebook quiz fields and settings, including `quizzes_weight`,
+  `quizzes_percent`, `GradebookQuizDetail`, and quiz override routes.
+
+Do not rename these in app code as a cosmetic cleanup. They require a planned
+migration, deterministic backfill, compatibility reads, rollback notes, and
+explicit approval.
+
+### API Routes And Payload Contracts
+
+Retain during the compatibility window:
+
+- Active Tests APIs emit both current and legacy response keys through
+  `src/lib/test-api-contract.ts`: `{ tests, quizzes }` for lists and
+  `{ test, quiz }` for details.
+- Student and teacher Tests UI reads current keys first and falls back to
+  legacy keys.
+- Tests that assert `data.tests === data.quizzes` or `data.test === data.quiz`
+  protect this compatibility contract.
+- Server access helpers may return both `assessment` and legacy `quiz` aliases.
+
+Next compatibility decision: choose the deprecation point for legacy response
+keys, then remove fallback readers in the same or next release after clients
+have moved to `test` / `tests`.
+
+### TypeScript Domain Types
+
+Retain while persisted and API compatibility names remain:
+
+- `TestAssessmentType = 'quiz' | 'test'`.
+- `Quiz*` aliases in `src/types/index.ts`.
+- Gradebook union members and payload fields that still include `quiz`.
+
+Safe cleanup is limited to comments, fixtures, and local variable names that are
+not documenting or exercising a legacy contract.
+
+### Server And Library Code
+
+Retain for compatibility or schema-backed behavior:
+
+- `src/lib/assessments.ts` legacy quiz exports and default handling for missing
+  assessment type.
+- `src/lib/server/assessment-drafts.ts` quiz draft helpers and
+  `quiz_questions` sync for legacy rows.
+- `src/lib/server/assessments.ts` access aliases.
+- `src/lib/quiz-markdown.ts` and `tests/lib/quiz-markdown.test.ts`, which cover
+  legacy quiz markdown import/export aliases.
+- Gradebook and notification server code that reads quiz tables separately from
+  active Tests.
+
+### UI Compatibility Wrappers
+
+Retain until their callers are removed:
+
+- Component props such as `quiz`, `quizId`, `quizTitle`, and `onQuizUpdate`
+  when paired with explicit compatibility tests.
+- `student-quiz-action-footer` test ids while component tests still use the old
+  identifier.
+- Legacy `tab=quizzes` route fallback tests, which prove old URLs fall back to
+  the supported tab instead of exposing a removed product surface.
+
+Safe cleanup: rename current-path fixtures and test descriptions from quiz to
+test when they are not exercising a compatibility fallback.
+
+### Tests
+
+Remaining quiz references usually fall into one of these groups:
+
+- Compatibility regressions for legacy response keys, props, route params, or
+  helper aliases.
+- Database-shaped mocks that must still use `quiz_id` or legacy table names.
+- Gradebook tests that cover legacy quiz rows and quiz category behavior.
+- Course blueprint/package tests that cover persisted `quizzes` package fields.
+- UI absence tests that assert "Quizzes" is not visible.
+
+Before renaming any test fixture, confirm whether the fixture is a current Tests
+path or a deliberate legacy fallback.
+
+### Docs
+
+Docs may keep legacy quiz references when they are:
+
+- Historical architecture context.
+- Explicit legacy drift warnings.
+- Course package compatibility notes.
+- Experimental UI notes that mention old surfaces.
+
+Docs should not introduce new user-facing "Quizzes" guidance.
+
+## Safe Now
+
+Safe without schema or API migration:
+
+- Rename arbitrary fixture text from "quiz" to "test" when no contract depends
+  on the string.
+- Rename local variables and comments that describe the active Tests path, as
+  long as compatibility assertions stay explicit.
+- Move compatibility helpers behind clearer `test`-named wrappers while keeping
+  old exports as aliases.
+- Add or update tests that make legacy fallback behavior explicit.
+- Update docs to classify a remaining quiz reference as intentional legacy
+  compatibility.
+
+## Requires Migration Or Backward Compatibility
+
+Requires a follow-up design and approval:
+
+- Renaming database tables, columns, functions, indexes, policies, or migration
+  history from quiz to test.
+- Removing `quiz` / `quizzes` API response keys.
+- Removing TypeScript `Quiz*` aliases used by callers or tests.
+- Changing gradebook quiz category fields, weights, override routes, or report
+  payloads.
+- Changing course blueprint/package `quizzes` fields or exported package shape.
+- Removing legacy route and prop fallbacks before older URLs/clients are out of
+  the compatibility window.
+
+## Recommended Phased Plan
+
+1. **Inventory and guardrails**
+   - Keep this guide current.
+   - Add targeted tests before each compatibility removal.
+   - Risk profile: `none` for docs/fixture-only cleanup; `workspace-state` only
+     if UI stateful shells are changed.
+
+2. **Low-risk naming cleanup**
+   - Continue replacing non-contract test fixture wording and local variable
+     names.
+   - Preserve explicit fallback tests for `quiz` / `quizzes`.
+   - Validate with focused tests for touched areas, then `pnpm lint` and
+     `pnpm test`.
+
+3. **Payload deprecation**
+   - Pick a release where active Tests APIs stop emitting legacy `quiz` keys.
+   - First add telemetry or targeted tests that prove all in-repo readers use
+     `test` / `tests`.
+   - Remove `withLegacyQuizKey`, `withLegacyQuizListKey`, and fallback reads in
+     one coordinated PR.
+   - Rollback: restore the helpers and response aliases without data changes.
+
+4. **Type and wrapper retirement**
+   - Remove `Quiz*` type aliases and legacy component prop aliases only after
+     payload deprecation lands.
+   - Rename remaining test ids if no external automation depends on them.
+   - Rollback: restore aliases; no data rollback required.
+
+5. **Gradebook and course package decision**
+   - Decide whether legacy quiz gradebook categories remain as archival data or
+     merge into Tests.
+   - Decide whether exported course packages keep `quizzes` for backward
+     compatibility or introduce a package format version bump.
+   - These decisions may need compatibility readers for old packages and
+     response payloads.
+
+6. **Schema migration**
+   - Only after explicit approval, create migrations for table/column/function
+     renames or archival handling.
+   - Follow `docs/guidance/schema-rollout-checklist.md`.
+   - Include deterministic backfill, compatibility views or aliases if needed,
+     regression tests for pre/post shapes, and rollback notes.
+   - Do not apply migrations as an AI agent.
+
+## Validation Checklist
+
+For each implementation pass:
+
+- Run `rg "\b[qQ]uiz(?:zes)?\b|\bquiz(?:zes)?\b|quiz_"` and classify new or
+  changed hits.
+- For payload changes, answer the schema checklist questions:
+  "What widened?", "What fallback exists?", "What breaks if the migration has
+  not been applied yet?", and "Which regression proves the intended payload
+  shape?"
+- Run focused tests for the touched area.
+- Run `pnpm lint`.
+- Run `pnpm test`.
+- If UI text or layout changes, run the required Playwright visual verification.
+
+## Next Implementation Pass
+
+The next safe pass should continue fixture-only cleanup in tests that still use
+arbitrary "Quiz" titles while not exercising a legacy fallback. Start with:
+
+- `tests/lib/quiz-markdown.test.ts` only if the test is rewritten to clearly say
+  it covers legacy quiz markdown compatibility.
+- Gradebook/course blueprint tests only after deciding whether their quiz rows
+  are archival compatibility data or active categories.
+
+Do not start payload or schema removal until the payload deprecation and
+gradebook/course package decisions are approved.


### PR DESCRIPTION
## Summary
- add a legacy quiz contract cleanup guide that inventories remaining internal quiz/quizzes references by category
- document which references are safe fixture/comment cleanup versus payload, gradebook, course package, or schema migration work
- route future cleanup passes to the guide from AI instructions and architecture docs

## Risk
- none; docs-only pass
- no production schema, API payload, or runtime behavior changes
- no migrations created or applied

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/course-blueprint-package-docs.test.ts
- pnpm lint
- pnpm test