### PR TITLE
Rename test AI gold fixture title

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz component prop alias pass
-
-**Completed:**
-- Created `codex/legacy-quiz-prop-aliases` from merged `origin/main`.
-- Added test-named component prop aliases while preserving legacy compatibility props:
-  `testId` for `StudentTestForm`, `StudentTestResults`, and `TestIndividualResponses`; `test`/`onTestUpdate` for `TestDetailPanel`.
-- Migrated active app callers in `StudentTestsTab`, `TeacherTestsTab`, `TeacherTestPreviewPage`, and `TestDetailPanel` to test-named props.
-- Left legacy `quizId`, `quiz`, and `onQuizUpdate` props supported for existing tests/hidden callers.
-- Did not touch database schema, migrations, RPCs, storage paths, API payload keys, or DB-shaped `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests)
-- `pnpm exec tsc --noEmit`
-- `pnpm vitest run tests/components/StudentTestsTab.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm lint`
-
 ## 2026-06-09 — Legacy quiz component test prop migration pass
 
 **Completed:**
@@ -669,5 +653,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash .codex/skills/pika-session-start/scripts/session_start.sh`
 - `pnpm test tests/lib/quiz-markdown.test.ts`
+- `pnpm lint`
+- `pnpm test`
+
+## 2026-06-16 — Test AI gold-set fixture wording
+
+**Completed:**
+- Renamed the active Test AI grading gold-set title from `Intro CS Concepts Quiz` to `Intro CS Concepts Test`.
+- Verified the old fixture wording is gone from scripts/tests/source docs.
+- Left AI grading logic, schema, API payloads, and runtime contracts unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm tsx scripts/measure-ai-grading-prompts.ts`
 - `pnpm lint`
 - `pnpm test`

--- a/scripts/fixtures/test-ai-grading-gold-set.ts
+++ b/scripts/fixtures/test-ai-grading-gold-set.ts
@@ -71,7 +71,7 @@ const nonCodingOsmosis = {
 } as const
 
 const nonCodingInheritance = {
-  testTitle: 'Intro CS Concepts Quiz',
+  testTitle: 'Intro CS Concepts Test',
   questionText: 'Explain what inheritance means in object-oriented programming.',
   maxPoints: 5,
   responseMonospace: false,


### PR DESCRIPTION
## Summary
- rename the active Test AI grading gold-set title from Intro CS Concepts Quiz to Intro CS Concepts Test
- verify the old fixture wording is gone from scripts/tests/source docs
- leave AI grading logic and runtime contracts unchanged

## Risk
- none; fixture wording only
- no production schema, API payload, or runtime behavior changes
- no migrations created or applied

## Validation
- bash .codex/skills/pika-session-start/scripts/session_start.sh
- pnpm tsx scripts/measure-ai-grading-prompts.ts
- pnpm lint
- pnpm test