### PR TITLE
Archive trimmed session-log entries instead of deleting them

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -11096,3 +11096,18 @@
 - `pnpm test tests/api/teacher/tests-student-access.test.ts tests/components/TeacherClassroomView.test.tsx tests/unit/test-student-access.test.ts`
 - `pnpm test:coverage`
 - `pnpm lint`
+
+## 2026-06-14 — Assessment draft sync error wording
+
+**Completed:**
+- Renamed `syncAssessmentQuestionsFromDraft` failure messages from quiz-question wording to assessment-question wording.
+- Updated nearby generic assessment draft helper comments to avoid quiz/test route wording.
+- Updated the focused unit assertion for the renamed insert failure message.
+- Left compatibility exports, `AssessmentDraftType = 'quiz' | 'test'`, `quiz_questions`, `quiz_id`, route contracts, and persisted payload shapes unchanged.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/unit/assessment-drafts.test.ts`
+- `pnpm lint`
+- `pnpm test`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -7,22 +7,8 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.
 - Use `node scripts/trim-session-log.mjs --check` to verify the log is within the 60-entry cap.
 - Keep enough recent entries for weekly automations to inspect roughly the last week of work.
+- The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
-
-## 2026-06-14 — Assessment draft sync error wording
-
-**Completed:**
-- Renamed `syncAssessmentQuestionsFromDraft` failure messages from quiz-question wording to assessment-question wording.
-- Updated nearby generic assessment draft helper comments to avoid quiz/test route wording.
-- Updated the focused unit assertion for the renamed insert failure message.
-- Left compatibility exports, `AssessmentDraftType = 'quiz' | 'test'`, `quiz_questions`, `quiz_id`, route contracts, and persisted payload shapes unchanged.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm exec tsc --noEmit`
-- `pnpm test tests/unit/assessment-drafts.test.ts`
-- `pnpm lint`
-- `pnpm test`
 
 ## 2026-06-14 — Current test fixture wording cleanup
 
