### PR TITLE
[codex] Add dev-flow skill guardrails

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,34 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Legacy quiz component test prop migration pass
-
-**Completed:**
-- Created `codex/legacy-quiz-test-prop-tests` from merged `origin/main`.
-- Migrated direct component tests for `StudentTestForm`, `StudentTestResults`, `TestIndividualResponses`, and `TestDetailPanel` to active `testId`, `test`, and `onTestUpdate` props.
-- Added narrow compatibility assertions for legacy `quizId`, `quiz`, and `onQuizUpdate` aliases so fallback support remains intentional.
-- Updated the `TeacherTestsTab` mock of `TestDetailPanel` to model the active test-named prop contract instead of accepting legacy aliases.
-- Did not touch production runtime code, database schema, migrations, RPCs, storage paths, API payload keys, or DB-shaped `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2655 tests before edits)
-- `pnpm vitest run tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx tests/components/TestIndividualResponses.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
-- `pnpm test` (301 files / 2662 tests)
-
-## 2026-06-09 — Session log trim buffer
-
-**Completed:**
-- Split the session-log trim policy into a 60-entry CI cap and a 40-entry default retention target.
-- Preserved `--check --keep` compatibility without adding another public flag.
-- Updated startup guidance and trim tests so agents compact below the CI boundary after appending.
-
-**Validation:**
-- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check` (kept 40 of 61 entries; cap 60)
-- `pnpm test tests/unit/trim-session-log.test.ts tests/unit/ai-startup-docs.test.ts`
-
 ## 2026-06-09 — Remove trim --max flag
 
 **Completed:**
@@ -668,3 +640,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm tsx scripts/measure-ai-grading-prompts.ts`
 - `pnpm lint`
 - `pnpm test`
