### PR TITLE
Align roster action surface

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -820,6 +820,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Replaced the Roster tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone Students primary action plus a quiet icon menu.
 - Preserved existing Roster behavior: the primary action still opens Add Students, selected-student email actions remain in the Roster actions menu, and removal actions stay destructive menu items.
 - Updated focused Roster component tests to assert the shared action-cluster shape without changing roster management behavior.
+- Addressed independent review by keeping the compact visual label while exposing the primary action as `Add students` for assistive technology.
 
 **UI verification:**
 - Teacher desktop light: default, open menu, selected-student menu

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz markdown helper aliases
-
-**Completed:**
-- Added assessment-named markdown helper exports in `src/lib/quiz-markdown.ts`: `assessmentToMarkdown`, `markdownToAssessment`, and `AssessmentMarkdown*` types.
-- Kept `quizToMarkdown`, `markdownToQuiz`, and `QuizMarkdown*` exports as compatibility aliases.
-- Updated active `TestDetailPanel` markdown editing code to import and call the assessment-named helpers.
-- Expanded markdown unit coverage for the new helper names and alias compatibility.
-- Did not change markdown format text, route payloads, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm lint`
-- `pnpm test tests/lib/quiz-markdown.test.ts tests/components/TestDetailPanel.test.tsx tests/unit/assessment-drafts.test.ts`
-- `git diff --check`
-
 ## 2026-06-13 — Legacy quiz assessment helper names
 
 **Completed:**
@@ -823,6 +807,32 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `pnpm test tests/components/TeacherGradebookTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Roster action surface
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the next canonical classroom action-surface slice.
+- Replaced the Roster tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone Students primary action plus a quiet icon menu.
+- Preserved existing Roster behavior: the primary action still opens Add Students, selected-student email actions remain in the Roster actions menu, and removal actions stay destructive menu items.
+- Updated focused Roster component tests to assert the shared action-cluster shape without changing roster management behavior.
+
+**UI verification:**
+- Teacher desktop light: default, open menu, selected-student menu
+- Teacher mobile light: default
+- Teacher desktop dark: default, open menu
+- Student: n/a; changed surface is teacher-only
+- Composite widget checklist reviewed: yes
+- Keyboard behavior covered by shared menu handling: yes
+- Semantic state covered by tests: yes
+- Remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -513,6 +513,7 @@ export function TeacherRosterTab({ classroom }: Props) {
               setAddModalOpen(true)
             }}
             disabled={isReadOnly || isRosterLoading}
+            aria-label="Add students"
           >
             <span className="inline-flex items-center gap-2 whitespace-nowrap">
               <Plus className="h-4 w-4" aria-hidden="true" />

