### PR TITLE
Reuse teacher classroom access helper

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz type contract cleanup
-
-**Completed:**
-- Inverted the shared assessment type definitions so active `TestAssessment*`, `StudentTest*`, and `TestFocus*` names are canonical in `src/types/index.ts`.
-- Kept legacy `Quiz*` type exports as compatibility aliases/interfaces for DB-shaped and older contract code.
-- Updated assessment utilities and server access helpers to consume canonical Test/Assessment type names while preserving legacy exports and response shapes.
-- Moved the active TeacherTestsTab component test from `QuizWithStats` to `TestAssessmentWithStats`.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/test-api-contract.test.ts tests/components/TeacherTestsTab.test.tsx`
-- `pnpm test` (303 files / 2678 tests)
-- `git diff --check`
-
 ## 2026-06-13 — Teacher lesson calendar stale classroom load guard
 
 **Completed:**
@@ -810,3 +794,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-06-22 — Teacher classroom access helper reuse
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a Supabase route/query helper consolidation slice.
+- Extended `assertTeacherOwnsClassroom` to include classroom `title` and accept an optional existing service-role client, preserving the default helper call shape.
+- Reused the helper in read-only teacher routes that previously duplicated `classrooms.select('teacher_id')` ownership checks: attendance, export CSV, log summary, logs, and student history.
+- Kept each route's current response style, status codes, payloads, and downstream query shape unchanged.
+- Added helper-level coverage proving the shared classroom access helper returns `title` and reuses a provided Supabase client.
+
+**Route/query helper checklist:**
+- Schema or migration changed: no
+- Browser-side Supabase access changed: no
+- Authorization semantics changed: no; 404 not found and 403 forbidden still come from the same ownership predicate
+- Payload shape changed: no
+- Supabase query count changed: no intended extra queries; migrated routes pass their existing service client into the helper
+- Visible behavior intended to change: none
+
+**Validation:**
+- `pnpm test tests/unit/server-access.test.ts tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts tests/api/teacher/log-summary.test.ts tests/api/teacher/logs.test.ts tests/api/teacher/student-history.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`

--- a/src/app/api/teacher/attendance/route.ts
+++ b/src/app/api/teacher/attendance/route.ts
@@ -9,6 +9,7 @@ import {
   loadAttendanceEntries,
   loadAttendanceRoster,
 } from '@/lib/server/attendance-report'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -28,20 +29,9 @@ export const GET = withErrorHandler('GetAttendance', async (request: NextRequest
   }
 
   const supabase = getServiceRoleClient()
-
-  // Verify ownership
-  const { data: classroom, error: classroomError } = await supabase
-    .from('classrooms')
-    .select('teacher_id')
-    .eq('id', classroomId)
-    .single()
-
-  if (classroomError || !classroom) {
-    throw new ApiError(404, 'Classroom not found')
-  }
-
-  if (classroom.teacher_id !== user.id) {
-    throw new ApiError(403, 'Forbidden')
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
+  if (!ownership.ok) {
+    throw new ApiError(ownership.status, ownership.error)
   }
 
   const { rows: classDays, error: classDaysError } = await loadAttendanceClassDays(supabase, classroomId)

--- a/src/app/api/teacher/export-csv/route.ts
+++ b/src/app/api/teacher/export-csv/route.ts
@@ -9,6 +9,7 @@ import {
   loadAttendanceEntries,
   loadAttendanceRoster,
 } from '@/lib/server/attendance-report'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -31,25 +32,11 @@ export const GET = withErrorHandler('GetTeacherExportCsv', async (request, conte
   }
 
   const supabase = getServiceRoleClient()
-
-  // Verify ownership
-  const { data: classroom, error: classroomError } = await supabase
-    .from('classrooms')
-    .select('teacher_id, title')
-    .eq('id', classroomId)
-    .single()
-
-  if (classroomError || !classroom) {
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
+  if (!ownership.ok) {
     return NextResponse.json(
-      { error: 'Classroom not found' },
-      { status: 404 }
-    )
-  }
-
-  if (classroom.teacher_id !== user.id) {
-    return NextResponse.json(
-      { error: 'Forbidden' },
-      { status: 403 }
+      { error: ownership.error },
+      { status: ownership.status }
     )
   }
 
@@ -136,7 +123,7 @@ export const GET = withErrorHandler('GetTeacherExportCsv', async (request, conte
   })
 
   // Return CSV file
-  const filename = `attendance-${classroom.title.replace(/\s+/g, '-')}-${new Date().toISOString().split('T')[0]}.csv`
+  const filename = `attendance-${ownership.classroom.title.replace(/\s+/g, '-')}-${new Date().toISOString().split('T')[0]}.csv`
   return new NextResponse(csv, {
     headers: {
       'Content-Type': 'text/csv',

--- a/src/app/api/teacher/log-summary/route.ts
+++ b/src/app/api/teacher/log-summary/route.ts
@@ -6,6 +6,7 @@ import {
   type RawSummaryResponse,
 } from '@/lib/log-summary'
 import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -35,25 +36,11 @@ export const GET = withErrorHandler('GetLogSummary', async (request: NextRequest
   }
 
   const supabase = getServiceRoleClient()
-
-  // Verify classroom ownership
-  const { data: classroom, error: classroomError } = await supabase
-    .from('classrooms')
-    .select('teacher_id')
-    .eq('id', classroomId)
-    .single()
-
-  if (classroomError || !classroom) {
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
+  if (!ownership.ok) {
     return NextResponse.json(
-      { error: 'Classroom not found' },
-      { status: 404 }
-    )
-  }
-
-  if (classroom.teacher_id !== user.id) {
-    return NextResponse.json(
-      { error: 'Forbidden' },
-      { status: 403 }
+      { error: ownership.error },
+      { status: ownership.status }
     )
   }
 

--- a/src/app/api/teacher/logs/route.ts
+++ b/src/app/api/teacher/logs/route.ts
@@ -3,6 +3,7 @@ import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
 import { loadClassroomRoster } from '@/lib/server/classroom-roster'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 import { chunkValues, loadChunkedRows } from '@/lib/server/query-chunks'
 import type { Entry } from '@/types'
 
@@ -54,24 +55,11 @@ export const GET = withErrorHandler('GetTeacherLogs', async (request: NextReques
   }
 
   const supabase = getServiceRoleClient()
-
-  const { data: classroom, error: classroomError } = await supabase
-    .from('classrooms')
-    .select('teacher_id')
-    .eq('id', classroomId)
-    .single()
-
-  if (classroomError || !classroom) {
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
+  if (!ownership.ok) {
     return NextResponse.json(
-      { error: 'Classroom not found' },
-      { status: 404 }
-    )
-  }
-
-  if (classroom.teacher_id !== user.id) {
-    return NextResponse.json(
-      { error: 'Forbidden' },
-      { status: 403 }
+      { error: ownership.error },
+      { status: ownership.status }
     )
   }
 

--- a/src/app/api/teacher/student-history/route.ts
+++ b/src/app/api/teacher/student-history/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServiceRoleClient } from '@/lib/supabase'
 import { requireRole } from '@/lib/auth'
 import { withErrorHandler } from '@/lib/api-handler'
+import { assertTeacherOwnsClassroom } from '@/lib/server/classrooms'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -33,24 +34,11 @@ export const GET = withErrorHandler('GetStudentHistory', async (request: NextReq
   }
 
   const supabase = getServiceRoleClient()
-
-  const { data: classroom, error: classroomError } = await supabase
-    .from('classrooms')
-    .select('teacher_id')
-    .eq('id', classroomId)
-    .single()
-
-  if (classroomError || !classroom) {
+  const ownership = await assertTeacherOwnsClassroom(user.id, classroomId, { supabase })
+  if (!ownership.ok) {
     return NextResponse.json(
-      { error: 'Classroom not found' },
-      { status: 404 }
-    )
-  }
-
-  if (classroom.teacher_id !== user.id) {
-    return NextResponse.json(
-      { error: 'Forbidden' },
-      { status: 403 }
+      { error: ownership.error },
+      { status: ownership.status }
     )
   }
 

--- a/src/lib/server/classrooms.ts
+++ b/src/lib/server/classrooms.ts
@@ -10,8 +10,11 @@ import {
 } from '@/lib/classroom-theme'
 import type { Classroom } from '@/types'
 
+type SupabaseClient = ReturnType<typeof getServiceRoleClient>
+
 export type ClassroomAccessRecord = {
   id: string
+  title: string
   teacher_id: string
   archived_at: string | null
   actual_site_slug: string | null
@@ -51,14 +54,19 @@ type AccessResult<T> =
   | { ok: true; classroom: T }
   | { ok: false; status: number; error: string }
 
+type ClassroomAccessOptions = {
+  supabase?: SupabaseClient
+}
+
 export async function assertTeacherOwnsClassroom(
   teacherId: string,
-  classroomId: string
+  classroomId: string,
+  options: ClassroomAccessOptions = {},
 ): Promise<AccessResult<ClassroomAccessRecord>> {
-  const supabase = getServiceRoleClient()
+  const supabase = options.supabase ?? getServiceRoleClient()
   const { data: classroom, error } = await supabase
     .from('classrooms')
-    .select('id, teacher_id, archived_at, actual_site_slug, actual_site_published')
+    .select('id, title, teacher_id, archived_at, actual_site_slug, actual_site_published')
     .eq('id', classroomId)
     .single()
 
@@ -75,9 +83,10 @@ export async function assertTeacherOwnsClassroom(
 
 export async function assertTeacherCanMutateClassroom(
   teacherId: string,
-  classroomId: string
+  classroomId: string,
+  options: ClassroomAccessOptions = {},
 ): Promise<AccessResult<ClassroomAccessRecord>> {
-  const ownership = await assertTeacherOwnsClassroom(teacherId, classroomId)
+  const ownership = await assertTeacherOwnsClassroom(teacherId, classroomId, options)
   if (!ownership.ok) {
     return ownership
   }

--- a/tests/unit/server-access.test.ts
+++ b/tests/unit/server-access.test.ts
@@ -72,6 +72,41 @@ describe('server access helpers', () => {
       })
     })
 
+    it('returns classroom title and reuses a provided Supabase client', async () => {
+      const providedSupabase = {
+        from: vi.fn((table: string) => {
+          expect(table).toBe('classrooms')
+          return createSingleSelectResult({
+            data: {
+              id: 'classroom-1',
+              title: 'Period 1',
+              teacher_id: 'teacher-1',
+              archived_at: null,
+              actual_site_slug: 'period-1',
+              actual_site_published: true,
+            },
+            error: null,
+          })
+        }),
+      }
+
+      await expect(
+        assertTeacherOwnsClassroom('teacher-1', 'classroom-1', { supabase: providedSupabase as any })
+      ).resolves.toEqual({
+        ok: true,
+        classroom: {
+          id: 'classroom-1',
+          title: 'Period 1',
+          teacher_id: 'teacher-1',
+          archived_at: null,
+          actual_site_slug: 'period-1',
+          actual_site_published: true,
+        },
+      })
+      expect(providedSupabase.from).toHaveBeenCalledTimes(1)
+      expect(mockSupabaseClient.from).not.toHaveBeenCalled()
+    })
+
     it('blocks mutation when the classroom is archived', async () => {
       mockSupabaseClient.from.mockImplementation((table: string) => {
         expect(table).toBe('classrooms')


### PR DESCRIPTION
## Summary
- Extend `assertTeacherOwnsClassroom` to return classroom `title` and optionally reuse an existing service-role client.
- Replace duplicated read-only teacher classroom ownership queries in attendance, export CSV, log summary, logs, and student history routes.
- Add helper-level coverage for title return and provided-client reuse.

## Scope
- No schema, migration, payload, or browser-side Supabase access change.
- Route status codes and response bodies are intended to stay unchanged.
- This is the Supabase route/query helper consolidation slice of the bounded architecture/UI improvement goal.

## Validation
- `pnpm test tests/unit/server-access.test.ts tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts tests/api/teacher/log-summary.test.ts tests/api/teacher/logs.test.ts tests/api/teacher/student-history.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test`
- `pnpm build`
