### PR TITLE
[codex] Simplify test draft route loading

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Assessment utility fixture naming
-
-**Completed:**
-- Updated generic assessment utility comments and local parameter names from quiz wording to assessment wording.
-- Switched generic `tests/unit/assessments.test.ts` cases to use test-shaped fixtures for response eligibility, result visibility, editing, activation, and aggregation.
-- Left explicit legacy quiz alias/status coverage on `createMockQuiz` where the test is intentionally about quiz compatibility.
-- Did not change API response shapes, route contracts, schema, migrations, RPCs, storage paths, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessments.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Production release sync
 
 **Completed:**
@@ -818,6 +803,22 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash .codex/skills/pika-audit/scripts/audit.sh`
 - `pnpm test`
 - `pnpm build`
+
+## 2026-07-05 — Test draft route simplification
+
+**Completed:**
+- Weekly Pika simplification selected the teacher test draft API route as the hotspot because it duplicated assessment draft creation/repair logic already available in `ensureAssessmentDraft`.
+- Removed the route-local `ensureTestDraft` helper from `src/app/api/teacher/tests/[id]/draft/route.ts` and routed GET/PATCH through the shared assessment draft helper.
+- Updated `tests/api/teacher/tests-draft-route.test.ts` to cover the shared helper path while preserving document validation and save behavior.
+- Opened draft PR #834: https://github.com/codepetca/pika/pull/834
+- Risk profile: workspace-state, because test draft preservation and repair are stateful editor concerns.
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `./node_modules/.bin/vitest run tests/api/teacher/tests-draft-route.test.ts`
+- `bash .codex/skills/pika-audit/scripts/audit.sh`
+- `./node_modules/.bin/vitest run`
+- `pnpm test` was attempted but blocked before Vitest by pnpm ignored build-script approval (`@parcel/watcher`, `esbuild`, `unrs-resolver`).
 
 ## 2026-06-23 — Teacher classroom cached JSON
 

--- a/src/app/api/teacher/tests/[id]/draft/route.ts
+++ b/src/app/api/teacher/tests/[id]/draft/route.ts
@@ -6,12 +6,9 @@ import { validateTestDocumentsPayload } from '@/lib/test-documents'
 import {
   buildNextDraftContent,
   buildTestDraftContentFromRows,
-  createAssessmentDraft,
-  getAssessmentDraftByType,
-  isMissingAssessmentDraftsError,
+  ensureAssessmentDraft,
   updateAssessmentDraft,
   validateTestDraftContent,
-  type AssessmentDraftRow,
   type TestDraftContent,
 } from '@/lib/server/assessment-drafts'
 import { withErrorHandler } from '@/lib/api-handler'
@@ -30,86 +27,6 @@ const TEST_DRAFT_CONFIG = {
   buildFromRows: buildTestDraftContentFromRows,
 }
 
-async function ensureTestDraft(
-  supabase: any,
-  test: { id: string; classroom_id: string; title: string; show_results: boolean },
-  userId: string
-): Promise<
-  | { ok: true; draft: AssessmentDraftRow<TestDraftContent> }
-  | { ok: false; status: number; error: string }
-> {
-  const { draft, error } = await getAssessmentDraftByType<TestDraftContent>(
-    supabase,
-    'test',
-    test.id
-  )
-
-  if (isMissingAssessmentDraftsError(error)) {
-    return {
-      ok: false,
-      status: 400,
-      error: 'Assessment drafts require migration 045 to be applied',
-    }
-  }
-
-  if (error) {
-    console.error('Error fetching test draft:', error)
-    return { ok: false, status: 500, error: 'Failed to fetch draft' }
-  }
-
-  if (draft) {
-    const valid = validateTestDraftContent(draft.content, {
-      allowEmptyQuestionText: true,
-    })
-    if (valid.valid) {
-      return { ok: true, draft: { ...draft, content: valid.value } }
-    }
-  }
-
-  const { data: questions, error: questionsError } = await supabase
-    .from('test_questions')
-    .select(TEST_DRAFT_CONFIG.questionsSelect)
-    .eq('test_id', test.id)
-    .order('position', { ascending: true })
-
-  if (questionsError) {
-    console.error('Error building baseline test draft:', questionsError)
-    return { ok: false, status: 500, error: 'Failed to build draft' }
-  }
-
-  const content = buildTestDraftContentFromRows(test, questions || [])
-
-  if (draft) {
-    const { draft: updatedDraft, error: updateError } = await updateAssessmentDraft(
-      supabase,
-      draft.id,
-      draft.version + 1,
-      userId,
-      content
-    )
-    if (updateError || !updatedDraft) {
-      return { ok: false, status: 500, error: 'Failed to reset invalid draft' }
-    }
-    return { ok: true, draft: updatedDraft }
-  }
-
-  const { draft: createdDraft, error: createError } = await createAssessmentDraft<TestDraftContent>(
-    supabase,
-    {
-      assessmentType: 'test',
-      assessmentId: test.id,
-      classroomId: test.classroom_id,
-      userId,
-      content,
-    }
-  )
-  if (createError || !createdDraft) {
-    console.error('Error creating test draft:', createError)
-    return { ok: false, status: 500, error: 'Failed to create draft' }
-  }
-  return { ok: true, draft: createdDraft }
-}
-
 export const GET = withErrorHandler('GetTestDraft', async (request, context) => {
   const user = await requireRole('teacher')
   const { id: testId } = await context.params
@@ -120,7 +37,11 @@ export const GET = withErrorHandler('GetTestDraft', async (request, context) => 
   }
 
   const supabase = getServiceRoleClient()
-  const ensured = await ensureTestDraft(supabase, access.test, user.id)
+  const ensured = await ensureAssessmentDraft<TestDraftContent>(supabase, {
+    ...TEST_DRAFT_CONFIG,
+    assessment: access.test,
+    userId: user.id,
+  })
   if (!ensured.ok) {
     return NextResponse.json({ error: ensured.error }, { status: ensured.status })
   }
@@ -161,7 +82,11 @@ export const PATCH = withErrorHandler('PatchTestDraft', async (request, context)
   }
 
   const supabase = getServiceRoleClient()
-  const ensured = await ensureTestDraft(supabase, access.test, user.id)
+  const ensured = await ensureAssessmentDraft<TestDraftContent>(supabase, {
+    ...TEST_DRAFT_CONFIG,
+    assessment: access.test,
+    userId: user.id,
+  })
   if (!ensured.ok) {
     return NextResponse.json({ error: ensured.error }, { status: ensured.status })
   }

--- a/tests/api/teacher/tests-draft-route.test.ts
+++ b/tests/api/teacher/tests-draft-route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
-import { PATCH } from '@/app/api/teacher/tests/[id]/draft/route'
+import { GET, PATCH } from '@/app/api/teacher/tests/[id]/draft/route'
 import { assertTeacherOwnsTest } from '@/lib/server/tests'
 import {
   buildNextDraftContent,
-  getAssessmentDraftByType,
+  ensureAssessmentDraft,
   updateAssessmentDraft,
 } from '@/lib/server/assessment-drafts'
 
@@ -40,9 +40,7 @@ vi.mock('@/lib/server/assessment-drafts', () => ({
     show_results: false,
     questions: [],
   })),
-  createAssessmentDraft: vi.fn(),
-  getAssessmentDraftByType: vi.fn(),
-  isMissingAssessmentDraftsError: vi.fn(() => false),
+  ensureAssessmentDraft: vi.fn(),
   updateAssessmentDraft: vi.fn(),
   validateTestDraftContent: vi.fn((content: any) => ({ valid: true, value: content })),
 }))
@@ -53,7 +51,8 @@ describe('PATCH /api/teacher/tests/[id]/draft', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    vi.mocked(getAssessmentDraftByType).mockResolvedValue({
+    vi.mocked(ensureAssessmentDraft).mockResolvedValue({
+      ok: true,
       draft: {
         id: 'draft-1',
         assessment_type: 'test',
@@ -72,7 +71,6 @@ describe('PATCH /api/teacher/tests/[id]/draft', () => {
         created_at: '2026-03-01T00:00:00.000Z',
         updated_at: '2026-03-01T00:00:00.000Z',
       },
-      error: null,
     } as any)
 
     vi.mocked(buildNextDraftContent).mockReturnValue({
@@ -107,6 +105,34 @@ describe('PATCH /api/teacher/tests/[id]/draft', () => {
       },
       error: null,
     } as any)
+  })
+
+  it('loads the draft through the shared assessment draft helper', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/teacher/tests/test-1/draft'),
+      { params: Promise.resolve({ id: 'test-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.draft.id).toBe('draft-1')
+    expect(ensureAssessmentDraft).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      expect.objectContaining({
+        assessmentType: 'test',
+        assessment: expect.objectContaining({
+          id: 'test-1',
+          classroom_id: 'classroom-1',
+        }),
+        userId: 'teacher-1',
+        questionsTable: 'test_questions',
+        questionsForeignKey: 'test_id',
+        validateOptions: { allowEmptyQuestionText: true },
+      })
+    )
+    expect(assertTeacherOwnsTest).toHaveBeenCalledWith('teacher-1', 'test-1', {
+      checkArchived: true,
+    })
   })
 
   it('persists validated documents when provided', async () => {
@@ -168,6 +194,14 @@ describe('PATCH /api/teacher/tests/[id]/draft', () => {
       })
     )
     expect(data.draft.content.title).toBe('Updated Test')
+    expect(ensureAssessmentDraft).toHaveBeenCalledWith(
+      mockSupabaseClient,
+      expect.objectContaining({
+        assessmentType: 'test',
+        assessment: expect.objectContaining({ id: 'test-1' }),
+        userId: 'teacher-1',
+      })
+    )
   })
 
   it('returns 400 and blocks save when documents payload is invalid', async () => {


### PR DESCRIPTION
## Summary
- Removed the route-local `ensureTestDraft` implementation from the teacher test draft API route.
- Routed draft GET/PATCH through the shared `ensureAssessmentDraft` helper with the existing test draft configuration.
- Updated focused route coverage to verify the shared helper path plus existing document validation/save behavior.

## Selected hotspot
Teacher test draft loading was selected because it duplicated assessment draft creation/repair logic already centralized in `src/lib/server/assessment-drafts.ts`. This is a fragile workspace-state area because invalid draft repair, draft versioning, migration fallback behavior, and draft preservation all affect the teacher test editor.

## Risk profile
- `workspace-state`

## Behavior
Preserved behavior intentionally. The route still enforces teacher ownership before loading drafts, allows empty question text for draft edits, validates document payloads before saving, checks draft version conflicts, and syncs title/show_results/documents after draft save.

## Tests
- Updated `tests/api/teacher/tests-draft-route.test.ts` with GET coverage for the shared helper path.
- Kept PATCH coverage for validated documents and invalid document rejection.

## Commands run
- `bash scripts/verify-env.sh`
- `./node_modules/.bin/vitest run tests/api/teacher/tests-draft-route.test.ts`
- `bash .codex/skills/pika-audit/scripts/audit.sh`
- `./node_modules/.bin/vitest run`
- Attempted `pnpm test`, but pnpm stopped before Vitest on ignored build-script approval for `@parcel/watcher`, `esbuild`, and `unrs-resolver`.

## Residual risks and follow-ups
- This PR does not remove remaining assessment draft migration-045 compatibility shims.
- This PR does not change activation or question sync logic in `src/app/api/teacher/tests/[id]/route.ts`.
- `pnpm test` needs local build-script approval cleanup outside this patch; direct Vitest passed fully.