### PR TITLE
Use cached JSON helper for student log history

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,22 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Teacher Tests payload type names
-
-**Completed:**
-- Added current-key local response types in `TeacherTestsTab` for teacher test list and results payloads.
-- Kept legacy `quiz` and `quizzes` fields documented as compatibility fallbacks in those local types.
-- Updated `TeacherTestsTab` component fixtures so current `test` results and create payloads are the default.
-- Added explicit legacy `quiz` results-payload fallback coverage.
-- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/components/TeacherTestsTab.test.tsx`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Assessment utility fixture naming
 
 **Completed:**
@@ -863,6 +847,24 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `bash scripts/verify-env.sh`
 - `pnpm vitest run tests/components/TeacherLessonCalendarTab.test.tsx tests/unit/request-cache.test.ts`
+- `pnpm exec tsc --noEmit`
+- `pnpm lint`
+- `git diff --check`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `pnpm test`
+- `pnpm build`
+
+## 2026-06-24 — Student log history cached JSON
+
+**Completed:**
+- Continued the bounded architecture/UI improvement goal with a small client read-cache consistency slice.
+- Replaced `StudentLogHistory`'s latest and load-more manual cached history GET fetchers with `fetchCachedJSON`.
+- Preserved existing cache keys, 60s TTL, pagination URL params, loading behavior, and error handling.
+- Added a focused regression proving the load-more history page is reused from cache on a repeated request.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `pnpm vitest run tests/components/StudentLogHistory.test.tsx tests/unit/request-cache.test.ts`
 - `pnpm exec tsc --noEmit`
 - `pnpm lint`
 - `git diff --check`

--- a/src/components/StudentLogHistory.tsx
+++ b/src/components/StudentLogHistory.tsx
@@ -3,7 +3,7 @@
 import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner } from '@/components/Spinner'
 import { entryHasContent } from '@/lib/attendance'
-import { fetchJSONWithCache } from '@/lib/request-cache'
+import { fetchCachedJSON } from '@/lib/request-cache'
 import type { Entry } from '@/types'
 
 interface Props {
@@ -56,16 +56,10 @@ export function StudentLogHistory({
     })
     const cacheKey = `teacher-student-history:${classroomId}:${studentId}:latest:${HISTORY_LIMIT}`
 
-    fetchJSONWithCache<StudentHistoryResponse>(
+    fetchCachedJSON<StudentHistoryResponse>(
       cacheKey,
-      async () => {
-        const res = await fetch(`/api/teacher/student-history?${params}`)
-        if (!res.ok) {
-          throw new Error('Failed to load student history')
-        }
-        return res.json()
-      },
-      HISTORY_CACHE_TTL_MS
+      `/api/teacher/student-history?${params}`,
+      { errorMessage: 'Failed to load student history', ttlMs: HISTORY_CACHE_TTL_MS },
     )
       .then(data => {
         if (cancelled) return
@@ -98,16 +92,10 @@ export function StudentLogHistory({
     })
     const cacheKey = `teacher-student-history:${classroomId}:${studentId}:before:${oldestDate}:${HISTORY_LIMIT}`
 
-    fetchJSONWithCache<StudentHistoryResponse>(
+    fetchCachedJSON<StudentHistoryResponse>(
       cacheKey,
-      async () => {
-        const res = await fetch(`/api/teacher/student-history?${params}`)
-        if (!res.ok) {
-          throw new Error('Failed to load more history')
-        }
-        return res.json()
-      },
-      HISTORY_CACHE_TTL_MS
+      `/api/teacher/student-history?${params}`,
+      { errorMessage: 'Failed to load more history', ttlMs: HISTORY_CACHE_TTL_MS },
     )
       .then(data => {
         const fetched: Entry[] = data.entries || []

--- a/tests/components/StudentLogHistory.test.tsx
+++ b/tests/components/StudentLogHistory.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { StudentLogHistory } from '@/components/StudentLogHistory'
 import type { Entry } from '@/types'
 
@@ -250,6 +250,51 @@ describe('StudentLogHistory', () => {
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('reuses cached load-more history when the same page is requested again', async () => {
+    const latestEntries = Array.from({ length: 10 }, (_, index) =>
+      entry({
+        id: `latest-${index}`,
+        student_id: 'student-cache-more',
+        classroom_id: 'classroom-cache-more',
+        date: `2026-03-${String(20 - index).padStart(2, '0')}`,
+        text: `Latest history ${index + 1}.`,
+      })
+    )
+    const olderEntry = entry({
+      id: 'older-cached-entry',
+      student_id: 'student-cache-more',
+      classroom_id: 'classroom-cache-more',
+      date: '2026-03-01',
+      text: 'Older cached history.',
+    })
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('before_date=2026-03-11')) {
+        return mockJson({ entries: [olderEntry] })
+      }
+      return mockJson({ entries: latestEntries })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = render(
+      <StudentLogHistory studentId="student-cache-more" classroomId="classroom-cache-more" />
+    )
+    await screen.findByText('Latest history 10.')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    await screen.findByText('Older cached history.')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    first.unmount()
+
+    render(<StudentLogHistory studentId="student-cache-more" classroomId="classroom-cache-more" />)
+    await screen.findByText('Latest history 10.')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    await screen.findByText('Older cached history.')
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
## Summary
- replace StudentLogHistory latest and load-more manual cached history GET fetchers with fetchCachedJSON
- preserve cache keys, 60s TTL, URL params, loading behavior, and catch/finally handling
- add a focused regression for reusing a cached load-more history page

## Validation
- bash scripts/verify-env.sh
- pnpm vitest run tests/components/StudentLogHistory.test.tsx tests/unit/request-cache.test.ts
- pnpm exec tsc --noEmit
- pnpm lint
- git diff --check
- bash .codex/skills/pika-audit/scripts/audit.sh
- pnpm test
- pnpm build

Non-visual helper refactor only; no screenshots required.