### PR TITLE
Remove stale staging environment references

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -11111,3 +11111,19 @@
 - `pnpm test tests/unit/assessment-drafts.test.ts`
 - `pnpm lint`
 - `pnpm test`
+
+## 2026-06-14 — Current test fixture wording cleanup
+
+**Completed:**
+- Renamed server assessment visibility unit-test descriptions and locals from quiz wording to assessment wording.
+- Updated `StudentTestResults` current-surface test fixtures to use `test-1` and `Test not found` while preserving the explicit legacy `quizId` alias test.
+- Updated the flagged-question helper file comment from test/quiz taking to test taking.
+- Did not change runtime behavior, schema, API payloads, compatibility aliases, or persisted `quiz_id` fields.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/server-assessments.test.ts tests/components/StudentTestResults.test.tsx tests/lib/flag-questions.test.ts`
+- `pnpm lint`
+- `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
+- `pnpm test`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,22 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Current test fixture wording cleanup
-
-**Completed:**
-- Renamed server assessment visibility unit-test descriptions and locals from quiz wording to assessment wording.
-- Updated `StudentTestResults` current-surface test fixtures to use `test-1` and `Test not found` while preserving the explicit legacy `quizId` alias test.
-- Updated the flagged-question helper file comment from test/quiz taking to test taking.
-- Did not change runtime behavior, schema, API payloads, compatibility aliases, or persisted `quiz_id` fields.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/server-assessments.test.ts tests/components/StudentTestResults.test.tsx tests/lib/flag-questions.test.ts`
-- `pnpm lint`
-- `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
-- `pnpm test`
-
 ## 2026-06-14 — Teacher work-surface docs test wording
 
 **Completed:**
@@ -854,18 +838,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
 - `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active
 
-## 2026-07-09 — Remove stale staging environment references
-
-**Completed:**
-- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
-- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
-- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `grep -rni staging` (only seed-data classroom title and journal archive remain)
-- `pnpm lint`
-- `pnpm exec tsc --noEmit`
 ## 2026-07-09 — Archive trimmed session-log entries instead of deleting
 
 **Completed:**
@@ -880,3 +852,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `pnpm test tests/unit/ai-startup-docs.test.ts`
 - `node scripts/trim-session-log.mjs --check`
 - `pnpm lint`
+
+## 2026-07-09 — Remove stale staging environment references
+
+**Completed:**
+- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
+- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
+- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `grep -rni staging` (only seed-data classroom title and journal archive remain)
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,37 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Production release sync
-
-**Completed:**
-- Merged latest `origin/main` into `production` through protected PR #795.
-- Verified required GitHub checks passed before merging.
-- Synced the local production worktree to `origin/production` at `f483bbcbdc055fef379b655d6162b03c5fee073e`.
-- Risk profile: runtime-platform.
-- Model recommendation: GPT-5 Codex - protected-branch release orchestration with CI and worktree synchronization.
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `bash .codex/skills/pika-main-to-production-merge/scripts/merge_main_into_production.sh`
-- `gh run watch 27520948663 --repo codepetca/pika --interval 15 --exit-status`
-- `gh pr merge 795 --repo codepetca/pika --merge --delete-branch`
-- `git -C /Users/stew/Repos/.worktrees/pika/production merge --ff-only origin/production`
-
-## 2026-06-14 — Draft hook assessment option names
-
-**Completed:**
-- Renamed the primary `useDraftMode` options from `quizId`/`quizTitle` to `assessmentId`/`assessmentTitle`.
-- Kept legacy `quizId`/`quizTitle` option aliases for compatibility and added focused test coverage for them.
-- Updated hook comments, examples, and tests to use assessment/test wording by default.
-- Left DB-shaped `quiz_id` question fields and draft route contracts unchanged.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/hooks/useDraftMode.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Assessment draft sync error wording
 
 **Completed:**
@@ -884,3 +853,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `bash scripts/verify-env.sh`
 - `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
 - `corepack pnpm lint`
+
+## 2026-07-09 — Remove stale staging environment references
+
+**Completed:**
+- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
+- Kept the generic `ENV_FILE=<path-to-env-file>` mechanism and reworded remote-testing guidance to Vercel preview deployments.
+- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `grep -rni staging` (only seed-data classroom title and journal archive remain)
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -858,7 +858,7 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Completed:**
 - Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
