### PR TITLE
Use cached JSON helper for student assignments

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Legacy quiz grading payload reader
-
-**Completed:**
-- Normalized `TestStudentGradingPanel` results payloads into a canonical `test` field.
-- Used the shared Tests API reader so current `test` payloads are preferred while legacy `quiz` payloads still work as fallback.
-- Updated grading panel fixtures to use the current `test` key and added explicit legacy `quiz` fallback coverage.
-- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/components/TestStudentGradingPanel.test.tsx tests/lib/test-api-contract.test.ts`
-- `pnpm lint`
-- `pnpm test`
-- `git diff --check`
-
 ## 2026-06-13 — Student Tests payload type names
 
 **Completed:**
@@ -850,5 +834,23 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm e2e:auth`
 - Playwright screenshots: `/tmp/pika-announcements-action-desktop-light-default.png`, `/tmp/pika-announcements-action-desktop-light-menu.png`, `/tmp/pika-announcements-action-mobile-light-default.png`, `/tmp/pika-announcements-action-mobile-light-menu.png`, `/tmp/pika-announcements-action-desktop-dark-default.png`, `/tmp/pika-announcements-action-desktop-dark-menu.png`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Student assignments cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a client read-cache consistency slice.
+- Replaced `StudentAssignmentsTab`'s three manual cached GET fetchers with the shared `fetchCachedJSON` helper for assignments, materials, and surveys.
+- Preserved existing cache keys, 20s TTLs, request-id stale response guard, classroom-change clearing, and optional survey fallback behavior.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm build`

--- a/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAssignmentsTab.tsx
@@ -22,7 +22,7 @@ import { RichTextViewer } from '@/components/editor'
 import { LimitedMarkdown } from '@/components/LimitedMarkdown'
 import { StudentSurveyPanel } from '@/components/surveys/StudentSurveyPanel'
 import { useDelayedBusy } from '@/hooks/useDelayedBusy'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchCachedJSON } from '@/lib/request-cache'
 import { buildOrderedClassworkItems } from '@/lib/classwork-order'
 import { getStudentSurveyStatus, getSurveyStatusBadgeClass, getSurveyStatusLabel } from '@/lib/surveys'
 
@@ -36,6 +36,9 @@ interface Props {
 }
 
 type StudentAssignmentsView = 'summary' | 'edit' | 'material' | 'survey'
+type StudentAssignmentsResponse = { assignments?: AssignmentWithStatus[] }
+type StudentMaterialsResponse = { materials?: ClassworkMaterial[] }
+type StudentSurveysResponse = { surveys?: StudentSurveyView[] }
 
 export function StudentAssignmentsTab({
   classroom,
@@ -93,32 +96,20 @@ export function StudentAssignmentsTab({
       }
       try {
         const [assignmentsData, materialsData, surveysData] = await Promise.all([
-          fetchJSONWithCache(
+          fetchCachedJSON<StudentAssignmentsResponse>(
             `student-assignments:${classroom.id}`,
-            async () => {
-              const res = await fetch(`/api/student/assignments?classroom_id=${classroom.id}`)
-              if (!res.ok) throw new Error('Failed to load assignments')
-              return res.json()
-            },
-            20_000,
+            `/api/student/assignments?classroom_id=${classroom.id}`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load assignments' },
           ),
-          fetchJSONWithCache(
+          fetchCachedJSON<StudentMaterialsResponse>(
             `student-materials:${classroom.id}`,
-            async () => {
-              const res = await fetch(`/api/student/classrooms/${classroom.id}/materials`)
-              if (!res.ok) throw new Error('Failed to load materials')
-              return res.json()
-            },
-            20_000,
+            `/api/student/classrooms/${classroom.id}/materials`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load materials' },
           ),
-          fetchJSONWithCache(
+          fetchCachedJSON<StudentSurveysResponse>(
             `student-surveys:${classroom.id}`,
-            async () => {
-              const res = await fetch(`/api/student/surveys?classroom_id=${classroom.id}`)
-              if (!res.ok) throw new Error('Failed to load surveys')
-              return res.json()
-            },
-            20_000,
+            `/api/student/surveys?classroom_id=${classroom.id}`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load surveys' },
           ).catch(() => ({ surveys: [] })),
         ])
         if (loadRequestIdRef.current !== requestId || currentClassroomIdRef.current !== classroom.id) return


### PR DESCRIPTION
## Summary
- Replace StudentAssignmentsTab manual cached GET fetchers with fetchCachedJSON
- Preserve existing cache keys, TTLs, stale request guard, and survey fallback behavior
- Keep the slice non-visual: no layout, copy, or interaction changes

## Verification
- bash scripts/verify-env.sh
- pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/unit/request-cache.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test
- pnpm build

## Notes
- UI verification not required; this is a client fetch/cache helper cleanup with no rendered output changes.