### PR TITLE
Use cached JSON helper for student calendar

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-13 — Student Tests payload type names
-
-**Completed:**
-- Renamed local `StudentTestsTab` response type aliases so current `test` and `tests` payload fields are primary.
-- Collapsed duplicated session-status test/quiz summary shapes into one current `StudentTestSessionStatusSummary`.
-- Kept legacy `quiz` and `quizzes` fields in the local types as documented compatibility fallbacks.
-- Did not change runtime behavior, API response shapes, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/components/StudentTestsTab.test.tsx tests/lib/test-api-contract.test.ts`
-- `pnpm lint`
-- `pnpm test`
-- `git diff --check`
-
 ## 2026-06-14 — Teacher exam access lifecycle e2e
 
 **Completed:**
@@ -848,6 +832,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash scripts/verify-env.sh`
 - `pnpm test tests/components/StudentAssignmentsTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Student calendar cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with another client read-cache consistency slice.
+- Replaced `StudentLessonCalendarTab`'s manual cached GET fetchers with the shared `fetchCachedJSON` helper for lesson plans, assignments, and announcements.
+- Preserved existing cache keys, 20s TTLs, request-id/classroom stale response guard, and per-resource fallback behavior.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `git diff --check`

--- a/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
+++ b/src/app/classrooms/[classroomId]/StudentLessonCalendarTab.tsx
@@ -8,7 +8,7 @@ import { LessonCalendar, CalendarViewMode } from '@/components/LessonCalendar'
 import { PageContent, PageLayout } from '@/components/PageLayout'
 import { useClassDays } from '@/hooks/useClassDays'
 import { readCookie, writeCookie } from '@/lib/cookies'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchCachedJSON } from '@/lib/request-cache'
 import type { Classroom, LessonPlan, Assignment, Announcement } from '@/types'
 
 interface Props {
@@ -16,6 +16,10 @@ interface Props {
   onNavigateToAssignments?: (assignmentId: string) => void
   onNavigateToAnnouncements?: () => void
 }
+
+type StudentLessonPlansResponse = { lesson_plans?: LessonPlan[]; max_date?: string | null }
+type StudentAssignmentsResponse = { assignments?: Assignment[] }
+type StudentAnnouncementsResponse = { announcements?: Announcement[] }
 
 export function StudentLessonCalendarTab({
   classroom,
@@ -72,38 +76,26 @@ export function StudentLessonCalendarTab({
       setLoading(true)
       try {
         const [lessonPlansData, assignmentsData, announcementsData] = await Promise.all([
-          fetchJSONWithCache<{ lesson_plans?: LessonPlan[]; max_date?: string | null }>(
+          fetchCachedJSON<StudentLessonPlansResponse>(
             `student-lesson-plans:${classroom.id}:${fetchRange.start}:${fetchRange.end}`,
-            async () => {
-              const res = await fetch(`/api/student/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`)
-              if (!res.ok) throw new Error('Failed to load lesson plans')
-              return res.json()
-            },
-            20_000,
+            `/api/student/classrooms/${classroom.id}/lesson-plans?start=${fetchRange.start}&end=${fetchRange.end}`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load lesson plans' },
           ).catch((err) => {
             console.error('Error loading lesson plans:', err)
             return { lesson_plans: [], max_date: null }
           }),
-          fetchJSONWithCache<{ assignments?: Assignment[] }>(
+          fetchCachedJSON<StudentAssignmentsResponse>(
             `student-assignments:${classroom.id}`,
-            async () => {
-              const res = await fetch(`/api/student/assignments?classroom_id=${classroom.id}`)
-              if (!res.ok) throw new Error('Failed to load assignments')
-              return res.json()
-            },
-            20_000,
+            `/api/student/assignments?classroom_id=${classroom.id}`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load assignments' },
           ).catch((err) => {
             console.error('Error loading calendar assignments:', err)
             return { assignments: [] }
           }),
-          fetchJSONWithCache<{ announcements?: Announcement[] }>(
+          fetchCachedJSON<StudentAnnouncementsResponse>(
             `student-announcements:${classroom.id}`,
-            async () => {
-              const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`)
-              if (!res.ok) throw new Error('Failed to load announcements')
-              return res.json()
-            },
-            20_000,
+            `/api/student/classrooms/${classroom.id}/announcements`,
+            { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
           ).catch((err) => {
             console.error('Error loading calendar announcements:', err)
             return { announcements: [] }


### PR DESCRIPTION
## Summary
- Replace StudentLessonCalendarTab manual cached GET fetchers with fetchCachedJSON
- Preserve existing cache keys, TTLs, request/classroom stale guards, and per-resource fallbacks
- Keep the slice non-visual: no layout, copy, or interaction changes

## Verification
- bash scripts/verify-env.sh
- pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test
- pnpm build

## Notes
- UI verification not required; this only changes client fetch/cache plumbing.