### PR TITLE
Validate and UTC-parse assignment due dates in relative date labels

### DIFF
--- a/src/lib/assignment-relative-date.ts
+++ b/src/lib/assignment-relative-date.ts
@@ -1,6 +1,34 @@
 import { getTodayInToronto } from '@/lib/timezone'
 import type { ClassDay } from '@/types'
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function toUtcDateOnlyMs(dateString: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
+  if (!match) return null
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > 31) return null
+
+  const utcMs = Date.UTC(year, month - 1, day)
+  const utcDate = new Date(utcMs)
+
+  if (
+    utcDate.getUTCFullYear() !== year ||
+    utcDate.getUTCMonth() !== month - 1 ||
+    utcDate.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return utcMs
+}
+
 function countClassDaysBetween(classDays: ClassDay[], fromDate: string, toDate: string): number {
   const start = fromDate < toDate ? fromDate : toDate
   const end = fromDate < toDate ? toDate : fromDate
@@ -19,6 +47,8 @@ export function getRelativeDueDate(dueAt: string, classDays?: ClassDay[]): Relat
   if (!dueAt) return null
 
   const today = getTodayInToronto()
+  const dueMs = toUtcDateOnlyMs(dueAt)
+  if (dueMs === null) return null
 
   if (classDays && classDays.length > 0) {
     const classCount = countClassDaysBetween(classDays, today, dueAt)
@@ -36,10 +66,10 @@ export function getRelativeDueDate(dueAt: string, classDays?: ClassDay[]): Relat
       : { text: `in ${absCount} classes`, isPast: false }
   }
 
-  const due = new Date(`${dueAt}T00:00:00`)
-  const todayDate = new Date(`${today}T00:00:00`)
-  const diffTime = due.getTime() - todayDate.getTime()
-  const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24))
+  const todayMs = toUtcDateOnlyMs(today)
+  if (todayMs === null) return null
+
+  const diffDays = Math.round((dueMs - todayMs) / MS_PER_DAY)
 
   if (diffDays === 0) return { text: 'today', isPast: false }
   if (diffDays === 1) return { text: 'tomorrow', isPast: false }

--- a/tests/unit/assignment-relative-date.test.ts
+++ b/tests/unit/assignment-relative-date.test.ts
@@ -13,6 +13,21 @@ describe('getRelativeDueDate', () => {
     expect(getRelativeDueDate('2026-03-02')).toEqual({ text: 'tomorrow', isPast: false })
   })
 
+  it('returns yesterday for the previous calendar day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+    expect(getRelativeDueDate('2026-02-28')).toEqual({ text: 'yesterday', isPast: true })
+  })
+
+  it('returns relative day counts beyond tomorrow/yesterday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+    expect(getRelativeDueDate('2026-03-04')).toEqual({ text: 'in 3 days', isPast: false })
+    expect(getRelativeDueDate('2026-02-20')).toEqual({ text: '9 days ago', isPast: true })
+  })
+
   it('returns next class when class-day logic applies', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
@@ -23,5 +38,16 @@ describe('getRelativeDueDate', () => {
         { date: '2026-03-03', is_class_day: true },
       ])
     ).toEqual({ text: 'next class', isPast: false })
+  })
+
+  it('returns null for invalid due dates', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T13:00:00.000Z')) // 2026-03-01 08:00 Toronto
+
+    expect(getRelativeDueDate('not-a-date')).toBeNull()
+    expect(getRelativeDueDate('2026-02-30')).toBeNull()
+    expect(
+      getRelativeDueDate('nope', [{ date: '2026-03-02', is_class_day: true }])
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
Rescued work found uncommitted in a stale worktree during repo cleanup.

- `getRelativeDueDate` now strictly validates date-only strings and returns `null` for malformed input (`2026-02-30` previously rolled over to Mar 2 and produced a wrong label).
- Day differences are computed from UTC date-only values instead of local-time `Date` parsing, removing DST/local-offset sensitivity.
- Adds tests for yesterday, multi-day counts, and invalid-date rejection (5/5 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)