### PR TITLE
[codex] Add teacher exam telemetry e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,13 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-12 — Assignment Layout Tooltip Copy
-
-- Changed the selected Assignment layout cycle tooltip to the concise copy `Toggle Layout`.
-- Left the accessible button label unchanged so screen reader users still hear the current layout context.
-- Verified with `bash scripts/verify-env.sh`, `pnpm exec tsc --noEmit --pretty false`, and `pnpm test tests/components/TeacherClassroomView.test.tsx`.
-- Playwright hover screenshot confirmed the tooltip renders exactly `Toggle Layout` and the previous dynamic `Layout: … Next: …` copy is gone.
-
 ## 2026-06-12 — Action Cluster PR Rebase
 
 - Rebased `codex/action-cluster-classwork` onto `origin/main` and resolved the `TeacherTestsTab.test.tsx` helper import conflict by keeping `createMockTest` plus the branch's `Classroom` typing.
@@ -747,3 +740,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
 - `pnpm lint`
 - Note: `E2E_BASE_URL=http://127.0.0.1:3101 ...` failed in auth setup with teacher login `Failed to fetch`; rerunning on `localhost:3101` passed.
+
+## 2026-06-21 — Teacher telemetry E2E review fix
+
+**Completed:**
+- Addressed review feedback on PR #815 by loosening the teacher grading-row away-duration assertion so valid one-away-session durations above nine seconds do not make the E2E flaky.
+- Kept the API-side `away_total_seconds >= 1` assertion as the source of truth for nonzero away time.
+
+**Validation:**
+- `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,69 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-09 — Classwork action chooser pilot
-
-**Completed:**
-- Added a reusable teacher work-surface action cluster with menu and icon-menu buttons for contextual FAB-style action areas.
-- Replaced the Classwork summary split button with `New Classwork` as a chooser for Assignment, Material, and Survey.
-- Moved `Edit list controls` and `Edit Markdown` behind a separate icon-only `Classwork options` pencil menu.
-- Renamed list management to `Organize classwork` and added `Done Organizing`.
-- Aligned Tests with the same action-cluster pattern: direct `New Test`, icon-only `Test options` pencil menu, `Organize tests`, and `Done Organizing`.
-- Updated the classroom list pencil control accessibility/tooltip language to `Organize classrooms`.
-- Removed subtitles from the Classwork/Test dropdown menus and switched the Assignment menu icon to the Classwork `ClipboardList` icon.
-- Switched the Material menu icon to Lucide `Paperclip`.
-- Deferred the organize-mode jiggle animation after visual review; no jiggle code ships in this PR.
-- Updated Classwork tests to exercise the new chooser/options menu semantics.
-- Fixed the PR CI failure in `StudentHistoryPage.test.tsx` by waiting for the async history-loading effect before asserting class-day and entry fetch calls.
-- Addressed review feedback by disabling the Classwork/Test options icon buttons in archived/read-only classrooms instead of opening dead disabled menus.
-- Replaced Classwork/Test options dropdowns with direct pencil organize toggles and moved Classwork markdown editing to a separate `Code` icon button shown only while organize mode is active and markdown editing is enabled.
-- Moved selected Assignment/Test edit actions out of their subshell dropdowns into direct pencil icon buttons beside the primary selected-item FABs.
-- Split the selected Assignment layout control out of the AI Grade split button into a standalone cycle button showing paired pane icons (`Menu`, `Percent`, `SquareMenu`).
-- Removed the visible number from the selected Assignment layout cycle button so it is icon-only.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/TeacherClassroomView.test.tsx`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherWorkItemPrimitives.test.tsx`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx tests/components/TeacherClassroomsIndex.test.tsx tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/SortableAssignmentCard.test.tsx tests/components/TeacherWorkItemPrimitives.test.tsx`
-- `pnpm lint`
-- `pnpm build`
-- `pnpm test tests/components/StudentHistoryPage.test.tsx`
-- `pnpm run test:coverage`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- `NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=placeholder-publishable-key SUPABASE_SECRET_KEY=placeholder-secret-key SESSION_SECRET=placeholder-session-secret-at-least-32-chars-long pnpm build`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments'`
-- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests'`
-- Playwright screenshot: active Classwork organize mode with pencil toggle selected and Markdown code button visible.
-- Playwright screenshots: teacher/student/mobile Classwork verify flow, Classwork pencil menu/organize mode, Tests pencil menu/organize mode, classroom list organize mode, and mobile Tests/classroom organize states.
-- Playwright screenshots confirmed compact no-subtitle Classwork and Tests dropdown menus.
-- Playwright screenshot confirmed the Classwork menu renders the Material paperclip icon.
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherTestsTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
-- `E2E_BASE_URL=http://localhost:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=tests&testId=91d01b50-807d-43ac-a5db-018c9645ac94&testMode=grading'`
-- Playwright screenshots confirmed selected Assignment/Test subshell action areas show a separate pencil edit button beside the primary split FAB on desktop and mobile.
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- `E2E_BASE_URL=http://localhost:3100 bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh 'classrooms/e80aa794-e2d6-4705-9da5-d08ab0fba861?tab=assignments&assignmentId=71f8b37f-831b-4e90-89f9-f04981a97d6a&assignmentStudentId=d8f8a040-c511-4da2-98a8-be5bca37e1a6'`
-- Playwright screenshots confirmed the selected Assignment layout cycle button renders the students+grading and content+grading icon pairs cleanly on desktop/mobile.
-- `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
-- `npx tsc --noEmit`
-- `pnpm lint`
-- Playwright screenshot confirmed the selected Assignment layout cycle button has no visible number/index label.
-
 ## 2026-06-12 — Assignment Layout Tooltip Copy
 
 - Changed the selected Assignment layout cycle tooltip to the concise copy `Toggle Layout`.
@@ -797,3 +734,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh classrooms`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
 - Additional open-state visual verification: reviewed `/tmp/pika-user-menu-open.png` and `/tmp/pika-classroom-dropdown-open.png`.
 - `pnpm test` (308 files / 2742 tests)