-- Kept the generic `ENV_FILE=<path-to-env-file>` mechanism and reworded remote-testing guidance to Vercel preview deployments.
+- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
 - Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
 
 **Validation:**

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -9,21 +9,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Assessment draft sync error wording
-
-**Completed:**
-- Renamed `syncAssessmentQuestionsFromDraft` failure messages from quiz-question wording to assessment-question wording.
-- Updated nearby generic assessment draft helper comments to avoid quiz/test route wording.
-- Updated the focused unit assertion for the renamed insert failure message.
-- Left compatibility exports, `AssessmentDraftType = 'quiz' | 'test'`, `quiz_questions`, `quiz_id`, route contracts, and persisted payload shapes unchanged.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessment-drafts.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Current test fixture wording cleanup
 
 **Completed:**
@@ -854,18 +839,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `corepack pnpm exec playwright test e2e/student-exam-mode.spec.ts --project=chromium-desktop --grep "preserves an open-response draft when teacher closes and reopens access"`
 - `corepack pnpm lint`
 
-## 2026-07-09 — Remove stale staging environment references
-
-**Completed:**
-- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
-- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
-- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
-
-**Validation:**
-- `bash scripts/verify-env.sh`
-- `grep -rni staging` (only seed-data classroom title and journal archive remain)
-- `pnpm lint`
-- `pnpm exec tsc --noEmit`
 ## 2026-07-09 — Collaborator readiness: rulesets, CODEOWNERS, onboarding docs
 
 **Completed:**
@@ -879,3 +852,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
 - `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active
+
+## 2026-07-09 — Remove stale staging environment references
+
+**Completed:**
+- Removed stale staging-environment references now that the staging Supabase environment is gone: README.md (seed `ENV_FILE` example, UI gallery wording, renamed the "Staging workflow" E2E section to a remote/preview workflow), docs/core/pilot-mvp.md (Environments section and manual cron trigger now reference Vercel preview deployments), docs/core/project-context.md, docs/core/tests.md, docs/semester-plan.md, docs/deployment/BREVO-SETUP.md, seed script headers (scripts/seed.ts, scripts/seed-gld2o.ts), and src/lib/email.ts comments.
+- Kept the generic `ENV_FILE` mechanism (examples now use a pasteable `.env.custom.local`) and reworded remote-testing guidance to Vercel preview deployments.
+- Left the seeded `GLD2O Staging` classroom title unchanged (test-data name, not an environment reference) and `.ai/JOURNAL-ARCHIVE.md` (historical archive).
+
+**Validation:**
+- `bash scripts/verify-env.sh`
+- `grep -rni staging` (only seed-data classroom title and journal archive remain)
+- `pnpm lint`
+- `pnpm exec tsc --noEmit`

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pnpm run seed
 
 If you keep multiple Supabase environments, you can point seed scripts at a specific env file:
 ```bash
-ENV_FILE=.env.staging.local ALLOW_DB_WIPE=true pnpm run seed:fresh
+ENV_FILE=<path-to-env-file> ALLOW_DB_WIPE=true pnpm run seed:fresh
 ```
 
 7) **Run dev server**
@@ -139,7 +139,7 @@ pnpm run test:ui
 
 ### UI Review (Gallery + Snapshots)
 
-Enable the UI gallery (recommended on staging):
+Enable the UI gallery (recommended on Vercel preview deployments):
 ```env
 ENABLE_UI_GALLERY=true
 ```
@@ -167,9 +167,9 @@ E2E_BASE_URL=http://localhost:3000 pnpm run e2e:snapshots
 pnpm exec playwright show-report playwright-report
 ```
 
-**Staging workflow**:
+**Remote workflow (e.g. a Vercel preview deployment)**:
 ```bash
-E2E_BASE_URL=https://your-staging-url \
+E2E_BASE_URL=https://your-preview-url \
 E2E_TEACHER_EMAIL=teacher@yrdsb.ca \
 E2E_STUDENT_EMAIL=student1@student.yrdsb.ca \
 E2E_PASSWORD=test1234 \

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pnpm run seed
 
 If you keep multiple Supabase environments, you can point seed scripts at a specific env file:
 ```bash
