### PR TITLE
Extract paged Supabase test helper

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,32 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Teacher lesson calendar stale classroom load guard
-
-**Completed:**
-- Continued the systems/UI audit client freshness track after PR #780.
-- Guarded teacher lesson calendar lesson-plan, assignment, announcement, and markdown async loads so late responses from a previous classroom cannot update the current classroom view.
-- Tagged loaded lesson plans, assignments, and announcements with the classroom id they belong to, so previously loaded classroom data is hidden while the next classroom loads.
-- Added regression coverage for both late stale responses after a classroom change and immediate hiding of previous-classroom data while the next classroom is pending.
-- Addressed subagent PR review feedback by clearing/reloading open markdown sidebar content when the classroom changes and blocking saves while markdown content is not associated with the current classroom.
-- Guarded late autosave PUT responses before they can retag or mutate visible lesson-plan state after the teacher switches classrooms.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx`
-- `git diff --check`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm build`
-- `pnpm vitest run --sequence.concurrent=false` (303 files / 2682 tests)
-- Subagent PR review found stale open-sidebar markdown and late autosave response gaps.
-- `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx` (after review fixes; 8 tests)
-- `git diff --check`
-- `pnpm lint`
-- `bash .codex/skills/pika-audit/scripts/audit.sh`
-- `pnpm build`
-- `pnpm vitest run --sequence.concurrent=false` (303 files / 2684 tests)
-
 ## 2026-06-13 — Legacy quiz server draft helper names
 
 **Completed:**
