### PR TITLE
Align gradebook action surface

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -809,6 +809,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Preserved existing Gradebook behavior: score display toggles when no students are selected, selected-student email remains the primary action, and column controls stay in the actions menu.
 - Added optional radio semantics to `TeacherWorkSurfaceActionItem` so mutually exclusive score display menu items expose `menuitemradio` while column controls remain `menuitemcheckbox`.
 - Added focused component coverage for Gradebook menu semantics and shared action-cluster checked roles.
+- Addressed independent review by including `menuitemradio` items in shared menu keyboard focus management and covering arrow/Home/End focus behavior.
 
 **UI verification:**
 - Teacher desktop light: default, open menu, selected email action

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz server draft helper names
-
-**Completed:**
-- Added assessment-named primary draft helpers in `src/lib/server/assessment-drafts.ts`: `AssessmentDraftContent`, `AssessmentDraftQuestion`, `validateAssessmentDraftContent`, `buildAssessmentDraftContentFromRows`, and `syncAssessmentQuestionsFromDraft`.
-- Kept legacy `QuizDraft*`, `validateQuizDraftContent`, `buildQuizDraftContentFromRows`, and `syncQuizQuestionsFromDraft` exports as compatibility aliases.
-- Updated internal markdown/course-blueprint typing and assessment draft unit tests to prefer assessment-named helpers.
-- Did not change database tables, persisted `quiz_id` fields, route payload shapes, migrations, RPCs, or storage paths.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessment-drafts.test.ts tests/lib/quiz-markdown.test.ts tests/lib/server/course-blueprints.test.ts tests/lib/server/course-sites.test.ts`
-- `pnpm lint`
-- `git diff --check`
-
 ## 2026-06-13 — Legacy quiz markdown helper aliases
 
 **Completed:**
@@ -815,3 +800,30 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm lint`
 - `git diff --check`
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
+
+## 2026-06-23 — Gradebook action surface
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the canonical classroom action-surface slice.
+- Replaced the Gradebook tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone score/email primary action plus a quiet icon menu.
+- Preserved existing Gradebook behavior: score display toggles when no students are selected, selected-student email remains the primary action, and column controls stay in the actions menu.
+- Added optional radio semantics to `TeacherWorkSurfaceActionItem` so mutually exclusive score display menu items expose `menuitemradio` while column controls remain `menuitemcheckbox`.
+- Added focused component coverage for Gradebook menu semantics and shared action-cluster checked roles.
+
+**UI verification:**
+- Teacher desktop light: default, open menu, selected email action
+- Teacher mobile light: default
+- Teacher desktop dark: default, open menu
+- Student: n/a; changed surface is teacher-only
+- Composite widget checklist reviewed: yes
+- Keyboard behavior covered by existing shared menu handling: yes
+- Semantic state covered by tests: yes
+- Remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
+- `pnpm test`
+- `pnpm build`