-ENV_FILE=<path-to-env-file> ALLOW_DB_WIPE=true pnpm run seed:fresh
+ENV_FILE=.env.custom.local ALLOW_DB_WIPE=true pnpm run seed:fresh
 ```
 
 7) **Run dev server**

--- a/docs/core/pilot-mvp.md
+++ b/docs/core/pilot-mvp.md
@@ -9,7 +9,7 @@ This doc captures the current pilot direction and decisions so we can move quick
 - **Internal dry-run:** Dec 16, 2025
 
 ## Environments
-- **Staging:** Vercel “staging” environment (used for dry-run and early pilot testing)
+- **Preview:** Vercel preview deployments (per-branch; used for dry-run and early pilot testing)
 
 ## Email (Brevo)
 - Use transactional email for signup verification / password reset.
@@ -94,7 +94,7 @@ To support automated history analysis, MVP should treat **Pika as the primary dr
 - On-demand summarization should return cached results unless the assignment doc has changed since the last summary.
 - Nightly batch recomputes summaries only for **submitted** assignment docs changed since last summary.
 - Scheduled execution: Vercel Cron (configured in Vercel dashboard; production recommended) at `0 6 * * *` (06:00 UTC; 1:00am Toronto in winter, 2:00am in summer) → `GET /api/cron/nightly-assignment-summaries` (protected via `CRON_SECRET`).
-- Manual staging trigger (non-production only):
+- Manual trigger (non-production only, e.g. a Vercel preview deployment):
   - `curl -X POST \"$NEXT_PUBLIC_APP_URL/api/cron/nightly-assignment-summaries?force=1\" -H \"Authorization: Bearer $CRON_SECRET\"`
 
 ## Out of Scope (for MVP)

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -57,7 +57,7 @@ Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
    - AI agents may create or edit migration files, but must not run `supabase db push`, `supabase db reset`, or similar migration commands
 4. `pnpm dev` and open http://localhost:3000
 5. Optional: `pnpm seed`
-   - To wipe + reseed against a specific env file: `ENV_FILE=.env.staging.local ALLOW_DB_WIPE=true pnpm seed:fresh`
+   - To wipe + reseed against a specific env file: `ENV_FILE=<path-to-env-file> ALLOW_DB_WIPE=true pnpm seed:fresh`
 
 Email sending is mocked (`ENABLE_MOCK_EMAIL=true` logs codes). For production email setup, see [`docs/deployment/BREVO-SETUP.md`](../deployment/BREVO-SETUP.md).
 

--- a/docs/core/project-context.md
+++ b/docs/core/project-context.md
@@ -57,7 +57,7 @@ Package manager: pnpm (recommended via Corepack; `package.json#packageManager`)
    - AI agents may create or edit migration files, but must not run `supabase db push`, `supabase db reset`, or similar migration commands
 4. `pnpm dev` and open http://localhost:3000
 5. Optional: `pnpm seed`
-   - To wipe + reseed against a specific env file: `ENV_FILE=<path-to-env-file> ALLOW_DB_WIPE=true pnpm seed:fresh`
+   - To wipe + reseed against a specific env file: `ENV_FILE=.env.custom.local ALLOW_DB_WIPE=true pnpm seed:fresh`
 
 Email sending is mocked (`ENABLE_MOCK_EMAIL=true` logs codes). For production email setup, see [`docs/deployment/BREVO-SETUP.md`](../deployment/BREVO-SETUP.md).
 

--- a/docs/core/tests.md
+++ b/docs/core/tests.md
@@ -140,7 +140,7 @@ Focus on **critical user flows**:
 
 ### UI Snapshot Runs (Playwright)
 
-For visual review (spacing/aesthetics), we also support a **manual** Playwright snapshot run against staging:
+For visual review (spacing/aesthetics), we also support a **manual** Playwright snapshot run against a deployed environment (e.g. a Vercel preview deployment):
 - Spec: `e2e/ui-snapshots.spec.ts`
 - Output (local): `artifacts/ui-snapshots/` (screenshots) and `playwright-report/` (HTML report)
 - Gallery (web): `/__ui` (gated by `ENABLE_UI_GALLERY=true`)

--- a/docs/deployment/BREVO-SETUP.md
+++ b/docs/deployment/BREVO-SETUP.md
@@ -26,7 +26,7 @@ Your Brevo template should include these variables:
 
 Configure these in Vercel Dashboard → Settings → Environment Variables:
 