@@ -814,6 +788,27 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/unit/server-access.test.ts tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts tests/api/teacher/log-summary.test.ts tests/api/teacher/logs.test.ts tests/api/teacher/student-history.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-22 — Paged Supabase test helper
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a test mock simplification slice.
+- Extracted the duplicated paged Supabase table/query-log mock from teacher attendance and export CSV API tests into `tests/support/paged-supabase.ts`.
+- Updated both route suites to use `createPagedQueryLog` and `mockPagedTable` from the shared support helper.
+- Kept production code, route behavior, mock behavior, and assertions unchanged.
+
+**Test mock checklist:**
+- Production code changed: no
+- Test behavior changed: no intended behavior change; affected tests still cover pagination, chunking, and query scoping
+- Helper scope: paged `select().in().order().range()` mocks only
+- Broad migration attempted: no; only identical local duplicates were consolidated
+
+**Validation:**
+- `pnpm test tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `git diff --check`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -632,6 +632,8 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
 
 ## 2026-06-21 — Stale async classroom-state audit
 

--- a/tests/api/teacher/attendance.test.ts
+++ b/tests/api/teacher/attendance.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/app/api/teacher/attendance/route'
 import { NextRequest } from 'next/server'
 import { mockAuthenticationError } from '../setup'
+import { createPagedQueryLog, mockPagedTable } from '../../support/paged-supabase'
 
 vi.mock('@/lib/supabase', () => ({
   getServiceRoleClient: vi.fn(() => mockSupabaseClient),
@@ -31,67 +32,6 @@ vi.mock('@/lib/attendance', () => ({
 }))
 
 const mockSupabaseClient = { from: vi.fn() }
-
-type QueryLog = {
-  inCalls: Array<{ table: string; column: string; values: string[] }>
-  orderCalls: Array<{ table: string; column: string }>
-  rangeCalls: Array<{ table: string; from: number; to: number }>
-}
-
-function createQueryLog(): QueryLog {
-  return { inCalls: [], orderCalls: [], rangeCalls: [] }
-}
-
-function mockPagedTable(
-  rows: Array<Record<string, any>>,
-  options: {
-    table?: string
-    log?: QueryLog
-    error?: any
-  } = {},
-) {
-  return {
-    select: vi.fn(() => {
-      const filters: Array<{ column: string; values: string[] }> = []
-      const query: any = {
-        in: vi.fn((column: string, values: string[]) => {
-          filters.push({ column, values })
-          if (options.table) {
-            options.log?.inCalls.push({ table: options.table, column, values })
-          }
-          return query
-        }),
-        order: vi.fn((column: string) => {
-          if (options.table) {
-            options.log?.orderCalls.push({ table: options.table, column })
-          }
-          return query
-        }),
-        range: vi.fn((from: number, to: number) => {
-          if (options.table) {
-            options.log?.rangeCalls.push({ table: options.table, from, to })
-          }
-          if (options.error) {
-            return Promise.resolve({ data: null, error: options.error })
-          }
-
-          const filteredRows = rows.filter((row) =>
-            filters.every((filter) => {
-              if (!(filter.column in row)) return true
-              return filter.values.includes(String(row[filter.column]))
-            })
-          )
-
-          return Promise.resolve({
-            data: filteredRows.slice(from, to + 1),
-            error: null,
-          })
-        }),
-      }
-      return query
-    }),
-  }
-}
 
 describe('GET /api/teacher/attendance', () => {
   beforeEach(() => {
@@ -239,7 +179,7 @@ describe('GET /api/teacher/attendance', () => {
   it('paginates enrollment rows so large rosters are not truncated', async () => {
     const { computeAttendanceRecords } = await import('@/lib/attendance')
     ;(computeAttendanceRecords as any).mockReturnValueOnce([])
-    const log = createQueryLog()
+    const log = createPagedQueryLog()
     const enrollments = Array.from({ length: 1001 }, (_, index) => {
       const ordinal = index + 1
       const studentId = `student-${ordinal.toString().padStart(4, '0')}`
@@ -285,7 +225,7 @@ describe('GET /api/teacher/attendance', () => {
   it('chunks profile and entry reads and paginates dense entry chunks', async () => {
     const { computeAttendanceRecords } = await import('@/lib/attendance')
     ;(computeAttendanceRecords as any).mockReturnValueOnce([])
-    const log = createQueryLog()
+    const log = createPagedQueryLog()
     const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
     const enrollments = studentIds.map((studentId, index) => ({
       id: `enrollment-${index + 1}`,

--- a/tests/api/teacher/export-csv.test.ts
+++ b/tests/api/teacher/export-csv.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/app/api/teacher/export-csv/route'
 import { NextRequest } from 'next/server'
+import { createPagedQueryLog, mockPagedTable } from '../../support/paged-supabase'
 
 vi.mock('@/lib/supabase', () => ({ getServiceRoleClient: vi.fn(() => mockSupabaseClient) }))
 vi.mock('@/lib/auth', () => ({ requireRole: vi.fn(async () => ({ id: 'teacher-1' })) }))
@@ -12,67 +13,6 @@ vi.mock('@/lib/attendance', () => ({ computeAttendanceRecords: vi.fn(() => []) }
 vi.mock('@/lib/timezone', () => ({ getTodayInToronto: vi.fn(() => '2026-04-25') }))
 
 const mockSupabaseClient = { from: vi.fn() }
-
-type QueryLog = {
-  inCalls: Array<{ table: string; column: string; values: string[] }>
-  orderCalls: Array<{ table: string; column: string }>
-  rangeCalls: Array<{ table: string; from: number; to: number }>
-}
-
-function createQueryLog(): QueryLog {
-  return { inCalls: [], orderCalls: [], rangeCalls: [] }
-}
-
-function mockPagedTable(
-  rows: Array<Record<string, any>>,
-  options: {
-    table?: string
-    log?: QueryLog
-    error?: any
-  } = {},
-) {
-  return {
-    select: vi.fn(() => {
-      const filters: Array<{ column: string; values: string[] }> = []
-      const query: any = {
-        in: vi.fn((column: string, values: string[]) => {
-          filters.push({ column, values })
-          if (options.table) {
-            options.log?.inCalls.push({ table: options.table, column, values })
-          }
-          return query
-        }),
-        order: vi.fn((column: string) => {
-          if (options.table) {
-            options.log?.orderCalls.push({ table: options.table, column })
-          }
-          return query
-        }),
-        range: vi.fn((from: number, to: number) => {
-          if (options.table) {
-            options.log?.rangeCalls.push({ table: options.table, from, to })
-          }
-          if (options.error) {
-            return Promise.resolve({ data: null, error: options.error })
-          }
-
-          const filteredRows = rows.filter((row) =>
-            filters.every((filter) => {
-              if (!(filter.column in row)) return true
-              return filter.values.includes(String(row[filter.column]))
-            })
-          )
-
-          return Promise.resolve({
-            data: filteredRows.slice(from, to + 1),
-            error: null,
-          })
-        }),
-      }
-      return query
-    }),
-  }
-}
 
 describe('GET /api/teacher/export-csv', () => {
   beforeEach(() => {
@@ -198,7 +138,7 @@ describe('GET /api/teacher/export-csv', () => {
   it('paginates large rosters before computing the CSV export', async () => {
     const { computeAttendanceRecords } = await import('@/lib/attendance')
     ;(computeAttendanceRecords as any).mockReturnValueOnce([])
-    const log = createQueryLog()
+    const log = createPagedQueryLog()
     const enrollments = Array.from({ length: 1001 }, (_, index) => {
       const ordinal = index + 1
       const padded = ordinal.toString().padStart(4, '0')
@@ -248,7 +188,7 @@ describe('GET /api/teacher/export-csv', () => {
   it('scopes and paginates dense entry reads for enrolled students', async () => {
     const { computeAttendanceRecords } = await import('@/lib/attendance')
     ;(computeAttendanceRecords as any).mockReturnValueOnce([])
-    const log = createQueryLog()
+    const log = createPagedQueryLog()
     const studentIds = Array.from({ length: 51 }, (_, index) => `student-${index + 1}`)
     const enrollments = studentIds.map((studentId, index) => ({
       id: `enrollment-${index + 1}`,

--- a/tests/support/paged-supabase.ts
+++ b/tests/support/paged-supabase.ts
@@ -1,0 +1,62 @@
+import { vi } from 'vitest'
+
+export type PagedQueryLog = {
+  inCalls: Array<{ table: string; column: string; values: string[] }>
+  orderCalls: Array<{ table: string; column: string }>
+  rangeCalls: Array<{ table: string; from: number; to: number }>
+}
+
+export function createPagedQueryLog(): PagedQueryLog {
+  return { inCalls: [], orderCalls: [], rangeCalls: [] }
+}
+
+export function mockPagedTable(
+  rows: Array<Record<string, any>>,
+  options: {
+    table?: string
+    log?: PagedQueryLog
+    error?: any
+  } = {},
+) {
+  return {
+    select: vi.fn(() => {
+      const filters: Array<{ column: string; values: string[] }> = []
+      const query: any = {
+        in: vi.fn((column: string, values: string[]) => {
+          filters.push({ column, values })
+          if (options.table) {
+            options.log?.inCalls.push({ table: options.table, column, values })
+          }
+          return query
+        }),
+        order: vi.fn((column: string) => {
+          if (options.table) {
+            options.log?.orderCalls.push({ table: options.table, column })
+          }
+          return query
+        }),
+        range: vi.fn((from: number, to: number) => {
+          if (options.table) {
+            options.log?.rangeCalls.push({ table: options.table, from, to })
+          }
+          if (options.error) {
+            return Promise.resolve({ data: null, error: options.error })
+          }
+
+          const filteredRows = rows.filter((row) =>
+            filters.every((filter) => {
+              if (!(filter.column in row)) return true
+              return filter.values.includes(String(row[filter.column]))
+            })
+          )
+
+          return Promise.resolve({
+            data: filteredRows.slice(from, to + 1),
+            error: null,
+          })
+        }),
+      }
+      return query
+    }),
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated paged Supabase table/query-log mock into `tests/support/paged-supabase.ts`.
- Update teacher attendance and export CSV API tests to use the shared helper.
- Leave production code and test assertions unchanged.

## Scope
- Test-only refactor.
- Helper supports the existing paged `select().in().order().range()` mock shape used by these two suites.
- This is the test mock simplification slice of the bounded architecture/UI improvement goal.

## Validation
- `pnpm test tests/api/teacher/attendance.test.ts tests/api/teacher/export-csv.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `git diff --check`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `pnpm test`
- `pnpm build`
