### PR TITLE
Unify announcements action surface

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,23 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz assessment helper names
-
-**Completed:**
-- Added assessment-named primary helper exports in `src/lib/assessments.ts` for status labels/badges, assessment type resolution, option validation, activation checks, edit policy, and focus-summary aggregation.
-- Updated `src/lib/tests.ts` to re-export test helpers from the assessment-named helpers instead of quiz-named aliases.
-- Updated active internal callers in markdown parsing and assessment draft validation to import `validateAssessmentOptions`.
-- Kept all legacy quiz-named helper exports as compatibility aliases and added alias coverage.
-- Updated test activation validation copy from quiz wording to test wording.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessments.test.ts tests/lib/assessments.test.ts tests/lib/quiz-markdown.test.ts tests/unit/assessment-drafts.test.ts tests/components/TestDetailPanel.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-- `git diff --check`
-
 ## 2026-06-13 — Legacy quiz grading payload reader
 
 **Completed:**
@@ -837,5 +820,35 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `bash .codex/skills/pika-audit/scripts/audit.sh && git diff --check`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Announcements action surface
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with the final legacy classroom action-surface caller.
+- Replaced the Announcements tab's custom split-button floating action with the shared teacher work-surface action cluster: a standalone New primary action plus a quiet icon menu.
+- Removed the unused `floatingAction` and `floatingActionStatus` compatibility path from `TeacherWorkSurfaceActionBar`.
+- Preserved existing Announcements behavior: the primary action still starts a new announcement, the action menu still exposes Announcement, and composer/editor Post/Schedule split buttons remain unchanged.
+- Updated focused Announcements component coverage and wrapped teacher renders in `TooltipProvider` to match the app shell used by the shared icon menu.
+
+**UI verification:**
+- Teacher desktop light: default, open menu
+- Teacher mobile light: default, open menu
+- Teacher desktop dark: default, open menu
+- Student: n/a; changed surface is teacher-only
+- Composite widget checklist reviewed: yes
+- Keyboard behavior covered by shared menu handling: yes
+- Semantic state covered by tests: yes
+- Remaining manual follow-up: none
+
+**Validation:**
+- `pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm e2e:auth`
+- Playwright screenshots: `/tmp/pika-announcements-action-desktop-light-default.png`, `/tmp/pika-announcements-action-desktop-light-menu.png`, `/tmp/pika-announcements-action-mobile-light-default.png`, `/tmp/pika-announcements-action-mobile-light-menu.png`, `/tmp/pika-announcements-action-desktop-dark-default.png`, `/tmp/pika-announcements-action-desktop-dark-menu.png`
 - `pnpm test`
 - `pnpm build`

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -1,12 +1,17 @@
 'use client'
 
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { Trash2, Plus, Clock, Calendar } from 'lucide-react'
+import { Trash2, Plus, Clock, Calendar, Settings } from 'lucide-react'
 import { Button, ConfirmDialog, FormField, Input, SplitButton } from '@/ui'
 import { Spinner } from '@/components/Spinner'
 import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { ScheduleDateTimePicker } from '@/components/ScheduleDateTimePicker'
 import { TeacherWorkSurfaceActionBar } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionBar'
+import {
+  TeacherWorkSurfaceActionCluster,
+  TeacherWorkSurfaceIconMenuButton,
+  type TeacherWorkSurfaceActionItem,
+} from '@/components/teacher-work-surface/TeacherWorkSurfaceActionCluster'
 import type { Announcement, Classroom } from '@/types'
 import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui/utils'
@@ -400,6 +405,13 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
 
   const currentAnnouncements = loadedClassroomId === classroom.id ? announcements : []
   const isLoading = loading || loadedClassroomId !== classroom.id
