### PR TITLE
Extract teacher tests list state

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,26 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-12 — Legacy quiz API compatibility contract helper
-
-**Completed:**
-- Created `codex/legacy-quiz-contract-compat` from current `origin/main`.
-- Inventoried remaining `quiz` / `quizzes` references and separated persisted/database contracts from active Tests API compatibility aliases.
-- Added `src/lib/test-api-contract.ts` to centralize the active Tests API `{ test, quiz }` and `{ tests, quizzes }` compatibility payloads.
-- Updated student and teacher Tests API routes to use the shared compatibility helper without changing response shape.
-- Added canonical `assessment` success data to `src/lib/server/assessments.ts` while preserving the legacy `quiz` alias.
-- Trimmed redundant `docs/ai-instructions.md` wording after the rebased `origin/main` startup-doc changes exceeded the enforced default startup context budget.
-- Did not touch production schema, migrations, RPCs, storage paths, gradebook contracts, course blueprint contracts, or DB-shaped `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/unit/server-access.test.ts tests/api/teacher/tests-route.test.ts tests/api/teacher/tests-id-route.test.ts tests/api/teacher/tests-results.test.ts tests/api/student/tests-route.test.ts tests/api/student/tests-id.test.ts tests/api/student/tests-results.test.ts tests/api/student/tests-session-status.test.ts`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm vitest run tests/unit/ai-startup-docs.test.ts tests/unit/ui-guidance-docs.test.ts`
-- `pnpm test` (303 files / 2672 tests)
-- `git diff --check`
-
 ## 2026-06-13 — Legacy quiz client response readers
 
 **Completed:**
@@ -793,3 +773,29 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test`
 - `pnpm build`
 - `bash .codex/skills/pika-ui-verify/scripts/ui_verify.sh "classrooms"`; reviewed `/tmp/pika-teacher.png`, `/tmp/pika-student.png`, and `/tmp/pika-teacher-mobile.png`.
+
+## 2026-06-22 — Teacher tests list-state extraction
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the next behavior-preserving TeacherTestsTab decomposition slice.
+- Extracted classroom-owned tests-list loading, visible-list ownership, event reload handling, request freshness checks, and selected-draft summary patching into `useTeacherTestList`.
+- Moved shared selected-test summary patching into `src/lib/test-summary-patch.ts` so the hook and parent mutations use the same behavior.
+- Kept rendering, routing, grading rows, mutations, dialogs, batch actions, and workspace mode state in `TeacherTestsTab`.
+- Added hook-level coverage for current-classroom loads, hiding prior-classroom data while loading, late response rejection, matching update-event reloads, and draft-summary patching.
+- Updated the parent component regression for visible list reload after `TEACHER_TESTS_UPDATED_EVENT`.
+
+**Workspace-state checklist:**
+- owner identity: classroom id
+- late responses ignored: yes, request id plus current classroom id checks in the hook
+- state clears immediately on owner change: visible tests are hidden when loaded owner differs from current classroom
+- A-after-B regression: covered in `tests/hooks/useTeacherTestList.test.ts` and parent coverage remains in `TeacherTestsTab.test.tsx`
+- visible behavior intended to change: none
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/hooks/useTeacherTestList.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -52,10 +52,12 @@ import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { getTestExitCount } from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
-import { readTestFromPayload, readTestsFromPayload } from '@/lib/test-api-contract'
+import { readTestFromPayload } from '@/lib/test-api-contract'
+import { applyTestSummaryPatchToTest } from '@/lib/test-summary-patch'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
 import { useScrollPositionMemory } from '@/hooks/useScrollPositionMemory'
