### PR TITLE
Add collaborator onboarding docs and CODEOWNERS

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,37 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Production release sync
-
-**Completed:**
-- Merged latest `origin/main` into `production` through protected PR #795.
-- Verified required GitHub checks passed before merging.
-- Synced the local production worktree to `origin/production` at `f483bbcbdc055fef379b655d6162b03c5fee073e`.
-- Risk profile: runtime-platform.
-- Model recommendation: GPT-5 Codex - protected-branch release orchestration with CI and worktree synchronization.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
-- `gh run watch 27520948663 --repo codepetca/pika --interval 15 --exit-status`
-- `gh pr merge 795 --repo codepetca/pika --merge --delete-branch`
-- `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
-
-## 2026-06-14 — Draft hook assessment option names
-
-**Completed:**
-- Renamed the primary `useDraftMode` options from `quizId`/`quizTitle` to `assessmentId`/`assessmentTitle`.
-- Kept legacy `quizId`/`quizTitle` option aliases for compatibility and added focused test coverage for them.
-- Updated hook comments, examples, and tests to use assessment/test wording by default.
-- Left DB-shaped `quiz_id` question fields and draft route contracts unchanged.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/hooks/useDraftMode.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Assessment draft sync error wording
 
 **Completed:**
@@ -884,3 +853,17 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
 - `corepack pnpm lint`
+
+## 2026-07-09 — Collaborator readiness: rulesets, CODEOWNERS, onboarding docs
+
+**Completed:**
+- Updated GitHub rulesets via API: `main` now requires a PR with 1 approving code-owner review plus the `Test & Build` status check (squash/rebase only); `production` mirrors the review + status-check requirements. Repo admins retain bypass.
+- Added `.github/CODEOWNERS` (`* @armorup`) and `CONTRIBUTING.md` (collaborator setup, PR workflow, contribution permission note).
+- README Getting Started rewritten: own-Supabase-per-developer with `supabase db push` (was stale "migrations 001–008 in dashboard"), required vs optional env split, seeded staging creds removed from docs.
+- Marked shared `.env.local` symlink convention as maintainer-specific in `.ai/START-HERE.md` and `docs/dev-workflow.md`.
+- Ran gitleaks over full history (1242 commits): no live secrets; flagged initial-commit README/tests 64-hex `SESSION_SECRET` example for precautionary rotation.
+- PR: https://github.com/codepetca/pika/pull/835
+
+**Validation:**
+- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
+- `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active