+
+## 2026-06-19 — Skill progression map refresh
+
+**Completed:**
+- Reviewed recent merged PRs and review evidence to identify the next engineering skills worth deepening.
+- Anchored recommendations to the June 8-16, 2026 PR cluster around legacy quiz-to-test contract cleanup and classroom-switch race-condition fixes.
+- Found that the strongest recurring review signals were stale async state during classroom navigation and compatibility gaps during naming-contract migration.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`
+- `gh pr list --repo codepetca/pika --state merged --limit 15 --json number,title,mergedAt,url`
+- `gh api graphql` review scan across recent merged PRs
+
+## 2026-06-19 — Dev-flow skill upgrades
+
+**Completed:**
+- Implemented the three skill improvements as repo guidance updates instead of a separate process layer.
+- Strengthened `docs/guidance/dev-flow-risk-checklists.md` with explicit route-owner identity, stale-response guards, and A-then-B regression expectations for workspace-state work.
+- Expanded `docs/guidance/schema-rollout-checklist.md` and `docs/guidance/legacy-quiz-contract-cleanup.md` to require explicit migration slices, new-contract-first readers, and listed surviving legacy aliases.
+- Expanded `docs/guidance/component-refactor-checklist.md` to require sliced refactors with grep/test exit criteria.
+- Wired the new checks into `.codex/prompts/session-start.md`, `.codex/prompts/audit.md`, and `.codex/prompts/tdd.md`.
+
+**Validation:**
+- `git diff -- docs/guidance/dev-flow-risk-checklists.md docs/guidance/schema-rollout-checklist.md docs/guidance/component-refactor-checklist.md docs/guidance/legacy-quiz-contract-cleanup.md .codex/prompts/session-start.md .codex/prompts/audit.md .codex/prompts/tdd.md`
+- `sed -n '1,220p' .codex/prompts/tdd.md`

--- a/.codex/prompts/audit.md
+++ b/.codex/prompts/audit.md
@@ -18,6 +18,15 @@ Also declare the task risk profile before reporting audit status:
 
 If a non-`none` risk profile applies, review `docs/guidance/dev-flow-risk-checklists.md` and report whether the relevant behavioral checks were covered by tests, visual verification, or explicit follow-up.
 
+If the change touches route-keyed async state or classroom/selection switching, also report:
+- owner identity named: yes/no
+- stale-response regression added: yes/no
+
+If the change is a contract or naming migration, also report:
+- migration slice named: yes/no
+- new-contract-first reader coverage added: yes/no
+- intentional legacy aliases remaining are listed: yes/no
+
 If changed UI files introduce or modify composite widget behavior, also review:
 - `docs/guidance/ui/composite-widget-accessibility.md`
 

--- a/.codex/prompts/session-start.md
+++ b/.codex/prompts/session-start.md
@@ -29,6 +29,8 @@ Manual fallback:
    - For large TSX refactors or shared shell extraction, read `docs/guidance/component-refactor-checklist.md`.
    - For non-trivial work, declare risk profile: `none`, `workspace-state`, `async-grading`, `exam-mode`, or `runtime-platform`.
    - If any risk profile applies, read `docs/guidance/dev-flow-risk-checklists.md`.
+   - If the change touches route-keyed async UI state, selected detail fetches, or classroom switching, explicitly name the owner identity and plan one stale-response regression before coding.
+   - If the change is a contract or naming migration, explicitly name the slice: producers, active consumers, compatibility aliases, fixtures, or docs.
    - When available in the current session, prefer `product-design:get-context`, `pika-ui-verify`, `supabase:supabase-postgres-best-practices`, and `vercel:react-best-practices` at their matching trigger points.
 8. If `$ARGUMENTS` is an issue number, run `gh issue view $ARGUMENTS --json number,title,body,labels`.
 9. State the task, propose the approach, and wait for approval before coding.

--- a/.codex/prompts/tdd.md
+++ b/.codex/prompts/tdd.md
@@ -2,6 +2,7 @@ Use TDD for the feature described in `$ARGUMENTS`.
 
 If you have not already loaded it, read `docs/core/tests.md` first.
 If the task touches workspace state, async grading, exam mode, or runtime/platform behavior, also read `docs/guidance/dev-flow-risk-checklists.md` and name the risk profile before writing tests.
+If the task is a naming or contract migration, also read `docs/guidance/schema-rollout-checklist.md` and name the slice before writing tests.
 
 Steps:
 1. Identify the target test file under `tests/lib/`, `tests/api/`, `tests/hooks/`, or `tests/components/`.
@@ -12,5 +13,7 @@ Steps:
 6. Re-run the focused test and any nearby regression tests.
 7. Check coverage when the change affects shared core logic.
 8. For workspace-state work, include a regression that the active editor/form/workspace stays mounted across non-destructive updates.
-9. For async-grading work, include recovery/retry/partial-failure coverage.
-10. For exam-mode work, include transient-loss, sustained-loss, restore, and draft-preservation coverage.
+9. For route-keyed workspace-state work, include a regression where request A resolves after switching to B and prove A is ignored.
+10. For async-grading work, include recovery/retry/partial-failure coverage.
+11. For exam-mode work, include transient-loss, sustained-loss, restore, and draft-preservation coverage.
+12. For contract-migration work, include both new-contract-first coverage and explicit fallback coverage when compatibility remains.

--- a/docs/guidance/component-refactor-checklist.md
+++ b/docs/guidance/component-refactor-checklist.md
@@ -25,6 +25,25 @@ Read this when any of these are true:
 - If a shared component replaces repeated markup, list the repeated structure it owns
 - List visible behavior that must remain unchanged if this is a structural refactor
 - Add focused regression tests for the extracted shell contract, not only the parent surface
+- Split large naming or shared-shell refactors into explicit passes when behavior, imports, and compatibility cleanup would otherwise land together
+- Give each pass a grep- or test-based exit criterion so "done" does not depend on memory
+- Keep compatibility wrappers or aliases in their own phase unless removing them is mechanically proven safe in the same diff
+
+## Refactor Slicing Pattern
+
+For broad structural or naming transitions, prefer this order:
+
+1. active callers and imports
+2. compatibility wrappers or aliases
+3. API/read-path cleanup
+4. fixtures and test wording
+5. docs and follow-up removals
+
+Each PR should name:
+
+- what moved in this slice
+- what intentionally stayed behind
+- which search or tests prove the slice boundary
 
 ## Review Prompt
 
@@ -35,4 +54,6 @@ Is this a shell extraction, a behavior extraction, or both?
 What business logic stayed out of the shared component?
 Which parent-level tests prove the refactor did not redesign the surface?
 Which component-level tests prove the new shared contract?
+If this is part of a larger migration, what exact slice is this PR responsible for?
+What grep or regression proves the remaining work is outside this PR on purpose?
 ```

--- a/docs/guidance/dev-flow-risk-checklists.md
+++ b/docs/guidance/dev-flow-risk-checklists.md
@@ -22,6 +22,11 @@ Applies when changing long-lived workspaces, split panes, editors, autosave surf
 - Preserve mounted workspace children across autosave, transient overlays, parent metadata updates, and background refetches.
 - Prefer local summary patching over full parent reloads when the child already has the fresh state.
 - Test that the active workspace does not remount when autosave completes or when non-destructive metadata changes.
