### PR TITLE
Improve dropdown accessibility state

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,19 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-12 — Skill progression workflow hardening
-
-**Completed:**
-- Added a new UI acceptance brief guide so non-trivial UI work records the target surface, reference, roles, viewports, themes, states, primary signal, and out-of-scope treatments before coding.
-- Added schema rollout and component refactor checklists to make migration/query-shape PRs and large TSX extraction PRs declare rollout risk, fallback expectations, and shared-component boundaries up front.
-- Updated AI routing, session-start, issue-worker, agent-role, UI canon, and UI verification guidance so the acceptance brief plus role/viewport/theme/state verification matrix are part of the default workflow.
-- Added explicit specialist-skill trigger guidance for `product-design:get-context`, `pika-ui-verify`, `supabase:supabase-postgres-best-practices`, and `vercel:react-best-practices`.
-
-**Validation:**
-- Reviewed diffs for `docs/ai-instructions.md`, `.codex/prompts/session-start.md`, `docs/guides/ai-ui-testing.md`, `.codex/prompts/ui-verify.md`, `.codex/skills/pika-ui-verify/SKILL.md`, `docs/core/agents.md`, `docs/issue-worker.md`, and the new guidance docs.
-- `node scripts/trim-session-log.mjs`
-- `node scripts/trim-session-log.mjs --check`
-
 ## 2026-06-09 — Classwork action chooser pilot
 
 **Completed:**
@@ -785,3 +772,28 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm build`
+
+## 2026-06-20 — Composite widget accessibility audit
+
+**Completed:**
+- Continued the bounded systems/UI audit program with the composite-widget accessibility slice.
+- Audited shared menu/listbox widgets and identified a concrete fix-now issue in the `useDropdownNav` consumers: closed account/classroom dropdown surfaces stayed exposed in the accessibility tree, and Escape/outside close did not return focus to the trigger.
+- Added a trigger ref and focus restoration path to `useDropdownNav` for Escape, outside click, and trigger-close behavior.
+- Marked closed `UserMenu` and `ClassroomDropdown` menu/listbox surfaces with `aria-hidden` while preserving their existing visual transitions.
+- Added semantic regression coverage for closed menus being unavailable by role and focus restoration after Escape/outside close.
+
+**Accessibility checklist:**
+- checklist reviewed: yes
+- keyboard behavior covered: yes
+- semantic state covered by tests: yes
+- remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/ClassroomDropdown.test.tsx tests/components/UserMenu.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+- Additional open-state visual verification: reviewed `/tmp/pika-user-menu-open.png` and `/tmp/pika-classroom-dropdown-open.png`.
+- `pnpm test` (308 files / 2742 tests)

--- a/src/components/ClassroomDropdown.tsx
+++ b/src/components/ClassroomDropdown.tsx
@@ -63,6 +63,7 @@ export function ClassroomDropdown({
     handleTriggerKeyDown,
     handleItemKeyDown,
     handleTriggerClick,
+    triggerRef,
     itemRefs,
     containerRef,
     setIsOpen,
@@ -99,6 +100,7 @@ export function ClassroomDropdown({
       {/* Trigger */}
       <button
         id={triggerId}
+        ref={triggerRef}
         type="button"
         onPointerDown={() => {
           if (openingClassroomId) return
@@ -139,6 +141,7 @@ export function ClassroomDropdown({
         }`}
         role="listbox"
         aria-labelledby={triggerId}
