### PR TITLE
[codex] Cache student notification reads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,24 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-12 — Startup orient-only mode and fast verify-env
-
-**Completed:**
-- Added `--orient-only` / `--read-only` support to `.codex/skills/pika-session-start/scripts/session_start.sh` so report-only and docs-only runs can load startup context without mutating `.env.local` or running `verify-env.sh`.
-- Changed `scripts/verify-env.sh` so the default path stops after environment and dependency checks; test execution now requires `--tests` or `--full`.
-- Updated startup guidance in `.ai/START-HERE.md`, `.codex/prompts/session-start.md`, `.claude/commands/session-start.md`, `AGENTS.md`, and the `pika-session-start` skill to document the read-only startup path and the new verify-env modes.
-- Extended `tests/unit/ai-startup-docs.test.ts` to lock the non-mutating orient-only behavior, the fast default `verify-env.sh` path, and the startup-doc references.
-
-**Validation:**
-- `pnpm install --frozen-lockfile`
-- `bash scripts/verify-env.sh --help`
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh --help`
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts`
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh --orient-only`
-- `bash scripts/verify-env.sh`
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `git diff --check`
-
 ## 2026-06-12 — Skill progression workflow hardening
 
 **Completed:**
@@ -782,6 +764,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `rg -n "@/lib/supabase|@supabase/supabase-js|getSupabaseClient|getServiceRoleClient" src/app src/components src/hooks src/lib src/ui --glob '*.{ts,tsx}' --glob '!src/app/api/**' --glob '!src/lib/server/**'`
 - `pnpm test tests/unit/browser-supabase-access.test.ts tests/unit/api-route-standards.test.ts tests/unit/supabase.test.ts`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+
+## 2026-06-20 — Student notification read-cache audit
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the client read-cache drift slice.
+- Audited client GET reads for repeated classroom-scoped requests and identified student notification reads as a concrete fix-now item.
+- Wrapped `StudentNotificationsProvider` notification GETs in `fetchJSONWithCache` with a short classroom-scoped TTL so same-classroom mounts/focus reads dedupe.
+- Invalidated the classroom notification cache when local notification helpers mark/decrement counts and before explicit `refresh()` so quick remounts or manual refreshes cannot replay stale pre-action counts.
+- Added regression coverage for simultaneous same-classroom provider reads, explicit refresh freshness, and post-local-update remount freshness.
+- No UI layout or styling changed.
+
+**Validation:**
+- `pnpm test tests/components/StudentNotificationsProvider.test.tsx`
 - `git diff --check`
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/components/StudentNotificationsProvider.tsx
+++ b/src/components/StudentNotificationsProvider.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 
 type NotificationState = {
   hasTodayEntry: boolean
@@ -25,6 +26,18 @@ type NotificationState = {
 }
 
 const NotificationsContext = createContext<NotificationState | null>(null)
+const NOTIFICATIONS_CACHE_TTL_MS = 15_000
+
+type StudentNotificationsResponse = {
+  hasTodayEntry: boolean
+  unviewedAssignmentsCount: number
+  activeTestsCount?: number
+  unreadAnnouncementsCount?: number
+}
+
+function getStudentNotificationsCacheKey(classroomId: string): string {
+  return `student-notifications:${classroomId}`
+}
 
 export function StudentNotificationsProvider({
   classroomId,
@@ -43,12 +56,18 @@ export function StudentNotificationsProvider({
 
   const fetchNotifications = useCallback(async () => {
     try {
-      const res = await fetch(`/api/student/notifications?classroom_id=${classroomId}`)
-      if (!res.ok) {
-        console.error('Failed to fetch notifications:', res.status)
-        return
-      }
-      const data = await res.json()
+      const data = await fetchJSONWithCache<StudentNotificationsResponse>(
+        getStudentNotificationsCacheKey(classroomId),
+        async () => {
+          const res = await fetch(`/api/student/notifications?classroom_id=${classroomId}`)
+          if (!res.ok) {
+            console.error('Failed to fetch notifications:', res.status)
+            throw new Error('Failed to fetch notifications')
+          }
+          return res.json()
+        },
+        NOTIFICATIONS_CACHE_TTL_MS,
+      )
       setHasTodayEntry(data.hasTodayEntry)
       setUnviewedAssignmentsCount(data.unviewedAssignmentsCount)
       setActiveTestsCount(data.activeTestsCount ?? 0)
@@ -75,26 +94,35 @@ export function StudentNotificationsProvider({
     return () => window.removeEventListener('focus', onFocus)
   }, [fetchNotifications, FOCUS_COOLDOWN_MS])
 
+  const invalidateNotificationsCache = useCallback(() => {
+    invalidateCachedJSON(getStudentNotificationsCacheKey(classroomId))
+  }, [classroomId])
+
   const refresh = useCallback(async () => {
+    invalidateNotificationsCache()
     setLoading(true)
     await fetchNotifications()
-  }, [fetchNotifications])
+  }, [fetchNotifications, invalidateNotificationsCache])
 
   const markTodayComplete = useCallback(() => {
+    invalidateNotificationsCache()
     setHasTodayEntry(true)
-  }, [])
+  }, [invalidateNotificationsCache])
 
   const decrementUnviewedCount = useCallback(() => {
+    invalidateNotificationsCache()
     setUnviewedAssignmentsCount((prev) => Math.max(0, prev - 1))
-  }, [])
+  }, [invalidateNotificationsCache])
 
   const decrementActiveTestsCount = useCallback(() => {
+    invalidateNotificationsCache()
     setActiveTestsCount((prev) => Math.max(0, prev - 1))
-  }, [])
+  }, [invalidateNotificationsCache])
 
   const markAnnouncementsRead = useCallback(() => {
+    invalidateNotificationsCache()
     setUnreadAnnouncementsCount(0)
-  }, [])
+  }, [invalidateNotificationsCache])
 
   const value = useMemo<NotificationState>(
     () => ({

--- a/tests/components/StudentNotificationsProvider.test.tsx
+++ b/tests/components/StudentNotificationsProvider.test.tsx
@@ -4,6 +4,7 @@ import {
   StudentNotificationsProvider,
   useStudentNotifications,
 } from '@/components/StudentNotificationsProvider'
+import { invalidateCachedJSONMatching } from '@/lib/request-cache'
 
 function notificationFetchCalls(fetchMock: ReturnType<typeof vi.fn>) {
   return fetchMock.mock.calls.filter(
@@ -38,12 +39,22 @@ describe('StudentNotificationsProvider', () => {
     )
   }
 
+  function RefreshProbe() {
+    const notifications = useStudentNotifications()
+    return (
+      <button type="button" onClick={() => void notifications?.refresh()}>
+        tests:{notifications?.activeTestsCount ?? 0}
+      </button>
+    )
+  }
+
   beforeEach(() => {
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
 
   afterEach(() => {
+    invalidateCachedJSONMatching('student-notifications:')
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -58,6 +69,85 @@ describe('StudentNotificationsProvider', () => {
 
     await waitFor(() => {
       expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+    })
+  })
+
+  it('deduplicates simultaneous same-classroom notification reads', async () => {
+    let resolveFetch: (value: Response) => void = () => {}
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve
+      }),
+    )
+
+    render(
+      <>
+        <StudentNotificationsProvider classroomId="c1">
+          <div />
+        </StudentNotificationsProvider>
+        <StudentNotificationsProvider classroomId="c1">
+          <div />
+        </StudentNotificationsProvider>
+      </>
+    )
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(1)
+    })
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({
+          hasTodayEntry: true,
+          unviewedAssignmentsCount: 0,
+          activeTestsCount: 0,
+          unreadAnnouncementsCount: 0,
+        }),
+      } as Response)
+    })
+  })
+
+  it('bypasses cached notifications on explicit refresh', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          hasTodayEntry: true,
+          unviewedAssignmentsCount: 0,
+          activeTestsCount: 2,
+          unreadAnnouncementsCount: 0,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          hasTodayEntry: true,
+          unviewedAssignmentsCount: 0,
+          activeTestsCount: 1,
+          unreadAnnouncementsCount: 0,
+        }),
+      })
+
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <RefreshProbe />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('tests:2')
+    })
+
+    await act(async () => {
+      document.querySelector('button')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+    })
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(2)
+      expect(document.body).toHaveTextContent('tests:1')
     })
   })
 
@@ -143,5 +233,57 @@ describe('StudentNotificationsProvider', () => {
     })
 
     expect(document.body).toHaveTextContent('tests:1')
+  })
+
+  it('invalidates cached notifications after local count updates', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hasTodayEntry: true,
+        unviewedAssignmentsCount: 0,
+        activeTestsCount: 2,
+        unreadAnnouncementsCount: 0,
+      }),
+    })
+
+    const { unmount } = render(
+      <StudentNotificationsProvider classroomId="c1">
+        <NotificationProbe />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('tests:2')
+    })
+
+    act(() => {
+      document.querySelector('button')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+    })
+
+    expect(document.body).toHaveTextContent('tests:1')
+    unmount()
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hasTodayEntry: true,
+        unviewedAssignmentsCount: 0,
+        activeTestsCount: 1,
+        unreadAnnouncementsCount: 0,
+      }),
+    })
+
+    render(
+      <StudentNotificationsProvider classroomId="c1">
+        <NotificationProbe />
+      </StudentNotificationsProvider>
+    )
+
+    await waitFor(() => {
+      expect(notificationFetchCalls(fetchMock)).toHaveLength(2)
+      expect(document.body).toHaveTextContent('tests:1')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- audited client read-cache drift and identified student notification reads as a repeated classroom-scoped GET
- wrapped `StudentNotificationsProvider` notification reads in `fetchJSONWithCache` with a short classroom-scoped TTL
- invalidates the classroom notification cache after local mark/decrement helpers and before explicit `refresh()` so quick remounts/manual refreshes cannot replay stale pre-action counts
- added regression coverage for same-classroom request dedupe, explicit refresh freshness, and post-local-update remount freshness

## Validation
- `pnpm test tests/components/StudentNotificationsProvider.test.tsx`
- `git diff --check`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm build`

No UI layout or styling changed.