### PR TITLE
Add /repo-tidy hygiene report script and command

### DIFF
--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -860,3 +860,16 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - CI `Test & Build` on the PR (self-validating workflow change)
+## 2026-07-10 — Repo cleanup and /repo-tidy skill
+
+**Completed:**
+- Deleted 101 stale remote branches (95 merged/closed-PR + 6 from closing stalled PRs) and ~140 local branches; pruned phantom `origin/pr/672` ref.
+- Removed 20 stale worktrees and 2 orphan directories; tagged 9 scratch-branch tips as `rescue/*` (local-only) before deleting.
+- Closed stalled PRs #298, #323, #328, #341, #568, #739. Rescued uncommitted work from an unattended worktree into PR #838.
+- Enabled `delete_branch_on_merge` on the repo so merged PR branches self-clean.
+- Added `scripts/repo-tidy.sh` (read-only hygiene report) plus `/repo-tidy` command in `.claude/commands/` and `.codex/prompts/`, and documented it in `docs/dev-workflow.md`.
+
+**Validation:**
+- `bash scripts/repo-tidy.sh` (clean run against the tidied repo)
+- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26 passed)
+- `pnpm lint`

--- a/.claude/commands/repo-tidy.md
+++ b/.claude/commands/repo-tidy.md
@@ -1,0 +1,35 @@
+Report and clean up repo cruft: stale branches, worktrees, and idle PRs.
+
+This command operates on the current repo/worktree.
+
+Rules:
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- The report script is read-only; all deletions happen in a second, explicit step.
+- Never delete anything holding unique work (dirty worktrees, branches with
+  unpushed commits, branches without a merged/closed PR) without showing the
+  user what it contains and getting confirmation.
+- `main` and `production` are never touched.
+
+Steps:
+
+1) Run the report
+   - `bash scripts/repo-tidy.sh`
+   - Summarize the findings for the user grouped by risk:
+     - **Safe**: remote branches whose PR is merged/closed (restorable from the
+       PR page), local branches with deleted upstreams, clean worktrees.
+     - **Needs a decision**: dirty worktrees, branches with commits that exist
+       nowhere else, branches with no PR, idle open PRs.
+
+2) Clean the safe group (after confirming with the user, or immediately if they
+   asked for cleanup up front)
+   - Delete merged/closed-PR remote branches: `git push origin --delete <branch>...`
+   - Delete gone-upstream local branches: `git branch -D <branch>...`
+   - Remove clean worktrees: `git worktree remove <path>` then `git worktree prune`
+
+3) Present the decision group
+   - For each item, show what it contains (diff stat, last commit, PR link) and
+     recommend one of: rescue to a PR, tag-rescue then delete
+     (`git tag rescue/<name> <branch>` before `git branch -D`), or keep.
+   - For idle PRs, recommend close vs revive based on age and drift from main.
+
+4) Exit with a summary: items cleaned, items awaiting decision, items kept.