+        aria-hidden={!isOpen}
       >
         {classrooms.map((classroom, index) => {
           const isCurrent = classroom.id === currentClassroom?.id

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -88,6 +88,7 @@ export function UserMenu({ user }: UserMenuProps) {
     handleTriggerKeyDown,
     handleItemKeyDown,
     handleTriggerClick,
+    triggerRef,
     itemRefs,
     containerRef,
   } = useDropdownNav({
@@ -116,6 +117,7 @@ export function UserMenu({ user }: UserMenuProps) {
       {/* Avatar trigger */}
       <button
         id={triggerId}
+        ref={triggerRef}
         onClick={handleTriggerClick}
         onKeyDown={handleTriggerKeyDown}
         className="flex items-center justify-center w-8 h-8 rounded-full transition-all hover:ring-2 hover:ring-border-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
@@ -143,6 +145,7 @@ export function UserMenu({ user }: UserMenuProps) {
         }`}
         role="menu"
         aria-labelledby={triggerId}
+        aria-hidden={!isOpen}
       >
         {/* User info section */}
         <div className="px-4 py-3 border-b border-border">

--- a/src/hooks/use-dropdown-nav.ts
+++ b/src/hooks/use-dropdown-nav.ts
@@ -21,6 +21,7 @@ interface UseDropdownNavReturn {
   handleTriggerKeyDown: (e: React.KeyboardEvent) => void
   handleItemKeyDown: (e: React.KeyboardEvent) => void
   handleTriggerClick: () => void
+  triggerRef: React.RefObject<HTMLButtonElement>
   itemRefs: React.MutableRefObject<(HTMLElement | null)[]>
   containerRef: React.RefObject<HTMLDivElement>
 }
@@ -39,6 +40,7 @@ export function useDropdownNav({
   const [isOpen, setIsOpen] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(-1)
   const containerRef = useRef<HTMLDivElement>(null!)
+  const triggerRef = useRef<HTMLButtonElement>(null!)
   const itemRefs = useRef<(HTMLElement | null)[]>([])
 
   // Generate unique IDs for ARIA relationships
@@ -61,15 +63,18 @@ export function useDropdownNav({
     return -1
   }, [isItemDisabled, itemCount])
 
-  const close = useCallback(() => {
+  const close = useCallback((options?: { restoreFocus?: boolean }) => {
     setIsOpen(false)
     setFocusedIndex(-1)
     onClose?.()
+    if (options?.restoreFocus) {
+      triggerRef.current?.focus()
+    }
   }, [onClose])
 
   const handleTriggerClick = useCallback(() => {
     if (isOpen) {
-      close()
+      close({ restoreFocus: true })
     } else {
       setIsOpen(true)
       setFocusedIndex(getNextEnabledIndex(initialFocusedIndex))
@@ -89,7 +94,7 @@ export function useDropdownNav({
     switch (e.key) {
       case 'Escape':
         e.preventDefault()
-        close()
+        close({ restoreFocus: true })
         break
       case 'ArrowDown':
         e.preventDefault()
@@ -116,7 +121,7 @@ export function useDropdownNav({
     switch (e.key) {
       case 'Escape':
         e.preventDefault()
-        close()
+        close({ restoreFocus: true })
         break
       case 'ArrowDown':
         e.preventDefault()
@@ -149,14 +154,16 @@ export function useDropdownNav({
 
   // Close on click outside
   useEffect(() => {
+    if (!isOpen) return
+
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        close()
+        close({ restoreFocus: true })
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [close])
+  }, [close, isOpen])
 
   // Reset refs array when item count changes
   useEffect(() => {
@@ -174,6 +181,7 @@ export function useDropdownNav({
     handleTriggerKeyDown,
     handleItemKeyDown,
     handleTriggerClick,
+    triggerRef,
     itemRefs,
     containerRef,
   }

--- a/tests/components/ClassroomDropdown.test.tsx
+++ b/tests/components/ClassroomDropdown.test.tsx
@@ -38,7 +38,8 @@ describe('ClassroomDropdown', () => {
     const trigger = screen.getByRole('button', { name: 'Select classroom' })
     fireEvent.mouseEnter(trigger)
 
-    expect(screen.getByRole('listbox')).toHaveClass('pointer-events-none')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(document.getElementById(trigger.getAttribute('aria-controls') ?? '')).toHaveAttribute('aria-hidden', 'true')
 
     pointerClick(trigger)
 
@@ -140,5 +141,54 @@ describe('ClassroomDropdown', () => {
     fireEvent.keyDown(gamma, { key: 'Enter' })
 
     expect(push).toHaveBeenCalledWith('/classrooms/class-3?tab=attendance')
+  })
+
+  it('closes with Escape and outside click while restoring focus to the trigger', () => {
+    render(
+      <ClassroomDropdown
+        classrooms={classrooms}
+        currentClassroomId="class-2"
+        currentTab="attendance"
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Select classroom' })
+    pointerClick(trigger)
+    const alpha = screen.getByRole('option', { name: /Alpha/ })
+    expect(alpha).toHaveFocus()
+
+    fireEvent.keyDown(alpha, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+
+    pointerClick(trigger)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('does not steal focus on outside clicks while closed', () => {
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <ClassroomDropdown
+          classrooms={classrooms}
+          currentClassroomId="class-2"
+          currentTab="attendance"
+        />
+      </>
+    )
+
+    const outsideTarget = screen.getByRole('button', { name: 'Outside target' })
+    outsideTarget.focus()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(outsideTarget).toHaveFocus()
+    expect(screen.getByRole('button', { name: 'Select classroom' })).not.toHaveFocus()
   })
 })

--- a/tests/components/UserMenu.test.tsx
+++ b/tests/components/UserMenu.test.tsx
@@ -12,6 +12,15 @@ function renderUserMenu() {
 }
 
 describe('UserMenu', () => {
+  it('keeps the closed account menu out of the accessibility tree', () => {
+    renderUserMenu()
+
+    const trigger = screen.getByRole('button', { name: 'User menu' })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(document.getElementById(trigger.getAttribute('aria-controls') ?? '')).toHaveAttribute('aria-hidden', 'true')
+  })
+
   it('keeps display preferences out of the account menu', async () => {
     renderUserMenu()
 
@@ -21,5 +30,46 @@ describe('UserMenu', () => {
     expect(screen.getByRole('menuitem', { name: /dark mode|light mode|toggle theme/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Send Feedback' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Logout' })).toBeInTheDocument()
+  })
+
+  it('closes with Escape and outside click while restoring focus to the trigger', () => {
+    renderUserMenu()
+
+    const trigger = screen.getByRole('button', { name: 'User menu' })
+    fireEvent.click(trigger)
+    const themeToggle = screen.getByRole('menuitem', { name: /dark mode|light mode|toggle theme/i })
+    expect(themeToggle).toHaveFocus()
+
+    fireEvent.keyDown(themeToggle, { key: 'Escape' })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+
+    fireEvent.click(trigger)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('does not steal focus on outside clicks while closed', () => {
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <ThemeProvider>
+          <UserMenu user={{ email: 'teacher@example.com', role: 'teacher' }} />
+        </ThemeProvider>
+      </>,
+    )
+
+    const outsideTarget = screen.getByRole('button', { name: 'Outside target' })
+    outsideTarget.focus()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(outsideTarget).toHaveFocus()
+    expect(screen.getByRole('button', { name: 'User menu' })).not.toHaveFocus()
   })
 })


### PR DESCRIPTION
## Summary
- hide closed classroom/account dropdown surfaces from the accessibility tree while preserving visual transitions
- restore focus to the dropdown trigger after Escape, outside click, and trigger-close behavior in the shared dropdown hook
- only register outside-click focus restoration while dropdowns are open, avoiding closed-widget focus stealing
- add semantic regression coverage for closed-role visibility, focus restoration after close, and no focus stealing while closed

## Composite widget accessibility
- checklist reviewed: yes
- keyboard behavior covered: yes
- semantic state covered by tests: yes
- remaining manual follow-up: none

## Review follow-up
- Fixed P2 review finding: closed dropdowns no longer run outside-click focus restoration.

## Validation
- pnpm test tests/components/ClassroomDropdown.test.tsx tests/components/UserMenu.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm build
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms
- open-state visual checks for /tmp/pika-user-menu-open.png and /tmp/pika-classroom-dropdown-open.png
- pnpm test (308 files / 2742 tests, before review follow-up)