### PR TITLE
Use cached JSON helper for announcements

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,19 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Teacher exam access lifecycle e2e
-
-**Completed:**
-- Added a focused Playwright teacher exam-mode flow covering draft test activation, opening all student access, closing all student access, and summary card open/closed access counts.
-- The spec creates a single open-response draft test through existing teacher API routes, selects a seeded classroom with enrolled students, drives lifecycle transitions through the teacher grading workspace UI, and deletes its test record in cleanup.
-- Risk profile: exam-mode.
-- Model recommendation: GPT-5 Codex - e2e coverage task with repo-specific Playwright and API setup.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `pnpm exec playwright test e2e/teacher-exam-mode.spec.ts --project=chromium-desktop`
-- `pnpm lint`
-
 ## 2026-06-14 — Legacy quiz server access names
 
 **Completed:**
@@ -850,6 +837,25 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash scripts/verify-env.sh`
 - `pnpm test tests/components/StudentLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit --pretty false`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-23 — Announcements cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a client read-cache consistency slice for announcements.
+- Replaced teacher and student announcement manual cached GET fetchers with the shared `fetchCachedJSON` helper.
+- Preserved existing cache keys, 20s TTLs, request-id stale response guards, and mutation cache invalidation.
+- Added a focused teacher announcement remount regression to prove the cache key is reused.
+- Kept the slice non-visual: no layout, copy, or interaction changes.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/unit/request-cache.test.ts`
 - `pnpm exec tsc --noEmit --pretty false`
 - `pnpm lint`
 - `git diff --check`

--- a/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/StudentAnnouncementsSection.tsx
@@ -6,7 +6,7 @@ import { AnnouncementContent } from '@/components/AnnouncementContent'
 import { Spinner } from '@/components/Spinner'
 import { useStudentNotifications } from '@/components/StudentNotificationsProvider'
 import type { Announcement, Classroom } from '@/types'
-import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui/utils'
 import { normalizeAnnouncementTitle, sortAnnouncementsNewestFirst } from '@/lib/announcements'
 
@@ -14,6 +14,8 @@ interface Props {
   classroom: Classroom
   className?: string
 }
+
+type AnnouncementsResponse = { announcements?: Announcement[] }
 
 export function StudentAnnouncementsSection({ classroom, className }: Props) {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
@@ -29,14 +31,10 @@ export function StudentAnnouncementsSection({ classroom, className }: Props) {
     loadRequestIdRef.current = requestId
     setLoading(true)
     try {
-      const data = await fetchJSONWithCache(
+      const data = await fetchCachedJSON<AnnouncementsResponse>(
         `student-announcements:${classroom.id}`,
-        async () => {
-          const res = await fetch(`/api/student/classrooms/${classroom.id}/announcements`)
-          if (!res.ok) throw new Error('Failed to load announcements')
-          return res.json()
-        },
-        20_000,
+        `/api/student/classrooms/${classroom.id}/announcements`,
+        { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
       )
       if (loadRequestIdRef.current !== requestId) return
       setAnnouncements(data.announcements || [])

--- a/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
+++ b/src/app/classrooms/[classroomId]/TeacherAnnouncementsSection.tsx
@@ -13,7 +13,7 @@ import {
   type TeacherWorkSurfaceActionItem,
 } from '@/components/teacher-work-surface/TeacherWorkSurfaceActionCluster'
 import type { Announcement, Classroom } from '@/types'
-import { fetchJSONWithCache, invalidateCachedJSON } from '@/lib/request-cache'
+import { fetchCachedJSON, invalidateCachedJSON } from '@/lib/request-cache'
 import { cn } from '@/ui/utils'
 import {
   ANNOUNCEMENT_TITLE_MAX_LENGTH,
@@ -32,6 +32,8 @@ interface Props {
   classroom: Classroom
   className?: string
 }
+
+type AnnouncementsResponse = { announcements?: Announcement[] }
 
 const ANNOUNCEMENT_TEXTAREA_MIN_HEIGHT_PX = 160
 
@@ -114,14 +116,10 @@ export function TeacherAnnouncementsSection({ classroom, className }: Props) {
     loadRequestIdRef.current = requestId
     setLoading(true)
     try {
-      const data = await fetchJSONWithCache(
+      const data = await fetchCachedJSON<AnnouncementsResponse>(
         `teacher-announcements:${classroom.id}`,
-        async () => {
-          const res = await fetch(`/api/teacher/classrooms/${classroom.id}/announcements`)
-          if (!res.ok) throw new Error('Failed to load announcements')
-          return res.json()
-        },
-        20_000,
+        `/api/teacher/classrooms/${classroom.id}/announcements`,
+        { ttlMs: 20_000, errorMessage: 'Failed to load announcements' },
       )
       if (loadRequestIdRef.current !== requestId) return
       setAnnouncements(data.announcements || [])

--- a/tests/components/AnnouncementsMarkdown.test.tsx
+++ b/tests/components/AnnouncementsMarkdown.test.tsx
@@ -107,6 +107,20 @@ describe('announcement markdown rendering', () => {
     })
   })
 
+  it('reuses the teacher announcement cache on remount', async () => {
+    const fetchMock = vi.mocked(fetch)
+
+    const firstRender = render(teacherAnnouncementsElement(classroom))
+
+    await screen.findByRole('link', { name: 'course outline' })
+
+    firstRender.unmount()
+    render(teacherAnnouncementsElement(classroom))
+
+    await screen.findByRole('link', { name: 'course outline' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('renders a larger, vertically resizable creation textarea', async () => {
     const { container } = render(teacherAnnouncementsElement(classroom))
 


### PR DESCRIPTION
## Summary
- Replace teacher and student announcement manual cached GET fetchers with fetchCachedJSON
- Preserve cache keys, 20s TTLs, stale request guards, and mutation cache invalidation
- Add a focused teacher announcement remount regression for cache reuse

## Verification
- bash scripts/verify-env.sh
- pnpm test tests/components/AnnouncementsMarkdown.test.tsx tests/unit/request-cache.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test
- pnpm build

## Notes
- UI verification not required; this only changes client fetch/cache plumbing. The teacher component still triggers the composite-widget audit reminder because it contains the existing action menu, but no menu markup or semantics changed.