--- a/.ai/START-HERE.md
+++ b/.ai/START-HERE.md
@@ -11,7 +11,7 @@
 ```
 [ ] Resolve repo root: git rev-parse --show-toplevel
 [ ] Verify repo root is a feature worktree, not $HOME/Repos/pika for branch work
-[ ] Ensure .env.local symlinks to $HOME/Repos/.env/pika/.env.local
+[ ] Ensure .env.local exists (shared setups symlink to $HOME/Repos/.env/pika/.env.local; collaborators: cp .env.example .env.local)
 [ ] Run: bash scripts/verify-env.sh
 [ ] Check status: git status --short --branch
 [ ] Read: .ai/CURRENT.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review from the project maintainer.
+* @armorup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Pika
+
+Thanks for helping out! This doc covers the workflow for invited collaborators.
+
+## Permission to contribute
+
+Pika is source-visible but not open source (see [LICENSE](./LICENSE)). By
+inviting you as a collaborator, the maintainer grants you permission to run,
+modify, and contribute to Pika **for the purpose of contributing to this
+repository**. By submitting a contribution you agree it becomes part of Pika
+under the LICENSE. This does not grant rights to use, host, or distribute
+Pika elsewhere.
+
+## Local setup
+
+Follow the [README Getting Started](./README.md#getting-started). In short:
+
+1. Node 24 + `corepack enable` + `pnpm install`
+2. Create **your own** Supabase database (free cloud project or `supabase start`)
+3. Apply migrations with `supabase db push` (never by hand — there are ~80)
+4. `cp .env.example .env.local` and fill in the required values
+5. `pnpm dev`
+
+You do **not** need Vercel, Brevo, or an OpenAI key for normal development.
+Never commit `.env*` files or real credentials.
+
+## Workflow: everything goes through a PR
+
+`main` and `production` are protected. Direct pushes are blocked; every change
+lands via a pull request that requires:
+
+1. **A passing CI run** (`Test & Build`: tests, typecheck, lint, build)
+2. **An approving review from the maintainer** (@armorup, enforced via CODEOWNERS)
+
+Steps:
+
+```bash
+git checkout -b <short-descriptive-branch> origin/main
+# ...make changes...
+pnpm test && npx tsc --noEmit && pnpm lint
+git push -u origin <branch>
+gh pr create --base main
+```
+
+- Keep PRs small and focused — one concern per PR.
+- `main` uses squash or rebase merges (linear history); the PR title becomes
+  the commit message, so write it well.
+- The `production` branch is a deploy target promoted from `main` by the
+  maintainer — don't target it directly.
+
+## Working with AI agents
+
+The repo ships AI-agent instructions (`CLAUDE.md`, `.ai/START-HERE.md`,
+`AGENTS.md`). Some conventions there (worktree layout under `$HOME/Repos/pika`,
+a shared `.env.local` symlink) describe the **maintainer's** machine — a plain
+clone with your own `.env.local` is fine. If your agent session appends to
+`.ai/SESSION-LOG.md`, expect occasional merge conflicts there; resolve by
+keeping both entries.
+
+## Questions
+
+Open a GitHub issue or leave a comment on your PR.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Next.js application for classroom attendance, daily journals, and assignment submissions backed by Supabase.
 
+**Contributing?** See [CONTRIBUTING.md](./CONTRIBUTING.md) for the PR workflow and what you need to get a local environment running.
+
 ## For AI Agents
 
 Start with: `.ai/START-HERE.md`
@@ -53,15 +55,18 @@ permission. See [LICENSE](./LICENSE).
 
 ## Prerequisites
 
-- Node.js 24.x
-- Supabase project (cloud or local)
+- Node.js 24.x (use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm): `nvm install 24`)
+- pnpm via corepack (`corepack enable` — the repo pins the pnpm version)
+- [Supabase CLI](https://supabase.com/docs/guides/local-development/cli/getting-started) (`brew install supabase/tap/supabase`)
 - Git
+
+You do **not** need a Vercel account for local development.
 
 ## Getting Started
 
 1) **Clone**
 ```bash
-git clone <repository-url>
+git clone https://github.com/codepetca/pika.git
 cd pika
 ```
 
@@ -71,48 +76,56 @@ corepack enable
 pnpm install
 ```
 
-3) **Supabase setup**
-- Create a project and grab:
-  - `NEXT_PUBLIC_SUPABASE_URL`
-  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (starts with `sb_publishable_`)
-  - `SUPABASE_SECRET_KEY` (starts with `sb_secret_`)
-- Apply migrations `supabase/migrations/001` through `008` (users, verification codes, class days, entries, auth refactor, classrooms, assignments, legacy cleanup).
-  - Dashboard: run each file in order.
-  - CLI: `supabase db push`
+3) **Set up a database (your own Supabase)**
 
-4) **Generate session secret**
+Every developer runs against their own Supabase database. Pick one:
+
+**Option A — free Supabase cloud project (simplest):**
+1. Create a project at [supabase.com](https://supabase.com) (free tier is fine).
+2. From Project Settings → API, note:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (starts with `sb_publishable_`)
+   - `SUPABASE_SECRET_KEY` (starts with `sb_secret_`)
+3. Apply all migrations (there are ~80 — do **not** run them by hand in the dashboard):
 ```bash
-pnpm run generate:secret
+supabase link --project-ref <your-project-ref>
+supabase db push
 ```
-Add to `.env.local` as `SESSION_SECRET`.
 
-5) **Environment variables**
+**Option B — local Supabase (Docker required):**
+```bash
+supabase start   # applies supabase/migrations/ automatically
+```
+Use the URL and keys it prints.
+
+4) **Environment variables**
+```bash
+cp .env.example .env.local
+```
+
+Only these are **required** for local dev:
+
 ```env
-# Supabase
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your-key-here
-SUPABASE_SECRET_KEY=sb_secret_your-key-here
-
-# Session
-SESSION_SECRET=your-64-char-hex-secret
-
-# Roles
-DEV_TEACHER_EMAILS=teacher@example.com,admin@yrdsb.ca
-
-# Email (mock logs codes to console in dev)
-ENABLE_MOCK_EMAIL=true
-
-# App
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+SUPABASE_SECRET_KEY=sb_secret_...
+SESSION_SECRET=...            # generate with: pnpm run generate:secret
+ENABLE_MOCK_EMAIL=true        # verification codes print to the dev server console
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-
-# Cron (Vercel Cron Jobs)
-CRON_SECRET=generate-a-secure-random-secret
+DEV_TEACHER_EMAILS=teacher@example.com   # emails that get the teacher role
 ```