--- a/.codex/prompts/repo-tidy.md
+++ b/.codex/prompts/repo-tidy.md
@@ -1,0 +1,35 @@
+Report and clean up repo cruft: stale branches, worktrees, and idle PRs.
+
+This command operates on the current repo/worktree.
+
+Rules:
+- Resolve the current repo root with `git rev-parse --show-toplevel`.
+- The report script is read-only; all deletions happen in a second, explicit step.
+- Never delete anything holding unique work (dirty worktrees, branches with
+  unpushed commits, branches without a merged/closed PR) without showing the
+  user what it contains and getting confirmation.
+- `main` and `production` are never touched.
+
+Steps:
+
+1) Run the report
+   - `bash scripts/repo-tidy.sh`
+   - Summarize the findings for the user grouped by risk:
+     - **Safe**: remote branches whose PR is merged/closed (restorable from the
+       PR page), local branches with deleted upstreams, clean worktrees.
+     - **Needs a decision**: dirty worktrees, branches with commits that exist
+       nowhere else, branches with no PR, idle open PRs.
+
+2) Clean the safe group (after confirming with the user, or immediately if they
+   asked for cleanup up front)
+   - Delete merged/closed-PR remote branches: `git push origin --delete <branch>...`
+   - Delete gone-upstream local branches: `git branch -D <branch>...`
+   - Remove clean worktrees: `git worktree remove <path>` then `git worktree prune`
+
+3) Present the decision group
+   - For each item, show what it contains (diff stat, last commit, PR link) and
+     recommend one of: rescue to a PR, tag-rescue then delete
+     (`git tag rescue/<name> <branch>` before `git branch -D`), or keep.
+   - For idle PRs, recommend close vs revive based on age and drift from main.
+
+4) Exit with a summary: items cleaned, items awaiting decision, items kept.

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -234,6 +234,20 @@ This keeps the hub checkout fast-forwarded to the merged `main` before removing
 the finished worktree and branch. Resolving the path from Git metadata lets
 cleanup handle both new Codex worktrees and older legacy worktrees.
 
+### Periodic hygiene check
+
+Merged PR branches are deleted automatically on GitHub, but local branches,
+worktrees, and idle PRs still accumulate. Run the read-only report at any time:
+
+```bash
+bash scripts/repo-tidy.sh
+```
+
+It lists remote branches whose PR is merged/closed, local branches with deleted
+upstreams, clean vs dirty worktrees, and open PRs idle for more than 30 days
+(override with `IDLE_DAYS`). It deletes nothing — it prints the command for each
+finding. `/repo-tidy` runs the report and walks through the cleanup with you.
+
 ---
 
 ## Merging `main` into `production` (PR-required)

