### PR TITLE
[codex] Add browser Supabase access guard

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,25 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-10 — Legacy quiz utility alias pass
-
-**Completed:**
-- Created `codex/legacy-quiz-utility-aliases` from merged `origin/main`.
-- Moved the primary assessment utility implementation from `src/lib/quizzes.ts` to `src/lib/assessments.ts`, leaving `src/lib/quizzes.ts` as a compatibility re-export shim.
-- Moved server assessment access helpers from `src/lib/server/quizzes.ts` to `src/lib/server/assessments.ts`, adding assessment-named exports while preserving quiz-named aliases.
-- Pointed active imports in test/markdown/draft helpers at `@/lib/assessments` and `@/lib/server/assessments`.
-- Added assessment-named mock factories and moved active Tests component tests to `createMockTest*` helpers while keeping legacy `createMockQuiz*` helpers for compatibility tests.
-- Renamed focused utility tests from quiz-named files to assessment-named files.
-- Did not touch production schema, migrations, API payload contracts, storage/RPC paths, or DB-shaped `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh` (includes `pnpm test`, 301 files / 2662 tests before edits)
-- `pnpm vitest run tests/lib/assessments.test.ts tests/unit/assessments.test.ts tests/unit/server-assessments.test.ts tests/unit/server-access.test.ts tests/components/StudentTestForm.test.tsx tests/components/TeacherTestsTab.test.tsx tests/lib/quiz-markdown.test.ts tests/unit/assessment-drafts.test.ts`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm vitest run tests/components/AssignmentModal.test.tsx` (reran after one unrelated full-suite timing failure)
-- `pnpm test` (301 files / 2662 tests)
-
 ## 2026-06-12 — Startup orient-only mode and fast verify-env
 
 **Completed:**
@@ -788,3 +769,20 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - Post-review fix validation: `pnpm vitest run tests/unit/ui-guidance-docs.test.ts`, `git diff --check`, `pnpm lint`, `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-20 — Browser Supabase access audit guard
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the browser-side Supabase access slice.
+- Audited non-API/non-server source imports and confirmed current direct Supabase runtime usage is limited to server-rendered classroom pages and the shared server client module; `src/lib/user-profile.ts` uses a type-only Supabase import.
+- Added static regression coverage that fails if a browser-reachable module imports `@/lib/supabase` or `@supabase/supabase-js` at runtime.
+- Addressed subagent review feedback by changing the guard from a direct client-file scan to a TypeScript-AST runtime import graph rooted at every `use client` source file, while allowing type-only Supabase imports and catching static imports, dynamic imports, and `require()` calls.
+- No production UI or runtime behavior changed.
+
+**Validation:**
+- `rg -n "@/lib/supabase|@supabase/supabase-js|getSupabaseClient|getServiceRoleClient" src/app src/components src/hooks src/lib src/ui --glob '*.{ts,tsx}' --glob '!src/app/api/**' --glob '!src/lib/server/**'`
+- `pnpm test tests/unit/browser-supabase-access.test.ts tests/unit/api-route-standards.test.ts tests/unit/supabase.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`

