### PR TITLE
[codex] Tokenize Pika logo dark filter

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-10 — Legacy quiz TestDetailPanel fixture cleanup pass
-
-**Completed:**
-- Created `codex/legacy-quiz-test-fixtures` from merged `origin/main`.
-- Renamed pure `TestDetailPanel` component-test fixtures from legacy quiz-shaped local names to test/assessment names.
-- Updated fake test ids and route expectations in stale-load/autosave cases from `quiz-*` to `test-*` where they are not DB fields or API compatibility payload keys.
-- Preserved intentional compatibility coverage for legacy `quiz`/`onQuizUpdate` props, API `quiz` response fallbacks, DB-shaped `quiz_id` fields, and the same-id legacy `assessment_type: 'quiz'` race case.
-- Did not touch production runtime code, database schema, migrations, RPCs, storage paths, or API payload contracts.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2662 tests before edits)
-- `pnpm vitest run tests/components/TestDetailPanel.test.tsx`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test` (301 files / 2662 tests)
-
 ## 2026-06-10 — Tests selected-student grading pane scrollbar fix
 
 **Completed:**
@@ -785,3 +769,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm build`
 - `pnpm vitest run --sequence.concurrent=false` (303 files / 2690 tests)
+
+## 2026-06-20 — Pika logo dark-token cleanup
+
+**Completed:**
+- Continued the systems/UI audit program with a bounded UI consistency slice.
+- Moved the Pika logo dark-mode filter out of component-local `dark:` utility classes and into `src/styles/tokens.css` as `--pika-logo-filter`.
+- Updated `PikaLogo` to use the semantic `pika-logo` class.
+- Removed the obsolete `PikaLogo` `dark:` exception from the active design guidance.
+- Added AppHeader regression coverage that asserts the logo uses the tokenized class and no component-level `dark:` utilities.
+- Addressed subagent review feedback by matching Tailwind's previous composed filter order for the dark-mode logo token.
+
+**Validation:**
+- `rg -n "dark:" src/app src/components --glob '*.tsx' --glob '*.ts'` returned no matches.
+- `pnpm vitest run tests/components/AppHeader.test.tsx`
+- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts tests/components/AppHeader.test.tsx`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- Visual verification: `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, and `/tmp/pika-student.png`.
+- Additional visual verification for role/viewport/theme matrix: reviewed `/tmp/pika-student-desktop.png`, `/tmp/pika-teacher-dark.png`, `/tmp/pika-teacher-mobile-dark.png`, `/tmp/pika-student-dark.png`, and `/tmp/pika-student-mobile-dark.png`.
+- Post-review fix validation: `pnpm vitest run tests/components/AppHeader.test.tsx tests/unit/ui-guidance-docs.test.ts`, `git diff --check`, `pnpm lint`, `bash .codex/skills/pika-audit/scripts/audit.sh`, `pnpm build`.
+- Post-review visual verification: reviewed `/tmp/pika-teacher-dark-after-review.png` and `/tmp/pika-student-mobile-dark-after-review.png`.

--- a/docs/core/design.md
+++ b/docs/core/design.md
@@ -92,8 +92,9 @@ The `/ui` layer handles dark mode internally via CVA. App code uses semantic cla
 
 `dark:` classes are **only allowed** in:
 1. `/src/ui/` - CVA component definitions
-2. `/src/components/PikaLogo.tsx` - CSS filter transformation (exception)
-3. `/src/components/editor/RichText*.tsx` - Code block styling (intentional dark regardless of theme)
+2. `/src/components/editor/RichText*.tsx` - Code block styling (intentional dark regardless of theme)
+
+Brand asset filters belong in `src/styles/tokens.css` and should be applied through semantic classes such as `pika-logo`, not component-local `dark:` utilities.
 
 **All other code must use semantic tokens.**
 

