### PR TITLE
chore(workflow): align teacher work-surface review prompt

### DIFF
--- a/.codex/prompts/teacher-work-surface-promotion-review.md
+++ b/.codex/prompts/teacher-work-surface-promotion-review.md
@@ -3,7 +3,6 @@
 Review the teacher work-surface family only:
 
 - teacher assignments
-- teacher quizzes
 - teacher tests
 
 Stay out of unrelated teacher tabs, the main classroom shell, and all student-only surfaces unless they materially affect the teacher-side implementation of this family.
@@ -16,7 +15,7 @@ Read and compare:
 - [`docs/guidance/ui/teacher-work-surfaces.md`](/docs/guidance/ui/teacher-work-surfaces.md)
 - [`docs/guidance/ui/audit-teacher-work-surfaces.md`](/docs/guidance/ui/audit-teacher-work-surfaces.md)
 - relevant files under [`docs/guidance/ui/experimental/`](/docs/guidance/ui/experimental/) only if they materially affect this family
-- current implementation of teacher assignments, teacher quizzes, and teacher tests
+- current implementation of teacher assignments and teacher tests
 
 ## Goal
 

--- a/tests/unit/ui-guidance-docs.test.ts
+++ b/tests/unit/ui-guidance-docs.test.ts
@@ -54,4 +54,18 @@ describe('ui guidance docs and prompts', () => {
     expect(auditSkill).toContain('without a relevant changed test')
     expect(auditSkill).toContain('path-aware guardrail, not a proof system')
   })
+
+  it('keeps teacher work-surface review prompts aligned with the assignments/tests canon', () => {
+    const uiCanon = readRepoFile('docs/guidance/ui/teacher-work-surfaces.md')
+    const auditDoc = readRepoFile('docs/guidance/ui/audit-teacher-work-surfaces.md')
+    const reviewPrompt = readRepoFile('.codex/prompts/teacher-work-surface-promotion-review.md')
+
+    for (const content of [uiCanon, auditDoc, reviewPrompt]) {
+      expect(content).toContain('teacher assignments')
+      expect(content).toContain('teacher tests')
+    }
+
+    expect(reviewPrompt).not.toContain('teacher quizzes')
+    expect(reviewPrompt).toContain('current implementation of teacher assignments and teacher tests')
+  })
 })


### PR DESCRIPTION
## Summary
- remove stale `teacher quizzes` scope from the Codex teacher work-surface promotion review prompt
- add a regression test so the prompt stays aligned with the current assignments/tests canon
- keep the repo change intentionally small; external read-only automation prompt updates were applied outside this repo

## Why
The repo canon for teacher work surfaces now covers teacher assignments and teacher tests only, but the review prompt still asked agents to evaluate `teacher quizzes`. That drift creates unnecessary confusion in UI review work and leaves a stale path open for future prompt copy-paste.

## Evidence this improves the workflow
- The stable canon already excludes teacher quizzes: `docs/guidance/ui/teacher-work-surfaces.md` and `docs/guidance/ui/audit-teacher-work-surfaces.md` now scope the family to assignments/tests only.
- The previous workflow-friction review found this exact repo prompt drift as an active mismatch.
- This patch converts that mismatch into a test-backed invariant, so the stale scope cannot quietly reappear.
- Targeted verification passed after the change, so the workflow guardrail is enforced now rather than remaining a report-only recommendation.

## Validation
- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
- `git diff --check`

## Out of scope
- External automation config edits under `/Users/stew/.codex/automations`
- Broader validation-policy or worktree-launcher changes
