### PR TITLE
Extract teacher tests workspace navigation

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,13 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Weekly Simplification: Test Response Normalization
-
-- Selected the student test-taking response normalization path in `src/lib/test-attempts.ts` as the hotspot because it handled several legacy payload shapes with duplicated coercion branches used by both form and API routes.
-- Refactored the parser into explicit typed and legacy coercion helpers without changing behavior, and added unit coverage for fallback object shapes, CRLF normalization, and required non-blank open responses.
-- Verified with `bash scripts/verify-env.sh` and `pnpm test` (full Vitest suite: 302 files, 2671 tests).
-- PR: https://github.com/codepetca/pika/pull/779
-
 ## 2026-06-12 — Legacy quiz API compatibility contract helper
 
 **Completed:**
@@ -769,6 +762,31 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/components/TeacherTestsTab.test.tsx`
+- `git diff --check`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+- `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+
+## 2026-06-22 — Teacher tests workspace navigation extraction
+
+**Completed:**
+- Started the bounded architecture/UI improvement goal with a behavior-preserving TeacherTestsTab decomposition slice.
+- Extracted controlled/uncontrolled tests workspace selection, workspace mode, selected grading student, and URL search-param mutation into `useTestWorkspaceNavigation`.
+- Kept grading data loading, business actions, modal state, and workspace side effects in `TeacherTestsTab`.
+- Added hook contract coverage for list defaults, grading navigation, authoring student-param cleanup, workspace clearing, and controlled-prop precedence.
+- Added a parent `TeacherTestsTab` regression proving grading row selection still writes `testStudentId` through search params.
+
+**Refactor checklist:**
+- boundary: workspace navigation/search-param state only
+- shell or behavior extraction: behavior extraction for local navigation state, no UI shell change
+- business logic moved: none
+- visible behavior intended to change: none
+- remaining decomposition: teacher tests grading/list/action state still intentionally stays in the parent for future slices
+
+**Validation:**
+- `pnpm test tests/hooks/useTestWorkspaceNavigation.test.ts tests/components/TeacherTestsTab.test.tsx`
 - `git diff --check`
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -56,6 +56,12 @@ import { readTestFromPayload, readTestsFromPayload } from '@/lib/test-api-contra
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
+import {
+  useTestWorkspaceNavigation,
+  type TestWorkspaceState as WorkspaceState,
+  type TestWorkspaceTab as WorkspaceTab,
+  type UpdateSearchParamsFn,
+} from '@/hooks/useTestWorkspaceNavigation'
 import { Button, ConfirmDialog, DialogPanel, EmptyState, RefreshingIndicator, Select, SplitButton, Tooltip, useAppMessage, useOverlayMessage, type SplitButtonProps } from '@/ui'
 import type {
   AssessmentEditorSummaryUpdate,
@@ -85,15 +91,6 @@ interface Props {
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onRequestDelete?: () => void
 }
-
-type UpdateSearchOptions = {
-  replace?: boolean
-}
-
-type UpdateSearchParamsFn = (
-  updater: (params: URLSearchParams) => void,
-  options?: UpdateSearchOptions,
-) => void
 
 interface TestGradingStudentRow {
   student_id: string
@@ -144,8 +141,6 @@ type TeacherTestResultsResponse = {
   error?: string
 }
 
-type WorkspaceState = 'list' | 'selected'
-type WorkspaceTab = 'authoring' | 'grading'
 type TestEditModalView = 'edit' | 'markdown'
 type TestEditSaveStatus = 'saved' | 'saving' | 'unsaved'
 type TestGradingSortColumn = 'first_name' | 'last_name'
@@ -357,8 +352,6 @@ export function TeacherTestsTab({
   const [loadedTestsClassroomId, setLoadedTestsClassroomId] = useState<string | null>(null)
   const { showMessage } = useAppMessage()
   const [loading, setLoading] = useState(true)
-  const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] = useState<WorkspaceTab>('grading')
-  const [internalSelectedTestId, setInternalSelectedTestId] = useState<string | null>(null)
   const [testEditMode, setTestEditMode] = useState(false)
   const [isReorderingTests, setIsReorderingTests] = useState(false)
   const [selectedTestDraftSummary, setSelectedTestDraftSummary] = useState<AssessmentEditorSummaryUpdate | null>(null)
@@ -382,7 +375,6 @@ export function TeacherTestsTab({
   const [gradingRefreshing, setGradingRefreshing] = useState(false)
   const [gradingError, setGradingError] = useState('')
   const [gradingSortColumn, setGradingSortColumn] = useState<TestGradingSortColumn>('last_name')
-  const [internalSelectedStudentId, setInternalSelectedStudentId] = useState<string | null>(null)
   const [gradingInspectorWidth, setGradingInspectorWidth] = useState(50)
   const [testGradingPanelRefreshToken, setTestGradingPanelRefreshToken] = useState(0)
   const [testGradingSaveState, setTestGradingSaveState] = useState<{
@@ -395,15 +387,20 @@ export function TeacherTestsTab({
     status: 'idle',
   })
 
-  const selectedTestId =
-    selectedTestIdProp !== undefined ? selectedTestIdProp : internalSelectedTestId
-  const selectedWorkspaceTab =
-    selectedTestMode === 'authoring' || selectedTestMode === 'grading'
-      ? selectedTestMode
-      : internalSelectedWorkspaceTab
-  const selectedStudentId =
-    selectedTestStudentId !== undefined ? selectedTestStudentId : internalSelectedStudentId
-  const workspaceState: WorkspaceState = selectedTestId ? 'selected' : 'list'
+  const {
+    selectedTestId,
+    selectedWorkspaceTab,
+    selectedStudentId,
+    workspaceState,
+    setSelectedStudentId,
+    navigateTestWorkspace,
+    clearTestWorkspace,
+  } = useTestWorkspaceNavigation({
+    selectedTestId: selectedTestIdProp,
+    selectedTestMode,
+    selectedTestStudentId,
+    updateSearchParams,
+  })
   currentClassroomIdRef.current = classroom.id
   const [gradingInfo, setGradingInfo] = useState('')
   const [gradingWarning, setGradingWarning] = useState('')
@@ -559,45 +556,6 @@ export function TeacherTestsTab({
     setExitAlertStudentId((prev) => (prev === studentId ? null : prev))
   }, [])
 
-  const setSelectedStudentId = useCallback((nextStudentId: string | null) => {
-    setInternalSelectedStudentId(nextStudentId)
-  }, [])
-
-  const navigateTestWorkspace = useCallback((
-    next: {
-      testId: string | null
-      mode?: WorkspaceTab | null
-      studentId?: string | null
-    },
-    options?: UpdateSearchOptions,
-  ) => {
-    const nextMode = next.testId ? (next.mode ?? 'grading') : null
-    setInternalSelectedTestId(next.testId)
-    setInternalSelectedWorkspaceTab(nextMode ?? 'grading')
-    setInternalSelectedStudentId(next.studentId ?? null)
-
-    updateSearchParams?.((params) => {
-      params.set('tab', 'tests')
-      if (next.testId) {
-        params.set('testId', next.testId)
-        params.set('testMode', nextMode ?? 'grading')
-        if (nextMode === 'grading' && next.studentId) {
-          params.set('testStudentId', next.studentId)
-        } else {
-          params.delete('testStudentId')
-        }
-      } else {
-        params.delete('testId')
-        params.delete('testMode')
-        params.delete('testStudentId')
-      }
-    }, options)
-  }, [updateSearchParams])
-
-  const clearTestWorkspace = useCallback((options?: UpdateSearchOptions) => {
-    navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
-  }, [navigateTestWorkspace])
-
   useEffect(() => {
     if (previousClassroomIdRef.current === classroom.id) return
 
@@ -674,7 +632,7 @@ export function TeacherTestsTab({
 
   const selectGradingStudent = useCallback((studentId: string | null) => {
     preserveGradingStudentTableScrollPosition()
-    setInternalSelectedStudentId(studentId)
+    setSelectedStudentId(studentId)
     if (!selectedTestId || selectedWorkspaceTab !== 'grading') return
     navigateTestWorkspace({
       testId: selectedTestId,
@@ -685,6 +643,7 @@ export function TeacherTestsTab({
     navigateTestWorkspace,
     preserveGradingStudentTableScrollPosition,
     selectedTestId,
+    setSelectedStudentId,
     selectedWorkspaceTab,
   ])
 

--- a/src/hooks/useTestWorkspaceNavigation.ts
+++ b/src/hooks/useTestWorkspaceNavigation.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react'
+
+export type TestWorkspaceState = 'list' | 'selected'
+export type TestWorkspaceTab = 'authoring' | 'grading'
+
+export type UpdateSearchOptions = {
+  replace?: boolean
+}
+
+export type UpdateSearchParamsFn = (
+  updater: (params: URLSearchParams) => void,
+  options?: UpdateSearchOptions,
+) => void
+
+type WorkspaceTarget = {
+  testId: string | null
+  mode?: TestWorkspaceTab | null
+  studentId?: string | null
+}
+
+type UseTestWorkspaceNavigationOptions = {
+  selectedTestId?: string | null
+  selectedTestMode?: TestWorkspaceTab | null
+  selectedTestStudentId?: string | null
+  updateSearchParams?: UpdateSearchParamsFn
+}
+
+export function useTestWorkspaceNavigation({
+  selectedTestId: selectedTestIdProp,
+  selectedTestMode,
+  selectedTestStudentId,
+  updateSearchParams,
+}: UseTestWorkspaceNavigationOptions) {
+  const [internalSelectedWorkspaceTab, setInternalSelectedWorkspaceTab] =
+    useState<TestWorkspaceTab>('grading')
+  const [internalSelectedTestId, setInternalSelectedTestId] = useState<string | null>(null)
+  const [internalSelectedStudentId, setInternalSelectedStudentId] = useState<string | null>(null)
+
+  const selectedTestId =
+    selectedTestIdProp !== undefined ? selectedTestIdProp : internalSelectedTestId
+  const selectedWorkspaceTab =
+    selectedTestMode === 'authoring' || selectedTestMode === 'grading'
+      ? selectedTestMode
+      : internalSelectedWorkspaceTab
+  const selectedStudentId =
+    selectedTestStudentId !== undefined ? selectedTestStudentId : internalSelectedStudentId
+  const workspaceState: TestWorkspaceState = selectedTestId ? 'selected' : 'list'
+
+  const navigateTestWorkspace = useCallback((
+    next: WorkspaceTarget,
+    options?: UpdateSearchOptions,
+  ) => {
+    const nextMode = next.testId ? (next.mode ?? 'grading') : null
+    setInternalSelectedTestId(next.testId)
+    setInternalSelectedWorkspaceTab(nextMode ?? 'grading')
+    setInternalSelectedStudentId(next.studentId ?? null)
+
+    updateSearchParams?.((params) => {
+      params.set('tab', 'tests')
+      if (next.testId) {
+        params.set('testId', next.testId)
+        params.set('testMode', nextMode ?? 'grading')
+        if (nextMode === 'grading' && next.studentId) {
+          params.set('testStudentId', next.studentId)
+        } else {
+          params.delete('testStudentId')
+        }
+      } else {
+        params.delete('testId')
+        params.delete('testMode')
+        params.delete('testStudentId')
+      }
+    }, options)
+  }, [updateSearchParams])
+
+  const clearTestWorkspace = useCallback((options?: UpdateSearchOptions) => {
+    navigateTestWorkspace({ testId: null, mode: null, studentId: null }, options)
+  }, [navigateTestWorkspace])
+
+  return {
+    selectedTestId,
+    selectedWorkspaceTab,
+    selectedStudentId,
+    workspaceState,
+    setSelectedStudentId: setInternalSelectedStudentId,
+    navigateTestWorkspace,
+    clearTestWorkspace,
+  }
+}

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -1559,6 +1559,31 @@ describe('TeacherTestsTab', () => {
     expect(params.get('testStudentId')).toBeNull()
   })
 
+  it('reports selected grading student changes through search params', async () => {
+    const updateSearchParams = vi.fn((updater: (params: URLSearchParams) => void) => {
+      const params = new URLSearchParams('tab=tests')
+      updater(params)
+    })
+
+    mockTestsResponse([makeTest({ id: 'test-1', title: 'Unit Test' })])
+    fetchMock.mockResolvedValueOnce(makeResultsResponse())
+    renderTab({ updateSearchParams })
+
+    fireEvent.click(await screen.findByText('Unit Test'))
+    expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Alice Zephyr'))
+
+    await waitFor(() => {
+      expect(updateSearchParams).toHaveBeenCalledTimes(2)
+    })
+
+    const params = new URLSearchParams('tab=tests&testId=test-1&testMode=grading')
+    updateSearchParams.mock.calls[1][0](params)
+    expect(params.get('testId')).toBe('test-1')
+    expect(params.get('testMode')).toBe('grading')
+    expect(params.get('testStudentId')).toBe('student-1')
+  })
+
   it('opens controlled authoring params in the test editor', async () => {
     const updateSearchParams = vi.fn()
 

--- a/tests/hooks/useTestWorkspaceNavigation.test.ts
+++ b/tests/hooks/useTestWorkspaceNavigation.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useTestWorkspaceNavigation } from '@/hooks/useTestWorkspaceNavigation'
+
+describe('useTestWorkspaceNavigation', () => {
+  it('defaults to the tests list in grading mode', () => {
+    const { result } = renderHook(() => useTestWorkspaceNavigation({}))
+
+    expect(result.current.workspaceState).toBe('list')
+    expect(result.current.selectedTestId).toBeNull()
+    expect(result.current.selectedWorkspaceTab).toBe('grading')
+    expect(result.current.selectedStudentId).toBeNull()
+  })
+
+  it('navigates to grading and writes test search params', () => {
+    const updateSearchParams = vi.fn()
+    const { result } = renderHook(() => useTestWorkspaceNavigation({ updateSearchParams }))
+
+    act(() => {
+      result.current.navigateTestWorkspace({
+        testId: 'test-1',
+        mode: 'grading',
+        studentId: 'student-1',
+      })
+    })
+
+    expect(result.current.workspaceState).toBe('selected')
+    expect(result.current.selectedTestId).toBe('test-1')
+    expect(result.current.selectedWorkspaceTab).toBe('grading')
+    expect(result.current.selectedStudentId).toBe('student-1')
+    expect(updateSearchParams).toHaveBeenCalledWith(expect.any(Function), undefined)
+
+    const params = new URLSearchParams()
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('tab')).toBe('tests')
+    expect(params.get('testId')).toBe('test-1')
+    expect(params.get('testMode')).toBe('grading')
+    expect(params.get('testStudentId')).toBe('student-1')
+  })
+
+  it('drops student params outside grading mode', () => {
+    const updateSearchParams = vi.fn()
+    const { result } = renderHook(() => useTestWorkspaceNavigation({ updateSearchParams }))
+
+    act(() => {
+      result.current.navigateTestWorkspace({
+        testId: 'test-1',
+        mode: 'authoring',
+        studentId: 'student-1',
+      })
+    })
+
+    expect(result.current.selectedWorkspaceTab).toBe('authoring')
+
+    const params = new URLSearchParams('testStudentId=student-1')
+    updateSearchParams.mock.calls[0][0](params)
+    expect(params.get('testId')).toBe('test-1')
+    expect(params.get('testMode')).toBe('authoring')
+    expect(params.get('testStudentId')).toBeNull()
+  })
+
+  it('clears test params with replace options', () => {
+    const updateSearchParams = vi.fn()
+    const { result } = renderHook(() => useTestWorkspaceNavigation({ updateSearchParams }))
+
+    act(() => {
+      result.current.navigateTestWorkspace({ testId: 'test-1', mode: 'grading', studentId: 'student-1' })
+    })
+    act(() => {
+      result.current.clearTestWorkspace({ replace: true })
+    })
+
+    expect(result.current.workspaceState).toBe('list')
+    expect(result.current.selectedTestId).toBeNull()
+    expect(result.current.selectedWorkspaceTab).toBe('grading')
+    expect(result.current.selectedStudentId).toBeNull()
+    expect(updateSearchParams).toHaveBeenLastCalledWith(expect.any(Function), { replace: true })
+
+    const params = new URLSearchParams('tab=tests&testId=test-1&testMode=grading&testStudentId=student-1')
+    updateSearchParams.mock.calls[1][0](params)
+    expect(params.get('tab')).toBe('tests')
+    expect(params.get('testId')).toBeNull()
+    expect(params.get('testMode')).toBeNull()
+    expect(params.get('testStudentId')).toBeNull()
+  })
+
+  it('lets controlled props override internal navigation state', () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useTestWorkspaceNavigation>[0]) =>
+        useTestWorkspaceNavigation(props),
+      {
+        initialProps: {
+          selectedTestId: null,
+          selectedTestMode: null,
+          selectedTestStudentId: null,
+        },
+      },
+    )
+
+    act(() => {
+      result.current.navigateTestWorkspace({ testId: 'internal-test', mode: 'grading', studentId: 'student-1' })
+    })
+
+    expect(result.current.workspaceState).toBe('list')
+    expect(result.current.selectedTestId).toBeNull()
+    expect(result.current.selectedStudentId).toBeNull()
+
+    rerender({
+      selectedTestId: 'controlled-test',
+      selectedTestMode: 'authoring',
+      selectedTestStudentId: 'controlled-student',
+    })
+
+    expect(result.current.workspaceState).toBe('selected')
+    expect(result.current.selectedTestId).toBe('controlled-test')
+    expect(result.current.selectedWorkspaceTab).toBe('authoring')
+    expect(result.current.selectedStudentId).toBe('controlled-student')
+  })
+})


### PR DESCRIPTION
## Summary
- extract TeacherTestsTab workspace navigation/search-param state into useTestWorkspaceNavigation
- keep grading data loading, business actions, modal state, and workspace side effects in TeacherTestsTab
- add hook contract coverage for workspace defaults, grading navigation, authoring cleanup, clearing, and controlled prop precedence
- add a parent TeacherTestsTab regression for selected grading student search-param updates

## Refactor checklist
- Boundary: workspace navigation/search-param state only
- Shell or behavior extraction: behavior extraction for local navigation state; no UI shell change
- Business logic moved: none
- Visible behavior intended to change: none
- Remaining decomposition: teacher tests grading/list/action state intentionally stays in the parent for future slices

## Validation
- pnpm test tests/hooks/useTestWorkspaceNavigation.test.ts tests/components/TeacherTestsTab.test.tsx
- git diff --check
- pnpm lint
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test (309 files / 2756 tests)
- pnpm build
- bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"; reviewed /tmp/pika-teacher.png, /tmp/pika-student.png, and /tmp/pika-teacher-mobile.png