### PR TITLE
[codex] Add student exam access e2e coverage

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Assessment utility fixture naming
-
-**Completed:**
-- Updated generic assessment utility comments and local parameter names from quiz wording to assessment wording.
-- Switched generic `tests/unit/assessments.test.ts` cases to use test-shaped fixtures for response eligibility, result visibility, editing, activation, and aggregation.
-- Left explicit legacy quiz alias/status coverage on `createMockQuiz` where the test is intentionally about quiz compatibility.
-- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessments.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Production release sync
 
 **Completed:**
@@ -871,3 +856,15 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-07-05 — Student exam access e2e coverage
+
+**Completed:**
+- Added one focused Playwright flow for student exam mode covering teacher-closed access during an in-progress open-response test.
+- The test creates an active open-response test through existing teacher APIs, saves a student draft, closes and reopens that student's access, and verifies the draft is restored after reopening.
+- Kept the patch to e2e coverage plus this continuity entry; no app logic, migrations, or dependencies changed.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
+- `corepack pnpm lint`

--- a/e2e/student-exam-mode.spec.ts
+++ b/e2e/student-exam-mode.spec.ts
@@ -31,6 +31,14 @@ interface StudentTestDetailRecord {
   } | null
 }
 
+interface AuthMeRecord {
+  user: {
+    id: string
+    email: string
+    role: string
+  }
+}
+
 function uniqueTitle(): string {
   return `Exam Mode E2E ${Date.now()}`
 }
@@ -154,6 +162,18 @@ async function cleanupTest(browser: Browser, testId: string | null): Promise<voi
   if (!testId) return
   await withTeacherPage(browser, async (teacherPage) => {
     await sendJson(teacherPage, 'DELETE', `/api/teacher/tests/${testId}`).catch(() => undefined)
+  })
+}
+
+async function updateStudentTestAccess(
+  teacherPage: Page,
+  testId: string,
+  studentId: string,
+  state: 'open' | 'closed',
+): Promise<void> {
+  await sendJson(teacherPage, 'POST', `/api/teacher/tests/${testId}/student-access`, {
+    student_ids: [studentId],
+    state,
   })
 }
 
@@ -358,6 +378,64 @@ test.describe('student exam mode', () => {
         const detail = await loadJson<StudentTestDetailRecord>(page, `/api/student/tests/${testId}`)
         return detail.focus_summary?.route_exit_attempts ?? 0
       }).toBeGreaterThanOrEqual(1)
+    } finally {
+      await cleanupTest(browser, testId)
+    }
+  })
+
+  test('preserves an open-response draft when teacher closes and reopens access', async ({ browser, page }) => {
+    test.setTimeout(90_000)
+    let testId: string | null = null
+
+    try {
+      await page.goto('/classrooms', { waitUntil: 'domcontentloaded' })
+
+      const testTitle = uniqueTitle()
+      const currentStudent = await loadJson<AuthMeRecord>(page, '/api/auth/me')
+      const classroom = await withTeacherPage(browser, async (teacherPage) => {
+        const shared = await findSharedClassroom(page, teacherPage)
+        const testRecord = await createActiveOpenResponseTest(teacherPage, shared.id, testTitle)
+        testId = testRecord.id
+        return shared
+      })
+
+      await page.goto(`/classrooms/${classroom.id}?tab=tests`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      const splitShell = page.locator('[data-testid="student-test-split-container"]')
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+
+      const responseBox = page.locator('textarea[placeholder="Write your response..."]')
+      await expect(responseBox).toBeVisible()
+      await responseBox.fill('Draft survives teacher-closed access.')
+      await expect(page.getByText('Saved', { exact: true })).toBeVisible({ timeout: 20_000 })
+
+      await withTeacherPage(browser, async (teacherPage) => {
+        await updateStudentTestAccess(teacherPage, testId!, currentStudent.user.id, 'closed')
+      })
+
+      await page.evaluate(() => window.dispatchEvent(new Event('focus')))
+      await expect(page.getByText('This test is closed.')).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText(/Your saved draft is preserved/)).toBeVisible()
+      await expect(responseBox).toBeHidden()
+
+      await withTeacherPage(browser, async (teacherPage) => {
+        await updateStudentTestAccess(teacherPage, testId!, currentStudent.user.id, 'open')
+      })
+
+      await page.reload({ waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: new RegExp(testTitle) }).first().click()
+      await prepareExamWindowForViewportCompliance(page)
+      await page.getByRole('button', { name: 'Start the Test' }).click()
+      await page.getByRole('button', { name: 'Start test' }).click()
+
+      await expect(splitShell).toBeVisible({ timeout: 15_000 })
+      await expect(responseBox).toBeVisible()
+      await expect(responseBox).toHaveValue('Draft survives teacher-closed access.')
     } finally {
       await cleanupTest(browser, testId)
     }


### PR DESCRIPTION
## Selected flow

Student exam mode: teacher closes and reopens access while a student has an in-progress open-response draft. This was chosen because the highest-priority student exam-mode area already covered window/focus/route exits and reload resume, but not the mid-session teacher access closure path that should preserve draft work.

## Risk profile

- exam-mode
- workspace-state

## Tests added or updated

- Added one Playwright flow in `e2e/student-exam-mode.spec.ts` that:
  - creates an active open-response test through existing teacher APIs
  - starts the test as the seeded student
  - saves an open-response draft
  - closes that student's access through the teacher student-access API
  - verifies the remote closure notice hides the editable response
  - reopens access and verifies the saved draft is restored after reselecting the test

## Commands run

- `bash scripts/verify-env.sh`
- `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
- `corepack pnpm lint`
- `node scripts/trim-session-log.mjs && node scripts/trim-session-log.mjs --check`
- `git diff --check`

## Seeded-data assumptions

- Existing e2e auth setup can log in the seeded teacher and student users.
- The seeded teacher and student share at least one classroom.
- The test student-access RPC/table migrations are applied in the target e2e database.

## Residual coverage gaps

- This does not cover teacher scheduled/open/closed test configuration UI.
- This does not cover multi-student batch access changes from the student perspective.
- This does not assert telemetry for the teacher-closed access transition, only draft preservation and restoration.