### PR TITLE
Add cached API JSON helper

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -790,12 +790,14 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Kept `fetchJSONWithCache` intact for existing custom fetcher callers and left API payload shape unchanged.
 - Added request-cache coverage for successful JSON parsing, API error precedence, fallback errors for non-JSON failures, and cached helper reuse.
 - Updated hook/component tests for the new helper call shape without changing visible UI behavior.
+- Addressed independent review by preserving JSON parse rejection for successful malformed responses and adding `init` passthrough coverage.
 
 **Cache/helper checklist:**
 - API schema or payload changed: no
 - Cache key semantics changed: no
 - TTL behavior changed: no; callers keep existing `0`, `60_000`, and notification TTL values
 - Error behavior changed: no; `{ error: string }` payloads still win over fallback messages
+- Successful malformed JSON behavior changed: no; successful parse failures still reject instead of caching `null`
 - Existing custom fetcher support: retained through `fetchJSONWithCache`
 - Visible behavior intended to change: none
 

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,35 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Student Today stale classroom load guard
-
-**Completed:**
-- Reestablished the systems/UI audit goal and continued the active client freshness slice.
-- Guarded `StudentTodayTab` entry and lesson-plan async responses by request id and classroom id so late responses from a previous classroom cannot overwrite the current classroom view.
-- Passed the loaded classroom id through `onLessonPlanLoad` and made `ClassroomPageClient` ignore stale lesson-plan updates.
-- Added regression coverage for switching from classroom A to classroom B before classroom A's entries and lesson plan resolve.
-- Updated the adjacent `ClassroomPageClientAssignmentsEditMode` mock to use the new lesson-plan callback contract.
-- Addressed subagent PR review feedback by storing the Today sidebar lesson plan with its classroom id so classroom route changes synchronously hide stale previous-classroom plan content.
-- Added parent-level regression coverage for clearing the Student Today sidebar plan when the classroom route changes.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx`
-- `pnpm vitest run tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx`
-- `git diff --check`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm build`
-- `pnpm vitest run --sequence.concurrent=false` (303 files / 2673 tests)
-- Subagent PR review found one P2 stale sidebar display gap.
-- `pnpm vitest run tests/components/StudentTodayTabHistory.test.tsx tests/components/ClassroomPageClientAssignmentsEditMode.test.tsx` (after review fix; 32 tests)
-- `git diff --check`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm build`
-- `pnpm vitest run --sequence.concurrent=false` (303 files / 2674 tests)
-
 ## 2026-06-13 — Legacy quiz type contract cleanup
 
 **Completed:**
@@ -804,6 +775,34 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm test tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-22 — Cached API JSON helper
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a typed client API/cache helper slice.
+- Added `fetchJSON` and `fetchCachedJSON` to `src/lib/request-cache.ts` so repeated client reads can share JSON parsing, API error payload handling, and cache TTL wiring.
+- Migrated `useTeacherTestList`, `useGradebookData`, and `StudentNotificationsProvider` from inline cached fetcher lambdas to the typed helper.
+- Kept `fetchJSONWithCache` intact for existing custom fetcher callers and left API payload shape unchanged.
+- Added request-cache coverage for successful JSON parsing, API error precedence, fallback errors for non-JSON failures, and cached helper reuse.
+- Updated hook/component tests for the new helper call shape without changing visible UI behavior.
+
+**Cache/helper checklist:**
+- API schema or payload changed: no
+- Cache key semantics changed: no
+- TTL behavior changed: no; callers keep existing `0`, `60_000`, and notification TTL values
+- Error behavior changed: no; `{ error: string }` payloads still win over fallback messages
+- Existing custom fetcher support: retained through `fetchJSONWithCache`
+- Visible behavior intended to change: none
+
+**Validation:**
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm test tests/unit/request-cache.test.ts tests/hooks/useTeacherTestList.test.ts tests/hooks/useGradebookData.test.ts tests/components/StudentNotificationsProvider.test.tsx`
+- `pnpm test tests/components/TeacherTestsTab.test.tsx`
 - `pnpm lint`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/components/StudentNotificationsProvider.tsx