--- a/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherGradebookTab.tsx
@@ -18,9 +18,9 @@ import type {
   GradebookStudentSummary,
 } from '@/types'
 import {
+  Button,
   Input,
   Tooltip,
-  type SplitButtonOption,
   useAppMessage,
 } from '@/ui'
 import {
@@ -29,6 +29,11 @@ import {
 } from '@/components/AssessmentStatusIndicator'
 import { Spinner } from '@/components/Spinner'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import {
+  TeacherWorkSurfaceActionCluster,
+  TeacherWorkSurfaceIconMenuButton,
+  type TeacherWorkSurfaceActionItem,
+} from '@/components/teacher-work-surface/TeacherWorkSurfaceActionCluster'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import { TeacherWorkspaceSplit } from '@/components/teacher-work-surface/TeacherWorkspaceSplit'
 import {
@@ -1660,21 +1665,23 @@ export function TeacherGradebookTab({
   }
 
   const isSettingsActive = columnEditorOpen
-  const scoreDisplayOptions: SplitButtonOption[] = [
+  const scoreDisplayOptions: TeacherWorkSurfaceActionItem[] = [
     {
       id: 'score-display-percent',
       label: 'Show %',
       checked: scoreDisplayMode === 'percent',
+      checkedRole: 'menuitemradio',
       onSelect: () => handleScoreDisplayModeChange('percent'),
     },
     {
       id: 'score-display-raw',
       label: 'Show Raw',
       checked: scoreDisplayMode === 'raw',
+      checkedRole: 'menuitemradio',
       onSelect: () => handleScoreDisplayModeChange('raw'),
     },
   ]
-  const selectedEmailOptions: SplitButtonOption[] = [
+  const selectedEmailOptions: TeacherWorkSurfaceActionItem[] = [
     {
       id: 'copy-selected-emails',
       label: `Copy emails (${selectedStudentEmails.length})`,
@@ -1696,7 +1703,7 @@ export function TeacherGradebookTab({
       onSelect: () => openOutlook(selectedStudentEmails),
     },
   ]
-  const gradebookActionOptions: SplitButtonOption[] = [
+  const gradebookActionOptions: TeacherWorkSurfaceActionItem[] = [
     ...scoreDisplayOptions,
     {
       id: 'column-controls',
@@ -1723,27 +1730,39 @@ export function TeacherGradebookTab({
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
-      floatingAction={{
-        label: hasSelectedEmailActions ? (
-          <span className="inline-flex items-center gap-2 whitespace-nowrap">
-            <Mail className="h-4 w-4" aria-hidden="true" />
-            <span>Email ({selectedStudentEmails.length})</span>
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-2 whitespace-nowrap">
-            <ListFilter className="h-4 w-4" aria-hidden="true" />
-            <span>{scoreDisplayLabel}</span>
-          </span>
-        ),
-        onPrimaryClick: hasSelectedEmailActions
-          ? () => openDefaultEmail(selectedStudentEmails)
-          : () => handleScoreDisplayModeChange(nextScoreDisplayMode),
-        options: gradebookActionOptions,
-        variant: hasSelectedEmailActions ? 'primary' : 'secondary',
-        size: 'sm',
-        toggleAriaLabel: 'Gradebook actions',
-        menuPlacement: 'down',
-      }}
+      center={
+        <TeacherWorkSurfaceActionCluster>
+          <Button
+            type="button"
+            variant={hasSelectedEmailActions ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={hasSelectedEmailActions
+              ? () => openDefaultEmail(selectedStudentEmails)
+              : () => handleScoreDisplayModeChange(nextScoreDisplayMode)}
+          >
+            {hasSelectedEmailActions ? (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <Mail className="h-4 w-4" aria-hidden="true" />
+                <span>Email ({selectedStudentEmails.length})</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                <ListFilter className="h-4 w-4" aria-hidden="true" />
+                <span>{scoreDisplayLabel}</span>
+              </span>
+            )}
+          </Button>
+          <TeacherWorkSurfaceIconMenuButton
+            ariaLabel="Gradebook actions"
+            tooltip="Gradebook actions"
+            icon={<Settings className="h-4 w-4" aria-hidden="true" />}
+            items={gradebookActionOptions}
+            menuPlacement="down"
+            menuAlign="center"
+            menuClassName="w-64"
+          />
+        </TeacherWorkSurfaceActionCluster>
+      }
       centerPlacement="floating"
     />
   )

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionCluster.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionCluster.tsx
@@ -85,7 +85,7 @@ function TeacherWorkSurfaceActionMenuButton({
   const getEnabledMenuItems = useCallback(() => {
     return Array.from(
       menuRef.current?.querySelectorAll<HTMLButtonElement>(
-        '[role="menuitem"], [role="menuitemcheckbox"]'
+        '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
       ) ?? []
     ).filter((item) => !item.disabled)
   }, [])

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionCluster.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionCluster.tsx
@@ -24,6 +24,7 @@ export interface TeacherWorkSurfaceActionItem {
   disabled?: boolean
   icon?: ReactNode
   checked?: boolean
+  checkedRole?: 'menuitemcheckbox' | 'menuitemradio'
   dividerBefore?: boolean
   destructive?: boolean
 }
@@ -210,7 +211,7 @@ function TeacherWorkSurfaceActionMenuButton({
               ) : null}
               <button
                 type="button"
-                role={item.checked === undefined ? 'menuitem' : 'menuitemcheckbox'}
+                role={item.checked === undefined ? 'menuitem' : item.checkedRole ?? 'menuitemcheckbox'}
                 aria-checked={item.checked === undefined ? undefined : item.checked}
                 disabled={item.disabled}
                 onClick={(event) => {

--- a/tests/components/TeacherGradebookTab.test.tsx
+++ b/tests/components/TeacherGradebookTab.test.tsx
@@ -196,7 +196,7 @@ describe('TeacherGradebookTab', () => {
 
   function toggleGradebookColumnControls() {
     const menu = openGradebookActions()
-    fireEvent.click(within(menu).getByRole('menuitemradio', { name: 'Column controls' }))
+    fireEvent.click(within(menu).getByRole('menuitemcheckbox', { name: 'Column controls' }))
   }
 
   it('renders the assessment matrix and delegates settings navigation', async () => {
@@ -266,7 +266,7 @@ describe('TeacherGradebookTab', () => {
     })
     fireEvent.click(adaSelect)
     gradebookMenu = openGradebookActions()
-    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
+    expect(within(gradebookMenu).getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
 
     fireEvent.click(screen.getByRole('row', { name: /Ada Lovelace.*80% 100% 90% 85\.0%/ }))
     const detailPanel = screen.getByRole('region', { name: 'Ada Lovelace assessment details' })
@@ -367,7 +367,7 @@ describe('TeacherGradebookTab', () => {
       </AppMessageProvider>,
     )
     gradebookMenu = openGradebookActions()
-    expect(within(gradebookMenu).getByRole('menuitemradio', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'true')
+    expect(within(gradebookMenu).getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'true')
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(`/api/teacher/gradebook?classroom_id=${classroom.id}`)
     })

--- a/tests/components/TeacherWorkSurfaceActionCluster.test.tsx
+++ b/tests/components/TeacherWorkSurfaceActionCluster.test.tsx
@@ -51,4 +51,41 @@ describe('TeacherWorkSurfaceActionCluster', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Organize classwork' }))
     expect(toggleControls).toHaveBeenCalledTimes(1)
   })
+
+  it('supports radio-style checked menu items for mutually exclusive options', () => {
+    render(
+      <TeacherWorkSurfaceMenuButton
+        label="Display"
+        menuAriaLabel="Display options"
+        items={[
+          {
+            id: 'percent',
+            label: 'Show %',
+            checked: true,
+            checkedRole: 'menuitemradio',
+            onSelect: vi.fn(),
+          },
+          {
+            id: 'raw',
+            label: 'Show Raw',
+            checked: false,
+            checkedRole: 'menuitemradio',
+            onSelect: vi.fn(),
+          },
+          {
+            id: 'columns',
+            label: 'Column controls',
+            checked: false,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Display' }))
+
+    expect(screen.getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
+  })
 })

--- a/tests/components/TeacherWorkSurfaceActionCluster.test.tsx
+++ b/tests/components/TeacherWorkSurfaceActionCluster.test.tsx
@@ -87,5 +87,13 @@ describe('TeacherWorkSurfaceActionCluster', () => {
     expect(screen.getByRole('menuitemradio', { name: 'Show %' })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByRole('menuitemradio', { name: 'Show Raw' })).toHaveAttribute('aria-checked', 'false')
     expect(screen.getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveAttribute('aria-checked', 'false')
+
+    expect(screen.getByRole('menuitemradio', { name: 'Show %' })).toHaveFocus()
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(screen.getByRole('menuitemradio', { name: 'Show Raw' })).toHaveFocus()
+    fireEvent.keyDown(window, { key: 'End' })
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Column controls' })).toHaveFocus()
+    fireEvent.keyDown(window, { key: 'Home' })
+    expect(screen.getByRole('menuitemradio', { name: 'Show %' })).toHaveFocus()
   })
 })


### PR DESCRIPTION
## Summary
- replace the Gradebook tab's custom split-button floating action with the shared teacher work-surface action cluster
- preserve existing score-display and selected-student email behavior while aligning the action surface with other classroom tabs
- add optional `menuitemradio` semantics for mutually exclusive action-cluster items and keep column controls as `menuitemcheckbox`

## UI verification
- Teacher desktop light: default, open menu, selected email action
- Teacher mobile light: default
- Teacher desktop dark: default, open menu
- Student: n/a; changed surface is teacher-only
- Composite widget checklist reviewed: yes
- Keyboard behavior covered by existing shared menu handling: yes
- Semantic state covered by tests: yes
- Remaining manual follow-up: none

## Validation
- `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
- `pnpm test`
- `pnpm build`