+  const announcementActionItems: TeacherWorkSurfaceActionItem[] = [
+    {
+      id: 'announcement',
+      label: 'Announcement',
+      onSelect: () => setIsCreating(true),
+    },
+  ]
 
   if (isLoading) {
     return (
@@ -414,27 +426,33 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
       {!isReadOnly && (
         <TeacherWorkSurfaceActionBar
           testId="announcements-actionbar-center"
-          floatingAction={{
-            label: (
-              <span className="inline-flex items-center gap-1.5">
-                <Plus className="h-4 w-4" aria-hidden="true" />
-                <span>New</span>
-              </span>
-            ),
-            onPrimaryClick: () => setIsCreating(true),
-            options: [
-              {
-                id: 'announcement',
-                label: 'Announcement',
-                onSelect: () => setIsCreating(true),
-              },
-            ],
-            disabled: isCreating || saving,
-            variant: 'primary',
-            toggleAriaLabel: 'Announcement actions',
-            menuPlacement: 'down',
-            primaryButtonProps: { 'aria-label': 'New announcement' },
-          }}
+          center={
+            <TeacherWorkSurfaceActionCluster>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => setIsCreating(true)}
+                disabled={isCreating || saving}
+                aria-label="New announcement"
+              >
+                <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  <span>New</span>
+                </span>
+              </Button>
+              <TeacherWorkSurfaceIconMenuButton
+                ariaLabel="Announcement actions"
+                tooltip="Announcement actions"
+                icon={<Settings className="h-4 w-4" aria-hidden="true" />}
+                items={announcementActionItems}
+                disabled={isCreating || saving}
+                menuPlacement="down"
+                menuAlign="center"
+                menuClassName="w-64"
+              />
+            </TeacherWorkSurfaceActionCluster>
+          }
           centerPlacement="floating"
         />
       )}

--- a/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
+++ b/src/components/teacher-work-surface/TeacherWorkSurfaceActionBar.tsx
@@ -2,14 +2,11 @@
 
 import type { ReactNode } from 'react'
 import { FloatingActionCluster } from '@/components/FloatingActionCluster'
-import { SplitButton, type SplitButtonProps } from '@/ui'
 import { cn } from '@/ui/utils'
 
 interface TeacherWorkSurfaceActionBarProps {
   label?: ReactNode
   center?: ReactNode
-  floatingAction?: SplitButtonProps
-  floatingActionStatus?: ReactNode
   trailing?: ReactNode
   className?: string
   labelClassName?: string
@@ -36,8 +33,6 @@ export function TeacherWorkSurfaceFloatingActionCluster({
 export function TeacherWorkSurfaceActionBar({
   label,
   center,
-  floatingAction,
-  floatingActionStatus,
   trailing,
   className,
   labelClassName,
@@ -47,12 +42,6 @@ export function TeacherWorkSurfaceActionBar({
   testId,
 }: TeacherWorkSurfaceActionBarProps) {
   const isCenterFloating = centerPlacement === 'floating'
-  const resolvedCenter = floatingAction ? (
-    <div className="flex max-w-[calc(100vw-2rem)] items-center justify-center gap-2">
-      <SplitButton {...floatingAction} />
-      {floatingActionStatus}
-    </div>
-  ) : center
 
   return (
     <div
@@ -65,14 +54,14 @@ export function TeacherWorkSurfaceActionBar({
       <div className={cn('min-w-0 max-w-full overflow-hidden justify-self-start text-sm font-semibold text-text-default', labelClassName)}>
         {label}
       </div>
-      {resolvedCenter ? (
+      {center ? (
         isCenterFloating ? (
           <TeacherWorkSurfaceFloatingActionCluster className={centerClassName}>
-            {resolvedCenter}
+            {center}
           </TeacherWorkSurfaceFloatingActionCluster>
         ) : (
           <div className={cn('min-w-0 justify-self-center', centerClassName)}>
-            {resolvedCenter}
+            {center}
           </div>
         )
       ) : (

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeacherAnnouncementsSection } from '@/app/classrooms/[classroomId]/TeacherAnnouncementsSection'
 import { StudentAnnouncementsSection } from '@/app/classrooms/[classroomId]/StudentAnnouncementsSection'
 import { invalidateCachedJSONMatching } from '@/lib/request-cache'
+import { TooltipProvider } from '@/ui'
 import type { Announcement, Classroom } from '@/types'
 
 const classroom: Classroom = {
@@ -71,6 +72,14 @@ function mockAnnouncementFetch(announcements: Announcement[] = [markdownAnnounce
   )
 }
 
+function teacherAnnouncementsElement(sectionClassroom: Classroom) {
+  return (
+    <TooltipProvider>
+      <TeacherAnnouncementsSection classroom={sectionClassroom} />
+    </TooltipProvider>
+  )
+}
+
 describe('announcement markdown rendering', () => {
   beforeEach(() => {
     invalidateCachedJSONMatching('teacher-announcements:')
@@ -83,7 +92,7 @@ describe('announcement markdown rendering', () => {
   })
 
   it('renders teacher announcements as markdown without turning link clicks into edit mode', async () => {
-    render(<TeacherAnnouncementsSection classroom={classroom} />)
+    render(teacherAnnouncementsElement(classroom))
 
     const link = await screen.findByRole('link', { name: 'course outline' })
 
@@ -99,7 +108,7 @@ describe('announcement markdown rendering', () => {
   })
 
   it('renders a larger, vertically resizable creation textarea', async () => {
-    const { container } = render(<TeacherAnnouncementsSection classroom={classroom} />)
+    const { container } = render(teacherAnnouncementsElement(classroom))
 
     await screen.findByRole('link', { name: 'course outline' })
     fireEvent.click(screen.getByRole('button', { name: 'New announcement' }))
@@ -120,8 +129,21 @@ describe('announcement markdown rendering', () => {
     expect(screen.getByRole('menuitem', { name: 'Schedule...' })).toBeInTheDocument()
   })
 
+  it('keeps announcement creation in the shared action surface menu', async () => {
+    render(teacherAnnouncementsElement(classroom))
+
+    await screen.findByRole('link', { name: 'course outline' })
+
+    expect(screen.getByRole('button', { name: 'New announcement' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Announcement actions' }))
+
+    const menu = screen.getByRole('menu', { name: 'Announcement actions' })
+    expect(menu).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Announcement' })).toBeInTheDocument()
+  })
+
   it('labels the edit announcement textarea', async () => {
-    render(<TeacherAnnouncementsSection classroom={classroom} />)
+    render(teacherAnnouncementsElement(classroom))
 
     await screen.findByRole('link', { name: 'course outline' })
     fireEvent.click(screen.getByText('bring notes'))
@@ -159,7 +181,7 @@ describe('announcement markdown rendering', () => {
       },
     ])
 
-    render(<TeacherAnnouncementsSection classroom={classroom} />)
+    render(teacherAnnouncementsElement(classroom))
 
     const newest = await screen.findByText('Newest update')
     const middle = screen.getByText('Middle update')
@@ -206,11 +228,11 @@ describe('announcement markdown rendering', () => {
       title: 'Second classroom update',
     }
 
-    const view = render(<TeacherAnnouncementsSection classroom={classroom} />)
+    const view = render(teacherAnnouncementsElement(classroom))
 
     await screen.findByText('Unit update')
 
-    view.rerender(<TeacherAnnouncementsSection classroom={secondClassroom} />)
+    view.rerender(teacherAnnouncementsElement(secondClassroom))
 
     expect(screen.queryByText('Unit update')).not.toBeInTheDocument()
 


### PR DESCRIPTION
## Summary
- Replace the Announcements tab legacy floating split-button action with the shared teacher work-surface action cluster
- Remove the now-unused TeacherWorkSurfaceActionBar floatingAction compatibility path
- Add focused coverage for the Announcements action menu and align test renders with the app TooltipProvider

## Verification
- pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/components/TeacherWorkSurfaceActionBar.test.tsx tests/components/TeacherWorkSurfaceActionCluster.test.tsx
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm e2e:auth
- Visual verification: teacher Announcements desktop/mobile light, desktop dark, menu open states
- pnpm test
- pnpm build

## Notes
- Student view is n/a for this slice; the changed action surface is teacher-only.
- Composer/editor Post/Schedule split buttons are intentionally unchanged.