### PR TITLE
Bump GitHub Actions to latest majors (off deprecated Node 20)

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -11127,3 +11127,17 @@
 - `pnpm lint`
 - `pnpm test` (first run hit an unrelated `StudentLessonCalendarTab.test.tsx` timeout; isolated rerun passed)
 - `pnpm test`
+
+## 2026-06-14 — Teacher work-surface docs test wording
+
+**Completed:**
+- Updated stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests.
+- Removed active teacher quiz authoring/state-machine references from the canon.
+- Updated the work-surface audit and stable guidance index to match the active Tests product surface.
+- Left the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
+- `pnpm lint`
+- `pnpm test`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -10,20 +10,6 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - The trim step appends removed entries to `.ai/JOURNAL-ARCHIVE.md`, so trimming never loses history.
 - Use `.ai/JOURNAL-ARCHIVE.md` only for historical investigation.
 
-## 2026-06-14 — Teacher work-surface docs test wording
-
-**Completed:**
-- Updated stable teacher work-surface guidance from assignments/quizzes/tests to assignments/tests.
-- Removed active teacher quiz authoring/state-machine references from the canon.
-- Updated the work-surface audit and stable guidance index to match the active Tests product surface.
-- Left the explicit legacy drift row for tests/quizzes shell paths because it documents drift to avoid copying.
-
-**Validation:**
-- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
-- `pnpm test tests/unit/ui-guidance-docs.test.ts tests/unit/ai-startup-docs.test.ts`
-- `pnpm lint`
-- `pnpm test`
-
 ## 2026-06-14 — Individual test response fixture wording
 
 **Completed:**
@@ -865,3 +851,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 - `grep -rni staging` (only seed-data classroom title and journal archive remain)
 - `pnpm lint`
 - `pnpm exec tsc --noEmit`
+
+## 2026-07-10 — Bump GitHub Actions off deprecated Node 20
+
+**Completed:**
+- Bumped pinned action majors in ci.yml and ui-policy.yml to clear the "Node.js 20 is deprecated" runner warning: checkout v4→v7, setup-node v4→v6, pnpm/action-setup v4→v6, cache v4→v6, upload-artifact v4→v7.
+- All step inputs used are stable across these majors (no removed inputs); relying on CI to validate.
+
+**Validation:**
+- CI `Test & Build` on the PR (self-validating workflow change)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.25.0
 
@@ -31,7 +31,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/ui-policy.yml
+++ b/.github/workflows/ui-policy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check for banned imports
         run: |
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: "Check for dark: classes outside /ui"
         run: |


### PR DESCRIPTION
Clears the CI deprecation warning surfaced during the repo cleanup: every pinned `@v4` action bundles the Node 20 runtime, which GitHub is deprecating on runners — they're currently being force-run on Node 24, and will fail outright once that fallback is removed.

## Changes (ci.yml + ui-policy.yml)
| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v6 |
| pnpm/action-setup | v4 | v6 |
| actions/cache | v4 | v6 |
| actions/upload-artifact | v4 | v7 |

Targets verified against each action's latest release. Every step input in use (`node-version`, pnpm `version`, cache `path`/`key`/`restore-keys`, artifact `name`/`path`/`retention-days`) is stable across these majors — no removed inputs — so this is a runtime bump only. The `Test & Build` run on this PR validates it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)