--- a/scripts/repo-tidy.sh
+++ b/scripts/repo-tidy.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Repo hygiene report: stale branches, worktrees, and idle PRs.
+# Read-only — prints findings and suggested commands, never deletes anything.
+#
+# Usage: bash scripts/repo-tidy.sh
+# Requires: git, gh (authenticated), jq
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+IDLE_DAYS="${IDLE_DAYS:-30}"
+ISSUES=0
+
+echo "🧹 Pika repo tidy report ($(date +%Y-%m-%d))"
+echo ""
+
+git fetch --prune --quiet
+
+# 1) Remote branches whose PR is already merged or closed (squash merges hide
+#    this from `git branch --merged`, so map through the PR list instead).
+echo "── Remote branches ──────────────────────────────"
+PR_MAP="$(gh pr list --state all --limit 1000 --json headRefName,state,number \
+  --jq 'group_by(.headRefName) | map({branch: .[0].headRefName, states: [.[].state], number: .[0].number})')"
+
+while read -r branch; do
+  [[ "$branch" == "main" || "$branch" == "production" ]] && continue
+  entry="$(jq -r --arg b "$branch" '.[] | select(.branch == $b)' <<<"$PR_MAP")"
+  age="$(git log -1 --format=%cs "origin/$branch" 2>/dev/null || echo '?')"
+  if [[ -z "$entry" ]]; then
+    echo "  ⚠️  $branch — no PR (last commit $age)"
+    ISSUES=$((ISSUES + 1))
+  elif ! jq -e '.states | index("OPEN")' <<<"$entry" > /dev/null; then
+    pr="$(jq -r '.number' <<<"$entry")"
+    state="$(jq -r '.states[0]' <<<"$entry")"
+    echo "  🗑  $branch — PR #$pr is $state; delete with: git push origin --delete $branch"
+    ISSUES=$((ISSUES + 1))
+  fi
+done < <(git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||')
+
+# 2) Local branches whose upstream is gone.
+echo ""
+echo "── Local branches ───────────────────────────────"
+while IFS='|' read -r name track wt; do
+  if [[ "$track" == "[gone]" && -z "$wt" ]]; then
+    echo "  🗑  $name — upstream deleted; delete with: git branch -D $name"
+    ISSUES=$((ISSUES + 1))
+  fi
+done < <(git for-each-ref refs/heads --format='%(refname:short)|%(upstream:track)|%(worktreepath)')
+
+# 3) Worktrees: flag dirty state and unpushed commits so nothing is lost blindly.
+#    The hub (main worktree) and the production release worktree are infrastructure.
+echo ""
+echo "── Worktrees ────────────────────────────────────"
+HUB_WT="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+while read -r wt; do
+  [[ "$wt" == "$HUB_WT" ]] && continue
+  dirty="$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+  label="${branch:-DETACHED}"
+  if [[ "$branch" == "production" ]]; then
+    echo "  🏛  $wt (production) — release infrastructure, keep"
+    continue
+  fi
+  flags=""
+  [[ "$dirty" != "0" ]] && flags+=" dirty:$dirty"
+  if [[ -n "$branch" ]] && ! git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+    flags+=" not-on-remote"
+  fi
+  if [[ -n "$flags" ]]; then
+    echo "  ⚠️  $wt ($label)$flags — inspect before removing"
+    ISSUES=$((ISSUES + 1))
+  else
+    echo "  ✓  $wt ($label) — clean; removable with: git worktree remove $wt"
+  fi
+done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}')
+
+# 4) Open PRs idle beyond the threshold.
+echo ""
+echo "── Open PRs idle > ${IDLE_DAYS} days ────────────────────"
+CUTOFF="$(date -v -"${IDLE_DAYS}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -d "-${IDLE_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+IDLE="$(gh pr list --state open --json number,title,updatedAt | jq -r --arg cutoff "$CUTOFF" \
+  '.[] | select(.updatedAt < $cutoff) | "  💤 #\(.number) \(.title) (updated \(.updatedAt[0:10]))"')"
+if [[ -n "$IDLE" ]]; then
+  echo "$IDLE"
+  ISSUES=$((ISSUES + $(wc -l <<<"$IDLE" | tr -d ' ')))
+else
+  echo "  none"
+fi
+
+echo ""
+if [[ "$ISSUES" -eq 0 ]]; then
+  echo "✅ Nothing to tidy."
+else
+  echo "Found $ISSUES item(s) to review. This script deletes nothing — run the suggested commands yourself, or ask an agent to run /repo-tidy."
+fi


### PR DESCRIPTION
Follow-up to the repo cleanup: makes the cleanup repeatable so branch/worktree cruft doesn't rebuild.

## What's here
- **`scripts/repo-tidy.sh`** — read-only report. Deletes nothing; prints the exact command for each finding.
  - Remote branches whose PR is merged or closed. It maps branches through `gh pr list` rather than `git branch --merged`, because this repo squash-merges and git can't see those merges — that's precisely why ~95 branches accumulated unnoticed.
  - Local branches whose upstream is gone (skipping any checked out in a worktree).
  - Worktrees, split into clean (safe to remove) vs dirty/not-on-remote (inspect first). The hub and the `production` release worktree are treated as infrastructure and never suggested for removal.
  - Open PRs idle beyond `IDLE_DAYS` (default 30).
- **`/repo-tidy` command** in `.claude/commands/` and `.codex/prompts/` (mirrored per repo convention) — runs the report, groups findings by risk, cleans the safe group, and requires a decision on anything holding unique work.
- **`docs/dev-workflow.md`** — documents it under worktree cleanup.

## Context
Also enabled `delete_branch_on_merge` on the repo, so merged PR branches now self-clean on GitHub. This script covers what that setting can't: local branches, worktrees, and idle PRs.

## Validation
- `bash scripts/repo-tidy.sh` against the tidied repo — correctly reports a clean branch state, flags its own dirty worktree, and surfaces #567 as idle
- `pnpm test tests/unit/ai-startup-docs.test.ts` (26/26)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)