-### For Staging (Preview environment):
+### For Preview deployments:
 
 ```bash
 # Disable mock email mode
@@ -128,7 +128,7 @@ Monitor email delivery:
 - [ ] Brevo template created with `{{ params.code }}`, `{{ params.expires }}`
 - [ ] Sender email verified in Brevo
 - [ ] Environment variables set in Vercel
-- [ ] `ENABLE_MOCK_EMAIL=false` for staging/production
+- [ ] `ENABLE_MOCK_EMAIL=false` for preview/production
 - [ ] Test email received successfully
 - [ ] Verification code works in app
 

--- a/docs/semester-plan.md
+++ b/docs/semester-plan.md
@@ -95,7 +95,7 @@ esac
 │    - Push branch to GitHub                              │
 │    - Supabase creates preview branch automatically      │
 │    - Or: Create manual preview in Supabase dashboard    │
-│    - Run smoke tests against staging                    │
+│    - Run smoke tests against the preview branch         │
 └─────────────────────┬───────────────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────────────┐
@@ -174,7 +174,7 @@ SELECT * FROM entries WHERE date > '2025-01-01';
 
 - [ ] Document current schema state (export via Supabase dashboard)
 - [ ] Test backup/restore procedure once
-- [ ] Set up Supabase preview branches for staging
+- [ ] Set up Supabase preview branches
 - [ ] Create rollback SQL for any planned migrations
 
 ---

--- a/scripts/seed-gld2o.ts
+++ b/scripts/seed-gld2o.ts
@@ -3,7 +3,7 @@
  * and enrolls student1 and student2.
  *
  * Usage: npx tsx scripts/seed-gld2o.ts
- *        ENV_FILE=.env.staging npx tsx scripts/seed-gld2o.ts
+ *        ENV_FILE=<path-to-env-file> npx tsx scripts/seed-gld2o.ts
  *
  * Prereq: the test teacher and students must already exist (run seed.ts first).
  */

--- a/scripts/seed-gld2o.ts
+++ b/scripts/seed-gld2o.ts
@@ -3,7 +3,7 @@
  * and enrolls student1 and student2.
  *
  * Usage: npx tsx scripts/seed-gld2o.ts
- *        ENV_FILE=<path-to-env-file> npx tsx scripts/seed-gld2o.ts
+ *        ENV_FILE=.env.custom.local npx tsx scripts/seed-gld2o.ts
  *
  * Prereq: the test teacher and students must already exist (run seed.ts first).
  */

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,7 +2,7 @@
  * Seed script for development/testing
  *
  * Usage: pnpm run seed
- *        ENV_FILE=<path-to-env-file> pnpm run seed
+ *        ENV_FILE=.env.custom.local pnpm run seed
  *
  * This script creates test data without clearing existing data:
  * 1. Creates test users (1 teacher, 2 students)

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,7 +2,7 @@
  * Seed script for development/testing
  *
  * Usage: pnpm run seed
- *        ENV_FILE=.env.staging pnpm run seed
+ *        ENV_FILE=<path-to-env-file> pnpm run seed
  *
  * This script creates test data without clearing existing data:
  * 1. Creates test users (1 teacher, 2 students)

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,7 +3,7 @@ import { sendBrevoEmail } from './brevo'
 /**
  * Sends an email with a signup verification code
  * In development mode (ENABLE_MOCK_EMAIL=true), logs to console instead
- * In production/staging, sends via Brevo template
+ * Otherwise (production and preview deployments), sends via Brevo template
  */
 export async function sendSignupCode(email: string, code: string): Promise<void> {
   const isMockMode = process.env.ENABLE_MOCK_EMAIL === 'true'
@@ -37,7 +37,7 @@ export async function sendSignupCode(email: string, code: string): Promise<void>
 /**
  * Sends an email with a password reset verification code
  * In development mode (ENABLE_MOCK_EMAIL=true), logs to console instead
- * In production/staging, sends via Brevo template
+ * Otherwise (production and preview deployments), sends via Brevo template
  */
 export async function sendPasswordResetCode(email: string, code: string): Promise<void> {
   const isMockMode = process.env.ENABLE_MOCK_EMAIL === 'true'


### PR DESCRIPTION
## Summary
The staging Supabase environment has been removed from the workflow. This PR cleans up the stale references while keeping guidance that's still useful for Vercel preview deployments:

- **README.md** — genericized the `ENV_FILE=.env.staging.local` seed example, changed the UI gallery "recommended on staging" wording to Vercel preview deployments, and renamed the "Staging workflow" E2E section to a remote workflow against a preview URL
- **docs/core/pilot-mvp.md** — Environments section and the manual cron trigger now reference Vercel preview deployments
- **docs/core/project-context.md**, **docs/core/tests.md**, **docs/semester-plan.md**, **docs/deployment/BREVO-SETUP.md** — staging wording replaced with preview-deployment / preview-branch equivalents
- **scripts/seed.ts**, **scripts/seed-gld2o.ts** — `ENV_FILE=.env.staging` usage examples genericized to `ENV_FILE=<path-to-env-file>`
- **src/lib/email.ts** — comments updated from "production/staging" to production and preview deployments
- **.ai/SESSION-LOG.md** — session entry appended and log trimmed via `node scripts/trim-session-log.mjs`

Intentionally left alone: the seeded `GLD2O Staging` classroom title in `scripts/seed-gld2o.ts` (test-data name, not an environment reference — renaming could duplicate classrooms in already-seeded databases) and historical entries in `.ai/JOURNAL-ARCHIVE.md`.

## Validation
- `bash scripts/verify-env.sh`
- `pnpm lint` — clean
- `pnpm exec tsc --noEmit` — clean
- `grep -rni staging` — only the seed-data classroom title and journal archive remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)