### PR TITLE
Clarify legacy quiz markdown fixtures

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz teacher Tests state naming pass
-
-**Completed:**
-- Created `codex/legacy-quiz-teacher-state-names` from merged `origin/main`.
-- Renamed `ClassroomPageClient` teacher Tests parent state from `selectedQuiz`/`handleSelectQuiz` to `selectedTest`/`handleSelectTest`.
-- Renamed the local pending-delete object key from `quiz` to `test` for active Tests deletion state.
-- Preserved legacy `quizId` query cleanup and existing child component/API compatibility contracts.
-- Did not touch database schema, migrations, RPCs, storage paths, or production API route contracts.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-
 ## 2026-06-09 — Legacy quiz component prop alias pass
 
 **Completed:**
@@ -671,5 +656,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts tests/unit/course-blueprint-package-docs.test.ts`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-16 — Legacy quiz markdown fixture clarity
+
+**Completed:**
+- Updated `tests/lib/quiz-markdown.test.ts` so the suite explicitly describes legacy quiz markdown compatibility.
+- Replaced arbitrary `Intro Quiz` fixture titles with `Legacy Check-in` while preserving the intentional `# Quiz` legacy markdown format.
+- Left production markdown helpers, schema, API payloads, and runtime behavior unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/lib/quiz-markdown.test.ts`
 - `pnpm lint`
 - `pnpm test`

--- a/tests/lib/quiz-markdown.test.ts
+++ b/tests/lib/quiz-markdown.test.ts
@@ -6,10 +6,10 @@ import {
   quizToMarkdown,
 } from '@/lib/quiz-markdown'
 
-describe('assessmentToMarkdown', () => {
-  it('serializes assessment draft content into markdown', () => {
+describe('legacy quiz markdown compatibility', () => {
+  it('serializes assessment draft content into legacy quiz markdown', () => {
     const markdown = assessmentToMarkdown({
-      title: 'Intro Quiz',
+      title: 'Legacy Check-in',
       show_results: false,
       questions: [
         {
@@ -20,17 +20,15 @@ describe('assessmentToMarkdown', () => {
       ],
     })
 
-    expect(markdown).toContain('Title: Intro Quiz')
+    expect(markdown).toContain('Title: Legacy Check-in')
     expect(markdown).toContain('Show Results: false')
     expect(markdown).toContain('Prompt:')
     expect(markdown).toContain('- Plan')
   })
-})
 
-describe('markdownToAssessment', () => {
-  it('parses assessment markdown into draft content', () => {
+  it('parses legacy quiz markdown into assessment draft content', () => {
     const markdown = `# Quiz
-Title: Intro Quiz
+Title: Legacy Check-in
 Show Results: true
 
 ## Questions
@@ -46,7 +44,7 @@ Options:
 
     expect(result.errors).toEqual([])
     expect(result.draftContent).toMatchObject({
-      title: 'Intro Quiz',
+      title: 'Legacy Check-in',
       show_results: true,
       questions: [
         {
@@ -57,10 +55,10 @@ Options:
       ],
     })
     expect(result.draftContent?.source_format).toBe('markdown')
-    expect(result.draftContent?.source_markdown).toContain('Title: Intro Quiz')
+    expect(result.draftContent?.source_markdown).toContain('Title: Legacy Check-in')
   })
 
-  it('returns actionable errors for invalid markdown', () => {
+  it('returns actionable errors for invalid legacy quiz markdown', () => {
     const markdown = `# Quiz
 Title: 
 


### PR DESCRIPTION
## Summary
- group quiz markdown tests under an explicit legacy compatibility suite
- replace arbitrary Intro Quiz fixture titles with Legacy Check-in
- preserve the intentional # Quiz markdown format and legacy alias assertions

## Risk
- none; test/documentation-log wording only
- no production schema, API payload, runtime helper, or markdown format changes
- no migrations created or applied

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm test tests/lib/quiz-markdown.test.ts
- pnpm lint
- pnpm test