### PR TITLE
Guard classroom async state

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,11 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-12 — Action Cluster PR Rebase
-
-- Rebased `codex/action-cluster-classwork` onto `origin/main` and resolved the `TeacherTestsTab.test.tsx` helper import conflict by keeping `createMockTest` plus the branch's `Classroom` typing.
-- Verified the rebased branch with `pnpm test tests/components/TeacherClassroomView.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx tests/components/TeacherTestsTab.test.tsx` and `pnpm exec tsc --noEmit --pretty false`.
-
 ## 2026-06-13 — Weekly Simplification: Test Response Normalization
 
 - Selected the student test-taking response normalization path in `src/lib/test-attempts.ts` as the hotspot because it handled several legacy payload shapes with duplicated coercion branches used by both form and API routes.
@@ -752,3 +747,31 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-21 — Stale async classroom-state audit
+
+**Completed:**
+- Continued the bounded systems/UI audit with the stale async classroom/workspace state slice.
+- Fixed `StudentLessonCalendarTab` so lesson plans, assignments, announcements, and max-date state clear on classroom changes and only current classroom request ids can write visible state.
+- Fixed `TeacherTestsTab` so the tests list and selected/grading workspace state reset on classroom changes, and late `/api/teacher/tests?classroom_id=...` responses cannot repaint the newly selected classroom with old-classroom tests.
+- Added regression coverage for late classroom A responses arriving after a switch to classroom B in both student calendar and teacher tests flows.
+- Addressed subagent review feedback by clearing owner-scoped teacher test modal/action state on classroom changes, including delete/edit/batch/status/access/return/unsubmit/delete-work pending state, and by ignoring late create-test responses from a previous classroom.
+- Addressed follow-up subagent review feedback by guarding create-test completion with a request id so an old classroom create cannot clear the current classroom's in-flight create state.
+
+**Workspace-state checklist:**
+- owner identity: classroom id
+- late responses ignored: yes, request id plus current classroom id checks
+- state clears immediately on owner change: yes, for calendar data and teacher tests workspace state
+- owner-scoped action state clears immediately on owner change: yes
+- current-owner create busy state protected from old requests: yes
+- cache boundary checked: yes, classroom-scoped cache keys invalidated in tests
+- remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { addMonths, addWeeks, endOfMonth, format, startOfMonth, startOfWeek, subMonths, subWeeks } from 'date-fns'
 import { CalendarActionBar } from '@/components/CalendarActionBar'
 import { Spinner } from '@/components/Spinner'