+
+Everything else in `.env.example` is **optional** and only needed for specific features:
+- `BREVO_*` — real email delivery (mock email covers dev)
+- `OPENAI_API_KEY` — AI grading and log summaries
+- `GRADEX_*` — Gradex grading integration
+- `CRON_SECRET` — Vercel cron endpoints (production concern)
+- `GITHUB_PAT` / `GITHUB_FEEDBACK_TOKEN` — repo review helper scripts
 
 Cron schedules are configured in the Vercel dashboard (recommended: production only).
 Recommended schedule: `0 6 * * *` (06:00 UTC → 1:00am Toronto in winter, 2:00am in summer).
 
-6) **Seed data (optional)**
+5) **Seed data (optional)**
 ```bash
 pnpm run seed
 ```
@@ -122,7 +135,7 @@ If you keep multiple Supabase environments, you can point seed scripts at a spec
 ENV_FILE=.env.staging.local ALLOW_DB_WIPE=true pnpm run seed:fresh
 ```
 
-7) **Run dev server**
+6) **Run dev server**
 ```bash
 pnpm dev
 ```
@@ -170,9 +183,9 @@ pnpm exec playwright show-report playwright-report
 **Staging workflow**:
 ```bash
 E2E_BASE_URL=https://your-staging-url \
-E2E_TEACHER_EMAIL=teacher@yrdsb.ca \
-E2E_STUDENT_EMAIL=student1@student.yrdsb.ca \
-E2E_PASSWORD=test1234 \
+E2E_TEACHER_EMAIL=your-seeded-teacher@example.com \
+E2E_STUDENT_EMAIL=your-seeded-student@example.com \
+E2E_PASSWORD=your-seeded-password \
 pnpm run e2e:snapshots
 
 pnpm exec playwright show-report playwright-report
@@ -227,7 +240,7 @@ pika/
 │   ├── components/                  # UI primitives and modals
 │   ├── lib/                         # Core logic (auth, crypto, timezone, attendance, calendar, assignments)
 │   └── types/                       # Shared TypeScript types
-├── supabase/migrations/             # 001–007 schema + RLS
+├── supabase/migrations/             # Schema + RLS (apply with supabase db push)
 ├── tests/                           # Vitest suites (unit + API)
 └── scripts/                         # Setup/seed utilities
 ```
@@ -265,4 +278,4 @@ pika/
 
 ## Support
 
-Open an issue or PR with questions or fixes.
+Open an issue with questions, or see [CONTRIBUTING.md](./CONTRIBUTING.md) to submit changes.

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -79,7 +79,12 @@ intended worktree.
 
 ### Environment files
 
-All worktrees share a single canonical `.env.local` file:
+> **Collaborators:** the shared canonical env file below is the maintainer's
+> machine-specific convention. If you don't have `$HOME/Repos/.env/pika/`,
+> just keep your own `.env.local` (copied from `.env.example` — see the
+> README) in each checkout and skip the symlink steps.
+
+On the maintainer's setup, all worktrees share a single canonical `.env.local` file:
 
 ```
 $HOME/Repos/.env/pika/.env.local


### PR DESCRIPTION
Prepares the repo for invited collaborators.

## Changes
- **CODEOWNERS** (`* @armorup`): combined with the updated `main` branch ruleset (now requires a PR + code-owner approval + passing `Test & Build`), all work must be reviewed by the maintainer before merge.
- **CONTRIBUTING.md**: local setup summary, PR workflow, what's required vs optional, and a note granting invited collaborators permission to contribute under the LICENSE.
- **README**: Getting Started rewritten around each collaborator running their own Supabase DB — `supabase link && supabase db push` (or `supabase start`) replaces the stale "apply migrations 001–008 in the dashboard" instruction (there are ~80 migrations now). Env vars split into required vs optional. Seeded staging credentials replaced with placeholders.
- **.ai/START-HERE.md / docs/dev-workflow.md**: the shared `.env.local` symlink convention is marked as maintainer-machine-specific so collaborators (and their AI agents) aren't blocked by it. The `ai-startup-docs` test suite still passes (26/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)