+import { useTeacherTestList } from '@/hooks/useTeacherTestList'
 import {
   useTestWorkspaceNavigation,
   type TestWorkspaceState as WorkspaceState,
@@ -117,12 +119,6 @@ interface TestGradingQuestionSummary {
   id: string
   questionType: 'multiple_choice' | 'open_response'
   responseMonospace: boolean
-}
-
-type TeacherTestListResponse = {
-  tests?: TestAssessmentWithStats[]
-  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
-  quizzes?: TestAssessmentWithStats[]
 }
 
 type TeacherTestResultsQuestionResponse = {
@@ -292,23 +288,6 @@ function withDefaultTestStats(test: TestAssessment): TestAssessmentWithStats {
   }
 }
 
-function applyTestSummaryPatchToTest(
-  test: TestAssessmentWithStats,
-  update: AssessmentWorkspaceSummaryPatch
-): TestAssessmentWithStats {
-  return {
-    ...test,
-    title: typeof update.title === 'string' ? update.title : test.title,
-    show_results: typeof update.show_results === 'boolean' ? update.show_results : test.show_results,
-    status: update.status ?? test.status,
-    stats: {
-      ...test.stats,
-      questions_count:
-        typeof update.questions_count === 'number' ? update.questions_count : test.stats.questions_count,
-    },
-  }
-}
-
 export function TeacherTestsTab({
   classroom,
   testsTabClickToken = 0,
@@ -340,18 +319,12 @@ export function TeacherTestsTab({
     testId: null,
     counts: new Map(),
   })
-  const latestTestsRequestIdRef = useRef(0)
   const latestCreateTestRequestIdRef = useRef(0)
   const currentClassroomIdRef = useRef(classroom.id)
   const previousClassroomIdRef = useRef(classroom.id)
   const handledCompletedRunKeysRef = useRef<Set<string>>(new Set())
-  const selectedTestIdRef = useRef<string | null>(null)
-  const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(null)
 
-  const [tests, setTests] = useState<TestAssessmentWithStats[]>([])
-  const [loadedTestsClassroomId, setLoadedTestsClassroomId] = useState<string | null>(null)
   const { showMessage } = useAppMessage()
-  const [loading, setLoading] = useState(true)
   const [testEditMode, setTestEditMode] = useState(false)
   const [isReorderingTests, setIsReorderingTests] = useState(false)
   const [selectedTestDraftSummary, setSelectedTestDraftSummary] = useState<AssessmentEditorSummaryUpdate | null>(null)
@@ -402,6 +375,18 @@ export function TeacherTestsTab({
     updateSearchParams,
   })
   currentClassroomIdRef.current = classroom.id
+  const {
+    tests,
+    setTests,
+    visibleTests,
+    loading,
+    loadTests,
+  } = useTeacherTestList({
+    classroomId: classroom.id,
+    selectedTestId,
+    selectedTestDraftSummary,
+    apiBasePath,
+  })
   const [gradingInfo, setGradingInfo] = useState('')
   const [gradingWarning, setGradingWarning] = useState('')
   const [isBatchAutoGrading, setIsBatchAutoGrading] = useState(false)
@@ -448,11 +433,6 @@ export function TeacherTestsTab({
     })
   )
 
-  const hasCurrentTests = loadedTestsClassroomId === classroom.id
-  const visibleTests = useMemo(
-    () => (hasCurrentTests ? tests : []),
-    [hasCurrentTests, tests],
-  )
   const selectedTest = useMemo(
     () => visibleTests.find((test) => test.id === selectedTestId) ?? null,
     [selectedTestId, visibleTests]
@@ -560,12 +540,8 @@ export function TeacherTestsTab({
     if (previousClassroomIdRef.current === classroom.id) return
 
     previousClassroomIdRef.current = classroom.id
-    latestTestsRequestIdRef.current += 1
     latestCreateTestRequestIdRef.current += 1
     latestGradingRequestIdRef.current += 1
-    setTests([])
-    setLoadedTestsClassroomId(null)
-    setLoading(true)
     setTestEditMode(false)
     setIsReorderingTests(false)
     setIsCreatingTest(false)
@@ -577,7 +553,6 @@ export function TeacherTestsTab({
     setIsDeletingTest(false)
     setStatusActionError('')
     setSelectedTestDraftSummary(null)
-    selectedTestDraftSummaryRef.current = null
     setGradingStudents([])
     setUnreviewedExitCounts({})
     setExitAlertStudentId(null)
@@ -758,13 +733,12 @@ export function TeacherTestsTab({
     setTests((prev) =>
       prev.map((test) => (test.id === testId ? applyTestSummaryPatchToTest(test, update) : test))
     )
-  }, [])
+  }, [setTests])
 
   const applySelectedTestDraftSummary = useCallback(
     (update: AssessmentEditorSummaryUpdate) => {
       if (!selectedTestId) return
 
-      selectedTestDraftSummaryRef.current = update
       setSelectedTestDraftSummary(update)
       applyTestSummaryPatch(selectedTestId, update)
     },
@@ -774,65 +748,8 @@ export function TeacherTestsTab({
     if (selectedTestId) {
       applyTestSummaryPatch(selectedTestId, update)
     }
-    selectedTestDraftSummaryRef.current = update
     setSelectedTestDraftSummary(update)
   }, [applyTestSummaryPatch, selectedTestId])
-
-  const loadTests = useCallback(async () => {
-    const requestId = latestTestsRequestIdRef.current + 1
-    latestTestsRequestIdRef.current = requestId
-    const requestedClassroomId = classroom.id
-    const isCurrentRequest = () => (
-      latestTestsRequestIdRef.current === requestId &&
-      currentClassroomIdRef.current === requestedClassroomId
-    )
-
-    setLoading(true)
-    try {
-      const query = new URLSearchParams({ classroom_id: requestedClassroomId })
-      const data = await fetchJSONWithCache<TeacherTestListResponse>(
-        `teacher-tests:${requestedClassroomId}`,
-        async () => {
-          const response = await fetch(`${apiBasePath}?${query.toString()}`)
-          const payload = await response.json()
-          if (!response.ok) throw new Error(payload.error || 'Failed to load tests')
-          return payload
-        },
-        0,
-      )
-      if (!isCurrentRequest()) return
-      const loadedTests = readTestsFromPayload<TestAssessmentWithStats>(data)
-      const currentSelectedTestId = selectedTestIdRef.current
-      const currentDraftSummary = selectedTestDraftSummaryRef.current
-      setTests(
-        currentSelectedTestId && currentDraftSummary
-          ? loadedTests.map((test) =>
-              test.id === currentSelectedTestId
-                ? applyTestSummaryPatchToTest(test, currentDraftSummary)
-                : test
-            )
-          : loadedTests
-      )
-      setLoadedTestsClassroomId(requestedClassroomId)
-    } catch (error) {
-      if (!isCurrentRequest()) return
-      console.error('Error loading tests:', error)
-      setTests([])
-      setLoadedTestsClassroomId(requestedClassroomId)
-    } finally {
-      if (isCurrentRequest()) {
-        setLoading(false)
-      }
-    }
-  }, [classroom.id])
-
-  useEffect(() => {
-    selectedTestIdRef.current = selectedTestId
-  }, [selectedTestId])
-
-  useEffect(() => {
-    selectedTestDraftSummaryRef.current = selectedTestDraftSummary
-  }, [selectedTestDraftSummary])
 
   const loadGradingRows = useCallback(async (options?: { preserveRows?: boolean }) => {
     if (!selectedTestId) {
@@ -921,22 +838,7 @@ export function TeacherTestsTab({
       setGradingLoading(false)
       setGradingRefreshing(false)
     }
-  }, [recordGradingExitCountChanges, selectedTestId])
-
-  useEffect(() => {
-    void loadTests()
-  }, [loadTests])
-
-  useEffect(() => {
-    function handleTestsUpdated(event: Event) {
-      const detail = (event as CustomEvent<{ classroomId?: string }>).detail
-      if (!detail || detail.classroomId !== classroom.id) return
-      void loadTests()
-    }
-
-    window.addEventListener(TEACHER_TESTS_UPDATED_EVENT, handleTestsUpdated)
-    return () => window.removeEventListener(TEACHER_TESTS_UPDATED_EVENT, handleTestsUpdated)
-  }, [classroom.id, loadTests])
+  }, [recordGradingExitCountChanges, selectedTestId, setTests])
 
   useEffect(() => {
     onSelectTest?.(workspaceState === 'selected' ? selectedTestWorkspace : null)
@@ -959,7 +861,6 @@ export function TeacherTestsTab({
   }, [clearBatchSelection, clearTestWorkspace, loading, selectedTestId, visibleTests])
 
   useEffect(() => {
-    selectedTestDraftSummaryRef.current = null
     setSelectedTestDraftSummary(null)
     gradingExitCountsRef.current = { testId: selectedTestId, counts: new Map() }
     setUnreviewedExitCounts({})
@@ -1412,7 +1313,6 @@ export function TeacherTestsTab({
 
     setTestEditMode(false)
     setHasPendingMarkdownImport(false)
-    selectedTestDraftSummaryRef.current = null
     setSelectedTestDraftSummary(null)
     setTests((prev) => {
       const next = prev.filter((existing) => existing.id !== createdTest.id)
@@ -1497,6 +1397,7 @@ export function TeacherTestsTab({
       isReadOnly,
       isReorderingTests,
       loadTests,
+      setTests,
       showMessage,
       testEditMode,
       visibleTests,

--- a/src/hooks/useTeacherTestList.ts
+++ b/src/hooks/useTeacherTestList.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
+import { fetchJSONWithCache } from '@/lib/request-cache'
+import { readTestsFromPayload } from '@/lib/test-api-contract'
+import { applyTestSummaryPatchToTest } from '@/lib/test-summary-patch'
+import type { AssessmentEditorSummaryUpdate, TestAssessmentWithStats } from '@/types'
+
+type TeacherTestListResponse = {
+  tests?: TestAssessmentWithStats[]
+  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
+  quizzes?: TestAssessmentWithStats[]
+}
+
+type UseTeacherTestListOptions = {
+  classroomId: string
+  selectedTestId: string | null
+  selectedTestDraftSummary: AssessmentEditorSummaryUpdate | null
+  apiBasePath?: string
+}
+
+export type UseTeacherTestListResult = {
+  tests: TestAssessmentWithStats[]
+  setTests: Dispatch<SetStateAction<TestAssessmentWithStats[]>>
+  visibleTests: TestAssessmentWithStats[]
+  loading: boolean
+  loadTests: () => Promise<void>
+}
+
+export function useTeacherTestList({
+  classroomId,
+  selectedTestId,
+  selectedTestDraftSummary,
+  apiBasePath = '/api/teacher/tests',
+}: UseTeacherTestListOptions): UseTeacherTestListResult {
+  const latestRequestIdRef = useRef(0)
+  const currentClassroomIdRef = useRef(classroomId)
+  const selectedTestIdRef = useRef<string | null>(selectedTestId)
+  const selectedTestDraftSummaryRef = useRef<AssessmentEditorSummaryUpdate | null>(selectedTestDraftSummary)
+
+  const [tests, setTests] = useState<TestAssessmentWithStats[]>([])
+  const [loadedTestsClassroomId, setLoadedTestsClassroomId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  currentClassroomIdRef.current = classroomId
+
+  const hasCurrentTests = loadedTestsClassroomId === classroomId
+  const visibleTests = useMemo(
+    () => (hasCurrentTests ? tests : []),
+    [hasCurrentTests, tests],
+  )
+
+  const loadTests = useCallback(async () => {
+    const requestId = latestRequestIdRef.current + 1
+    latestRequestIdRef.current = requestId
+    const requestedClassroomId = classroomId
+    const isCurrentRequest = () => (
+      latestRequestIdRef.current === requestId &&
+      currentClassroomIdRef.current === requestedClassroomId
+    )
+
+    setLoading(true)
+    try {
+      const query = new URLSearchParams({ classroom_id: requestedClassroomId })
+      const data = await fetchJSONWithCache<TeacherTestListResponse>(
+        `teacher-tests:${requestedClassroomId}`,
+        async () => {
+          const response = await fetch(`${apiBasePath}?${query.toString()}`)
+          const payload = await response.json()
+          if (!response.ok) throw new Error(payload.error || 'Failed to load tests')
+          return payload
+        },
+        0,
+      )
+      if (!isCurrentRequest()) return
+
+      const loadedTests = readTestsFromPayload<TestAssessmentWithStats>(data)
+      const currentSelectedTestId = selectedTestIdRef.current
+      const currentDraftSummary = selectedTestDraftSummaryRef.current
+      setTests(
+        currentSelectedTestId && currentDraftSummary
+          ? loadedTests.map((test) =>
+              test.id === currentSelectedTestId
+                ? applyTestSummaryPatchToTest(test, currentDraftSummary)
+                : test
+            )
+          : loadedTests,
+      )
+      setLoadedTestsClassroomId(requestedClassroomId)
+    } catch (error) {
+      if (!isCurrentRequest()) return
+      console.error('Error loading tests:', error)
+      setTests([])
+      setLoadedTestsClassroomId(requestedClassroomId)
+    } finally {
+      if (isCurrentRequest()) {
+        setLoading(false)
+      }
+    }
+  }, [apiBasePath, classroomId])
+
+  useEffect(() => {
+    selectedTestIdRef.current = selectedTestId
+  }, [selectedTestId])
+
+  useEffect(() => {
+    selectedTestDraftSummaryRef.current = selectedTestDraftSummary
+  }, [selectedTestDraftSummary])
+
+  useEffect(() => {
+    void loadTests()
+  }, [loadTests])
+
+  useEffect(() => {
+    function handleTestsUpdated(event: Event) {
+      const detail = (event as CustomEvent<{ classroomId?: string }>).detail
+      if (!detail || detail.classroomId !== classroomId) return
+      void loadTests()
+    }
+
+    window.addEventListener(TEACHER_TESTS_UPDATED_EVENT, handleTestsUpdated)
+    return () => window.removeEventListener(TEACHER_TESTS_UPDATED_EVENT, handleTestsUpdated)
+  }, [classroomId, loadTests])
+
+  return {
+    tests,
+    setTests,
+    visibleTests,
+    loading,
+    loadTests,
+  }
+}

--- a/src/lib/test-summary-patch.ts
+++ b/src/lib/test-summary-patch.ts
@@ -1,0 +1,21 @@
+import type {
+  AssessmentWorkspaceSummaryPatch,
+  TestAssessmentWithStats,
+} from '@/types'
+
+export function applyTestSummaryPatchToTest(
+  test: TestAssessmentWithStats,
+  update: AssessmentWorkspaceSummaryPatch,
+): TestAssessmentWithStats {
+  return {
+    ...test,
+    title: typeof update.title === 'string' ? update.title : test.title,
+    show_results: typeof update.show_results === 'boolean' ? update.show_results : test.show_results,
+    status: update.status ?? test.status,
+    stats: {
+      ...test.stats,
+      questions_count:
+        typeof update.questions_count === 'number' ? update.questions_count : test.stats.questions_count,
+    },
+  }
+}

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -2904,7 +2904,7 @@ describe('TeacherTestsTab', () => {
     expect(screen.getByRole('menuitem', { name: /AI Grade/ })).toBeEnabled()
   })
 
-  it('reloads the list once when the update event fires', async () => {
+  it('reloads the visible list once when the update event fires', async () => {
     mockTestsResponse([])
     renderTab()
 
@@ -2912,7 +2912,7 @@ describe('TeacherTestsTab', () => {
       expect(listFetchCalls(fetchMock)).toHaveLength(1)
     })
 
-    mockTestsResponse([])
+    mockTestsResponse([makeTest({ id: 'test-reloaded', title: 'Reloaded Test' })])
 
     act(() => {
       window.dispatchEvent(
@@ -2925,5 +2925,6 @@ describe('TeacherTestsTab', () => {
     await waitFor(() => {
       expect(listFetchCalls(fetchMock)).toHaveLength(2)
     })
+    expect(await screen.findByText('Reloaded Test')).toBeInTheDocument()
   })
 })

--- a/tests/hooks/useTeacherTestList.test.ts
+++ b/tests/hooks/useTeacherTestList.test.ts
@@ -1,0 +1,234 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTeacherTestList } from '@/hooks/useTeacherTestList'
+import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
+import { invalidateCachedJSON } from '@/lib/request-cache'
+import { createMockTest } from '../helpers/mocks'
+import type { TestAssessmentWithStats } from '@/types'
+
+function makeTest(overrides: Partial<TestAssessmentWithStats> = {}): TestAssessmentWithStats {
+  return {
+    ...createMockTest({
+      assessment_type: 'test',
+      status: 'draft',
+      ...overrides,
+    }),
+    assessment_type: 'test',
+    stats: {
+      total_students: 10,
+      responded: 5,
+      submitted: 2,
+      open_access: 0,
+      closed_access: 0,
+      questions_count: 3,
+      ...overrides.stats,
+    },
+    ...overrides,
+  } as TestAssessmentWithStats
+}
+
+describe('useTeacherTestList', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    invalidateCachedJSON('teacher-tests:classroom-1')
+    invalidateCachedJSON('teacher-tests:classroom-2')
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    invalidateCachedJSON('teacher-tests:classroom-1')
+    invalidateCachedJSON('teacher-tests:classroom-2')
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('loads tests for the current classroom', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Unit Test' })] }),
+    })
+
+    const { result } = renderHook(() =>
+      useTeacherTestList({
+        classroomId: 'classroom-1',
+        selectedTestId: null,
+        selectedTestDraftSummary: null,
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1')
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.tests).toHaveLength(1)
+    expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Unit Test'])
+  })
+
+  it('hides prior classroom tests while the next classroom is loading', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Class A Test' })] }),
+    })
+
+    const { result, rerender } = renderHook(
+      ({ classroomId }: { classroomId: string }) =>
+        useTeacherTestList({
+          classroomId,
+          selectedTestId: null,
+          selectedTestDraftSummary: null,
+        }),
+      { initialProps: { classroomId: 'classroom-1' } },
+    )
+
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Class A Test']))
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tests: [makeTest({ id: 'test-2', title: 'Class B Test' })] }),
+    })
+
+    rerender({ classroomId: 'classroom-2' })
+
+    expect(result.current.visibleTests).toEqual([])
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Class B Test']))
+  })
+
+  it('ignores late responses from a previous classroom', async () => {
+    type PendingRequest = {
+      url: string
+      resolve: (value: { ok: boolean; json: () => Promise<{ tests: TestAssessmentWithStats[] }> }) => void
+    }
+    const pending: PendingRequest[] = []
+
+    fetchMock.mockImplementation((url: string) => (
+      new Promise((resolve) => {
+        pending.push({ url, resolve: resolve as PendingRequest['resolve'] })
+      })
+    ))
+
+    function resolveTests(classroomId: string, tests: TestAssessmentWithStats[]) {
+      const request = pending.find((item) => item.url === `/api/teacher/tests?classroom_id=${classroomId}`)
+      expect(request).toBeTruthy()
+      request?.resolve({
+        ok: true,
+        json: async () => ({ tests }),
+      })
+    }
+
+    const { result, rerender } = renderHook(
+      ({ classroomId }: { classroomId: string }) =>
+        useTeacherTestList({
+          classroomId,
+          selectedTestId: null,
+          selectedTestDraftSummary: null,
+        }),
+      { initialProps: { classroomId: 'classroom-1' } },
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1')
+    })
+
+    rerender({ classroomId: 'classroom-2' })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-2')
+    })
+
+    await act(async () => {
+      resolveTests('classroom-2', [makeTest({ id: 'test-b', title: 'Class B Test' })])
+      await Promise.resolve()
+    })
+
+    expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Class B Test'])
+
+    await act(async () => {
+      resolveTests('classroom-1', [makeTest({ id: 'test-a', title: 'Class A Test' })])
+      await Promise.resolve()
+    })
+
+    expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Class B Test'])
+  })
+
+  it('reloads only for matching classroom update events', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Initial Test' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-2', title: 'Reloaded Test' })] }),
+      })
+
+    const { result } = renderHook(() =>
+      useTeacherTestList({
+        classroomId: 'classroom-1',
+        selectedTestId: null,
+        selectedTestDraftSummary: null,
+      }),
+    )
+
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Initial Test']))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, { detail: { classroomId: 'classroom-2' } }),
+      )
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TEACHER_TESTS_UPDATED_EVENT, { detail: { classroomId: 'classroom-1' } }),
+      )
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Reloaded Test']))
+  })
+
+  it('applies the current selected draft summary to reloaded tests', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Original Test' })] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ tests: [makeTest({ id: 'test-1', title: 'Server Test' })] }),
+      })
+
+    const { result, rerender } = renderHook(
+      ({ selectedTestDraftSummary }: Pick<Parameters<typeof useTeacherTestList>[0], 'selectedTestDraftSummary'>) =>
+        useTeacherTestList({
+          classroomId: 'classroom-1',
+          selectedTestId: 'test-1',
+          selectedTestDraftSummary,
+        }),
+      { initialProps: { selectedTestDraftSummary: null } },
+    )
+
+    await waitFor(() => expect(result.current.visibleTests.map((test) => test.title)).toEqual(['Original Test']))
+
+    rerender({
+      selectedTestDraftSummary: {
+        title: 'Draft Title',
+        show_results: false,
+        questions_count: 7,
+      },
+    })
+
+    await act(async () => {
+      await result.current.loadTests()
+    })
+
+    expect(result.current.visibleTests[0]).toMatchObject({
+      title: 'Draft Title',
+      show_results: false,
+      stats: expect.objectContaining({ questions_count: 7 }),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Extract TeacherTestsTab classroom-owned tests-list loading into `useTeacherTestList`
- Share selected-test summary patching through `src/lib/test-summary-patch.ts`
- Add hook-level workspace-state regressions plus parent visible-reload coverage

## Refactor checklist
- Slice boundary: tests-list async state, owner identity, event reloads, and selected-draft summary patching only
- Risk profile: `workspace-state`
- Business logic moved: selected-test summary patch utility; no routing, grading actions, modal flows, or rendering moved
- Visible behavior intended to change: none
- Owner identity: classroom id
- Late responses ignored: request id plus current classroom id checks in the hook
- Immediate owner-change behavior: prior classroom tests are hidden whenever loaded owner differs from current classroom
- A-after-B regression: covered in `tests/hooks/useTeacherTestList.test.ts`; parent stale-response coverage remains in `TeacherTestsTab.test.tsx`

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test tests/hooks/useTeacherTestList.test.ts tests/components/TeacherTestsTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test`
- `pnpm build`