@@ -867,3 +853,18 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 **Validation:**
 - `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
 - `gh api repos/codepetca/pika/rulesets/{10460660,12273665}` confirmed new rules active
+
+## 2026-07-09 — Archive trimmed session-log entries instead of deleting
+
+**Completed:**
+- Fixed `scripts/trim-session-log.mjs` so entries it removes from `.ai/SESSION-LOG.md` are appended to the bottom of `.ai/JOURNAL-ARCHIVE.md` (preserving entry markdown and chronological order) instead of being permanently deleted, matching the header claim that full history lives in the archive.
+- Added `--archive <path>` and `--no-archive` flags; archiving is on by default and skipped when nothing is trimmed. A missing archive file is created with a minimal append-only header.
+- Documented the archiving behavior in the generated session-log header rules and script usage text.
+- Updated `tests/unit/trim-session-log.test.ts`: existing temp-path tests now pass explicit `--archive`/`--no-archive` (so they cannot write to the real archive), plus new coverage for appending to an existing archive, default-path archive creation, and no-op trims leaving the archive untouched.
+- Note: entries trimmed between ~2026-05-05 and 2026-06-14 predate this fix; they are gone from the archive but recoverable from `.ai/SESSION-LOG.md` git history.
+
+**Validation:**
+- `pnpm test tests/unit/trim-session-log.test.ts` (8/8 passed)
+- `pnpm test tests/unit/ai-startup-docs.test.ts`
+- `node scripts/trim-session-log.mjs --check`
+- `pnpm lint`

--- a/scripts/trim-session-log.mjs
+++ b/scripts/trim-session-log.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -7,6 +7,7 @@ const DEFAULT_MAX_ENTRIES = 60
 const DEFAULT_KEEP = Math.floor(DEFAULT_MAX_ENTRIES * 2 / 3)
 const DEFAULT_SOURCE = '.ai/SESSION-LOG.md'
 const DEFAULT_OUTPUT = '.ai/SESSION-LOG.md'
+const DEFAULT_ARCHIVE = '.ai/JOURNAL-ARCHIVE.md'
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 function parseArgs(argv) {
@@ -16,6 +17,7 @@ function parseArgs(argv) {
     keepWasSet: false,
     source: DEFAULT_SOURCE,
     output: DEFAULT_OUTPUT,
+    archive: DEFAULT_ARCHIVE,
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -34,6 +36,11 @@ function parseArgs(argv) {
     } else if (arg === '--output' && next) {
       args.output = next
       index += 1
+    } else if (arg === '--archive' && next) {
+      args.archive = next
+      index += 1
+    } else if (arg === '--no-archive') {
+      args.archive = null
     } else if (arg === '--help' || arg === '-h') {
       args.help = true
     } else {
@@ -51,10 +58,11 @@ function parseArgs(argv) {
 
 function usage() {
   return [
-    'Usage: node scripts/trim-session-log.mjs [--keep 40] [--source .ai/SESSION-LOG.md] [--output .ai/SESSION-LOG.md]',
+    'Usage: node scripts/trim-session-log.mjs [--keep 40] [--source .ai/SESSION-LOG.md] [--output .ai/SESSION-LOG.md] [--archive .ai/JOURNAL-ARCHIVE.md | --no-archive]',
     '       node scripts/trim-session-log.mjs --check [--keep 60] [--source .ai/SESSION-LOG.md]',
     '',
     'Keeps the latest session entries, where each entry starts with a markdown "## " heading.',
+    'Trimmed entries are appended to the archive file so history is preserved; pass --no-archive to discard them instead.',
     'Use --check to fail when the source has more entries than the check cap.',
   ].join('\n')
 }
@@ -81,6 +89,7 @@ function buildSessionLog(entries) {
     '- CI allows at most 60 entries; the trim step compacts to the latest 40 entries by default so there is headroom for future appends.',
     '- Use `node scripts/trim-session-log.mjs --check` to verify the log is within the 60-entry cap.',
     '- Keep enough recent entries for weekly automations to inspect roughly the last week of work.',
+    '- The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.',
     '- Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.',
     '',
     '',
@@ -89,7 +98,23 @@ function buildSessionLog(entries) {
   return `${header}${entries.join('\n\n')}\n`
 }
 
-function trimSessionLog({ keep, source, output }) {
+function appendToArchive(archivePath, entries) {
+  const archiveHeader = [
+    '# Pika Project Journal',
+    '',
+    '**Rules:**',
+    '- Append-only. Never delete entries.',
+    '- `scripts/trim-session-log.mjs` appends entries trimmed from `.ai/SESSION-LOG.md` here.',
+    '',
+    '',
+  ].join('\n')
+  const existing = existsSync(archivePath) ? readFileSync(archivePath, 'utf8') : ''
+  const base = existing.trim().length > 0 ? `${existing.replace(/\n+$/, '')}\n\n` : archiveHeader
+
+  writeFileSync(archivePath, `${base}${entries.join('\n\n')}\n`)
+}
+
+function trimSessionLog({ keep, source, output, archive }) {
   const sourcePath = resolve(repoRoot, source)
   const outputPath = resolve(repoRoot, output)
   const markdown = readFileSync(sourcePath, 'utf8')
@@ -100,13 +125,21 @@ function trimSessionLog({ keep, source, output }) {
   }
 
   const retainedEntries = entries.slice(-keep)
+  const removedEntries = entries.slice(0, entries.length - retainedEntries.length)
+
+  if (archive && removedEntries.length > 0) {
+    appendToArchive(resolve(repoRoot, archive), removedEntries)
+  }
+
   writeFileSync(outputPath, buildSessionLog(retainedEntries))
 
   return {
     source,
     output,
+    archive,
     total: entries.length,
     retained: retainedEntries.length,
+    archived: archive ? removedEntries.length : 0,
   }
 }
 
@@ -145,8 +178,9 @@ try {
     console.log(`${result.source} is within cap: ${result.total}/${result.maxEntries} entries`)
   } else {
     const result = trimSessionLog(args)
+    const archiveNote = result.archived > 0 ? `; archived ${result.archived} to ${result.archive}` : ''
     console.log(
-      `Trimmed ${result.output}: kept ${result.retained} of ${result.total} entries from ${result.source}`,
+      `Trimmed ${result.output}: kept ${result.retained} of ${result.total} entries from ${result.source}${archiveNote}`,
     )
   }
 } catch (error) {

--- a/tests/unit/trim-session-log.test.ts
+++ b/tests/unit/trim-session-log.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,6 +15,7 @@ describe('trim-session-log script', () => {
     try {
       const sourcePath = join(repoRoot, 'source.md')
       const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
 
       writeFileSync(
         sourcePath,
@@ -35,7 +36,7 @@ describe('trim-session-log script', () => {
 
       execFileSync(
         'node',
-        [scriptPath, '--source', sourcePath, '--output', outputPath, '--keep', '2'],
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '2'],
         { cwd: repoRoot },
       )
 
@@ -49,6 +50,12 @@ describe('trim-session-log script', () => {
       expect(output).toContain('## 2026-05-02 - Second')
       expect(output).toContain('## 2026-05-03 - Third')
       expect(output.match(/^## /gm)).toHaveLength(2)
+
+      const archived = readFileSync(archivePath, 'utf8')
+
+      expect(archived).toContain('## 2026-05-01 - First')
+      expect(archived).toContain('first entry')
+      expect(archived).not.toContain('## 2026-05-02 - Second')
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
     }
@@ -67,7 +74,9 @@ describe('trim-session-log script', () => {
 
       writeFileSync(sourcePath, ['# Pika Session Log', '', ...entries].join('\n\n'))
 
-      execFileSync('node', [scriptPath, '--source', sourcePath, '--output', outputPath], { cwd: repoRoot })
+      execFileSync('node', [scriptPath, '--source', sourcePath, '--output', outputPath, '--no-archive'], {
+        cwd: repoRoot,
+      })
 
       const output = readFileSync(outputPath, 'utf8')
 
@@ -111,9 +120,95 @@ describe('trim-session-log script', () => {
       expect(output).not.toContain('## 2026-05-01 - First')
       expect(output).toContain('## 2026-05-02 - Second')
       expect(output.match(/^## /gm)).toHaveLength(1)
+
+      const archived = readFileSync(join(repoRoot, '.ai/JOURNAL-ARCHIVE.md'), 'utf8')
+
+      expect(archived).toContain('## 2026-05-01 - First')
+      expect(archived).toContain('first entry')
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
       rmSync(otherCwd, { recursive: true, force: true })
+    }
+  })
+
+  it('appends trimmed entries to an existing archive without altering prior content', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-archive-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+      const existingArchive = [
+        '# Pika Project Journal',
+        '',
+        '## 2026-04-30 - Archived earlier',
+        'older archived entry',
+        '',
+      ].join('\n')
+
+      writeFileSync(archivePath, existingArchive)
+      writeFileSync(
+        sourcePath,
+        [
+          '# Pika Session Log',
+          '',
+          '## 2026-05-01 - First',
+          'first entry',
+          '',
+          '## 2026-05-02 - Second',
+          'second entry',
+          '',
+          '## 2026-05-03 - Third',
+          'third entry',
+          '',
+        ].join('\n'),
+      )
+
+      execFileSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '1'],
+        { cwd: repoRoot },
+      )
+
+      const archived = readFileSync(archivePath, 'utf8')
+
+      expect(archived).toContain('# Pika Project Journal')
+      expect(archived).toContain('## 2026-04-30 - Archived earlier')
+      expect(archived.indexOf('## 2026-04-30 - Archived earlier')).toBeLessThan(
+        archived.indexOf('## 2026-05-01 - First'),
+      )
+      expect(archived.indexOf('## 2026-05-01 - First')).toBeLessThan(archived.indexOf('## 2026-05-02 - Second'))
+      expect(archived).toContain('second entry')
+      expect(archived).not.toContain('## 2026-05-03 - Third')
+      expect(archived.endsWith('second entry\n')).toBe(true)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch the archive when nothing is trimmed', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'pika-session-log-noop-'))
+
+    try {
+      const sourcePath = join(repoRoot, 'source.md')
+      const outputPath = join(repoRoot, 'SESSION-LOG.md')
+      const archivePath = join(repoRoot, 'JOURNAL-ARCHIVE.md')
+
+      writeFileSync(
+        sourcePath,
+        ['# Pika Session Log', '', '## 2026-05-01 - First', 'first entry', ''].join('\n'),
+      )
+
+      execFileSync(
+        'node',
+        [scriptPath, '--source', sourcePath, '--output', outputPath, '--archive', archivePath, '--keep', '5'],
+        { cwd: repoRoot },
+      )
+
+      expect(readFileSync(outputPath, 'utf8')).toContain('## 2026-05-01 - First')
+      expect(existsSync(archivePath)).toBe(false)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Problem

`scripts/trim-session-log.mjs` writes a header into `.ai/SESSION-LOG.md` claiming "full historical session history lives in `.ai/JOURNAL-ARCHIVE.md`", but the script permanently deleted trimmed entries — nothing appended to the archive since around #607. The archive's last entries are dated 2026-05-05 while the session log starts at 2026-06-14, so entries in that gap were silently lost (still recoverable from `.ai/SESSION-LOG.md` git history if ever needed).

## Fix

- `trim-session-log.mjs` now appends the entries it removes to the bottom of `.ai/JOURNAL-ARCHIVE.md` (matching the archive's existing append-only, chronological convention) before rewriting the trimmed log, preserving entry markdown as-is.
- New `--archive <path>` flag (defaults to `.ai/JOURNAL-ARCHIVE.md`) and `--no-archive` to opt out. Archiving is skipped when nothing is trimmed; a missing archive file is created with a minimal append-only header.
- Generated session-log header and script usage text now document the archiving behavior.
- Tests: existing temp-path tests pass explicit `--archive`/`--no-archive` so runs can't write into the real repo archive; new coverage for appending to an existing archive (order + content preserved), default-path archive creation, and no-op trims leaving the archive untouched.
- This PR's own session-log append + trim exercised the new path: the trimmed `2026-06-14 — Assessment draft sync error wording` entry now sits at the bottom of `.ai/JOURNAL-ARCHIVE.md`.

## Validation

- `pnpm test tests/unit/trim-session-log.test.ts` (8/8)
- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26)
- `node scripts/trim-session-log.mjs --check` → 40/60 entries
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)