### PR TITLE
Normalize teacher test results payloads

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,23 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz client response readers
-
-**Completed:**
-- Created `codex/legacy-quiz-client-readers` from current `origin/main`.
-- Added `readTestFromPayload` and `readTestsFromPayload` to `src/lib/test-api-contract.ts` so active client code reads current Tests API keys first and legacy quiz keys only as compatibility fallback.
-- Replaced scattered `data.test ?? data.quiz` and `data.tests || data.quizzes || []` reads in teacher/student Tests UI, test document sync flows, the teacher preview page, and the assessment URL-state e2e helper.
-- Expanded `tests/lib/test-api-contract.test.ts` to cover current-key preference, legacy fallback, and empty payload behavior.
-- Did not change server payloads, schema, migrations, RPCs, storage paths, gradebook contracts, course blueprint contracts, or DB-shaped `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx tests/components/StudentTestsTab.test.tsx tests/components/TestDetailPanel.test.tsx tests/components/StudentTestForm.test.tsx tests/components/StudentTestResults.test.tsx`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test` (303 files / 2676 tests)
-- `git diff --check`
-
 ## 2026-06-13 — Student Today stale classroom load guard
 
 **Completed:**
@@ -794,6 +777,33 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm test tests/hooks/useTeacherTestList.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-22 — Teacher test results normalization
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a behavior-preserving legacy contract cleanup slice.
+- Moved teacher test results payload normalization from `TeacherTestsTab` into `readTeacherTestResultsFromPayload` in `src/lib/test-api-contract.ts`.
+- Kept current `test` payload keys preferred while retaining the legacy `quiz` fallback for compatibility.
+- Exported typed teacher grading student/question result shapes from the contract helper and kept UI state, fetch ownership, grading actions, and rendering in `TeacherTestsTab`.
+- Added contract tests for current-key preference, legacy fallback, active run/error passthrough, question summary mapping, and unknown-status filtering.
+- Strengthened the parent `TeacherTestsTab` legacy fallback regression to prove the normalized results request still loads without the generic results error.
+
+**Compatibility checklist:**
+- What widened: no API payload, query, or schema widened; only client-side normalization moved to a helper.
+- Fallback: legacy `quiz` detail key remains supported through `readTestFromPayload`.
+- Migration dependency: none; no schema or server contract changed.
+- Intended payload regression: `tests/lib/test-api-contract.test.ts` covers current `test` preference and legacy `quiz` fallback.
+- Legacy aliases still alive: `quiz`/`quizzes` response aliases and fallback readers remain intentionally alive.
+- Visible behavior intended to change: none.
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
 - `pnpm lint`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherTestsTab.tsx
@@ -52,7 +52,13 @@ import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
 import { getTestExitCount } from '@/lib/tests'
 import { fetchJSONWithCache } from '@/lib/request-cache'
 import { validateTestQuestionCreate } from '@/lib/test-questions'
-import { readTestFromPayload } from '@/lib/test-api-contract'
+import {
+  readTeacherTestResultsFromPayload,
+  readTestFromPayload,
+  type TeacherTestGradingQuestionSummary as TestGradingQuestionSummary,
+  type TeacherTestGradingStudentRow as TestGradingStudentRow,
+  type TeacherTestResultsPayload,
+} from '@/lib/test-api-contract'
 import { applyTestSummaryPatchToTest } from '@/lib/test-summary-patch'
 import { compareByNameFields } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
@@ -70,7 +76,6 @@ import type {
   AssessmentWorkspaceSummaryPatch,
   Classroom,
   TestAssessment,
-  TestFocusSummary,
   TestAssessmentWithStats,
   TestAiGradingRunSummary,
 } from '@/types'
@@ -92,49 +97,6 @@ interface Props {
   }) => void
   onRequestTestPreview?: (preview: { testId: string; title: string }) => void
   onRequestDelete?: () => void
-}
-
-interface TestGradingStudentRow {
-  student_id: string
-  name: string | null
-  first_name: string | null
-  last_name: string | null
-  email: string
-  status: 'not_started' | 'in_progress' | 'closed' | 'submitted' | 'returned'
-  submitted_at: string | null
-  closed_for_grading_at?: string | null
-  last_activity_at: string | null
-  points_earned: number
-  points_possible: number
-  percent: number | null
-  graded_open_responses: number
-  ungraded_open_responses: number
-  access_state?: 'open' | 'closed' | null
-  effective_access?: 'open' | 'closed'
-  access_source?: 'test' | 'student'
-  focus_summary: TestFocusSummary | null
-}
-
-interface TestGradingQuestionSummary {
-  id: string
-  questionType: 'multiple_choice' | 'open_response'
-  responseMonospace: boolean
-}
-
-type TeacherTestResultsQuestionResponse = {
-  id: string
-  question_type?: unknown
-  response_monospace?: unknown
-}
-
-type TeacherTestResultsResponse = {
-  test?: TestAssessment | null
-  /** Legacy compatibility key retained by active Tests APIs during contract migration. */
-  quiz?: TestAssessment | null
-  students?: TestGradingStudentRow[]
-  questions?: TeacherTestResultsQuestionResponse[]
-  active_ai_grading_run?: TestAiGradingRunSummary | null
-  error?: string
 }
 
 type TestEditModalView = 'edit' | 'markdown'
@@ -785,7 +747,7 @@ export function TeacherTestsTab({
     }
     setGradingError('')
     try {
-      const { ok, data } = await fetchJSONWithCache<{ ok: boolean; data: TeacherTestResultsResponse }>(
+      const { ok, data } = await fetchJSONWithCache<{ ok: boolean; data: TeacherTestResultsPayload }>(
         `teacher-test-results:${requestedTestId}:${requestId}`,
         async () => {
           const response = await fetch(`${apiBasePath}/${requestedTestId}/results`, { cache: 'no-store' })
@@ -794,17 +756,13 @@ export function TeacherTestsTab({
         0,
       )
       if (isStaleRequest()) return
-      if (!ok) throw new Error(data.error || 'Failed to load test results')
+      const results = readTeacherTestResultsFromPayload(data)
+      if (!ok) throw new Error(results.error || 'Failed to load test results')
 
-      const responseTest = readTestFromPayload<TestAssessment>(data)
-      const nextStatus =
-        responseTest?.status === 'draft' || responseTest?.status === 'active' || responseTest?.status === 'closed'
-          ? (responseTest.status as TestAssessment['status'])
-          : null
-
+      const nextStatus = results.testStatus
       setGradingServerTestStatus(nextStatus)
       setGradingServerTestId(requestedTestId)
-      setTestAiGradingRun((data.active_ai_grading_run as TestAiGradingRunSummary | null) ?? null)
+      setTestAiGradingRun(results.activeAiGradingRun)
       if (nextStatus) {
         setTests((prev) =>
           prev.map((test) =>
@@ -812,19 +770,10 @@ export function TeacherTestsTab({
           )
         )
       }
-      const nextStudents = (data.students || []) as TestGradingStudentRow[]
+      const nextStudents = results.students
       recordGradingExitCountChanges(requestedTestId, nextStudents)
       setGradingStudents(nextStudents)
-      setGradingQuestions(
-        Array.isArray(data.questions)
-          ? data.questions.map((question) => ({
-              id: String(question.id),
-              questionType:
-                question.question_type === 'open_response' ? 'open_response' : 'multiple_choice',
-              responseMonospace: question.response_monospace === true,
-            }))
-          : []
-      )
+      setGradingQuestions(results.questions)
     } catch (error: any) {
       if (isStaleRequest()) return
       setGradingError(error.message || 'Failed to load test results')

--- a/src/lib/test-api-contract.ts
+++ b/src/lib/test-api-contract.ts
@@ -1,3 +1,9 @@
+import type {
+  TestAiGradingRunSummary,
+  TestAssessment,
+  TestFocusSummary,
+} from '@/types'
+
 /**
  * Tests are the active product surface, but these routes still emit legacy
  * quiz-shaped keys for older clients during the contract transition.
@@ -32,4 +38,79 @@ export function readTestsFromPayload<T>(payload: TestApiListPayload<T> | null | 
 
 export function readTestFromPayload<T>(payload: TestApiDetailPayload<T> | null | undefined): T | undefined {
   return payload?.test ?? payload?.quiz ?? undefined
+}
+
+export interface TeacherTestGradingStudentRow {
+  student_id: string
+  name: string | null
+  first_name: string | null
+  last_name: string | null
+  email: string
+  status: 'not_started' | 'in_progress' | 'closed' | 'submitted' | 'returned'
+  submitted_at: string | null
+  closed_for_grading_at?: string | null
+  last_activity_at: string | null
+  points_earned: number
+  points_possible: number
+  percent: number | null
+  graded_open_responses: number
+  ungraded_open_responses: number
+  access_state?: 'open' | 'closed' | null
+  effective_access?: 'open' | 'closed'
+  access_source?: 'test' | 'student'
+  focus_summary: TestFocusSummary | null
+}
+
+export interface TeacherTestGradingQuestionSummary {
+  id: string
+  questionType: 'multiple_choice' | 'open_response'
+  responseMonospace: boolean
+}
+
+type TeacherTestResultsQuestionPayload = {
+  id: string
+  question_type?: unknown
+  response_monospace?: unknown
+}
+
+export type TeacherTestResultsPayload = TestApiDetailPayload<TestAssessment> & {
+  students?: TeacherTestGradingStudentRow[]
+  questions?: TeacherTestResultsQuestionPayload[]
+  active_ai_grading_run?: TestAiGradingRunSummary | null
+  error?: string
+}
+
+export type TeacherTestResults = {
+  test: TestAssessment | undefined
+  testStatus: TestAssessment['status'] | null
+  students: TeacherTestGradingStudentRow[]
+  questions: TeacherTestGradingQuestionSummary[]
+  activeAiGradingRun: TestAiGradingRunSummary | null
+  error?: string
+}
+
+function readTeacherTestStatus(test: TestAssessment | undefined): TestAssessment['status'] | null {
+  return test?.status === 'draft' || test?.status === 'active' || test?.status === 'closed'
+    ? test.status
+    : null
+}
+
+export function readTeacherTestResultsFromPayload(
+  payload: TeacherTestResultsPayload | null | undefined,
+): TeacherTestResults {
+  const test = readTestFromPayload<TestAssessment>(payload)
+  return {
+    test,
+    testStatus: readTeacherTestStatus(test),
+    students: payload?.students || [],
+    questions: Array.isArray(payload?.questions)
+      ? payload.questions.map((question) => ({
+          id: String(question.id),
+          questionType: question.question_type === 'open_response' ? 'open_response' : 'multiple_choice',
+          responseMonospace: question.response_monospace === true,
+        }))
+      : [],
+    activeAiGradingRun: payload?.active_ai_grading_run ?? null,
+    error: payload?.error,
+  }
 }

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -640,6 +640,8 @@ describe('TeacherTestsTab', () => {
     fireEvent.click(await screen.findByText('Unit Test'))
 
     expect(await screen.findByText('Alice Zephyr')).toBeInTheDocument()
+    expect(resultsFetchCalls(fetchMock)).toHaveLength(1)
+    expect(screen.queryByText('Failed to load test results')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Close All' })).toBeInTheDocument()
   })
 

--- a/tests/lib/test-api-contract.test.ts
+++ b/tests/lib/test-api-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  readTeacherTestResultsFromPayload,
   readTestFromPayload,
   readTestsFromPayload,
   withLegacyQuizKey,
@@ -51,5 +52,74 @@ describe('test API compatibility contract', () => {
 
     expect(readTestFromPayload({ quiz: legacyTest })).toBe(legacyTest)
     expect(readTestFromPayload(undefined)).toBeUndefined()
+  })
+
+  it('normalizes teacher test results from the current test key first', () => {
+    const currentTest = { id: 'test-current', status: 'active' } as any
+    const legacyTest = { id: 'test-legacy', status: 'closed' } as any
+    const students = [
+      {
+        student_id: 'student-1',
+        name: 'Alice Zephyr',
+        first_name: 'Alice',
+        last_name: 'Zephyr',
+        email: 'alice@example.com',
+        status: 'submitted',
+        submitted_at: null,
+        last_activity_at: null,
+        points_earned: 3,
+        points_possible: 5,
+        percent: 60,
+        graded_open_responses: 1,
+        ungraded_open_responses: 0,
+        focus_summary: null,
+      },
+    ] as any
+    const activeRun = { id: 'run-1', test_id: 'test-current', status: 'running' } as any
+
+    const result = readTeacherTestResultsFromPayload({
+      test: currentTest,
+      quiz: legacyTest,
+      students,
+      questions: [
+        { id: 'q-open', question_type: 'open_response', response_monospace: true },
+        { id: 'q-choice', question_type: 'multiple_choice', response_monospace: false },
+      ],
+      active_ai_grading_run: activeRun,
+    })
+
+    expect(result.test).toBe(currentTest)
+    expect(result.testStatus).toBe('active')
+    expect(result.students).toBe(students)
+    expect(result.questions).toEqual([
+      { id: 'q-open', questionType: 'open_response', responseMonospace: true },
+      { id: 'q-choice', questionType: 'multiple_choice', responseMonospace: false },
+    ])
+    expect(result.activeAiGradingRun).toBe(activeRun)
+  })
+
+  it('normalizes teacher test results from the legacy quiz fallback', () => {
+    const legacyTest = { id: 'test-legacy', status: 'closed' } as any
+
+    const result = readTeacherTestResultsFromPayload({
+      quiz: legacyTest,
+      error: 'No results',
+    })
+
+    expect(result.test).toBe(legacyTest)
+    expect(result.testStatus).toBe('closed')
+    expect(result.students).toEqual([])
+    expect(result.questions).toEqual([])
+    expect(result.activeAiGradingRun).toBeNull()
+    expect(result.error).toBe('No results')
+  })
+
+  it('drops unknown teacher test result statuses while preserving the payload test', () => {
+    const test = { id: 'test-1', status: 'archived' } as any
+
+    const result = readTeacherTestResultsFromPayload({ test })
+
+    expect(result.test).toBe(test)
+    expect(result.testStatus).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Move teacher test results response normalization from `TeacherTestsTab` into `readTeacherTestResultsFromPayload`
- Keep current `test` payload keys preferred while retaining the legacy `quiz` fallback
- Add contract coverage for normalized grading rows/questions, active run/error passthrough, and legacy fallback behavior

## Refactor / compatibility checklist
- Slice boundary: client-side normalization for `/api/teacher/tests/:id/results` payloads only
- Risk profile: none; no schema, route payload, fetch ownership, rendering, grading action, or workspace state change
- What widened: nothing; API payload/query/schema unchanged
- Fallback: legacy `quiz` detail key remains supported via `readTestFromPayload`
- Migration dependency: none
- Intended payload regression: `tests/lib/test-api-contract.test.ts` covers current-key preference and legacy fallback
- Parent regression: `TeacherTestsTab.test.tsx` still proves legacy quiz-keyed results load without the generic results error
- Legacy aliases intentionally still alive: `quiz`/`quizzes` response aliases and fallback readers
- Visible behavior intended to change: none

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test`
- `pnpm build`