+
+## 2026-06-21 — Teacher exam telemetry E2E coverage
+
+**Completed:**
+- Added a focused Playwright teacher exam-mode flow that creates an active open-response test, has the seeded student generate one route-exit attempt, one window/full-screen exit, and one away/focus event, then verifies the teacher grading row distinguishes those telemetry categories.
+- Reused existing teacher/student storage state setup and API-backed test creation/cleanup patterns; no app logic, migrations, or dependencies changed.
+- Selected this flow because student exam-mode E2E already covered lock/restoration/draft preservation, while teacher-side telemetry visibility remained a bounded exam-mode coverage gap.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
+- `pnpm lint`
+- Note: `E2E_BASE_URL=http://127.0.0.1:3101 ...` failed in auth setup with teacher login `Failed to fetch`; rerunning on `localhost:3101` passed.

--- a/e2e/teacher-exam-mode.spec.ts
+++ b/e2e/teacher-exam-mode.spec.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto'
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Browser, type Page } from '@playwright/test'
 
 const TEACHER_STORAGE = '.auth/teacher.json'
+const STUDENT_STORAGE = '.auth/student.json'
 
 interface ClassroomRecord {
   id: string
@@ -32,7 +33,23 @@ interface TestResultsRecord {
   students?: Array<{
     student_id: string
     effective_access?: 'open' | 'closed'
+    focus_summary?: TestFocusSummary | null
   }>
+}
+
+interface AuthMeRecord {
+  user: {
+    id: string
+    email: string
+    role: string
+  }
+}
+
+interface TestFocusSummary {
+  away_count?: number
+  away_total_seconds?: number
+  route_exit_attempts?: number
+  window_unmaximize_attempts?: number
 }
 
 function uniqueTitle(): string {
@@ -116,6 +133,18 @@ async function createDraftOpenResponseTest(
   return testRecord
 }
 
+async function createActiveOpenResponseTest(
+  page: Page,
+  classroomId: string,
+  title: string,
+): Promise<AssessmentRecord> {
+  const testRecord = await createDraftOpenResponseTest(page, classroomId, title)
+  await sendJson(page, 'PATCH', `/api/teacher/tests/${testRecord.id}`, {
+    status: 'active',
+  })
+  return testRecord
+}
+
 async function createDraftTestInClassroomWithStudents(page: Page, title: string): Promise<{
   classroom: ClassroomRecord
   testRecord: AssessmentRecord
@@ -143,9 +172,58 @@ async function createDraftTestInClassroomWithStudents(page: Page, title: string)
   throw new Error('No seeded teacher classroom has enrolled students.')
 }
 
+async function withStudentPage<T>(
+  browser: Browser,
+  callback: (page: Page) => Promise<T>,
+): Promise<T> {
+  const context = await browser.newContext({ storageState: STUDENT_STORAGE })
+  const page = await context.newPage()
+  try {
+    await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+    return await callback(page)
+  } finally {
+    await context.close()
+  }
+}
+
+async function findSharedClassroom(studentPage: Page, teacherPage: Page): Promise<ClassroomRecord> {
+  const [studentData, teacherData] = await Promise.all([
+    loadJson<{ classrooms?: ClassroomRecord[] }>(studentPage, '/api/student/classrooms'),
+    loadJson<{ classrooms?: ClassroomRecord[] }>(teacherPage, '/api/teacher/classrooms'),
+  ])
+
+  const teacherClassroomIds = new Set((teacherData.classrooms || []).map((classroom) => classroom.id))
+  const sharedClassroom = (studentData.classrooms || []).find((classroom) =>
+    teacherClassroomIds.has(classroom.id)
+  )
+
+  expect(
+    sharedClassroom,
+    'Seed teacher and student auth users with at least one shared classroom before running teacher telemetry e2e tests.',
+  ).toBeTruthy()
+  return sharedClassroom!
+}
+
 async function cleanupTest(page: Page, testId: string | null): Promise<void> {
   if (!testId) return
   await sendJson(page, 'DELETE', `/api/teacher/tests/${testId}`).catch(() => undefined)
+}
+
+async function prepareExamWindowForViewportCompliance(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: () => Promise.resolve(),
+    })
+    Object.defineProperty(window.screen, 'availWidth', {
+      configurable: true,
+      value: 1440,
+    })
+    Object.defineProperty(window.screen, 'availHeight', {
+      configurable: true,
+      value: 900,
+    })
+  })
 }
 
 function getResultsStatus(results: TestResultsRecord): 'draft' | 'active' | 'closed' | undefined {
@@ -227,6 +305,93 @@ test.describe('teacher exam mode', () => {
       await expect(testCard.getByLabel('0 open')).toBeVisible()
       await expect(testCard.getByLabel(`${studentCount} closed`)).toBeVisible()
     } finally {
+      await cleanupTest(page, testId)
+    }
+  })
+
+  test('shows student route, window, and away telemetry in the grading row', async ({ browser, page }) => {
+    test.setTimeout(120_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const { classroom, studentId } = await withStudentPage(browser, async (studentPage) => {
+        const shared = await findSharedClassroom(studentPage, page)
+        const testRecord = await createActiveOpenResponseTest(page, shared.id, testTitle)
+        testId = testRecord.id
+
+        const currentStudent = await loadJson<AuthMeRecord>(studentPage, '/api/auth/me')
+
+        await studentPage.goto(`/classrooms/${shared.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+        await studentPage.getByRole('button', { name: new RegExp(escapeRegExp(testTitle)) }).first().click()
+        await prepareExamWindowForViewportCompliance(studentPage)
+
+        await studentPage.getByRole('button', { name: 'Start the Test' }).click()
+        await studentPage.getByRole('button', { name: 'Start test' }).click()
+
+        const splitShell = studentPage.locator('[data-testid="student-test-split-container"]')
+        await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+        const responseBox = studentPage.locator('textarea[placeholder="Write your response..."]')
+        await expect(responseBox).toBeVisible()
+        await responseBox.fill('Teacher telemetry should distinguish route, window, and focus events.')
+        await expect(studentPage.getByText('Saved')).toBeVisible({ timeout: 20_000 })
+
+        await studentPage.getByRole('link', { name: 'Home' }).click()
+        await expect(studentPage).toHaveURL(new RegExp(`/classrooms/${escapeRegExp(shared.id)}\\?tab=tests`))
+
+        await studentPage.setViewportSize({ width: 900, height: 500 })
+        await expect(studentPage.locator('[data-testid="exam-content-obscurer"]')).toBeVisible({ timeout: 5_000 })
+        await studentPage.setViewportSize({ width: 1440, height: 900 })
+        await expect(studentPage.locator('[data-testid="exam-content-obscurer"]')).toHaveCount(0)
+
+        await studentPage.evaluate(() => window.dispatchEvent(new Event('blur')))
+        await studentPage.waitForTimeout(1100)
+        await studentPage.evaluate(() => window.dispatchEvent(new Event('focus')))
+
+        await expect.poll(async () => {
+          if (!testId) return { awayCount: 0, awaySeconds: 0, routeExits: 0, windowExits: 0 }
+          const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testId}/results`)
+          const student = (results.students || []).find((candidate) => candidate.student_id === currentStudent.user.id)
+          return {
+            awayCount: student?.focus_summary?.away_count ?? 0,
+            awaySeconds: student?.focus_summary?.away_total_seconds ?? 0,
+            routeExits: student?.focus_summary?.route_exit_attempts ?? 0,
+            windowExits: student?.focus_summary?.window_unmaximize_attempts ?? 0,
+          }
+        }).toEqual({
+          awayCount: 1,
+          awaySeconds: expect.any(Number),
+          routeExits: 1,
+          windowExits: 1,
+        })
+
+        await expect.poll(async () => {
+          if (!testId) return 0
+          const results = await loadJson<TestResultsRecord>(page, `/api/teacher/tests/${testId}/results`)
+          const student = (results.students || []).find((candidate) => candidate.student_id === currentStudent.user.id)
+          return student?.focus_summary?.away_total_seconds ?? 0
+        }).toBeGreaterThanOrEqual(1)
+
+        return { classroom: shared, studentId: currentStudent.user.id }
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests&testId=${testId}&testMode=grading`, {
+        waitUntil: 'domcontentloaded',
+      })
+
+      const gradingRow = page.getByTestId(`test-grading-student-row-${studentId}`)
+      await expect(gradingRow).toBeVisible({ timeout: 15_000 })
+      await expect(
+        gradingRow.getByLabel(/Exits [1-9]\. Away\/focus 1, in-app exits 1, window\/full-screen exits 1\./),
+      ).toBeVisible()
+      await expect(
+        gradingRow.getByLabel(/Away time 0:0[1-9]\. Away from test route for 0:0[1-9] total\./),
+      ).toBeVisible()
+    } finally {
+      await page.setViewportSize({ width: 1440, height: 900 }).catch(() => undefined)
       await cleanupTest(page, testId)
     }
   })

--- a/e2e/teacher-exam-mode.spec.ts
+++ b/e2e/teacher-exam-mode.spec.ts
@@ -387,8 +387,14 @@ test.describe('teacher exam mode', () => {
       await expect(
         gradingRow.getByLabel(/Exits [1-9]\. Away\/focus 1, in-app exits 1, window\/full-screen exits 1\./),
       ).toBeVisible()
+      const positiveAwayDurationPattern = '(?:0:0[1-9]|0:[1-5]\\d|[1-9]\\d*:[0-5]\\d)'
       await expect(
-        gradingRow.getByLabel(/Away time 0:0[1-9]\. Away from test route for 0:0[1-9] total\./),
+        gradingRow.getByLabel(
+          new RegExp(
+            `Away time ${positiveAwayDurationPattern}\\. ` +
+              `Away from test route for ${positiveAwayDurationPattern} total\\.`,
+          ),
+        ),
       ).toBeVisible()
     } finally {
       await page.setViewportSize({ width: 1440, height: 900 }).catch(() => undefined)


### PR DESCRIPTION
## Selected flow
Teacher exam mode: a seeded student starts an active open-response test, triggers one blocked route exit, one sustained window/full-screen compliance loss, and one away/focus session, then the teacher grading row is verified for distinct telemetry categories.

This was chosen because existing student exam-mode E2E coverage already exercises lock/restoration/draft preservation and route/focus/window student telemetry, while teacher-side grading visibility for those telemetry distinctions was a bounded remaining gap.

## Risk profile
exam-mode

## Tests added or updated
- Updated `e2e/teacher-exam-mode.spec.ts` with `shows student route, window, and away telemetry in the grading row`.
- Reused existing auth storage, API-backed test creation, and cleanup patterns.

## Commands run
- `bash scripts/verify-env.sh`
- `pnpm install` (required because `node_modules` was missing; lockfile unchanged)
- `E2E_BASE_URL=http://localhost:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`

Also attempted `E2E_BASE_URL=http://127.0.0.1:3101 pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`; teacher auth setup failed with a login `Failed to fetch` form error. Rerunning against `localhost:3101` passed.

## Seeded-data assumptions
- `teacher@example.com` and `student1@example.com` can authenticate with the standard E2E password.
- The seeded teacher and student share at least one classroom.
- The teacher can create/delete tests through existing API routes in that shared classroom.

## Residual coverage gaps
- This does not cover teacher telemetry after submitted/returned tests.
- This does not assert the exact aggregate `exit_count` because route/window/away events are burst-deduplicated; it asserts the distinct subcounts and visible away duration.
- The passing run emitted a server warning for a duplicate test-attempt insert during the student start flow; this patch documents but does not investigate that existing behavior.