--- a/tests/unit/browser-supabase-access.test.ts
+++ b/tests/unit/browser-supabase-access.test.ts
@@ -1,0 +1,221 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+type SourceImport = {
+  specifier: string
+  runtime: boolean
+}
+
+type SourceModule = {
+  filePath: string
+  imports: SourceImport[]
+  isClientEntry: boolean
+}
+
+const sourceRoot = resolve(process.cwd(), 'src')
+const sourceFilePattern = /\.(ts|tsx)$/
+const declarationFilePattern = /\.d\.ts$/
+const supabaseRuntimeSpecifiers = new Set(['@/lib/supabase', '@supabase/supabase-js'])
+
+function collectSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectSourceFiles(entryPath)
+    }
+
+    return sourceFilePattern.test(entry.name) && !declarationFilePattern.test(entry.name)
+      ? [entryPath]
+      : []
+  })
+}
+
+function parseSourceFile(filePath: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+}
+
+function hasUseClientDirective(sourceFile: ts.SourceFile): boolean {
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isExpressionStatement(statement) &&
+      ts.isStringLiteral(statement.expression)
+    ) {
+      if (statement.expression.text === 'use client') return true
+      continue
+    }
+
+    return false
+  }
+
+  return false
+}
+
+function importDeclarationHasRuntimeBinding(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause
+  if (!clause) return true
+  if (clause.isTypeOnly) return false
+  if (clause.name) return true
+  if (!clause.namedBindings) return false
+  if (ts.isNamespaceImport(clause.namedBindings)) return true
+
+  return clause.namedBindings.elements.some((element) => !element.isTypeOnly)
+}
+
+function collectRuntimeAwareImports(sourceFile: ts.SourceFile): SourceImport[] {
+  const imports = sourceFile.statements.flatMap((statement) => {
+    if (!ts.isImportDeclaration(statement)) return []
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) return []
+
+    return {
+      specifier: statement.moduleSpecifier.text,
+      runtime: importDeclarationHasRuntimeBinding(statement),
+    }
+  })
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      if (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require')
+      ) {
+        imports.push({
+          specifier: node.arguments[0].text,
+          runtime: true,
+        })
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(sourceFile, visit)
+
+  return imports
+}
+
+function createSourceModule(filePath: string, source: string): SourceModule {
+  const sourceFile = parseSourceFile(filePath, source)
+
+  return {
+    filePath,
+    imports: collectRuntimeAwareImports(sourceFile),
+    isClientEntry: hasUseClientDirective(sourceFile),
+  }
+}
+
+function createSourceModules(): Map<string, SourceModule> {
+  return new Map(
+    collectSourceFiles(sourceRoot).map((filePath) => [
+      filePath,
+      createSourceModule(filePath, readFileSync(filePath, 'utf8')),
+    ]),
+  )
+}
+
+function resolveInternalImport(
+  modules: Map<string, SourceModule>,
+  fromFilePath: string,
+  specifier: string,
+): string | null {
+  const unresolvedPath = specifier.startsWith('@/')
+    ? resolve(sourceRoot, specifier.slice(2))
+    : specifier.startsWith('.')
+      ? resolve(dirname(fromFilePath), specifier)
+      : null
+
+  if (!unresolvedPath) return null
+
+  const candidates = [
+    unresolvedPath,
+    `${unresolvedPath}.ts`,
+    `${unresolvedPath}.tsx`,
+    resolve(unresolvedPath, 'index.ts'),
+    resolve(unresolvedPath, 'index.tsx'),
+  ]
+
+  return candidates.find((candidate) => modules.has(candidate)) ?? null
+}
+
+function findBrowserSupabaseAccessViolations(modules: Map<string, SourceModule>): string[] {
+  const violations: string[] = []
+  const queue = Array.from(modules.values())
+    .filter((sourceModule) => sourceModule.isClientEntry)
+    .map((sourceModule) => ({
+      filePath: sourceModule.filePath,
+      chain: [sourceModule.filePath],
+    }))
+  const visited = new Set(queue.map((item) => item.filePath))
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index]
+    const sourceModule = modules.get(current.filePath)
+    if (!sourceModule) continue
+
+    for (const sourceImport of sourceModule.imports) {
+      if (!sourceImport.runtime) continue
+
+      if (supabaseRuntimeSpecifiers.has(sourceImport.specifier)) {
+        violations.push(
+          `${current.chain.map((filePath) => relative(process.cwd(), filePath)).join(' -> ')} imports ${sourceImport.specifier}`,
+        )
+        continue
+      }
+
+      const resolvedImport = resolveInternalImport(modules, current.filePath, sourceImport.specifier)
+      if (!resolvedImport || visited.has(resolvedImport)) continue
+
+      visited.add(resolvedImport)
+      queue.push({
+        filePath: resolvedImport,
+        chain: [...current.chain, resolvedImport],
+      })
+    }
+  }
+
+  return violations
+}
+
+function sourceHasSupabaseRuntimeImport(source: string): boolean {
+  return createSourceModule('fixture.tsx', source).imports.some(
+    (sourceImport) => sourceImport.runtime && supabaseRuntimeSpecifiers.has(sourceImport.specifier),
+  )
+}
+
+describe('browser Supabase access guard', () => {
+  it('keeps Supabase runtime clients out of browser-reachable modules', () => {
+    expect(findBrowserSupabaseAccessViolations(createSourceModules())).toEqual([])
+  })
+
+  it('ignores type-only Supabase imports', () => {
+    expect(sourceHasSupabaseRuntimeImport(`
+      'use client'
+      import { useMemo } from 'react'
+      import type { SupabaseClient } from '@supabase/supabase-js'
+      import { type SupabaseClient as InlineTypeClient } from '@supabase/supabase-js'
+    `)).toBe(false)
+  })
+
+  it('detects runtime Supabase imports', () => {
+    expect(sourceHasSupabaseRuntimeImport(`
+      'use client'
+      import {
+        getServiceRoleClient,
+      } from '@/lib/supabase'
+    `)).toBe(true)
+    expect(sourceHasSupabaseRuntimeImport("const supabase = require('@supabase/supabase-js')")).toBe(true)
+    expect(sourceHasSupabaseRuntimeImport("const supabase = await import('@/lib/supabase')")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- audited non-API/non-server source imports for direct Supabase runtime usage
- confirmed current browser-reachable modules do not import `@/lib/supabase` or `@supabase/supabase-js` at runtime
- added a TypeScript-AST import-graph regression test rooted at every `use client` source file to keep Supabase runtime clients out of browser bundles while allowing type-only imports
- guard covers static imports, dynamic `import()`, and `require()` calls

## Validation
- `pnpm test tests/unit/browser-supabase-access.test.ts tests/unit/api-route-standards.test.ts tests/unit/supabase.test.ts`
- `git diff --check`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm build`

No UI/runtime behavior changed.