### PR TITLE
Auto-label new issues with needs-triage

### DIFF
--- a/.ai/JOURNAL-ARCHIVE.md
+++ b/.ai/JOURNAL-ARCHIVE.md
@@ -11172,3 +11172,18 @@
 - `pnpm lint`
 - `pnpm test` (first run hit unrelated component timeout failures; failed files passed on isolated rerun)
 - `pnpm test`
+
+## 2026-06-14 — Student tests response fixture keys
+
+**Completed:**
+- Updated `StudentTestsTab` test fixtures to use current `tests`/`test` response keys by default.
+- Added explicit legacy `quiz`/`quizzes` response-key fallback coverage for the student tests component.
+- Left DB-shaped `quiz_id` question fields and legacy `student-quiz-action-footer` test id unchanged.
+- No production code, schema, or API contract changes.
+
+**Validation:**
+- `bash .codex/skills/pika-session-start/scripts/session_start.sh`
+- `pnpm exec tsc --noEmit`
+- `pnpm test tests/components/StudentTestsTab.test.tsx` (first run hit an unrelated exam-mode timeout after the new fallback test passed; rerun passed)
+- `pnpm lint`
+- `pnpm test`

--- a/.ai/SESSION-LOG.md
+++ b/.ai/SESSION-LOG.md
@@ -896,3 +896,12 @@ Rolling recent session log for AI/human handoffs. Keep this file small; full his
 
 **Validation:**
 - `gh issue list` label coverage check (0 unlabeled)
+
+## 2026-07-10 — Auto-label new issues with needs-triage
+
+**Completed:**
+- Added .github/workflows/triage-label.yml: on issue `opened`, adds `needs-triage` if the issue has zero labels (leaves template/pre-labeled issues alone).
+- Dependency-free (uses pre-installed gh CLI, no pinned actions) and least-privilege (`permissions: issues: write` only, over the repo's read-only default).
+
+**Validation:**
+- YAML parse check; workflow runs only on issue events (no CI impact to validate here)

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -1,0 +1,32 @@
+name: Auto-label new issues
+
+# Keeps the backlog legible: any newly opened issue that arrives without a
+# label gets `needs-triage` so it shows up in the triage filter instead of
+# disappearing into the unlabeled pile. Issues opened with a label (e.g. via a
+# template) are left alone.
+
+on:
+  issues:
+    types: [opened]
+
+# The repo default is read-only; grant only what this job needs.
+permissions:
+  issues: write
+
+jobs:
+  label-if-unlabeled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage when the issue has no labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          count="$(gh issue view "$ISSUE" --repo "$REPO" --json labels --jq '.labels | length')"
+          if [ "$count" -eq 0 ]; then
+            gh issue edit "$ISSUE" --repo "$REPO" --add-label needs-triage
+            echo "Added needs-triage to #$ISSUE"
+          else
+            echo "#$ISSUE already has $count label(s); leaving as-is"
+          fi


### PR DESCRIPTION
Keeps the freshly-triaged backlog from drifting back to a pile of unlabeled issues.

## Behavior
On `issues: opened`, if the issue has **zero** labels, it gets `needs-triage`. Issues opened with a label (e.g. via a future issue template) are left untouched.

## Design
- **Dependency-free** — uses the `gh` CLI pre-installed on runners via `run:`, so there's no pinned action to keep off deprecated Node runtimes (the thing #840 just cleaned up).
- **Least-privilege** — grants only `permissions: issues: write`, layered over the repo's read-only default `GITHUB_TOKEN`. It can label issues and nothing else.
- Runs only on issue events, so it never touches or gates code CI.

## Note
This is the automated half of keeping issues legible for collaborators; the manual triage (labels + CONTRIBUTING guide) already landed in #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)