+- If async state belongs to a route, classroom, selected record, or pane owner, name that identity boundary before editing.
+- Tag loaded state with its owner identity when stale data could remain visible during navigation or reselection.
+- Guard late async completions before every visible state write; a response for classroom A must not repaint classroom B.
+- Clear or hide owner-scoped sidebar/detail state synchronously when the owner changes, even before the next request resolves.
+- Add at least one stale-response regression for risky route-keyed work: start load A, switch to B, resolve A late, prove B stays visible.
 - For structural refactors, use this implementation contract:
 
 ```text
@@ -34,6 +39,17 @@ Do not move business logic, data loading, selection state, grading behavior, rou
 The migrated assignment UI should look and behave the same after the refactor. Any visible difference must be explicitly listed and justified before continuing.
 
 Stop and reassess if the new shell API starts needing domain-specific props such as assignment status, test status, grading state, AI run state, student selection, rubric state, or return behavior.
+```
+
+### Workspace-State Review Prompt
+
+Before opening the PR, answer:
+
+```text
+What is the owner identity for this async state?
+Which late responses are now ignored?
+Which state clears immediately on owner change?
+Which regression proves A resolving after switching to B cannot repaint the UI?
 ```
 
 ## Async Grading

--- a/docs/guidance/legacy-quiz-contract-cleanup.md
+++ b/docs/guidance/legacy-quiz-contract-cleanup.md
@@ -152,6 +152,11 @@ Requires a follow-up design and approval:
    - Continue replacing non-contract test fixture wording and local variable
      names.
    - Preserve explicit fallback tests for `quiz` / `quizzes`.
+   - Prefer narrow slices: active callers first, compatibility helpers next,
+     fixtures/docs last.
+   - For each slice, record the exit criterion up front, for example:
+     "all active Tests readers prefer `test/tests` first" or
+     "remaining `quiz` hits are compatibility tests only".
    - Validate with focused tests for touched areas, then `pnpm lint` and
      `pnpm test`.
 
@@ -195,6 +200,9 @@ For each implementation pass:
   "What widened?", "What fallback exists?", "What breaks if the migration has
   not been applied yet?", and "Which regression proves the intended payload
   shape?"
+- For active contract renames, also answer:
+  "Which readers prefer the new contract first?" and
+  "Which legacy aliases are intentionally still alive after this pass?"
 - Run focused tests for the touched area.
 - Run `pnpm lint`.
 - Run `pnpm test`.

--- a/docs/guidance/schema-rollout-checklist.md
+++ b/docs/guidance/schema-rollout-checklist.md
@@ -9,6 +9,7 @@ Use this checklist for migrations, Supabase query-shape changes, compatibility s
 - introducing a new persisted field
 - adding a fallback for pre-migration or partially rolled-out environments
 - changing a teacher or student API response contract
+- renaming an active contract while legacy keys, props, or helpers remain supported
 
 ## Pre-Change Checks
 
@@ -17,6 +18,7 @@ Use this checklist for migrations, Supabase query-shape changes, compatibility s
 - Confirm browser-side Supabase access is not being added
 - Confirm writes stay in server routes with existing auth helpers
 - Identify whether reads must tolerate both pre-migration and post-migration schemas during rollout
+- Name the compatibility boundary explicitly: persisted schema, API payload, TypeScript alias, prop contract, or test fixture contract
 
 ## Migration Checklist
 
@@ -31,8 +33,23 @@ Use this checklist for migrations, Supabase query-shape changes, compatibility s
 - Narrow the select list to rendered or returned fields
 - Avoid accidentally exposing extra columns while adding a new field
 - Keep teacher/student response shaping explicit when rollout fallbacks exist
+- Decide whether the pass is dual-read, dual-write, or dual-read plus dual-write; do not leave that implicit
+- List every in-repo producer and consumer that still touches the legacy key or shape
+- Add a regression for any current-path reader that must prefer the new key while still accepting the legacy fallback
 - Add a regression for the fallback path when a new column is unavailable
 - Add a regression for the steady-state path when the column is present
+
+## Compatibility Migration Slice
+
+When the change is a naming or contract migration, split the work into narrow passes:
+
+- producers: where the contract is emitted or stored
+- active consumers: current UI, hooks, and server readers
+- compatibility aliases: wrappers, fallback readers, legacy response keys
+- tests and fixtures: current-path wording versus deliberate fallback coverage
+- docs: guidance that should explain what remains intentionally legacy
+
+Each pass should say what is intentionally not changing yet.
 
 ## Review Prompt
 
@@ -43,4 +60,6 @@ What widened?
 What fallback exists?
 What breaks if the migration has not been applied yet?
 Which regression proves the intended payload shape?
+Which readers now prefer the new contract first?
+Which legacy readers or aliases are intentionally still alive after this pass?
 ```


### PR DESCRIPTION
## Summary
- add route-owner and stale-response expectations to the workspace-state risk guidance
- add compatibility migration slicing and new-contract-first checks to rollout guidance
- wire the new guardrails into session-start, audit, and TDD prompts

## Validation
- git diff --check
- node scripts/trim-session-log.mjs --check