+++ b/src/components/StudentNotificationsProvider.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 
 type NotificationState = {
   hasTodayEntry: boolean
@@ -56,17 +56,13 @@ export function StudentNotificationsProvider({
 
   const fetchNotifications = useCallback(async () => {
     try {
-      const data = await fetchJSONWithCache<StudentNotificationsResponse>(
+      const data = await fetchCachedJSON<StudentNotificationsResponse>(
         getStudentNotificationsCacheKey(classroomId),
-        async () => {
-          const res = await fetch(`/api/student/notifications?classroom_id=${classroomId}`)
-          if (!res.ok) {
-            console.error('Failed to fetch notifications:', res.status)
-            throw new Error('Failed to fetch notifications')
-          }
-          return res.json()
+        `/api/student/notifications?classroom_id=${classroomId}`,
+        {
+          ttlMs: NOTIFICATIONS_CACHE_TTL_MS,
+          errorMessage: 'Failed to fetch notifications',
         },
-        NOTIFICATIONS_CACHE_TTL_MS,
       )
       setHasTodayEntry(data.hasTodayEntry)
       setUnviewedAssignmentsCount(data.unviewedAssignmentsCount)

--- a/src/hooks/useGradebookData.ts
+++ b/src/hooks/useGradebookData.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { DESKTOP_BREAKPOINT } from '@/lib/layout-config'
 import { invalidateGradebookForClassroom } from '@/lib/gradebook-cache'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchCachedJSON } from '@/lib/request-cache'
 import type { GradebookClassSummary, GradebookStudentDetail, GradebookStudentSummary } from '@/types'
 
 interface UseGradebookDataOptions {
@@ -99,17 +99,13 @@ export function useGradebookData({
       setGradebookStudentDetailError('')
       try {
         const cacheKey = `gradebook:${classroomId}:${selectedStudentId}`
-        const data = await fetchJSONWithCache(
+        const data = await fetchCachedJSON<{ selected_student?: GradebookStudentDetail | null }>(
           cacheKey,
-          async () => {
-            const response = await fetch(
-              `/api/teacher/gradebook?classroom_id=${classroomId}&student_id=${selectedStudentId}`
-            )
-            const json = await response.json()
-            if (!response.ok) throw new Error(json.error || 'Failed to load gradebook details')
-            return json
+          `/api/teacher/gradebook?classroom_id=${classroomId}&student_id=${selectedStudentId}`,
+          {
+            ttlMs: 60_000, // 60s TTL — gradebook details are stable within a session
+            errorMessage: 'Failed to load gradebook details',
           },
-          60_000, // 60s TTL — gradebook details are stable within a session
         )
 
         if (!cancelled) {

--- a/src/hooks/useTeacherTestList.ts
+++ b/src/hooks/useTeacherTestList.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { TEACHER_TESTS_UPDATED_EVENT } from '@/lib/events'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchCachedJSON } from '@/lib/request-cache'
 import { readTestsFromPayload } from '@/lib/test-api-contract'
 import { applyTestSummaryPatchToTest } from '@/lib/test-summary-patch'
 import type { AssessmentEditorSummaryUpdate, TestAssessmentWithStats } from '@/types'
@@ -61,15 +61,10 @@ export function useTeacherTestList({
     setLoading(true)
     try {
       const query = new URLSearchParams({ classroom_id: requestedClassroomId })
-      const data = await fetchJSONWithCache<TeacherTestListResponse>(
+      const data = await fetchCachedJSON<TeacherTestListResponse>(
         `teacher-tests:${requestedClassroomId}`,
-        async () => {
-          const response = await fetch(`${apiBasePath}?${query.toString()}`)
-          const payload = await response.json()
-          if (!response.ok) throw new Error(payload.error || 'Failed to load tests')
-          return payload
-        },
-        0,
+        `${apiBasePath}?${query.toString()}`,
+        { ttlMs: 0, errorMessage: 'Failed to load tests' },
       )
       if (!isCurrentRequest()) return
 

--- a/src/lib/request-cache.ts
+++ b/src/lib/request-cache.ts
@@ -26,13 +26,14 @@ export async function fetchJSON<T>(
   options: FetchJSONOptions = {},
 ): Promise<T> {
   const response = await fetch(input, options.init)
-  const payload = await response.json().catch(() => null) as unknown
 
-  if (!response.ok) {
-    throw new Error(readPayloadError(payload) || options.errorMessage || 'Request failed')
+  if (response.ok) {
+    return await response.json() as T
   }
 
-  return payload as T
+  const payload = await response.json().catch(() => null) as unknown
+
+  throw new Error(readPayloadError(payload) || options.errorMessage || 'Request failed')
 }
 
 export async function fetchJSONWithCache<T>(

--- a/src/lib/request-cache.ts
+++ b/src/lib/request-cache.ts
@@ -6,6 +6,35 @@ type CacheEntry = {
 
 const cache = new Map<string, CacheEntry>()
 
+type FetchJSONOptions = {
+  init?: RequestInit
+  errorMessage?: string
+}
+
+type FetchCachedJSONOptions = FetchJSONOptions & {
+  ttlMs?: number
+}
+
+function readPayloadError(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const error = (payload as { error?: unknown }).error
+  return typeof error === 'string' && error.trim() ? error : null
+}
+
+export async function fetchJSON<T>(
+  input: RequestInfo | URL,
+  options: FetchJSONOptions = {},
+): Promise<T> {
+  const response = await fetch(input, options.init)
+  const payload = await response.json().catch(() => null) as unknown
+
+  if (!response.ok) {
+    throw new Error(readPayloadError(payload) || options.errorMessage || 'Request failed')
+  }
+
+  return payload as T
+}
+
 export async function fetchJSONWithCache<T>(
   key: string,
   fetcher: () => Promise<T>,
@@ -46,6 +75,19 @@ export async function fetchJSONWithCache<T>(
   })
 
   return pending
+}
+
+export function fetchCachedJSON<T>(
+  key: string,
+  input: RequestInfo | URL,
+  options: FetchCachedJSONOptions = {},
+): Promise<T> {
+  const { ttlMs = 15_000, ...fetchOptions } = options
+  return fetchJSONWithCache(
+    key,
+    () => fetchJSON<T>(input, fetchOptions),
+    ttlMs,
+  )
 }
 
 export function prefetchJSON<T>(

--- a/tests/components/TeacherTestsTab.test.tsx
+++ b/tests/components/TeacherTestsTab.test.tsx
@@ -379,7 +379,7 @@ describe('TeacherTestsTab', () => {
     const view = renderTab({ classroom })
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${classroom.id}`)
+      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${classroom.id}`, undefined)
     })
 
     view.rerender(
@@ -389,7 +389,7 @@ describe('TeacherTestsTab', () => {
     )
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${secondClassroom.id}`)
+      expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/tests?classroom_id=${secondClassroom.id}`, undefined)
     })
 
     await act(async () => {

--- a/tests/hooks/useGradebookData.test.ts
+++ b/tests/hooks/useGradebookData.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { useGradebookData } from '@/hooks/useGradebookData'
-import { fetchJSONWithCache, invalidateCachedJSONMatching } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSONMatching } from '@/lib/request-cache'
 import type {
   GradebookClassSummary,
   GradebookStudentDetail,
@@ -9,7 +9,7 @@ import type {
 } from '@/types'
 
 vi.mock('@/lib/request-cache', () => ({
-  fetchJSONWithCache: vi.fn(),
+  fetchCachedJSON: vi.fn(),
   invalidateCachedJSONMatching: vi.fn(),
 }))
 
@@ -72,7 +72,7 @@ describe('useGradebookData', () => {
       tests: [],
     }
 
-    const cacheFetchMock = vi.mocked(fetchJSONWithCache)
+    const cacheFetchMock = vi.mocked(fetchCachedJSON)
     cacheFetchMock
       .mockResolvedValueOnce({ selected_student: firstDetail })
       .mockResolvedValueOnce({ selected_student: secondDetail })

--- a/tests/hooks/useTeacherTestList.test.ts
+++ b/tests/hooks/useTeacherTestList.test.ts
@@ -58,7 +58,7 @@ describe('useTeacherTestList', () => {
       }),
     )
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1')
+    expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1', undefined)
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     expect(result.current.tests).toHaveLength(1)
@@ -127,13 +127,13 @@ describe('useTeacherTestList', () => {
     )
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1')
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-1', undefined)
     })
 
     rerender({ classroomId: 'classroom-2' })
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-2')
+      expect(fetchMock).toHaveBeenCalledWith('/api/teacher/tests?classroom_id=classroom-2', undefined)
     })
 
     await act(async () => {

--- a/tests/unit/request-cache.test.ts
+++ b/tests/unit/request-cache.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchCachedJSON,
+  fetchJSON,
   fetchJSONWithCache,
   invalidateCachedJSON,
   invalidateCachedJSONMatching,
@@ -19,6 +21,10 @@ function deferred<T>() {
 }
 
 describe('request cache', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   afterEach(() => {
     invalidateCachedJSONMatching(TEST_PREFIX)
   })
@@ -100,5 +106,50 @@ describe('request cache', () => {
 
     expect(freshFetcher).toHaveBeenCalledTimes(1)
     expect(fallbackFetcher).not.toHaveBeenCalled()
+  })
+
+  it('fetchJSON returns parsed JSON for successful responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchJSON('/api/example')).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledWith('/api/example', undefined)
+  })
+
+  it('fetchJSON throws API error messages before fallback errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Specific failure' }),
+    }))
+
+    await expect(fetchJSON('/api/example', { errorMessage: 'Fallback failure' })).rejects.toThrow('Specific failure')
+  })
+
+  it('fetchJSON throws fallback errors when error payload is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => {
+        throw new Error('not json')
+      },
+    }))
+
+    await expect(fetchJSON('/api/example', { errorMessage: 'Fallback failure' })).rejects.toThrow('Fallback failure')
+  })
+
+  it('fetchCachedJSON reuses cached API responses', async () => {
+    const key = `${TEST_PREFIX}cached-api-json`
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 1 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchCachedJSON(key, '/api/example', { ttlMs: 60_000 })).resolves.toEqual({ version: 1 })
+    await expect(fetchCachedJSON(key, '/api/example', { ttlMs: 60_000 })).resolves.toEqual({ version: 1 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/request-cache.test.ts
+++ b/tests/unit/request-cache.test.ts
@@ -119,6 +119,17 @@ describe('request cache', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/example', undefined)
   })
 
+  it('fetchJSON rejects successful responses with malformed JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('bad json')
+      },
+    }))
+
+    await expect(fetchJSON('/api/example')).rejects.toThrow('bad json')
+  })
+
   it('fetchJSON throws API error messages before fallback errors', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
@@ -151,5 +162,19 @@ describe('request cache', () => {
     await expect(fetchCachedJSON(key, '/api/example', { ttlMs: 60_000 })).resolves.toEqual({ version: 1 })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetchCachedJSON passes request init to fetch', async () => {
+    const key = `${TEST_PREFIX}cached-api-json-init`
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ saved: true }),
+    })
+    const init = { headers: { accept: 'application/json' } }
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchCachedJSON(key, '/api/example', { init })).resolves.toEqual({ saved: true })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/example', init)
   })
 })


### PR DESCRIPTION
## Summary
- Add `fetchJSON` and `fetchCachedJSON` helpers in `src/lib/request-cache.ts` for typed JSON reads with shared error fallback behavior.
- Migrate `useTeacherTestList`, `useGradebookData`, and `StudentNotificationsProvider` to the typed cached helper while keeping existing TTL/cache-key semantics.
- Add request-cache coverage and update affected hook/component expectations for the helper call shape.

## Scope
- No API schema, payload, or UI behavior change intended.
- `fetchJSONWithCache` remains available for custom fetcher callers.
- This is the typed client API/cache helper slice of the bounded architecture/UI audit goal.

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test tests/unit/request-cache.test.ts tests/hooks/useTeacherTestList.test.ts tests/hooks/useGradebookData.test.ts tests/components/StudentNotificationsProvider.test.tsx`
- `pnpm test tests/components/TeacherTestsTab.test.tsx`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test`
- `pnpm build`