--- a/src/components/PikaLogo.tsx
+++ b/src/components/PikaLogo.tsx
@@ -6,10 +6,6 @@ interface PikaLogoProps {
 
 /**
  * Pika logo icon - simple, playful brand mark
- *
- * Note: Uses dark: CSS filter classes to transform the image for dark mode.
- * This is an intentional exception to the semantic token pattern since
- * CSS filters require explicit values rather than CSS variables.
  */
 export function PikaLogo({ className = 'w-8 h-8' }: PikaLogoProps) {
   return (
@@ -19,7 +15,7 @@ export function PikaLogo({ className = 'w-8 h-8' }: PikaLogoProps) {
       width={32}
       height={32}
       priority
-      className={`${className} block object-contain dark:brightness-0 dark:invert dark:sepia dark:saturate-[0.3] dark:hue-rotate-[15deg]`}
+      className={`${className} pika-logo block object-contain`}
     />
   )
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -39,6 +39,9 @@
   --color-text-muted: #6b7280;
   --color-text-inverse: #ffffff;
 
+  /* Brand assets */
+  --pika-logo-filter: none;
+
   /* Primary accent */
   --color-primary: #2563eb;
   --color-primary-hover: #1d4ed8;
@@ -100,6 +103,9 @@
   --color-text-default: #f3f4f6;
   --color-text-muted: #9ca3af;
   --color-text-inverse: #ffffff;
+
+  /* Brand assets - dark mode */
+  --pika-logo-filter: brightness(0) hue-rotate(15deg) invert(1) saturate(0.3) sepia(1);
 
   /* Primary accent - dark mode */
   --color-primary: #3b82f6;
@@ -166,4 +172,8 @@
 
 .classroom-theme-option-selected {
   border-left-color: var(--classroom-accent) !important;
+}
+
+.pika-logo {
+  filter: var(--pika-logo-filter);
 }

--- a/tests/components/AppHeader.test.tsx
+++ b/tests/components/AppHeader.test.tsx
@@ -79,13 +79,24 @@ describe('AppHeader classroom theme', () => {
     expect(header).not.toHaveClass('border')
     expect(header.getAttribute('style')).toContain('--classroom-accent-light')
     expect(header.getAttribute('style')).toContain('--classroom-accent-dark')
-    expect(screen.getByAltText('Pika')).not.toHaveClass('pika-logo-classroom')
+    expect(screen.getByAltText('Pika')).toHaveClass('pika-logo')
   })
 
   it('keeps the brand logo on unthemed appbars', () => {
     render(<AppHeader pageTitle="Classrooms" />, { wrapper: Wrapper })
 
-    expect(screen.getByAltText('Pika')).not.toHaveClass('pika-logo-classroom')
+    expect(screen.getByAltText('Pika')).toHaveClass('pika-logo')
+  })
+
+  it('themes the brand logo through design tokens instead of component dark utilities', () => {
+    const logoSource = readFileSync(resolve(process.cwd(), 'src/components/PikaLogo.tsx'), 'utf8')
+    const tokens = readFileSync(resolve(process.cwd(), 'src/styles/tokens.css'), 'utf8')
+
+    expect(logoSource).toContain('pika-logo')
+    expect(logoSource).not.toContain('dark:')
+    expect(tokens).toContain('--pika-logo-filter: none;')
+    expect(tokens).toContain('--pika-logo-filter: brightness(0) hue-rotate(15deg) invert(1) saturate(0.3) sepia(1);')
+    expect(tokens).toContain('filter: var(--pika-logo-filter);')
   })
 
   it('keeps appbar classroom theme to the gradient without an accent underline', () => {


### PR DESCRIPTION
## Summary
- move the Pika logo dark-mode filter from component-local `dark:` utilities into `src/styles/tokens.css`
- update `PikaLogo` to use the semantic `pika-logo` class
- remove the obsolete PikaLogo exception from active design guidance
- add AppHeader regression coverage for tokenized logo theming

## Impact
This is a small UI consistency cleanup from the systems/UI audit. It preserves the existing light/dark logo appearance while making the app-code `dark:` invariant easier to enforce.

## UI Change Brief
- Surface: shared app header logo on classroom list/header views
- Reference: semantic token guidance in `docs/core/design.md` and `docs/guidance/ui/stable.md`
- Affected roles: teacher and student
- Viewports: desktop and mobile
- Themes: light and dark
- States: default header/classroom list state
- Primary signal: unchanged brand logo visibility in both themes
- Must not add: new UI elements, classroom-logo variant, border/accent changes, layout changes
- Composite widget accessibility review needed: no

## Validation
- `rg -n "dark:" src/app src/components --glob '*.tsx' --glob '*.ts'` returned no matches
- `pnpm vitest run tests/components/AppHeader.test.tsx`
- `pnpm vitest run tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts tests/components/AppHeader.test.tsx`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm build`

## Visual Verification
- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`
- Reviewed `/tmp/pika-teacher.png`, `/tmp/pika-teacher-mobile.png`, `/tmp/pika-student.png`
- Reviewed dark/light matrix screenshots: `/tmp/pika-student-desktop.png`, `/tmp/pika-teacher-dark.png`, `/tmp/pika-teacher-mobile-dark.png`, `/tmp/pika-student-dark.png`, `/tmp/pika-student-mobile-dark.png`