@@ -25,6 +25,10 @@ export function StudentLessonCalendarTab({
   const [lessonPlans, setLessonPlans] = useState<LessonPlan[]>([])
   const [assignments, setAssignments] = useState<Assignment[]>([])
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [loadedClassroomId, setLoadedClassroomId] = useState<string | null>(null)
+  const loadRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  currentClassroomIdRef.current = classroom.id
   const classDays = useClassDays(classroom.id)
   const [loading, setLoading] = useState(true)
   const [viewMode, setViewMode] = useState<CalendarViewMode>(() => {
@@ -44,9 +48,27 @@ export function StudentLessonCalendarTab({
     end: classroom.end_date || format(endOfMonth(currentDate), 'yyyy-MM-dd'),
   }
 
+  useEffect(() => {
+    loadRequestIdRef.current += 1
+    setLessonPlans([])
+    setAssignments([])
+    setAnnouncements([])
+    setMaxDate(null)
+    setLoadedClassroomId(null)
+    setLoading(true)
+  }, [classroom.id])
+
   // Fetch lesson plans, assignments, and announcements in parallel
   useEffect(() => {
     async function loadCalendarData() {
+      const requestId = loadRequestIdRef.current + 1
+      loadRequestIdRef.current = requestId
+      const requestedClassroomId = classroom.id
+      const isCurrentLoad = () => (
+        loadRequestIdRef.current === requestId &&
+        currentClassroomIdRef.current === requestedClassroomId
+      )
+
       setLoading(true)
       try {
         const [lessonPlansData, assignmentsData, announcementsData] = await Promise.all([
@@ -87,18 +109,34 @@ export function StudentLessonCalendarTab({
             return { announcements: [] }
           }),
         ])
+        if (!isCurrentLoad()) return
         setLessonPlans(lessonPlansData.lesson_plans || [])
         setMaxDate(lessonPlansData.max_date || null)
         setAssignments(assignmentsData.assignments || [])
         setAnnouncements(announcementsData.announcements || [])
+        setLoadedClassroomId(requestedClassroomId)
       } catch (err) {
+        if (!isCurrentLoad()) return
         console.error('Error loading calendar data:', err)
+        setLessonPlans([])
+        setMaxDate(null)
+        setAssignments([])
+        setAnnouncements([])
+        setLoadedClassroomId(requestedClassroomId)
       } finally {
-        setLoading(false)
+        if (isCurrentLoad()) {
+          setLoading(false)
+        }
       }
     }
     loadCalendarData()
   }, [classroom.id, fetchRange.start, fetchRange.end])
+
+  const hasCurrentClassroomData = loadedClassroomId === classroom.id
+  const currentLessonPlans = hasCurrentClassroomData ? lessonPlans : []
+  const currentAssignments = hasCurrentClassroomData ? assignments : []
+  const currentAnnouncements = hasCurrentClassroomData ? announcements : []
+  const isLoading = loading || !hasCurrentClassroomData
 
   // Handle assignment click - navigate to assignments tab with the assignment selected
   const handleAssignmentClick = useCallback(
@@ -145,7 +183,7 @@ export function StudentLessonCalendarTab({
     handleDateChange(new Date())
   }, [handleDateChange])
 
-  if (loading && lessonPlans.length === 0) {
+  if (isLoading && currentLessonPlans.length === 0) {
     return (
       <PageLayout bleedX={false}>
         <PageContent>
@@ -173,9 +211,9 @@ export function StudentLessonCalendarTab({
         <div className="overflow-hidden rounded-lg border border-border bg-surface">
           <LessonCalendar
             classroom={classroom}
-            lessonPlans={lessonPlans}
-            assignments={assignments}
-            announcements={announcements}
+            lessonPlans={currentLessonPlans}
+            assignments={currentAssignments}
+            announcements={currentAnnouncements}
             classDays={classDays}
             viewMode={viewMode}
             currentDate={currentDate}

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -345,11 +345,16 @@ export function TeacherTestsTab({
     testId: null,
     counts: new Map(),
   })
+  const latestTestsRequestIdRef = useRef(0)
+  const latestCreateTestRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroom.id)
+  const previousClassroomIdRef = useRef(classroom.id)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
   const selectedTestIdRef = useRef<string | null>(null)
   const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(null)
 
   const [tests, setTests] = useState<TestAssessmentWithStats[]>([])
+  const [loadedTestsClassroomId, setLoadedTestsClassroomId] = useState<string | null>(null)
   const { showMessage } = useAppMessage()
   const [loading, setLoading] = useState(true)
   const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('grading')
@@ -399,6 +404,7 @@ export function TeacherTestsTab({
   const selectedStudentId =
     selectedTestStudentId !== undefined ? selectedTestStudentId : internalSelectedStudentId
   const workspaceState: WorkspaceState = selectedTestId ? 'selected' : 'list'
+  currentClassroomIdRef.current = classroom.id
   const [gradingInfo, setGradingInfo] = useState('')
   const [gradingWarning, setGradingWarning] = useState('')
   const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
@@ -445,9 +451,14 @@ export function TeacherTestsTab({
     })
   )
 
+  const hasCurrentTests = loadedTestsClassroomId === classroom.id
+  const visibleTests = useMemo(
+    () => (hasCurrentTests ? tests : []),
+    [hasCurrentTests, tests],
+  )
   const selectedTest = useMemo(
-    () => tests.find((test) => test.id === selectedTestId) ?? null,
-    [selectedTestId, tests]
+    () => visibleTests.find((test) => test.id === selectedTestId) ?? null,
+    [selectedTestId, visibleTests]
   )
   const activeTestAiRun = useMemo(() => {
     if (!selectedTestId || !testAiGradingRun) return null
@@ -586,6 +597,64 @@ export function TeacherTestsTab({
   const clearTestWorkspace = useCallback((options?: UpdateSearchOptions) => {
     navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
   }, [navigateTestWorkspace])
+
+  useEffect(() => {
+    if (previousClassroomIdRef.current === classroom.id) return
+
+    previousClassroomIdRef.current = classroom.id
+    latestTestsRequestIdRef.current += 1
+    latestCreateTestRequestIdRef.current += 1
+    latestGradingRequestIdRef.current += 1
+    setTests([])
+    setLoadedTestsClassroomId(null)
+    setLoading(true)
+    setTestEditMode(false)
+    setIsReorderingTests(false)
+    setIsCreatingTest(false)
+    setShowEditModal(false)
+    setTestEditModalView('edit')
+    setTestEditSaveStatus('saved')
+    setHasPendingMarkdownImport(false)
+    setPendingDeleteTest(null)
+    setIsDeletingTest(false)
+    setStatusActionError('')
+    setSelectedTestDraftSummary(null)
+    selectedTestDraftSummaryRef.current = null
+    setGradingStudents([])
+    setUnreviewedExitCounts({})
+    setExitAlertStudentId(null)
+    setGradingQuestions([])
+    setGradingServerTestStatus(null)
+    setGradingServerTestId(null)
+    setTestAiGradingRun(null)
+    setGradingLoading(false)
+    setGradingRefreshing(false)
+    setGradingError('')
+    setGradingInfo('')
+    setGradingWarning('')
+    setTestGradingSaveState({ canSave: false, isSaving: false, status: 'idle' })
+    setIsBatchAutoGrading(false)
+    setIsBatchReturning(false)
+    setIsBatchUnsubmitting(false)
+    setIsBatchUpdatingAccess(false)
+    setShowReturnConfirm(false)
+    setShowUnsubmitConfirm(false)
+    setPendingUnsubmitStudent(null)
+    setPendingOpenAccessStudent(null)
+    setPendingCloseAccessStudent(null)
+    setShowCloseAccessConfirm(false)
+    setPendingOpenAccessStudentIds(null)
+    setPendingCloseAccessStudentIds(null)
+    setShowBatchGradeModal(false)
+    setPendingDeleteStudentAttemptIds(null)
+    setIsDeletingStudentAttempt(false)
+    setStatusUpdating(false)
+    setCheckingActivation(false)
+    setShowActivateConfirm(false)
+    setShowCloseConfirm(false)
+    clearBatchSelection()
+    clearTestWorkspace({ replace: true })
+  }, [classroom.id, clearBatchSelection, clearTestWorkspace])
 
   const {
     scrollRef: gradingStudentTableScrollRef,
@@ -751,11 +820,19 @@ export function TeacherTestsTab({
   }, [applyTestSummaryPatch, selectedTestId])
 
   const loadTests = useCallback(async () => {
+    const requestId = latestTestsRequestIdRef.current + 1
+    latestTestsRequestIdRef.current = requestId
+    const requestedClassroomId = classroom.id
+    const isCurrentRequest = () => (
+      latestTestsRequestIdRef.current === requestId &&
+      currentClassroomIdRef.current === requestedClassroomId
+    )
+
     setLoading(true)
     try {
-      const query = new URLSearchParams({ classroom_id: classroom.id })
+      const query = new URLSearchParams({ classroom_id: requestedClassroomId })
       const data = await fetchJSONWithCache<TeacherTestListResponse>(
-        `teacher-tests:${classroom.id}`,
+        `teacher-tests:${requestedClassroomId}`,
         async () => {
           const response = await fetch(`${apiBasePath}?${query.toString()}`)
           const payload = await response.json()
@@ -764,6 +841,7 @@ export function TeacherTestsTab({
         },
         0,
       )
+      if (!isCurrentRequest()) return
       const loadedTests = readTestsFromPayload<TestAssessmentWithStats>(data)
       const currentSelectedTestId = selectedTestIdRef.current
       const currentDraftSummary = selectedTestDraftSummaryRef.current
@@ -776,10 +854,16 @@ export function TeacherTestsTab({
             )
           : loadedTests
       )
+      setLoadedTestsClassroomId(requestedClassroomId)
     } catch (error) {
+      if (!isCurrentRequest()) return
       console.error('Error loading tests:', error)
+      setTests([])
+      setLoadedTestsClassroomId(requestedClassroomId)
     } finally {
-      setLoading(false)
+      if (isCurrentRequest()) {
+        setLoading(false)
+      }
     }
   }, [classroom.id])
 
@@ -909,11 +993,11 @@ export function TeacherTestsTab({
 
   useEffect(() => {
     if (!selectedTestId || loading) return
-    if (tests.some((test) => test.id === selectedTestId)) return
+    if (visibleTests.some((test) => test.id === selectedTestId)) return
 
     clearTestWorkspace({ replace: true })
     clearBatchSelection()
-  }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, tests])
+  }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, visibleTests])
 
   useEffect(() => {
     selectedTestDraftSummaryRef.current = null
@@ -1329,12 +1413,20 @@ export function TeacherTestsTab({
   async function handleNewTest() {
     if (isCreatingTest || isReadOnly || loading) return
 
+    const requestId = latestCreateTestRequestIdRef.current + 1
+    latestCreateTestRequestIdRef.current = requestId
+    const requestedClassroomId = classroom.id
+    const isCurrentCreate = () => (
+      latestCreateTestRequestIdRef.current === requestId &&
+      currentClassroomIdRef.current === requestedClassroomId
+    )
+
     setIsCreatingTest(true)
     try {
       const response = await fetch(apiBasePath, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ classroom_id: classroom.id }),
+        body: JSON.stringify({ classroom_id: requestedClassroomId }),
       })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
@@ -1344,11 +1436,15 @@ export function TeacherTestsTab({
       if (!createdTest) {
         throw new Error('Failed to create test')
       }
+      if (!isCurrentCreate()) return
       handleTestCreated(createdTest)
     } catch (error: any) {
+      if (!isCurrentCreate()) return
       showMessage({ text: error?.message || 'Failed to create test', tone: 'warning' })
     } finally {
-      setIsCreatingTest(false)
+      if (isCurrentCreate()) {
+        setIsCreatingTest(false)
+      }
     }
   }
 
@@ -1404,11 +1500,11 @@ export function TeacherTestsTab({
       const { active, over } = event
       if (!over || active.id === over.id || isReorderingTests || isReadOnly || !testEditMode) return
 
-      const oldIndex = tests.findIndex((test) => test.id === active.id)
-      const newIndex = tests.findIndex((test) => test.id === over.id)
+      const oldIndex = visibleTests.findIndex((test) => test.id === active.id)
+      const newIndex = visibleTests.findIndex((test) => test.id === over.id)
       if (oldIndex === -1 || newIndex === -1) return
 
-      const reordered = arrayMove(tests, oldIndex, newIndex)
+      const reordered = arrayMove(visibleTests, oldIndex, newIndex)
       setTests(reordered)
       setIsReorderingTests(true)
       try {
@@ -1444,7 +1540,7 @@ export function TeacherTestsTab({
       loadTests,
       showMessage,
       testEditMode,
-      tests,
+      visibleTests,
     ]
   )
 
@@ -2584,7 +2680,7 @@ export function TeacherTestsTab({
     <div className="flex justify-center py-12">
       <Spinner size="lg" />
     </div>
-  ) : tests.length === 0 ? (
+  ) : visibleTests.length === 0 ? (
     <EmptyState
       title="No tests yet"
       description="Create a test to get started."
@@ -2598,11 +2694,11 @@ export function TeacherTestsTab({
       onDragEnd={handleTestDragEnd}
     >
       <SortableContext
-        items={tests.map((test) => test.id)}
+        items={visibleTests.map((test) => test.id)}
         strategy={verticalListSortingStrategy}
       >
         <TeacherWorkItemList>
-          {tests.map((test) => (
+          {visibleTests.map((test) => (
             <TeacherTestCard
               key={test.id}
               test={test}

--- a/tests/components/StudentLessonCalendarTab.test.tsx
+++ b/tests/components/StudentLessonCalendarTab.test.tsx
@@ -24,6 +24,9 @@ vi.mock('@/components/LessonCalendar', () => ({
       data-lesson-count={lessonPlans.length}
       data-assignment-count={assignments.length}
       data-announcement-count={announcements.length}
+      data-lesson-ids={lessonPlans.map((lesson: { id: string }) => lesson.id).join(',')}
+      data-assignment-ids={assignments.map((assignment: { id: string }) => assignment.id).join(',')}
+      data-announcement-ids={announcements.map((announcement: { id: string }) => announcement.id).join(',')}
     />
   ),
   CalendarViewMode: {},
@@ -34,12 +37,20 @@ describe('StudentLessonCalendarTab', () => {
     start_date: '2025-01-01',
     end_date: '2025-06-30',
   })
+  const secondClassroom = createMockClassroom({
+    id: 'classroom-2',
+    start_date: '2025-01-01',
+    end_date: '2025-06-30',
+  })
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     invalidateCachedJSON(`student-lesson-plans:${classroom.id}:2025-01-01:2025-06-30`)
     invalidateCachedJSON(`student-assignments:${classroom.id}`)
     invalidateCachedJSON(`student-announcements:${classroom.id}`)
+    invalidateCachedJSON(`student-lesson-plans:${secondClassroom.id}:2025-01-01:2025-06-30`)
+    invalidateCachedJSON(`student-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`student-announcements:${secondClassroom.id}`)
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -48,6 +59,9 @@ describe('StudentLessonCalendarTab', () => {
     invalidateCachedJSON(`student-lesson-plans:${classroom.id}:2025-01-01:2025-06-30`)
     invalidateCachedJSON(`student-assignments:${classroom.id}`)
     invalidateCachedJSON(`student-announcements:${classroom.id}`)
+    invalidateCachedJSON(`student-lesson-plans:${secondClassroom.id}:2025-01-01:2025-06-30`)
+    invalidateCachedJSON(`student-assignments:${secondClassroom.id}`)
+    invalidateCachedJSON(`student-announcements:${secondClassroom.id}`)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -174,5 +188,71 @@ describe('StudentLessonCalendarTab', () => {
       expect(screen.getByTestId('lesson-calendar')).toHaveAttribute('data-announcement-count', '1')
     })
     expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('ignores late calendar responses after switching classrooms', async () => {
+    type PendingFetch = {
+      url: string
+      resolve: (value: { ok: boolean; json: () => Promise<Record<string, unknown>> }) => void
+    }
+    const pending: PendingFetch[] = []
+
+    fetchMock.mockImplementation((url: string) => (
+      new Promise((resolve) => {
+        pending.push({ url, resolve: resolve as PendingFetch['resolve'] })
+      })
+    ))
+
+    function payloadFor(url: string, classroomId: string) {
+      if (url.includes('lesson-plans')) {
+        return { lesson_plans: [{ id: `${classroomId}-lesson` }], max_date: '2025-06-30' }
+      }
+      if (url.includes('assignments')) {
+        return { assignments: [{ id: `${classroomId}-assignment` }] }
+      }
+      if (url.includes('announcements')) {
+        return { announcements: [{ id: `${classroomId}-announcement` }] }
+      }
+      return {}
+    }
+
+    async function resolveClassroom(classroomId: string) {
+      await act(async () => {
+        pending
+          .filter((request) => request.url.includes(classroomId))
+          .forEach((request) => {
+            request.resolve({
+              ok: true,
+              json: async () => payloadFor(request.url, classroomId),
+            })
+          })
+        await Promise.resolve()
+      })
+    }
+
+    const view = render(<StudentLessonCalendarTab classroom={classroom} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+
+    view.rerender(<StudentLessonCalendarTab classroom={secondClassroom} />)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(6)
+    })
+
+    await resolveClassroom(classroom.id)
+
+    expect(screen.queryByTestId('lesson-calendar')).not.toBeInTheDocument()
+
+    await resolveClassroom(secondClassroom.id)
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId('lesson-calendar')
+      expect(calendar).toHaveAttribute('data-lesson-ids', 'classroom-2-lesson')
+      expect(calendar).toHaveAttribute('data-assignment-ids', 'classroom-2-assignment')
+      expect(calendar).toHaveAttribute('data-announcement-ids', 'classroom-2-announcement')
+    })
   })
 })

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -6,6 +6,7 @@ import { TeacherTestsTab } from '@/app/classrooms/[classroomId]/TeacherTestsTab'
 import { AppMessageProvider, TooltipProvider } from '@/ui'
 import { TEACHER_TESTS_UPDATED_EVENT, TEACHER_TEST_GRADING_ROW_UPDATED_EVENT } from '@/lib/events'
 import { createMockClassroom, createMockTest } from '../helpers/mocks'
+import { invalidateCachedJSON } from '@/lib/request-cache'
 import type { Classroom, TestAssessmentWithStats } from '@/types'
 
 const { setOpenMock } = vi.hoisted(() => ({
@@ -265,9 +266,12 @@ function makeResultsResponse(overrides?: {
 
 describe('TeacherTestsTab', () => {
   const classroom = createMockClassroom()
+  const secondClassroom = createMockClassroom({ id: 'classroom-2', title: 'Second Classroom' })
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    invalidateCachedJSON(`teacher-tests:${classroom.id}`)
+    invalidateCachedJSON(`teacher-tests:${secondClassroom.id}`)
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     setOpenMock.mockReset()
@@ -275,6 +279,8 @@ describe('TeacherTestsTab', () => {
   })
 
   afterEach(() => {
+    invalidateCachedJSON(`teacher-tests:${classroom.id}`)
+    invalidateCachedJSON(`teacher-tests:${secondClassroom.id}`)
     vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
@@ -346,6 +352,233 @@ describe('TeacherTestsTab', () => {
     expect(screen.queryByRole('button', { name: 'Authoring' })).not.toBeInTheDocument()
     expect(screen.queryByText('Choose a test to review settings, questions, and grading details.')).not.toBeInTheDocument()
     expect(listFetchCalls(fetchMock)[0][0]).toContain('/api/teacher/tests?classroom_id=')
+  })
+
+  it('ignores late tests-list responses after switching classrooms', async () => {
+    type PendingFetch = {
+      url: string
+      resolve: (value: { ok: boolean; json: () => Promise<{ tests: TestAssessmentWithStats[] }> }) => void
+    }
+    const pending: PendingFetch[] = []
+
+    fetchMock.mockImplementation((url: string) => (
+      new Promise((resolve) => {
+        pending.push({ url, resolve: resolve as PendingFetch['resolve'] })
+      })
+    ))
+
+    function resolveTests(classroomId: string, tests: TestAssessmentWithStats[]) {
+      const request = pending.find((item) => item.url === `/api/teacher/tests?classroom_id=${classroomId}`)
+      expect(request).toBeTruthy()
+      request?.resolve({
+        ok: true,
+        json: async () => ({ tests }),
+      })
+    }
+
+    const view = renderTab({ classroom })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${classroom.id}`)
+    })
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={secondClassroom}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${secondClassroom.id}`)
+    })
+
+    await act(async () => {
+      resolveTests(secondClassroom.id, [makeTest({ id: 'test-b', classroom_id: secondClassroom.id, title: 'Class B Test' })])
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('Class B Test')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveTests(classroom.id, [makeTest({ id: 'test-a', classroom_id: classroom.id, title: 'Class A Test' })])
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByText('Class A Test')).not.toBeInTheDocument()
+    expect(screen.getByText('Class B Test')).toBeInTheDocument()
+  })
+
+  it('clears pending test delete confirmation after switching classrooms', async () => {
+    mockTestsResponse([makeTest({ id: 'test-a', classroom_id: classroom.id, title: 'Class A Test' })])
+    const view = renderTab({ classroom })
+
+    expect(await screen.findByText('Class A Test')).toBeInTheDocument()
+
+    toggleTestListControls()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Class A Test' }))
+    expect(await screen.findByText('Delete test?')).toBeInTheDocument()
+
+    mockTestsResponse([makeTest({ id: 'test-b', classroom_id: secondClassroom.id, title: 'Class B Test' })])
+    view.rerender(
+      <TeacherTestsTab
+        classroom={secondClassroom}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete test?')).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText('Class B Test')).toBeInTheDocument()
+  })
+
+  it('closes the edit dialog after switching classrooms', async () => {
+    mockTestsResponse([makeTest({ id: 'test-a', classroom_id: classroom.id, title: 'Class A Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse({ testId: 'test-a', testTitle: 'Class A Test' }))
+    const view = renderTab({ classroom })
+
+    fireEvent.click(await screen.findByText('Class A Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Test' }))
+    expect(await screen.findByTestId('mock-test-detail')).toHaveTextContent('Detail for Class A Test')
+
+    mockTestsResponse([makeTest({ id: 'test-b', classroom_id: secondClassroom.id, title: 'Class B Test' })])
+    view.rerender(
+      <TeacherTestsTab
+        classroom={secondClassroom}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText('Class B Test')).toBeInTheDocument()
+  })
+
+  it('ignores a late create-test response after switching classrooms', async () => {
+    type PendingCreate = {
+      resolve: (value: { ok: boolean; json: () => Promise<{ test: TestAssessmentWithStats }> }) => void
+    }
+    let pendingCreate: PendingCreate | null = null
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/teacher/tests' && init?.method === 'POST') {
+        return new Promise((resolve) => {
+          pendingCreate = { resolve: resolve as PendingCreate['resolve'] }
+        })
+      }
+      if (url === `/api/teacher/tests?classroom_id=${secondClassroom.id}`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tests: [makeTest({ id: 'test-b', classroom_id: secondClassroom.id, title: 'Class B Test' })],
+          }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ tests: [] }),
+      })
+    })
+
+    const view = renderTab({ classroom })
+
+    expect(await screen.findByRole('button', { name: 'New test' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'New test' }))
+
+    await waitFor(() => {
+      expect(pendingCreate).toBeTruthy()
+    })
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={secondClassroom}
+      />,
+    )
+
+    expect(await screen.findByText('Class B Test')).toBeInTheDocument()
+
+    await act(async () => {
+      pendingCreate?.resolve({
+        ok: true,
+        json: async () => ({
+          test: makeTest({ id: 'test-a-created', classroom_id: classroom.id, title: 'Created In Class A' }),
+        }),
+      })
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByText('Created In Class A')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mock-test-detail')).not.toBeInTheDocument()
+    expect(screen.getByText('Class B Test')).toBeInTheDocument()
+  })
+
+  it('does not let an old create request clear the current classroom create state', async () => {
+    type PendingCreate = {
+      classroomId: string
+      resolve: (value: { ok: boolean; json: () => Promise<{ test: TestAssessmentWithStats }> }) => void
+    }
+    const pendingCreates: PendingCreate[] = []
+
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/teacher/tests' && init?.method === 'POST') {
+        const classroomId = JSON.parse(init.body as string).classroom_id as string
+        return new Promise((resolve) => {
+          pendingCreates.push({ classroomId, resolve: resolve as PendingCreate['resolve'] })
+        })
+      }
+      if (url === `/api/teacher/tests?classroom_id=${secondClassroom.id}`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tests: [makeTest({ id: 'test-b', classroom_id: secondClassroom.id, title: 'Class B Test' })],
+          }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ tests: [] }),
+      })
+    })
+
+    const view = renderTab({ classroom })
+
+    expect(await screen.findByRole('button', { name: 'New test' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'New test' }))
+
+    await waitFor(() => {
+      expect(pendingCreates.some((request) => request.classroomId === classroom.id)).toBe(true)
+    })
+
+    view.rerender(
+      <TeacherTestsTab
+        classroom={secondClassroom}
+      />,
+    )
+
+    expect(await screen.findByText('Class B Test')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'New test' }))
+
+    await waitFor(() => {
+      expect(pendingCreates.some((request) => request.classroomId === secondClassroom.id)).toBe(true)
+    })
+
+    const newTestButton = screen.getByRole('button', { name: 'New test' })
+    expect(newTestButton).toBeDisabled()
+
+    const oldRequest = pendingCreates.find((request) => request.classroomId === classroom.id)
+    await act(async () => {
+      oldRequest?.resolve({
+        ok: true,
+        json: async () => ({
+          test: makeTest({ id: 'test-a-created', classroom_id: classroom.id, title: 'Created In Class A' }),
+        }),
+      })
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('button', { name: 'New test' })).toBeDisabled()
+    expect(screen.queryByText('Created In Class A')).not.toBeInTheDocument()
+    expect(screen.getByText('Class B Test')).toBeInTheDocument()
   })
 
   it('disables test create and options actions for archived classrooms', async () => {


### PR DESCRIPTION
## Summary
- guard student lesson calendar data with classroom/request ownership so late old-classroom responses cannot render after a switch
- reset teacher tests list, workspace, modal, and pending action state on classroom changes
- ignore late old-classroom tests-list and create-test responses after switching classrooms
- guard create-test completion with request ownership so old requests cannot clear the current classroom create state
- add regressions for late classroom A responses, stale delete/edit dialogs, and late create-test responses after switching to classroom B

## Workspace-state checklist
- Owner identity: classroom id
- Late responses ignored: yes, request id plus current classroom id checks
- State clears immediately on owner change: yes, for calendar data, teacher tests workspace state, and owner-scoped teacher tests action/modal state
- Current-owner create busy state protected from old requests: yes
- Cache boundary checked: yes, classroom-scoped cache keys invalidated in tests
- Accessibility reminder: Pika audit reminder reviewed; this patch does not change composite widget keyboard/ARIA semantics

## Validation
- pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherTestsTab.test.tsx (66 tests)
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test (308 files / 2750 tests)
- pnpm build
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"; reviewed /tmp/pika-teacher.png, /tmp/pika-student.png, and /tmp/pika-teacher-mobile.png