--- a/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherRosterTab.tsx
@@ -2,10 +2,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
-import { ConfirmDialog, type SplitButtonOption, useAppMessage } from '@/ui'
+import { Button, ConfirmDialog, useAppMessage } from '@/ui'
 import { UploadRosterModal } from '@/components/UploadRosterModal'
 import { AddStudentsModal } from '@/components/AddStudentsModal'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import {
+  TeacherWorkSurfaceActionCluster,
+  TeacherWorkSurfaceIconMenuButton,
+  type TeacherWorkSurfaceActionItem,
+} from '@/components/teacher-work-surface/TeacherWorkSurfaceActionCluster'
 import { TeacherWorkSurfaceShell } from '@/components/teacher-work-surface/TeacherWorkSurfaceShell'
 import {
   DataTable,
@@ -20,7 +25,7 @@ import {
   TableCard,
 } from '@/components/DataTable'
 import type { Classroom, RosterJoinSource } from '@/types'
-import { Check, Copy, Mail, Pencil, X } from 'lucide-react'
+import { Check, Copy, Mail, Pencil, Plus, Settings, X } from 'lucide-react'
 import { CountBadge, StudentCountBadge } from '@/components/StudentCountBadge'
 import { compareByNameFields, toggleSort } from '@/lib/table-sort'
 import { useStudentSelection } from '@/hooks/useStudentSelection'
@@ -412,7 +417,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     }`
   }
 
-  const rosterActionOptions: SplitButtonOption[] = [
+  const rosterActionOptions: TeacherWorkSurfaceActionItem[] = [
     {
       id: 'upload-csv',
       label: '+ CSV',
@@ -431,7 +436,7 @@ export function TeacherRosterTab({ classroom }: Props) {
     })
   }
 
-  const selectedEmailOptions: SplitButtonOption[] = [
+  const selectedEmailOptions: TeacherWorkSurfaceActionItem[] = [
     {
       id: 'copy-student-emails',
       label: `Copy emails (${selectedStudentEmails.length})`,
@@ -485,7 +490,7 @@ export function TeacherRosterTab({ classroom }: Props) {
       },
     )
   }
-  const combinedRosterActionOptions: SplitButtonOption[] = [
+  const combinedRosterActionOptions: TeacherWorkSurfaceActionItem[] = [
     ...rosterActionOptions,
     ...(someSelected
       ? selectedEmailOptions.map((option, index) => ({
@@ -497,18 +502,35 @@ export function TeacherRosterTab({ classroom }: Props) {
 
   const actionBar = (
     <TeacherWorkSurfaceActionBar
-      floatingAction={{
-        label: '+ Students',
-        onPrimaryClick: () => {
-          if (isReadOnly || isRosterLoading) return
-          setAddModalOpen(true)
-        },
-        options: combinedRosterActionOptions,
-        disabled: isReadOnly || isRosterLoading,
-        size: 'sm',
-        toggleAriaLabel: 'Roster actions',
-        menuPlacement: 'down',
-      }}
+      center={
+        <TeacherWorkSurfaceActionCluster>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              if (isReadOnly || isRosterLoading) return
+              setAddModalOpen(true)
+            }}
+            disabled={isReadOnly || isRosterLoading}
+          >
+            <span className="inline-flex items-center gap-2 whitespace-nowrap">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              <span>Students</span>
+            </span>
+          </Button>
+          <TeacherWorkSurfaceIconMenuButton
+            ariaLabel="Roster actions"
+            tooltip="Roster actions"
+            icon={<Settings className="h-4 w-4" aria-hidden="true" />}
+            items={combinedRosterActionOptions}
+            disabled={isReadOnly || isRosterLoading}
+            menuPlacement="down"
+            menuAlign="center"
+            menuClassName="w-64"
+          />
+        </TeacherWorkSurfaceActionCluster>
+      }
       centerPlacement="floating"
     />
   )

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -307,7 +307,7 @@ describe('TeacherRosterTab', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))
     await user.click(screen.getByRole('checkbox', { name: 'Select Grace Hopper' }))
 
-    expect(screen.getByRole('button', { name: 'Students' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add students' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Email \(2\)/ })).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Roster actions' }))

--- a/tests/components/TeacherRosterTab.test.tsx
+++ b/tests/components/TeacherRosterTab.test.tsx
@@ -235,7 +235,7 @@ describe('TeacherRosterTab', () => {
     expect(screen.queryByRole('separator', { name: 'Resize Roster panes' })).not.toBeInTheDocument()
   })
 
-  it('opens single-student removal from the floating roster actions dropdown with confirmation', async () => {
+  it('opens single-student removal from the roster actions menu with confirmation', async () => {
     const user = userEvent.setup()
     const fetchMock = mockRosterFetch()
 
@@ -265,7 +265,7 @@ describe('TeacherRosterTab', () => {
     expect(getIndividualDeleteCalls(fetchMock)).toHaveLength(0)
   })
 
-  it('shows and confirms removal for multiple checked students from the floating actions dropdown', async () => {
+  it('shows and confirms removal for multiple checked students from the roster actions menu', async () => {
     const user = userEvent.setup()
     const fetchMock = mockRosterFetch()
 
@@ -307,7 +307,7 @@ describe('TeacherRosterTab', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Ada Lovelace' }))
     await user.click(screen.getByRole('checkbox', { name: 'Select Grace Hopper' }))
 
-    expect(screen.getByRole('button', { name: '+ Students' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Students' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Email \(2\)/ })).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Roster actions' }))


### PR DESCRIPTION
## Summary
- replace the Roster tab's custom split-button floating action with the shared teacher work-surface action cluster
- keep the primary action as Add Students while moving roster/email actions into the quiet icon menu
- preserve selected-student email and destructive removal behavior, with focused test updates for the shared action-cluster shape

## UI verification
- Teacher desktop light: default, open menu, selected-student menu
- Teacher mobile light: default
- Teacher desktop dark: default, open menu
- Student: n/a; changed surface is teacher-only
- Composite widget checklist reviewed: yes
- Keyboard behavior covered by shared menu handling: yes
- Semantic state covered by tests: yes
- Remaining manual follow-up: none

## Validation
- `pnpm test tests/components/TeacherRosterTab.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
- `pnpm test`
- `pnpm build`
